### PR TITLE
Adding data iceberg model for E3SM through MPAS-Seaice.

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1881,7 +1881,8 @@
 				filename_template="forcing/data_icebergs.nc"
 				filename_interval="none"
 				input_interval="none"
-				immutable="true">
+				clobber_mode="replace_files"
+				runtime_format="single_file">
 			<var name="bergFreshWaterFluxData"/>
 		</stream>
 

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -2173,6 +2173,9 @@
 		<!-- other column packages -->
 		<package name="pkgColumnFormDrag" description=""/>
 
+		<!-- iceberg packages -->
+		<package name="pkgBergs" description=""/>
+
 		<!-- testing system test -->
 		<package name="pkgTestingSystemTest" description=""/>
 
@@ -3504,12 +3507,12 @@
 	</var_struct>
 
 	<!-- fluxes from data icebergs -->
-	<var_struct name="iceberg_forcing" time_levs="1">
+	<var_struct name="iceberg_forcing" time_levs="1" packages="pkgBergs">
 		<var name="bergFreshWaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFluxData"/>
 	</var_struct>
 
 	<!-- fluxes from icebergs to ocean -->
-	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgColumnPackage">
+	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgBergs">
 		<var name="bergFreshWaterFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
 		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergLatentHeatFlux"/>
 	</var_struct>

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -3507,12 +3507,12 @@
 	</var_struct>
 
 	<!-- fluxes from data icebergs -->
-	<var_struct name="iceberg_forcing" time_levs="1" packages="pkgBergs">
+	<var_struct name="berg_forcing" time_levs="1" packages="pkgBergs">
 		<var name="bergFreshwaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshwaterFluxData"/>
 	</var_struct>
 
 	<!-- fluxes from icebergs to ocean -->
-	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgBergs">
+	<var_struct name="berg_fluxes" time_levs="1" packages="pkgBergs">
 		<var name="bergFreshwaterFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergFreshwaterFlux"/>
 		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergLatentHeatFlux"/>
 	</var_struct>

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -3509,7 +3509,7 @@
 
 	<!-- fluxes from icebergs to ocean -->
 	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgColumnPackage">
-		<var name="bergFreshWaterFlux"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
+		<var name="bergFreshWaterFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
 		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergLatentHeatFlux"/>
 	</var_struct>
 

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1883,7 +1883,7 @@
 				input_interval="none"
 				clobber_mode="replace_files"
 				runtime_format="single_file">
-			<var name="bergFreshWaterFluxData"/>
+			<var name="bergFreshwaterFluxData"/>
 		</stream>
 
 		<!-- Aerosols input -->
@@ -3508,12 +3508,12 @@
 
 	<!-- fluxes from data icebergs -->
 	<var_struct name="iceberg_forcing" time_levs="1" packages="pkgBergs">
-		<var name="bergFreshWaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFluxData"/>
+		<var name="bergFreshwaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshwaterFluxData"/>
 	</var_struct>
 
 	<!-- fluxes from icebergs to ocean -->
 	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgBergs">
-		<var name="bergFreshWaterFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
+		<var name="bergFreshwaterFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergFreshwaterFlux"/>
 		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergLatentHeatFlux"/>
 	</var_struct>
 

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -285,7 +285,7 @@
 			units="unitless" description="The maximum number of points in any group."
 		/>
 		<dim name="nForcingGroupsMax"
-			definition="4"
+			definition="5"
 			description="The maximum number of forcing groups defined in the core."
 		/>
 	</dims>
@@ -1876,7 +1876,6 @@
 			<var name="oceanMixedLayerDepth"/>
 			<var name="oceanHeatFluxConvergence"/>
 		</stream>
-		<!-- dc data icebergs -->
 		<stream name="dataIcebergForcing"
 				type="input"
 				filename_template="forcing/data_icebergs.nc"
@@ -3501,11 +3500,17 @@
 		<var name="oceanHeatFluxArea"			type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFluxArea"/>
 		<var name="oceanShortwaveFluxArea"		type="real"	dimensions="nCells Time"		name_in_code="oceanShortwaveFluxArea"/>
 		<var name="oceanHeatFluxIceBottom"		type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFluxIceBottom"/>
-		<!-- dc data icebergs -->
-		<var name="bergFreshWaterFlux"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
-		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergHeatLatentFlux"/>
-		<!-- dc this is input only, not being sent to coupler - place elsewhere? -->
+	</var_struct>
+
+	<!-- fluxes from data icebergs -->
+	<var_struct name="iceberg_forcing" time_levs="1">
 		<var name="bergFreshWaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFluxData"/>
