### PR TITLE
Support data iceberg fluxes from ICE in E3SM

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1676,10 +1676,12 @@
 			<var name="longWaveHeatFluxUp"/>
 			<var name="longWaveHeatFluxDown"/>
 			<var name="seaIceHeatFlux"/>
+			<var name="icebergHeatFlux"/>
 			<var name="shortWaveHeatFlux"/>
 			<var name="evaporationFlux"/>
 			<var name="seaIceSalinityFlux"/>
 			<var name="seaIceFreshWaterFlux"/>
+			<var name="icebergFreshWaterFlux"/>
 			<var name="riverRunoffFlux"/>
 			<var name="iceRunoffFlux"/>
 			<var name="rainFlux"/>
@@ -2742,6 +2744,10 @@
 			 description="Sea ice heat flux at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG"
 		/>
+		<var name="icebergHeatFlux" type="real" dimensions="nCells Time" units="W m^{-2}"
+			 description="Iceberg heat flux at cell centers from coupler. Positive into the ocean."
+			 packages="activeTracersBulkRestoringPKG"
+		/>
 		<var name="shortWaveHeatFlux" type="real" dimensions="nCells Time" units="W m^{-2}"
 			 description="Short wave flux at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;ecosysTracersPKG"
@@ -2759,6 +2765,10 @@
 		/>
 		<var name="seaIceFreshWaterFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from sea ice at cell centers from coupler. Positive into the ocean."
+			 packages="thicknessBulkPKG"
+		/>
+		<var name="icebergFreshWaterFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+			 description="Fresh water flux from iceberg melt at cell centers from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
 		<var name="riverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -699,6 +699,10 @@
 					description="Timescale for relaxation of the ssh gradient for coupling. A value of 0.0 (default) removes any relaxation and gives instantaneous response."
 					possible_values="Any positive real number."
 		/>
+		<nml_option name="config_remove_AIS_coupler_runoff" type="logical" default_value=".false." units="unitless"
+					description="If true, solid and liquid runoff from the Antarctic Ice Sheet (below 60S latitude) coming from the coupled is zeroed in the coupler import routines.  To be used with data iceberg fluxes coming from the sea ice model."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="shortwaveRadiation" mode="init;forward">
 		<nml_option name="config_sw_absorption_type" type="character" default_value="none" units="unitless"
@@ -2775,8 +2779,24 @@
 			 description="Fresh water flux from river runoff at cell centers from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
+		<var name="removedRiverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+			 description="Fresh water flux from river runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
+			 packages="thicknessBulkPKG"
+		/>
+		<var name="totalRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^{-1}"
+			 description="Global sum of fresh water flux from river runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
+			 packages="thicknessBulkPKG"
+		/>
 		<var name="iceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from ice runoff at cell centers from coupler. Positive into the ocean."
+			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
+		/>
+		<var name="removedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+			 description="Fresh water flux from ice runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
+			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
+		/>
+		<var name="totalRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg s^{-1}"
+			 description="Global sum of fresh water flux from ice runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
 		/>
 		<var name="rainFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"

--- a/src/core_ocean/analysis_members/Registry_global_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_global_stats.xml
@@ -127,6 +127,9 @@
 			<var name="seaIceFreshWaterFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
 				 description="Minimum global value of seaIceFreshWaterFlux in ocean cells."
 			/>
+			<var name="icebergFreshWaterFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
+				 description="Minimum global value of icebergFreshWaterFlux in ocean cells."
+			/>
 			<var name="riverRunoffFluxMin" array_group="mins" units="kg m^{-2} s^{-1}"
 				 description="Minimum global value of riverRunoffFlux in ocean cells."
 			/>
@@ -222,6 +225,9 @@
 			/>
 			<var name="seaIceFreshWaterFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
 				 description="Maximum global value of seaIceFreshWaterFlux in ocean cells."
