### PR TITLE
In COMPASS, change "quiet" to write stderr (but still not stdout)

### DIFF
--- a/testing_and_setup/compass/setup_testcase.py
+++ b/testing_and_setup/compass/setup_testcase.py
@@ -1135,7 +1135,7 @@ def wrap_subprocess_comment(command_args, indentation):  # {{{
 def wrap_subprocess_command(command_args, indentation, quiet):  # {{{
     # Setup command redirection
     if quiet:
-        redirect = ", stdout=dev_null, stderr=dev_null"
+        redirect = ", stdout=dev_null, stderr=None"
     else:
         redirect = ""
 


### PR DESCRIPTION
Before this merge, calls that are quiet suppress stderr.  Since stderr is also not captured in a log file, it is not easy to know what went wrong without rerunning the step that failed.

