### PR TITLE
Remove calls to get subpools, left over from sounding code that was relocated

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -693,15 +693,10 @@ module atm_core
 
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
 
-         block_ptr => domain % blocklist
-         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block_ptr % structs, 'state', state)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diag_physics', diag_physics)
-
       end do
    
    end function atm_core_run
+
    
    subroutine atm_compute_output_diagnostics(state, time_lev, diag, mesh)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
This merge removes calls to get subpools that were only needed by sounding
code that has since been relocated.

The call to `mpas_atm_soundings_write` was originally made at the end of the time
integration loop directly from `atm_core_run`. Commit 156cae7a moved
calls to the soundings module into the diagnostics framework, but it didn't
remove the calls to `mpas_pool_get_subpool`. These subpool calls are not
needed and can be safely deleted.