+			/>
+			<var name="icebergFreshWaterFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
+				 description="Maximum global value of icebergFreshWaterFlux in ocean cells."
 			/>
 			<var name="riverRunoffFluxMax" array_group="maxes" units="kg m^{-2} s^{-1}"
 				 description="Maximum global value of riverRunoffFlux in ocean cells."
@@ -319,6 +325,9 @@
 			<var name="seaIceFreshWaterFluxSum" array_group="sums" units="kg s^{-1}"
 				 description="Accumulated global value of seaIceFreshWaterFlux in ocean cells."
 			/>
+			<var name="icebergFreshWaterFluxSum" array_group="sums" units="kg s^{-1}"
+				 description="Accumulated global value of icebergFreshWaterFlux in ocean cells."
+			/>
 			<var name="riverRunoffFluxSum" array_group="sums" units="kg s^{-1}"
 				 description="Accumulated global value of riverRunoffFlux in ocean cells."
 			/>
@@ -414,6 +423,9 @@
 			/>
 			<var name="seaIceFreshWaterFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
 				 description="Global root mean square value of seaIceFreshWaterFlux in ocean cells."
+			/>
+			<var name="icebergFreshWaterFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
+				 description="Global root mean square value of icebergFreshWaterFlux in ocean cells."
 			/>
 			<var name="riverRunoffFluxRms" array_group="rms" units="kg m^{-2} s^{-1}"
 				 description="Global root mean square value of riverRunoffFlux in ocean cells."
@@ -511,6 +523,9 @@
 			<var name="seaIceFreshWaterFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
 				 description="Average value of seaIceFreshWaterFlux in ocean cells."
 			/>
+			<var name="icebergFreshWaterFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
+				 description="Average value of icebergFreshWaterFlux in ocean cells."
+			/>
 			<var name="riverRunoffFluxAvg" array_group="avg" units="kg m^{-2} s^{-1}"
 				 description="Average value of riverRunoffFlux in ocean cells."
 			/>
@@ -607,6 +622,9 @@
 			<var name="seaIceFreshWaterFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
 				 description="Minimum vertical sum of seaIceFreshWaterFlux in ocean cells."
 			/>
+			<var name="icebergFreshWaterFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
+				 description="Minimum vertical sum of icebergFreshWaterFlux in ocean cells."
+			/>
 			<var name="riverRunoffFluxMinVertSum" array_group="vertSumMin" units="kg m^{-2} s^{-1}"
 				 description="Minimum vertical sum of riverRunoffFlux in ocean cells."
 			/>
@@ -702,6 +720,9 @@
 			/>
 			<var name="seaIceFreshWaterFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}"
 				 description="Maximum vertical sum of seaIceFreshWaterFlux in ocean cells."
+			/>
+			<var name="icebergFreshWaterFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}"
+				 description="Maximum vertical sum of icebergFreshWaterFlux in ocean cells."
 			/>
 			<var name="riverRunoffFluxMaxVertSum" array_group="vertSumMax" units="kg m^{-2} s^{-1}"
 				 description="Maximum vertical sum of riverRunoffFlux in ocean cells."

--- a/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
@@ -1,5 +1,5 @@
 	<dims>
-		<dim name="nLayerVolWeightedAvgFields" definition="30" units="unitless"
+		<dim name="nLayerVolWeightedAvgFields" definition="32" units="unitless"
 			 description="A number equal to or greater than the number of var arrays in the layerVolumeWeightedAverageAM var structure below."
 		/>
 		<dim name="nOceanRegionsTmp" definition="7" units="unitless"

--- a/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
@@ -54,6 +54,9 @@
 			<var name="minSeaIceHeatFlux" array_group="mins" units="W m^{-2}"
 				 description="Minimum sea ice heat flux in each region"
 			/>
+			<var name="minIcebergHeatFlux" array_group="mins" units="W m^{-2}"
+				 description="Minimum iceberg heat flux in each region"
+			/>
 			<var name="minShortWaveHeatFlux" array_group="mins" units="W m^{-2}"
 				 description="Minimum short wave heat flux in each region"
 			/>
