### PR TITLE
Refactoring and GPU optimization of the ocean equation of state

### DIFF
--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -102,7 +102,7 @@ module ocn_analysis_mode
       call mpas_timer_stop('io_reset_alarms')
 
       ! Initialize submodules before initializing blocks.
-      call ocn_equation_of_state_init(err_tmp)
+      call ocn_equation_of_state_init(domain, err_tmp)
       ierr = ior(ierr, err_tmp)
 
       call ocn_analysis_init(domain, err_tmp)

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -242,7 +242,7 @@ module ocn_forward_mode
       call ocn_vmix_init(domain, err_tmp)
       ierr = ior(ierr, err_tmp)
 
-      call ocn_equation_of_state_init(err_tmp)
+      call ocn_equation_of_state_init(domain, err_tmp)
       ierr = ior(ierr, err_tmp)
 
       call ocn_tendency_init(err_tmp)

--- a/src/core_ocean/mode_init/mpas_ocn_init_mode.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_mode.F
@@ -137,7 +137,7 @@ module ocn_init_mode
       call mpas_timer_stop('reset_io_alarms')
 
       ! Initialize submodules before initializing blocks.
-      call ocn_equation_of_state_init(err_tmp)
+      call ocn_equation_of_state_init(domain, err_tmp)
       ierr = ior(ierr, err_tmp)
       if(ierr.eq.1) then
           call mpas_log_write('An error was encountered while initializing the MPAS-Ocean init mode', MPAS_LOG_CRIT)

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -10,11 +10,11 @@
 !  ocn_equation_of_state
 !
 !> \brief MPAS ocean equation of state driver
-!> \author Mark Petersen
-!> \date   September 2011
+!> \author Mark Petersen, modified Phil Jones
+!> \date   September 2011, modified May 2018
 !> \details
-!>  This module contains the main driver routine for calling
-!>  the equation of state.
+!>  This module contains the main driver routines for calling
+!>  the equation of state and related quantities.
 !
 !-----------------------------------------------------------------------
 
@@ -56,8 +56,12 @@ module ocn_equation_of_state
    !
    !--------------------------------------------------------------------
 
-   logical :: linearEos, jmEos
+   integer ::                   &
+      ocnEqStateChoice           ! user choice of eq state method
 
+   integer, parameter ::        &! supported equation of state methods
+      ocnEqStateTypeLinear = 1, &! linear equation of state
+      ocnEqStateTypeJM     = 2   ! Jackett-McDougall  eqn of state
 
 !***********************************************************************
 
@@ -67,62 +71,85 @@ contains
 !
 !  routine ocn_equation_of_state
 !
-!> \brief   Calls equation of state
-!> \author  Mark Petersen
-!> \date    September 2011
+!> \brief   Computes density using an ocean equation of state
+!> \author  Mark Petersen, modified by Phil Jones
+!> \date    September 2011, modified May 2018
 !> \details
-!>  This routine calls the equation of state to update the density
+!>  This routine calls the equation of state to compute a density
+!>  from model temperature and salinity. 
+!>  If kDisplaced equals 0, density for the current vertical level is 
+!>           returned
+!>  If kDisplaced is not 0, density is returned for a parcel 
+!>           adiabatically displaced from its original level to level
+!>           kDisplaced.  
+!>  When using the linear EOS, these options are ignored since the
+!>           density is independent of pressure/depth.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, nCells, k_displaced, & !{{{
-                                            displacement_type, density, err, thermalExpansionCoeff, &
-                                            salineContractionCoeff, timeLevelIn)
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !  This module contains routines necessary for computing the density
-   !  from model temperature and salinity using an equation of state.
-   !
-   ! Input: mesh - mesh metadata
-   !        s - state: activeTracers
-   !        k_displaced
-   !
-   !  If k_displaced==0, density is returned with no displacement
-   !
-   !  If k_displaced~=0, density is returned, and is for
-   !  a parcel adiabatically displaced from its original level to level
-   !  k_displaced.  When using the linear EOS, state % displacedDensity is
-   !  still filled, but depth (i.e. pressure) does not modify the output.
-   !
-   ! Output: s - state: computed density
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      implicit none
+   subroutine ocn_equation_of_state_density(statePool, diagnosticsPool,&
+                           meshPool, scratchPool, nCells, kDisplaced,  &
+                           displacement_type, density, err,            &
+                           thermalExpansionCoeff,                      &
+                           salineContractionCoeff, timeLevelIn) 
+      !{{{
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: statePool
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool
-      type (mpas_pool_type), intent(in) :: meshPool
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
-      integer, intent(in) :: nCells
-      integer, intent(in), optional :: timeLevelIn
-      type (mpas_pool_type), pointer :: tracersPool
-      integer :: k_displaced
-      character(len=*), intent(in) :: displacement_type
-      real (kind=RKIND), dimension(:,:), intent(out) :: density
-      integer, intent(out) :: err
+      integer, intent(in) :: &
+         nCells,             &! number of horiz mesh cells
+         kDisplaced           ! target vert level for adiab displacement
+
+      integer, intent(in), optional :: &
+         timeLevelIn          ! time level for state variables
+
+      character(len=*), intent(in) :: &
+         displacement_type    ! choice for adiabatic displacement
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,           &! pool containing state variables
+         diagnosticsPool,     &! pool containing some forcing fields
+         meshPool,            &! pool containing mesh quantities
+         scratchPool           ! pool containing some scratch space
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! returned error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density of sea water
+
+      ! optional expansion coefficients
+      ! Thermal expansion, defined as $-1/\rho d\rho/dT$ (note neg sign)
+      ! Saline contraction, defined as $1/\rho d\rho/dS$
       real (kind=RKIND), dimension(:,:), intent(out), optional :: &
-         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign)
-         salineContractionCoeff   ! Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$
+         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha)
+         salineContractionCoeff   ! Saline contraction coefficient (beta)
 
-      integer, dimension(:), pointer :: maxLevelCell
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: tracersPool
+
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      integer :: iCell, k
-      integer, pointer :: indexT, indexS
-      type (dm_info) :: dminfo
+      integer :: iCell, k, nVertLevels, indexT, indexS
+      integer, pointer :: indexTptr, indexSptr, nVertLevelsPtr
       integer :: timeLevel
 
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag, start timer
       err = 0
 
       call mpas_timer_start("equation of state")
+
+      !*** initialize or extract relevant fields
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -130,76 +157,140 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexT)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexS)
+      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', &
+                                                 tracersSurfaceValue)
+      call mpas_pool_get_subpool  (statePool,   'tracers', &
+                                                 tracersPool)
+      call mpas_pool_get_array    (tracersPool, 'activeTracers', &
+                                                 activeTracers, timeLevel)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTptr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSptr)
+      call mpas_pool_get_dimension(meshPool,    'nVertLevels', &
+                                                 nVertLevelsPtr)
+      indexT      = indexTptr
+      indexS      = indexSptr
+      nVertLevels = nVertLevelsPtr
 
-      if (linearEos) then
+      !*** call specific equation of state based on user choice
 
-         call ocn_equation_of_state_linear_density(meshPool, nCells, k_displaced, displacement_type, indexT, indexS, &
-                                                   activeTracers, density, err, tracersSurfaceValue, &
-                                                   thermalExpansionCoeff, salineContractionCoeff)
+      select case (ocnEqStateChoice)
 
-      elseif (jmEos) then
+      case (ocnEqStateTypeLinear)
 
-         call ocn_equation_of_state_jm_density(meshPool, scratchPool, nCells, k_displaced, displacement_type, indexT, indexS, &
-                                               activeTracers, density, err, tracersSurfaceValue, thermalExpansionCoeff, &
-                                               salineContractionCoeff)
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_linear_density(nVertLevels,  &
+                     nCells, kDisplaced, displacement_type,         &
+                     indexT, indexS, activeTracers, density, err,   &
+                     thermalExpansionCoeff, salineContractionCoeff, &
+                     tracersSurfaceValue)
+         else
+            call ocn_equation_of_state_linear_density(nVertLevels, &
+                     nCells, kDisplaced, displacement_type,        &
+                     indexT, indexS, activeTracers, density, err,  &
+                     tracersSurfaceValue)
+         endif
 
-      endif
+      case (ocnEqStateTypeJM)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_jm_density(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_jm_density(nVertLevels,        &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, density, err,     &
+                     tracersSurfaceValue)
+         endif
+
+      case default
+         !*** error handled during init
+      end select
+
+      !*** stop timer and exit
 
       call mpas_timer_stop("equation of state")
+
+      !-----------------------------------------------------------------
 
    end subroutine ocn_equation_of_state_density!}}}
 
 !***********************************************************************
 !
-!  routine ocn_equation_of_stateInit
+!  routine ocn_equation_of_state_init
 !
-!> \brief   Initializes ocean momentum horizontal mixing quantities
-!> \author  Mark Petersen
-!> \date    September 2011
+!> \brief   Initializes ocean equation of state quantities
+!> \author  Mark Petersen, modified by Phil Jones
+!> \date    September 2011, modified May 2018
 !> \details
 !>  This routine initializes a variety of quantities related to
