### PR TITLE
Fixes mpich execution in compass

### DIFF
--- a/testing_and_setup/compass/setup_testcase.py
+++ b/testing_and_setup/compass/setup_testcase.py
@@ -1083,7 +1083,7 @@ def process_model_run_step(model_run_tag, configs, script):  # {{{
                              config.get('executables', executable_name),
                              link_path],
                             stdout=dev_null, stderr=dev_null)
-                        grandchild.text = executable_link
+                        grandchild.text = './{}'.format(executable_link)
                     elif arg_text.find('attr_') >= 0:
                         attr_array = arg_text.split('_')
                         try:


### PR DESCRIPTION
Ensures that mpich can find executable for `ocean_model`.

PR related to issue #50.