@@ -62,6 +65,9 @@
 			/>
 			<var name="minSeaIceFreshWaterFlux" array_group="mins" units="kg m^{-2} s^{-1}"
 				 description="Minimum sea ice melt rate in each region"
+			/>
+			<var name="minIcebergFreshWaterFlux" array_group="mins" units="kg m^{-2} s^{-1}"
+				 description="Minimum iceberg melt rate in each region"
 			/>
 			<var name="minRiverRunoffFlux" array_group="mins" units="kg m^{-2} s^{-1}"
 				 description="Minimum river run off in each region"
@@ -146,6 +152,9 @@
 			<var name="maxSeaIceHeatFlux" array_group="maxs" units="W m^{-2}"
 				 description="Maximum sea ice heat flux in each region"
 			/>
+			<var name="maxIcebergHeatFlux" array_group="maxs" units="W m^{-2}"
+				 description="Maximum iceberg heat flux in each region"
+			/>
 			<var name="maxShortWaveHeatFlux" array_group="maxs" units="W m^{-2}"
 				 description="Maximum short wave heat flux in each region"
 			/>
@@ -154,6 +163,9 @@
 			/>
 			<var name="maxSeaIceFreshWaterFlux" array_group="maxs" units="kg m^{-2} s^{-1}"
 				 description="Maximum sea ice melt rate in each region"
+			/>
+			<var name="maxIcebergFreshWaterFlux" array_group="maxs" units="kg m^{-2} s^{-1}"
+				 description="Maximum iceberg melt rate in each region"
 			/>
 			<var name="maxRiverRunoffFlux" array_group="maxs" units="kg m^{-2} s^{-1}"
 				 description="Maximum river run off in each region"
@@ -238,6 +250,9 @@
 			<var name="avgSeaIceHeatFlux" array_group="avg" units="W m^{-2}"
 				 description="Surface area-weighted average of sea ice heat flux in each region"
 			/>
+			<var name="avgIcebergHeatFlux" array_group="avg" units="W m^{-2}"
+				 description="Surface area-weighted average of iceberg heat flux in each region"
+			/>
 			<var name="avgShortWaveHeatFlux" array_group="avg" units="W m^{-2}"
 				 description="Surface area-weighted average of short wave heat flux in each region"
 			/>
@@ -246,6 +261,9 @@
 			/>
 			<var name="avgSeaIceFreshWaterFlux" array_group="avg" units="kg m^{-2} s^{-1}"
 				 description="Surface area-weighted average of sea ice melt rate in each region"
+			/>
+			<var name="avgIcebergFreshWaterFlux" array_group="avg" units="kg m^{-2} s^{-1}"
+				 description="Surface area-weighted average of iceberg melt rate in each region"
 			/>
 			<var name="avgRiverRunoffFlux" array_group="avg" units="kg m^{-2} s^{-1}"
 				 description="Surface area-weighted average of river run off in each region"

--- a/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
@@ -1,5 +1,5 @@
 	<dims>
-		<dim name="nSfcAreaWeightedAvgFields" definition="30" units="unitless"
+		<dim name="nSfcAreaWeightedAvgFields" definition="32" units="unitless"
 			 description="A number equal to or greater than the number of var arrays in the surfaceAreaWeightedAveragesAM var structure below."
 		/>
 		<dim name="nOceanRegions" definition="7" units="unitless"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_monthly.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_monthly.xml
@@ -150,10 +150,12 @@
 			<var name="longWaveHeatFluxUp"/>
 			<var name="longWaveHeatFluxDown"/>
 			<var name="seaIceHeatFlux"/>
+			<var name="icebergHeatFlux"/>
 			<var name="shortWaveHeatFlux"/>
 			<var name="evaporationFlux"/>
 			<var name="seaIceSalinityFlux"/>
 			<var name="seaIceFreshWaterFlux"/>