+	</var_struct>
+
+	<!-- fluxes from icebergs to ocean -->
+	<var_struct name="iceberg_fluxes" time_levs="1" packages="pkgColumnPackage">
+		<var name="bergFreshWaterFlux"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
+		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergLatentHeatFlux"/>
 	</var_struct>
 
 	<!-- ocean atmosphere interaction -->

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1638,6 +1638,10 @@
 			description=""
 			possible_values="true or false"
 		/>
+		<nml_option name="config_use_data_icebergs" type="logical" default_value="false" units="unitless"
+			description="Use data iceberg meltwater forcing"
+			possible_values="true or false"
+		/>
 	</nml_record>
 
 	<nml_record name="diagnostics" in_defaults="true">
@@ -1871,6 +1875,15 @@
 			<var name="seaSurfaceTiltV"/>
 			<var name="oceanMixedLayerDepth"/>
 			<var name="oceanHeatFluxConvergence"/>
+		</stream>
+		<!-- dc data icebergs -->
+		<stream name="dataIcebergForcing"
+				type="input"
+				filename_template="forcing/data_icebergs.nc"
+				filename_interval="none"
+				input_interval="none"
+				immutable="true">
+			<var name="bergFreshWaterFluxData"/>
 		</stream>
 
 		<!-- Aerosols input -->
@@ -3488,6 +3501,11 @@
 		<var name="oceanHeatFluxArea"			type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFluxArea"/>
 		<var name="oceanShortwaveFluxArea"		type="real"	dimensions="nCells Time"		name_in_code="oceanShortwaveFluxArea"/>
 		<var name="oceanHeatFluxIceBottom"		type="real"	dimensions="nCells Time"		name_in_code="oceanHeatFluxIceBottom"/>
+		<!-- dc data icebergs -->
+		<var name="bergFreshWaterFlux"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFlux"/>
+		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"		name_in_code="bergHeatLatentFlux"/>
+		<!-- dc this is input only, not being sent to coupler - place elsewhere? -->
+		<var name="bergFreshWaterFluxData"		type="real"	dimensions="nCells Time"		name_in_code="bergFreshWaterFluxData"/>
 	</var_struct>
 
 	<!-- ocean atmosphere interaction -->

--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -111,6 +111,9 @@ module seaice_core_interface
       ! set up analysis member packages
       call seaice_analysis_setup_packages(configPool, packagePool, iocontext, ierr)
 
+      ! icebergs
+      call setup_packages_bergs(configPool, packagePool, ierr)
+
       ! testing system test
       call setup_packages_other(configPool, packagePool, ierr)
 
@@ -528,6 +531,43 @@ module seaice_core_interface
      !pkgColumnFormDragActive = .true.
 
    end subroutine setup_packages_column_physics!}}}
+
+   !***********************************************************************
+   !
+   !  routine setup_packages_bergs
+   !
+   !> \brief   Setup icebergs package
+   !> \author  Darin Comeau
+   !> \date    19 May 2017
+   !> \details This routine is intended to set the icebergs package PkgBergs
+   !> as active/deactive based on the namelist option config_use_bergs.
+   !
+   !-----------------------------------------------------------------------
+
+   subroutine setup_packages_bergs(configPool, packagePool, ierr)!{{{
+
+     type (mpas_pool_type), intent(in) :: configPool
+     type (mpas_pool_type), intent(in) :: packagePool
+     integer, intent(out) :: ierr
+
+          ! icebergs package
+     logical, pointer :: &
+          config_use_data_icebergs
+
+     logical, pointer :: &
+          pkgBergsActive
+
+     ierr = 0
+
+     !-----------------------------------------------------------------------
+     ! iceberg routines
+     !-----------------------------------------------------------------------
+
+     call MPAS_pool_get_config(configPool, "config_use_data_icebergs", config_use_data_icebergs)
+     call MPAS_pool_get_package(packagePool, "pkgBergsActive", pkgBergsActive)
+     pkgBergsActive = config_use_data_icebergs
+
+   end subroutine setup_packages_bergs!}}}
 
    !***********************************************************************
    !

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1656,7 +1656,7 @@ contains
          "seaice_data_iceberg_forcing_monthly", &
          "bergFreshwaterFluxData", &
          "dataIcebergForcing", &
-         "iceberg_forcing", &
+         "berg_forcing", &
          "bergFreshwaterFluxData", &
          "linear", &
          forcingReferenceTimeMonthly, &