-!>  horizontal velocity mixing in the ocean. Since a variety of
-!>  parameterizations are available, this routine primarily calls the
-!>  individual init routines for each parameterization.
+!>  the ocean equation of state for computing the density of sea water.
 !
 !----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_init(err)!{{{
+   subroutine ocn_equation_of_state_init(domain, err)!{{{
 
    !--------------------------------------------------------------------
 
       !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: &
+         domain            ! domain information primarily for vert grid
+
+      !-----------------------------------------------------------------
+      ! Output variables
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err
 
-      character (len=StrKIND), pointer :: config_eos_type
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      character (len=StrKIND), pointer :: &
+         config_eos_type   ! for extracting EOS choice from use inputs
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
 
       err = 0
 
+      !*** extract user choice for equation of state from config
+
       call mpas_pool_get_config(ocnConfigs, 'config_eos_type', config_eos_type)
 
-      linearEos = .false.
-      jmEos = .false.
+      !*** set use choice based on config and call appropriate
+      !***  init routine
 
-      if (config_eos_type.eq.'linear') then
-         linearEos = .true.
+      select case (trim(config_eos_type))
+
+      case ('linear','Linear','LINEAR')
+
+         ocnEqStateChoice  = ocnEqStateTypeLinear
          call ocn_equation_of_state_linear_init(err)
-      elseif (config_eos_type.eq.'jm') then
-         jmEos = .true.
-         call ocn_equation_of_state_jm_init(err)
-      else
-         call mpas_log_write('Invalid choice for config_eos_type. Choices are: linear, jm')
+
+      case ('jm','JM')
+
+         ocnEqStateChoice  = ocnEqStateTypeJM
+         call ocn_equation_of_state_jm_init(domain, err)
+
+      case default
+
+         call mpas_log_write(&
+         'Invalid choice for config_eos_type. Choices are: linear, jm')
          err = 1
-      endif
+
+      end select
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -76,12 +76,12 @@ contains
 !> \date    September 2011, modified May 2018
 !> \details
 !>  This routine calls the equation of state to compute a density
-!>  from model temperature and salinity. 
-!>  If kDisplaced equals 0, density for the current vertical level is 
+!>  from model temperature and salinity.
+!>  If kDisplaced equals 0, density for the current vertical level is
 !>           returned
-!>  If kDisplaced is not 0, density is returned for a parcel 
+!>  If kDisplaced is not 0, density is returned for a parcel
 !>           adiabatically displaced from its original level to level
-!>           kDisplaced.  
+!>           kDisplaced.
 !>  When using the linear EOS, these options are ignored since the
 !>           density is independent of pressure/depth.
 !
@@ -91,7 +91,7 @@ contains
                            meshPool, scratchPool, nCells, kDisplaced,  &
                            displacement_type, density, err,            &
                            thermalExpansionCoeff,                      &
-                           salineContractionCoeff, timeLevelIn) 
+                           salineContractionCoeff, timeLevelIn)
       !{{{
       !-----------------------------------------------------------------
       ! Input variables

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -9,12 +9,15 @@
 !
 !  ocn_equation_of_state_jm
 !
-!> \brief MPAS ocean equation of state driver
-!> \author Mark Petersen
-!> \date   September 2011
+!> \brief MPAS ocean Jackett and McDougall equation of state
+!> \author Mark Petersen, modified by Phil Jones
+!> \date   September 2011, modified May 2018
 !> \details
-!>  This module contains the main driver routine for calling
-!>  the equation of state.
+!>  This module contains the routines for computing density from
+!>  temperature and salinity using an equation of state by Jackett
+!>  and McDougall that approximates the nonlinear equation of state
+!>  using a set of polynomials.
+!>  See Jackett and McDougall, JTECH, Vol.12, pp 381-389, April, 1995.
 !
 !-----------------------------------------------------------------------
 
@@ -46,11 +49,103 @@ module ocn_equation_of_state_jm
    public :: ocn_equation_of_state_jm_density, &
              ocn_equation_of_state_jm_init
 
+   !*** generic interface for case of density only or density and
+   !*** expansion coeffs
+   interface ocn_equation_of_state_jm_density
+      module procedure ocn_equation_of_state_jm_density_only
+      module procedure ocn_equation_of_state_jm_density_exp
+   end interface
+
    !--------------------------------------------------------------------
    !
    ! Private module variables
    !
    !--------------------------------------------------------------------
+
+   !*** temporary array to hold modified T,S for EOS calculation
+   !*** declared here to make it thread-shared - could be replaced
+   !***   by a local subroutine temporary in a different thread model 
+
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      tracerTemp, tracerSalt
+
+   !*** depth-based reference pressure for pressure term in eq state
+
+   real (kind=RKIND), dimension(:), allocatable :: &
+      ocnEqStatePRef   ! reference pressure at each layer
+
+   !*** valid range of T,S for Jackett and McDougall
+
+   real (kind=RKIND), parameter :: &
+      ocnEqStateTmin = -2.0_RKIND, &! valid pot. temp. range
+      ocnEqStateTmax = 40.0_RKIND, &
+      ocnEqStateSmin =  0.0_RKIND, &! valid salinity, in psu
+      ocnEqStateSmax = 42.0_RKIND
+
+   !***  UNESCO EOS constants and JMcD bulk modulus constants
+
+   !*** for density of fresh water (standard UNESCO)
+
+   real (kind=RKIND), parameter ::         &
+      unt0 =   999.842594_RKIND,           &
+      unt1 =  6.793952e-2_RKIND,           &
+      unt2 = -9.095290e-3_RKIND,           &
+      unt3 =  1.001685e-4_RKIND,           &
+      unt4 = -1.120083e-6_RKIND,           &
+      unt5 =  6.536332e-9_RKIND
+
+   !*** for dependence of surface density on salinity (UNESCO)
+
+   real (kind=RKIND), parameter ::         &
+      uns1t0 =  0.824493_RKIND ,           &
+      uns1t1 = -4.0899e-3_RKIND,           &
+      uns1t2 =  7.6438e-5_RKIND,           &
+      uns1t3 = -8.2467e-7_RKIND,           &
+      uns1t4 =  5.3875e-9_RKIND,           &
+      unsqt0 = -5.72466e-3_RKIND,          &
+      unsqt1 =  1.0227e-4_RKIND,           &
+      unsqt2 = -1.6546e-6_RKIND,           &
+      uns2t0 =  4.8314e-4_RKIND
+
+   !*** from Table A1 of Jackett and McDougall
+
+   real (kind=RKIND), parameter ::         &
+      bup0s0t0 =  1.965933e+4_RKIND,       &
+      bup0s0t1 =  1.444304e+2_RKIND,       &
+      bup0s0t2 = -1.706103_RKIND   ,       &
+      bup0s0t3 =  9.648704e-3_RKIND,       &
+      bup0s0t4 = -4.190253e-5_RKIND
+
+   real (kind=RKIND), parameter ::         &
+      bup0s1t0 =  5.284855e+1_RKIND,       &
+      bup0s1t1 = -3.101089e-1_RKIND,       &
+      bup0s1t2 =  6.283263e-3_RKIND,       &
+      bup0s1t3 = -5.084188e-5_RKIND
+
+   real (kind=RKIND), parameter ::         &
+      bup0sqt0 =  3.886640e-1_RKIND,       &
+      bup0sqt1 =  9.085835e-3_RKIND,       &
+      bup0sqt2 = -4.619924e-4_RKIND
+
+   real (kind=RKIND), parameter ::         &
+      bup1s0t0 =  3.186519_RKIND   ,       &
+      bup1s0t1 =  2.212276e-2_RKIND,       &
+      bup1s0t2 = -2.984642e-4_RKIND,       &
+      bup1s0t3 =  1.956415e-6_RKIND
+
+   real (kind=RKIND), parameter ::         &
+      bup1s1t0 =  6.704388e-3_RKIND,       &
+      bup1s1t1 = -1.847318e-4_RKIND,       &
+      bup1s1t2 =  2.059331e-7_RKIND,       &
+      bup1sqt0 =  1.480266e-4_RKIND
+
+   real (kind=RKIND), parameter ::         &
+      bup2s0t0 =  2.102898e-4_RKIND,       &
+      bup2s0t1 = -1.202016e-5_RKIND,       &
+      bup2s0t2 =  1.394680e-7_RKIND,       &
+      bup2s1t0 = -2.040237e-6_RKIND,       &
+      bup2s1t1 =  6.128773e-8_RKIND,       &
+      bup2s1t2 =  6.207323e-10_RKIND
 
 !***********************************************************************
 
@@ -58,377 +153,586 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_equation_of_state_jm_density
+!  routine ocn_equation_of_state_jm_density_only
 !
 !> \brief   Calls JM equation of state
-!> \author  Mark Petersen and Todd Ringler
-!> \date    September 2011, updated August 2013
+!> \author  Mark Petersen and Todd Ringler, modified Phil Jones
+!> \date    September 2011, updated August 2013, May 2018
 !> \details
-!>  This routine uses a JM equation of state to update the density.
+!>  This routine computes the density from model temperature and 
+!>  salinity using a potential-temperature-based bulk modulus from 
+!>  Jackett and McDougall (JTECH, Vol.12, pp 381-389, April, 1995)
+!>  to approximate the UNESCO equation of state.
 !>
-!>  Density can be computed in-situ using k_displaced=0 and
-!>      displacement_type = 'relative'.
+!>  Density can be computed in-situ using kDisplaced=0 and
+!>      displacementType = 'relative'.
 !>
 !>  Potential density (referenced to top layer) can be computed
-!>      using k_displaced=1 and displacement_type = 'absolute'.
+!>      using kDisplaced=1 and displacementType = 'absolute'.
 !>
 !>  The density of SST/SSS after adiabatic displacement to each layer
-!>      can be computed using displacement_type = 'surfaceDisplaced'.
+!>      can be computed using displacementType = 'surfaceDisplaced'.
 !>
-!>  When using displacement_type = 'surfaceDisplaced', k_displaced is
+!>  When using displacementType = 'surfaceDisplaced', kDisplaced is
 !>      ignored and tracersSurfaceLayerValue must be present.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_jm_density(meshPool, scratchPool, nCells, k_displaced, displacement_type, &
-       indexT, indexS, tracers, density, err, &
-       tracersSurfaceLayerValue, thermalExpansionCoeff, salineContractionCoeff)!{{{
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !  This module contains routines necessary for computing the density
-   !  from model temperature and salinity using an equation of state.
-   !
-   !  The UNESCO equation of state computed using the
-   !  potential-temperature-based bulk modulus from Jackett and
-   !  McDougall, JTECH, Vol.12, pp 381-389, April, 1995.
-   !
-   ! Input: mesh - mesh metadata
-   !        s - state: tracers
-   !        k_displaced
+   subroutine ocn_equation_of_state_jm_density_only(nVertLevels,      &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, density, err, &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
 
-   !  If k_displaced=0, density is returned with no displacement
-   !  If k_displaced>0,the density returned is that for a parcel
-   !  adiabatically displaced from its original level to level
-   !  k_displaced.
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-   !
-   ! Output: s - state: computed density
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
 
-      implicit none
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
 
-      type (mpas_pool_type), intent(in) :: meshPool
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
-      integer, intent(in) :: nCells
-      integer, intent(in) :: k_displaced, indexT, indexS
-      character(len=*), intent(in) :: displacement_type
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers
-      real (kind=RKIND), dimension(:,:), intent(out) :: density
-      integer, intent(out) :: err
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: tracersSurfaceLayerValue
-      real (kind=RKIND), dimension(:,:), intent(out), optional :: &
-         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign)
-         salineContractionCoeff   ! Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
 
-      integer :: iEdge, iCell, iVertex, k, k_displaced_local
-      integer, pointer :: nVertices, nVertLevels
-      integer, dimension(:), pointer :: maxLevelCell
-      character(len=60) :: displacement_type_local
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
 
-      real (kind=RKIND) :: &
-         depth, &
-         DRDT0,             &! d(density)/d(temperature), for surface
-         DRDS0,             &! d(density)/d(salinity   ), for surface
-         DKDT,              &! d(bulk modulus)/d(pot. temp.)
-         DKDS,              &! d(bulk modulus)/d(salinity  )
-         DRHODT,            &! derivative of density with respect to temperature
-         DRHODS,            &! derivative of density with respect to salinity
-         tmin, tmax,        &! valid temperature range for level k
-         smin, smax          ! valid salinity    range for level k
-      real (kind=RKIND), dimension(:), pointer :: &
-        refBottomDepth, pRefEOS
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         iCell, k,        &! cell and vertical level loop indices
+         kTmp, kRef,      &! indices to determine ref level for pressure
+         kDisplacedLocal   ! locally modified diplacement target level
+
+      character(len=60) :: &
+         displacementTypeLocal ! locally modified displacement type
+
       real (kind=RKIND), dimension(:), allocatable :: &
          p, p2 ! temporary pressure scalars
-      real (kind=RKIND), dimension(:), pointer :: &
-         TQ,SQ,             &! adjusted T,S
-         BULK_MOD,          &! Bulk modulus
-         SQR,DENOMK,        &! work arrays
-         RHO_S,             &! density at the surface
-         WORK1, WORK2, WORK3, WORK4, T2
-      real (kind=RKIND), dimension(:), allocatable :: &
-         tracerTemp, tracerSalt
 
-!-----------------------------------------------------------------------
-!
-!  UNESCO EOS constants and JMcD bulk modulus constants
-!
-!-----------------------------------------------------------------------
+      real (kind=RKIND) :: &
+         work1, work2,     &! temporary scalars for calc
+         work3, work4,     &!
+         tq, sq,           &! adjusted T,S
+         t2, sqr,          &! temperature squared and square root salt
+         bulkMod,          &! Bulk modulus
+         rhosfc             ! density at the surface
 
-      !*** for density of fresh water (standard UNESCO)
+      !-----------------------------------------------------------------
 
-      real (kind=RKIND), parameter ::              &
-         unt0 =   999.842594_RKIND,           &
-         unt1 =  6.793952e-2_RKIND,           &
-         unt2 = -9.095290e-3_RKIND,           &
-         unt3 =  1.001685e-4_RKIND,           &
-         unt4 = -1.120083e-6_RKIND,           &
-         unt5 =  6.536332e-9_RKIND
-
-      !*** for dependence of surface density on salinity (UNESCO)
-
-      real (kind=RKIND), parameter ::              &
-         uns1t0 =  0.824493_RKIND ,           &
-         uns1t1 = -4.0899e-3_RKIND,           &
-         uns1t2 =  7.6438e-5_RKIND,           &
-         uns1t3 = -8.2467e-7_RKIND,           &
-         uns1t4 =  5.3875e-9_RKIND,           &
-         unsqt0 = -5.72466e-3_RKIND,          &
-         unsqt1 =  1.0227e-4_RKIND,           &
-         unsqt2 = -1.6546e-6_RKIND,           &
-         uns2t0 =  4.8314e-4_RKIND
-
-      !*** from Table A1 of Jackett and McDougall
-
-      real (kind=RKIND), parameter ::              &
-         bup0s0t0 =  1.965933e+4_RKIND,       &
-         bup0s0t1 =  1.444304e+2_RKIND,       &
-         bup0s0t2 = -1.706103_RKIND   ,       &
-         bup0s0t3 =  9.648704e-3_RKIND,       &
-         bup0s0t4 = -4.190253e-5_RKIND
-
-      real (kind=RKIND), parameter ::              &
-         bup0s1t0 =  5.284855e+1_RKIND,       &
-         bup0s1t1 = -3.101089e-1_RKIND,       &
-         bup0s1t2 =  6.283263e-3_RKIND,       &
-         bup0s1t3 = -5.084188e-5_RKIND
-
-      real (kind=RKIND), parameter ::              &
-         bup0sqt0 =  3.886640e-1_RKIND,       &
-         bup0sqt1 =  9.085835e-3_RKIND,       &
-         bup0sqt2 = -4.619924e-4_RKIND
-
-      real (kind=RKIND), parameter ::              &
-         bup1s0t0 =  3.186519_RKIND   ,       &
-         bup1s0t1 =  2.212276e-2_RKIND,       &
-         bup1s0t2 = -2.984642e-4_RKIND,       &
-         bup1s0t3 =  1.956415e-6_RKIND
-
-      real (kind=RKIND), parameter ::              &
-         bup1s1t0 =  6.704388e-3_RKIND,       &
-         bup1s1t1 = -1.847318e-4_RKIND,       &
-         bup1s1t2 =  2.059331e-7_RKIND,       &
-         bup1sqt0 =  1.480266e-4_RKIND
-
-      real (kind=RKIND), parameter ::              &
-         bup2s0t0 =  2.102898e-4_RKIND,       &
-         bup2s0t1 = -1.202016e-5_RKIND,       &
-         bup2s0t2 =  1.394680e-7_RKIND,       &
-         bup2s1t0 = -2.040237e-6_RKIND,       &
-         bup2s1t1 =  6.128773e-8_RKIND,       &
-         bup2s1t2 =  6.207323e-10_RKIND
-
-      integer :: k_test, k_ref
+      !*** initialize error flag
 
       err = 0
 
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+      !*** allocate and compute pressure array
 
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      allocate(p(nVertLevels),p2(nVertLevels))
 
-      allocate(tracerTemp(nVertLevels))
-      allocate(tracerSalt(nVertLevels))
+      ! Determine pressure to use in density calculation
+      !  If kDisplaced=0, in-situ density is returned (no displacement)
+      !  If kDisplaced/=0, potential density is returned
 
-!  Jackett and McDougall
-      tmin = -2.0_RKIND  ! valid pot. temp. range
-      tmax = 40.0_RKIND
-      smin =  0.0_RKIND  ! valid salinity, in psu
-      smax = 42.0_RKIND
-
-!  This function computes pressure in bars from depth in meters
-!  using a mean density derived from depth-dependent global
-!  average temperatures and salinities from Levitus 1994, and
-!  integrating using hydrostatic balance.
-
-      allocate(pRefEOS(nVertLevels),p(nVertLevels),p2(nVertLevels))
-
-      allocate(SQ(nVertLevels), TQ(nVertLevels), SQR(nVertLevels), T2(nVertLevels), WORK1(nVertLevels), &
-               WORK2(nVertLevels), RHO_S(nVertLevels), WORK3(nVertLevels), WORK4(nVertLevels), &
-               BULK_MOD(nVertLevels), DENOMK(nVertLevels))
-
-      ! This could be put in the init routine.
-      ! Note I am using refBottomDepth, so pressure on top level does
-      ! not include SSH contribution.  I am not sure if that matters, but
-      ! POP does it the same way.
-      depth = 0.5_RKIND*refBottomDepth(1)
-      pRefEOS(1) = 0.059808_RKIND*(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
-          + 0.100766_RKIND*depth + 2.28405e-7_RKIND*depth**2
-      do k = 2,nVertLevels
-         depth = 0.5_RKIND*(refBottomDepth(k)+refBottomDepth(k-1))
-         pRefEOS(k) = 0.059808_RKIND*(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
-             + 0.100766_RKIND*depth + 2.28405e-7_RKIND*depth**2
-      enddo
-
-      !  If k_displaced=0, in-situ density is returned (no displacement)
-      !  If k_displaced/=0, potential density is returned
-
-      !  if displacement_type = 'relative', potential density is calculated
-      !     referenced to level k + k_displaced
-      !  if displacement_type = 'absolute', potential density is calculated
-      !     referenced to level k_displaced for all k
-      !  NOTE: k_displaced = 0 or > nVertLevels is incompatible with 'absolute'
+      !  if displacementType = 'relative', potential density is calculated
+      !     referenced to level k + kDisplaced
+      !  if displacementType = 'absolute', potential density is calculated
+      !     referenced to level kDisplaced for all k
+      !  NOTE: kDisplaced = 0 or > nVertLevels is incompatible with 'absolute'
       !     so abort if necessary
-      if (displacement_type == 'surfaceDisplaced') then
-        if(present(tracersSurfaceLayerValue)) then
-          displacement_type_local = 'relative'
-          k_displaced_local = 0
-        else
-           call mpas_log_write( &
-             'tracersSurfaceLayerValue must be present when displacement_type is ' &
-                                    // '''surfaceDisplaced'' in JM EOS', &
-               MPAS_LOG_CRIT)
-        endif
+
+      if (displacementType == 'surfaceDisplaced') then
+         displacementTypeLocal = 'relative'
+         kDisplacedLocal = 0
       else
-        displacement_type_local = trim(displacement_type)
-        k_displaced_local = k_displaced
+         displacementTypeLocal = trim(displacementType)
+         kDisplacedLocal = kDisplaced
       endif
 
-      if (displacement_type_local == 'absolute' .and.   &
-         (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+      ! Eliminate this error check for performance reasons
+      !if (displacementTypeLocal == 'absolute' .and.   &
+      !   (kDisplacedLocal <= 0 .or. kDisplacedLocal > nVertLevels) ) then
+      !
+      !   call mpas_log_write('Abort: In equation_of_state_jm' // &
+      !       ' kDisplaced must be between 1 and nVertLevels for ' // &
+      !       'displacementType = absolute', MPAS_LOG_CRIT)
+      !endif
 
-         call mpas_log_write('Abort: In equation_of_state_jm' // &
-             ' k_displaced must be between 1 and nVertLevels for ' // &
-             'displacement_type = absolute', MPAS_LOG_CRIT)
-      endif
-
-      if (k_displaced_local == 0) then
+      if (kDisplacedLocal == 0) then
+         ! use pressure at in situ level
          do k=1,nVertLevels
-            p(k)   = pRefEOS(k)
-            p2(k)  = p(k)*p(k)
+            p (k) = ocnEqStatePRef(k)
+            p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
          enddo
-      else ! k_displaced_local /= 0
+      else ! kDisplacedLocal /= 0
          do k=1,nVertLevels
-            if (displacement_type_local == 'relative') then
-               k_test = min(k + k_displaced_local, nVertLevels)
-               k_ref  = max(k_test, 1)
+            ! determine level to which parcel is displaced
+            !  and thus which pressure (depth) to use in EOS
+            if (displacementTypeLocal == 'relative') then
+               kTmp = min(k + kDisplacedLocal, nVertLevels)
             else
-               k_test = min(k_displaced_local, nVertLevels)
-               k_ref  = max(k_test, 1)
+               kTmp = min(kDisplacedLocal, nVertLevels)
             endif
-            p(k)   = pRefEOS(k_ref)
-            p2(k)  = p(k)*p(k)
+            kRef  = max(kTmp, 1)  ! make sure index bounded to 1
+            p (k) = ocnEqStatePRef(kRef)
+            p2(k) = ocnEqStatePRef(kRef)*ocnEqStatePRef(kRef)
          enddo
       endif
 
-      !$omp do schedule(runtime) private(k, DRDT0, DKDT, DRHODT, DRDS0, DKDS, DRHODS)
-      do iCell=1,nCells
-         if (displacement_type == 'surfaceDisplaced') then
-           if(present(tracersSurfaceLayerValue)) then
-             do k=1,nVertLevels
-               tracerTemp(k) = tracersSurfaceLayerValue(indexT,iCell)
-               tracerSalt(k) = tracersSurfaceLayerValue(indexS,iCell)
-             enddo
-           else
-             call mpas_log_write( &
-               'tracersSurfaceLayerValue must be present in JM EOS call',  &
-               MPAS_LOG_CRIT)
-           endif
-         else
-           do k = 1, nVertLevels
-              tracerTemp(k) = tracers(indexT, k, iCell)
-              tracerSalt(k) = tracers(indexS, k, iCell)
-           end do
-         endif
+      !*** compute modified T,S to account for displacement and 
+      !*** valid range
 
-         do k=1,maxLevelCell(iCell)
-            SQ(k)  = max(min(tracerSalt(k),smax),smin)
-            TQ(k)  = max(min(tracerTemp(k),tmax),tmin)
+      !$omp single
+      allocate(tracerTemp(nVertLevels,nCells))
+      allocate(tracerSalt(nVertLevels,nCells))
+      !$omp end single
 
-            SQR(k) = sqrt(SQ(k))
-            T2(k)  = TQ(k)*TQ(k)
+      if (displacementType == 'surfaceDisplaced') then
 
-            !***
-            !*** first calculate surface (p=0) values from UNESCO eqns.
-            !***
-
-            WORK1(k) = uns1t0 + uns1t1*TQ(k) + &
-                   (uns1t2 + uns1t3*TQ(k) + uns1t4*T2(k))*T2(k)
-            WORK2(k) = SQR(k)*(unsqt0 + unsqt1*TQ(k) + unsqt2*T2(k))
-
-            RHO_S(k) = unt1*TQ(k) + (unt2 + unt3*TQ(k) + (unt4 + unt5*TQ(k))*T2(k))*T2(k) &
-                            + (uns2t0*SQ(k) + WORK1(k) + WORK2(k))*SQ(k)
-
-            !***
-            !*** now calculate bulk modulus at pressure p from
-            !*** Jackett and McDougall formula
-            !***
-
-            WORK3(k) = bup0s1t0 + bup0s1t1*TQ(k) +                    &
-                    (bup0s1t2 + bup0s1t3*TQ(k))*T2(k) +                &
-                    p(k) *(bup1s1t0 + bup1s1t1*TQ(k) + bup1s1t2*T2(k)) + &
-                    p2(k)*(bup2s1t0 + bup2s1t1*TQ(k) + bup2s1t2*T2(k))
-            WORK4(k) = SQR(k)*(bup0sqt0 + bup0sqt1*TQ(k) + bup0sqt2*T2(k) + &
-                         bup1sqt0*p(k))
-
-            BULK_MOD(k)  = bup0s0t0 + bup0s0t1*TQ(k) +                    &
-                        (bup0s0t2 + bup0s0t3*TQ(k) + bup0s0t4*T2(k))*T2(k) + &
-                        p(k) *(bup1s0t0 + bup1s0t1*TQ(k) +                &
-                        (bup1s0t2 + bup1s0t3*TQ(k))*T2(k)) +           &
-                        p2(k)*(bup2s0t0 + bup2s0t1*TQ(k) + bup2s0t2*T2(k)) + &
-                        SQ(k)*(WORK3(k) + WORK4(k))
-
-            DENOMK(k) = 1.0/(BULK_MOD(k) - p(k))
-
-            density(k, iCell) = (unt0 + RHO_S(k))*BULK_MOD(k)*DENOMK(k)
-
+         !$omp do schedule(runtime) private(k,tq,sq)
+         do iCell=1,nCells
+         do k=1,nVertLevels
+            tq = min(tracersSurfaceLayerValue(indexT,iCell), &
+                     ocnEqStateTmax)
+            sq = min(tracersSurfaceLayerValue(indexS,iCell), &
+                     ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         enddo
          end do
+         !$omp end do
 
-         if (present(thermalExpansionCoeff)) then
-            do k=1,maxLevelCell(iCell)
-               DRDT0 =  unt1 + 2.0_RKIND*unt2*TQ(k) +                      &
-                  (3.0_RKIND*unt3 + 4.0_RKIND*unt4*TQ(k) + 5.0_RKIND*unt5*T2(k))*T2(k) + &
-                  (uns1t1 + 2.0_RKIND*uns1t2*TQ(k) +                 &
-                   (3.0_RKIND*uns1t3 + 4.0_RKIND*uns1t4*TQ(k))*T2(k) +         &
-                   (unsqt1 + 2.0_RKIND*unsqt2*TQ(k))*SQR(k) )*SQ(k)
+      else
 
-               DKDT  = bup0s0t1 + 2.0_RKIND*bup0s0t2*TQ(k) +                       &
-                 (3.0_RKIND*bup0s0t3 + 4.0_RKIND*bup0s0t4*TQ(k))*T2(k) +               &
-                  p(k) *(bup1s0t1 + 2.0_RKIND*bup1s0t2*TQ(k) + 3.0_RKIND*bup1s0t3*T2(k)) + &
-                  p2(k)*(bup2s0t1 + 2.0_RKIND*bup2s0t2*TQ(k)) +                  &
-                  SQ(k)*(bup0s1t1 + 2.0_RKIND*bup0s1t2*TQ(k) + 3.0_RKIND*bup0s1t3*T2(k) +  &
-                  p(k)  *(bup1s1t1 + 2.0_RKIND*bup1s1t2*TQ(k)) +             &
-                  p2(k) *(bup2s1t1 + 2.0_RKIND*bup2s1t2*TQ(k)) +             &
-                  SQR(k)*(bup0sqt1 + 2.0_RKIND*bup0sqt2*TQ(k)))
+         !$omp do schedule(runtime) private(k,tq,sq)
+         do iCell=1,nCells
+         do k = 1, nVertLevels
+            tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
+            sq = min(tracers(indexS,k,iCell), ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         end do
+         end do
+         !$omp end do
 
-               DRHODT = (DENOMK(k)*(DRDT0*BULK_MOD(k) -                    &
-                  p(k)*(unt0+RHO_S(k))*DKDT*DENOMK(k)))
+      endif
 
-               thermalExpansionCoeff(k,iCell) = -DRHODT/density(k,iCell)
-            end do
-         end if
+#ifdef MPAS_OPENACC
+      !$omp single
+      !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt)
+      !$acc parallel loop gang vector collapse(2) &
+      !$acc&   present(density, p, p2, tracerTemp, tracerSalt)
+#else
+      !$omp  do schedule(runtime) &
+      !$omp& private(k,tq,sq,t2,sqr,bulkMod,rhosfc,work1,work2,work3,work4)
+#endif
+      do iCell=1,nCells
+      do k=1,nVertLevels
 
-         if (present(salineContractionCoeff)) then
-            do k=1,maxLevelCell(iCell)
-               DRDS0  = 2.0_RKIND*uns2t0*SQ(k) + WORK1(k) + 1.5_RKIND*WORK2(k)
-               DKDS = WORK3(k) + 1.5_RKIND*WORK4(k)
+         sq  = tracerSalt(k,iCell)
+         tq  = tracerTemp(k,iCell)
 
-               DRHODS = DENOMK(k)*(DRDS0*BULK_MOD(k) -                    &
-                   p(k)*(unt0+RHO_S(k))*DKDS*DENOMK(k))
+         sqr = sqrt(sq)
+         t2  = tq*tq
 
-               salineContractionCoeff(k,iCell) = DRHODS/density(k,iCell)
+         !***
+         !*** first calculate surface (p=0) values from UNESCO eqns.
+         !***
 
-            end do
+         work1 =      uns1t0 + uns1t1*tq + &
+                     (uns1t2 + uns1t3*tq + uns1t4*t2)*t2
+         work2 = sqr*(unsqt0 + unsqt1*tq + unsqt2*t2)
 
-         end if
+         rhosfc = unt1*tq + (unt2 + unt3*tq + (unt4 + unt5*tq)*t2)*t2 &
+                          + (uns2t0*sq + work1 + work2)*sq
+
+         !***
+         !*** now calculate bulk modulus at pressure p from
+         !*** Jackett and McDougall formula
+         !***
+
+         work3 = bup0s1t0 + bup0s1t1*tq +     &
+                (bup0s1t2 + bup0s1t3*tq)*t2 + &
+          p(k) *(bup1s1t0 + bup1s1t1*tq + bup1s1t2*t2) + &
+          p2(k)*(bup2s1t0 + bup2s1t1*tq + bup2s1t2*t2)
+
+         work4 = sqr*(bup0sqt0 + bup0sqt1*tq + bup0sqt2*t2 + &
+                      bup1sqt0*p(k))
+
+         bulkMod = bup0s0t0 + bup0s0t1*tq +                    &
+                  (bup0s0t2 + bup0s0t3*tq + bup0s0t4*t2)*t2 + &
+            p(k) *(bup1s0t0 + bup1s0t1*tq +                &
+                  (bup1s0t2 + bup1s0t3*tq)*t2) +           &
+            p2(k)*(bup2s0t0 + bup2s0t1*tq + bup2s0t2*t2) + &
+                   sq*(work3 + work4)
+
+
+         density(k,iCell) = (unt0 + rhosfc)*bulkMod/ &
+                            (bulkMod - p(k))
+
       end do
+      end do
+#ifdef MPAS_OPENACC
+      !$acc update host(density)
+      !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt)
+      !$omp end single
+#else
       !$omp end do
+#endif
 
-      deallocate(pRefEOS,p,p2)
+      deallocate(p,p2)
+      !$omp barrier
+      !$omp single
       deallocate(tracerTemp)
       deallocate(tracerSalt)
+      !$omp end single nowait
 
-      deallocate(SQ)
-      deallocate(TQ)
-      deallocate(SQR)
-      deallocate(T2)
-      deallocate(WORK1)
-      deallocate(WORK2)
-      deallocate(RHO_S)
-      deallocate(WORK3)
-      deallocate(WORK4)
-      deallocate(BULK_MOD)
-      deallocate(DENOMK)
+   !--------------------------------------------------------------------
 
-   end subroutine ocn_equation_of_state_jm_density!}}}
+   end subroutine ocn_equation_of_state_jm_density_only!}}}
+
+!***********************************************************************
+!
+!  routine ocn_equation_of_state_jm_density
+!
+!> \brief   Calls JM equation of state
+!> \author  Mark Petersen and Todd Ringler, modified Phil Jones
+!> \date    September 2011, updated August 2013, May 2018
+!> \details
+!>  This routine computes the density from model temperature and 
+!>  salinity using a potential-temperature-based bulk modulus from 
+!>  Jackett and McDougall (JTECH, Vol.12, pp 381-389, April, 1995)
+!>  to approximate the UNESCO equation of state.
+!>
+!>  Density can be computed in-situ using kDisplaced=0 and
+!>      displacementType = 'relative'.
+!>
+!>  Potential density (referenced to top layer) can be computed
+!>      using kDisplaced=1 and displacementType = 'absolute'.
+!>
+!>  The density of SST/SSS after adiabatic displacement to each layer
+!>      can be computed using displacementType = 'surfaceDisplaced'.
+!>
+!>  When using displacementType = 'surfaceDisplaced', kDisplaced is
+!>      ignored and tracersSurfaceLayerValue must be present.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_equation_of_state_jm_density_exp(nVertLevels,       &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, density, err, &
+                               thermalExpansionCoeff,                 &
+                               salineContractionCoeff,                &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      ! Thermal expansion coeff, $-1/\rho d\rho/dT$ (note negative sign)
+      ! Saline contraction coeff, $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion  coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         iCell, k,        &! cell and vertical level loop indices
+         kTmp, kRef,      &! indices to determine ref level for pressure
+         kDisplacedLocal   ! locally modified diplacement target level
+
+      character(len=60) :: &
+         displacementTypeLocal ! locally modified displacement type
+
+      real (kind=RKIND) :: &
+         tq, sq,           &! adjusted T,S
+         t2, sqr,          &! T squared and square root salt
+         rhosfc,           &! density at the surface
+         bulkMod,          &! Bulk modulus
+         denomk,           &! temp for avoiding division
+         work1, work2,     &! temporary work space
+         work3, work4,     &! 
+         drdt0,            &! d(density)/d(temperature), for surface
+         drds0,            &! d(density)/d(salinity   ), for surface
+         dkdt,             &! d(bulk modulus)/d(pot. temp.)
+         dkds,             &! d(bulk modulus)/d(salinity  )
+         drhodt,           &! derivative of density with respect to temperature
+         drhods             ! derivative of density with respect to salinity
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         p, p2 ! temporary pressure scalars
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** allocate and compute pressure array
+
+      allocate(p(nVertLevels),p2(nVertLevels))
+
+      ! Determine pressure to use in density calculation
+      !  If kDisplaced=0, in-situ density is returned (no displacement)
+      !  If kDisplaced/=0, potential density is returned
+
+      !  if displacementType = 'relative', potential density is calculated
+      !     referenced to level k + kDisplaced
+      !  if displacementType = 'absolute', potential density is calculated
+      !     referenced to level kDisplaced for all k
+      !  NOTE: kDisplaced = 0 or > nVertLevels is incompatible with 'absolute'
+      !     so abort if necessary
+
+      if (displacementType == 'surfaceDisplaced') then
+         displacementTypeLocal = 'relative'
+         kDisplacedLocal = 0
+      else
+         displacementTypeLocal = trim(displacementType)
+         kDisplacedLocal = kDisplaced
+      endif
+
+      ! Eliminate this error check for performance reasons
+      !if (displacementTypeLocal == 'absolute' .and.   &
+      !   (kDisplacedLocal <= 0 .or. kDisplacedLocal > nVertLevels) ) then
+      !
+      !   call mpas_log_write('Abort: In equation_of_state_jm' // &
+      !       ' kDisplaced must be between 1 and nVertLevels for ' // &
+      !       'displacementType = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      if (kDisplacedLocal == 0) then
+         ! use pressure at in situ level
+         do k=1,nVertLevels
+            p (k) = ocnEqStatePRef(k)
+            p2(k) = ocnEqStatePRef(k)*ocnEqStatePRef(k)
+         enddo
+      else ! kDisplacedLocal /= 0
+         do k=1,nVertLevels
+            ! determine level to which parcel is displaced
+            !  and thus which pressure (depth) to use in EOS
+            if (displacementTypeLocal == 'relative') then
+               kTmp = min(k + kDisplacedLocal, nVertLevels)
+            else
+               kTmp = min(kDisplacedLocal, nVertLevels)
+            endif
+            kRef  = max(kTmp, 1)  ! make sure index bounded to 1
+            p (k) = ocnEqStatePRef(kRef)
+            p2(k) = ocnEqStatePRef(kRef)*ocnEqStatePRef(kRef)
+         enddo
+      endif
+
+      !*** compute modified T,S to account for displacement and 
+      !*** valid range
+
+      !$omp single
+      allocate(tracerTemp(nVertLevels,nCells))
+      allocate(tracerSalt(nVertLevels,nCells))
+      !$omp end single
+
+      if (displacementType == 'surfaceDisplaced') then
+
+         !$omp do schedule(runtime) private(k,tq,sq)
+         do iCell=1,nCells
+         do k=1,nVertLevels
+            tq = min(tracersSurfaceLayerValue(indexT,iCell), &
+                     ocnEqStateTmax)
+            sq = min(tracersSurfaceLayerValue(indexS,iCell), &
+                     ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         enddo
+         end do
+         !$omp end do
+
+      else
+
+         !$omp do schedule(runtime) private(k,tq,sq)
+         do iCell=1,nCells
+         do k = 1, nVertLevels
+            tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
+            sq = min(tracers(indexS,k,iCell), ocnEqStateSmax)
+            tracerTemp(k,iCell) = max(tq,ocnEqStateTmin)
+            tracerSalt(k,iCell) = max(sq,ocnEqStateSmin)
+         end do
+         end do
+         !$omp end do
+
+      endif
+
+#ifdef MPAS_OPENACC
+      !$omp single
+      !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt, &
+      !$acc&                  thermalExpansionCoeff,  &
+      !$acc&                  salineContractionCoeff)
+      !$acc parallel loop gang vector collapse(2)     &
+      !$acc&   present(density, p, p2, tracerTemp, tracerSalt, &
+      !$acc&           thermalExpansionCoeff,         &
+      !$acc&           salineContractionCoeff)
+#else
+      !$omp do schedule(runtime) private(k, tq, sq, t2, sqr, rhosfc, &
+      !$omp&   bulkMod, denomk, work1, work2, work3, work4, &
+      !$omp&   drdt0, drds0, dkdt, dkds, drhodt, drhods)
+#endif
+      do iCell=1,nCells
+      do k=1,nVertLevels
+
+         sq  = tracerSalt(k,iCell)
+         tq  = tracerTemp(k,iCell)
+
+         sqr = sqrt(sq)
+         t2  = tq*tq
+
+         !***
+         !*** first calculate surface (p=0) values from UNESCO eqns.
+         !***
+
+         work1 = uns1t0 + uns1t1*tq + &
+                (uns1t2 + uns1t3*tq + uns1t4*t2)*t2
+         work2 = sqr*(unsqt0 + unsqt1*tq + unsqt2*t2)
+
+         rhosfc = unt1*tq + (unt2 + unt3*tq + (unt4 + unt5*tq)*t2)*t2 &
+                          + (uns2t0*sq + work1 + work2)*sq
+
+         !***
+         !*** now calculate bulk modulus at pressure p from
+         !*** Jackett and McDougall formula
+         !***
+
+         work3 = bup0s1t0 + bup0s1t1*tq +                    &
+                (bup0s1t2 + bup0s1t3*tq)*t2 +                &
+          p(k) *(bup1s1t0 + bup1s1t1*tq + bup1s1t2*t2) + &
+          p2(k)*(bup2s1t0 + bup2s1t1*tq + bup2s1t2*t2)
+
+         work4 = sqr*(bup0sqt0 + bup0sqt1*tq + bup0sqt2*t2 + &
+                                 bup1sqt0*p(k))
+
+         bulkMod  = bup0s0t0 + bup0s0t1*tq +                    &
+                   (bup0s0t2 + bup0s0t3*tq + bup0s0t4*t2)*t2 + &
+             p(k) *(bup1s0t0 + bup1s0t1*tq +                &
+                   (bup1s0t2 + bup1s0t3*tq)*t2) +           &
+             p2(k)*(bup2s0t0 + bup2s0t1*tq + bup2s0t2*t2) + &
+                                        sq*(work3 + work4)
+
+         !***
+         !*** compute density
+         !***
+
+         denomk = 1.0/(bulkMod - p(k))
+
+         density(k, iCell) = (unt0 + rhosfc)*bulkMod*denomk
+
+         !***
+         !*** compute temperature expansion coeff
+         !***  by differentiating above formulae
+         !***
+
+         drdt0 =             unt1 + 2.0_RKIND*unt2*tq +        &
+                  (3.0_RKIND*unt3 + 4.0_RKIND*unt4*tq +        &
+                                    5.0_RKIND*unt5*t2)*t2 +    &
+                          (uns1t1 + 2.0_RKIND*uns1t2*tq +      &
+                (3.0_RKIND*uns1t3 + 4.0_RKIND*uns1t4*tq)*t2 +  &
+                          (unsqt1 + 2.0_RKIND*unsqt2*tq)*sqr )*sq
+
+         dkdt  =            bup0s0t1 + 2.0_RKIND*bup0s0t2*tq +      &
+                 (3.0_RKIND*bup0s0t3 + 4.0_RKIND*bup0s0t4*tq)*t2 +  &
+                     p(k) *(bup1s0t1 + 2.0_RKIND*bup1s0t2*tq +      &
+                                       3.0_RKIND*bup1s0t3*t2) +     &
+                     p2(k)*(bup2s0t1 + 2.0_RKIND*bup2s0t2*tq) +     &
+                        sq*(bup0s1t1 + 2.0_RKIND*bup0s1t2*tq +      &
+                                       3.0_RKIND*bup0s1t3*t2 +      &
+                    p(k)  *(bup1s1t1 + 2.0_RKIND*bup1s1t2*tq) +     &
+                    p2(k) *(bup2s1t1 + 2.0_RKIND*bup2s1t2*tq) +     &
+                       sqr*(bup0sqt1 + 2.0_RKIND*bup0sqt2*tq))
+
+         drhodt = (denomk*(drdt0*bulkMod -                    &
+                  p(k)*(unt0+rhosfc)*dkdt*denomk))
+
+         thermalExpansionCoeff(k,iCell) = -drhodt/density(k,iCell)
+
+         !***
+         !*** compute salinity contraction coeff
+         !***  by differentiating above formulae
+         !***
+
+         drds0  = 2.0_RKIND*uns2t0*sq + work1 + 1.5_RKIND*work2
+         dkds   = work3 + 1.5_RKIND*work4
+
+         drhods = denomk*(drds0*bulkMod -                    &
+                   p(k)*(unt0+rhosfc)*dkds*denomk)
+
+         salineContractionCoeff(k,iCell) = drhods/density(k,iCell)
+
+      end do
+      end do
+#ifdef MPAS_OPENACC
+      !$acc update host(density,                &
+      !$acc&            thermalExpansionCoeff,  &
+      !$acc&            salineContractionCoeff)
+      !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt, &
+      !$acc&                 thermalExpansionCoeff,  &
+      !$acc&                 salineContractionCoeff)
+      !$omp end single
+#else
+      !$omp end do
+#endif
+
+      deallocate(p,p2)
+      !$omp barrier
+      !$omp single
+      deallocate(tracerTemp)
+      deallocate(tracerSalt)
+      !$omp end single nowait
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_jm_density_exp!}}}
 
 !***********************************************************************
 !
@@ -445,18 +749,87 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_jm_init(err)!{{{
+   subroutine ocn_equation_of_state_jm_init(domain, err)!{{{
 
    !--------------------------------------------------------------------
 
       !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
+      ! Input variables
       !-----------------------------------------------------------------
-      integer, intent(out) :: err
+
+      type (domain_type), intent(in) :: &
+         domain        ! domain containing all state, mesh info
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::            &
+         k,                 &! depth loop index
+         nVertLevels         ! max number of vertical levels
+
+      real (RKIND) :: depth  ! depth of layer midpoint
+
+      integer, pointer ::   &
+         nVertLevelsPtr      ! pointer for extracting max vert levels
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         refBottomDepth      ! depth at bottom of each layer for
+                             !  a reference depth profile
+
+      type (block_type), pointer :: block ! pool info for each block
+
+      type (mpas_pool_type), pointer :: meshPool
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
 
       err = 0
+
+      !*** extract vertical mesh info for computing ref pressure
+      !*** since vertical mesh info same for all blocks, only need first
+
+      block => domain % blocklist
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_array(meshPool,     'refBottomDepth', &
+                                              refBottomDepth)
+
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', &
+                                              nVertLevelsPtr)
+      nVertLevels = nVertLevelsPtr
+
+      !*** compute reference pressure in bars from depth in meters
+      !***  using a mean density derived from depth-dependent global
+      !***  average temperatures and salinities from Levitus 1994, and
+      !***  integrating using hydrostatic balance.
+      !*** Note this calculation uses refBottomDepth, so pressure on 
+      !***  top level does not include SSH contribution. 
+      !*** Also note that this is only valid for case in which the
+      !***  vertical mesh does not vary significantly in time. Future
+      !***  Lagrangian meshes will likely need to use full
+      !***  3-d dynamic depth/press
+
+      allocate(ocnEqStatePRef(nVertLevels))
+      depth = 0.5_RKIND*refBottomDepth(1)
+      ocnEqStatePRef(1) = &
+           0.059808_RKIND  *(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
+         + 0.100766_RKIND  *depth &
+         + 2.28405e-7_RKIND*depth**2
+      do k = 2,nVertLevels
+         depth = 0.5_RKIND*(refBottomDepth(k) + refBottomDepth(k-1))
+         ocnEqStatePRef(k) = &
+              0.059808_RKIND  *(exp(-0.025_RKIND*depth) - 1.0_RKIND) &
+            + 0.100766_RKIND  *depth                                 &
+            + 2.28405e-7_RKIND*depth**2
+      enddo
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -64,7 +64,7 @@ module ocn_equation_of_state_jm
 
    !*** temporary array to hold modified T,S for EOS calculation
    !*** declared here to make it thread-shared - could be replaced
-   !***   by a local subroutine temporary in a different thread model 
+   !***   by a local subroutine temporary in a different thread model
 
    real (kind=RKIND), dimension(:,:), allocatable :: &
       tracerTemp, tracerSalt
@@ -159,8 +159,8 @@ contains
 !> \author  Mark Petersen and Todd Ringler, modified Phil Jones
 !> \date    September 2011, updated August 2013, May 2018
 !> \details
-!>  This routine computes the density from model temperature and 
-!>  salinity using a potential-temperature-based bulk modulus from 
+!>  This routine computes the density from model temperature and
+!>  salinity using a potential-temperature-based bulk modulus from
 !>  Jackett and McDougall (JTECH, Vol.12, pp 381-389, April, 1995)
 !>  to approximate the UNESCO equation of state.
 !>
@@ -296,7 +296,7 @@ contains
          enddo
       endif
 
-      !*** compute modified T,S to account for displacement and 
+      !*** compute modified T,S to account for displacement and
       !*** valid range
 
       !$omp single
@@ -416,8 +416,8 @@ contains
 !> \author  Mark Petersen and Todd Ringler, modified Phil Jones
 !> \date    September 2011, updated August 2013, May 2018
 !> \details
-!>  This routine computes the density from model temperature and 
-!>  salinity using a potential-temperature-based bulk modulus from 
+!>  This routine computes the density from model temperature and
+!>  salinity using a potential-temperature-based bulk modulus from
 !>  Jackett and McDougall (JTECH, Vol.12, pp 381-389, April, 1995)
 !>  to approximate the UNESCO equation of state.
 !>
@@ -498,7 +498,7 @@ contains
          bulkMod,          &! Bulk modulus
          denomk,           &! temp for avoiding division
          work1, work2,     &! temporary work space
-         work3, work4,     &! 
+         work3, work4,     &!
          drdt0,            &! d(density)/d(temperature), for surface
          drds0,            &! d(density)/d(salinity   ), for surface
          dkdt,             &! d(bulk modulus)/d(pot. temp.)
@@ -568,7 +568,7 @@ contains
          enddo
       endif
 
-      !*** compute modified T,S to account for displacement and 
+      !*** compute modified T,S to account for displacement and
       !*** valid range
 
       !$omp single
@@ -664,7 +664,7 @@ contains
          !*** compute density
          !***
 
-         denomk = 1.0/(bulkMod - p(k))
+         denomk = 1.0_RKIND/(bulkMod - p(k))
 
          density(k, iCell) = (unt0 + rhosfc)*bulkMod*denomk
 
@@ -810,8 +810,8 @@ contains
       !***  using a mean density derived from depth-dependent global
       !***  average temperatures and salinities from Levitus 1994, and
       !***  integrating using hydrostatic balance.
-      !*** Note this calculation uses refBottomDepth, so pressure on 
-      !***  top level does not include SSH contribution. 
+      !*** Note this calculation uses refBottomDepth, so pressure on
+      !***  top level does not include SSH contribution.
       !*** Also note that this is only valid for case in which the
       !***  vertical mesh does not vary significantly in time. Future
       !***  Lagrangian meshes will likely need to use full

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -166,7 +166,7 @@ contains
 
       ! copy some intent(in) into local work space
 
-      !*** if surfaceDisplaced, then compute density at all levels 
+      !*** if surfaceDisplaced, then compute density at all levels
       !*** based on input surface values
 
       if (trim(displacementType) == 'surfaceDisplaced') then
@@ -299,7 +299,7 @@ contains
 
       ! copy some intent(in) into local work space
 
-      !*** if surfaceDisplaced, then compute density at all levels 
+      !*** if surfaceDisplaced, then compute density at all levels
       !*** based on input surface values
       !*** return fixed values of expansion coefficients
 
@@ -388,7 +388,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), pointer ::    &
-         config_eos_linear_densityref, &! linear options extracted  
+         config_eos_linear_densityref, &! linear options extracted
          config_eos_linear_alpha,      &!  from input namelist
          config_eos_linear_beta,       &
          config_eos_linear_Tref,       &

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -9,12 +9,12 @@
 !
 !  ocn_equation_of_state_linear
 !
-!> \brief MPAS ocean equation of state driver
-!> \author Mark Petersen, Todd Ringler
-!> \date   September 2011
+!> \brief MPAS ocean linear equation of state
+!> \author Mark Petersen, Todd Ringler, modified Phil Jones
+!> \date   September 2011, modified May 2018
 !> \details
-!>  This module contains the main driver routine for calling
-!>  the equation of state.
+!>  This module contains routines for computing density of sea water
+!>  using a linear approximation.
 !
 !-----------------------------------------------------------------------
 
@@ -46,18 +46,23 @@ module ocn_equation_of_state_linear
    public :: ocn_equation_of_state_linear_density, &
              ocn_equation_of_state_linear_init
 
+   interface ocn_equation_of_state_linear_density
+      module procedure ocn_equation_of_state_linear_density_only
+      module procedure ocn_equation_of_state_linear_density_exp
+   end interface
+
    !--------------------------------------------------------------------
    !
    ! Private module variables
    !
    !--------------------------------------------------------------------
-   real (kind=RKIND), pointer :: config_eos_linear_densityref
-   real (kind=RKIND), pointer :: config_eos_linear_alpha
-   real (kind=RKIND), pointer :: config_eos_linear_beta
-   real (kind=RKIND), pointer :: config_eos_linear_Tref
-   real (kind=RKIND), pointer :: config_eos_linear_Sref
 
-
+   real (kind=RKIND) ::       &
+      ocnEqStateLinearRhoRef, &! reference density
+      ocnEqStateLinearAlpha,  &! scalar temperature expansion coeff
+      ocnEqStateLinearBeta,   &! scalar salinity  contraction coeff
+      ocnEqStateLinearTref,   &! reference density
+      ocnEqStateLinearSref     ! reference density
 
 !***********************************************************************
 
@@ -65,160 +70,301 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_equation_of_state_linear_density
+!  routine ocn_equation_of_state_linear_density_only
 !
-!> \brief   Calls equation of state
-!> \author  Mark Petersen, Todd Ringler
-!> \date    September 2011
+!> \brief   Computes density using a linear equation of state
+!> \author  Mark Petersen, Todd Ringler, modified by Phil Jones
+!> \date    September 2011, modified May 2018
 !> \details
-!>  This routine uses a linear equation of state to update the density
+!>  This routine uses a linear equation of state to update the density.
+!>  The density is a linear perturbation from a reference density
+!>  at reference T,S values using fixed (linear) expansion coefficients.
+!>
+!>  While somewhat unnecessary, we make the interface and capability
+!>  of linear eos to be identical to nonlinear eos
+!>
+!>  Density can be computed in-situ using k_displaced=0 and
+!>      displacement_type = 'relative'.
+!>
+!>  Potential density (referenced to top layer) can be computed
+!>      using k_displaced=1 and displacement_type = 'absolute'.
+!>
+!>  The density of SST/SSS after adiabatic displacement to each layer
+!>      can be computed using displacement_type = 'surfaceDisplaced'.
+!>
+!>  When using displacement_type = 'surfaceDisplaced', k_displaced is
+!>      ignored and tracersSurfaceLayerValue must be present.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_linear_density(meshPool, nCells, k_displaced, displacement_type, & !{{{
-       indexT, indexS, tracers, density, err, tracersSurfaceLayerValue, thermalExpansionCoeff, &
-       salineContractionCoeff)
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   !  This module contains routines necessary for computing the density
-   !  from model temperature and salinity using an equation of state.
-   !
-   ! Input: mesh - mesh metadata
-   !        s - state: tracers
-   !
-   ! Output: s - state: computed density
-   !
-   !
-   !>  While somewhat unnecessary, we make the interface and capability
-   !>  of linear eos to be identical to nonlinear eos
-   !>
-   !>  Density can be computed in-situ using k_displaced=0 and
-   !>      displacement_type = 'relative'.
-   !>
-   !>  Potential density (referenced to top layer) can be computed
-   !>      using k_displaced=1 and displacement_type = 'absolute'.
-   !>
-   !>  The density of SST/SSS after adiabatic displacement to each layer
-   !>      can be computed using displacement_type = 'surfaceDisplaced'.
-   !>
-   !>  When using displacement_type = 'surfaceDisplaced', k_displaced is
-   !>      ignored and tracersSurfaceLayerValue must be present.
-   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      implicit none
+   subroutine ocn_equation_of_state_linear_density_only(          &
+              nVertLevels, nCells, kDisplaced, displacementType,  &
+              indexT, indexS, tracers, density, err,              &
+              tracersSurfaceLayerValue)
+      !{{{
+      !-----------------------------------------------------------------
+      !
+      ! Input variables
+      !
+      !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: meshPool
-      integer, intent(in) :: nCells
-      character(len=*), intent(in) :: displacement_type
-      integer, intent(in) :: k_displaced, indexT, indexS
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers
-      real (kind=RKIND), dimension(:,:), intent(inout) :: density
-      integer, intent(out) :: err
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: tracersSurfaceLayerValue
-      real (kind=RKIND), dimension(:,:), intent(out), optional :: &
-         thermalExpansionCoeff,  &! Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign)
-         salineContractionCoeff   ! Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$
+      integer, intent(in) ::     &
+         nCells,                 &! num of horizontal cells
+         nVertLevels,            &! num of vertical levels
+         kDisplaced,             &! num of levels to displace parcel
+         indexT, indexS           ! index into tracer array for T,S
 
-      integer, dimension(:), pointer :: maxLevelCell
-      integer :: iCell, k, k_displaced_local, k_ref
-      integer, pointer :: nVertLevels
-      character(len=60) :: displacement_type_local
-      type (dm_info) :: dminfo
+      character(len=*), intent(in) :: &
+         displacementType
 
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers                  ! array containing T,S for calculation
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         tracersSurfaceLayerValue ! optional sfc tracer values for sfc
+                                  ! displacement option
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density
+
+      !-----------------------------------------------------------------
+      !
+      ! Local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k    ! cell and level loop indices
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
 
       err = 0
 
-      ! copy some intent(in) into local work space
-      displacement_type_local = trim(displacement_type)
-      k_displaced_local = k_displaced
+      !*** check for displacement choice
+      !*** for linear EOS, only choice that impacts the
+      !*** density is surface displacement
 
+      ! ignore this test for performance reasons
       ! test of request to address out of bounds
-      if (displacement_type_local == 'absolute' .and.   &
-         (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
-         call mpas_log_write('Abort: In equation_of_state_linear' // &
-             ' k_displaced must be between 1 and nVertLevels for ' // &
-             'displacement_type = absolute', MPAS_LOG_CRIT)
-      endif
+      !if (displacement_type_local == 'absolute' .and.   &
+      !   (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+      !   call mpas_log_write('Abort: In equation_of_state_linear' // &
+      !       ' k_displaced must be between 1 and nVertLevels for ' // &
+      !       'displacement_type = absolute', MPAS_LOG_CRIT)
+      !endif
 
-      ! if surfaceDisplaced, then compute density at all levels based on surface values
-      if (displacement_type_local == 'surfaceDisplaced') then
+      ! copy some intent(in) into local work space
+
+      !*** if surfaceDisplaced, then compute density at all levels 
+      !*** based on input surface values
+
+      if (trim(displacementType) == 'surfaceDisplaced') then
+
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-               ! Linear equation of state
-               density(k,iCell) =  config_eos_linear_densityref &
-                     - config_eos_linear_alpha * (tracersSurfaceLayerValue(indexT,iCell) - config_eos_linear_Tref) &
-                     + config_eos_linear_beta  * (tracersSurfaceLayerValue(indexS,iCell) - config_eos_linear_Sref)
-            end do
+         do k = 1, nVertLevels
+
+            density(k,iCell) =  ocnEqStateLinearRhoRef &
+                             - ocnEqStateLinearAlpha * &
+                               (tracersSurfaceLayerValue(indexT,iCell) - &
+                                ocnEqStateLinearTref)  &
+                             + ocnEqStateLinearBeta  * &
+                               (tracersSurfaceLayerValue(indexS,iCell) - &
+                                ocnEqStateLinearSref)
+         end do
          end do
          !$omp end do
-      endif
 
+      else  ! all other displacement types
 
-      ! if absolute, then compute density at all levels based on pressure of k_displaced value
-      ! but since linear EOS does not (at present) have a pressure dependency, this just returns density
-      if (displacement_type_local == 'absolute') then
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-               ! Linear equation of state
-               density(k,iCell) =  config_eos_linear_densityref &
-                     - config_eos_linear_alpha * (tracers(indexT,k,iCell) - config_eos_linear_Tref) &
-                     + config_eos_linear_beta  * (tracers(indexS,k,iCell) - config_eos_linear_Sref)
-            end do
+         do k = 1, nVertLevels
+
+            density(k,iCell) = ocnEqStateLinearRhoRef     &
+                             - ocnEqStateLinearAlpha *    &
+                               (tracers(indexT,k,iCell) - &
+                                ocnEqStateLinearTref)     &
+                             + ocnEqStateLinearBeta  *    &
+                               (tracers(indexS,k,iCell) - &
+                                ocnEqStateLinearSref)
+         end do
          end do
          !$omp end do
+
       endif
 
-      ! if relative, then compute density at all levels based on k+k_displaced pressure value
-      ! but since (at present) linear EOS has not dependence on pressure, it returns density
-      if (displacement_type_local == 'relative') then
+      !-----------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_linear_density_only!}}}
+
+!***********************************************************************
+!
+!  routine ocn_equation_of_state_linear_density_exp
+!
+!> \brief   Computes density using a linear equation of state
+!> \author  Mark Petersen, Todd Ringler, modified by Phil Jones
+!> \date    September 2011, modified May 2018
+!> \details
+!>  This routine uses a linear equation of state to update the density.
+!>  This instance also returns the expansion coefficients.
+!>
+!-----------------------------------------------------------------------
+
+   subroutine ocn_equation_of_state_linear_density_exp(           &
+              nVertLevels, nCells, kDisplaced, displacementType,  &
+              indexT, indexS, tracers, density, err,              &
+              thermalExpansionCoeff, salineContractionCoeff,      &
+              tracersSurfaceLayerValue)
+      !{{{
+      !-----------------------------------------------------------------
+      !
+      ! Input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) ::     &
+         nCells,                 &! num of horizontal cells
+         nVertLevels,            &! num of vertical levels
+         kDisplaced,             &! num of levels to displace parcel
+         indexT, indexS           ! index into tracer array for T,S
+
+      character(len=*), intent(in) :: &
+         displacementType
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers                  ! array containing T,S for calculation
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         tracersSurfaceLayerValue ! optional sfc tracer values for sfc
+                                  ! displacement option
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: &
+         err                   ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density               ! computed density
+
+      ! Optional expansion (contraction) coefficients
+      ! alpha defined as $-1/\rho d\rho/dT$ (note negative sign)
+      ! beta  defined as $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      !
+      ! Local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k    ! cell and level loop indices
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      !*** check for displacement choice
+      !*** for linear EOS, only choice that impacts the
+      !*** density is surface displacement
+
+      ! ignore this test for performance reasons
+      ! test of request to address out of bounds
+      !if (displacement_type_local == 'absolute' .and.   &
+      !   (k_displaced_local <= 0 .or. k_displaced_local > nVertLevels) ) then
+      !   call mpas_log_write('Abort: In equation_of_state_linear' // &
+      !       ' k_displaced must be between 1 and nVertLevels for ' // &
+      !       'displacement_type = absolute', MPAS_LOG_CRIT)
+      !endif
+
+      ! copy some intent(in) into local work space
+
+      !*** if surfaceDisplaced, then compute density at all levels 
+      !*** based on input surface values
+      !*** return fixed values of expansion coefficients
+
+      if (trim(displacementType) == 'surfaceDisplaced') then
+
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-               ! Linear equation of state
-               density(k,iCell) =  config_eos_linear_densityref &
-                     - config_eos_linear_alpha * (tracers(indexT,k,iCell) - config_eos_linear_Tref) &
-                     + config_eos_linear_beta  * (tracers(indexS,k,iCell) - config_eos_linear_Sref)
-            end do
+         do k = 1, nVertLevels
+
+            density(k,iCell) =  ocnEqStateLinearRhoRef &
+                             - ocnEqStateLinearAlpha * &
+                               (tracersSurfaceLayerValue(indexT,iCell) - &
+                                ocnEqStateLinearTref)  &
+                             + ocnEqStateLinearBeta  * &
+                               (tracersSurfaceLayerValue(indexS,iCell) - &
+                                ocnEqStateLinearSref)
+
+            thermalExpansionCoeff(k,iCell) = ocnEqStateLinearAlpha/ &
+                                             density(k,iCell)
+
+            salineContractionCoeff(k,iCell) = ocnEqStateLinearBeta/ &
+                                              density(k,iCell)
+         end do
          end do
          !$omp end do
-      endif
 
-      if (present(thermalExpansionCoeff)) then
+      else  ! all other displacement types
+
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-               thermalExpansionCoeff(k,iCell) = config_eos_linear_alpha / density(k,iCell)
-            end do
+         do k = 1, nVertLevels
+
+            density(k,iCell) = ocnEqStateLinearRhoRef     &
+                             - ocnEqStateLinearAlpha *    &
+                               (tracers(indexT,k,iCell) - &
+                                ocnEqStateLinearTref)     &
+                             + ocnEqStateLinearBeta  *    &
+                               (tracers(indexS,k,iCell) - &
+                                ocnEqStateLinearSref)
+
+            thermalExpansionCoeff(k,iCell) = ocnEqStateLinearAlpha/ &
+                                             density(k,iCell)
+
+            salineContractionCoeff(k,iCell) = ocnEqStateLinearBeta/ &
+                                              density(k,iCell)
+         end do
          end do
          !$omp end do
+
       endif
 
-      if (present(salineContractionCoeff)) then
-         !$omp do schedule(runtime) private(k)
-         do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-               salineContractionCoeff(k,iCell) = config_eos_linear_beta / density(k,iCell)
-            end do
-         end do
-         !$omp end do
-      endif
+      !-----------------------------------------------------------------
 
-   end subroutine ocn_equation_of_state_linear_density!}}}
+   end subroutine ocn_equation_of_state_linear_density_exp!}}}
 
 !***********************************************************************
 !
 !  routine ocn_equation_of_state_linear_init
 !
-!> \brief   Initializes ocean momentum horizontal mixing quantities
-!> \author  Mark Petersen, Todd Ringler
-!> \date    September 2011
+!> \brief   Initializes linear ocean equation of state
+!> \author  Mark Petersen, Todd Ringler, modified by Phil Jones
+!> \date    September 2011, modified May 2018
 !> \details
-!>  This routine initializes a variety of quantities related to
-!>  horizontal velocity mixing in the ocean. Since a variety of
-!>  parameterizations are available, this routine primarily calls the
-!>  individual init routines for each parameterization.
+!>  This routine initializes a variety of quantities for computing
+!>  density from temperature and salinity using a linear approximation.
 !
 !-----------------------------------------------------------------------
 
@@ -228,21 +374,54 @@ contains
 
       !-----------------------------------------------------------------
       !
-      ! call individual init routines for each parameterization
+      ! output variables
       !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err
+      integer, intent(out) :: &
+         err                   ! error flag
 
-      integer :: err1, err2
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), pointer ::    &
+         config_eos_linear_densityref, &! linear options extracted  
+         config_eos_linear_alpha,      &!  from input namelist
+         config_eos_linear_beta,       &
+         config_eos_linear_Tref,       &
+         config_eos_linear_Sref
+
+      !-----------------------------------------------------------------
+
+      !*** Initialize error flag
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_densityref', config_eos_linear_densityref)
-      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_alpha', config_eos_linear_alpha)
-      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_beta', config_eos_linear_beta)
-      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_Tref', config_eos_linear_Tref)
-      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_Sref', config_eos_linear_Sref)
+      !***
+      !*** Extract input namelist options into module variables
+      !*** Needed both to rename and because scalar pointers can
+      !*** cause problems for some compilers
+      !***
+
+      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_densityref', &
+                                             config_eos_linear_densityref)
+      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_alpha', &
+                                             config_eos_linear_alpha)
+      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_beta', &
+                                             config_eos_linear_beta)
+      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_Tref', &
+                                             config_eos_linear_Tref)
+      call mpas_pool_get_config(ocnConfigs, 'config_eos_linear_Sref', &
+                                             config_eos_linear_Sref)
+
+      ocnEqStateLinearRhoRef = config_eos_linear_densityref
+      ocnEqStateLinearAlpha  = config_eos_linear_alpha
+      ocnEqStateLinearBeta   = config_eos_linear_beta
+      ocnEqStateLinearTref   = config_eos_linear_Tref
+      ocnEqStateLinearSref   = config_eos_linear_Sref
 
    !--------------------------------------------------------------------
 


### PR DESCRIPTION
Large refactoring and GPU optimization of the ocean equation of state routines. Minor performance improvements on KNL, traditional clusters, but enables significant GPU (>2x) improvement on Summit. Roundoff level differences with QU240 standalone tests on Cori and Summit. Did not check Jackett and McDougall reference values.

Changes include:
   - moving calculation of reference pressure to initialization
   - separating EOS calls to routines with and without expansion coefficients
   - merged some loops to reduce arrays to scalars
   - moved tracer modification to separate loop for optimization
   - changed loop limits to fixed nVertLevels rather than maxLevelCell
   - pushed extraction of pool variables up one call level
   - added OpenACC directives to enable computations on GPU
   - convert JM allowable T,S range to parameters
   - introduce enums for EOS types to reduce string manipulation
   - changed scalar pointers to scalar variables
   - corrections and updates to a number of comments
   - general code cleanup