+			<var name="icebergFreshWaterFlux"/>
 			<var name="riverRunoffFlux"/>
 			<var name="iceRunoffFlux"/>
 			<var name="rainFlux"/>

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -261,7 +261,7 @@ contains
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       real (kind=RKIND), dimension(:), pointer :: evaporationFlux, snowFlux
-      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: rainFlux, landIceFreshwaterFlux
       real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMass, accumulatedLandIceHeat, &
           accumulatedLandIceFrazilMass
@@ -383,6 +383,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
          call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
          call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+         call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
          call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
          call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
@@ -831,6 +832,28 @@ contains
          verticalSumMaxes(variableIndex) = maxes(variableIndex)
 
 
+         ! icebergFreshWaterFlux
+         variableIndex = variableIndex + 1
+         if ( associated(icebergFreshWaterFlux) ) then
+            call ocn_compute_field_area_weighted_local_stats_surface(dminfo, nCellsSolve, &
+                         areaCell(1:nCellsSolve), &
+                         icebergFreshWaterFlux(1:nCellsSolve), sums_tmp(variableIndex), &
+                         sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
+                         maxes_tmp(variableIndex))
+         else
+            sums_tmp(variableIndex) = 0.0_RKIND
+            sumSquares_tmp(variableIndex) = 0.0_RKIND
+            mins_tmp(variableIndex) = 0.0_RKIND
+            maxes_tmp(variableIndex) = 0.0_RKIND
+         end if
+         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
+         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
+         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
+         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
+         verticalSumMins(variableIndex) = mins(variableIndex)
+         verticalSumMaxes(variableIndex) = maxes(variableIndex)
+
+
          ! riverRunoffFlux
          variableIndex = variableIndex + 1
          if ( associated(riverRunoffFlux) ) then
@@ -1244,6 +1267,14 @@ contains
       netFreshwaterInput = netFreshwaterInput + sums(variableIndex) * dt/rho_sw
 
       ! seaIceFreshWaterFlux
+      variableIndex = variableIndex + 1
+      averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
+      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))
+
+      ! continue accumulating fresh water inputs
+      netFreshwaterInput = netFreshwaterInput + sums(variableIndex) * dt/rho_sw
+
+      ! icebergFreshWaterFlux
       variableIndex = variableIndex + 1
       averages(variableIndex) = sums(variableIndex)/(areaCellGlobal)
       rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaCellGlobal))

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -175,9 +175,11 @@ contains
       real (kind=RKIND), dimension(:), pointer :: longWaveHeatFluxUp
       real (kind=RKIND), dimension(:), pointer :: longWaveHeatFluxDown
       real (kind=RKIND), dimension(:), pointer :: seaIceHeatFlux
+      real (kind=RKIND), dimension(:), pointer :: icebergHeatFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux
       real (kind=RKIND), dimension(:), pointer :: evaporationFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux
+      real (kind=RKIND), dimension(:), pointer :: icebergFreshWaterFlux
       real (kind=RKIND), dimension(:), pointer :: riverRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: rainFlux
@@ -213,6 +215,7 @@ contains
       ! local variables
       integer :: iDataField, nDefinedDataFields
       integer :: iCell, iRegion, iTracer, err_tmp
+      integer :: n
 
       ! package flag
       logical, pointer :: activeTracersBulkRestoringPKG
@@ -320,9 +323,11 @@ contains
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'longWaveHeatFluxUp', longWaveHeatFluxUp)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'longWaveHeatFluxDown', longWaveHeatFluxDown)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'seaIceHeatFlux', seaIceHeatFlux)
+         if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'icebergHeatFlux', icebergHeatFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'shortWaveHeatFlux', shortWaveHeatFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+         if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
          if (activeTracersBulkRestoringPKG) call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
@@ -343,58 +348,98 @@ contains
          call compute_mask(nCells, nCellsSolve, iRegion, lonCell, latCell, workMask)
 
          ! copy data into work array