@@ -1736,8 +1736,8 @@ contains
 
     type(MPAS_pool_type), pointer :: &
          mesh, &
-         iceberg_forcing, &
-         iceberg_fluxes
+         berg_forcing, &
+         berg_fluxes
 
     integer, pointer :: &
          nCellsSolve
@@ -1759,14 +1759,14 @@ contains
     do while (associated(block))
 
        call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
-       call MPAS_pool_get_subpool(block % structs, "iceberg_forcing", iceberg_forcing)
-       call MPAS_pool_get_subpool(block % structs, "iceberg_fluxes", iceberg_fluxes)
+       call MPAS_pool_get_subpool(block % structs, "berg_forcing", berg_forcing)
+       call MPAS_pool_get_subpool(block % structs, "berg_fluxes", berg_fluxes)
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
 
-       call MPAS_pool_get_array(iceberg_forcing, "bergFreshwaterFluxData", bergFreshwaterFluxData)
-       call MPAS_pool_get_array(iceberg_fluxes, "bergFreshwaterFlux", bergFreshwaterFlux)
-       call MPAS_pool_get_array(iceberg_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+       call MPAS_pool_get_array(berg_forcing, "bergFreshwaterFluxData", bergFreshwaterFluxData)
+       call MPAS_pool_get_array(berg_fluxes, "bergFreshwaterFlux", bergFreshwaterFlux)
+       call MPAS_pool_get_array(berg_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
 
        do iCell = 1, nCellsSolve
 
@@ -2036,7 +2036,7 @@ contains
 
        if (config_use_data_icebergs) then
 
-          call MPAS_pool_get_subpool(block % structs, "iceberg_fluxes", icebergFluxes)
+          call MPAS_pool_get_subpool(block % structs, "berg_fluxes", icebergFluxes)
 
           call MPAS_pool_get_array(icebergFluxes, "bergFreshwaterFlux", bergFreshwaterFlux)
           call MPAS_pool_get_array(icebergFluxes, "bergLatentHeatFlux", bergLatentHeatFlux)

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1654,10 +1654,10 @@ contains
          domain % streamManager, &
          seaiceForcingGroups, &
          "seaice_data_iceberg_forcing_monthly", &
-         "bergFreshWaterFluxData", &
+         "bergFreshwaterFluxData", &
          "dataIcebergForcing", &
          "iceberg_forcing", &
-         "bergFreshWaterFluxData", &
+         "bergFreshwaterFluxData", &
          "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
@@ -1743,8 +1743,8 @@ contains
          nCellsSolve
 
     real(kind=RKIND), dimension(:), pointer :: &
-         bergFreshWaterFluxData, & ! iceberg freshwater flux read in from file (kg/m^2/s)
-         bergFreshWaterFlux, & ! iceberg freshwater flux for ocean (kg/m^2/s)
+         bergFreshwaterFluxData, & ! iceberg freshwater flux read in from file (kg/m^2/s)
+         bergFreshwaterFlux, & ! iceberg freshwater flux for ocean (kg/m^2/s)
          bergLatentHeatFlux ! iceberg latent heat flux for ocean (J/m^2/s)
 
     integer :: &
@@ -1764,14 +1764,14 @@ contains
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
 
-       call MPAS_pool_get_array(iceberg_forcing, "bergFreshWaterFluxData", bergFreshWaterFluxData)
-       call MPAS_pool_get_array(iceberg_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+       call MPAS_pool_get_array(iceberg_forcing, "bergFreshwaterFluxData", bergFreshwaterFluxData)
+       call MPAS_pool_get_array(iceberg_fluxes, "bergFreshwaterFlux", bergFreshwaterFlux)
        call MPAS_pool_get_array(iceberg_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
 
        do iCell = 1, nCellsSolve
 
-          bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
-          bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
+          bergFreshwaterFlux(iCell) = bergFreshwaterFluxData(iCell)
+          bergLatentHeatFlux(iCell) = bergFreshwaterFluxData(iCell) * &
                                      (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
 
        enddo
@@ -1949,7 +1949,7 @@ contains
          oceanShortwaveFlux
 
     real(kind=RKIND), dimension(:), pointer :: &
-         bergFreshWaterFlux, &
+         bergFreshwaterFlux, &
          bergLatentHeatFlux
 
     real(kind=RKIND), dimension(:), pointer :: &
@@ -2038,10 +2038,10 @@ contains
 
           call MPAS_pool_get_subpool(block % structs, "iceberg_fluxes", icebergFluxes)
 
-          call MPAS_pool_get_array(icebergFluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+          call MPAS_pool_get_array(icebergFluxes, "bergFreshwaterFlux", bergFreshwaterFlux)
           call MPAS_pool_get_array(icebergFluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
 
-          bergFreshWaterFlux = 0.0_RKIND
+          bergFreshwaterFlux = 0.0_RKIND
           bergLatentHeatFlux = 0.0_RKIND
 
        endif

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -68,9 +68,11 @@ contains
     type (domain_type) :: domain
 
     logical, pointer :: &
-         config_use_forcing
+         config_use_forcing, &
+         config_use_data_icebergs
 
     call MPAS_pool_get_config(domain % configs, "config_use_forcing", config_use_forcing)
+    call MPAS_pool_get_config(domain % configs, "config_use_data_icebergs", config_use_data_icebergs)
 
     if (config_use_forcing) then
 
@@ -79,6 +81,9 @@ contains
 
        ! init the ocean forcing
        call init_oceanic_forcing(domain)
+
+       ! init the data iceberg forcing (dc here, or as part of oceanic forcing?)
+       if (config_use_data_icebergs) call init_data_iceberg_forcing(domain)
 
     endif
 
@@ -310,9 +315,11 @@ contains
          firstTimeStep
 
     logical, pointer :: &
-         config_use_forcing
+         config_use_forcing, &
+         config_use_data_icebergs
 
     call MPAS_pool_get_config(domain % configs, "config_use_forcing", config_use_forcing)
+    call MPAS_pool_get_config(domain % configs, "config_use_data_icebergs", config_use_data_icebergs)
 
     if (config_use_forcing) then
 
@@ -326,6 +333,16 @@ contains
             domain, &
             simulationClock, &
             firstTimeStep)
+
+       !dc add data iceberg forcing
+       if (config_use_data_icebergs) then
+
+          call data_iceberg_forcing(&
+               streamManager, &
+               domain, &
+               simulationClock)
+
+       endif
 
     endif
 
@@ -1490,71 +1507,6 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  get_data_iceberg_fluxes
-!
-!> \brief   Initialize with icebergs calving mass
-!> \author  Darin Comeau, LANL
-!> \date    20 Aug 2018
-!> \details This routine is intended to initialize the set data iceberg
-!> meltwater and latent heat fluxes from a forcing file of monthly
-!> climatologies.
-!
-!-----------------------------------------------------------------------
-
-! dcnote - not yet called anywhere
-! dcnote - need to make monthly
-
-  subroutine get_data_iceberg_fluxes(block)
-
-    use seaice_constants, only: &
-         seaiceLatentHeatMelting ! latent heat of melting of fresh ice (J/kg)
-
-    type(block_type), intent(inout) :: &
-         block
-
-    type(MPAS_pool_type), pointer :: &
-         mesh, &
-         ocean_fluxes
-
-    integer, pointer :: &
-         nCellsSolve
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         bergFreshWaterFluxData, & ! iceberg freshwater flux read in from file (kg/m^2/s)
-         bergFreshWaterFlux, & ! iceberg freshwater flux for ocean (kg/m^2/s)
-         bergLatentHeatFlux ! iceberg latent heat flux for ocean (J/m^2/s)
-
-    integer :: &
-         iCell
-
-    ! dc including as parameters here so as not to create new namelist options
-    real(kind=RKIND), parameter :: &
-         specificHeatFreshIce = 2106.0_RKIND, & ! specific heat of fresh ice J * kg^-1 * K^-1
-         bergTemperature = -4.0_RKIND           ! iceberg temperature, assumed constant
-
-
-    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
-    call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", ocean_fluxes)
-
-    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
-
-    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFluxData", bergFreshWaterFluxData)
-    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
-    call MPAS_pool_get_array(ocean_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
-
-    do iCell = 1, nCellsSolve
-
-       bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
-       bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
-                               (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
-
-    enddo
-
-  end subroutine get_data_iceberg_fluxes
-
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
 !  post_oceanic_coupling
 !
 !> \brief
@@ -1654,6 +1606,183 @@ contains
     enddo ! iCell
 
   end subroutine post_oceanic_coupling
+
+!-----------------------------------------------------------------------
+! data iceberg forcing
+!-----------------------------------------------------------------------
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_data_iceberg_forcing
+!
+!> \brief
+!> \author Darin Comeau, LANL
+!> \date 27th August 2018
+!> \details This initializes the data iceberg forcing group.
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_data_iceberg_forcing(domain)
+
+    type (domain_type) :: domain
+
+    logical, pointer :: &
+         config_do_restart
+
+    character(len=strKIND) :: &
+         forcingIntervalMonthly, &
+         forcingReferenceTimeMonthly
+
+    ! get oceanic forcing configuration options
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+
+    forcingIntervalMonthly = "00-01-00_00:00:00"
+    forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
+
+    ! create the sea surface temperature forcing group
+    call MPAS_forcing_init_group(&
+         seaiceForcingGroups, &
+         "seaice_data_iceberg_forcing_monthly", &
+         domain, &
+         '0000-01-01_00:00:00', &
+         '0000-01-01_00:00:00', &
+         '0001-00-00_00:00:00', &
+         config_do_restart)
+
+    ! sea surface temperature
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_data_iceberg_forcing_monthly", &
+         "bergFreshWaterFluxData", &
+         "dataIcebergForcing", &
+         "ocean_coupling", &
+         "bergFreshWaterFluxData", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    call MPAS_forcing_init_field_data(&
+         seaiceForcingGroups, &
+         "seaice_data_iceberg_forcing_monthly", &
+         domain % streamManager, &
+         config_do_restart, &
+         .false.)
+
+  end subroutine init_data_iceberg_forcing
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  data_iceberg_forcing
+!
+!> \brief
+!> \author Darin Comeau, LANL
+!> \date 27th Aug 2018
+!> \details This routine is the timestep for getting and setting fluxes
+!> from data icebergs.
+!
+!-----------------------------------------------------------------------
+
+  subroutine data_iceberg_forcing(&
+       streamManager, &
+       domain, &
+       simulationClock)
+
+    type (MPAS_streamManager_type), intent(inout) :: streamManager
+
+    type (domain_type) :: domain
+
+    type (MPAS_clock_type) :: simulationClock ! dc is this being used?
+
+    type(block_type), pointer :: &
+         block
+
+    real(kind=RKIND), pointer :: &
+         config_dt
+
+
+    call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
+
+    ! use the forcing layer to get data
+    call MPAS_forcing_get_forcing(&
+       seaiceForcingGroups, &
+       "seaice_data_iceberg_forcing_monthly", &
+       streamManager, &
+       config_dt)
+
+    block => domain % blocklist
+    do while (associated(block))
+
+       call get_data_iceberg_fluxes(block)
+
+       block => block % next
+    end do
+
+  end subroutine data_iceberg_forcing
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  get_data_iceberg_fluxes
+!
+!> \brief   Initialize with icebergs calving mass
+!> \author  Darin Comeau, LANL
+!> \date    20 Aug 2018
+!> \details This routine is intended to initialize the set data iceberg
+!> meltwater and latent heat fluxes from a forcing file of monthly
+!> climatologies.
+!
+!-----------------------------------------------------------------------
+
+! dcnote - need to make monthly
+
+  subroutine get_data_iceberg_fluxes(block)
+
+    use seaice_constants, only: &
+         seaiceLatentHeatMelting ! latent heat of melting of fresh ice (J/kg)
+
+    type(block_type), intent(inout) :: &
+         block
+
+    type(MPAS_pool_type), pointer :: &
+         mesh, &
+         ocean_fluxes
+
+    integer, pointer :: &
+         nCellsSolve
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         bergFreshWaterFluxData, & ! iceberg freshwater flux read in from file (kg/m^2/s)
+         bergFreshWaterFlux, & ! iceberg freshwater flux for ocean (kg/m^2/s)
+         bergLatentHeatFlux ! iceberg latent heat flux for ocean (J/m^2/s)
+
+    integer :: &
+         iCell
+
+    ! dc including as parameters here so as not to create new namelist options
+    real(kind=RKIND), parameter :: &
+         specificHeatFreshIce = 2106.0_RKIND, & ! specific heat of fresh ice J * kg^-1 * K^-1
+         bergTemperature = -4.0_RKIND           ! iceberg temperature, assumed constant
+
+
+    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+    call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", ocean_fluxes)
+
+    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
+
+    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFluxData", bergFreshWaterFluxData)
+    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+    call MPAS_pool_get_array(ocean_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+
+    do iCell = 1, nCellsSolve
+
+       bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
+       bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
+                               (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
+
+    enddo
+
+  end subroutine get_data_iceberg_fluxes
 
 !-----------------------------------------------------------------------
 ! coupler fluxes initialization

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -334,7 +334,7 @@ contains
             simulationClock, &
             firstTimeStep)
 
-       !dc add data iceberg forcing
+       ! data iceberg forcing
        if (config_use_data_icebergs) then
 
           call data_iceberg_forcing(&
@@ -1634,13 +1634,13 @@ contains
          forcingIntervalMonthly, &
          forcingReferenceTimeMonthly
 
-    ! get oceanic forcing configuration options
+    ! get configuration options
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
     forcingIntervalMonthly = "00-01-00_00:00:00"
     forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
 
-    ! create the sea surface temperature forcing group
+    ! create own data iceberg forcing group
     call MPAS_forcing_init_group(&
          seaiceForcingGroups, &
          "seaice_data_iceberg_forcing_monthly", &
@@ -1650,7 +1650,7 @@ contains
          '0001-00-00_00:00:00', &
          config_do_restart)
 
-    ! sea surface temperature
+    ! iceberg freshwater fluxes
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
@@ -1951,6 +1951,10 @@ contains
          oceanShortwaveFlux
 
     real(kind=RKIND), dimension(:), pointer :: &
+         bergFreshWaterFlux, &
+         bergLatentHeatFlux
+
+    real(kind=RKIND), dimension(:), pointer :: &
          oceanNitrateFlux, &
          oceanSilicateFlux, &
          oceanAmmoniumFlux, &
@@ -1970,7 +1974,8 @@ contains
          oceanDissolvedIronFlux
 
     logical, pointer :: &
-         config_use_column_biogeochemistry
+         config_use_column_biogeochemistry, &
+         config_use_data_icebergs
 
     block => domain % blocklist
     do while (associated(block))
@@ -1982,7 +1987,7 @@ contains
        call MPAS_pool_get_array(oceanFluxes, "oceanSaltFlux", oceanSaltFlux)
        call MPAS_pool_get_array(oceanFluxes, "oceanHeatFlux", oceanHeatFlux)
        call MPAS_pool_get_array(oceanFluxes, "oceanShortwaveFlux", oceanShortwaveFlux)
-!dc add berg terms here
+
        oceanFreshWaterFlux      = 0.0_RKIND
        oceanSaltFlux            = 0.0_RKIND
        oceanHeatFlux            = 0.0_RKIND
@@ -2025,6 +2030,19 @@ contains
           oceanParticulateIronFlux = 0.0_RKIND
           oceanDissolvedIronFlux   = 0.0_RKIND
           oceanDustIronFlux        = 0.0_RKIND
+
+       endif
+
+       ! data icebergs
+       call MPAS_pool_get_config(block % configs, "config_use_data_icebergs", config_use_data_icebergs)
+
+       if (config_use_data_icebergs) then
+
+          call MPAS_pool_get_array(oceanFluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+          call MPAS_pool_get_array(oceanFluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+
+          bergFreshWaterFlux = 0.0_RKIND
+          bergLatentHeatFlux = 0.0_RKIND
 
        endif
 

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -82,7 +82,7 @@ contains
        ! init the ocean forcing
        call init_oceanic_forcing(domain)
 
-       ! init the data iceberg forcing (dc here, or as part of oceanic forcing?)
+       ! init the data iceberg forcing
        if (config_use_data_icebergs) call init_data_iceberg_forcing(domain)
 
     endif
@@ -1657,7 +1657,7 @@ contains
          "seaice_data_iceberg_forcing_monthly", &
          "bergFreshWaterFluxData", &
          "dataIcebergForcing", &
-         "ocean_coupling", &
+         "iceberg_forcing", &
          "bergFreshWaterFluxData", &
          "linear", &
          forcingReferenceTimeMonthly, &
@@ -1695,12 +1695,8 @@ contains
 
     type (MPAS_clock_type) :: simulationClock ! dc is this being used?
 
-    type(block_type), pointer :: &
-         block
-
     real(kind=RKIND), pointer :: &
          config_dt
-
 
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
 
@@ -1711,13 +1707,7 @@ contains
        streamManager, &
        config_dt)
 
-    block => domain % blocklist
-    do while (associated(block))
-
-       call get_data_iceberg_fluxes(block)
-
-       block => block % next
-    end do
+    call get_data_iceberg_fluxes(domain)
 
   end subroutine data_iceberg_forcing
 
@@ -1734,19 +1724,21 @@ contains
 !
 !-----------------------------------------------------------------------
 
-! dcnote - need to make monthly
-
-  subroutine get_data_iceberg_fluxes(block)
+  subroutine get_data_iceberg_fluxes(domain)
 
     use seaice_constants, only: &
          seaiceLatentHeatMelting ! latent heat of melting of fresh ice (J/kg)
 
-    type(block_type), intent(inout) :: &
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
          block
 
     type(MPAS_pool_type), pointer :: &
          mesh, &
-         ocean_fluxes
+         iceberg_forcing, &
+         iceberg_fluxes
 
     integer, pointer :: &
          nCellsSolve
@@ -1764,22 +1756,28 @@ contains
          specificHeatFreshIce = 2106.0_RKIND, & ! specific heat of fresh ice J * kg^-1 * K^-1
          bergTemperature = -4.0_RKIND           ! iceberg temperature, assumed constant
 
+    block => domain % blocklist
+    do while (associated(block))
 
-    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
-    call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", ocean_fluxes)
+       call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+       call MPAS_pool_get_subpool(block % structs, "iceberg_forcing", iceberg_forcing)
+       call MPAS_pool_get_subpool(block % structs, "iceberg_fluxes", iceberg_fluxes)
 
-    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
+       call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
 
-    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFluxData", bergFreshWaterFluxData)
-    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
-    call MPAS_pool_get_array(ocean_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+       call MPAS_pool_get_array(iceberg_forcing, "bergFreshWaterFluxData", bergFreshWaterFluxData)
+       call MPAS_pool_get_array(iceberg_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+       call MPAS_pool_get_array(iceberg_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
 
-    do iCell = 1, nCellsSolve
+       do iCell = 1, nCellsSolve
 
-       bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
-       bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
-                               (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
+          bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
+          bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
+                                     (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
 
+       enddo
+
+       block => block % next
     enddo
 
   end subroutine get_data_iceberg_fluxes
@@ -1942,6 +1940,7 @@ contains
 
     type(MPAS_pool_type), pointer :: &
          oceanFluxes, &
+         icebergFluxes, &
          biogeochemistry
 
     real(kind=RKIND), dimension(:), pointer :: &
@@ -2038,8 +2037,10 @@ contains
 
        if (config_use_data_icebergs) then
 
-          call MPAS_pool_get_array(oceanFluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
-          call MPAS_pool_get_array(oceanFluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+          call MPAS_pool_get_subpool(block % structs, "iceberg_fluxes", icebergFluxes)
+
+          call MPAS_pool_get_array(icebergFluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+          call MPAS_pool_get_array(icebergFluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
 
           bergFreshWaterFlux = 0.0_RKIND
           bergLatentHeatFlux = 0.0_RKIND

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1490,6 +1490,71 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!  get_data_iceberg_fluxes
+!
+!> \brief   Initialize with icebergs calving mass
+!> \author  Darin Comeau, LANL
+!> \date    20 Aug 2018
+!> \details This routine is intended to initialize the set data iceberg
+!> meltwater and latent heat fluxes from a forcing file of monthly
+!> climatologies.
+!
+!-----------------------------------------------------------------------
+
+! dcnote - not yet called anywhere
+! dcnote - need to make monthly
+
+  subroutine get_data_iceberg_fluxes(block)
+
+    use seaice_constants, only: &
+         seaiceLatentHeatMelting ! latent heat of melting of fresh ice (J/kg)
+
+    type(block_type), intent(inout) :: &
+         block
+
+    type(MPAS_pool_type), pointer :: &
+         mesh, &
+         ocean_fluxes
+
+    integer, pointer :: &
+         nCellsSolve
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         bergFreshWaterFluxData, & ! iceberg freshwater flux read in from file (kg/m^2/s)
+         bergFreshWaterFlux, & ! iceberg freshwater flux for ocean (kg/m^2/s)
+         bergLatentHeatFlux ! iceberg latent heat flux for ocean (J/m^2/s)
+
+    integer :: &
+         iCell
+
+    ! dc including as parameters here so as not to create new namelist options
+    real(kind=RKIND), parameter :: &
+         specificHeatFreshIce = 2106.0_RKIND, & ! specific heat of fresh ice J * kg^-1 * K^-1
+         bergTemperature = -4.0_RKIND           ! iceberg temperature, assumed constant
+
+
+    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+    call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", ocean_fluxes)
+
+    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
+
+    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFluxData", bergFreshWaterFluxData)
+    call MPAS_pool_get_array(ocean_fluxes, "bergFreshWaterFlux", bergFreshWaterFlux)
+    call MPAS_pool_get_array(ocean_fluxes, "bergLatentHeatFlux", bergLatentHeatFlux)
+
+    do iCell = 1, nCellsSolve
+
+       bergFreshWaterFlux(iCell) = bergFreshWaterFluxData(iCell)
+       bergLatentHeatFlux(iCell) = bergFreshWaterFluxData(iCell) * &
+                               (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
+
+    enddo
+
+  end subroutine get_data_iceberg_fluxes
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !  post_oceanic_coupling
 !
 !> \brief
@@ -1788,7 +1853,7 @@ contains
        call MPAS_pool_get_array(oceanFluxes, "oceanSaltFlux", oceanSaltFlux)
        call MPAS_pool_get_array(oceanFluxes, "oceanHeatFlux", oceanHeatFlux)
        call MPAS_pool_get_array(oceanFluxes, "oceanShortwaveFlux", oceanShortwaveFlux)
-
+!dc add berg terms here
        oceanFreshWaterFlux      = 0.0_RKIND
        oceanSaltFlux            = 0.0_RKIND
        oceanHeatFlux            = 0.0_RKIND

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1620,7 +1620,6 @@ contains
 !> \date 27th August 2018
 !> \details This initializes the data iceberg forcing group.
 !>
-!
 !-----------------------------------------------------------------------
 
   subroutine init_data_iceberg_forcing(domain)

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -82,10 +82,10 @@ contains
        ! init the ocean forcing
        call init_oceanic_forcing(domain)
 
-       ! init the data iceberg forcing
-       if (config_use_data_icebergs) call init_data_iceberg_forcing(domain)
-
     endif
+
+    ! init the data iceberg forcing
+    if (config_use_data_icebergs) call init_data_iceberg_forcing(domain)
 
   end subroutine seaice_forcing_init
 
@@ -334,15 +334,15 @@ contains
             simulationClock, &
             firstTimeStep)
 
-       ! data iceberg forcing
-       if (config_use_data_icebergs) then
+    endif
 
-          call data_iceberg_forcing(&
-               streamManager, &
-               domain, &
-               simulationClock)
+    ! data iceberg forcing
+    if (config_use_data_icebergs) then
 
-       endif
+       call data_iceberg_forcing(&
+            streamManager, &
+            domain, &
+            simulationClock)
 
     endif
 

--- a/testing_and_setup/seaice/configurations/standard_physics/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/namelist.seaice
@@ -314,6 +314,7 @@
     config_sea_freezing_temperature_type = 'mushy'
     config_ocean_surface_type = 'free'
     config_couple_biogeochemistry_fields = false
+    config_use_data_icebergs = false
 /
 &diagnostics
     config_check_state = false

--- a/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
@@ -56,11 +56,14 @@
                   filename_interval="none"
                   input_interval="none" />
 
-<immutable_stream name="dataIcebergForcing"
+<stream name="dataIcebergForcing"
                   type="input"
                   filename_template="forcing/data_icebergs.nc"
                   filename_interval="none"
-                  input_interval="none" />
+                  input_interval="none" >
+    <var name="bergFreshWaterFluxData"/>
+    <var name="xtime" />
+</stream>
 
 <stream name="abort_block"
         type="output"

--- a/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
@@ -61,7 +61,7 @@
                   filename_template="forcing/data_icebergs.nc"
                   filename_interval="none"
                   input_interval="none" >
-    <var name="bergFreshWaterFluxData"/>
+    <var name="bergFreshwaterFluxData"/>
     <var name="xtime" />
 </stream>
 

--- a/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
@@ -56,6 +56,12 @@
                   filename_interval="none"
                   input_interval="none" />
 
+<immutable_stream name="dataIcebergForcing"
+                  type="input"
+                  filename_template="data_icebergs.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
 <stream name="abort_block"
         type="output"
         filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s_block_$B.nc"

--- a/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/streams.seaice
@@ -58,7 +58,7 @@
 
 <immutable_stream name="dataIcebergForcing"
                   type="input"
-                  filename_template="data_icebergs.nc"
+                  filename_template="forcing/data_icebergs.nc"
                   filename_interval="none"
                   input_interval="none" />
 


### PR DESCRIPTION
This PR adds functionality of a data iceberg model, based on [Merino et al 2016](https://www.sciencedirect.com/science/article/pii/S1463500316300300). Iceberg meltwater is read in through a monthly climatology file, and written to bergFreshWaterFlux and bergLatentHeatFlux, which are sent to the coupler separate from their sea ice counterparts. The data icebergs have no direct effect on sea ice.

Currently a work-in-progress; opening this PR for visibility.

BFB when config_use_data_icebergs = false.