-         workArray( :,:) = 0.0_RKIND
-         workArray( 1,:) = workMask(:)
-         workArray( 2,:) = areaCell(:)
-         if (activeTracersBulkRestoringPKG) workArray( 3,:) = latentHeatFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray( 4,:) = sensibleHeatFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray( 5,:) = longWaveHeatFluxUp(:)
-         if (activeTracersBulkRestoringPKG) workArray( 6,:) = longWaveHeatFluxDown(:)
-         if (activeTracersBulkRestoringPKG) workArray( 7,:) = seaIceHeatFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray( 8,:) = shortWaveHeatFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray( 9,:) = evaporationFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray(10,:) = seaIceFreshWaterFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray(11,:) = riverRunoffFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray(12,:) = iceRunoffFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray(13,:) = rainFlux(:)
-         if (activeTracersBulkRestoringPKG) workArray(14,:) = snowFlux(:)
-         if (frazilIcePkgActive) workArray(15,:) = seaIceEnergy(:)
-         workArray(16,:) = surfaceThicknessFlux(:)
-         workArray(17,:) = activeTracersSurfaceFlux(indexTemperature,:)
-         workArray(18,:) = activeTracersSurfaceFlux(indexSalinity,:)
-         if (activeTracersBulkRestoringPKG) workArray(19,:) = seaIceSalinityFlux(:)
-         workArray(20,:) = surfaceStressMagnitude(:)
-         if (activeTracersBulkRestoringPKG) workArray(21,:) = windStressZonal(:)
-         if (activeTracersBulkRestoringPKG) workArray(22,:) = windStressMeridional(:)
-         workArray(23,:) = atmosphericPressure(:)
-         workArray(24,:) = ssh(:)
-         workArray(25,:) = activeTracers(indexTemperature,1,:)
-         workArray(26,:) = activeTracers(indexSalinity,1,:)
-         workArray(27,:) = boundaryLayerDepth(:)
+         ! Note: Order of indices must match the ordering of vars in var_arrays in Registry_surface_area_weighted_averages.xml
+         !       (and all var_arrays in Registry_surface_area_weighted_averages.xml must have same ordering!)
+         n = 1
+         workArray(n,:) = 0.0_RKIND
+         n = n + 1
+         workArray(n,:) = workMask(:)
+         n = n + 1
+         workArray(n,:) = areaCell(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = latentHeatFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = sensibleHeatFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = longWaveHeatFluxUp(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = longWaveHeatFluxDown(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = seaIceHeatFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = icebergHeatFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = shortWaveHeatFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = evaporationFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = seaIceFreshWaterFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = icebergFreshWaterFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = riverRunoffFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = iceRunoffFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = rainFlux(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = snowFlux(:)
+         n = n + 1
+         if (frazilIcePkgActive) workArray(n,:) = seaIceEnergy(:)
+         n = n + 1
+         workArray(n,:) = surfaceThicknessFlux(:)
+         n = n + 1
+         workArray(n,:) = activeTracersSurfaceFlux(indexTemperature,:)
+         n = n + 1
+         workArray(n,:) = activeTracersSurfaceFlux(indexSalinity,:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = seaIceSalinityFlux(:)
+         n = n + 1
+         workArray(n,:) = surfaceStressMagnitude(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = windStressZonal(:)
+         n = n + 1
+         if (activeTracersBulkRestoringPKG) workArray(n,:) = windStressMeridional(:)
+         n = n + 1
+         workArray(n,:) = atmosphericPressure(:)
+         n = n + 1
+         workArray(n,:) = ssh(:)
+         n = n + 1
+         workArray(n,:) = activeTracers(indexTemperature,1,:)
+         n = n + 1
+         workArray(n,:) = activeTracers(indexSalinity,1,:)
+         n = n + 1
+         workArray(n,:) = boundaryLayerDepth(:)
 
          ! build net heat, salinity and fresh water budget
          ! net heat into ocean = latentHeatFlux + sensibleHeatFlux + longWaveHeatFluxUp + longWaveHeatFluxDown
-         !                     + shortWaveHeatFlux + seaIceHeatFlux + (?seaIceEnergy?)
+         !                     + shortWaveHeatFlux + seaIceHeatFlux + icebergHeatFlux+ (?seaIceEnergy?)
          ! net salinity into ocean = seaIceSalinityFlux
-         ! net freshwater into ocean = evaporationFlux + seaIceFreshWaterFlux + riverRunoffFlux + iceRunoffFlux
+         ! net freshwater into ocean = evaporationFlux + seaIceFreshWaterFlux + icebergHeatFlux + riverRunoffFlux + iceRunoffFlux
          !                           + rainFlux + snowFlux + (?seaIceEnergy?)
          if (activeTracersBulkRestoringPKG) then
-            workArray(28,:) =   latentHeatFlux(:) &
+            n = n + 1
+            workArray(n,:) =   latentHeatFlux(:) &
                               + sensibleHeatFlux(:) &
                               + longWaveHeatFluxUp(:) &
                               + longWaveHeatFluxDown(:) &
                               + shortWaveHeatFlux(:)  &
-                              + seaIceHeatFlux(:)
+                              + seaIceHeatFlux(:) &
+                              + icebergHeatFlux(:)
                      !        + seaIceEnergy
-            workArray(29,:) =   seaIceSalinityFlux(:)
-            workArray(30,:) =   evaporationFlux(:) &
+            n = n + 1
+            workArray(n,:) =   seaIceSalinityFlux(:)
+            n = n + 1
+            workArray(n,:) =   evaporationFlux(:) &
                               + seaIceFreshWaterFlux(:) &
+                              + icebergFreshWaterFlux(:) &
                               + riverRunoffFlux(:) &
                               + iceRunoffFlux(:) &
                               + rainFlux(:) &
                               + snowFlux(:)
                      !        + seaIceEnergy(:)
          end if
+         ! Note: if any fields get added after this, the indexing for previous 3 needs to moved outside if-statement
 
          call compute_statistics(nDefinedDataFields, nCellsSolve, workArray, workMask, workMin, workMax, workSum)
 
@@ -417,6 +462,7 @@ contains
       call mpas_dmpar_max_real_array(dminfo, kBufferLength, workBufferMax, workBufferMaxReduced )
 
       ! unpack the buffer into intent(out) of this analysis member
+      ! Note: Order of indices matchies the ordering of vars in var_arrays in Registry_surface_area_weighted_averages.xml
       kBuffer=0
       do iRegion=1,nOceanRegions
         do iDataField=1,nDefinedDataFields

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2391,8 +2391,8 @@ contains
                call ocn_write_field_statistics(debugUnit, fieldName, minValue, maxValue)
             end if
 
-            ! Test seaIceFreshWaterFlux
-            fieldName = 'snowFlux'
+            ! Test icebergHeatFlux
+            fieldName = 'icebergHeatFlux'
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
@@ -2404,6 +2404,31 @@ contains
                call ocn_write_field_statistics(debugUnit, fieldName, minValue, maxValue)
             end if
 
+            ! Test seaIceFreshWaterFlux
+            fieldName = 'seaIceFreshWaterFlux'
+            minValue = HUGE(minValue)
+            maxValue = -HUGE(maxValue)
+            call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
+            if ( associated(real1DArr) ) then
+               do iCell = 1, nCellsSolve
+                  minValue = min( minValue, real1DArr(iCell) )
+                  maxValue = max( maxValue, real1DArr(iCell) )
+               end do
+               call ocn_write_field_statistics(debugUnit, fieldName, minValue, maxValue)
+            end if
+
+            ! Test icebergFreshWaterFlux
+            fieldName = 'icebergFreshWaterFlux'
+            minValue = HUGE(minValue)
+            maxValue = -HUGE(maxValue)
+            call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
+            if ( associated(real1DArr) ) then
+               do iCell = 1, nCellsSolve
+                  minValue = min( minValue, real1DArr(iCell) )
+                  maxValue = max( maxValue, real1DArr(iCell) )
+               end do
+               call ocn_write_field_statistics(debugUnit, fieldName, minValue, maxValue)
+            end if
 
             ! Test rainFlux
             fieldName = 'rainFlux'

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -272,7 +272,7 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       real (kind=RKIND), dimension(:), pointer :: evaporationFlux, snowFlux
-      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, riverRunoffFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: rainFlux
 
       err = 0
@@ -286,6 +286,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
       call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
       call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
       call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
@@ -296,7 +297,7 @@ contains
       !$omp do schedule(runtime)
       do iCell = 1, nCells
         surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) &
-                                    + seaIceFreshWaterFlux(iCell) + iceRunoffFlux(iCell) ) / rho_sw
+                                    + seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell) + iceRunoffFlux(iCell) ) / rho_sw
         surfaceThicknessFluxRunoff(iCell) = riverRunoffFlux(iCell) / rho_sw
       end do
       !$omp end do
@@ -396,8 +397,8 @@ contains
       type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
 
       real (kind=RKIND), dimension(:), pointer :: latentHeatFlux, sensibleHeatFlux, longWaveHeatFluxUp, longWaveHeatFluxDown, &
-                                                  seaIceHeatFlux, evaporationFlux, riverRunoffFlux
-      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
+                                                  seaIceHeatFlux, icebergHeatFlux, evaporationFlux, riverRunoffFlux
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
       real (kind=RKIND) :: requiredSalt, allowedSalt
@@ -416,12 +417,14 @@ contains
       call mpas_pool_get_array(forcingPool, 'longWaveHeatFluxUp', longWaveHeatFluxUp)
       call mpas_pool_get_array(forcingPool, 'longWaveHeatFluxDown', longWaveHeatFluxDown)
       call mpas_pool_get_array(forcingPool, 'seaIceHeatFlux', seaIceHeatFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergHeatFlux', icebergHeatFlux)
       call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
       call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
       call mpas_pool_get_array(forcingPool, 'shortWaveHeatFlux', shortWaveHeatFlux)
       call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
 
       call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
       call mpas_pool_get_array(forcingPool, 'seaIceSalinityFlux', seaIceSalinityFlux)
       call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
@@ -435,7 +438,8 @@ contains
         tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
                                                            + (latentHeatFlux(iCell) + sensibleHeatFlux(iCell) &
                                                            + longWaveHeatFluxUp(iCell) + longWaveHeatFluxDown(iCell) &
-                                                           + seaIceHeatFlux(iCell) - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
+                                                           + seaIceHeatFlux(iCell) + icebergHeatFlux(iCell) &
+                                                           - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
                                                            * latent_heat_fusion_mks) * hflux_factor
 
         ! Negative seaIceSalinityFlux is an extraction of salt from the ocean
@@ -478,9 +482,9 @@ contains
 
            ! Accumulate fluxes that use the freezing point
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
-               + seaIceFreshWaterFlux(iCell) * ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell) , &
-                                                                         pressure=0.0_RKIND, &
-                                                                         inLandIceCavity=.false.) / rho_sw
+               + (seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell)) * &
+               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, inLandIceCavity=.false.)&
+               / rho_sw
 
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux


### PR DESCRIPTION
This merge introduces changes to the ocean model to support coupling of data iceberg fluxes from the sea ice component in E3SM.  First, new fields are added (icebergFreshWaterFlux and icebergHeatFlux) to use the new fluxes within MPAS-O.  Second, an option is added that will disable solid and liquid runoff from Antarctica coming from E3SM's runoff model.  (This option does nothing in standalone.)

The existing MPAS-O support for iceRunoffFlux (solid flux from the runoff model) is retained as we anticipate using a mixture of the two approaches for some time (specifically, solid discharge from the runoff model for GIS and iceberg melt flux from the sea ice model for AIS).