### PR TITLE
MYNN Surface Layer and PBL Schemes Unified with WRFV4.0

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -646,9 +646,9 @@
                  th       = th_p        , dz       = dz_p        , u        = u_p        , &
                  v        = v_p         , qv       = qv_p        , qc       = qc_p       , &
                  qi       = qi_p        , qni      = ni_p        , rho      = rho_p      , &
-                 du       = rublten_p   , dv       = rvblten_p   , dth      = rthblten_p , &
-                 dqv      = rqvblten_p  , dqc      = rqcblten_p  , dqi      = rqiblten_p , &
-                 dqni     = rniblten_p  , flag_qc  = f_qc        , flag_qnc = f_qnc      , &
+                 rublten  = rublten_p   , rvblten  = rvblten_p   , rthblten = rthblten_p , &
+                 rqvblten = rqvblten_p  , rqcblten = rqcblten_p  , rqiblten = rqiblten_p , &
+                 rqniblten= rniblten_p  , flag_qc  = f_qc        , flag_qnc = f_qnc      , &
                  flag_qi  = f_qi        , flag_qni = f_qni       , kpbl     = kpbl_p     , &
                  pblh     = hpbl_p      , xland    = xland_p     , ts       = tsk_p      , &
                  hfx      = hfx_p       , qfx      = qfx_p       , ch       = ch_p       , &
@@ -656,8 +656,8 @@
                  cov      = cov_p       , el_pbl   = elpbl_p     , qsfc     = qsfc_p     , &
                  qcg      = qcg_p       , ust      = ust_p       , rmol     = rmol_p     , &
                  wspd     = wspd_p      , wstar    = wstar_p     , delta    = delta_p    , &
-                 delt     = dt_pbl      , k_h      = kzh_p       , k_m      = kzm_p      , &
-                 k_q      = kzq_p       , uoce     = uoce_p      , voce     = voce_p     , &
+                 delt     = dt_pbl      , exch_h   = kzh_p       , exch_m   = kzm_p      , &
+                 uoce     = uoce_p      , voce     = voce_p     , &
                  qke      = qke_p       , qke_adv  = qkeadv_p    , vdfg     = vdfg_p     , &
                  tke_pbl  = tkepbl_p    , dqke     = dqke_p      , qwt      = qwt_p      , &
                  qshear   = qshear_p    , qbuoy    = qbuoy_p     , qdiss    = qdiss_p    , &
@@ -668,7 +668,12 @@
                  bl_mynn_tkebudget = bl_mynn_tkebudget ,                                   &
                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde   , &
                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme   , &
-                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte     &
+                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   , &
+                 dx  = 0.0,  &
+                 bl_mynn_mixlength = 0, icloud_bl = 0,  &
+                 bl_mynn_edmf = 0, bl_mynn_edmf_mom = 0, bl_mynn_edmf_tke = 0,  &
+                 bl_mynn_edmf_part = 0, bl_mynn_cloudmix = 0, bl_mynn_mixqt = 0,  &
+                 spp_pbl = 0    &
                             )
        call mpas_timer_stop('MYNN_pbl')
 

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_mynn.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_mynn.F
@@ -1,17 +1,9 @@
-!==================================================================================================
-! copied for implementation in MPAS from WRF version 3.6.1.
-
-! modifications made to sourcecode:
-! * used preprocessing option to replace module_model_constants with mpas_atmphys_constants.
-! * used preprocessing option to not compile subroutine mynn_bl_init_driver.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-09-25.
-
-!==================================================================================================
-
+!WRF:MODEL_LAYER:PHYSICS
+!
 ! translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
 ! NOAA/GSD & CIRA/CSU, Feb 2008
 ! changes to original code:
-! 1. code is 1d (in z)
+! 1. code is 1D (in z)
 ! 2. no advection of TKE, covariances and variances 
 ! 3. Cranck-Nicholson replaced with the implicit scheme
 ! 4. removed terrain dependent grid since input in WRF in actual
@@ -19,57 +11,142 @@
 ! 5. cosmetic changes to adhere to WRF standard (remove common blocks, 
 !            intent etc)
 !-------------------------------------------------------------------
-!Modifications implemented by Joseph Olson NOAA/GSD/AMB - CU/CIRES
-!(approved by Mikio Nakanishi or under consideration):
+!Modifications primarily from Joseph Olson and Jaymes Kenyon NOAA/GSD/MDB - CU/CIRES
+!
+! Departures from original MYNN (Nakanish & Niino 2009)
 ! 1. Addition of BouLac mixing length in the free atmosphere.
 ! 2. Changed the turbulent mixing length to be integrated from the
 !    surface to the top of the BL + a transition layer depth.
-! 3. v3.4.1: Option to use Kitamura/Canuto modification which removes 
-!    the critical Richardson number and negative TKE (default).
-! 4. v3.4.1: Hybrid PBL height diagnostic, which blends a theta-v-based
-!    definition in neutral/convective BL and a TKE-based definition
-!    in stable conditions.
-! 5. v3.4.1: TKE budget output option (bl_mynn_tkebudget)
-! 6. v3.5.0: TKE advection option (bl_mynn_tkeadvect)
-! 7. v3.5.1: Fog deposition related changes.
-!
-! For changes 1 and 3, see "JOE's mods" below:
+! v3.4.1:    Option to use Kitamura/Canuto modification which removes 
+!            the critical Richardson number and negative TKE (default).
+!            Hybrid PBL height diagnostic, which blends a theta-v-based
+!            definition in neutral/convective BL and a TKE-based definition
+!            in stable conditions.
+!            TKE budget output option (bl_mynn_tkebudget)
+! v3.5.0:    TKE advection option (bl_mynn_tkeadvect)
+! v3.5.1:    Fog deposition related changes.
+! v3.6.0:    Removed fog deposition from the calculation of tendencies
+!            Added mixing of qc, qi, qni
+!            Added output for wstar, delta, TKE_PBL, & KPBL for correct 
+!                   coupling to shcu schemes  
+! v3.8.0:    Added subgrid scale cloud output for coupling to radiation
+!            schemes (activated by setting icloud_bl =1 in phys namelist).
+!            Added WRF_DEBUG prints (at level 3000)
+!            Added Tripoli and Cotton (1981) correction.
+!            Added namelist option bl_mynn_cloudmix to test effect of mixing
+!                cloud species (default = 1: on). 
+!            Added mass-flux option (bl_mynn_edmf, = 1 for StEM, 2 for TEMF).
+!                This option is off by default (=0).
+!                Related (hidden) options: 
+!                 bl_mynn_edmf_mom = 1 : activate momentum transport in MF scheme
+!                 bl_mynn_edmf_tke = 1 : activate TKE transport in MF scheme
+!                 bl_mynn_edmf_part= 1 : activate areal partitioning of ED & MF
+!            Added mixing length option (bl_mynn_mixlength, see notes below)
+!            Added more sophisticated saturation checks, following Thompson scheme
+!            Added new cloud PDF option (bl_mynn_cloudpdf = 2) from Chaboureau
+!                and Bechtold (2002, JAS, with mods) 
+!            Added capability to mix chemical species when env variable
+!                WRF_CHEM = 1, thanks to Wayne Angevine.
+!            Added scale-aware mixing length, following Junshi Ito's work
+!                Ito et al. (2015, BLM).
+! v3.9.0    Improvement to the mass-flux scheme (dynamic number of plumes,
+!                better plume/cloud depth, significant speed up, better cloud
+!                fraction). 
+!            Added Stochastic Parameter Perturbation (SPP) implementation.
+!            Many miscellaneous tweaks to the mixing lengths and stratus
+!                component of the subgrid clouds.
+! v.4.0      Removed or added alternatives for WRF-specific functions/modules
+!                the sake of portability to other models.
+!            Further refinement of mass-flux scheme from SCM experiments with
+!                Wayne Angevine: switch to linear entrainment and back to
+!                Simpson and Wiggert-type w-equation.
+!            Addition of TKE production due to radiation cooling at top of 
+!                clouds (proto-version); not activated by default.
+!            Some code rewrites to move if-thens out of loops in an attempt to
+!                improve computational efficiency.
+!            New tridiagonal solver, which is supposedly 14% faster and more
+!                conservative. Impact seems very small.
+!            Many miscellaneous tweaks to the mixing lengths and stratus
+!                component of the subgrid clouds.
+! 
 !-------------------------------------------------------------------
 
 MODULE module_bl_mynn
 
 #if defined(mpas)
- use mpas_atmphys_constants, only: &
-          karman,        &
-          g => gravity,  &
-          p1000mb => P0, &
-          cp,            &
-          r_d => R_d,    &
-          rcp,           &
-          xlv,           &
-          xlf,           &
-          svp1,          &
-          svp2,          &
-          svp3,          &
-          svpt0,         &
-          ep_1,          &
-          ep_2
- use error_function, only: erf
+ USE mpas_atmphys_constants, only: &
+          karman,              &
+          g => gravity,        &
+          p1000mb => P0,       &
+          cp,                  &
+          r_d,                 &
+          r_v,                 &
+          rvovrd => rvord,     &
+          rcp,                 &
+          xlv,                 &  
+          xlf,                 &
+          xls,                 &
+          svp1,                &
+          svp2,                &
+          svp3,                &
+          svpt0,               &
+          ep_1,                &
+          ep_2,                &
+          cice,                &
+          cliq,                &
+          cpv      
+ USE error_function, only: erf
 
  implicit none
  private
- public:: tv0,mym_condensation,mynn_bl_driver
+ public:: tv0,mym_condensation,mynn_bl_driver,p608,ev,rd, &
+              esat_blend,xl_blend,qsat_blend 
+
 #else
   USE module_model_constants, only: &
        &karman, g, p1000mb, &
-       &cp, r_d, rcp, xlv, xlf,&
-       &svp1, svp2, svp3, svpt0, ep_1, ep_2
+       &cp, r_d, r_v, rcp, xlv, xlf, xls, &
+       &svp1, svp2, svp3, svpt0, ep_1, ep_2, rvovrd, &
+       &cpv, cliq, cice
+
   USE module_state_description, only: param_first_scalar, &
-       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni
+       &p_qc, p_qr, p_qi, p_qs, p_qg, p_qnc, p_qni 
+
 !-------------------------------------------------------------------
   IMPLICIT NONE
 !-------------------------------------------------------------------
 #endif
+
+!For non-WRF
+!   REAL    , PARAMETER :: karman       = 0.4
+!   REAL    , PARAMETER :: g            = 9.81
+!   REAL    , PARAMETER :: r_d          = 287.
+!   REAL    , PARAMETER :: cp           = 7.*r_d/2.
+!   REAL    , PARAMETER :: r_v          = 461.6
+!   REAL    , PARAMETER :: cpv          = 4.*r_v
+!   REAL    , PARAMETER :: cliq         = 4190.
+!   REAL    , PARAMETER :: Cice         = 2106.
+!   REAL    , PARAMETER :: rcp          = r_d/cp
+!   REAL    , PARAMETER :: XLS          = 2.85E6
+!   REAL    , PARAMETER :: XLV          = 2.5E6
+!   REAL    , PARAMETER :: XLF          = 3.50E5
+!   REAL    , PARAMETER :: p1000mb      = 100000.
+!   REAL    , PARAMETER :: rvovrd       = r_v/r_d
+!   REAL    , PARAMETER :: SVP1         = 0.6112
+!   REAL    , PARAMETER :: SVP2         = 17.67
+!   REAL    , PARAMETER :: SVP3         = 29.65
+!   REAL    , PARAMETER :: SVPT0        = 273.15
+!   REAL    , PARAMETER :: EP_1         = R_v/R_d-1.
+!   REAL    , PARAMETER :: EP_2         = R_d/R_v
+! The following depends on the microphysics scheme used:
+!   INTEGER , PARAMETER :: param_first_scalar = 1
+!   INTEGER , PARAMETER :: p_qc = 2
+!   INTEGER , PARAMETER :: p_qr = 0
+!   INTEGER , PARAMETER :: p_qi = 2
+!   INTEGER , PARAMETER :: p_qs = 0
+!   INTEGER , PARAMETER :: p_qg = 0
+!   INTEGER , PARAMETER :: p_qnc= 0
+!   INTEGER , PARAMETER :: p_qni= 0
 
 ! The parameters below depend on stability functions of module_sf_mynn.
   REAL, PARAMETER :: cphm_st=5.0, cphm_unst=16.0, &
@@ -78,14 +155,15 @@ MODULE module_bl_mynn
   REAL, PARAMETER :: xlvcp=xlv/cp, xlscp=(xlv+xlf)/cp, ev=xlv, rd=r_d, &
        &rk=cp/rd, svp11=svp1*1.e3, p608=ep_1, ep_3=1.-ep_2
 
-  REAL, PARAMETER :: tref=300.0    ! reference temperature (K)
+  REAL, PARAMETER :: tref=300.0     ! reference temperature (K)
+  REAL, PARAMETER :: TKmin=253.0    ! for total water conversion, Tripoli and Cotton (1981)
   REAL, PARAMETER :: tv0=p608*tref, tv1=(1.+p608)*tref, gtr=g/tref
 
 ! Closure constants
-  REAL, PARAMETER :: &
+  REAL, PARAMETER, PUBLIC :: &
        &vk  = karman, &
-       &pr  =  0.74, &
-       &g1  =  0.229, &  ! NN2009 = 0.235
+       &pr  =  0.74,  &
+       &g1  =  0.235, &  ! NN2009 = 0.235
        &b1  = 24.0, &
        &b2  = 15.0, &    ! CKmod     NN2009
        &c2  =  0.729, &  ! 0.729, & !0.75, &
@@ -107,46 +185,105 @@ MODULE module_bl_mynn
        &e4c = 12.0*a1*a2*cc2, &
        &e5c =  6.0*a1*a1
 
-! Constants for length scale (alps & cns) and TKE diffusion (Sqfac)
-! Original (Nakanishi and Niino 2009) (for CKmod=0.):
-!  REAL, PARAMETER :: qmin=0.0, zmax=1.0, cns=2.7, & 
-!           &alp1=0.23, alp2=1.0, alp3=5.0, alp4=100.0, &
-!           &alp5=0.40, Sqfac=3.0
-! Modified for Rapid Refresh/HRRR (and for CKmod=1.):
-  REAL, PARAMETER :: qmin=0.0, zmax=1.0, cns=2.1, &
-            &alp1=0.23, alp2=0.65, alp3=3.0, alp4=20.0, &
-            &alp5=1.0, Sqfac=2.0
+! Constants for min tke in elt integration (qmin), max z/L in els (zmax), 
+! and factor for eddy viscosity for TKE (Kq = Sqfac*Km):
+  REAL, PARAMETER :: qmin=0.0, zmax=1.0, Sqfac=3.0
+! Note that the following mixing-length constants are now specified in mym_length
+!      &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.4
 
 ! Constants for gravitational settling
 !  REAL, PARAMETER :: gno=1.e6/(1.e8)**(2./3.), gpw=5./3., qcgmin=1.e-8
   REAL, PARAMETER :: gno=1.0  !original value seems too agressive: 4.64158883361278196
   REAL, PARAMETER :: gpw=5./3., qcgmin=1.e-8, qkemin=1.e-12
-!  REAL, PARAMETER :: pblh_ref=1500.
 
 ! Constants for cloud PDF (mym_condensation)
   REAL, PARAMETER :: rr2=0.7071068, rrp=0.3989423
 
-!JOE's mods
+! 'parameters' for Poisson distribution (StEM EDMF scheme)
+  REAL, PARAMETER  :: zero = 0.0, half = 0.5, one = 1.0, two = 2.0
+
   !Use Canuto/Kitamura mod (remove Ric and negative TKE) (1:yes, 0:no)
   !For more info, see Canuto et al. (2008 JAS) and Kitamura (Journal of the 
   !Meteorological Society of Japan, Vol. 88, No. 5, pp. 857-864, 2010).
   !Note that this change required further modification of other parameters
-  !above (c2, c3, alp2, and Sqfac). If you want to remove this option, set these
-  !parameters back to NN2009 values (see commented out lines next to the
+  !above (c2, c3). If you want to remove this option, set c2 and c3 constants 
+  !(above) back to NN2009 values (see commented out lines next to the
   !parameters above). This only removes the negative TKE problem
   !but does not necessarily improve performance - neutral impact.
   REAL, PARAMETER :: CKmod=1.
 
-  !Use BouLac mixing length in free atmosphere (1:yes, 0:no)
-  !This helps remove excessively large mixing in unstable layers aloft.
-  REAL, PARAMETER :: BLmod=1.
+  !Use Ito et al. (2015, BLM) scale-aware (0: no, 1: yes). Note that this also has impacts
+  !on the cloud PDF and mass-flux scheme, using Honnert et al. (2011) similarity function
+  !for TKE in the upper PBL/cloud layer.
+  REAL, PARAMETER :: scaleaware=1.
 
-  !Mix couds (water & ice): (0: no, 1: yes)                                                                
-! REAL, PARAMETER :: Cloudmix=0.
-  REAL, PARAMETER :: Cloudmix=1.
-!JOE-end
+  !Temporary switch to deactivate the mixing of chemical species (already done when WRF_CHEM = 1)
+  INTEGER, PARAMETER :: bl_mynn_mixchem = 0
 
+  !Adding top-down diffusion driven by cloud-top radiative cooling
+  INTEGER, PARAMETER :: bl_mynn_topdown = 0
+
+  !option to print out more stuff for debugging purposes
+  LOGICAL, PARAMETER :: debug_code = .false.
+
+! JAYMES-
+! Constants used for empirical calculations of saturation
+! vapor pressures (in function "esat") and saturation mixing ratios
+! (in function "qsat"), reproduced from module_mp_thompson.F, 
+! v3.6 
+  REAL, PARAMETER:: J0= .611583699E03
+  REAL, PARAMETER:: J1= .444606896E02
+  REAL, PARAMETER:: J2= .143177157E01
+  REAL, PARAMETER:: J3= .264224321E-1
+  REAL, PARAMETER:: J4= .299291081E-3
+  REAL, PARAMETER:: J5= .203154182E-5
+  REAL, PARAMETER:: J6= .702620698E-8
+  REAL, PARAMETER:: J7= .379534310E-11
+  REAL, PARAMETER:: J8=-.321582393E-13
+
+  REAL, PARAMETER:: K0= .609868993E03
+  REAL, PARAMETER:: K1= .499320233E02
+  REAL, PARAMETER:: K2= .184672631E01
+  REAL, PARAMETER:: K3= .402737184E-1
+  REAL, PARAMETER:: K4= .565392987E-3
+  REAL, PARAMETER:: K5= .521693933E-5
+  REAL, PARAMETER:: K6= .307839583E-7
+  REAL, PARAMETER:: K7= .105785160E-9
+  REAL, PARAMETER:: K8= .161444444E-12
+! end-
+
+!JOE & JAYMES'S mods
+!
+! Mixing Length Options 
+!   specifed through namelist:  bl_mynn_mixlength
+!   added:  16 Apr 2015
+!
+! 0: Uses original MYNN mixing length formulation (except elt is calculated from 
+!    a 10-km vertical integration).  No scale-awareness is applied to the master
+!    mixing length (el), regardless of "scaleaware" setting. 
+!
+! 1 (*DEFAULT*): Instead of (0), uses BouLac mixing length in free atmosphere.  
+!    This helps remove excessively large mixing in unstable layers aloft.  Scale-
+!    awareness in dx is available via the "scaleaware" setting.  As of Apr 2015, 
+!    this mixing length formulation option is used in the ESRL RAP/HRRR configuration.
+!
+! 2: As in (1), but elb is lengthened using separate cloud mixing length functions 
+!    for statically stable and unstable regimes.  This elb adjustment is only 
+!    possible for nonzero cloud fractions, such that cloud-free cells are treated 
+!    as in (1), but BouLac calculation is used more sparingly - when elb > 500 m. 
+!    This is to reduce the computational expense that comes with the BouLac calculation.
+!    Also, This option is  scale-aware in dx if "scaleaware" = 1. (Following Ito et al. 2015). 
+!
+!JOE & JAYMES- end
+
+
+#if defined(mpas)
   INTEGER :: mynn_level=2
+#else
+  INTEGER :: mynn_level
+#endif
+
+  CHARACTER*128 :: mynn_message
 
   INTEGER, PARAMETER :: kdebug=27
 
@@ -190,13 +327,13 @@ CONTAINS
 ! *                                                                    *
 ! *   Variables worthy of special mention:                             *
 ! *     tref   : Reference temperature                                 *
-! *     thl     : Liquid water potential temperature               *
+! *     thl     : Liquid water potential temperature                   *
 ! *     qw     : Total water (water vapor+liquid water) content        *
 ! *     ql     : Liquid water content                                  *
 ! *     vt, vq : Functions for computing the buoyancy flux             *
 ! *                                                                    *
 ! *     If the water contents are unnecessary, e.g., in the case of    *
-! *     ocean models, thl is the potential temperature and qw, ql, vt   *
+! *     ocean models, thl is the potential temperature and qw, ql, vt  *
 ! *     and vq are all zero.                                           *
 ! *                                                                    *
 ! *   Grid arrangement:                                                *
@@ -210,7 +347,7 @@ CONTAINS
 ! *     All the predicted variables are defined at the center (*) of   *
 ! *     the grid boxes. The diffusivity coefficients are, however,     *
 ! *     defined on the walls of the grid boxes.                        *
-! *     # Upper boundary values are given at k=nz.                   *
+! *     # Upper boundary values are given at k=nz.                     *
 ! *                                                                    *
 ! *   References:                                                      *
 ! *     1. Nakanishi, M., 2001:                                        *
@@ -229,78 +366,76 @@ CONTAINS
 !       iniflag         : <>0; turbulent quantities will be initialized
 !                         = 0; turbulent quantities have been already
 !                              given, i.e., they will not be initialized
-!       mx, my          : Maximum numbers of grid boxes
-!                         in the x and y directions, respectively
-!       nx, ny, nz      : Numbers of the actual grid boxes
-!                         in the x, y and z directions, respectively
+!       nx, ny, nz      : Dimension sizes of the
+!                         x, y and z directions, respectively
 !       tref            : Reference temperature                      (K)
 !       dz(nz)        : Vertical grid spacings                     (m)
 !                         # dz(nz)=dz(nz-1)
 !       zw(nz+1)        : Heights of the walls of the grid boxes     (m)
 !                         # zw(1)=0.0 and zw(k)=zw(k-1)+dz(k-1)
-!       h(mx,ny)        : G^(1/2) in the terrain-following coordinate
+!       h(nx,ny)        : G^(1/2) in the terrain-following coordinate
 !                         # h=1-zg/zt, where zg is the height of the
 !                           terrain and zt the top of the model domain
-!       pi0(mx,my,nz) : Exner function at zw*h+zg             (J/kg K)
+!       pi0(nx,my,nz) : Exner function at zw*h+zg             (J/kg K)
 !                         defined by c_p*( p_basic/1000hPa )^kappa
 !                         This is usually computed by integrating
 !                         d(pi0)/dz = -h*g/tref.
-!       rmo(mx,ny)      : Inverse of the Obukhov length         (m^(-1))
-!       flt, flq(mx,ny) : Turbulent fluxes of sensible and latent heat,
+!       rmo(nx,ny)      : Inverse of the Obukhov length         (m^(-1))
+!       flt, flq(nx,ny) : Turbulent fluxes of sensible and latent heat,
 !                         respectively, e.g., flt=-u_*Theta_* (K m/s)
 !! flt - liquid water potential temperature surface flux
 !! flq - total water flux surface flux
-!       ust(mx,ny)      : Friction velocity                        (m/s)
-!       pmz(mx,ny)      : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
+!       ust(nx,ny)      : Friction velocity                        (m/s)
+!       pmz(nx,ny)      : phi_m-zeta at z1*h+z0, where z1 (=0.5*dz(1))
 !                         is the first grid point above the surafce, z0
 !                         the roughness length and zeta=(z1*h+z0)*rmo
-!       phh(mx,ny)      : phi_h at z1*h+z0
-!       u, v(mx,my,nz): Components of the horizontal wind        (m/s)
-!       thl(mx,my,nz)  : Liquid water potential temperature
+!       phh(nx,ny)      : phi_h at z1*h+z0
+!       u, v(nx,nz,ny): Components of the horizontal wind        (m/s)
+!       thl(nx,nz,ny)  : Liquid water potential temperature
 !                                                                    (K)
-!       qw(mx,my,nz)  : Total water content Q_w                (kg/kg)
+!       qw(nx,nz,ny)  : Total water content Q_w                (kg/kg)
 !
 !     Output variables:
-!       ql(mx,my,nz)  : Liquid water content                   (kg/kg)
-!       v?(mx,my,nz)  : Functions for computing the buoyancy flux
-!       qke(mx,my,nz) : Twice the turbulent kinetic energy q^2
+!       ql(nx,nz,ny)  : Liquid water content                   (kg/kg)
+!       v?(nx,nz,ny)  : Functions for computing the buoyancy flux
+!       qke(nx,nz,ny) : Twice the turbulent kinetic energy q^2
 !                                                              (m^2/s^2)
-!       tsq(mx,my,nz) : Variance of Theta_l                      (K^2)
-!       qsq(mx,my,nz) : Variance of Q_w
-!       cov(mx,my,nz) : Covariance of Theta_l and Q_w              (K)
-!       el(mx,my,nz)  : Master length scale L                      (m)
+!       tsq(nx,nz,ny) : Variance of Theta_l                      (K^2)
+!       qsq(nx,nz,ny) : Variance of Q_w
+!       cov(nx,nz,ny) : Covariance of Theta_l and Q_w              (K)
+!       el(nx,nz,ny)  : Master length scale L                      (m)
 !                         defined on the walls of the grid boxes
-!       bsh             : no longer used
-!       via common      : Closure constants
 !
 !     Work arrays:        see subroutine mym_level2
-!       pd?(mx,my,nz) : Half of the production terms at Level 2
+!       pd?(nx,nz,ny) : Half of the production terms at Level 2
 !                         defined on the walls of the grid boxes
-!       qkw(mx,my,nz) : q on the walls of the grid boxes         (m/s)
+!       qkw(nx,nz,ny) : q on the walls of the grid boxes         (m/s)
 !
 !     # As to dtl, ...gh, see subroutine mym_turbulence.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_initialize ( kts,kte,&
-       &            dz, zw,  &
-       &            u, v, thl, qw, &
-!       &            ust, rmo, pmz, phh, flt, flq,&
-!JOE-BouLac/PBLH mod
-       &        zi,theta,&
-       &        sh,&
-!JOE-end
-       &            ust, rmo, el,&
-       &            Qke, Tsq, Qsq, Cov)
+  SUBROUTINE  mym_initialize (                                & 
+       &            kts,kte,                                  &
+       &            dz, zw,                                   &
+       &            u, v, thl, qw,                            &
+!       &            ust, rmo, pmz, phh, flt, flq,             &
+       &            zi, theta, sh,                            &
+       &            ust, rmo, el,                             &
+       &            Qke, Tsq, Qsq, Cov, Psig_bl, cldfra_bl1D, &
+       &            bl_mynn_mixlength,                        &
+       &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,    &
+       &            spp_pbl,rstoch_col)
 !
 !-------------------------------------------------------------------
     
     INTEGER, INTENT(IN)   :: kts,kte
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
 !    REAL, INTENT(IN)   :: ust, rmo, pmz, phh, flt, flq
-    REAL, INTENT(IN)   :: ust, rmo
+    REAL, INTENT(IN)   :: ust, rmo, Psig_bl
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw
-
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,cldfra_bl1D,&
+                                          edmf_w1,edmf_a1,edmf_qc1
     REAL, DIMENSION(kts:kte), INTENT(out) :: tsq,qsq,cov
     REAL, DIMENSION(kts:kte), INTENT(inout) :: el,qke
 
@@ -309,11 +444,11 @@ CONTAINS
          &gm,gh,sm,sh,qkw,vt,vq
     INTEGER :: k,l,lmax
     REAL :: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,flt=0.,flq=0.,tmpq
-!JOE-BouLac and PBLH mod
     REAL :: zi
     REAL, DIMENSION(kts:kte) :: theta
-!JOE-end
 
+    REAL, DIMENSION(kts:kte) :: rstoch_col
+    INTEGER ::spp_pbl
 
 !   **  At first ql, vt and vq are set to zero.  **
     DO k = kts,kte
@@ -354,17 +489,18 @@ CONTAINS
 !
     DO l = 1,lmax
 !
-       CALL mym_length ( kts,kte,&
-            &            dz, zw, &
-            &            rmo, flt, flq, &
-            &            vt, vq, &
-            &            qke, &
-            &            dtv, &
-            &            el, &
-!JOE-added for BouLac/PBHL
-            &            zi,theta,&
-!JOE-end
-            &            qkw)
+       CALL mym_length (                     &
+            &            kts,kte,            &
+            &            dz, zw,             &
+            &            rmo, flt, flq,      &
+            &            vt, vq,             &
+            &            qke,                &
+            &            dtv,                &
+            &            el,                 &
+            &            zi,theta,           &
+            &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength,&
+            &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
+            &            spp_pbl,rstoch_col)
 !
        DO k = kts+1,kte
           elq = el(k)*qkw(k)
@@ -429,13 +565,13 @@ CONTAINS
 !     Input variables:    see subroutine mym_initialize
 !
 !     Output variables:
-!       dtl(mx,my,nz) : Vertical gradient of Theta_l             (K/m)
-!       dqw(mx,my,nz) : Vertical gradient of Q_w
-!       dtv(mx,my,nz) : Vertical gradient of Theta_V             (K/m)
-!       gm (mx,my,nz) : G_M divided by L^2/q^2                (s^(-2))
-!       gh (mx,my,nz) : G_H divided by L^2/q^2                (s^(-2))
-!       sm (mx,my,nz) : Stability function for momentum, at Level 2
-!       sh (mx,my,nz) : Stability function for heat, at Level 2
+!       dtl(nx,nz,ny) : Vertical gradient of Theta_l             (K/m)
+!       dqw(nx,nz,ny) : Vertical gradient of Q_w
+!       dtv(nx,nz,ny) : Vertical gradient of Theta_V             (K/m)
+!       gm (nx,nz,ny) : G_M divided by L^2/q^2                (s^(-2))
+!       gh (nx,nz,ny) : G_H divided by L^2/q^2                (s^(-2))
+!       sm (nx,nz,ny) : Stability function for momentum, at Level 2
+!       sh (nx,nz,ny) : Stability function for heat, at Level 2
 !
 !       These are defined on the walls of the grid boxes.
 !
@@ -448,6 +584,12 @@ CONTAINS
 !-------------------------------------------------------------------
 
     INTEGER, INTENT(IN)   :: kts,kte
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq
 
@@ -491,8 +633,8 @@ CONTAINS
        dtz = ( thl(k)-thl(k-1) )/( dzk )
        dqz = ( qw(k)-qw(k-1) )/( dzk )
 !
-       vtt =  1.0 +vt(k)*abk +vt(k-1)*afk
-       vqq =  tv0 +vq(k)*abk +vq(k-1)*afk
+       vtt =  1.0 +vt(k)*abk +vt(k-1)*afk  ! Beta-theta in NN09, Eq. 39
+       vqq =  tv0 +vq(k)*abk +vq(k-1)*afk  ! Beta-q
        dtq =  vtt*dtz +vqq*dqz
 !
        dtl(k) =  dtz
@@ -537,7 +679,12 @@ CONTAINS
        sm (k) = smc*( rf1-rf )/( rf2-rf ) * sh(k)
     END DO
 !
-    RETURN
+!    RETURN
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_level2
 
@@ -549,39 +696,58 @@ CONTAINS
 !     Output variables:   see subroutine mym_initialize
 !
 !     Work arrays:
-!       elt(mx,ny)      : Length scale depending on the PBL depth    (m)
-!       vsc(mx,ny)      : Velocity scale q_c                       (m/s)
+!       elt(nx,ny)      : Length scale depending on the PBL depth    (m)
+!       vsc(nx,ny)      : Velocity scale q_c                       (m/s)
 !                         at first, used for computing elt
 !
 !     NOTE: the mixing lengths are meant to be calculated at the full-
 !           sigmal levels (or interfaces beween the model layers).
 !
-  SUBROUTINE  mym_length ( kts,kte,&
-    &            dz, zw, &
-    &            rmo, flt, flq, &
-    &            vt, vq, &
-    &            qke, &
-    &            dtv, &
-    &            el, &
-    &            zi,theta,&       !JOE-BouLac mod
-    &            qkw)
+  SUBROUTINE  mym_length (                     & 
+    &            kts,kte,                      &
+    &            dz, zw,                       &
+    &            rmo, flt, flq,                &
+    &            vt, vq,                       &
+    &            qke,                          &
+    &            dtv,                          &
+    &            el,                           &
+    &            zi,theta,                     &
+    &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength,&
+    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
+    &            spp_pbl,rstoch_col)
     
 !-------------------------------------------------------------------
 
     INTEGER, INTENT(IN)   :: kts,kte
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
     REAL, DIMENSION(kts:kte), INTENT(in)   :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq
-    REAL, DIMENSION(kts:kte), INTENT(IN)   :: qke,vt,vq
-
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl
+    REAL, DIMENSION(kts:kte), INTENT(IN)   :: qke,vt,vq,cldfra_bl1D,&
+                                          edmf_w1,edmf_a1,edmf_qc1
     REAL, DIMENSION(kts:kte), INTENT(out)  :: qkw, el
     REAL, DIMENSION(kts:kte), INTENT(in)   :: dtv
 
     REAL :: elt,vsc
-!JOE-added for BouLac ML
+
     REAL, DIMENSION(kts:kte), INTENT(IN) :: theta
     REAL, DIMENSION(kts:kte) :: qtke,elBLmin,elBLavg,thetaw
-    REAL :: wt,zi,zi2,h1,h2
+    REAL :: wt,wt2,zi,zi2,h1,h2,hs,elBLmin0,elBLavg0
+
+    ! THE FOLLOWING CONSTANTS ARE IMPORTANT FOR REGULATING THE
+    ! MIXING LENGTHS:
+    REAL :: cns,   &   ! for surface layer (els) in stable conditions
+            alp1,  &   ! for turbulent length scale (elt)
+            alp2,  &   ! for buoyancy length scale (elb)
+            alp3,  &   ! for buoyancy enhancement factor of elb
+            alp4,  &   ! for surface layer (els) in unstable conditions
+            alp5       ! for BouLac mixing length
 
     !THE FOLLOWING LIMITS DO NOT DIRECTLY AFFECT THE ACTUAL PBLH.
     !THEY ONLY IMPOSE LIMITS ON THE CALCULATION OF THE MIXING LENGTH 
@@ -591,138 +757,489 @@ CONTAINS
     REAL, PARAMETER :: maxdz = 750.  !max (half) transition layer depth
                                      !=0.3*2500 m PBLH, so the transition
                                      !layer stops growing for PBLHs > 2.5 km.
-    REAL, PARAMETER :: mindz = 300.  !min (half) transition layer depth
+    REAL, PARAMETER :: mindz = 300.  !300  !min (half) transition layer depth
 
     !SURFACE LAYER LENGTH SCALE MODS TO REDUCE IMPACT IN UPPER BOUNDARY LAYER
     REAL, PARAMETER :: ZSLH = 100. ! Max height correlated to surface conditions (m)
     REAL, PARAMETER :: CSL = 2.    ! CSL = constant of proportionality to L O(1)
     REAL :: z_m
 
-!Joe-end
 
     INTEGER :: i,j,k
-    REAL :: afk,abk,zwk,dzk,qdz,vflx,bv,elb,els,elf
+    REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,elb,els,els1,elf, &
+            & el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,PBLH_PLUS_ENT,el_les
+
+    INTEGER, INTENT(IN)   :: spp_pbl
+    REAL, DIMENSION(kts:kte), INTENT(in)   :: rstoch_col
 
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
-!
-!JOE-added to impose limits on the height integration for elt as well 
-!    as the transition layer depth
-    IF ( BLmod .EQ. 0. ) THEN
-       zi2=5000.  !originally integrated to model top, not just 5000 m.
-    ELSE
-       zi2=MAX(zi,minzi)
-    ENDIF
-    h1=MAX(0.3*zi2,mindz)
-    h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
-    h2=h1/2.0                ! 1/4 transition layer depth
 
-    qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
-    thetaw(kts)=theta(kts)          !theta at full-sigma levels
-!JOE-end
-    qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+    SELECT CASE(bl_mynn_mixlength)
 
-    DO k = kts+1,kte
-       afk = dz(k)/( dz(k)+dz(k-1) )
-       abk = 1.0 -afk
-       qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
+      CASE (0) ! ORIGINAL MYNN MIXING LENGTH
 
-!JOE- BouLac Start 
-       qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
-       thetaw(k)= theta(k)*abk + theta(k-1)*afk
-!JOE- BouLac End
+        cns  = 2.7
+        alp1 = 0.23
+        alp2 = 1.0
+        alp3 = 5.0
+        alp4 = 100.
+        alp5 = 0.4
 
-    END DO
-!
-    elt = 1.0e-5
-    vsc = 1.0e-5
-!
-!   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
-!JOE-Lt mod: only integrate to top of PBL (+ transition/entrainment
-!   layer), since TKE aloft is not relevant. Make WHILE loop, so it
-!   exits after looping through the boundary layer.
-!
-     k = kts+1
-     zwk = zw(k)
-     DO WHILE (zwk .LE. MIN((zi2+h1), 4000.)) !JOE: 20130523 reduce too high diffusivity over mts 
-       dzk = 0.5*( dz(k)+dz(k-1) )
-       qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
-             elt = elt +qdz*zwk
-             vsc = vsc +qdz
-       k   = k+1
-       zwk = zw(k)
-    END DO
-!
-    elt =  alp1*elt/vsc
-    vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
-    vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
-!
-!   **  Strictly, el(i,j,1) is not zero.  **
-    el(kts) = 0.0
-!
-!JOE- BouLac Start
-    IF ( BLmod .GT. 0. ) THEN
-       ! COMPUTE BouLac mixing length
-       CALL boulac_length(kts,kte,zw,dz,qtke,thetaw,elBLmin,elBLavg)
-    ENDIF
-!JOE- BouLac END
+        ! Impose limits on the height integration for elt and the transition layer depth
+        zi2  = MIN(10000.,zw(kte-2))  !originally integrated to model top, not just 10 km.
+        h1=MAX(0.3*zi2,mindz)
+        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        h2=h1/2.0                ! 1/4 transition layer depth
 
-    DO k = kts+1,kte
-       zwk = zw(k)              !full-sigma levels
+        qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+        DO k = kts+1,kte
+           afk = dz(k)/( dz(k)+dz(k-1) )
+           abk = 1.0 -afk
+           qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
+        END DO
 
-!   **  Length scale limited by the buoyancy effect  **
-       IF ( dtv(k) .GT. 0.0 ) THEN
-          bv  = SQRT( gtr*dtv(k) )
-          elb = alp2*qkw(k) / bv &
-               &       *( 1.0 + alp3/alp2*&
-               &SQRT( vsc/( bv*elt ) ) )
+        elt = 1.0e-5
+        vsc = 1.0e-5        
 
-          elf = alp2 * qkw(k)/bv
-       ELSE
-          elb = 1.0e10
-          elf = elb
-       END IF
-!
-       z_m = MAX(ZSLH,CSL*zwk*rmo)
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        k = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. zi2+h1)
+           dzk = 0.5*( dz(k)+dz(k-1) )
+           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
 
-!   **  Length scale in the surface layer  **
-       IF ( rmo .GT. 0.0 ) THEN
-       !   IF ( zwk <= z_m ) THEN  ! use original cns
-             els = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
-             !els = vk*zwk/(1.0+cns*MIN( 0.5*zw(kts+1)*rmo, zmax ))
-       !   ELSE
-       !      !blend to neutral values (kz) above z_m
-       !      els = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax )) + vk*(zwk - z_m)
-       !   ENDIF
-       ELSE
-          els =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
-       END IF
-!
-!   ** HARMONC AVERGING OF MIXING LENGTH SCALES: 
-!       el(k) =      MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-!       el(k) =      elb/( elb/elt+elb/els+1.0 )
-!JOE- BouLac Start
-       IF ( BLmod .EQ. 0. ) THEN
-          el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-       ELSE
-          !add blending to use BouLac mixing length in free atmos;
-          !defined relative to the PBLH (zi) + transition layer (h1)
-          el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-          wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
-          el(k) = el(k)*(1.-wt) + alp5*elBLmin(k)*wt
-       ENDIF
-!JOE- BouLac End
+        elt =  alp1*elt/vsc
+        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
 
-       !IF (el(k) > 1000.) THEN
-       !   print*,"SUSPICIOUSLY LARGE Lm:",el(k),k
-       !ENDIF
-    END DO
-!
-    RETURN
+        !   **  Strictly, el(i,j,1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)
+
+        DO k = kts+1,kte
+           zwk = zw(k)              !full-sigma levels
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              bv  = SQRT( gtr*dtv(k) )
+              elb = alp2*qkw(k) / bv &
+                  &       *( 1.0 + alp3/alp2*&
+                  &SQRT( vsc/( bv*elt ) ) )
+              elf = alp2 * qkw(k)/bv
+
+           ELSE
+              elb = 1.0e10
+              elf = elb
+           ENDIF
+
+           z_m = MAX(0.,zwk - 4.)
+
+           !   **  Length scale in the surface layer  **
+           IF ( rmo .GT. 0.0 ) THEN
+              els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+           ELSE
+              els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+              els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+           END IF
+
+           !   ** HARMONC AVERGING OF MIXING LENGTH SCALES:
+           !       el(k) =      MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           !       el(k) =      elb/( elb/elt+elb/els+1.0 )
+
+           wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
+
+           el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+
+        END DO
+
+      CASE (1) !OPERATIONAL FORM OF MIXING LENGTH
+
+        cns  = 2.3
+        alp1 = 0.23
+        alp2 = 0.65
+        alp3 = 3.0
+        alp4 = 20.
+        alp5 = 0.4
+
+        ! Impose limits on the height integration for elt and the transition layer depth
+        zi2=MAX(zi,minzi)
+        h1=MAX(0.3*zi2,mindz)
+        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        h2=h1/2.0                ! 1/4 transition layer depth
+
+        qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
+        thetaw(kts)=theta(kts)          !theta at full-sigma levels
+        qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+
+        DO k = kts+1,kte
+           afk = dz(k)/( dz(k)+dz(k-1) )
+           abk = 1.0 -afk
+           qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
+           qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
+           thetaw(k)= theta(k)*abk + theta(k-1)*afk
+        END DO
+
+        elt = 1.0e-5
+        vsc = 1.0e-5
+
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        k = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. zi2+h1)
+           dzk = 0.5*( dz(k)+dz(k-1) )
+           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
+
+        elt =  alp1*elt/vsc
+        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
+
+        !   **  Strictly, el(i,j,1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)              !full-sigma levels
+
+        ! COMPUTE BouLac mixing length
+        CALL boulac_length(kts,kte,zw,dz,qtke,thetaw,elBLmin,elBLavg)
+
+        DO k = kts+1,kte
+           zwk = zw(k)              !full-sigma levels
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              bv  = SQRT( gtr*dtv(k) ) 
+              elb = alp2*qkw(k) / bv &                ! formulation,
+                  &       *( 1.0 + alp3/alp2*&       ! except keep
+                  &SQRT( vsc/( bv*elt ) ) )          ! elb bounded by
+              elb = MIN(elb, zwk)                     ! zwk
+              elf = alp2 * qkw(k)/bv
+           ELSE
+              elb = 1.0e10
+              elf = elb
+           ENDIF
+
+           z_m = MAX(0.,zwk - 4.)
+
+           !   **  Length scale in the surface layer  **
+           IF ( rmo .GT. 0.0 ) THEN
+              els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+              els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+           ELSE
+              els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+              els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+           END IF
+
+           !   ** NOW BLEND THE MIXING LENGTH SCALES:
+           wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
+
+           !add blending to use BouLac mixing length in free atmos;
+           !defined relative to the PBLH (zi) + transition layer (h1)
+           el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           el(k) = el(k)*(1.-wt) + alp5*elBLmin(k)*wt
+
+           ! include scale-awareness, except for original MYNN
+           el(k) = el(k)*Psig_bl
+
+         END DO
+
+      CASE (2) !Experimental mixing length formulation
+
+        cns  = 3.5
+        alp1 = 0.23
+        alp2 = 0.3
+        alp3 = 2.0
+        alp4 = 10.
+        alp5 = 0.3 !obsolete?
+
+        ! Impose limits on the height integration for elt and the transition layer depth
+        zi2=MAX(zi,minzi)
+        h1=MAX(0.3*zi2,mindz)
+        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
+        h2=h1/2.0                ! 1/4 transition layer depth
+
+        qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
+        qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
+
+        DO k = kts+1,kte
+           afk = dz(k)/( dz(k)+dz(k-1) )
+           abk = 1.0 -afk
+           qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
+           qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
+        END DO
+
+        elt = 1.0e-5
+        vsc = 1.0e-5
+
+        !   **  Strictly, zwk*h(i,j) -> ( zwk*h(i,j)+z0 )  **
+        PBLH_PLUS_ENT = MAX(zi, 100.)
+        k = kts+1
+        zwk = zw(k)
+        DO WHILE (zwk .LE. PBLH_PLUS_ENT)
+           dzk = 0.5*( dz(k)+dz(k-1) )
+           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk  !consider reducing 0.3
+           elt = elt +qdz*zwk
+           vsc = vsc +qdz
+           k   = k+1
+           zwk = zw(k)
+        END DO
+
+        elt =  MAX(alp1*elt/vsc, 10.)
+        vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
+
+        !   **  Strictly, el(i,j,1) is not zero.  **
+        el(kts) = 0.0
+        zwk1    = zw(kts+1)
+
+        DO k = kts+1,kte
+           zwk = zw(k)              !full-sigma levels
+
+           !   **  Length scale limited by the buoyancy effect  **
+           IF ( dtv(k) .GT. 0.0 ) THEN
+              bv  = SQRT( gtr*dtv(k) )
+              !elb_mf = alp2*qkw(k) / bv  &
+              elb_mf = alp2*MAX(qkw(k),edmf_a1(k)*edmf_w1(k)) / bv  &
+                  &       *( 1.0 + alp3/alp2*&
+                  &SQRT( vsc/( bv*elt ) ) )
+              elb = MIN(alp2*qkw(k)/bv, zwk)
+              elf = elb/(1. + (elb/600.))  !bound free-atmos mixing length to < 600 m.
+              !IF (zwk > zi .AND. elf > 400.) THEN
+              !   ! COMPUTE BouLac mixing length
+              !   !CALL boulac_length0(k,kts,kte,zw,dz,qtke,thetaw,elBLmin0,elBLavg0)
+              !   !elf = alp5*elBLavg0
+              !   elf = MIN(MAX(50.*SQRT(qtke(k)), 400.), zwk)
+              !ENDIF
+
+           ELSE
+              ! use version in development for RAP/HRRR 2016
+              ! JAYMES-
+              ! tau_cloud is an eddy turnover timescale;
+              ! see Teixeira and Cheinet (2004), Eq. 1, and
+              ! Cheinet and Teixeira (2003), Eq. 7.  The
+              ! coefficient 0.5 is tuneable. Expression in
+              ! denominator is identical to vsc (a convective
+              ! velocity scale), except that elt is relpaced
+              ! by zi, and zero is replaced by 1.0e-4 to
+              ! prevent division by zero.
+              tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(flt,1.0e-4))**(1.0/3.0)),10.),100.)
+              !minimize influence of surface heat flux on tau far away from the PBLH.
+              wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
+              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
+
+              elb = MIN(tau_cloud*SQRT(MIN(qtke(k),50.)), zwk)
+              elf = elb
+              elb_mf = elb
+         END IF
+
+         z_m = MAX(0.,zwk - 4.)
+
+         !   **  Length scale in the surface layer  **
+         IF ( rmo .GT. 0.0 ) THEN
+            els  = vk*zwk/(1.0+cns*MIN( zwk*rmo, zmax ))
+            els1 = vk*z_m/(1.0+cns*MIN( zwk*rmo, zmax ))
+         ELSE
+            els  =  vk*zwk*( 1.0 - alp4* zwk*rmo )**0.2
+            els1 =  vk*z_m*( 1.0 - alp4* zwk*rmo )**0.2
+         END IF
+
+         !   ** NOW BLEND THE MIXING LENGTH SCALES:
+         wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
+
+         ! "el_unstab" = blended els-elt
+         el_unstab = els/(1. + (els1/elt))
+         el(k) = MIN(el_unstab, elb_mf)
+         el(k) = el(k)*(1.-wt) + elf*wt
+
+         ! include scale-awareness. For now, use simple asymptotic kz -> 12 m.
+         el_les= MIN(els/(1. + (els1/12.)), elb_mf)
+         el(k) = el(k)*Psig_bl + (1.-Psig_bl)*el_les
+
+       END DO
+
+    END SELECT
+
+
+!   Stochastic perturbations of turbulent mixing length
+    if (spp_pbl==1) then
+       DO k = kts+1,kte
+         if (k.lt.25) then
+            zwk = zw(k)
+            el(k)= el(k) + el(k)* rstoch_col(k) * 1.5 * MAX(exp(-MAX(zwk-3000.,0.0)/2000.),0.01)
+         endif
+       END DO
+    endif
+
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_length
 
 !JOE- BouLac Code Start -
+
+! ==================================================================
+  SUBROUTINE boulac_length0(k,kts,kte,zw,dz,qtke,theta,lb1,lb2)
+!
+!    NOTE: This subroutine was taken from the BouLac scheme in WRF-ARW
+!          and modified for integration into the MYNN PBL scheme.
+!          WHILE loops were added to reduce the computational expense.
+!          This subroutine computes the length scales up and down
+!          and then computes the min, average of the up/down
+!          length scales, and also considers the distance to the
+!          surface.
+!
+!      dlu = the distance a parcel can be lifted upwards give a finite
+!            amount of TKE.
+!      dld = the distance a parcel can be displaced downwards given a
+!            finite amount of TKE.
+!      lb1 = the minimum of the length up and length down
+!      lb2 = the average of the length up and length down
+!-------------------------------------------------------------------
+
+     INTEGER, INTENT(IN) :: k,kts,kte
+     REAL, DIMENSION(kts:kte), INTENT(IN) :: qtke,dz,theta
+     REAL, INTENT(OUT) :: lb1,lb2
+     REAL, DIMENSION(kts:kte+1), INTENT(IN) :: zw
+
+     !LOCAL VARS
+     INTEGER :: izz, found
+     REAL :: dlu,dld
+     REAL :: dzt, zup, beta, zup_inf, bbb, tl, zdo, zdo_sup, zzz
+
+
+     !----------------------------------
+     ! FIND DISTANCE UPWARD             
+     !----------------------------------
+     zup=0.
+     dlu=zw(kte+1)-zw(k)-dz(k)/2.
+     zzz=0.
+     zup_inf=0.
+     beta=g/theta(k)           !Buoyancy coefficient
+
+     !print*,"FINDING Dup, k=",k," zw=",zw(k)
+
+     if (k .lt. kte) then      !cant integrate upwards from highest level
+        found = 0
+        izz=k
+        DO WHILE (found .EQ. 0)
+
+           if (izz .lt. kte) then
+              dzt=dz(izz)                    ! layer depth above
+              zup=zup-beta*theta(k)*dzt     ! initial PE the parcel has at k
+              !print*,"  ",k,izz,theta(izz),dz(izz)
+              zup=zup+beta*(theta(izz+1)+theta(izz))*dzt/2. ! PE gained by lifting a parcel to izz+1
+              zzz=zzz+dzt                   ! depth of layer k to izz+1
+              !print*,"  PE=",zup," TKE=",qtke(k)," z=",zw(izz)
+              if (qtke(k).lt.zup .and. qtke(k).ge.zup_inf) then
+                 bbb=(theta(izz+1)-theta(izz))/dzt
+                 if (bbb .ne. 0.) then
+                    !fractional distance up into the layer where TKE becomes < PE
+                    tl=(-beta*(theta(izz)-theta(k)) + &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2. + &
+                      &       2.*bbb*beta*(qtke(k)-zup_inf))))/bbb/beta
+                 else
+                    if (theta(izz) .ne. theta(k))then
+                       tl=(qtke(k)-zup_inf)/(beta*(theta(izz)-theta(k)))
+                    else
+                       tl=0.
+                    endif
+                 endif
+                 dlu=zzz-dzt+tl
+                 !print*,"  FOUND Dup:",dlu," z=",zw(izz)," tl=",tl
+                 found =1
+              endif
+              zup_inf=zup
+              izz=izz+1
+           ELSE
+              found = 1
+           ENDIF
+
+        ENDDO
+
+     endif
+
+     !----------------------------------
+     ! FIND DISTANCE DOWN               
+     !----------------------------------
+     zdo=0.
+     zdo_sup=0.
+     dld=zw(k)
+     zzz=0.
+
+     !print*,"FINDING Ddown, k=",k," zwk=",zw(k)
+     if (k .gt. kts) then  !cant integrate downwards from lowest level
+
+        found = 0
+        izz=k
+        DO WHILE (found .EQ. 0)
+
+           if (izz .gt. kts) then
+              dzt=dz(izz-1)
+              zdo=zdo+beta*theta(k)*dzt
+              !print*,"  ",k,izz,theta(izz),dz(izz-1)
+              zdo=zdo-beta*(theta(izz-1)+theta(izz))*dzt/2.
+              zzz=zzz+dzt
+              !print*,"  PE=",zdo," TKE=",qtke(k)," z=",zw(izz)
+              if (qtke(k).lt.zdo .and. qtke(k).ge.zdo_sup) then
+                 bbb=(theta(izz)-theta(izz-1))/dzt
+                 if (bbb .ne. 0.) then
+                    tl=(beta*(theta(izz)-theta(k))+ &
+                      & sqrt( max(0.,(beta*(theta(izz)-theta(k)))**2. + &
+                      &       2.*bbb*beta*(qtke(k)-zdo_sup))))/bbb/beta
+                 else
+                    if (theta(izz) .ne. theta(k)) then
+                       tl=(qtke(k)-zdo_sup)/(beta*(theta(izz)-theta(k)))
+                    else
+                       tl=0.
+                    endif
+                 endif
+                 dld=zzz-dzt+tl
+                 !print*,"  FOUND Ddown:",dld," z=",zw(izz)," tl=",tl
+                 found = 1
+              endif
+              zdo_sup=zdo
+              izz=izz-1
+           ELSE
+              found = 1
+           ENDIF
+        ENDDO
+
+     endif
+
+     !----------------------------------
+     ! GET MINIMUM (OR AVERAGE)         
+     !----------------------------------
+     !The surface layer length scale can exceed z for large z/L,
+     !so keep maximum distance down > z.
+     dld = min(dld,zw(k+1))!not used in PBL anyway, only free atmos
+     lb1 = min(dlu,dld)     !minimum
+     !JOE-fight floating point errors
+     dlu=MAX(0.1,MIN(dlu,1000.))
+     dld=MAX(0.1,MIN(dld,1000.))
+     lb2 = sqrt(dlu*dld)    !average - biased towards smallest
+     !lb2 = 0.5*(dlu+dld)   !average
+
+     if (k .eq. kte) then
+        lb1 = 0.
+        lb2 = 0.
+     endif
+     !print*,"IN MYNN-BouLac",k,lb1
+     !print*,"IN MYNN-BouLac",k,dld,dlu
+
+  END SUBROUTINE boulac_length0
+
 ! ==================================================================
   SUBROUTINE boulac_length(kts,kte,zw,dz,qtke,theta,lb1,lb2)
 !
@@ -864,6 +1381,9 @@ CONTAINS
         !so keep maximum distance down > z.
         dld(iz) = min(dld(iz),zw(iz+1))!not used in PBL anyway, only free atmos
         lb1(iz) = min(dlu(iz),dld(iz))     !minimum
+        !JOE-fight floating point errors
+        dlu(iz)=MAX(0.1,MIN(dlu(iz),1000.))
+        dld(iz)=MAX(0.1,MIN(dld(iz),1000.))
         lb2(iz) = sqrt(dlu(iz)*dld(iz))    !average - biased towards smallest
         !lb2(iz) = 0.5*(dlu(iz)+dld(iz))   !average
 
@@ -894,17 +1414,17 @@ CONTAINS
 !     # ql, vt, vq, qke, tsq, qsq and cov are changed to input variables.
 !
 !     Output variables:   see subroutine mym_initialize
-!       dfm(mx,my,nz) : Diffusivity coefficient for momentum,
+!       dfm(nx,nz,ny) : Diffusivity coefficient for momentum,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       dfh(mx,my,nz) : Diffusivity coefficient for heat,
+!       dfh(nx,nz,ny) : Diffusivity coefficient for heat,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       dfq(mx,my,nz) : Diffusivity coefficient for q^2,
+!       dfq(nx,nz,ny) : Diffusivity coefficient for q^2,
 !                         divided by dz (not dz*h(i,j))            (m/s)
-!       tcd(mx,my,nz)   : Countergradient diffusion term for Theta_l
+!       tcd(nx,nz,ny)   : Countergradient diffusion term for Theta_l
 !                                                                  (K/s)
-!       qcd(mx,my,nz)   : Countergradient diffusion term for Q_w
+!       qcd(nx,nz,ny)   : Countergradient diffusion term for Q_w
 !                                                              (kg/kg s)
-!       pd?(mx,my,nz) : Half of the production terms
+!       pd?(nx,nz,ny) : Half of the production terms
 !
 !       Only tcd and qcd are defined at the center of the grid boxes
 !
@@ -916,46 +1436,51 @@ CONTAINS
 !     # dtl, dqw, dtv, gm and gh are allowed to share storage units with
 !       dfm, dfh, dfq, tcd and qcd, respectively, for saving memory.
 !
-  SUBROUTINE  mym_turbulence ( kts,kte,&
-    &            levflag, &
-    &            dz, zw, &
-    &            u, v, thl, ql, qw, &
-    &            qke, tsq, qsq, cov, &
-    &            vt, vq,&
-    &            rmo, flt, flq, &
-!JOE-BouLac/PBLH test
-    &            zi,theta,&
-    &            sh,&
-!JOE-end
-    &            El,&
-    &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc &
-!JOE-TKE BUDGET
-    &		 ,qWT1D,qSHEAR1D,qBUOY1D,qDISS1D &
-    &            ,bl_mynn_tkebudget &
-!JOE-end
-    &)
+  SUBROUTINE  mym_turbulence (                                &
+    &            kts,kte,                                     &
+    &            levflag,                                     &
+    &            dz, zw,                                      &
+    &            u, v, thl, ql, qw,                           &
+    &            qke, tsq, qsq, cov,                          &
+    &            vt, vq,                                      &
+    &            rmo, flt, flq,                               &
+    &            zi,theta,                                    &
+    &            sh,                                          &
+    &            El,                                          &
+    &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
+    &		 qWT1D,qSHEAR1D,qBUOY1D,qDISS1D,              &
+    &            bl_mynn_tkebudget,                           &
+    &            Psig_bl,Psig_shcu,cldfra_bl1D,bl_mynn_mixlength,&
+    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,       &
+    &            TKEprodTD,                                   &
+    &            spp_pbl,rstoch_col)
 
 !-------------------------------------------------------------------
 !
     INTEGER, INTENT(IN)   :: kts,kte
-    INTEGER, INTENT(IN)   :: levflag
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    INTEGER, INTENT(IN)   :: levflag,bl_mynn_mixlength,bl_mynn_edmf
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
-    REAL, INTENT(in) :: rmo,flt,flq   
+    REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu
     REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,& 
-         &ql,vt,vq,qke,tsq,qsq,cov
+         &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,edmf_qc1,&
+         &TKEprodTD
 
     REAL, DIMENSION(kts:kte), INTENT(out) :: dfm,dfh,dfq,&
          &pdk,pdt,pdq,pdc,tcd,qcd,el
 
-!JOE-TKE BUDGET
     REAL, DIMENSION(kts:kte), INTENT(inout) :: &
          qWT1D,qSHEAR1D,qBUOY1D,qDISS1D
     REAL :: q3sq_old,dlsq1,qWTP_old,qWTP_new
     REAL :: dudz,dvdz,dTdz,&
             upwp,vpwp,Tpwp
     INTEGER, INTENT(in) :: bl_mynn_tkebudget
-!JOE-end
 
     REAL, DIMENSION(kts:kte) :: qkw,dtl,dqw,dtv,gm,gh,sm,sh
 
@@ -964,16 +1489,24 @@ CONTAINS
     REAL :: e6c,dzk,afk,abk,vtt,vqq,&
          &cw25,clow,cupp,gamt,gamq,smd,gamv,elq,elh
 
-!JOE-added for BouLac/PBLH test
     REAL :: zi
     REAL, DIMENSION(kts:kte), INTENT(in) :: theta
-!JOE-end
 
     REAL ::  a2den, duz, ri, HLmod  !JOE-Canuto/Kitamura mod
+!JOE-stability criteria for cw
+    REAL:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2
+!JOE-end
 
     DOUBLE PRECISION  q2sq, t2sq, r2sq, c2sq, elsq, gmel, ghel
     DOUBLE PRECISION  q3sq, t3sq, r3sq, c3sq, dlsq, qdiv
     DOUBLE PRECISION  e1, e2, e3, e4, enum, eden, wden
+
+!   Stochastic
+    INTEGER,  INTENT(IN)                          ::    spp_pbl
+    REAL, DIMENSION(KTS:KTE)                      ::    rstoch_col
+    REAL :: prlimit
+
+
 !
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
@@ -993,15 +1526,18 @@ CONTAINS
     &            ql, vt, vq, &
     &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
-    CALL mym_length (kts,kte, &
-    &            dz, zw, &
-    &            rmo, flt, flq, &
-    &            vt, vq, &
-    &            qke, &
-    &            dtv, &
-    &            el, &
-    &            zi,theta,&  !JOE-hybrid PBLH
-    &            qkw)
+    CALL mym_length (                           &
+    &            kts,kte,                       &
+    &            dz, zw,                        &
+    &            rmo, flt, flq,                 &
+    &            vt, vq,                        &
+    &            qke,                           &
+    &            dtv,                           &
+    &            el,                            &
+    &            zi,theta,                      &
+    &            qkw,Psig_bl,cldfra_bl1D,bl_mynn_mixlength, &
+    &            edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf, &
+    &            spp_pbl,rstoch_col)
 !
 
     DO k = kts+1,kte
@@ -1028,72 +1564,83 @@ CONTAINS
        gmel = gm (k)*elsq
        ghel = gh (k)*elsq
 !  Modified: Dec/22/2005, up to here
-!
-!JOE-add prints
-       IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-          PRINT*,"MYM_TURBULENCE2.0: k=",k," sh=",sh(k)
-          PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-          PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-          PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-          PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
+
+       ! Level 2.0 debug prints
+       IF ( debug_code ) THEN
+         IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
+           print*,"MYNN; mym_turbulence2.0; sh=",sh(k)," k=",k
+           print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)," ri=",ri
+           print*," PBLH=",zi," u=",u(k)," v=",v(k)
+         ENDIF
        ENDIF
+
 !JOE-Apply Helfand & Labraga stability check for all Ric
-!    when CKmod == 1. Suggested by Kitamura. Not applied below.
+!      when CKmod == 1. (currently not forced below)
        IF (CKmod .eq. 1) THEN
           HLmod = q2sq -1.
        ELSE
           HLmod = q3sq
        ENDIF
+
 !     **  Since qkw is set to more than 0.0, q3sq > 0.0.  **
+
+!JOE-test new stability criteria in level 2.5 (as well as level 3) - little/no impact
+!     **  Limitation on q, instead of L/q  **
+          dlsq =  elsq
+          IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
+!JOE-end
+
        IF ( q3sq .LT. q2sq ) THEN
-!       IF ( HLmod .LT. q2sq ) THEN
-!JOE-END
+       !IF ( HLmod .LT. q2sq ) THEN
+          !Apply Helfand & Labraga mod
           qdiv = SQRT( q3sq/q2sq )   !HL89: (1-alfa)
           sm(k) = sm(k) * qdiv
           sh(k) = sh(k) * qdiv
 !
-!JOE-Canuto/Kitamura mod
-!          e1   = q3sq - e1c*ghel * qdiv**2
-!          e2   = q3sq - e2c*ghel * qdiv**2
-!          e3   = e1   + e3c*ghel * qdiv**2
-!          e4   = e1   - e4c*ghel * qdiv**2
+          !JOE-Canuto/Kitamura mod
+          !e1   = q3sq - e1c*ghel * qdiv**2
+          !e2   = q3sq - e2c*ghel * qdiv**2
+          !e3   = e1   + e3c*ghel * qdiv**2
+          !e4   = e1   - e4c*ghel * qdiv**2
           e1   = q3sq - e1c*ghel/a2den * qdiv**2
           e2   = q3sq - e2c*ghel/a2den * qdiv**2
           e3   = e1   + e3c*ghel/(a2den**2) * qdiv**2
           e4   = e1   - e4c*ghel/a2den * qdiv**2
-!JOE-end
           eden = e2*e4 + e3*e5c*gmel * qdiv**2
           eden = MAX( eden, 1.0d-20 )
        ELSE
-!JOE-Canuto/Kitamura mod
-!          e1   = q3sq - e1c*ghel
-!          e2   = q3sq - e2c*ghel
-!          e3   = e1   + e3c*ghel
-!          e4   = e1   - e4c*ghel
+          !JOE-Canuto/Kitamura mod
+          !e1   = q3sq - e1c*ghel
+          !e2   = q3sq - e2c*ghel
+          !e3   = e1   + e3c*ghel
+          !e4   = e1   - e4c*ghel
           e1   = q3sq - e1c*ghel/a2den
           e2   = q3sq - e2c*ghel/a2den
           e3   = e1   + e3c*ghel/(a2den**2)
           e4   = e1   - e4c*ghel/a2den
-!JOE-end
           eden = e2*e4 + e3*e5c*gmel
           eden = MAX( eden, 1.0d-20 )
-!
+
           qdiv = 1.0
           sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
-!JOE-Canuto/Kitamura mod
-!          sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          !JOE-Canuto/Kitamura mod
+          !sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
           sh(k) = q3sq*(a2/a2den)*( e2+3.0*c1*e5c*gmel )/eden
-!JOE-end
-       END IF
-!
-!      HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
-       IF (sh(k)<0.0 .OR. sm(k)<0.0 .OR. &
+       END IF !end Helfand & Labraga check
+
+       !JOE: Level 2.5 debug prints
+       ! HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
+       IF ( debug_code ) THEN
+         IF (sh(k)<0.0 .OR. sm(k)<0.0 .OR. &
            sh(k) > 0.76*b2 .or. (sm(k)**2*gm(k) .gt. .44**2)) THEN
-          PRINT*,"MYM_TURBULENCE2.5: k=",k," sh=",sh(k)
-          PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-          PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-          PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-          PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
+           print*,"MYNN; mym_turbulence2.5; sh=",sh(k)," k=",k
+           print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)," ri=",ri
+           print*," PBLH=",zi," u=",u(k)," v=",v(k)
+         ENDIF
        ENDIF
 
 !   **  Level 3 : start  **
@@ -1104,7 +1651,7 @@ CONTAINS
           t3sq = MAX( tsq(k)*abk+tsq(k-1)*afk, 0.0 )
           r3sq = MAX( qsq(k)*abk+qsq(k-1)*afk, 0.0 )
           c3sq =      cov(k)*abk+cov(k-1)*afk
-!
+
 !  Modified: Dec/22/2005, from here
           c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
 !
@@ -1124,26 +1671,55 @@ CONTAINS
           IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
 !
 !     **  Limitation on c3sq (0.12 =< cw =< 0.76) **
-!JOE-Canuto/Kitamura mod
-!          e2   = q3sq - e2c*ghel * qdiv**2
-!          e3   = q3sq + e3c*ghel * qdiv**2
-!          e4   = q3sq - e4c*ghel * qdiv**2
+          !JOE: use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
+          ! to calculate an exact limit for c3sq:
+          auh = 27.*a1*((a2/a2den)**2)*b2*(g/tref)**2
+          aum = 54.*(a1**2)*(a2/a2den)*b2*c1*(g/tref)
+          adh = 9.*a1*((a2/a2den)**2)*(12.*a1 + 3.*b2)*(g/tref)**2
+          adm = 18.*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))*(g/tref)
+
+          aeh = (9.*a1*((a2/a2den)**2)*b1 +9.*a1*((a2/a2den)**2)* &
+                (12.*a1 + 3.*b2))*(g/tref)
+          aem = 3.*a1*(a2/a2den)*b1*(3.*(a2/a2den) + 3.*b2*c1 + &
+                (18.*a1*c1 - b2)) + &
+                (18.)*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))
+
+          Req = -aeh/aem
+          Rsl = (auh + aum*Req)/(3.*adh + 3.*adm*Req)
+          !For now, use default values, since tests showed little/no sensitivity
+          Rsl = .12             !lower limit
+          Rsl2= 1.0 - 2.*Rsl    !upper limit
+          !IF (k==2)print*,"Dynamic limit RSL=",Rsl
+          !IF (Rsl < 0.10 .OR. Rsl > 0.18) THEN
+          !   wrf_err_message = '--- ERROR: MYNN: Dynamic Cw '// &
+          !        'limit exceeds reasonable limits'
+          !   CALL wrf_message ( wrf_err_message )
+          !   WRITE ( mynn_message , FMT='(A,F8.3)' ) &
+          !   " MYNN: Dynamic Cw limit needs attention=",Rsl
+          !   CALL wrf_debug ( 0 , mynn_message )
+          !ENDIF
+
+          !JOE-Canuto/Kitamura mod
+          !e2   = q3sq - e2c*ghel * qdiv**2
+          !e3   = q3sq + e3c*ghel * qdiv**2
+          !e4   = q3sq - e4c*ghel * qdiv**2
           e2   = q3sq - e2c*ghel/a2den * qdiv**2
           e3   = q3sq + e3c*ghel/(a2den**2) * qdiv**2
           e4   = q3sq - e4c*ghel/a2den * qdiv**2
-!JOE-end
           eden = e2*e4  + e3 *e5c*gmel * qdiv**2
-!
-!JOE-Canuto/Kitamura mod
-!          wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
-!               &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
+
+          !JOE-Canuto/Kitamura mod
+          !wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
+          !     &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
           wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
                &        *( e2*e4c/a2den - e3c*e5c*gmel/(a2den**2) * qdiv**2 )
-!JOE-end
-!
+
           IF ( wden .NE. 0.0 ) THEN
-             clow = q3sq*( 0.12-cw25 )*eden/wden
-             cupp = q3sq*( 0.76-cw25 )*eden/wden
+             !JOE: test dynamic limits
+             !clow = q3sq*( 0.12-cw25 )*eden/wden
+             !cupp = q3sq*( 0.76-cw25 )*eden/wden
+             clow = q3sq*( Rsl -cw25 )*eden/wden
+             cupp = q3sq*( Rsl2-cw25 )*eden/wden
 !
              IF ( wden .GT. 0.0 ) THEN
                 c3sq  = MIN( MAX( c3sq, c2sq+clow ), c2sq+cupp )
@@ -1155,56 +1731,61 @@ CONTAINS
           e1   = e2 + e5c*gmel * qdiv**2
           eden = MAX( eden, 1.0d-20 )
 !  Modified: Dec/22/2005, up to here
-!
-!JOE-Canuto/Kitamura mod
-!          e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
+
+          !JOE-Canuto/Kitamura mod
+          !e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
           e6c  = 3.0*(a2/a2den)*cc3*gtr * dlsq/elsq
-!JOE-end
-!
-!     **  for Gamma_theta  **
-!!          enum = qdiv*e6c*( t3sq-t2sq )
+
+          !============================
+          !     **  for Gamma_theta  **
+          !!          enum = qdiv*e6c*( t3sq-t2sq )
           IF ( t2sq .GE. 0.0 ) THEN
              enum = MAX( qdiv*e6c*( t3sq-t2sq ), 0.0d0 )
           ELSE
              enum = MIN( qdiv*e6c*( t3sq-t2sq ), 0.0d0 )
           ENDIF
-
           gamt =-e1  *enum    /eden
-!
-!     **  for Gamma_q  **
-!!          enum = qdiv*e6c*( r3sq-r2sq )
+
+          !============================
+          !     **  for Gamma_q  **
+          !!          enum = qdiv*e6c*( r3sq-r2sq )
           IF ( r2sq .GE. 0.0 ) THEN
              enum = MAX( qdiv*e6c*( r3sq-r2sq ), 0.0d0 )
           ELSE
              enum = MIN( qdiv*e6c*( r3sq-r2sq ), 0.0d0 )
           ENDIF
-
           gamq =-e1  *enum    /eden
-!
-!     **  for Sm' and Sh'd(Theta_V)/dz  **
-!!          enum = qdiv*e6c*( c3sq-c2sq )
+
+          !============================
+          !     **  for Sm' and Sh'd(Theta_V)/dz  **
+          !!          enum = qdiv*e6c*( c3sq-c2sq )
           enum = MAX( qdiv*e6c*( c3sq-c2sq ), 0.0d0)
 
-!JOE-Canuto/Kitamura mod
-!          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
+          !JOE-Canuto/Kitamura mod
+          !smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
           smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c/(a2den**2) + &
                & e4c/a2den)*a1/(a2/a2den)
-!JOE-end
+
           gamv = e1  *enum*gtr/eden
-!
           sm(k) = sm(k) +smd
-!
-!     **  For elh (see below), qdiv at Level 3 is reset to 1.0.  **
+
+          !============================
+          !     **  For elh (see below), qdiv at Level 3 is reset to 1.0.  **
           qdiv = 1.0
-!   **  Level 3 : end  **
-!
-          IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-            PRINT*,"MYM_TURBULENCE3.0: k=",k," sh=",sh(k)
-            PRINT*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
-            PRINT*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
-            PRINT*," qke=",qke(k)," el=",el(k)," ri=",ri
-            PRINT*," PBLH=",zi," u=",u(k)," v=",v(k)
+
+          ! Level 3 debug prints
+          IF ( debug_code ) THEN
+            IF (sh(k)<-0.3 .OR. sm(k)<-0.3 .OR. &
+              qke(k) < -0.1 .or. ABS(smd) .gt. 2.0) THEN
+              print*," MYNN; mym_turbulence3.0; sh=",sh(k)," k=",k
+              print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+              print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+              print*," qke=",qke(k)," el=",el(k)," ri=",ri
+              print*," PBLH=",zi," u=",u(k)," v=",v(k)
+            ENDIF
           ENDIF
+
+!   **  Level 3 : end  **
 
        ELSE
 !     **  At Level 2.5, qdiv is not reset.  **
@@ -1213,22 +1794,35 @@ CONTAINS
           gamv = 0.0
        END IF
 !
+!      Add stochastic perturbation of prandtl number limit
+       if (spp_pbl==1) then
+          prlimit = MIN(MAX(1.,2.5 + 5.0*rstoch_col(k)), 10.)
+          IF(sm(k) > sh(k)*Prlimit) THEN
+             sm(k) = sh(k)*Prlimit
+          ENDIF
+       ENDIF
+!
        elq = el(k)*qkw(k)
        elh = elq*qdiv
-!
+
+       ! Production of TKE (pdk), T-variance (pdt),
+       ! q-variance (pdq), and covariance (pdc)
        pdk(k) = elq*( sm(k)*gm(k) &
-            &                    +sh(k)*gh(k)+gamv )
+            &                    +sh(k)*gh(k)+gamv ) + & ! JAYMES TKE
+            &   TKEprodTD(k)                             ! JOE-top-down
        pdt(k) = elh*( sh(k)*dtl(k)+gamt )*dtl(k)
        pdq(k) = elh*( sh(k)*dqw(k)+gamq )*dqw(k)
        pdc(k) = elh*( sh(k)*dtl(k)+gamt )&
             &*dqw(k)*0.5 &
                   &+elh*( sh(k)*dqw(k)+gamq )*dtl(k)*0.5
-!
+
+       ! Contergradient terms
        tcd(k) = elq*gamt
        qcd(k) = elq*gamq
-!
-       dfm(k) = elq*sm (k) / dzk
-       dfh(k) = elq*sh (k) / dzk
+
+       ! Eddy Diffusivity/Viscosity divided by dz
+       dfm(k) = elq*sm(k) / dzk
+       dfh(k) = elq*sh(k) / dzk
 !  Modified: Dec/22/2005, from here
 !   **  In sub.mym_predict, dfq for the TKE and scalar variance **
 !   **  are set to 3.0*dfm and 1.0*dfm, respectively. (Sqfac)   **
@@ -1302,7 +1896,11 @@ CONTAINS
       qDISS1D(kts)=qDISS1D(kts+1)
    ENDIF
 
-    RETURN
+!    RETURN
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_turbulence
 
@@ -1310,17 +1908,17 @@ CONTAINS
 !     SUBROUTINE  mym_predict:
 !
 !     Input variables:    see subroutine mym_initialize and turbulence
-!       qke(mx,my,nz) : qke at (n)th time level
+!       qke(nx,nz,ny) : qke at (n)th time level
 !       tsq, ...cov     : ditto
 !
 !     Output variables:
-!       qke(mx,my,nz) : qke at (n+1)th time level
+!       qke(nx,nz,ny) : qke at (n+1)th time level
 !       tsq, ...cov     : ditto
 !
 !     Work arrays:
-!       qkw(mx,my,nz)   : q at the center of the grid boxes        (m/s)
-!       bp (mx,my,nz)   : = 1/2*F,     see below
-!       rp (mx,my,nz)   : = P-1/2*F*Q, see below
+!       qkw(nx,nz,ny)   : q at the center of the grid boxes        (m/s)
+!       bp (nx,nz,ny)   : = 1/2*F,     see below
+!       rp (nx,nz,ny)   : = P-1/2*F*Q, see below
 !
 !     # The equation for a turbulent quantity Q can be expressed as
 !          dQ/dt + Ah + Av = Dh + Dv + P - F*Q,                      (1)
@@ -1357,38 +1955,51 @@ CONTAINS
        &            ust, flt, flq, pmz, phh, &
        &            el, dfq, &
        &            pdk, pdt, pdq, pdc,&
-       &            qke, tsq, qsq, cov &
+       &            qke, tsq, qsq, cov, &
+       &            s_aw,s_awqke,bl_mynn_edmf_tke &
        &)
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(IN)   :: kts,kte    
+    INTEGER, INTENT(IN) :: kts,kte    
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
     INTEGER, INTENT(IN) :: levflag
-    REAL, INTENT(IN) :: delt
+    INTEGER, INTENT(IN) :: bl_mynn_edmf_tke
+    REAL, INTENT(IN)    :: delt
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq,el
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: pdk, pdt, pdq, pdc
-    REAL, INTENT(IN) ::  flt, flq, ust, pmz, phh
+    REAL, INTENT(IN)    ::  flt, flq, ust, pmz, phh
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: qke,tsq, qsq, cov
+! WA 8/3/15
+    REAL, DIMENSION(kts:kte+1), INTENT(INOUT) :: s_awqke,s_aw
 
     INTEGER :: k,nz
     REAL, DIMENSION(kts:kte) :: qkw, bp, rp, df3q
-    REAL :: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l
+    REAL :: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l,onoff
     REAL, DIMENSION(kts:kte) :: dtz
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
+    REAL, DIMENSION(kts:kte) :: a,b,c,d,x
 
-    nz=kte-kts+1
+    nz=kte
+
+    ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
+    IF (bl_mynn_edmf_tke == 0) THEN
+       onoff=0.0
+    ELSE
+       onoff=1.0
+    ENDIF
 
 !   **  Strictly, vkz*h(i,j) -> vk*( 0.5*dz(1)*h(i,j)+z0 )  **
     vkz = vk*0.5*dz(kts)
 !
-!  Modified: Dec/22/2005, from here
 !   **  dfq for the TKE is 3.0*dfm.  **
-!    CALL coefvu ( dfq, 3.0 ) ! make change here
-!  Modified: Dec/22/2005, up to here
 !
     DO k = kts,kte
 !!       qke(k) = MAX(qke(k), 0.0)
        qkw(k) = SQRT( MAX( qke(k), 0.0 ) )
-       !df3q(k)=3.*dfq(k)
        df3q(k)=Sqfac*dfq(k)
        dtz(k)=delt/dz(k)
     END DO
@@ -1414,9 +2025,9 @@ CONTAINS
     DO k = kts,kte-1
        b1l = b1*0.5*( el(k+1)+el(k) )
        bp(k) = 2.*qkw(k) / b1l
-       rp(k) = pdk(k+1) + pdk(k) 
+       rp(k) = pdk(k+1) + pdk(k)
     END DO
-    
+
 !!    a(1)=0.
 !!    b(1)=1.
 !!    c(1)=-1.
@@ -1424,10 +2035,16 @@ CONTAINS
 
 ! Since df3q(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*df3q(k+1)+bp(k)*delt.
     DO k=kts,kte-1
-       a(k-kts+1)=-dtz(k)*df3q(k)
-       b(k-kts+1)=1.+dtz(k)*(df3q(k)+df3q(k+1))+bp(k)*delt
-       c(k-kts+1)=-dtz(k)*df3q(k+1)
-       d(k-kts+1)=rp(k)*delt + qke(k)
+!       a(k-kts+1)=-dtz(k)*df3q(k)
+!       b(k-kts+1)=1.+dtz(k)*(df3q(k)+df3q(k+1))+bp(k)*delt
+!       c(k-kts+1)=-dtz(k)*df3q(k+1)
+!       d(k-kts+1)=rp(k)*delt + qke(k)
+! WA 8/3/15 add EDMF contribution
+       a(k-kts+1)=-dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
+       b(k-kts+1)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
+                     + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
+       c(k-kts+1)=-dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k-kts+1)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
     ENDDO
 
 !!    DO k=kts+1,kte-1
@@ -1442,10 +2059,12 @@ CONTAINS
     c(nz)=0.
     d(nz)=0.
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
 
-    DO k=kts,kte   
-       qke(k)=d(k-kts+1)
+    DO k=kts,kte
+!       qke(k)=max(d(k-kts+1), 1.e-4)
+       qke(k)=max(x(k), 1.e-4)
     ENDDO
       
 
@@ -1490,11 +2109,13 @@ CONTAINS
        b(nz)=1.
        c(nz)=0.
        d(nz)=0.
-       
-       CALL tridiag(nz,a,b,c,d)
+
+!       CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
        
        DO k=kts,kte
-          tsq(k)=d(k-kts+1)
+!          tsq(k)=d(k-kts+1)
+           tsq(k)=x(k)
        ENDDO
        
 !   **  Prediction of the moisture variance  **
@@ -1532,10 +2153,12 @@ CONTAINS
        c(nz)=0.
        d(nz)=0.
        
-       CALL tridiag(nz,a,b,c,d)
-       
+!       CALL tridiag(nz,a,b,c,d)
+       CALL tridiag2(nz,a,b,c,d,x)
+
        DO k=kts,kte
-          qsq(k)=d(k-kts+1)
+!          qsq(k)=d(k-kts+1)
+           qsq(k)=x(k)
        ENDDO
        
 !   **  Prediction of the temperature-moisture covariance  **
@@ -1572,11 +2195,13 @@ CONTAINS
        b(nz)=1.
        c(nz)=0.
        d(nz)=0.
-       
-       CALL tridiag(nz,a,b,c,d)
+
+!       CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
        
        DO k=kts,kte
-          cov(k)=d(k-kts+1)
+!          cov(k)=d(k-kts+1)
+          cov(k)=x(k)
        ENDDO
        
     ELSE
@@ -1603,6 +2228,11 @@ CONTAINS
       
     END IF
 
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
   END SUBROUTINE mym_predict
   
 ! ==================================================================
@@ -1617,14 +2247,14 @@ CONTAINS
 !                         virtual potential temperature minus tref.
 !
 !     Output variables:   see subroutine mym_initialize
-!       cld(mx,my,nz)   : Cloud fraction
+!       cld(nx,nz,ny)   : Cloud fraction
 !
 !     Work arrays:
-!       qmq(mx,my,nz)   : Q_w-Q_{sl}, where Q_{sl} is the saturation
+!       qmq(nx,nz,ny)   : Q_w-Q_{sl}, where Q_{sl} is the saturation
 !                         specific humidity at T=Tl
-!       alp(mx,my,nz)   : Functions in the condensation process
-!       bet(mx,my,nz)   : ditto
-!       sgm(mx,my,nz)   : Combined standard deviation sigma_s
+!       alp(nx,nz,ny)   : Functions in the condensation process
+!       bet(nx,nz,ny)   : ditto
+!       sgm(nx,nz,ny)   : Combined standard deviation sigma_s
 !                         multiplied by 2/alp
 !
 !     # qmq, alp, bet and sgm are allowed to share storage units with
@@ -1634,43 +2264,84 @@ CONTAINS
 !       Set these values to those adopted by you.
 !
 !-------------------------------------------------------------------
-  SUBROUTINE  mym_condensation (kts,kte, &
-    &            dz, &
-    &            thl, qw, &
-    &            p,exner, &
-    &            tsq, qsq, cov, &
-    &            Sh, el, bl_mynn_cloudpdf,&  !JOE - cloud PDF testing
-    &            Vt, Vq)
+  SUBROUTINE  mym_condensation (kts,kte,  &
+    &            dx, dz,                  &
+    &            thl, qw,                 &
+    &            p,exner,                 &
+    &            tsq, qsq, cov,           &
+    &            Sh, el, bl_mynn_cloudpdf,&
+    &            qc_bl1D, cldfra_bl1D,    &
+    &            PBLH1,HFX1,              &
+    &            Vt, Vq, th, sgm)
 
 !-------------------------------------------------------------------
+
     INTEGER, INTENT(IN)   :: kts,kte, bl_mynn_cloudpdf
 
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+    REAL, INTENT(IN)      :: dx,PBLH1,HFX1
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
     REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner, thl, qw, &
-         &tsq, qsq, cov
+         &tsq, qsq, cov, th
 
-    REAL, DIMENSION(kts:kte), INTENT(OUT) :: vt,vq
+    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: vt,vq,sgm
 
-    REAL, DIMENSION(kts:kte) :: qmq,alp,bet,sgm,ql,cld
-
+    REAL, DIMENSION(kts:kte) :: qmq,alp,a,bet,b,ql,q1,cld,RH
+    REAL, DIMENSION(kts:kte), INTENT(OUT) :: qc_bl1D,cldfra_bl1D
     DOUBLE PRECISION :: t3sq, r3sq, c3sq
-!
 
-    REAL :: p2a,t,esl,qsl,dqsl,q1,cld0,eq1,qll,&
-         &q2p,pt,rac,qt
+    REAL :: qsl,esat,qsat,tlk,qsat_tl,dqsl,cld0,q1k,eq1,qll,&
+         &q2p,pt,rac,qt,t,xl,rsl,cpm,cdhdz,Fng,qww,alpha,beta,bb,ls_min,ls,wt
     INTEGER :: i,j,k
 
     REAL :: erf
 
     !JOE: NEW VARIABLES FOR ALTERNATE SIGMA
-    REAL::dth,dqw,dzk
+    REAL::dth,dtl,dqw,dzk
     REAL, DIMENSION(kts:kte), INTENT(IN) :: Sh,el
 
-! Note: kte needs to be larger than kts, i.e., kte >= kts+1.
+    !JOE: variables for BL clouds
+    REAL::zagl,cld9,damp,edown,RHcrit,RHmean,RHsum,RHnum,Hshcu,PBLH2,ql_limit
+    REAL, PARAMETER :: Hfac = 3.0     !cloud depth factor for HFX (m^3/W)
+    REAL, PARAMETER :: HFXmin = 50.0  !min W/m^2 for BL clouds
+    REAL            :: RH_00L, RH_00O, phi_dz, lfac
+    REAL, PARAMETER :: cdz = 2.0
+    REAL, PARAMETER :: mdz = 1.5
 
-    DO k = kts,kte-1
-       p2a = exner(k)
-       t  = thl(k)*p2a 
+    !JAYMES:  variables for tropopause-height estimation
+    REAL            :: theta1, theta2, ht1, ht2
+    INTEGER         :: k_tropo
+
+! First, obtain an estimate for the tropopause height (k), using the method employed in the
+! Thompson subgrid-cloud scheme.  This height will be a consideration later when determining 
+! the "final" subgrid-cloud properties.
+! JAYMES:  added 3 Nov 2016, adapted from G. Thompson
+
+    DO k = kte-3, kts, -1
+       theta1 = th(k)
+       theta2 = th(k+2)
+       ht1 = 44307.692 * (1.0 - (p(k)/101325.)**0.190)
+       ht2 = 44307.692 * (1.0 - (p(k+2)/101325.)**0.190)
+       if ( (((theta2-theta1)/(ht2-ht1)) .lt. 10./1500. ) .AND.       &
+     &                       (ht1.lt.19000.) .and. (ht1.gt.4000.) ) then 
+          goto 86
+       endif
+    ENDDO
+ 86   continue
+    k_tropo = MAX(kts+2, k+2)
+
+    zagl = 0.
+
+    SELECT CASE(bl_mynn_cloudpdf)
+
+      CASE (0) ! ORIGINAL MYNN PARTIAL-CONDENSATION SCHEME
+
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
 
 !x      if ( ct .gt. 0.0 ) then
 !       a  =  17.27
@@ -1681,107 +2352,388 @@ CONTAINS
 !x      end if
 !
 !   **  3.8 = 0.622*6.11 (hPa)  **
-       !SATURATED VAPOR PRESSURE
-       esl=svp11*EXP(svp2*(t-svpt0)/(t-svp3))
-       !SATURATED SPECIFIC HUMIDITY
-       qsl=ep_2*esl/(p(k)-ep_3*esl)
-       !dqw/dT: Clausius-Clapeyron
-       dqsl = qsl*ep_2*ev/( rd*t**2 )
-       !DEFICIT/EXCESS WATER CONTENT
-       qmq(k) = qw(k) -qsl
 
-       alp(k) = 1.0/( 1.0+dqsl*xlvcp )
-       bet(k) = dqsl*p2a
-!
-       t3sq = MAX( tsq(k), 0.0 )
-       r3sq = MAX( qsq(k), 0.0 )
-       c3sq =      cov(k)
-       c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
-!
-       r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
-       IF (bl_mynn_cloudpdf == 0) THEN
-          !ORIGINAL STANDARD DEVIATION: limit e-6 produces ~10% more BL clouds than e-10
-          sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
-       ELSE
-          !ALTERNATIVE FORM (Nakanishi & Niino 2004 BLM, eq. B6, and 
-          ! Kuwano-Yoshida et al. 2010 QJRMS, eq. 7):
-          if (k .eq. kts) then 
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           !NOTE: negative bl_mynn_cloudpdf will zero-out the stratus subgrid clouds
+           !      at the end of this subroutine. 
+           !Sommeria and Deardorff (1977) scheme, as implemented
+           !in Nakanishi and Niino (2009), Appendix B
+           t3sq = MAX( tsq(k), 0.0 )
+           r3sq = MAX( qsq(k), 0.0 )
+           c3sq =      cov(k)
+           c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
+           r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
+           !DEFICIT/EXCESS WATER CONTENT
+           qmq(k) = qw(k) -qsl
+           !ORIGINAL STANDARD DEVIATION: limit e-6 produces ~10% more BL clouds
+           !than e-10
+           sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
+           !NORMALIZED DEPARTURE FROM SATURATION
+           q1(k)   = qmq(k) / sgm(k)
+           !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
+           cld(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+
+        END DO
+
+      CASE (1, -1) !ALTERNATIVE FORM (Nakanishi & Niino 2004 BLM, eq. B6, and
+                       !Kuwano-Yoshida et al. 2010 QJRMS, eq. 7):
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           if (k .eq. kts) then 
              dzk = 0.5*dz(k)
-          else
+           else
              dzk = 0.5*( dz(k) + dz(k-1) )
-          end if
-          dth = 0.5*(thl(k+1)+thl(k)) - 0.5*(thl(k)+thl(MAX(k-1,kts)))
-          dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
-          sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,1.) * &
+           end if
+           dth = 0.5*(thl(k+1)+thl(k)) - 0.5*(thl(k)+thl(MAX(k-1,kts)))
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+           sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,0.1) * &
                              b2 * MAX(Sh(k),0.03))/4. * &
                       (dqw/dzk - bet(k)*(dth/dzk ))**2 , 1.0e-10) )
-       ENDIF
-    END DO
-!
-    DO k = kts,kte-1
-       !NORMALIZED DEPARTURE FROM SATURATION
-       q1   = qmq(k) / sgm(k)
-       !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
-       cld(k) = 0.5*( 1.0+erf( q1*rr2 ) )
-!       IF (cld(k) < 0. .OR. cld(k) > 1.) THEN
-!          PRINT*,"MYM_CONDENSATION, k=",k," cld=",cld(k)
-!          PRINT*," r3sq=",r3sq," t3sq=",t3sq," c3sq=",c3sq
-!       ENDIF
-!       q1=0.
-!       cld(k)=0.
+           qmq(k) = qw(k) -qsl
+           q1(k)   = qmq(k) / sgm(k)
+           cld(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+        END DO
 
-       !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
-       !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
-       eq1  = rrp*EXP( -0.5*q1*q1 )
-       qll  = MAX( cld(k)*q1 + eq1, 0.0 )
-       !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
-       ql (k) = alp(k)*sgm(k)*qll
-!
-       q2p  = xlvcp/exner(k) 
-       !POTENTIAL TEMPERATURE
-       pt   = thl(k) +q2p*ql(k)
-       !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
-       qt   = 1.0 +p608*qw(k) -(1.+p608)*ql(k)
-       rac  = alp(k)*( cld(k)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
+      CASE (2, -2)
+          !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
+          !JAYMES- this added 27 Apr 2015
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
 
-       !BUOYANCY FACTORS: wherever vt and vq are used, there is a
-       !"+1" and "+tv0", respectively, so these are subtracted out here.
-       !vt is unitless and vq has units of K.
-       vt (k) =      qt-1.0 -rac*bet(k)
-       vq (k) = p608*pt-tv0 +rac
-    END DO
-!
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
 
-    cld(kte) = cld(kte-1)
-    ql(kte) = ql(kte-1)
-    vt(kte) = vt(kte-1)
-    vq(kte) = vq(kte-1)
+           xl = xl_blend(t)                    ! obtain latent heat
+
+           tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
+
+           qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
+                                               !   at tl and p
+
+           rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
+                                               ! CB02, Eqn. 4
+ 
+           cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
+     
+           a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
+
+           qmq(k) = a(k) * (qw(k) - qsat_tl) ! saturation deficit/excess;
+                                               !   the numerator of Q1
+
+           b(k) = a(k)*rsl                     ! CB02 variable "b"
+
+           dtl =    0.5*(thl(k+1)*(p(k+1)/p1000mb)**rcp + tlk) &
+               & - 0.5*(tlk + thl(MAX(k-1,kts))*(p(MAX(k-1,kts))/p1000mb)**rcp)
+
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+
+           if (k .eq. kts) then
+             dzk = 0.5*dz(k)
+           else
+             dzk = 0.5*( dz(k) + dz(k-1) )
+           end if
+
+           cdhdz = dtl/dzk + (g/cpm)*(1.+qw(k))  ! expression below Eq. 9
+                                                 ! in CB02
+
+           zagl = zagl + dz(k)
+
+           ls_min = 400. + MIN(3.*MAX(HFX1,0.),500.)
+           ls_min = MIN(MAX(zagl,25.),ls_min) ! Let this be the minimum possible length scale:
+           if (zagl > PBLH1+2000.) ls_min = MAX(ls_min + 0.5*(PBLH1+2000.-zagl),400.)
+                                        !   25 m < ls_min(=zagl) < 300 m
+           lfac=MIN(4.25+dx/4000.,6.)   ! A dx-dependent multiplier for the master length scale:
+                                        !   lfac(750 m) = 4.4
+                                        !   lfac(3 km)  = 5.0
+                                        !   lfac(13 km) = 6.0
+
+           ls = MAX(MIN(lfac*el(k),900.),ls_min)  ! Bounded:  ls_min < ls < 900 m
+                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale. 
+
+                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the 
+                   ! MYNN master length scale (el) must exceed 60 m before ls
+                   ! becomes responsive to el, otherwise ls = ls_min = 300 m.
+
+           sgm(k) = MAX(1.e-10, 0.225*ls*SQRT(MAX(0., & ! Eq. 9 in CB02:
+                   & (a(k)*dqw/dzk)**2              & ! < 1st term in brackets,
+                   & -2*a(k)*b(k)*cdhdz*dqw/dzk     & ! < 2nd term,
+                   & +b(k)**2 * cdhdz**2)))           ! < 3rd term
+                   ! CB02 use a multiplier of 0.2, but 0.225 is chosen
+                   ! based on tests
+
+           q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
+
+           cld(k) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
+
+         END DO
+
+    END SELECT
+
+    zagl = 0.
+    RHsum=0.
+    RHnum=0.
+    RHmean=0.1 !initialize with small value for small PBLH cases
+    damp =0
+    PBLH2=MAX(10.,PBLH1)
+
+    SELECT CASE(bl_mynn_cloudpdf)
+
+      CASE (-1 : 1) ! ORIGINAL MYNN PARTIAL-CONDENSATION SCHEME
+                    ! OR KUWANO ET AL.
+        DO k = kts,kte-1
+           t    = th(k)*exner(k)
+           q1k  = q1(k)
+           zagl = zagl + dz(k)
+           !q1=0.
+           !cld(k)=0.
+
+           !COMPUTE MEAN RH IN PBL (NOT PRESSURE WEIGHTED).
+           IF (zagl < PBLH2 .AND. PBLH2 > 400.) THEN
+              RHsum=RHsum+RH(k)
+              RHnum=RHnum+1.0
+              RHmean=RHsum/RHnum
+           ENDIF
+
+           RHcrit = 1. - 0.35*(1.0 - (MAX(250.- MAX(HFX1,HFXmin),0.0)/200.)**2)
+           if (HFX1 > HFXmin) then
+              cld9=MIN(MAX(0., (rh(k)-RHcrit)/(1.1-RHcrit)), 1.)**2
+           else
+              cld9=0.0
+           endif
+       
+           edown=PBLH2*.1
+           !Vary BL cloud depth (Hshcu) by mean RH in PBL and HFX 
+           !(somewhat following results from Zhang and Klein (2013, JAS))
+           Hshcu=200. + (RHmean+0.5)**1.5*MAX(HFX1,0.)*Hfac
+           if (zagl < PBLH2-edown) then
+              damp=MIN(1.0,exp(-ABS(((PBLH2-edown)-zagl)/edown)))
+           elseif(zagl >= PBLH2-edown .AND. zagl < PBLH2+Hshcu)then
+              damp=1.
+           elseif (zagl >= PBLH2+Hshcu)then
+              damp=MIN(1.0,exp(-ABS((zagl-(PBLH2+Hshcu))/500.)))
+           endif
+           cldfra_bl1D(k)=cld9*damp
+           !cldfra_bl1D(k)=cld(k) ! JAYMES: use this form to retain the Sommeria-Deardorff value
+       
+           !use alternate cloud fraction to estimate qc for use in BL clouds-radiation
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cldfra_bl1D(k)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql (k) = alp(k)*sgm(k)*qll
+           if(cldfra_bl1D(k)>0.01 .and. ql(k)<1.E-6)ql(k)=1.E-6
+           qc_bl1D(k)=ql(k)*damp
+           !qc_bl1D(k)=ql(k) ! JAYMES: use this form to retain the Sommeria-Deardorff value
+       
+           !now recompute estimated lwc for PBL scheme's use
+           !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
+           !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cld(k)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql (k) = alp(k)*sgm(k)*qll
+       
+           q2p = xlvcp/exner(k)
+           pt = thl(k) +q2p*ql(k) ! potential temp
+       
+           !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
+           qt   = 1.0 +p608*qw(k) -(1.+p608)*ql(k)
+           rac  = alp(k)*( cld(k)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
+       
+           !BUOYANCY FACTORS: wherever vt and vq are used, there is a
+           !"+1" and "+tv0", respectively, so these are subtracted out here.
+           !vt is unitless and vq has units of K.
+           vt(k) =      qt-1.0 -rac*bet(k)
+           vq(k) = p608*pt-tv0 +rac
+
+           !To avoid FPE in radiation driver, when these two quantities are multiplied by eachother,
+           ! add limit to qc_bl and cldfra_bl:
+           IF (QC_BL1D(k) < 1E-6 .AND. ABS(CLDFRA_BL1D(k)) > 0.01) QC_BL1D(k)= 1E-6
+           IF (CLDFRA_BL1D(k) < 1E-2)THEN
+              CLDFRA_BL1D(k)=0.
+              QC_BL1D(k)=0.
+           ENDIF
+
+        END DO
+      CASE ( 2, -2)
+        ! JAYMES- this option added 8 May 2015
+        ! The cloud water formulations are taken from CB02, Eq. 8.
+        ! "fng" represents the non-Gaussian contribution to the liquid
+        ! water flux; these formulations are from Cuijpers and Bechtold
+        ! (1995), Eq. 7.  CB95 also draws from Bechtold et al. 1995,
+        ! hereafter BCMT95
+        DO k = kts,kte-1
+           t    = th(k)*exner(k)
+           q1k  = q1(k)
+           zagl = zagl + dz(k)
+           IF (q1k < 0.) THEN                 
+              ql (k) = sgm(k)*EXP(1.2*q1k-1)
+           ELSE IF (q1k > 2.) THEN
+              ql (k) = sgm(k)*q1k
+           ELSE
+              ql (k) = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
+           ENDIF
+  
+           !Next, adjust our initial estimates of cldfra and ql based
+           !on tropopause-height and PBLH considerations
+           !JAYMES:  added 4 Nov 2016
+           if ((cld(k) .gt. 0.) .or. (ql(k) .gt. 0.))  then
+              if (k .le. k_tropo) then
+                 !At and below tropopause: impose an upper limit on ql; assume that
+                 !a maximum of 0.5 percent supersaturation in water vapor can be
+                 !available for cloud production
+                 ql_limit = 0.005 * qsat_blend( th(k)*exner(k), p(k) )
+                 ql(k) = MIN( ql(k), ql_limit )
+              else
+                 !Above tropopause:  eliminate subgrid clouds from CB scheme
+                 cld(k) = 0.
+                 ql(k) = 0.
+              endif 
+           endif
+       
+           !Buoyancy-flux-related calculations follow...
+           ! "Fng" represents the non-Gaussian transport factor
+           ! (non-dimensional) from from Bechtold et al. 1995 
+           ! (hereafter BCMT95), section 3(c).  Their suggested 
+           ! forms for Fng (from their Eq. 20) are:
+           !IF (q1k < -2.) THEN
+           !  Fng = 2.-q1k
+           !ELSE IF (q1k > 0.) THEN
+           !  Fng = 1.
+           !ELSE
+           !  Fng = 1.-1.5*q1k
+           !ENDIF
+           ! For purposes of the buoyancy flux in stratus, we will use Fng = 1
+           Fng = 1.
+       
+           xl    = xl_blend(t)
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
+                             ! "b" in CB02 (i.e., b(k) above) by a factor 
+                             ! of T/theta.  Strictly, b(k) above is formulated in
+                             ! terms of sat. mixing ratio, but bb in BCMT95 is
+                             ! cast in terms of sat. specific humidity.  The
+                             ! conversion is neglected here. 
+           qww   = 1.+0.61*qw(k)
+           alpha = 0.61*th(k)
+           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+       
+           vt(k) = qww   - MIN(cld(k),0.5)*beta*bb*Fng   - 1.
+           vq(k) = alpha + MIN(cld(k),0.5)*beta*a(k)*Fng - tv0
+           ! vt and vq correspond to beta-theta and beta-q, respectively,  
+           ! in NN09, Eq. B8.  They also correspond to the bracketed
+           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+           ! The "-1" and "-tv0" terms are included for consistency with 
+           ! the legacy vt and vq formulations (above).
+
+           ! increase the cloud fraction estimate below PBLH+1km
+           if (zagl .lt. PBLH2+1000.) cld(k) = MIN( 1., 2.0*cld(k) ) 
+           ! return a cloud condensate and cloud fraction for icloud_bl option:
+           cldfra_bl1D(k) = cld(k)
+           qc_bl1D(k) = ql(k)
+
+           !To avoid FPE in radiation driver, when these two quantities are multiplied by eachother,
+           ! add limit to qc_bl and cldfra_bl:
+           IF (QC_BL1D(k) < 1E-6 .AND. ABS(CLDFRA_BL1D(k)) > 0.01) QC_BL1D(k)= 1E-6
+           IF (CLDFRA_BL1D(k) < 1E-2)THEN
+              CLDFRA_BL1D(k)=0.
+              QC_BL1D(k)=0.
+           ENDIF
+
+         END DO
+
+      END SELECT !end cloudPDF option
+
+      !FOR TESTING PURPOSES ONLY, ISOLATE ON THE MASS-CLOUDS.
+      IF (bl_mynn_cloudpdf .LT. 0) THEN
+         DO k = kts,kte-1
+              cldfra_bl1D(k) = 0.0
+              qc_bl1D(k) = 0.0
+         END DO
+      ENDIF
+!
+      cld(kte) = cld(kte-1)
+      ql(kte) = ql(kte-1)
+      vt(kte) = vt(kte-1)
+      vq(kte) = vq(kte-1)
+      qc_bl1D(kte)=0.
+      cldfra_bl1D(kte)=0.
 
     RETURN
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE mym_condensation
 
 ! ==================================================================
-  SUBROUTINE mynn_tendencies(kts,kte,&
-       &levflag,grav_settling,&
-       &delt,&
-       &dz,&
-       &u,v,th,qv,qc,qi,qni,& !qnc,&
-       &p,exner,&
-       &thl,sqv,sqc,sqi,sqw,&
-       &ust,flt,flq,flqv,flqc,wspd,qcg,&
-       &uoce,voce,&
-       &tsq,qsq,cov,&
-       &tcd,qcd,&
-       &dfm,dfh,dfq,&
-       &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqni&!,Dqnc&
-       &,vdfg1&               !Katata/JOE-fogdes
-       &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
-       &)
+  SUBROUTINE mynn_tendencies(kts,kte,      &
+       &levflag,grav_settling,             &
+       &delt,dz,                           &
+       &u,v,th,tk,qv,qc,qi,qni,qnc,        &
+       &p,exner,                           &
+       &thl,sqv,sqc,sqi,sqw,               &
+       &ust,flt,flq,flqv,flqc,wspd,qcg,    &
+       &uoce,voce,                         &
+       &tsq,qsq,cov,                       &
+       &tcd,qcd,                           &
+       &dfm,dfh,dfq,                       &
+       &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqni,        &!Dqnc,   &
+       &vdfg1,                             &
+       &s_aw,s_awthl,s_awqt,s_awqv,s_awqc, &
+       &s_awu,s_awv,                       &
+       &FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC, &
+       &cldfra_bl1d,                       &
+#if defined(wrfmodel)
+       &ztop_shallow,ktop_shallow,         &
+#endif
+       &bl_mynn_cloudmix,                  &
+       &bl_mynn_mixqt,                     &
+       &bl_mynn_edmf,                      &
+       &bl_mynn_edmf_mom                  )
 
 !-------------------------------------------------------------------
     INTEGER, INTENT(in) :: kts,kte
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
     INTEGER, INTENT(in) :: grav_settling,levflag
+    INTEGER, INTENT(in) :: bl_mynn_cloudmix,bl_mynn_mixqt,&
+                           bl_mynn_edmf,bl_mynn_edmf_mom
     LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC
 
 !! grav_settling = 1 or 2 for gravitational settling of droplets
@@ -1792,86 +2744,126 @@ CONTAINS
 ! flt - surface flux of thl
 ! flq - surface flux of qw
 
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,th,qv,qc,qi,qni,&!qnc,&
-         &p,exner,dfm,dfh,dfq,dz,tsq,qsq,cov,tcd,qcd
-    REAL, DIMENSION(kts:kte), INTENT(inout) :: thl,sqw,sqv,sqc,sqi
+    REAL,DIMENSION(kts:kte+1), INTENT(in) :: s_aw,s_awthl,s_awqt,&
+                             s_awqv,s_awqc,s_awu,s_awv
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,th,tk,qv,qc,qi,qni,qnc,&
+         &p,exner,dfq,dz,tsq,qsq,cov,tcd,qcd,cldfra_bl1d
+    REAL, DIMENSION(kts:kte), INTENT(inout) :: thl,sqw,sqv,sqc,sqi,&
+         &dfm,dfh
     REAL, DIMENSION(kts:kte), INTENT(inout) :: du,dv,dth,dqv,dqc,dqi,&
-         &dqni!,dqnc
+         &dqni !,dqnc
     REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
+#if defined(wrfmodel)
+    REAL, INTENT(IN):: ztop_shallow
+    INTEGER, INTENT(IN) :: ktop_shallow
+#endif
 
 !    REAL, INTENT(IN) :: delt,ust,flt,flq,qcg,&
 !         &gradu_top,gradv_top,gradth_top,gradqv_top
 
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz,vt,vq,qni2!,qnc2
+    REAL, DIMENSION(kts:kte) :: dtz,vt,vq,dfhc,dfmc !Kh for clouds (Pr < 2)
+    REAL, DIMENSION(kts:kte) :: sqv2,sqc2,sqi2,sqw2,qni2 !,qnc2 !AFTER MIXING
+    REAL, DIMENSION(kts:kte) :: zfac,plumeKh
+    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d,x
 
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
-
-    REAL :: rhs,gfluxm,gfluxp,dztop
-
+    REAL :: rhs,gfluxm,gfluxp,dztop,maxdfh,mindfh,maxcf,maxKh,zw
     REAL :: grav_settling2,vdfg1    !Katata-fogdes
-
+    REAL :: t,esat,qsl,onoff
     INTEGER :: k,kk,nz
 
     nz=kte-kts+1
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
+    ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
+    ! Note that s_awu and s_awv already come in as 0.0 if bl_mynn_edmf_mom == 0, so
+    ! we only need to zero-out the MF term
+    IF (bl_mynn_edmf_mom == 0) THEN
+       onoff=0.0
+    ELSE
+       onoff=1.0
+    ENDIF
+
+    !set up values for background diffusivity when MF scheme is active
+!    maxdfh=maxval(dfh(1:14))
+!    maxcf=maxval(cldfra_bl1D(kts:MAX(ktop_shallow,14)))
+    !allow maxKh to vary according to cloud fraction in lowest ~2 km
+!    maxKh = 1.*(1.-MIN(MAX(maxcf-0.5,0.0)/0.25, 0.9))
+!    mindfh=min(maxKh,maxdfh*0.01)
+
+!    zw=0.
     DO k=kts,kte
        dtz(k)=delt/dz(k)
+       !IF (dfm(k) > dfh(k)) THEN 
+       !  !in stable regime only, limit Prandtl number to < 2 within clouds
+       !  IF (qc(k) > 1.e-6 .OR. &
+       !      qi(k) > 1.e-6 .OR. &
+       !      cldfra_bl1D(k) > 0.05 ) THEN
+       !      dfh(k)= MAX(dfh(k),dfm(k)*0.5)
+       !  ENDIF
+       !ENDIF
+       !Add small minimum Km & Kh in MF updrafts is no stratus is in the column. 
+       !Note that maxval of plumeKh is mindfh*0.15, with max at about 0.75*ztop_shallow
+!        IF (ktop_shallow > 0) THEN
+!           zfac(k) = min( max(1.-(zw/ztop_shallow), 0.01), 1.)
+!           plumeKh(k)=mindfh*max((ztop_shallow-zw)/ztop_shallow,0.0)*(1.-zfac(k))**2
+!           dfh(k)=MAX(mindfh,dfh(k))
+!           dfm(k)=MAX(mindfh,dfm(k))
+!       ENDIF
+!       zw=zw+dz(k)
     ENDDO
 
 !!============================================
 !! u
 !!============================================
-   
+
     k=kts
 
     a(1)=0.
-    b(1)=1.+dtz(k)*(dfm(k+1)+ust**2/wspd)
-    c(1)=-dtz(k)*dfm(k+1)
-!    d(1)=u(k)
-    d(1)=u(k)+dtz(k)*uoce*ust**2/wspd
+    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
+    c(1)=-dtz(k)*dfm(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+    d(1)=u(k) + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff
 
-!!    a(1)=0.
-!!    b(1)=1.+dtz(k)*dfm(k+1)
-!!    c(1)=-dtz(k)*dfm(k+1)
-!!    d(1)=u(k)*(1.-ust**2/wspd*dtz(k))
-    
+!JOE - tend test
+!    a(k)=0.
+!    b(k)=1.+dtz(k)*dfm(k+1)    - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    c(k)=-dtz(k)*dfm(k+1)      - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    d(k)=u(k)*(1.-ust**2/wspd*dtz(k)) + &
+!         dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff
+
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfm(k)
-       b(kk)=1.+dtz(k)*(dfm(k)+dfm(k+1))
-       c(kk)=-dtz(k)*dfm(k+1)
-       d(kk)=u(k)
+       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
+       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k)=u(k) + dtz(k)*(s_awu(k)-s_awu(k+1))*onoff
     ENDDO
 
 !! no flux at the top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=0.
 
 !! specified gradient at the top 
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=gradu_top*dztop
 
 !! prescribed value
-
     a(nz)=0
     b(nz)=1.
     c(nz)=0.
     d(nz)=u(kte)
 
-    CALL tridiag(nz,a,b,c,d)
-    
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
+
     DO k=kts,kte
-       du(k)=(d(k-kts+1)-u(k))/delt
+!       du(k)=(d(k-kts+1)-u(k))/delt
+       du(k)=(x(k)-u(k))/delt
     ENDDO
 
 !!============================================
@@ -1881,382 +2873,256 @@ CONTAINS
     k=kts
 
     a(1)=0.
-    b(1)=1.+dtz(k)*(dfm(k+1)+ust**2/wspd)
-    c(1)=-dtz(k)*dfm(k+1)
-!    d(1)=v(k)
-    d(1)=v(k)+dtz(k)*voce*ust**2/wspd
+    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
+    c(1)=   - dtz(k)*dfm(k+1)               - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    d(1)=v(k)
+    d(1)=v(k) + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff
 
-!!    a(1)=0.
-!!    b(1)=1.+dtz(k)*dfm(k+1)
-!!    c(1)=-dtz(k)*dfm(k+1)
-!!    d(1)=v(k)*(1.-ust**2/wspd*dtz(k))
+!JOE - tend test
+!    a(k)=0.
+!    b(k)=1.+dtz(k)*dfm(k+1)  - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    c(k)=  -dtz(k)*dfm(k+1)  - 0.5*dtz(k)*s_aw(k+1)*onoff
+!    d(k)=v(k)*(1.-ust**2/wspd*dtz(k)) + &
+!         dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff
 
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfm(k)
-       b(kk)=1.+dtz(k)*(dfm(k)+dfm(k+1))
-       c(kk)=-dtz(k)*dfm(k+1)
-       d(kk)=v(k)
+       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
+       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k)=v(k) + dtz(k)*(s_awv(k)-s_awv(k+1))*onoff
     ENDDO
 
 !! no flux at the top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=0.
 
-
 !! specified gradient at the top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=gradv_top*dztop
 
 !! prescribed value
-
     a(nz)=0
     b(nz)=1.
     c(nz)=0.
     d(nz)=v(kte)
 
-    CALL tridiag(nz,a,b,c,d)
-    
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
+
     DO k=kts,kte
-       dv(k)=(d(k-kts+1)-v(k))/delt
+!       dv(k)=(d(k-kts+1)-v(k))/delt
+       dv(k)=(x(k)-v(k))/delt
     ENDDO
 
 !!============================================
-!! thl 
+!! thl tendency
 !! NOTE: currently, gravitational settling is removed
 !!============================================
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    
-!Katata - added
-!    grav_settling2 = MIN(REAL(grav_settling),1.)
-!Katata - end
-!
-! if qcg not used then assume constant flux in the surface layer
-!JOE-remove original code
-!    IF (qcg < qcgmin) THEN
-!       IF (sqc(k) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!    ELSE
-!       gfluxm=grav_settling2*gno*(qcg/(1.+qcg))**gpw
-!    ENDIF
-!and replace with vdfg1 is computed in module_sf_fogdes.F.
-!    IF (sqc(k) > qcgmin) THEN
-!       !gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       gfluxm=grav_settling2*sqc(k)*vdfg1
-!    ELSE
-!       gfluxm=0.
-!    ENDIF
-!JOE-end
-!
-!    IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!       gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!    ELSE
-!       gfluxp=0.
-!    ENDIF
+    a(k)=0.
+    b(k)=1.+dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=thl(k) + dtz(k)*flt + tcd(k)*delt -dtz(k)*s_awthl(kts+1)
 
-    rhs= tcd(k) !-xlvcp/exner(k)*&
-!         ((gfluxp - gfluxm)/dz(k))
-
-    d(1)=thl(k) + dtz(k)*flt + rhs*delt
-    
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1)) 
-       c(kk)=-dtz(k)*dfh(k+1)
-
-!       IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!          gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxp=0.
-!       ENDIF
-!       
-!       IF (.5*(sqc(k-1)+sqc(k)) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*(.5*(sqc(k-1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-
-       rhs= tcd(k) !-xlvcp/exner(k)*&
-!            &((gfluxp - gfluxm)/dz(k))
-
-       d(kk)=thl(k) + rhs*delt
+       a(k)=  -dtz(k)*dfh(k)            + 0.5*dtz(k)*s_aw(k)
+       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*dfh(k+1)          - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=thl(k) + tcd(k)*delt + dtz(k)*(s_awthl(k)-s_awthl(k+1))
     ENDDO
 
 !! no flux at the top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=0.
- 
+
 !! specified gradient at the top
-
 !assume gradthl_top=gradth_top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=gradth_top*dztop
 
 !! prescribed value
-
     a(nz)=0.
     b(nz)=1.
     c(nz)=0.
     d(nz)=thl(kte)
 
-    CALL tridiag(nz,a,b,c,d)
-    
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,x)
+
     DO k=kts,kte
-       thl(k)=d(k-kts+1)
+       !thl(k)=d(k-kts+1)
+       thl(k)=x(k)
     ENDDO
 
-!!============================================
-!! NO LONGER MIX total water (sqw = sqc + sqv)
-!! NOTE: no total water tendency is output
-!!============================================
-!
-!    k=kts
-!  
-!    a(1)=0.
-!    b(1)=1.+dtz(k)*dfh(k+1)
-!    c(1)=-dtz(k)*dfh(k+1)
-!    
-!JOE: replace orig code with fogdep
-!    IF (qcg < qcgmin) THEN
-!       IF (sqc(k) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*sqc(k)**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!    ELSE
-!       gfluxm=grav_settling2*gno*(qcg/(1.+qcg))**gpw
-!    ENDIF
-!and replace with fogdes code + remove use of qcg:
-!    IF (sqc(k) > qcgmin) THEN
-!       !gfluxm=grav_settling2*gno*(.5*(sqc(k)+sqc(k)))**gpw
-!       gfluxm=grav_settling2*sqc(k)*vdfg1
-!    ELSE
-!       gfluxm=0.
-!    ENDIF
-!JOE-end
-!    
-!    IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!       gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!    ELSE
-!       gfluxp=0.
-!    ENDIF
-!
-!    rhs= qcd(k) !+ (gfluxp - gfluxm)/dz(k)& 
-!
-!    d(1)=sqw(k) + dtz(k)*flq + rhs*delt
-!    
-!    DO k=kts+1,kte-1
-!       kk=k-kts+1
-!       a(kk)=-dtz(k)*dfh(k)
-!       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1)) 
-!       c(kk)=-dtz(k)*dfh(k+1)
-!
-!       IF (.5*(sqc(k+1)+sqc(k)) > qcgmin) THEN
-!          gfluxp=grav_settling2*gno*(.5*(sqc(k+1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxp=0.
-!       ENDIF
-!
-!       IF (.5*(sqc(k-1)+sqc(k)) > qcgmin) THEN
-!          gfluxm=grav_settling2*gno*(.5*(sqc(k-1)+sqc(k)))**gpw
-!       ELSE
-!          gfluxm=0.
-!       ENDIF
-!
-!       rhs= qcd(k) !+ (gfluxp - gfluxm)/dz(k)&
-!
-!       d(kk)=sqw(k) + rhs*delt
-!    ENDDO
+IF (bl_mynn_mixqt > 0) THEN
+ !============================================
+ ! MIX total water (sqw = sqc + sqv + sqi)
+ ! NOTE: no total water tendency is output; instead, we must calculate
+ !       the saturation specific humidity and then 
+ !       subtract out the moisture excess (sqc & sqi)
+ !============================================
 
+    k=kts
+
+    a(k)=0.
+    b(k)=1.+dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+
+    !rhs= qcd(k) !+ (gfluxp - gfluxm)/dz(k)& 
+
+    d(k)=sqw(k) + dtz(k)*flq + qcd(k)*delt - dtz(k)*s_awqt(k+1)
+
+    DO k=kts+1,kte-1
+       a(k)=  -dtz(k)*dfh(k)            + 0.5*dtz(k)*s_aw(k)
+       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*dfh(k+1)          - 0.5*dtz(k)*s_aw(k+1)
+
+       d(k)=sqw(k) + qcd(k)*delt + dtz(k)*(s_awqt(k)-s_awqt(k+1))
+    ENDDO
 
 !! no flux at the top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=0.
- 
 !! specified gradient at the top
 !assume gradqw_top=gradqv_top
-
 !    a(nz)=-1.
 !    b(nz)=1.
 !    c(nz)=0.
 !    d(nz)=gradqv_top*dztop
-
 !! prescribed value
+    a(nz)=0.
+    b(nz)=1.
+    c(nz)=0.
+    d(nz)=sqw(kte)
 
-!    a(nz)=0.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=sqw(kte)
-!
 !    CALL tridiag(nz,a,b,c,d)
-!
-!    DO k=kts,kte
-!       sqw(k)=d(k-kts+1)
-!    ENDDO
+    CALL tridiag2(nz,a,b,c,d,sqw2)
 
-!!============================================
-!! cloud water ( sqc )
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QC) THEN
+!    DO k=kts,kte
+!       sqw2(k)=d(k-kts+1)
+!    ENDDO
+ELSE
+    sqw2=sqw
+ENDIF
+
+IF (bl_mynn_mixqt == 0) THEN
+!============================================
+! cloud water ( sqc ). If mixing total water (bl_mynn_mixqt > 0),
+! then sqc will be backed out of saturation check (below).
+!============================================
+  IF (bl_mynn_cloudmix > 0 .AND. FLAG_QC) THEN
 
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
+    a(k)=0.
+    b(k)=1.+dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
 
-    rhs   =  qcd(k)
-    d(1)=sqc(k) + dtz(k)*flqc + rhs*delt
+    d(k)=sqc(k) + dtz(k)*flqc + qcd(k)*delt -dtz(k)*s_awqc(k+1)
 
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
+       a(k)=  -dtz(k)*dfh(k)            + 0.5*dtz(k)*s_aw(k)
+       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*dfh(k+1)          - 0.5*dtz(k)*s_aw(k+1)
 
-       rhs = qcd(k)
-       d(kk)=sqc(k) + rhs*delt
+       d(k)=sqc(k) + qcd(k)*delt + dtz(k)*(s_awqc(k)-s_awqc(k+1))
     ENDDO
 
-!! prescribed value                                                                                     
+! prescribed value
     a(nz)=0.
     b(nz)=1.
     c(nz)=0.
     d(nz)=sqc(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,sqc2)
 
-    DO k=kts,kte
-       sqc(k)=d(k-kts+1)
-    ENDDO
-
+!    DO k=kts,kte
+!       sqc2(k)=d(k-kts+1)
+!    ENDDO
+  ELSE
+    !If not mixing clouds, set "updated" array equal to original array
+    sqc2=sqc
+  ENDIF
 ENDIF
 
-!!============================================
-!! cloud water number concentration ( qnc )
-!!============================================
-!IF (Cloudmix > 0.5 .AND. FLAG_QNC) THEN
-!
-!    k=kts
-!
-!    a(1)=0.
-!    b(1)=1.+dtz(k)*dfh(k+1)
-!    c(1)=-dtz(k)*dfh(k+1)
-!
-!    rhs =qcd(k)
-!    d(1)=qnc(k) !+ dtz(k)*flqc + rhs*delt
-!
-!    DO k=kts+1,kte-1
-!       kk=k-kts+1
-!       a(kk)=-dtz(k)*dfh(k)
-!       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-!       c(kk)=-dtz(k)*dfh(k+1)
-!
-!       rhs = qcd(k)
-!       d(kk)=qnc(k) + rhs*delt
-!    ENDDO
-!
-!! prescribed value
-!    a(nz)=0.
-!    b(nz)=1.
-!    c(nz)=0.
-!    d(nz)=qnc(kte)
-!
-!    CALL tridiag(nz,a,b,c,d)
-!
-!    DO k=kts,kte
-!       qnc2(k)=d(k-kts+1)
-!    ENDDO
-!
-!ELSE
-!    qnc2=qnc
-!ENDIF
-
-!!============================================
-!! MIX WATER VAPOR ONLY ( sqv )                                                                         
-!!============================================                                                          
+IF (bl_mynn_mixqt == 0) THEN
+  !============================================
+  ! MIX WATER VAPOR ONLY ( sqv ). If mixing total water (bl_mynn_mixqt > 0),
+  ! then sqv will be backed out of saturation check (below).
+  !============================================
 
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    d(1)=sqv(k) + dtz(k)*flqv + qcd(k)*delt
+    a(k)=0.
+    b(k)=1.+dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*dfh(k+1) - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=sqv(k) + dtz(k)*flqv + qcd(k)*delt - dtz(k)*s_awqv(k+1)  !note: using qt, not qv...
 
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-       d(kk)=sqv(k) + qcd(k)*delt
+       a(k)=  -dtz(k)*dfh(k)            + 0.5*dtz(k)*s_aw(k)
+       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*dfh(k+1)          - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=sqv(k) + qcd(k)*delt + dtz(k)*(s_awqv(k)-s_awqv(k+1))
     ENDDO
 
-!! no flux at the top                                                                                   
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=0.                                                                                           
+! no flux at the top
+!    a(nz)=-1.
+!    b(nz)=1.
+!    c(nz)=0.
+!    d(nz)=0.
 
-!! specified gradient at the top                                                                        
-!assume gradqw_top=gradqv_top                                                                           
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=gradqv_top*dztop                                                                             
+! specified gradient at the top
+! assume gradqw_top=gradqv_top
+!    a(nz)=-1.
+!    b(nz)=1.
+!    c(nz)=0.
+!    d(nz)=gradqv_top*dztop
 
-!! prescribed value                                                                                     
+! prescribed value
     a(nz)=0.
     b(nz)=1.
     c(nz)=0.
     d(nz)=sqv(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,sqv2)
 
-    DO k=kts,kte
-       sqv(k)=d(k-kts+1)
-    ENDDO
+!    DO k=kts,kte
+!       sqv2(k)=d(k-kts+1)
+!    ENDDO
+ELSE
+    sqv2=sqv
+ENDIF
 
-!!============================================
-!! MIX CLOUD ICE ( sqi )                      
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QI) THEN
+!============================================
+! MIX CLOUD ICE ( sqi )                      
+!============================================
+IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
 
     k=kts
 
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-    d(1)=sqi(k) + qcd(k)*delt !should we have qcd for ice???
+    a(k)=0.
+    b(k)=1.+dtz(k)*dfh(k+1)
+    c(k)=  -dtz(k)*dfh(k+1)
+    d(k)=sqi(k) !+ qcd(k)*delt !should we have qcd for ice?
 
     DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-       d(kk)=sqi(k) + qcd(k)*delt
+       a(k)=  -dtz(k)*dfh(k)
+       b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1))
+       c(k)=  -dtz(k)*dfh(k+1)
+       d(k)=sqi(k) !+ qcd(k)*delt
     ENDDO
 
 !! no flux at the top
@@ -2267,87 +3133,273 @@ IF (Cloudmix > 0.5 .AND. FLAG_QI) THEN
 
 !! specified gradient at the top
 !assume gradqw_top=gradqv_top
-!    a(nz)=-1.                                                                                          
-!    b(nz)=1.                                                                                           
-!    c(nz)=0.                                                                                           
-!    d(nz)=gradqv_top*dztop                                                                             
-
-!! prescribed value                                                                                     
-    a(nz)=0.
-    b(nz)=1.
-    c(nz)=0.
-    d(nz)=sqi(kte)
-
-    CALL tridiag(nz,a,b,c,d)
-
-    DO k=kts,kte
-       sqi(k)=d(k-kts+1)
-    ENDDO
-
-ENDIF
-
-!!============================================
-!! ice water number concentration (qni)       
-!!============================================
-IF (Cloudmix > 0.5 .AND. FLAG_QNI) THEN
-
-    k=kts
-
-    a(1)=0.
-    b(1)=1.+dtz(k)*dfh(k+1)
-    c(1)=-dtz(k)*dfh(k+1)
-
-    rhs = qcd(k)               
-
-    d(1)=qni(k) !+ dtz(k)*flqc + rhs*delt
-
-    DO k=kts+1,kte-1
-       kk=k-kts+1
-       a(kk)=-dtz(k)*dfh(k)
-       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
-       c(kk)=-dtz(k)*dfh(k+1)
-
-       rhs = qcd(k)
-       d(kk)=qni(k) + rhs*delt
-
-    ENDDO
+!    a(nz)=-1.
+!    b(nz)=1.
+!    c(nz)=0.
+!    d(nz)=gradqv_top*dztop
 
 !! prescribed value
     a(nz)=0.
     b(nz)=1.
     c(nz)=0.
-    d(nz)=qni(kte)
+    d(nz)=sqi(kte)
 
-    CALL tridiag(nz,a,b,c,d)
+!    CALL tridiag(nz,a,b,c,d)
+    CALL tridiag2(nz,a,b,c,d,sqi2)
 
-    DO k=kts,kte
-       qni2(k)=d(k-kts+1)
-    ENDDO
+!    DO k=kts,kte
+!       sqi2(k)=d(k-kts+1)
+!    ENDDO
 ELSE
-    qni2=qni
+   sqi2=sqi
 ENDIF
 
 !!============================================
-!! convert to mixing ratios for wrf
+!! cloud ice number concentration (qni)
 !!============================================
-!!NOTE: added number conc tendencies for double moment schemes
+! diasbled this since scalar_pblmix option can be invoked instead
+!IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNI) THEN
+!
+!    k=kts
+!
+!    a(1)=0.
+!    b(1)=1.+dtz(k)*dfh(k+1)
+!    c(1)=-dtz(k)*dfh(k+1)
+!
+!    rhs = qcd(k)
+!
+!    d(1)=qni(k) !+ dtz(k)*flqc + rhs*delt
+!
+!    DO k=kts+1,kte-1
+!       kk=k-kts+1
+!       a(kk)=-dtz(k)*dfh(k)
+!       b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
+!       c(kk)=-dtz(k)*dfh(k+1)
+!
+!       rhs = qcd(k)
+!       d(kk)=qni(k) !+ rhs*delt
+!
+!    ENDDO
+!
+!! prescribed value
+!    a(nz)=0.
+!    b(nz)=1.
+!    c(nz)=0.
+!    d(nz)=qni(kte)
+!
+!    CALL tridiag(nz,a,b,c,d)
+!
+!    DO k=kts,kte
+!       qni2(k)=d(k-kts+1)
+!    ENDDO
+!ELSE
+    qni2=qni
+!ENDIF
+
+!!============================================
+!! Compute tendencies and convert to mixing ratios for WRF.
+!! Note that the momentum tendencies are calculated above.
+!!============================================
 
     DO k=kts,kte
-       !sqw(k)=d(k-kts+1)
-       Dqv(k)=(sqv(k)/(1.-sqv(k))-qv(k))/delt
-       !qc settling tendency is now computed in module_bl_fogdes.F, so
-       !sqc should only be changed by turbulent mixing.
-       Dqc(k)=(sqc(k)/(1.-sqc(k))-qc(k))/delt
-       Dqi(k)=(sqi(k)/(1.-sqi(k))-qi(k))/delt
- !      Dqnc(k)=(qnc2(k)-qnc(k))/delt
-       Dqni(k)=(qni2(k)-qni(k))/delt
-       Dth(k)=(thl(k) + xlvcp/exner(k)*sqc(k) &
-         &            + xlscp/exner(k)*sqi(k) &
-         &            - th(k))/delt
-       !Dth(k)=(thl(k)+xlvcp/exner(k)*sqc(k)-th(k))/delt
+
+       IF (bl_mynn_mixqt > 0) THEN
+         t  = th(k)*exner(k)
+         !SATURATED VAPOR PRESSURE
+         esat=esat_blend(t)
+         !SATURATED SPECIFIC HUMIDITY
+         qsl=ep_2*esat/(p(k)-ep_3*esat)
+
+         !IF (qsl >= sqw2(k)) THEN !unsaturated
+         !   sqv2(k) = MAX(0.0,sqw2(k))
+         !   sqi2(k) = MAX(0.0,sqi2(k))
+         !   sqc2(k) = MAX(0.0,sqw2(k) - sqv2(k) - sqi2(k))
+         !ELSE                     !saturated
+            IF (FLAG_QI) THEN
+              !sqv2(k) = qsl
+              sqi2(k) = MAX(0., sqi2(k))
+              sqc2(k) = MAX(0., sqw2(k) - sqi2(k) - qsl)      !updated cloud water
+              sqv2(k) = MAX(0., sqw2(k) - sqc2(k) - sqi2(k))  !updated water vapor
+            ELSE
+              !sqv2(k) = qsl
+              sqi2(k) = 0.0
+              sqc2(k) = MAX(0., sqw2(k) - qsl)         !updated cloud water
+              sqv2(k) = MAX(0., sqw2(k) - sqc2(k))     ! updated water vapor
+            ENDIF
+         !ENDIF
+       ENDIF
+
+       !=====================
+       ! WATER VAPOR TENDENCY
+       !=====================
+       Dqv(k)=(sqv2(k)/(1.-sqv2(k)) - qv(k))/delt
+       !IF(-Dqv(k) > qv(k)) Dqv(k)=-qv(k)
+
+       !=====================
+       ! CLOUD WATER TENDENCY
+       !=====================
+       !qc fog settling tendency is now computed in module_bl_fogdes.F, so
+       !sqc should only be changed by eddy diffusion or mass-flux.
+       !print*,"FLAG_QC:",FLAG_QC
+       IF (bl_mynn_cloudmix > 0 .AND. FLAG_QC) THEN
+         Dqc(k)=(sqc2(k)/(1.-sqc2(k)) - qc(k))/delt
+         IF(Dqc(k)*delt + qc(k) < 0.) THEN
+           !print*,'  neg qc: ',qsl,' ',sqw2(k),' ',sqi2(k),' ',sqc2(k),' ',qc(k),' ',tk(k)
+           Dqc(k)=-qc(k)/delt 
+         ENDIF
+
+         !REMOVED MIXING OF QNC - PERFORMED IN THE SCALAR_PBLMIX OPTION
+         !IF (FLAG_QNC) THEN
+         !  IF(sqc2(k)>1.e-9)qnc2(k)=MAX(qnc2(k),1.e6)
+         !  Dqnc(k) = (qnc2(k)-qnc(k))/delt
+         !  IF(Dqnc(k)*delt + qnc(k) < 0.)Dqnc(k)=-qnc(k)/delt 
+         !ELSE
+         !  Dqnc(k) = 0.
+         !ENDIF
+       ELSE
+         Dqc(k)=0.
+         !Dqnc(k)=0.
+       ENDIF
+
+       !===================
+       ! CLOUD ICE TENDENCY
+       !===================
+       IF (bl_mynn_cloudmix > 0 .AND. FLAG_QI) THEN
+         Dqi(k)=(sqi2(k)/(1.-sqi2(k)) - qi(k))/delt
+         IF(Dqi(k)*delt + qi(k) < 0.) THEN
+           !print*,' neg qi; ',qsl,' ',sqw2(k),' ',sqi2(k),' ',sqc2(k),' ',qi(k),' ',tk(k)
+           Dqi(k)=-qi(k)/delt
+         ENDIF
+
+         !REMOVED MIXING OF QNI - PERFORMED IN THE SCALAR_PBLMIX OPTION
+         !SET qni2 = qni above, so all tendencies are zero
+         IF (FLAG_QNI) THEN
+           Dqni(k)=(qni2(k)-qni(k))/delt
+           IF(Dqni(k)*delt + qni(k) < 0.)Dqni(k)=-qni(k)/delt
+         ELSE
+           Dqni(k)=0.
+         ENDIF
+       ELSE
+         Dqi(k)=0.
+         Dqni(k)=0.
+       ENDIF
+
+       !===================
+       ! THETA TENDENCY
+       !===================
+       IF (FLAG_QI) THEN
+         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc(k) &
+           &            + xlscp/exner(k)*sqi(k) &
+           &            - th(k))/delt
+         !Use form from Tripoli and Cotton (1981) with their
+         !suggested min temperature to improve accuracy:
+         !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc2(k)  &
+         !  &               + xlscp/MAX(tk(k),TKmin)*sqi2(k)) &
+         !  &               - th(k))/delt
+       ELSE
+         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc2(k) - th(k))/delt
+         !Use form from Tripoli and Cotton (1981) with their
+         !suggested min temperature to improve accuracy.
+         !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc2(k))  &
+         !&               - th(k))/delt
+       ENDIF
+
     ENDDO
 
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
   END SUBROUTINE mynn_tendencies
+
+! ==================================================================
+#if (WRF_CHEM == 1)
+  SUBROUTINE mynn_mix_chem(kts,kte,      &
+       levflag,grav_settling,             &
+       delt,dz,                           &
+       nchem, kdvel, ndvel, num_vert_mix, &
+       chem1, vd1,                        &
+       qni,qnc,        &
+       p,exner,                           &
+       thl,sqv,sqc,sqi,sqw,               &
+       ust,flt,flq,flqv,flqc,wspd,qcg,    &
+       uoce,voce,                         &
+       tsq,qsq,cov,                       &
+       tcd,qcd,                           &
+       dfm,dfh,dfq,                       &
+       s_awchem,                          &
+       bl_mynn_cloudmix)
+
+!-------------------------------------------------------------------
+    INTEGER, INTENT(in) :: kts,kte
+    INTEGER, INTENT(in) :: grav_settling,levflag
+    INTEGER, INTENT(in) :: bl_mynn_cloudmix
+
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: qni,qnc,&
+         &p,exner,dfm,dfh,dfq,dz,tsq,qsq,cov,tcd,qcd
+    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: thl,sqw,sqv,sqc,sqi
+    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
+    INTEGER, INTENT(IN   )   ::   nchem, kdvel, ndvel, num_vert_mix
+    REAL, DIMENSION( kts:kte, nchem ), INTENT(INOUT) :: chem1
+    REAL, DIMENSION( kts:kte+1,nchem), INTENT(IN) :: s_awchem
+    REAL, DIMENSION( ndvel ), INTENT(INOUT) :: vd1
+
+!local vars
+
+    REAL, DIMENSION(kts:kte) :: dtz,vt,vq
+    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
+    REAL :: rhs,gfluxm,gfluxp,dztop
+    REAL :: t,esl,qsl
+    INTEGER :: k,kk,nz
+    INTEGER :: ic  ! Chemical array loop index
+    REAL, DIMENSION( kts:kte, nchem ) :: chem_new
+
+    nz=kte-kts+1
+
+    dztop=.5*(dz(kte)+dz(kte-1))
+
+    DO k=kts,kte
+       dtz(k)=delt/dz(k)
+    ENDDO
+
+  !============================================
+  ! Patterned after mixing of water vapor in mynn_tendencies.
+  !============================================
+
+    DO ic = 1,nchem
+       k=kts
+
+       a(1)=0.
+       b(1)=1.+dtz(k)*dfh(k+1)
+       c(1)=-dtz(k)*dfh(k+1)
+       ! d(1)=sqv(k) + dtz(k)*flqv + qcd(k)*delt
+       d(1)=chem1(k,ic) + dtz(k) * -vd1(ic)*chem1(1,ic)
+
+       DO k=kts+1,kte-1
+          kk=k-kts+1
+          a(kk)=-dtz(k)*dfh(k)
+          b(kk)=1.+dtz(k)*(dfh(k)+dfh(k+1))
+          c(kk)=-dtz(k)*dfh(k+1)
+          ! d(kk)=chem1(k,ic) + qcd(k)*delt
+          d(kk)=chem1(k,ic) + rhs*delt + dtz(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
+       ENDDO
+
+      ! prescribed value at top
+       a(nz)=0.
+       b(nz)=1.
+       c(nz)=0.
+       d(nz)=chem1(kte,ic)
+
+       CALL tridiag(nz,a,b,c,d)
+
+       DO k=kts,kte
+          chem_new(k,ic)=d(k-kts+1)
+       ENDDO
+    ENDDO
+
+  END SUBROUTINE mynn_mix_chem
+#endif
 
 ! ==================================================================
   SUBROUTINE retrieve_exchange_coeffs(kts,kte,&
@@ -2375,7 +3427,7 @@ ENDIF
        dzk = 0.5  *( dz(k)+dz(k-1) )
        K_m(k)=dfm(k)*dzk
        K_h(k)=dfh(k)*dzk
-       K_q(k)=dfq(k)*dzk
+       K_q(k)=Sqfac*dfq(k)*dzk
     ENDDO
 
   END SUBROUTINE retrieve_exchange_coeffs
@@ -2416,32 +3468,78 @@ ENDIF
   END SUBROUTINE tridiag
 
 ! ==================================================================
-  SUBROUTINE mynn_bl_driver(&
-       &initflag,&
-       &grav_settling,&
-       &delt,&
-       &dz,&
-       &u,v,th,qv,qc,qi,qni,&! qnc&       !JOE: ice & num conc mixing
-       &p,exner,rho,&
-       &xland,ts,qsfc,qcg,ps,&
-       &ust,ch,hfx,qfx,rmol,wspd,&
-       &uoce,voce,&                     !ocean current
-       &vdfg,&                          !Katata-added for fog dep
-       &Qke,tke_pbl,&                   !JOE: add TKE for coupling
-       &qke_adv,bl_mynn_tkeadvect,&     !ACF for QKE advection
-       &Tsq,Qsq,Cov,&
-       &Du,Dv,Dth,&
-       &Dqv,Dqc,Dqi,Dqni,& !Dqnc,&         !JOE: ice & nim conc mixing
-       &K_m,K_h,K_q,&
-!      &K_h,k_m,&
-       &Pblh,kpbl&                      !JOE-added kpbl for coupling
-       &,el_pbl&
-       &,dqke,qWT,qSHEAR,qBUOY,qDISS    & !JOE-TKE BUDGET
-       &,wstar,delta                    & !JOE-added for grims
-       &,bl_mynn_tkebudget              & !JOE-TKE BUDGET
-       &,bl_mynn_cloudpdf,Sh3D          & !JOE-cloudPDF testing
-       ! optional arguments
-       &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
+      subroutine tridiag2(n,a,b,c,d,x)
+      implicit none
+!      a - sub-diagonal (means it is the diagonal below the main diagonal)
+!      b - the main diagonal
+!      c - sup-diagonal (means it is the diagonal above the main diagonal)
+!      d - right part
+!      x - the answer
+!      n - number of unknowns (levels)
+
+        integer,intent(in) :: n
+        real, dimension(n),intent(in) :: a,b,c,d
+        real ,dimension(n),intent(out) :: x
+        real ,dimension(n) :: cp,dp
+        real :: m
+        integer :: i
+
+        ! initialize c-prime and d-prime
+        cp(1) = c(1)/b(1)
+        dp(1) = d(1)/b(1)
+        ! solve for vectors c-prime and d-prime
+        do i = 2,n
+           m = b(i)-cp(i-1)*a(i)
+           cp(i) = c(i)/m
+           dp(i) = (d(i)-dp(i-1)*a(i))/m
+        enddo
+        ! initialize x
+        x(n) = dp(n)
+        ! solve for x from the vectors c-prime and d-prime
+        do i = n-1, 1, -1
+           x(i) = dp(i)-cp(i)*x(i+1)
+        end do
+
+    end subroutine tridiag2
+! ==================================================================
+  SUBROUTINE mynn_bl_driver(            &
+       &initflag,grav_settling,         &
+       &delt,dz,dx,znt,                 &
+       &u,v,w,th,qv,qc,qi,qni,qnc,      &
+       &p,exner,rho,T3D,                &
+       &xland,ts,qsfc,qcg,ps,           &
+       &ust,ch,hfx,qfx,rmol,wspd,       &
+       &uoce,voce,                      & !ocean current
+       &vdfg,                           & !Katata-added for fog dep
+       &Qke,tke_pbl,                    &
+       &qke_adv,bl_mynn_tkeadvect,      & !ACF for QKE advection
+#if (WRF_CHEM == 1)
+       chem3d, vd3d, nchem,             & ! WA 7/29/15 For WRF-Chem
+       kdvel, ndvel, num_vert_mix,      &
+#endif
+       &Tsq,Qsq,Cov,                    &
+       &RUBLTEN,RVBLTEN,RTHBLTEN,       &
+       &RQVBLTEN,RQCBLTEN,RQIBLTEN,     &
+       &RQNIBLTEN,                      &
+       &exch_h,exch_m,                  &
+       &Pblh,kpbl,                      & 
+       &el_pbl,                         &
+       &dqke,qWT,qSHEAR,qBUOY,qDISS,    & !JOE-TKE BUDGET
+       &wstar,delta,                    & !JOE-added for grims
+       &bl_mynn_tkebudget,              &
+       &bl_mynn_cloudpdf,Sh3D,          &
+       &bl_mynn_mixlength,              &
+       &icloud_bl,qc_bl,cldfra_bl,      &
+       &bl_mynn_edmf,                   &
+       &bl_mynn_edmf_mom,bl_mynn_edmf_tke, &
+       &bl_mynn_edmf_part,              &
+       &bl_mynn_cloudmix,bl_mynn_mixqt, &
+       &edmf_a,edmf_w,edmf_qt,          &
+       &edmf_thl,edmf_ent,edmf_qc,      &
+       &nupdraft,maxMF,ktop_shallow,    &
+       &spp_pbl,pattern_spp_pbl,        &
+       &RTHRATEN,                       &
+       &FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
        &,IDS,IDE,JDS,JDE,KDS,KDE        &
        &,IMS,IME,JMS,JME,KMS,KME        &
        &,ITS,ITE,JTS,JTE,KTS,KTE)
@@ -2453,7 +3551,15 @@ ENDIF
     INTEGER, INTENT(in) :: grav_settling
     INTEGER, INTENT(in) :: bl_mynn_tkebudget
     INTEGER, INTENT(in) :: bl_mynn_cloudpdf
+    INTEGER, INTENT(in) :: bl_mynn_mixlength
+    INTEGER, INTENT(in) :: bl_mynn_edmf
     LOGICAL, INTENT(IN) :: bl_mynn_tkeadvect
+    INTEGER, INTENT(in) :: bl_mynn_edmf_mom
+    INTEGER, INTENT(in) :: bl_mynn_edmf_tke
+    INTEGER, INTENT(in) :: bl_mynn_edmf_part
+    INTEGER, INTENT(in) :: bl_mynn_cloudmix
+    INTEGER, INTENT(in) :: bl_mynn_mixqt
+    INTEGER, INTENT(in) :: icloud_bl
 
     LOGICAL, INTENT(IN) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC
     
@@ -2461,7 +3567,11 @@ ENDIF
          & IDS,IDE,JDS,JDE,KDS,KDE &
          &,IMS,IME,JMS,JME,KMS,KME &
          &,ITS,ITE,JTS,JTE,KTS,KTE
-    
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
 
 ! initflag > 0  for TRUE
 ! else        for FALSE
@@ -2470,16 +3580,18 @@ ENDIF
 ! grav_settling = 1 when gravitational settling accounted for
 ! grav_settling = 0 when gravitational settling NOT accounted for
     
-    REAL, INTENT(in) :: delt
+    REAL, INTENT(in) :: delt,dx
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(in) :: dz,&
-         &u,v,th,qv,qc,p,exner,rho
+         &u,v,th,qv,p,exner,rho
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(in) :: &
+         &w,T3D
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(in)::&
-         &qi,qni! ,qnc
+         &qc,qi,qni,qnc
     REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: xland,ust,&
-!         &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx, wspd,uoce,voce
-!Katata-added for extra in-output
          &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx, wspd,uoce,voce, vdfg
-!Katata-end
+
+    REAL, DIMENSION(IMS:IME,JMS:JME), OPTIONAL, INTENT(in) :: &
+         &znt
 
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &Qke,Tsq,Qsq,Cov, &
@@ -2487,48 +3599,111 @@ ENDIF
          &qke_adv    !ACF for QKE advection
 
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
-         &Du,Dv,Dth,Dqv,Dqc,Dqi,Dqni!,Dqnc
+         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,&
+         &RQIBLTEN,RQNIBLTEN !,RQNCBLTEN
+
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(inout) :: &
+         &RTHRATEN
 
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
-         &K_h,K_m
+         &exch_h,exch_m
+
+   REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(inout) :: &
+         & edmf_a,edmf_w,edmf_qt,edmf_thl,edmf_ent,edmf_qc
 
     REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(inout) :: &
          &Pblh,wstar,delta  !JOE-added for GRIMS
+
+    REAL, DIMENSION(IMS:IME,JMS:JME) :: &
+         &Psig_bl,Psig_shcu
+
     INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: & 
          &KPBL
-    
+ 
+    INTEGER,DIMENSION(IMS:IME,JMS:JME),OPTIONAL,INTENT(INOUT) :: &
+         &ktop_shallow,nupdraft
+
+    REAL, DIMENSION(IMS:IME,JMS:JME), OPTIONAL,INTENT(OUT) :: &
+         &maxmf
+
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &el_pbl
 
-!JOE-TKE BUDGET
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
          &qWT,qSHEAR,qBUOY,qDISS,dqke
     ! 3D budget arrays are not allocated when bl_mynn_tkebudget == 0.
     ! 1D (local) budget arrays are used for passing between subroutines.
     REAL, DIMENSION(KTS:KTE) :: qWT1,qSHEAR1,qBUOY1,qDISS1,dqke1
-!JOE-end
+
     REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: K_q,Sh3D
+
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(inout) :: &
+         &qc_bl,cldfra_bl
+
+    REAL, DIMENSION(KTS:KTE) :: qc_bl1D,cldfra_bl1D,&
+                            qc_bl1D_old,cldfra_bl1D_old
+
+! WA 7/29/15 Mix chemical arrays
+#if (WRF_CHEM == 1)
+    INTEGER, INTENT(IN   )   ::   nchem, kdvel, ndvel, num_vert_mix
+    REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, nchem ), INTENT(INOUT) :: chem3d
+    REAL,    DIMENSION( ims:ime, kdvel, jms:jme, ndvel ), INTENT(IN) :: vd3d
+    REAL,    DIMENSION( kts:kte, nchem ) :: chem1
+    REAL,    DIMENSION( kts:kte+1, nchem ) :: s_awchem1
+    REAL,    DIMENSION( ndvel ) :: vd1
+    INTEGER ic
+#endif
 
 !local vars
     INTEGER :: ITF,JTF,KTF, IMD,JMD
     INTEGER :: i,j,k
-    REAL, DIMENSION(KTS:KTE) :: thl,sqv,sqc,sqi,sqw,&
-         &El, Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, Vt, Vq
+    REAL, DIMENSION(KTS:KTE) :: thl,thvl,tl,sqv,sqc,sqi,sqw,&
+         &El, Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
+         &Vt, Vq, sgm
 
-    REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,p1,ex1,dz1,th1,qke1, &
-           & tsq1,qsq1,cov1,qv1,qi1,qc1,du1,dv1,dth1,dqv1,dqc1,dqi1, &
-           & k_m1,k_h1,k_q1,qni1,dqni1!,qnc1,dqnc1
+    REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,w1,p1,ex1,dz1,th1,tk1,rho1,&
+           & qke1,tsq1,qsq1,cov1,qv1,qi1,qc1,du1,dv1,dth1,dqv1,dqc1,dqi1, &
+           & k_m1,k_h1,k_q1,qni1,dqni1,qnc1 !,dqnc1
+
+!JOE: mass-flux variables
+    REAL, DIMENSION(KTS:KTE) :: dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
+    REAL, DIMENSION(KTS:KTE) :: edmf_a1,edmf_w1,edmf_qt1,edmf_thl1,&
+                                edmf_ent1,edmf_qc1
+    REAL,DIMENSION(KTS:KTE+1) :: s_aw1,s_awthl1,s_awqt1,&
+                  s_awqv1,s_awqc1,s_awu1,s_awv1,s_awqke1
 
     REAL, DIMENSION(KTS:KTE+1) :: zw
-    
-      REAL :: cpm,sqcg,flt,flq,flqv,flqc,pmz,phh,exnerg,zet,& 
-              &afk,abk
+    REAL :: cpm,sqcg,flt,flq,flqv,flqc,pmz,phh,exnerg,zet,& 
+              &afk,abk,ts_decay,th_sfc,ztop_shallow
+
 !JOE-add GRIMS parameters & variables
    real,parameter    ::  d1 = 0.02, d2 = 0.05, d3 = 0.001
    real,parameter    ::  h1 = 0.33333335, h2 = 0.6666667
    REAL :: govrth, sflux, bfx0, wstar3, wm2, wm3, delb
 !JOE-end GRIMS
+!JOE-top-down diffusion
+   REAL, DIMENSION(ITS:ITE,JTS:JTE) :: maxKHtopdown
+   REAL,DIMENSION(KTS:KTE) :: KHtopdown,zfac,wscalek2,&
+                             zfacent,TKEprodTD
+   REAL :: bfxpbl,dthvx,tmp1,temps,templ,zl1,wstar3_2
+   real :: ent_eff,radsum,radflux,we,rcldb,rvls,&
+           minrad,zminrad
+   real, parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
+   integer :: kk,kminrad
+   logical :: cloudflg
+!JOE-end top down
+
     INTEGER, SAVE :: levflag
+
+! Stochastic fields 
+     INTEGER,  INTENT(IN)                                               ::spp_pbl
+     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
+     REAL, DIMENSION(KTS:KTE)                         ::    rstoch_col
+
+
+    IF ( debug_code ) THEN
+       print*,'in MYNN driver; at beginning'
+    ENDIF
 
 !***  Begin debugging
     IMD=(IMS+IME)/2
@@ -2541,25 +3716,56 @@ ENDIF
 
     levflag=mynn_level
 
+    IF (bl_mynn_edmf > 0) THEN
+      ! setup random seed
+      !call init_random_seed
+
+      edmf_a(its:ite,kts:kte,jts:jte)=0.
+      edmf_w(its:ite,kts:kte,jts:jte)=0.
+      edmf_qt(its:ite,kts:kte,jts:jte)=0.
+      edmf_thl(its:ite,kts:kte,jts:jte)=0.
+      edmf_ent(its:ite,kts:kte,jts:jte)=0.
+      edmf_qc(its:ite,kts:kte,jts:jte)=0.
+      ktop_shallow(its:ite,jts:jte)=0 !int
+      nupdraft(its:ite,jts:jte)=0     !int
+      maxmf(its:ite,jts:jte)=0.
+    ENDIF
+    maxKHtopdown(its:ite,jts:jte)=0.
+
     IF (initflag > 0) THEN
-!      write(0,*)
-!      write(0,*) '--- bl_mynn initflag = ', initflag
-!      write(0,*) '--- bl_mynn mynn_level = ', levflag
-!      write(0,*) '--- initialize sh3d, el_pbl, tsq, qsq, cov'
-!      write(0,*)
+ 
        Sh3D(its:ite,kts:kte,jts:jte)=0.
        el_pbl(its:ite,kts:kte,jts:jte)=0.
        tsq(its:ite,kts:kte,jts:jte)=0.
        qsq(its:ite,kts:kte,jts:jte)=0.
        cov(its:ite,kts:kte,jts:jte)=0.
+       dqc1(kts:kte)=0.0
+       dqi1(kts:kte)=0.0
+       dqni1(kts:kte)=0.0
+       !dqnc1(kts:kte)=0.0
+       qc_bl1D(kts:kte)=0.0
+       cldfra_bl1D(kts:kte)=0.0
+       qc_bl1D_old(kts:kte)=0.0
+       cldfra_bl1D_old(kts:kte)=0.0
+       edmf_a1(kts:kte)=0.0
+       edmf_w1(kts:kte)=0.0
+       edmf_qc1(kts:kte)=0.0
+       sgm(kts:kte)=0.0
+       vt(kts:kte)=0.0
+       vq(kts:kte)=0.0
 
        DO j=JTS,JTF
           DO i=ITS,ITF
-             DO k=KTS,KTF
+             DO k=KTS,KTE !KTF
                 dz1(k)=dz(i,k,j)
                 u1(k) = u(i,k,j)
                 v1(k) = v(i,k,j)
+#if defined(wrfmodel)
+                w1(k) = w(i,k,j)
+                tk1(k)=T3D(i,k,j)
+#endif
                 th1(k)=th(i,k,j)
+                rho1(k)=rho(i,k,j)
                 sqc(k)=qc(i,k,j)/(1.+qc(i,k,j))
                 sqv(k)=qv(i,k,j)/(1.+qv(i,k,j))
                 thetav(k)=th(i,k,j)*(1.+0.61*sqv(k))
@@ -2568,10 +3774,17 @@ ENDIF
                    sqw(k)=sqv(k)+sqc(k)+sqi(k)
                    thl(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc(k) &
                        &           - xlscp/exner(i,k,j)*sqi(k)
+                   !Use form from Tripoli and Cotton (1981) with their
+                   !suggested min temperature to improve accuracy.
+                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                   !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
                 ELSE
                    sqi(k)=0.0
                    sqw(k)=sqv(k)+sqc(k)
                    thl(k)=th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
+                   !Use form from Tripoli and Cotton (1981) with their 
+                   !suggested min temperature to improve accuracy.      
+                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
                 ENDIF
 
                 IF (k==kts) THEN
@@ -2579,17 +3792,23 @@ ENDIF
                 ELSE
                    zw(k)=zw(k-1)+dz(i,k-1,j)
                 ENDIF
-
-                k_m(i,k,j)=0.
-                k_h(i,k,j)=0.
-                k_q(i,k,j)=0.
-                qke(i,k,j)=0.1-MIN(zw(k)*0.001, 0.0)
+                thvl(k)=thl(k)*(1.+0.61*sqv(k))
+                exch_m(i,k,j)=0.
+                exch_h(i,k,j)=0.
+                K_q(i,k,j)=0.
+                qke(i,k,j)=0.1-MIN(zw(k)*0.001, 0.0) !for initial PBLH calc only
                 qke1(k)=qke(i,k,j)
                 el(k)=el_pbl(i,k,j)
                 sh(k)=Sh3D(i,k,j)
                 tsq1(k)=tsq(i,k,j)
                 qsq1(k)=qsq(i,k,j)
                 cov1(k)=cov(i,k,j)
+                if (spp_pbl==1) then
+                    rstoch_col(k)=pattern_spp_pbl(i,k,j)
+                else
+                    rstoch_col(k)=0.0
+                endif
+
 
                 IF ( bl_mynn_tkebudget == 1) THEN
                    !TKE BUDGET VARIABLES
@@ -2602,16 +3821,28 @@ ENDIF
              ENDDO
 
              zw(kte+1)=zw(kte)+dz(i,kte,j)
-             
-             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
-               &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
 
-             CALL mym_initialize ( kts,kte,&
-                  &dz1, zw, u1, v1, thl, sqv,&
-                  &PBLH(i,j),th1,&                      !JOE-BouLac mod
-                  &sh,&                                 !JOE-cloudPDF mod
-                  &ust(i,j), rmol(i,j),&
-                  &el, Qke1, Tsq1, Qsq1, Cov1)
+!             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
+             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
+               &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
+             
+             IF (scaleaware > 0.) THEN
+                CALL SCALE_AWARE(dx,PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
+             ELSE
+                Psig_bl(i,j)=1.0
+                Psig_shcu(i,j)=1.0
+             ENDIF
+
+             CALL mym_initialize (             & 
+                  &kts,kte,                    &
+                  &dz1, zw, u1, v1, thl, sqv,  &
+                  &PBLH(i,j), th1, sh,         &
+                  &ust(i,j), rmol(i,j),        &
+                  &el, Qke1, Tsq1, Qsq1, Cov1, &
+                  &Psig_bl(i,j), cldfra_bl1D,  &
+                  &bl_mynn_mixlength,          &
+                  &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
+                  &spp_pbl,rstoch_col )
 
              !UPDATE 3D VARIABLES
              DO k=KTS,KTE !KTF
@@ -2621,18 +3852,17 @@ ENDIF
                 tsq(i,k,j)=tsq1(k)
                 qsq(i,k,j)=qsq1(k)
                 cov(i,k,j)=cov1(k)
-!ACF,JOE- initialize qke_adv array if using advection
+                !ACF,JOE- initialize qke_adv array if using advection
                 IF (bl_mynn_tkeadvect) THEN
                    qke_adv(i,k,j)=qke1(k)
                 ENDIF
-!ACF,JOE-end                
              ENDDO
 
 !***  Begin debugging
 !             k=kdebug
 !             IF(I==IMD .AND. J==JMD)THEN
 !               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh(k)
-!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",k_m(i,k,j)
+!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",exch_m(i,k,j)
 !               PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
 !               PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",Tsq(i,k,j)
 !               PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
@@ -2644,53 +3874,71 @@ ENDIF
 
     ENDIF ! end initflag
 
-!ACF copy qke_adv array into qke if using advection
+    !ACF- copy qke_adv array into qke if using advection
     IF (bl_mynn_tkeadvect) THEN
        qke=qke_adv
     ENDIF
-!ACF-end
 
     DO j=JTS,JTF
        DO i=ITS,ITF
-          DO k=KTS,KTF
-             !JOE-TKE BUDGET
+          DO k=KTS,KTE !KTF
+            !JOE-TKE BUDGET
              IF ( bl_mynn_tkebudget == 1) THEN
                 dqke(i,k,j)=qke(i,k,j)
              END IF
              dz1(k)= dz(i,k,j)
              u1(k) = u(i,k,j)
              v1(k) = v(i,k,j)
+#if defined(wrfmodel)
+             w1(k) = w(i,k,j)
+             tk1(k)=T3D(i,k,j)
+#endif
              th1(k)= th(i,k,j)
+             rho1(k)=rho(i,k,j)
              qv1(k)= qv(i,k,j)
              qc1(k)= qc(i,k,j)
              sqv(k)= qv(i,k,j)/(1.+qv(i,k,j))
              sqc(k)= qc(i,k,j)/(1.+qc(i,k,j))
+             IF(icloud_bl > 0)cldfra_bl1D_old(k)=cldfra_bl(i,k,j)
+             IF(icloud_bl > 0)qc_bl1D_old(k)=qc_bl(i,k,j)
+             dqc1(k)=0.0
+             dqi1(k)=0.0
+             dqni1(k)=0.0
+             !dqnc1(k)=0.0
              IF(PRESENT(qi) .AND. FLAG_QI)THEN
                 qi1(k)= qi(i,k,j)
                 sqi(k)= qi(i,k,j)/(1.+qi(i,k,j))
                 sqw(k)= sqv(k)+sqc(k)+sqi(k)
                 thl(k)= th(i,k,j) - xlvcp/exner(i,k,j)*sqc(k) &
                      &            - xlscp/exner(i,k,j)*sqi(k)
-                !print*,"MYNN: Flag_qi=",FLAG_QI,qi(i,k,j)
+                !Use form from Tripoli and Cotton (1981) with their
+                !suggested min temperature to improve accuracy.    
+                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
              ELSE
                 qi1(k)=0.0
                 sqi(k)=0.0
                 sqw(k)= sqv(k)+sqc(k)
                 thl(k)= th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
+                !Use form from Tripoli and Cotton (1981) with their
+                !suggested min temperature to improve accuracy.    
+                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
              ENDIF
+
              IF (PRESENT(qni) .AND. FLAG_QNI ) THEN
                 qni1(k)=qni(i,k,j)
                 !print*,"MYNN: Flag_qni=",FLAG_QNI,qni(i,k,j)
              ELSE
                 qni1(k)=0.0
              ENDIF
-             !IF (PRESENT(qnc) .AND. FLAG_QNC ) THEN
-             !   qnc1(k)=qnc(i,k,j)
-             !   !print*,"MYNN: Flag_qnc=",FLAG_QNC,qnc(i,k,j)
-             !ELSE
-             !   qnc1(k)=0.0
-             !ENDIF
+             IF (PRESENT(qnc) .AND. FLAG_QNC ) THEN
+                qnc1(k)=qnc(i,k,j)
+                !print*,"MYNN: Flag_qnc=",FLAG_QNC,qnc(i,k,j)
+             ELSE
+                qnc1(k)=0.0
+             ENDIF
              thetav(k)=th(i,k,j)*(1.+0.608*sqv(k))
+             thvl(k)=thl(k)*(1.+0.61*sqv(k))
              p1(k) = p(i,k,j)
              ex1(k)= exner(i,k,j)
              el(k) = el_pbl(i,k,j)
@@ -2699,19 +3947,73 @@ ENDIF
              tsq1(k)=tsq(i,k,j)
              qsq1(k)=qsq(i,k,j)
              cov1(k)=cov(i,k,j)
+             if (spp_pbl==1) then
+                rstoch_col(k)=pattern_spp_pbl(i,k,j)
+             else
+                rstoch_col(k)=0.0
+             endif
+
+
+             !edmf
+             edmf_a1(k)=0.0
+             edmf_w1(k)=0.0
+             edmf_qc1(k)=0.0
+             s_aw1(k)=0.
+             s_awthl1(k)=0.
+             s_awqt1(k)=0.
+             s_awqv1(k)=0.
+             s_awqc1(k)=0.
+             s_awu1(k)=0.
+             s_awv1(k)=0.
+             s_awqke1(k)=0.
+
+#if (WRF_CHEM == 1)
+             ! WA 7/29/15 Set up chemical arrays
+             DO ic = 1,nchem
+                chem1(k,ic) = chem3d(i,k,j,ic)
+                s_awchem1(k,ic)=0.
+             ENDDO
+             DO ic = 1,ndvel
+                IF (k == KTS) THEN
+                   vd1(ic) = vd3d(i,1,j,ic)
+                ENDIF
+             ENDDO
+#endif
 
              IF (k==kts) THEN
                 zw(k)=0.
              ELSE
                 zw(k)=zw(k-1)+dz(i,k-1,j)
              ENDIF
-          ENDDO
+          ENDDO ! end k
 
-          zw(kte+1)=zw(kte)+dz(i,kte,j)          
-          
-          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
+          zw(kte+1)=zw(kte)+dz(i,kte,j)
+          !EDMF
+          s_aw1(kte+1)=0.
+          s_awthl1(kte+1)=0.
+          s_awqt1(kte+1)=0.
+          s_awqv1(kte+1)=0.
+          s_awqc1(kte+1)=0.
+          s_awu1(kte+1)=0.
+          s_awv1(kte+1)=0.
+          s_awqke1(kte+1)=0.
+#if (WRF_CHEM == 1)
+          DO ic = 1,nchem
+             s_awchem1(kte+1,ic)=0.
+          ENDDO
+#endif
+
+!          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
+          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
           & Qke1,zw,dz1,xland(i,j),KPBL(i,j))
-          
+
+          IF (scaleaware > 0.) THEN
+             CALL SCALE_AWARE(dx,PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
+          ELSE
+             Psig_bl(i,j)=1.0
+             Psig_shcu(i,j)=1.0
+          ENDIF
+
           sqcg= 0.0   !JOE, it was: qcg(i,j)/(1.+qcg(i,j))
           cpm=cp*(1.+0.84*qv(i,kts,j))
           exnerg=(ps(i,j)/p1000mb)**rcp
@@ -2723,14 +4025,18 @@ ENDIF
           !flq = qfx(i,j)/  rho(i,kts,j)       &
           !    -ch(i,j)*(sqc(kts)   -sqcg )
           !-----------------------------------------------------
-          ! Katata-added - The deposition velocity of cloud (fog) 
+          ! Katata-added - The deposition velocity of cloud (fog)
           ! water is used instead of CH.
           flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
             & +xlvcp*vdfg(i,j)*(sqc(kts)/exner(i,kts,j)- sqcg/exnerg)
           flq = qfx(i,j)/  rho(i,kts,j)       &
             & -vdfg(i,j)*(sqc(kts) - sqcg )
+!JOE-test- should this be after the call to mym_condensation?-using old vt & vq
+!same as original form
+!         flt = flt + xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
           flqv = qfx(i,j)/rho(i,kts,j)
           flqc = -vdfg(i,j)*(sqc(kts) - sqcg )
+          th_sfc = ts(i,j)/ex1(kts)
 
           zet = 0.5*dz(i,kts,j)*rmol(i,j)
           if ( zet >= 0.0 ) then
@@ -2741,7 +4047,7 @@ ENDIF
             phh = 1.0/SQRT(1.0-cphh_unst*zet)
           end if
 
-!!!!! estimate wstar & delta for GRIMS shallow-cu
+          !-- Estimate wstar & delta for GRIMS shallow-cu-------
           govrth = g/th1(kts)
           sflux = hfx(i,j)/rho(i,kts,j)/cpm + &
                   qfx(i,j)/rho(i,kts,j)*ep_1*th1(kts)
@@ -2752,76 +4058,344 @@ ENDIF
           wm2        = wm3**h2
           delb       = govrth*d3*pblh(i,j)
           delta(i,j) = min(d1*pblh(i,j) + d2*wm2/delb, 100.)
-!!!!! end GRIMS
+          !-- End GRIMS-----------------------------------------
 
-          CALL  mym_condensation ( kts,kte,&
-               &dz1,thl,sqw,p1,ex1, &
-               &tsq1, qsq1, cov1, &
-               &Sh,el,bl_mynn_cloudpdf, & !JOE-added for cloud PDF testing (from Kuwano-Yoshida et al. 2010)
-               &Vt, Vq)
+          CALL  mym_condensation ( kts,kte,      &
+               &dx,dz1,thl,sqw,p1,ex1,           &
+               &tsq1, qsq1, cov1,                &
+               &Sh,el,bl_mynn_cloudpdf,          &
+               &qc_bl1D,cldfra_bl1D,             &
+               &PBLH(i,j),HFX(i,j),              &
+               &Vt, Vq, th1, sgm )
 
-          CALL mym_turbulence ( kts,kte,levflag, &
-               &dz1, zw, u1, v1, thl, sqc, sqw, &
-               &qke1, tsq1, qsq1, cov1, &
-               &vt, vq,&
-               &rmol(i,j), flt, flq, &
-               &PBLH(i,j),th1,&                  !JOE-BouLac mod
-               &Sh,&                             !JOE-cloudPDF mod
-               &el,&  
-               &Dfm,Dfh,Dfq, &
-               &Tcd,Qcd,Pdk, &
-               &Pdt,Pdq,Pdc &
-               &,qWT1,qSHEAR1,qBUOY1,qDISS1  &   !JOE-TKE BUDGET
-               &,bl_mynn_tkebudget           &   !JOE-TKE BUDGET
-               &)
+          !ADD TKE source driven by cloud top cooling
+          IF (bl_mynn_topdown.eq.1)then
+             cloudflg=.false.
+             minrad=100.
+             kminrad=kpbl(i,j)
+             zminrad=PBLH(i,j)
+             KHtopdown(kts:kte)=0.0
+             TKEprodTD(kts:kte)=0.0
+             maxKHtopdown(i,j)=0.0
+             !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
+             DO kk = MAX(1,kpbl(i,j)-2),kpbl(i,j)+3
+                if(sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
+                   cldfra_bl1D(kk).gt.0.5) then
+                   cloudflg=.true.
+                endif
+                if(rthraten(i,kk,j) < minrad)then
+                   minrad=rthraten(i,kk,j)
+                   kminrad=kk
+                   zminrad=zw(kk) + 0.5*dz1(kk)
+                endif
+             ENDDO
+             IF (cloudflg) THEN
+                zl1 = dz1(kts)
+                k = MAX(kpbl(i,j)-1, kminrad-1)
+                !Best estimate of height of TKE source (top of downdrafts):
+                !zminrad = 0.5*pblh(i,j) + 0.5*zminrad
 
-          CALL mym_predict (kts,kte,levflag,  &
-               &delt, dz1, &
-               &ust(i,j), flt, flq, pmz, phh, &
-               &el, dfq, pdk, pdt, pdq, pdc, &
-               &Qke1, Tsq1, Qsq1, Cov1)
+                templ=thl(k)*ex1(k)
+                !rvls is ws at full level
+                rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
+                temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(rd*templ**2))
+                rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
+                rcldb=max(sqw(k)-rvls,0.)
 
-          CALL mynn_tendencies(kts,kte,&
-               &levflag,grav_settling,&
-               &delt, dz1,&
-               &u1, v1, th1, qv1, qc1, qi1, qni1,&! qnc1,&
+                !entrainment efficiency
+                dthvx     = (thl(k+2) + th1(k+2)*ep_1*sqw(k+2)) &
+                          - (thl(k)   + th1(k)  *ep_1*sqw(k))
+                dthvx     = max(dthvx,0.1)
+                tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
+                !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
+                !here to 8, as in Grenier and Bretherton (2001).
+                ent_eff   = 0.2 + 0.2*8.*tmp1
+
+                radsum=0.
+                DO kk = MAX(1,kpbl(i,j)-3),kpbl(i,j)+3
+                   radflux=rthraten(i,kk,j)*ex1(kk)         !converts theta/s to temp/s
+                   radflux=radflux*cp/g*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
+                   if (radflux < 0.0 ) radsum=abs(radflux)+radsum
+                ENDDO
+                radsum=MIN(radsum,60.0)
+
+                !entrainment from PBL top thermals
+                bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
+                !bfx0 = max(radsum/rho1(k)/cp,0.)
+                wm3    = g/thetav(k)*bfx0*MIN(pblh(i,j),1500.) ! this is wstar3(i)
+                wm2    = wm2 + wm3**h2
+                bfxpbl = - ent_eff * bfx0
+                dthvx  = max(thetav(k+1)-thetav(k),0.1)
+                we     = max(bfxpbl/dthvx,-sqrt(wm3**h2))
+
+                DO kk = kts,kpbl(i,j)+3
+                   !Analytic vertical profile
+                   zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
+                   zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
+
+                   !Calculate an eddy diffusivity profile (not used at the moment)
+                   wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**h1
+                   !Modify shape of KH to be similar to Lock et al (2000): use pfac = 3.0
+                   KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
+                   KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
+                   !Do not include xkzm at kpbl-1 since it changes entrainment
+                   !if (kk.eq.kpbl(i,j)-1 .and. cloudflg .and. we.lt.0.0) then
+                   !   KHtopdown(kk) = 0.0
+                   !endif
+                   
+                   !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
+                   !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
+                   !An analytic profile controls the magnitude of this TKE prod in the vertical. 
+                   TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh(i,j),100.)*zfacent(kk)
+                   TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
+                ENDDO
+             ENDIF !end cloud check
+             maxKHtopdown(i,j)=MAXVAL(KHtopdown(:))
+          ELSE
+             maxKHtopdown(i,j)=0.0
+             KHtopdown(kts:kte) = 0.0
+             TKEprodTD(kts:kte)=0.0
+          ENDIF !end top-down check
+
+          IF (bl_mynn_edmf == 1) THEN
+            !PRINT*,"Calling StEM Mass-Flux: i= ",i," j=",j
+            CALL StEM_mf(                         &
+               &kts,kte,delt,zw,dz1,p1,           &
+               &bl_mynn_edmf_mom,                 &
+               &bl_mynn_edmf_tke,                 &
+               &u1,v1,w1,th1,thl,thetav,tk1,      &
+               &sqw,sqv,sqc,qke1,                 &
+               &ex1,Vt,Vq,sgm,                    &
+               &ust(i,j),flt,flq,flqv,flqc,       &
+               &PBLH(i,j),KPBL(i,j),DX,           &
+               &xland(i,j),th_sfc,                &
+            ! now outputs - tendencies
+            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf &
+            ! outputs - updraft properties
+               & edmf_a1,edmf_w1,edmf_qt1,        &
+               & edmf_thl1,edmf_ent1,edmf_qc1,    &
+            ! for the solver
+               & s_aw1,s_awthl1,s_awqt1,          &
+               & s_awqv1,s_awqc1,s_awu1,s_awv1,   &
+               & s_awqke1,                        &
+#if (WRF_CHEM == 1)
+               & nchem,chem1,s_awchem1,           &
+#endif
+               & qc_bl1D,cldfra_bl1D,             &
+               & FLAG_QI,FLAG_QC,                 &
+               & Psig_shcu(i,j),                  &
+               & nupdraft(i,j),ktop_shallow(i,j), &
+               & maxmf(i,j),ztop_shallow,         &
+               & spp_pbl,rstoch_col               &
+            )
+
+          ELSEIF (bl_mynn_edmf == 2) THEN
+            CALL temf_mf(                         &
+               &kts,kte,delt,zw,p1,ex1,           &
+               &u1,v1,w1,th1,thl,thetav,          &
+               &sqw,sqv,sqc,qke1,                 &
+               &ust(i,j),flt,flq,flqv,flqc,       &
+               &hfx(i,j),qfx(i,j),ts(i,j),        &
+               &pblh(i,j),rho1,dfh,dx,znt(i,j),ep_2,   &
+            ! outputs - updraft properties
+               & edmf_a1,edmf_w1,edmf_qt1,        &
+               & edmf_thl1,edmf_ent1,edmf_qc1,    &
+            ! for the solver
+               & s_aw1,s_awthl1,s_awqt1,          &
+               & s_awqv1,s_awqc1,                 &
+               & s_awu1,s_awv1,s_awqke1,          &
+#if (WRF_CHEM == 1)
+               & nchem,chem1,s_awchem1,           &
+#endif
+               & qc_bl1D,cldfra_bl1D              &
+               &,FLAG_QI,FLAG_QC                  &
+               &,Psig_shcu(i,j)                   &
+               &,spp_pbl,rstoch_col               &
+               &,i,j,ids,ide,jds,jde              &
+             )
+          ENDIF
+
+          CALL mym_turbulence (                  & 
+               &kts,kte,levflag,                 &
+               &dz1, zw, u1, v1, thl, sqc, sqw,  &
+               &qke1, tsq1, qsq1, cov1,          &
+               &vt, vq,                          &
+               &rmol(i,j), flt, flq,             &
+               &PBLH(i,j),th1,                   &
+               &Sh,el,                           &
+               &Dfm,Dfh,Dfq,                     &
+               &Tcd,Qcd,Pdk,                     &
+               &Pdt,Pdq,Pdc,                     &
+               &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
+               &bl_mynn_tkebudget,               &
+               &Psig_bl(i,j),Psig_shcu(i,j),     &     
+               &cldfra_bl1D,bl_mynn_mixlength,   &
+               &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
+               &TKEprodTD,                       &
+               &spp_pbl,rstoch_col)
+
+
+!          IF (bl_mynn_edmf > 0) THEN
+!            !DEBUG
+!             DO k=kts,kte
+!               IF (s_aw1(k)<0. .OR. s_aw1(k)>0.5) THEN
+!                  PRINT*,"After Mass-Flux: i= ",i," j=",j," k=",k
+!                  PRINT*," s_aw1=",s_aw1(k)," s_awthl1=",s_awthl1(k)," s_awqt1=",s_awqt1(k)
+!                  PRINT*," s_awu1=",s_awu1(k)," s_awv1=",s_awu1(k)
+!               ENDIF
+!             ENDDO
+!          ENDIF
+
+          IF (bl_mynn_edmf_part > 0 .AND. bl_mynn_edmf > 0) THEN
+             !Partition the fluxes from each component (ed & mf).
+             !Assume overlap of 50%: Reduce eddy diffusivities by 50% of the estimated
+             !area fraction of mass-flux scheme's updraft.
+             DO k=kts,kte
+                dfm(k)=dfm(k) * (1. - 0.5*edmf_a1(k))
+                dfh(k)=dfh(k) * (1. - 0.5*edmf_a1(k))
+                dfq(k)=dfq(k) * (1. - 0.5*edmf_a1(k))
+             ENDDO
+          ENDIF
+
+          CALL mym_predict (kts,kte,levflag,     &
+               &delt, dz1,                       &
+               &ust(i,j), flt, flq, pmz, phh,    &
+               &el, dfq, pdk, pdt, pdq, pdc,     &
+               &Qke1, Tsq1, Qsq1, Cov1,          &
+               &s_aw1, s_awqke1, bl_mynn_edmf_tke)
+
+          CALL mynn_tendencies(kts,kte,          &
+               &levflag,grav_settling,           &
+               &delt, dz1,                       &
+               &u1, v1, th1, tk1, qv1, qc1, qi1, &
+               &qni1,qnc1,                       &
                &p1, ex1, thl, sqv, sqc, sqi, sqw,&
-               &ust(i,j),flt,flq,flqv,flqc,wspd(i,j),qcg(i,j),&
-               &uoce(i,j),voce(i,j),&
-               &tsq1, qsq1, cov1,&
-               &tcd, qcd, &
-               &dfm, dfh, dfq,&
-               &Du1, Dv1, Dth1, Dqv1, Dqc1, Dqi1, Dqni1& !, Dqnc1&
-               &,vdfg(i,j)&                 !JOE/Katata- fog deposition
-               &,FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC &
-               &)
+               &ust(i,j),flt,flq,flqv,flqc,      &
+               &wspd(i,j),qcg(i,j),              &
+               &uoce(i,j),voce(i,j),             &
+               &tsq1, qsq1, cov1,                &
+               &tcd, qcd,                        &
+               &dfm, dfh, dfq,                   &
+               &Du1, Dv1, Dth1, Dqv1,            &
+               &Dqc1, Dqi1, Dqni1,               & !Dqnc1,        &
+               &vdfg(i,j),                       & !JOE/Katata- fog deposition
+               ! mass flux components
+               &s_aw1,s_awthl1,s_awqt1,          &
+               &s_awqv1,s_awqc1,s_awu1,s_awv1,   &
+               &FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
+               &cldfra_bl1d,                     &
+#if defined(wrfmodel)
+               &ztop_shallow,ktop_shallow(i,j),  &
+#endif
+               &bl_mynn_cloudmix,                &
+               &bl_mynn_mixqt,                   &
+               &bl_mynn_edmf,                    &
+               &bl_mynn_edmf_mom)
 
-                !print*,"MYNN: qi_ten, qni_ten=",Dqi1(4),Dqni1(4)
-                !print*,"MYNN: qc_ten, qnc_ten=",Dqc1(4),Dqnc1(4)
+#if (WRF_CHEM == 1)
+    IF (bl_mynn_mixchem == 1) THEN
+          CALL mynn_mix_chem(kts,kte,          &
+               levflag,grav_settling,           &
+               delt, dz1,                       &
+               nchem, kdvel, ndvel, num_vert_mix, &
+               chem1, vd1,                      &
+               qni1,qnc1,                       &
+               p1, ex1, thl, sqv, sqc, sqi, sqw,&
+               ust(i,j),flt,flq,flqv,flqc,      &
+               wspd(i,j),qcg(i,j),              &
+               uoce(i,j),voce(i,j),             &
+               tsq1, qsq1, cov1,                &
+               tcd, qcd,                        &
+               &dfm, dfh, dfq,                  &
+               ! mass flux components
+               & s_awchem1,                      &
+               &bl_mynn_cloudmix)
+    ENDIF
+#endif
 
+!
+! add mass flux tendencies and calculate the new variables. 
+! Now done implicitly in the mynn_tendencies subroutine
+!           do k=kts,kte
+!             du1(k)=du1(k)+du1mf(k)
+!             dv1(k)=dv1(k)+dv1mf(k)
+!             dth1(k)=dth1(k)+dth1mf(k)
+!             dqv1(k)=dqv1(k)+dqv1mf(k)
+! that is supposed to be done by bl_fogdes
+!             dqc1(k)=dqc1(k)+dqc1mf(k) 
+!           enddo
+ 
           CALL retrieve_exchange_coeffs(kts,kte,&
                &dfm, dfh, dfq, dz1,&
                &K_m1, K_h1, K_q1)
 
           !UPDATE 3D ARRAYS
-          DO k=KTS,KTF
-             K_m(i,k,j)=K_m1(k)
-             K_h(i,k,j)=K_h1(k)
+          DO k=KTS,KTE !KTF
+             exch_m(i,k,j)=K_m1(k)
+             exch_h(i,k,j)=K_h1(k)
              K_q(i,k,j)=K_q1(k)
-             du(i,k,j)=du1(k)
-             dv(i,k,j)=dv1(k)
-             dth(i,k,j)=dth1(k)
-             dqv(i,k,j)=dqv1(k)
-             dqc(i,k,j)=dqc1(k)
-             IF (PRESENT(qi) .AND. FLAG_QI) dqi(i,k,j)=dqi1(k)
-             !IF (PRESENT(qnc) .AND. FLAG_QNC) dqnc(i,k,j)=dqnc1(k)
-             IF (PRESENT(qni) .AND. FLAG_QNI) dqni(i,k,j)=dqni1(k)
+             RUBLTEN(i,k,j)=du1(k)
+             RVBLTEN(i,k,j)=dv1(k)
+             RTHBLTEN(i,k,j)=dth1(k)
+             RQVBLTEN(i,k,j)=dqv1(k)
+             IF(bl_mynn_cloudmix > 0)THEN
+               IF (PRESENT(qc) .AND. FLAG_QC) RQCBLTEN(i,k,j)=dqc1(k)
+               IF (PRESENT(qi) .AND. FLAG_QI) RQIBLTEN(i,k,j)=dqi1(k)
+               !IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=dqnc1(k)
+               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=dqni1(k)
+             ELSE
+               IF (PRESENT(qc) .AND. FLAG_QC) RQCBLTEN(i,k,j)=0.
+               IF (PRESENT(qi) .AND. FLAG_QI) RQIBLTEN(i,k,j)=0.
+               !IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=0.
+               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=0.
+             ENDIF
+
+             IF(icloud_bl > 0)THEN
+               !make BL clouds scale aware - may already be done in mym_condensation
+               qc_bl(i,k,j)=qc_bl1D(k) !*Psig_shcu(i,j)
+               cldfra_bl(i,k,j)=cldfra_bl1D(k) !*Psig_shcu(i,j)
+
+               !Stochastic perturbations to cldfra_bl and qc_bl
+               if (spp_pbl==1) then
+                  cldfra_bl(i,k,j)= cldfra_bl(i,k,j)*(1.0-rstoch_col(k))
+                  IF ((cldfra_bl(i,k,j) > 1.0) .or. (cldfra_bl(i,k,j) < 0.0)) then
+                     cldfra_bl(i,k,j)=MAX(MIN(cldfra_bl(i,k,j),1.0),0.0)
+                  ENDIF
+               ELSE
+                  !DIAGNOSTIC-DECAY FOR SUBGRID-SCALE CLOUDS
+                  IF (CLDFRA_BL(i,k,j) > cldfra_bl1D_old(k)) THEN
+                     !KEEP UPDATED CLOUD FRACTION & MIXING RATIO
+                  ELSE
+                     !DECAY TIMESCALE FOR CALM CONDITION IS THE EDDY TURNOVER TIMESCALE, 
+                     !BUT FOR WINDY CONDITIONS, IT IS THE ADVECTIVE TIMESCALE.
+                     !USE THE MINIMUM OF THE TWO.
+                     ts_decay = MIN( 1800., 3.*dx/MAX(SQRT(u1(k)**2 + v1(k)**2), 1.0) )
+                     cldfra_bl(i,k,j)= MAX(cldfra_bl1D(k), cldfra_bl1D_old(k)-(0.25*delt/ts_decay))
+                     IF (cldfra_bl(i,k,j) > 0.01) THEN
+                        IF (QC_BL(i,k,j) < 1E-5)QC_BL(i,k,j)= MAX(qc_bl1D_old(k), 1E-5)
+                     ELSE
+                        CLDFRA_BL(i,k,j)= 0.
+                        QC_BL(i,k,j)    = 0.
+                     ENDIF
+                  ENDIF
+               ENDIF
+
+               !Reapply checks on cldfra_bl and qc_bl to avoid FPEs in radiation driver
+               ! when these two quantities are multiplied by eachother (they may have changed
+               ! in the MF scheme:
+               IF (icloud_bl > 0) THEN
+                 IF (QC_BL(i,k,j) < 1E-6 .AND. ABS(CLDFRA_BL(i,k,j)) > 0.1)QC_BL(i,k,j)= 1E-6
+                 IF (CLDFRA_BL(i,k,j) < 1E-2)CLDFRA_BL(i,k,j)= 0.
+               ENDIF
+             ENDIF
+
              el_pbl(i,k,j)=el(k)
              qke(i,k,j)=qke1(k)
              tsq(i,k,j)=tsq1(k)
              qsq(i,k,j)=qsq1(k)
              cov(i,k,j)=cov1(k)
              sh3d(i,k,j)=sh(k)
+
              IF ( bl_mynn_tkebudget == 1) THEN
                 dqke(i,k,j)  = (qke1(k)-dqke(i,k,j))*0.5  !qke->tke
                 qWT(i,k,j)   = qWT1(k)*delt
@@ -2829,32 +4403,54 @@ ENDIF
                 qBUOY(i,k,j) = qBUOY1(k)*delt
                 qDISS(i,k,j) = qDISS1(k)*delt
              ENDIF
-             !***  Begin debugging
-!             IF ( sh(k) < 0. .OR. sh(k)> 200. .OR. &
-!                & qke(i,k,j) < -5. .OR. qke(i,k,j)> 200. .OR. &
-!                & el_pbl(i,k,j) < 0. .OR. el_pbl(i,k,j)> 2000. .OR. &
-!                & ABS(vt(k)) > 0.8 .OR. ABS(vq(k)) > 1100. .OR. &
-!                & k_m(i,k,j) < 0. .OR. k_m(i,k,j)> 2000. .OR. &
-!                & vdfg(i,j) < 0. .OR. vdfg(i,j)>5. ) THEN
-!                  PRINT*,"SUSPICIOUS VALUES AT: k=",k," sh=",sh(k)
-!                  PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",k_m(i,k,j)
-!                  PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
-!                  PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",tsq(i,k,j)
-!                  PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
-!                  PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i,j)
-!             ENDIF
-             !***  End debugging
+
+             !update updraft properties
+             IF (bl_mynn_edmf > 0) THEN
+               edmf_a(i,k,j)=edmf_a1(k)
+               edmf_w(i,k,j)=edmf_w1(k)
+               edmf_qt(i,k,j)=edmf_qt1(k)
+               edmf_thl(i,k,j)=edmf_thl1(k)
+               edmf_ent(i,k,j)=edmf_ent1(k)
+               edmf_qc(i,k,j)=edmf_qc1(k)
+             ENDIF
+
+             !***  Begin debug prints
+             IF ( debug_code ) THEN
+               IF ( sh(k) < 0. .OR. sh(k)> 200.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," sh=",sh(k)
+               IF ( qke(i,k,j) < -1. .OR. qke(i,k,j)> 200.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," qke=",qke(i,k,j)
+               IF ( el_pbl(i,k,j) < 0. .OR. el_pbl(i,k,j)> 2000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," el_pbl=",el_pbl(i,k,j)
+               IF ( ABS(vt(k)) > 0.8 )print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vt=",vt(k)
+               IF ( ABS(vq(k)) > 6000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vq=",vq(k) 
+               IF ( exch_m(i,k,j) < 0. .OR. exch_m(i,k,j)> 2000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," exxch_m=",exch_m(i,k,j)
+               IF ( vdfg(i,j) < 0. .OR. vdfg(i,j)>5. )print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vdfg=",vdfg(i,j)
+               IF ( ABS(QFX(i,j))>.001)print*,&
+                  "SUSPICIOUS VALUES AT: i,j=",i,j," QFX=",QFX(i,j)
+               IF ( ABS(HFX(i,j))>1000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j=",i,j," HFX=",HFX(i,j)
+               IF (icloud_bl > 0) then
+                  IF( cldfra_bl(i,k,j) < 0.0 .OR. cldfra_bl(i,k,j)> 1.)THEN
+                  PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl(i,k,j)," qc_bl=",QC_BL(i,k,j)
+                  ENDIF
+               ENDIF
+             ENDIF
+             !***  End debug prints
           ENDDO
-!JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
-!    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
+
+          !JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
+          !    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
           tke_pbl(i,kts,j) = 0.5*MAX(qke(i,kts,j),1.0e-10)
           DO k = kts+1,kte
              afk = dz1(k)/( dz1(k)+dz1(k-1) )
              abk = 1.0 -afk
              tke_pbl(i,k,j) = 0.5*MAX(qke(i,k,j)*abk+qke(i,k-1,j)*afk,1.0e-3)
           ENDDO
-!JOE-end tke_pbl
-!JOE-end addition
 
 !***  Begin debugging
 !          IF(I==IMD .AND. J==JMD)THEN
@@ -2876,15 +4472,21 @@ ENDIF
        qke_adv=qke
     ENDIF
 !ACF-end
-    
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
   END SUBROUTINE mynn_bl_driver
 
-#if !defined(mpas)
+#if defined(wrfmodel)
 ! ==================================================================
-  SUBROUTINE mynn_bl_init_driver(&
-       &Du,Dv,Dth,Dqv,Dqc,Dqi                       &
-       !&,Dqnc,Dqni                                  &
+  SUBROUTINE mynn_bl_init_driver(                   &
+       &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,          &
+       &RQCBLTEN,RQIBLTEN & !,RQNIBLTEN,RQNCBLTEN       &
        &,QKE,TKE_PBL,EXCH_H                         &
+!       &,icloud_bl,qc_bl,cldfra_bl                 & !JOE-subgrid bl clouds 
        &,RESTART,ALLOWED_TO_READ,LEVEL              &
        &,IDS,IDE,JDS,JDE,KDS,KDE                    &
        &,IMS,IME,JMS,JME,KMS,KME                    &
@@ -2892,7 +4494,7 @@ ENDIF
 
     !---------------------------------------------------------------
     LOGICAL,INTENT(IN) :: ALLOWED_TO_READ,RESTART
-    INTEGER,INTENT(IN) :: LEVEL
+    INTEGER,INTENT(IN) :: LEVEL !,icloud_bl
 
     INTEGER,INTENT(IN) :: IDS,IDE,JDS,JDE,KDS,KDE,                    &
          &                IMS,IME,JMS,JME,KMS,KME,                    &
@@ -2900,8 +4502,12 @@ ENDIF
     
     
     REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
-         &Du,Dv,Dth,Dqv,Dqc,Dqi, & !Dqnc,Dqni,
+         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
+         &RQCBLTEN,RQIBLTEN,& !RQNIBLTEN,RQNCBLTEN       &
          &QKE,TKE_PBL,EXCH_H
+
+!    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
+!         &qc_bl,cldfra_bl
 
     INTEGER :: I,J,K,ITF,JTF,KTF
     
@@ -2913,17 +4519,19 @@ ENDIF
        DO J=JTS,JTF
           DO K=KTS,KTF
              DO I=ITS,ITF
-                Du(i,k,j)=0.
-                Dv(i,k,j)=0.
-                Dth(i,k,j)=0.
-                Dqv(i,k,j)=0.
-                if( p_qc >= param_first_scalar ) Dqc(i,k,j)=0.
-                if( p_qi >= param_first_scalar ) Dqi(i,k,j)=0.
-                !if( p_qnc >= param_first_scalar ) Dqnc(i,k,j)=0.
-                !if( p_qni >= param_first_scalar ) Dqni(i,k,j)=0.
-                QKE(i,k,j)=0.
+                RUBLTEN(i,k,j)=0.
+                RVBLTEN(i,k,j)=0.
+                RTHBLTEN(i,k,j)=0.
+                RQVBLTEN(i,k,j)=0.
+                if( p_qc >= param_first_scalar ) RQCBLTEN(i,k,j)=0.
+                if( p_qi >= param_first_scalar ) RQIBLTEN(i,k,j)=0.
+                !if( p_qnc >= param_first_scalar ) RQNCBLTEN(i,k,j)=0.
+                !if( p_qni >= param_first_scalar ) RQNIBLTEN(i,k,j)=0.
+                !QKE(i,k,j)=0.
                 TKE_PBL(i,k,j)=0.
                 EXCH_H(i,k,j)=0.
+!                if(icloud_bl > 0) qc_bl(i,k,j)=0.
+!                if(icloud_bl > 0) cldfra_bl(i,k,j)=0.
              ENDDO
           ENDDO
        ENDDO
@@ -2956,6 +4564,12 @@ ENDIF
     !---------------------------------------------------------------
 
     INTEGER,INTENT(IN) :: KTS,KTE
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
     REAL, INTENT(OUT) :: zi
     REAL, INTENT(IN) :: landsea
     REAL, DIMENSION(KTS:KTE), INTENT(IN) :: thetav1D, qke1D, dz1D
@@ -2963,59 +4577,54 @@ ENDIF
     !LOCAL VARS
     REAL ::  PBLH_TKE,qtke,qtkem1,wt,maxqke,TKEeps,minthv
     REAL :: delt_thv   !delta theta-v; dependent on land/sea point
-    REAL, PARAMETER :: sbl_lim  = 200. !typical scale of stable BL (m).
+    REAL, PARAMETER :: sbl_lim  = 200. !upper limit of stable BL height (m).
     REAL, PARAMETER :: sbl_damp = 400. !transition length for blending (m).
     INTEGER :: I,J,K,kthv,ktke,kzi,kzi2
 
-    !ADD KPBL (kzi) for coupling to some Cu schemes, initialize at k=2                                  
-    !kzi2 is the TKE-based part of the hybrid KPBL                                                      
-    kzi = 1
-    kzi2= 1
+    !ADD KPBL (kzi)
+    !KZI2 is the TKE-based part of the hybrid KPBL
+    kzi = 2
+    kzi2= 2
 
-    !FIND MAX TKE AND MIN THETAV IN THE LOWEST 500 M
+    !FIND MIN THETAV IN THE LOWEST 200 M AGL
     k = kts+1
     kthv = 1
-    ktke = 1
-    maxqke = 0.
     minthv = 9.E9
-    DO WHILE (zw1D(k) .LE. 500.)
-       qtke  =MAX(Qke1D(k),0.)   ! maximum QKE
-       IF (maxqke < qtke) then
-           maxqke = qtke
-           ktke = k
-       ENDIF
+    DO WHILE (zw1D(k) .LE. 200.)
+    !DO k=kts+1,kte-1
        IF (minthv > thetav1D(k)) then
            minthv = thetav1D(k)
            kthv = k
        ENDIF
        k = k+1
+       !IF (zw1D(k) .GT. sbl_lim) exit
     ENDDO
-    !TKEeps = maxtke/20. = maxqke/40.
-    TKEeps = maxqke/40. 
-    TKEeps = MAX(TKEeps,0.025)
 
     !FIND THETAV-BASED PBLH (BEST FOR DAYTIME).
     zi=0.
     k = kthv+1
-    IF((landsea-1.5).GE.0)THEN                                            
+    IF((landsea-1.5).GE.0)THEN
         ! WATER
         delt_thv = 0.75
-    ELSE         
-        ! LAND     
+    ELSE
+        ! LAND
         delt_thv = 1.25
     ENDIF
 
     zi=0.
     k = kthv+1
-    DO WHILE (zi .EQ. 0.) 
+!    DO WHILE (zi .EQ. 0.) 
+    DO k=kts+1,kte-1
        IF (thetav1D(k) .GE. (minthv + delt_thv))THEN
-          kzi = MAX(k-1,1)
+          !kzi = MAX(k-1,1)
           zi = zw1D(k) - dz1D(k-1)* &
              & MIN((thetav1D(k)-(minthv + delt_thv))/ &
              & MAX(thetav1D(k)-thetav1D(k-1),1E-6),1.0)
+          kzi= MAX(k-1,1) + NINT((zi-zw1D(k-1))/dz1D(k-1))
        ENDIF
-       k = k+1
+       !k = k+1
        IF (k .EQ. kte-1) zi = zw1D(kts+1) !EXIT SAFEGUARD
+       IF (zi .NE. 0.0) exit
     ENDDO
     !print*,"IN GET_PBLH:",thsfc,zi
 
@@ -3023,42 +4632,2297 @@ ENDIF
     !THETAV-BASED DEFINITION (WHEN THE THETA-V BASED PBLH IS BELOW ~0.5 KM).
     !THE TANH WEIGHTING FUNCTION WILL MAKE THE TKE-BASED DEFINITION NEGLIGIBLE 
     !WHEN THE THETA-V-BASED DEFINITION IS ABOVE ~1 KM.
-
+    ktke = 1
+    maxqke = MAX(Qke1D(kts),0.)
+    !Use 5% of tke max (Kosovic and Curry, 2000; JAS)
+    !TKEeps = maxtke/20. = maxqke/40.
+    TKEeps = maxqke/40.
+    TKEeps = MAX(TKEeps,0.02) !0.025) 
     PBLH_TKE=0.
+
     k = ktke+1
-    DO WHILE (PBLH_TKE .EQ. 0.) 
+!    DO WHILE (PBLH_TKE .EQ. 0.) 
+    DO k=kts+1,kte-1
        !QKE CAN BE NEGATIVE (IF CKmod == 0)... MAKE TKE NON-NEGATIVE.
        qtke  =MAX(Qke1D(k)/2.,0.)      ! maximum TKE
        qtkem1=MAX(Qke1D(k-1)/2.,0.)
        IF (qtke .LE. TKEeps) THEN
-           kzi2 = MAX(k-1,1)
+           !kzi2 = MAX(k-1,1)
            PBLH_TKE = zw1D(k) - dz1D(k-1)* &
              & MIN((TKEeps-qtke)/MAX(qtkem1-qtke, 1E-6), 1.0)
            !IN CASE OF NEAR ZERO TKE, SET PBLH = LOWEST LEVEL.
            PBLH_TKE = MAX(PBLH_TKE,zw1D(kts+1))
+           kzi2 = MAX(k-1,1) + NINT((PBLH_TKE-zw1D(k-1))/dz1D(k-1))
            !print *,"PBLH_TKE:",i,j,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
        ENDIF
-       k = k+1
+       !k = k+1
        IF (k .EQ. kte-1) PBLH_TKE = zw1D(kts+1) !EXIT SAFEGUARD
+       IF (PBLH_TKE .NE. 0.) exit
     ENDDO
 
     !With TKE advection turned on, the TKE-based PBLH can be very large 
     !in grid points with convective precipitation (> 8 km!),
-    !so an artificial limit is imposed to not let PBLH_TKE exceed 4km.
+    !so an artificial limit is imposed to not let PBLH_TKE exceed the
+    !theta_v-based PBL height +/- 350 m.
     !This has no impact on 98-99% of the domain, but is the simplest patch
     !that adequately addresses these extremely large PBLHs.
-    !PBLH_TKE = MIN(PBLH_TKE,4000.)
-    PBLH_TKE = MIN(PBLH_TKE,zi+500.)
+    PBLH_TKE = MIN(PBLH_TKE,zi+350.)
+    PBLH_TKE = MAX(PBLH_TKE,MAX(zi-350.,10.))
 
-    !BLEND THE TWO PBLH TYPES HERE: 
     wt=.5*TANH((zi - sbl_lim)/sbl_damp) + .5
-    zi=PBLH_TKE*(1.-wt) + zi*wt
+    IF (maxqke <= 0.05) THEN
+       !Cold pool situation - default to theta_v-based def
+    ELSE
+       !BLEND THE TWO PBLH TYPES HERE: 
+       zi=PBLH_TKE*(1.-wt) + zi*wt
+    ENDIF
 
     !ADD KPBL (kzi) for coupling to some Cu schemes
-     kzi = INT(kzi2*(1.-wt) + kzi*wt)
+     kzi = MAX(INT(kzi2*(1.-wt) + kzi*wt),1)
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
 
   END SUBROUTINE GET_PBLH
   
 ! ==================================================================
+! Much thanks to Kay Suslj of NASA-JPL for contributing the original version
+! of this mass-flux scheme. Considerable changes have been made from it's
+! original form. Some additions include:
+!  1) scale-aware tapering as dx -> 0
+!  2) transport of TKE (extra namelist option)
+!  3) Chaboureau-Bechtold cloud fraction & coupling to radiation (when icloud_bl > 0)
+!  4) some extra limits for numerical stability
+! This scheme remains under development, so consider it experimental code. 
+!
+  SUBROUTINE StEM_mf(                       &
+                 & kts,kte,dt,zw,dz,p,      &
+                 & momentum_opt,            &
+                 & tke_opt,                 &
+                 & u,v,w,th,thl,thv,tk,     &
+                 & qt,qv,qc,qke,            &
+                 & exner,vt,vq,sgm,         &
+                 & ust,flt,flq,flqv,flqc,   &
+                 & pblh,kpbl,DX,landsea,ts, &
+            ! outputs - tendencies
+            !  &dth,dqv,dqc,du,dv,&
+            ! outputs - updraft properties   
+                 & edmf_a,edmf_w,           &
+                 & edmf_qt,edmf_thl,        &
+                 & edmf_ent,edmf_qc,        &
+            ! outputs - variables needed for solver 
+                 & s_aw,s_awthl,s_awqt,     &
+                 & s_awqv,s_awqc,           &
+                 & s_awu,s_awv,s_awqke,     &
+#if (WRF_CHEM == 1)
+                 & nchem,chem,s_awchem,      &
+#endif
+            ! in/outputs - subgrid scale clouds
+                 & qc_bl1d,cldfra_bl1d,     &
+            ! inputs - flags for moist arrays
+                 &F_QC,F_QI,                &
+                 &Psig_shcu,                &
+            ! output info
+                 &nup2,ktop,maxmf,ztop,     &
+            ! unputs for stochastic perturbations
+                 &spp_pbl,rstoch_col) 
+
+  ! inputs:
+     INTEGER, INTENT(IN) :: KTS,KTE,momentum_opt,tke_opt,kpbl
+
+#ifdef HARDCODE_VERTICAL
+# define kts 1
+# define kte HARDCODE_VERTICAL
+#endif
+
+! Stochastic 
+     INTEGER,  INTENT(IN)          :: spp_pbl
+     REAL, DIMENSION(KTS:KTE)      :: rstoch_col
+
+     REAL,DIMENSION(KTS:KTE), INTENT(IN) :: U,V,W,TH,THL,TK,QT,QV,QC,&
+                                            THV,P,qke,exner,dz
+     REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW  !height at full-sigma
+     REAL, INTENT(IN) :: DT,UST,FLT,FLQ,FLQV,FLQC,PBLH,&
+                         DX,Psig_shcu,landsea,ts
+     LOGICAL, OPTIONAL :: F_QC,F_QI
+
+  ! outputs - tendencies
+  !   REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: DTH,DQV,DQC,DU,DV
+  ! outputs - updraft properties
+     REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: edmf_a,edmf_w,        &
+                      & edmf_qt,edmf_thl, edmf_ent,edmf_qc
+  ! output
+     INTEGER, INTENT(OUT) :: nup2,ktop
+     REAL, INTENT(OUT) :: maxmf,ztop
+  ! outputs - variables needed for solver
+     REAL,DIMENSION(KTS:KTE+1) :: s_aw,      & !sum ai*wis_awphi
+                               s_awthl,      & !sum ai*wi*phii
+                                s_awqt,      &
+                                s_awqv,      &
+                                s_awqc,      &
+                                 s_awu,      &
+                                 s_awv,      &
+                               s_awqke, s_aw2
+
+     REAL,DIMENSION(KTS:KTE), INTENT(INOUT) :: qc_bl1d,cldfra_bl1d
+
+    INTEGER, PARAMETER :: NUP=10, debug_mf=0
+  ! local variables
+  ! updraft properties
+     REAL,DIMENSION(KTS:KTE+1,1:NUP) :: UPW,UPTHL,UPQT,UPQC,UPQV,  &
+                                        UPA,UPU,UPV,UPTHV,UPQKE
+  ! entrainment variables
+     REAL,DIMENSION(KTS:KTE,1:NUP) :: ENT,ENTf
+     INTEGER,DIMENSION(KTS:KTE,1:NUP) :: ENTi
+  ! internal variables
+     INTEGER :: K,I,k50
+     REAL :: fltv,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0,    &
+             pwmin,pwmax,wmin,wmax,wlv,wtv,Psig_w,maxw,maxqc,wpbl
+     REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,Wn2,Wn,EntEXP,EntW,BCOEFF
+
+  ! w parameters
+     REAL,PARAMETER :: &
+          &Wa=2./3., &
+          &Wb=0.002,&
+          &Wc=1.5 
+        
+  ! Lateral entrainment parameters ( L0=100 and ENT0=0.1) were taken from
+  ! Suselj et al (2013, jas). Note that Suselj et al (2014,waf) use L0=200 and ENT0=0.2.
+     REAL,PARAMETER :: &
+         & L0=100.,&
+         & ENT0=0.1
+
+  ! Implement ideas from Neggers (2016, JAMES):
+     REAL, PARAMETER :: Atot = 0.10 ! Maximum total fractional area of all updrafts
+     REAL, PARAMETER :: lmax = 1000.! diameter of largest plume
+     REAL, PARAMETER :: dl   = 100. ! diff size of each plume - the differential multiplied by the integrand
+     REAL, PARAMETER :: dcut = 1.0  ! max diameter of plume to parameterize relative to dx (km)
+     REAL ::  d            != -2.3 to -1.7  ;=-1.9 in Neggers paper; power law exponent for number density (N=Cl^d).
+          ! Note that changing d to -2.0 makes each size plume equally contribute to the total coverage of all plumes.
+          ! Note that changing d to -1.7 doubles the area coverage of the largest plumes relative to the smallest plumes.
+     REAL :: cn,c,l,n,an2,hux,maxwidth,wspd_pbl,cloud_base,width_flx
+
+#if (WRF_CHEM == 1)
+     INTEGER, INTENT(IN) :: nchem
+     REAL,DIMENSION(kts:kte, nchem) :: chem
+     REAL,DIMENSION(kts:kte+1, nchem) :: s_awchem
+     REAL,DIMENSION(nchem) :: chemn
+     REAL,DIMENSION(KTS:KTE+1,1:NUP, nchem) :: UPCHEM
+     INTEGER :: ic
+     REAL,DIMENSION(KTS:KTE+1, nchem) :: edmf_chem
+#endif
+
+  !JOE: add declaration of ERF
+   REAL :: ERF
+
+   LOGICAL :: superadiabatic
+
+  ! VARIABLES FOR CHABOUREAU-BECHTOLD CLOUD FRACTION
+   REAL,DIMENSION(KTS:KTE), INTENT(INOUT) :: vt, vq, sgm
+   REAL :: sigq,xl,tlk,qsat_tl,rsl,cpm,a,qmq,mf_cf,diffqt,&
+           Fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid
+
+   ! WA TEST 11/9/15 for consistent reduction of updraft params
+   REAL :: csigma,acfac,EntThrottle
+
+   !JOE- plume overshoot
+   INTEGER :: overshoot
+   REAL :: bvf, Frz
+
+   !Flux limiter: not let mass-flux of heat between k=1&2 exceed (fluxportion)*(surface heat flux).
+   !This limiter makes adjustments to the entire column.
+   REAL :: adjustment, flx1
+   REAL, PARAMETER :: fluxportion=0.75 ! set liberally, so has minimal impact. 0.5 starts to have a noticeable impact
+                                       ! over land (decrease maxMF by 10-20%), but no impact over water.
+! check the inputs
+!     print *,'dt',dt
+!     print *,'dz',dz
+!     print *,'u',u
+!     print *,'v',v
+!     print *,'thl',thl
+!     print *,'qt',qt
+!     print *,'ust',ust
+!     print *,'flt',flt
+!     print *,'flq',flq
+!     print *,'pblh',pblh
+
+! Initialize individual updraft properties
+  UPW=0.
+  UPTHL=0.
+  UPTHV=0.
+  UPQT=0.
+  UPA=0.
+  UPU=0.
+  UPV=0.
+  UPQC=0.
+  UPQV=0.
+  UPQKE=0.
+#if (WRF_CHEM == 1)
+  UPCHEM(KTS:KTE+1,1:NUP,1:nchem)=0.0
+#endif
+  ENT=0.001
+! Initialize mean updraft properties
+  edmf_a  =0.
+  edmf_w  =0.
+  edmf_qt =0.
+  edmf_thl=0.
+  edmf_ent=0.
+  edmf_qc =0.
+#if (WRF_CHEM == 1)
+  edmf_chem(kts:kte+1,1:nchem) = 0.0
+#endif
+! Initialize the variables needed for implicit solver
+  s_aw=0.
+  s_awthl=0.
+  s_awqt=0.
+  s_awqv=0.
+  s_awqc=0.
+  s_awu=0.
+  s_awv=0.
+  s_awqke=0.
+#if (WRF_CHEM == 1)
+  s_awchem(kts:kte+1,1:nchem) = 0.0
+#endif
+
+
+  ! Taper off MF scheme when significant resolved-scale motions
+  ! are present This function needs to be asymetric...
+  k      = 1
+  maxw   = 0.0
+  cloud_base  = 9000.0
+!  DO WHILE (ZW(k) < pblh + 500.)
+  DO k=1,kte-1
+     IF(ZW(k) > pblh + 500.) exit
+
+     wpbl = w(k)
+     IF(w(k) < 0.)wpbl = 2.*w(k)
+     maxw = MAX(maxw,ABS(wpbl))
+
+     !Find highest k-level below 50m AGL
+     IF(ZW(k)<=50.)k50=k
+
+     !Search for cloud base
+     IF(qc(k)>1E-5 .AND. cloud_base == 9000.0)THEN
+       cloud_base = 0.5*(ZW(k)+ZW(k+1))
+     ENDIF
+
+     !k = k + 1
+  ENDDO
+  !print*," maxw before manipulation=", maxw
+  maxw = MAX(0.,maxw - 0.5)         ! do nothing for small w, but
+  Psig_w = MAX(0.0, 1.0 - maxw/0.5) ! linearly taper off for w > 0.5 m/s
+  Psig_w = MIN(Psig_w, Psig_shcu)
+  !print*," maxw=", maxw," Psig_w=",Psig_w," Psig_shcu=",Psig_shcu
+
+  fltv = flt + svp1*flq
+  !PRINT*," fltv=",fltv," zi=",pblh 
+
+  !Completely shut off MF scheme for strong resolved-scale vertical velocities.
+  IF(Psig_w == 0.0 .and. fltv > 0.0) fltv = -1.*fltv
+
+! if surface buoyancy is positive we do integration, otherwise not, and make sure that 
+! PBLH > twice the height of the surface layer (set at z0 = 50m)
+! Also, ensure that it is at least slightly superadiabatic up through 50 m
+      superadiabatic = .false.
+  IF((landsea-1.5).GE.0)THEN
+     hux = -0.002   ! WATER  ! dT/dz must be < - 0.2 K per 100 m.
+  ELSE
+     hux = -0.005  ! LAND    ! dT/dz must be < - 0.5 K per 100 m.
+  ENDIF
+  DO k=1,MAX(1,k50-1)
+    IF (k == 1) then
+      IF ((th(k)-ts)/(0.5*dz(k)) < hux) THEN
+        superadiabatic = .true.
+      ELSE
+        superadiabatic = .false.
+        exit
+      ENDIF
+    ELSE
+      IF ((th(k)-th(k-1))/(0.5*(dz(k)+dz(k-1))) < hux) THEN
+        superadiabatic = .true.
+      ELSE
+        superadiabatic = .false.
+        exit
+      ENDIF
+    ENDIF
+  ENDDO
+
+  ! Determine the numer of updrafts/plumes in the grid column:
+  ! Some of these criteria may be a little redundant but useful for bullet-proofing.
+  !   (1) largest plume = 1.0 * dx.
+  !   (2) Apply a scale-break, assuming no plumes with diameter larger than PBLH can exist.
+  !   (3) max plume size beneath clouds deck approx = 0.5 * cloud_base.
+  !   (4) add shear-dependent limit, when plume model breaks down. (taken out)
+  !   (5) land-only limit to reduce plume sizes in weakly forced conditions
+  ! Criteria (1)
+  NUP2 = max(1,min(NUP,INT(dx*dcut/dl)))
+  ! Criteria (2) and (4)
+  !wspd_pbl=SQRT(MAX(u(kpbl)**2 + v(kpbl)**2, 0.01))
+  maxwidth = 1.0*PBLH !- MIN(15.*MAX(wspd_pbl - 7.5, 0.), 0.3*PBLH)
+  ! Criteria (3)
+  maxwidth = MIN(maxwidth,0.5*cloud_base)
+  ! Criteria (5)
+  IF((landsea-1.5).LT.0)THEN
+    IF (cloud_base .LT. 2000.) THEN
+      width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.120)/0.03) + .5),1000.), 0.)
+    ELSE
+      !width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.085)/0.04) + .5),1000.), 0.)
+      width_flx = MAX(MIN(1000.*(0.6*tanh((flt - 0.050)/0.03) + .5),1000.), 0.)
+    ENDIF
+    maxwidth = MIN(maxwidth,width_flx)
+  ENDIF
+  ! Convert maxwidth to number of plumes
+  NUP2 = MIN(MAX(INT((maxwidth - MOD(maxwidth,100.))/100), 0), NUP2)
+
+  !Initialize values:
+  ktop = 0
+  ztop = 0.0
+  maxmf= 0.0
+
+  IF ( fltv > 0.002 .AND. NUP2 .GE. 1 .AND. superadiabatic) then
+    !PRINT*," Conditions met to run mass-flux scheme",fltv,pblh
+
+    ! Find coef C for number size density N
+    cn = 0.
+    d=-1.9  !set d to value suggested by Neggers 2015 (JAMES).
+    !d=-1.9 + .2*tanh((fltv - 0.05)/0.15) 
+    do I=1,NUP !NUP2
+       IF(I > NUP2) exit
+       l  = dl*I                            ! diameter of plume
+       cn = cn + l**d * (l*l)/(dx*dx) * dl  ! sum fractional area of each plume
+    enddo
+    C = Atot/cn   !Normalize C according to the defined total fraction (Atot)
+
+    ! Find the portion of the total fraction (Atot) of each plume size:
+    An2 = 0.
+    do I=1,NUP !NUP2
+       IF(I > NUP2) exit
+       l  = dl*I                            ! diameter of plume
+       N = C*l**d                           ! number density of plume n
+       UPA(1,I) = N*l*l/(dx*dx) * dl        ! fractional area of plume n
+       ! Make updraft area (UPA) a function of the buoyancy flux
+!       acfac = .5*tanh((fltv - 0.05)/0.2) + .5
+!       acfac = .5*tanh((fltv - 0.07)/0.09) + .5 
+       acfac = .5*tanh((fltv - 0.03)/0.09) + .5
+       UPA(1,I)=UPA(1,I)*acfac
+       An2 = An2 + UPA(1,I)                 ! total fractional area of all plumes
+       !print*," plume size=",l,"; area=",An,"; total=",An2
+    end do
+
+    ! get entrainment coefficient
+    ! get dz/L0
+    !ENTf(kts:kte,1:Nup)=0.1
+    !ENTi(kts:kte,1:Nup)=0.1
+    !ENT(kts:kte,1:Nup)=0.001
+    !do i=1,Nup2
+    !  do k=kts+1,kte
+    !    ENTf(k,i)=(ZW(k)-ZW(k-1))/L0    ! input into Poisson
+    !    ENTf(k,i)=MIN(ENTf(k,i),9.9) !JOE: test avoiding FPE
+    !    ENTf(k,i)=MAX(ENTf(k,i),0.05) !JOE: test avoiding FPE
+    !  enddo
+    !enddo
+    ! get Poisson P(dz/L0)
+    !call Poisson(1,Nup2,kts+1,kte,ENTf,ENTi)
+    ! entrainent: Ent=Ent0/dz*P(dz/L0)             
+
+    ! set initial conditions for updrafts
+    z0=50.
+    pwmin=0.1       ! was 0.5
+    pwmax=0.5       ! was 3.0
+
+    wstar=max(1.E-2,(g/thv(1)*fltv*pblh)**(1./3.))
+    qstar=max(flq,1.0E-5)/wstar
+    thstar=flt/wstar
+
+    IF((landsea-1.5).GE.0)THEN
+       csigma = 1.34   ! WATER
+    ELSE
+       csigma = 1.34   ! LAND
+    ENDIF
+    sigmaW =1.34*wstar*(z0/pblh)**(1./3.)*(1 - 0.8*z0/pblh)
+    sigmaQT=csigma*qstar*(z0/pblh)**(-1./3.)
+    sigmaTH=csigma*thstar*(z0/pblh)**(-1./3.)
+
+    wmin=MIN(sigmaW*pwmin,0.1)
+    wmax=MIN(sigmaW*pwmax,0.5)
+
+    !recompute acfac for plume excess
+    acfac = .5*tanh((fltv - 0.08)/0.07) + .5
+
+    !SPECIFY SURFACE UPDRAFT PROPERTIES
+    DO I=1,NUP !NUP2
+       IF(I > NUP2) exit
+       wlv=wmin+(wmax-wmin)/NUP2*(i-1)
+       wtv=wmin+(wmax-wmin)/NUP2*i
+
+       !SURFACE UPDRAFT VERTICAL VELOCITY
+       !UPW(1,I)=0.5*(wlv+wtv)
+       UPW(1,I)=wmin + REAL(i)/REAL(NUP)*(wmax-wmin)
+       !IF (UPW(1,I) > 0.5*ZW(2)/dt) UPW(1,I) = 0.5*ZW(2)/dt
+
+       !SURFACE UPDRAFT AREA
+       !UPA(1,I)=0.5*ERF(wtv/(sqrt(2.)*sigmaW)) - 0.5*ERF(wlv/(sqrt(2.)*sigmaW))
+       !UPA(1,I)=0.25*ERF(wtv/(sqrt(2.)*sigmaW)) - 0.25*ERF(wlv/(sqrt(2.)*sigmaW))  !12.0
+
+       UPU(1,I)=U(1)
+       UPV(1,I)=V(1)
+       UPQC(1,I)=0
+       !UPQT(1,I) =QT(1) +0.58*UPW(1,I)*sigmaQT/sigmaW       
+       !UPTHV(1,I)=THV(1)+0.58*UPW(1,I)*sigmaTH/sigmaW
+       !Alternatively, initialize parcel over lowest 50m
+       UPQT(1,I) = 0.
+       UPTHV(1,I)= 0.
+       UPTHL(1,I)= 0.
+       k50=1 !for now, keep at lowest model layer...
+       DO k=1,k50
+         UPQT(1,I) = UPQT(1,I) +QT(k) +0.58*UPW(1,I)*sigmaQT/sigmaW *acfac
+         UPTHV(1,I)= UPTHV(1,I)+THV(k)+0.58*UPW(1,I)*sigmaTH/sigmaW *acfac
+         UPTHL(1,I)= UPTHL(1,I)+THL(k)+0.58*UPW(1,I)*sigmaTH/sigmaW *acfac
+       ENDDO
+       UPQT(1,I) = UPQT(1,I)/REAL(k50)
+       UPTHV(1,I)= UPTHV(1,I)/REAL(k50)
+!was       UPTHL(1,I)= UPTHV(1,I)/(1.+svp1*UPQT(1,I))  !assume no saturated parcel at surface
+       UPTHL(1,I)= UPTHL(1,I)/REAL(k50)             ! now, if the lowest layer is saturated, it will be counted for.
+       UPQKE(1,I)= QKE(1)
+#if (WRF_CHEM == 1)
+       do ic = 1,nchem
+          UPCHEM(1,I,ic)= CHEM(1,ic)
+       enddo
+#endif
+
+!       !DEBUG
+!       IF (UPA(1,I)<0. .OR. UPA(1,I)>0.5 .OR. wstar<0. .OR. wstar>4.0 .OR. &
+!           ABS(thstar)> 5. .OR. sigmaW>1.5) THEN
+!          PRINT*,"IN Mass-Flux: UPA(1,i)=",UPA(1,i)
+!          PRINT*," wstar=",wstar," qstar=",qstar
+!          PRINT*," thstar=",thstar," sigmaW=",sigmaW
+!       ENDIF
+
+    ENDDO
+
+  EntThrottle = 0.001  !MAX(0.02/MAX((flt*1.25*1004.)-25.,5.),0.0002)
+  !QCn = 0.
+  ! do integration  updraft
+    DO I=1,NUP !NUP2
+       IF(I > NUP2) exit
+       QCn = 0.
+       overshoot = 0
+       l  = dl*I                            ! diameter of plume
+       DO k=KTS+1,KTE
+          !w-dependency for entrainment a la Tian and Kuang (2016)
+          ENT(k,i) = 0.5/(MIN(MAX(UPW(K-1,I),0.75),1.5)*l)
+          !Entrainment from Negggers (2015, JAMES)
+          !ENT(k,i) = 0.02*l**-0.35 - 0.0009
+          !JOE - implement minimum background entrainment 
+          ENT(k,i) = max(ENT(k,i),0.0003)
+          !ENT(k,i) = max(ENT(k,i),0.05/ZW(k))  !not needed for Tian and Kuang
+          !JOE - increase entrainment for plumes extending very high.
+          IF(ZW(k) >= MIN(pblh+1500., 3500.))THEN
+            ENT(k,i)=ENT(k,i) + (ZW(k)-MIN(pblh+1500.,3500.))*5.0E-6
+          ENDIF
+          IF(UPW(K-1,I) > 2.0) ENT(k,i) = ENT(k,i) + EntThrottle*(UPW(K-1,I) - 2.0)
+          ENT(k,i) = min(ENT(k,i),0.9/(ZW(k)-ZW(k-1)))
+
+          ! Linear entrainment:
+          EntExp= ENT(K,I)*(ZW(k)-ZW(k-1))
+          QTn =UPQT(k-1,I) *(1.-EntExp) + QT(k-1)*EntExp
+          THLn=UPTHL(k-1,I)*(1.-EntExp) + THL(k-1)*EntExp
+          Un  =UPU(k-1,I)  *(1.-EntExp) + U(k-1)*EntExp
+          Vn  =UPV(k-1,I)  *(1.-EntExp) + V(k-1)*EntExp
+          QKEn=UPQKE(k-1,I)*(1.-EntExp) + QKE(k-1)*EntExp
+
+          ! Exponential Entrainment:
+          !EntExp= exp(-ENT(K,I)*(ZW(k)-ZW(k-1)))
+          !QTn =QT(K) *(1-EntExp)+UPQT(K-1,I)*EntExp
+          !THLn=THL(K)*(1-EntExp)+UPTHL(K-1,I)*EntExp
+          !Un  =U(K)  *(1-EntExp)+UPU(K-1,I)*EntExp
+          !Vn  =V(K)  *(1-EntExp)+UPV(K-1,I)*EntExp
+          !QKEn=QKE(k)*(1-EntExp)+UPQKE(K-1,I)*EntExp
+
+#if (WRF_CHEM == 1)
+          do ic = 1,nchem
+             ! Exponential Entrainment:
+             !chemn(ic) = chem(k,ic)*(1-EntExp)+UPCHEM(K-1,I,ic)*EntExp
+             ! Linear entrainment:
+             chemn(ic)=UPCHEM(k-1,I,ic)*(1.-EntExp) + chem(k-1,ic)*EntExp
+         enddo
+#endif
+
+          ! get thvn,qcn
+          call condensation_edmf(QTn,THLn,(P(K)+P(K-1))/2.,ZW(k),THVn,QCn)
+
+          B=g*(0.5*(THVn+UPTHV(k-1,I))/THV(k-1) - 1.0)
+          IF(B>0.)THEN
+            BCOEFF = 0.15        !w typically stays < 2.5, so doesnt hit the limits nearly as much
+          ELSE
+            BCOEFF = 0.2 !0.33
+          ENDIF
+
+          ! Original StEM with exponential entrainment
+          !EntW=exp(-2.*(Wb+Wc*ENT(K,I))*(ZW(k)-ZW(k-1)))
+          !Wn2=UPW(K-1,I)**2*EntW + (1.-EntW)*0.5*Wa*B/(Wb+Wc*ENT(K,I))
+          ! Original StEM with linear entrainment
+          !Wn2=UPW(K-1,I)**2*(1.-EntExp) + EntExp*0.5*Wa*B/(Wb+Wc*ENT(K,I))
+          !Wn2=MAX(Wn2,0.0)
+          !WA: TEMF form
+!          IF (B>0.0 .AND. UPW(K-1,I) < 0.2 ) THEN
+          IF (UPW(K-1,I) < 0.2 ) THEN
+             Wn = UPW(K-1,I) + (-2. * ENT(K,I) * UPW(K-1,I) + BCOEFF*B / MAX(UPW(K-1,I),0.2)) * MIN(ZW(k)-ZW(k-1), 250.)
+          ELSE
+             Wn = UPW(K-1,I) + (-2. * ENT(K,I) * UPW(K-1,I) + BCOEFF*B / UPW(K-1,I)) * MIN(ZW(k)-ZW(k-1), 250.)
+          ENDIF
+          !Do not allow a parcel to accelerate more than 1.25 m/s over 200 m.
+          !Add max increase of 2.0 m/s for coarse vertical resolution.
+          IF(Wn > UPW(K-1,I) + MIN(1.25*(ZW(k)-ZW(k-1))/200., 2.0) ) THEN
+             Wn = UPW(K-1,I) + MIN(1.25*(ZW(k)-ZW(k-1))/200., 2.0)
+          ENDIF
+          Wn = MIN(MAX(Wn,0.0), 3.0)
+
+          IF (debug_mf == 1) THEN
+            IF (Wn .GE. 3.0) THEN
+              ! surface values
+              print *," **** SUSPICIOUSLY LARGE W:"
+              print *,' QCn:',QCn,' ENT=',ENT(k,i),' Nup2=',Nup2
+              print *,'pblh:',pblh,' Wn:',Wn,' UPW(k-1)=',UPW(K-1,I)
+              print *,'K=',k,' B=',B,' dz=',ZW(k)-ZW(k-1)
+            ENDIF
+          ENDIF
+
+          !Allow strongly forced plumes to overshoot if KE is sufficient
+          IF (fltv > 0.05 .AND. Wn <= 0 .AND. overshoot == 0) THEN
+             overshoot = 1
+             IF ( THV(k)-THV(k-1) .GT. 0.0 ) THEN
+                bvf = SQRT( gtr*(THV(k)-THV(k-1))/(0.5*(dz(k)+dz(k-1))) )
+                !vertical Froude number
+                Frz = UPW(K-1,I)/(bvf*0.5*(dz(k)+dz(k-1)))
+                IF ( Frz >= 0.5 ) Wn =  MIN(Frz,1.0)*UPW(K-1,I)
+             ENDIF
+          ELSEIF (fltv > 0.05 .AND. overshoot == 1) THEN
+             !Do not let overshooting parcel go more than 1 layer up
+             Wn = 0.0
+          ENDIF
+
+          !Limit very tall plumes
+!          Wn2=Wn2*EXP(-MAX(ZW(k)-(pblh+2000.),0.0)/1000.)
+!          IF(ZW(k) >= pblh+3000.)Wn2=0.
+          Wn=Wn*EXP(-MAX(ZW(k)-MIN(pblh+2000.,3000.),0.0)/1000.)
+          IF(ZW(k) >= MIN(pblh+3000.,4500.))Wn=0.
+
+          !JOE- minimize the plume penetratration in stratocu-topped PBL
+          IF (fltv < 0.06) THEN
+             IF(ZW(k) >= pblh-200. .AND. qc(k) > 1e-5 .AND. I > 4) Wn=0.
+          ENDIF
+
+          IF (Wn > 0.) THEN
+             UPW(K,I)=Wn  !Wn !sqrt(Wn2)
+             UPTHV(K,I)=THVn
+             UPTHL(K,I)=THLn
+             UPQT(K,I)=QTn
+             UPQC(K,I)=QCn
+             UPU(K,I)=Un
+             UPV(K,I)=Vn
+             UPQKE(K,I)=QKEn
+             UPA(K,I)=UPA(K-1,I)
+#if (WRF_CHEM == 1)
+             do ic = 1,nchem
+                UPCHEM(k,I,ic) = chemn(ic)
+             enddo
+#endif
+             ktop = MAX(ktop,k)
+          ELSE
+             exit  !exit k-loop
+          END IF
+       ENDDO
+       IF (debug_mf == 1) THEN
+          IF (MAXVAL(UPW(:,I)) > 10.0 .OR. MINVAL(UPA(:,I)) < 0.0 .OR. &
+              MAXVAL(UPA(:,I)) > Atot .OR. NUP2 > 10) THEN
+             ! surface values
+             print *,'flq:',flq,' fltv:',fltv,' Nup2=',Nup2
+             print *,'pblh:',pblh,' wstar:',wstar,' ktop=',ktop
+             print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
+             ! means
+             print *,'u:',u
+             print *,'v:',v
+             print *,'thl:',thl
+             print *,'UPA:',UPA(:,I)
+             print *,'UPW:',UPW(:,I)
+             print *,'UPTHL:',UPTHL(:,I)
+             print *,'UPQT:',UPQT(:,I)
+             print *,'ENT:',ENT(:,I)
+          ENDIF
+       ENDIF
+    ENDDO
+  ELSE
+    !At least one of the conditions was not met for activating the MF scheme.
+    NUP2=0. 
+  END IF !end criteria for mass-flux scheme
+
+  ktop=MIN(ktop,KTE-1)  !  Just to be safe...
+  IF (ktop == 0) THEN
+     ztop = 0.0
+  ELSE
+     ztop=zw(ktop)
+  ENDIF
+
+  IF(nup2 > 0) THEN
+
+    !Calclulate combined fluxes for all plumes
+    DO k=KTS,KTE
+      IF(k > KTOP) exit
+      DO I=1,NUP !NUP2
+        IF(I > NUP2) exit
+        s_aw(k)   = s_aw(K)    + UPA(K,I)*UPW(K,I)*Psig_w * (1.0+rstoch_col(k))
+        s_awthl(k)= s_awthl(K) + UPA(K,i)*UPW(K,I)*UPTHL(K,I)*Psig_w * (1.0+rstoch_col(k))
+        s_awqt(k) = s_awqt(K)  + UPA(K,i)*UPW(K,I)*UPQT(K,I)*Psig_w * (1.0+rstoch_col(k))
+        s_awqc(k) = s_awqc(K)  + UPA(K,i)*UPW(K,I)*UPQC(K,I)*Psig_w * (1.0+rstoch_col(k))
+        IF (momentum_opt > 0) THEN
+          s_awu(k)  = s_awu(K)   + UPA(K,i)*UPW(K,I)*UPU(K,I)*Psig_w * (1.0+rstoch_col(k))
+          s_awv(k)  = s_awv(K)   + UPA(K,i)*UPW(K,I)*UPV(K,I)*Psig_w * (1.0+rstoch_col(k))
+        ENDIF
+        IF (tke_opt > 0) THEN
+          s_awqke(k)= s_awqke(K) + UPA(K,i)*UPW(K,I)*UPQKE(K,I)*Psig_w * (1.0+rstoch_col(k))
+        ENDIF
+#if (WRF_CHEM == 1)
+        do ic = 1,nchem
+          s_awchem(k,ic) = s_awchem(k,ic) + UPA(K,i)*UPW(K,I)*UPCHEM(K,I,ic)*Psig_w * (1.0+rstoch_col(k))
+        enddo
+#endif
+      ENDDO
+      s_awqv(k) = s_awqt(k)  - s_awqc(k)
+    ENDDO
+
+    !Flux limiter: Check for too large heat flux at first model level
+    flx1 = (s_awthl(kts+1)-s_awthl(kts))!/(0.5*(dz(k)+dz(k-1)))
+    IF (flx1 > fluxportion*flt .AND. flx1>0.0) THEN
+       adjustment= fluxportion*flt/flx1
+       s_aw   = s_aw*adjustment
+       s_awthl= s_awthl*adjustment
+       s_awqt = s_awqt*adjustment
+       s_awqc = s_awqc*adjustment
+       s_awqv = s_awqv*adjustment
+       IF (momentum_opt > 0) THEN
+          s_awu  = s_awu*adjustment
+          s_awv  = s_awv*adjustment
+       ENDIF
+       IF (tke_opt > 0) THEN
+          s_awqke= s_awqke*adjustment
+       ENDIF
+#if (WRF_CHEM == 1)
+       s_awchem = s_awchem*adjustment
+#endif
+       UPA = UPA*adjustment
+    ENDIF
+
+    !Calculate mean updraft properties for output:
+    DO k=KTS,KTE-1
+      IF(k > KTOP) exit
+      DO I=1,NUP !NUP2
+        IF(I > NUP2) exit
+        edmf_a(K)=edmf_a(K)+UPA(K+1,I)
+        edmf_w(K)=edmf_w(K)+UPA(K+1,I)*UPW(K+1,I)
+        edmf_qt(K)=edmf_qt(K)+UPA(K+1,I)*UPQT(K+1,I)
+        edmf_thl(K)=edmf_thl(K)+UPA(K+1,I)*UPTHL(K+1,I)
+        edmf_ent(K)=edmf_ent(K)+UPA(K+1,I)*ENT(K+1,I)
+        edmf_qc(K)=edmf_qc(K)+UPA(K+1,I)*UPQC(K+1,I)
+#if (WRF_CHEM == 1)
+        do ic = 1,nchem
+          edmf_chem(k,ic) = edmf_chem(k,ic) + UPA(K+1,I)*UPCHEM(k,I,ic)
+        enddo
+#endif
+      ENDDO
+
+      IF (edmf_a(k)>0.) THEN
+        edmf_w(k)=edmf_w(k)/edmf_a(k)
+        edmf_qt(k)=edmf_qt(k)/edmf_a(k)
+        edmf_thl(k)=edmf_thl(k)/edmf_a(k)
+        edmf_ent(k)=edmf_ent(k)/edmf_a(k)
+        edmf_qc(k)=edmf_qc(k)/edmf_a(k)
+#if (WRF_CHEM == 1)
+        do ic = 1,nchem
+          edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a(k)
+        enddo
+#endif
+        edmf_a(k)=edmf_a(k)*Psig_w
+
+        !FIND MAXIMUM MASS-FLUX IN THE COLUMN:
+        IF(edmf_a(k)*edmf_w(k) > maxmf) maxmf = edmf_a(k)*edmf_w(k)
+      ENDIF
+    ENDDO
+
+!JOE: ADD CLDFRA_bl1d, qc_bl1d. Note that they have already been defined in
+!     mym_condensation. Here, a shallow-cu component is added.  
+     DO K=KTS,KTE
+        IF(k > KTOP) exit
+        IF(edmf_qc(k)>0.0)THEN
+            satvp = 3.80*exp(17.27*(th(k)-273.)/ &
+                   (th(k)-36.))/(.01*p(k))
+            rhgrid = max(.01,MIN( 1., qv(k) /satvp))
+
+            !COMPUTE CLDFRA & QC_BL FROM MASS-FLUX SCHEME and recompute vt & vq
+
+            xl = xl_blend(tk(k))                ! obtain blended heat capacity 
+            tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
+            qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
+                                                !   at tl and p
+            rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
+                                                ! CB02, Eqn. 4
+            cpm = cp + qt(k)*cpv                ! CB02, sec. 2, para. 1
+            a   = 1./(1. + xl*rsl/cpm)          ! CB02 variable "a"
+            b9  = a*rsl                         ! CB02 variable "b" 
+
+            q2p  = xlvcp/exner(k)
+            pt = thl(k) +q2p*edmf_qc(k) ! potential temp
+            bb = b9*tk(k)/pt ! bb is "b9" in BCMT95.  Their "b9" differs from
+                           ! "b9" in CB02 by a factor
+                           ! of T/theta.  Strictly, b9 above is formulated in
+                           ! terms of sat. mixing ratio, but bb in BCMT95 is
+                           ! cast in terms of sat. specific humidity.  The
+                           ! conversion is neglected here.
+            qww   = 1.+0.61*qt(k)
+            alpha = 0.61*pt
+            t     = th(k)*exner(k)
+            beta  = pt*xl/(t*cp) - 1.61*pt
+            !Buoyancy flux terms have been moved to the end of this section...
+
+            !Now calculate convective component of the cloud fraction:
+            if (a > 0.0) then
+               f = MIN(1.0/a, 4.0)              ! f is vertical profile scaling function (CB2005)
+            else
+               f = 1.0
+            endif
+            sigq = 9.E-3 * edmf_a(k) * edmf_w(k) * f ! convective component of sigma (CB2005)
+            !sigq = MAX(sigq, 1.0E-4)         
+            sigq = SQRT(sigq**2 + sgm(k)**2)    ! combined conv + stratus components
+
+            qmq = a * (qt(k) - qsat_tl)         ! saturation deficit/excess;
+                                                !   the numerator of Q1
+            mf_cf = min(max(0.5 + 0.36 * atan(1.55*(qmq/sigq)),0.02),0.6)
+            IF ( debug_code ) THEN
+               print*,"In MYNN, StEM edmf"
+               print*,"  CB: qt=",qt(k)," qsat=",qsat_tl," satdef=",qt(k) - qsat_tl
+               print*,"  CB: sigq=",sigq," qmq=",qmq," tlk=",tlk
+               print*,"  CB: mf_cf=",mf_cf," cldfra_bl=",cldfra_bl1d(k)," edmf_a=",edmf_a(k)
+            ENDIF
+            IF (rhgrid >= .93) THEN
+               !IN high RH, defer to stratus component if > convective component
+               cldfra_bl1d(k) = MAX(mf_cf, cldfra_bl1d(k))
+               IF (cldfra_bl1d(k) > edmf_a(k)) THEN
+                  qc_bl1d(k) = edmf_qc(k)*edmf_a(k)/cldfra_bl1d(k)
+               ELSE
+                 cldfra_bl1d(k)=edmf_a(k)
+                 qc_bl1d(k) = edmf_qc(k)
+               ENDIF
+            ELSE
+               IF (mf_cf > edmf_a(k)) THEN
+                  cldfra_bl1d(k) = mf_cf
+                  qc_bl1d(k) = edmf_qc(k)*edmf_a(k)/mf_cf
+               ELSE
+                  cldfra_bl1d(k)=edmf_a(k)
+                  qc_bl1d(k) = edmf_qc(k)
+               ENDIF
+            ENDIF
+            !Now recalculate the terms for the buoyancy flux for mass-flux clouds:
+            !See mym_condensation for details on these formulations.  The
+            !cloud-fraction bounding was added to improve cloud retention,
+            !following RAP and HRRR testing.
+            Fng = 2.05 ! the non-Gaussian transport factor (assumed constant)
+            vt(k) = qww   - MIN(0.20,cldfra_bl1D(k))*beta*bb*Fng - 1.
+            vq(k) = alpha + MIN(0.20,cldfra_bl1D(k))*beta*a*Fng  - tv0
+         ENDIF
+
+      ENDDO
+
+    ENDIF  !end nup2 > 0
+
+    !modify output (negative: dry plume, positive: moist plume)
+    IF (ktop > 0) THEN
+      maxqc = maxval(edmf_qc(1:ktop)) 
+      IF ( maxqc < 1.E-8) maxmf = -1.0*maxmf
+    ENDIF
+       
+!       
+! debugging   
+!
+IF (edmf_w(1) > 4.0) THEN 
+! surface values
+    print *,'flq:',flq,' fltv:',fltv
+    print *,'pblh:',pblh,' wstar:',wstar
+    print *,'sigmaW=',sigmaW,' sigmaTH=',sigmaTH,' sigmaQT=',sigmaQT
+! means
+!   print *,'u:',u
+!   print *,'v:',v  
+!   print *,'thl:',thl
+!   print *,'thv:',thv
+!   print *,'qt:',qt
+!   print *,'p:',p
+ 
+! updrafts
+! DO I=1,NUP2
+!   print *,'up:A',i
+!   print *,UPA(:,i)
+!   print *,'up:W',i
+!   print*,UPW(:,i)
+!   print *,'up:thv',i
+!   print *,UPTHV(:,i)
+!   print *,'up:thl',i 
+!   print *,UPTHL(:,i)
+!   print *,'up:qt',i
+!   print *,UPQT(:,i)
+!   print *,'up:tQC',i
+!   print *,UPQC(:,i)
+!   print *,'up:ent',i
+!   print *,ENT(:,i)   
+! ENDDO
+ 
+! mean updrafts
+   print *,' edmf_a',edmf_a(1:14)
+   print *,' edmf_w',edmf_w(1:14)
+   print *,' edmf_qt:',edmf_qt(1:14)
+   print *,' edmf_thl:',edmf_thl(1:14)
+ 
+ENDIF !END Debugging
+
+! initialization of deltas
+!  DO k=kts,kte 
+!    dth(k)=0.
+!    dqv(k)=0.
+!    dqc(k)=0.
+!    du(k)=0.
+!    dv(k)=0.
+!  ENDDO        
+
+#ifdef HARDCODE_VERTICAL
+# undef kts
+# undef kte
+#endif
+
+END SUBROUTINE StEM_MF
+!=================================================================
+subroutine Poisson(istart,iend,jstart,jend,mu,POI)
+
+  integer, intent(in) :: istart,iend,jstart,jend 
+  real,dimension(istart:iend,jstart:jend),intent(in) :: MU
+  integer, dimension(istart:iend,jstart:jend), intent(out) :: POI
+  integer :: i,j
+  !
+  ! do this only once
+  ! call init_random_seed
+
+  do i=istart,iend
+    do j=jstart,jend
+      call   random_Poisson(mu(i,j),.true.,POI(i,j))
+    enddo
+  enddo
+
+end subroutine Poisson
+!=================================================================  
+subroutine init_random_seed()
+   !JOE: PGI had problem! use iso_fortran_env, only: int64
+   !JOE: PGI had problem! use ifport, only: getpid 
+   implicit none
+   integer, allocatable :: seed(:)
+   integer :: i, n, un, istat, dt(8), pid
+   !JOE: PGI had problem! integer(int64) :: t
+   integer :: t
+
+   call random_seed(size = n)
+   allocate(seed(n))
+
+   ! First try if the OS provides a random number generator
+   !JOE: PGI had problem! open(newunit=un, file="/dev/urandom", access="stream", &
+   un=191
+   open(unit=un, file="/dev/urandom", access="stream", &
+   form="unformatted", action="read", status="old", iostat=istat)
+
+   if (istat == 0) then
+      read(un) seed
+      close(un)
+   else
+      ! Fallback to XOR:ing the current time and pid. The PID is
+      ! useful in case one launches multiple instances of the same
+      ! program in parallel.
+      call system_clock(t)
+      if (t == 0) then
+         call date_and_time(values=dt)
+         !t = (dt(1) - 1970) * 365_int64 * 24 * 60 * 60 * 1000 &
+         !   + dt(2) * 31_int64 * 24 * 60 * 60 * 1000 &
+         !   + dt(3) * 24_int64 * 60 * 60 * 1000 &
+         !   + dt(5) * 60 * 60 * 1000 &
+         !   + dt(6) * 60 * 1000 + dt(7) * 1000 &
+         !   + dt(8)
+         t = dt(6) * 60 &  ! only return seconds for smaller t
+           + dt(7)
+      end if
+
+      !JOE: PGI had problem!pid = getpid()
+      ! for distributed memory jobs we need to fix this
+      !pid=1
+      pid = 666 + MOD(t,10)  !JOE: doesnt work for PG compilers: getpid()
+ 
+      t = ieor(t, int(pid, kind(t)))
+      do i = 1, n
+         seed(i) = lcg(t)
+      end do
+   end if
+   call random_seed(put=seed)
+
+  contains
+
+  ! Pseudo-random number generator (PRNG) 
+  ! This simple PRNG might not be good enough for real work, but is
+  ! sufficient for seeding a better PRNG.
+  function lcg(s)
+
+   integer :: lcg
+   !JOE: PGI had problem! integer(int64) :: s
+   integer :: s
+
+   if (s == 0) then
+      !s = 104729
+      s = 1047
+   else
+      !s = mod(s, 4294967296_int64)
+      s = mod(s, 71)
+   end if
+   !s = mod(s * 279470273_int64, 4294967291_int64)
+   s = mod(s * 23, 17)
+   !lcg = int(mod(s, int(huge(0), int64)), kind(0))
+   lcg = int(mod(s, int(s/3.5)))
+
+  end function lcg
+
+  end subroutine init_random_seed
+
+
+subroutine random_Poisson(mu,first,ival) 
+!**********************************************************************
+!     Translated to Fortran 90 by Alan Miller from:  RANLIB
+!
+!     Library of Fortran Routines for Random Number Generation
+!
+!                    Compiled and Written by:
+!
+!                         Barry W. Brown
+!                          James Lovato
+!
+!             Department of Biomathematics, Box 237
+!             The University of Texas, M.D. Anderson Cancer Center
+!             1515 Holcombe Boulevard
+!             Houston, TX      77030
+!
+! Generates a single random deviate from a Poisson distribution with mean mu.
+! Scalar Arguments:
+	REAL, INTENT(IN)    :: mu  !The mean of the Poisson distribution from which
+                                   !a random deviate is to be generated.
+	LOGICAL, INTENT(IN) :: first
+        INTEGER             :: ival
+
+!     TABLES: COEFFICIENTS A0-A7 FOR STEP F. FACTORIALS FACT
+!     COEFFICIENTS A(K) - FOR PX = FK*V*V*SUM(A(K)*V**K)-DEL
+!     SEPARATION OF CASES A AND B
+!
+!     .. Local Scalars ..
+!JOE: since many of these scalars conflict with globally declared closure constants (above),
+!     need to change XX to XX_s
+!	REAL          :: b1, b2, c, c0, c1, c2, c3, del, difmuk, e, fk, fx, fy, g,  &
+!                    omega, px, py, t, u, v, x, xx
+	REAL          :: b1_s, b2_s, c, c0, c1_s, c2_s, c3_s, del, difmuk, e, fk, fx, fy, g_s,  &
+                    omega, px, py, t, u, v, x, xx
+	REAL, SAVE    :: s, d, p, q, p0
+        INTEGER       :: j, k, kflag
+	LOGICAL, SAVE :: full_init
+        INTEGER, SAVE :: l, m
+!     ..
+!     .. Local Arrays ..
+	REAL, SAVE    :: pp(35)
+!     ..
+!     .. Data statements ..
+!JOE: since many of these scalars conflict with globally declared closure constants (above),
+!     need to change XX to XX_s
+!	REAL, PARAMETER :: a0 = -.5, a1 = .3333333, a2 = -.2500068, a3 = .2000118,  &
+	REAL, PARAMETER :: a0 = -.5, a1_s = .3333333, a2_s = -.2500068, a3 = .2000118,  &
+                           a4 = -.1661269, a5 = .1421878, a6 = -0.1384794,  &
+                           a7 = .1250060
+
+	REAL, PARAMETER :: fact(10) = (/ 1., 1., 2., 6., 24., 120., 720., 5040.,  &
+                 40320., 362880. /)
+
+!JOE: difmuk,fk,u errors - undefined
+   difmuk = 0.
+   fk = 1.0
+   u = 0.
+
+!     ..
+!     .. Executable Statements ..
+   IF (mu > 10.0) THEN
+!     C A S E  A. (RECALCULATION OF S, D, L IF MU HAS CHANGED)
+
+      IF (first) THEN
+         s = SQRT(mu)
+         d = 6.0*mu*mu
+
+!             THE POISSON PROBABILITIES PK EXCEED THE DISCRETE NORMAL
+!             PROBABILITIES FK WHENEVER K >= M(MU). L=IFIX(MU-1.1484)
+!             IS AN UPPER BOUND TO M(MU) FOR ALL MU >= 10 .
+
+         l = mu - 1.1484
+         full_init = .false.
+      END IF
+
+!     STEP N. NORMAL SAMPLE - random_normal() FOR STANDARD NORMAL DEVIATE
+      g_s = mu + s*random_normal()
+      IF (g_s > 0.0) THEN
+         ival = g_s
+
+ 	 !     STEP I. IMMEDIATE ACCEPTANCE IF ival IS LARGE ENOUGH
+         IF (ival>=l) RETURN
+
+	 !     STEP S. SQUEEZE ACCEPTANCE - SAMPLE U
+		fk = ival
+		difmuk = mu - fk
+		CALL RANDOM_NUMBER(u)
+		IF (d*u >= difmuk*difmuk*difmuk) RETURN
+      END IF
+
+      !     STEP P. PREPARATIONS FOR STEPS Q AND H.
+      !             (RECALCULATIONS OF PARAMETERS IF NECESSARY)
+      !             .3989423=(2*PI)**(-.5)  .416667E-1=1./24.  .1428571=1./7.
+      !             THE QUANTITIES B1_S, B2_S, C3_S, C2_S, C1_S, C0 ARE FOR THE HERMITE
+      !             APPROXIMATIONS TO THE DISCRETE NORMAL PROBABILITIES FK.
+      !             C=.1069/MU GUARANTEES MAJORIZATION BY THE 'HAT'-FUNCTION.
+
+      IF (.NOT. full_init) THEN
+         omega = .3989423/s
+		b1_s = .4166667E-1/mu
+		b2_s = .3*b1_s*b1_s
+		c3_s = .1428571*b1_s*b2_s
+		c2_s = b2_s - 15.*c3_s
+		c1_s = b1_s - 6.*b2_s + 45.*c3_s
+		c0 = 1. - b1_s + 3.*b2_s - 15.*c3_s
+		c = .1069/mu
+		full_init = .true.
+      END IF
+
+	  IF (g_s < 0.0) GO TO 50
+
+	!             'SUBROUTINE' F IS CALLED (KFLAG=0 FOR CORRECT RETURN)
+
+	  kflag = 0
+	  GO TO 70
+
+	!     STEP Q. QUOTIENT ACCEPTANCE (RARE CASE)
+
+	  40 IF (fy-u*fy <= py*EXP(px-fx)) RETURN
+
+	!     STEP E. EXPONENTIAL SAMPLE - random_exponential() FOR STANDARD EXPONENTIAL
+	!             DEVIATE E AND SAMPLE T FROM THE LAPLACE 'HAT'
+	!             (IF T <= -.6744 THEN PK < FK FOR ALL MU >= 10.)
+
+	  50 e = random_exponential()
+	  CALL RANDOM_NUMBER(u)
+	  u = u + u - one
+	  t = 1.8 + SIGN(e, u)
+	  IF (t <= (-.6744)) GO TO 50
+	  ival = mu + s*t
+	  fk = ival
+	  difmuk = mu - fk
+
+	!             'SUBROUTINE' F IS CALLED (KFLAG=1 FOR CORRECT RETURN)
+
+	  kflag = 1
+	  GO TO 70
+
+	!     STEP H. HAT ACCEPTANCE (E IS REPEATED ON REJECTION)
+
+	  60 IF (c*ABS(u) > py*EXP(px+e) - fy*EXP(fx+e)) GO TO 50
+	  RETURN
+
+	!     STEP F. 'SUBROUTINE' F. CALCULATION OF PX, PY, FX, FY.
+	!             CASE ival < 10 USES FACTORIALS FROM TABLE FACT
+
+	  70 IF (ival>=10) GO TO 80
+	  px = -mu
+!JOE: had error " Subscript #1 of FACT has value -858993459"; shouldn't be < 1.
+         !py = mu**ival/fact(ival+1)
+	  py = mu**ival/fact(MAX(ival+1,1))
+	  GO TO 110
+
+	!             CASE ival >= 10 USES POLYNOMIAL APPROXIMATION
+	!             A0-A7 FOR ACCURACY WHEN ADVISABLE
+	!             .8333333E-1=1./12.  .3989423=(2*PI)**(-.5)
+
+	  80 del = .8333333E-1/fk
+	  del = del - 4.8*del*del*del
+	  v = difmuk/fk
+	  IF (ABS(v)>0.25) THEN
+		px = fk*LOG(one + v) - difmuk - del
+	  ELSE
+		px = fk*v*v* (((((((a7*v+a6)*v+a5)*v+a4)*v+a3)*v+a2_s)*v+a1_s)*v+a0) - del
+	  END IF
+	  py = .3989423/SQRT(fk)
+	  110 x = (half - difmuk)/s
+	  xx = x*x
+	  fx = -half*xx
+	  fy = omega* (((c3_s*xx + c2_s)*xx + c1_s)*xx + c0)
+	  IF (kflag <= 0) GO TO 40
+	  GO TO 60
+
+	!---------------------------------------------------------------------------
+	!     C A S E  B.    mu < 10
+	!     START NEW TABLE AND CALCULATE P0 IF NECESSARY
+      ELSE
+
+	  IF (first) THEN
+		m = MAX(1, INT(mu))
+		l = 0
+                !print*,"mu=",mu
+                !print*," mu=",mu," p=",EXP(-mu)
+		p = EXP(-mu)
+		q = p
+		p0 = p
+	  END IF
+
+	!     STEP U. UNIFORM SAMPLE FOR INVERSION METHOD
+
+	  DO
+		CALL RANDOM_NUMBER(u)
+		ival = 0
+		IF (u <= p0) RETURN
+
+	!     STEP T. TABLE COMPARISON UNTIL THE END PP(L) OF THE
+	!             PP-TABLE OF CUMULATIVE POISSON PROBABILITIES
+	!             (0.458=PP(9) FOR MU=10)
+
+		IF (l == 0) GO TO 150
+		j = 1
+		IF (u > 0.458) j = MIN(l, m)
+		DO k = j, l
+		  IF (u <= pp(k)) GO TO 180
+		END DO
+		IF (l == 35) CYCLE
+
+	!     STEP C. CREATION OF NEW POISSON PROBABILITIES P
+	!             AND THEIR CUMULATIVES Q=PP(K)
+
+		150 l = l + 1
+		DO k = l, 35
+		  p = p*mu / k
+		  q = q + p
+		  pp(k) = q
+		  IF (u <= q) GO TO 170
+		END DO
+		l = 35
+	  END DO
+
+	  170 l = k
+	  180 ival = k
+	  RETURN
+	END IF
+
+	RETURN
+	END subroutine random_Poisson
+
+!==================================================================
+
+	FUNCTION random_normal() RESULT(fn_val)
+
+	! Adapted from the following Fortran 77 code
+	!      ALGORITHM 712, COLLECTED ALGORITHMS FROM ACM.
+	!      THIS WORK PUBLISHED IN TRANSACTIONS ON MATHEMATICAL SOFTWARE,
+	!      VOL. 18, NO. 4, DECEMBER, 1992, PP. 434-435.
+
+	!  The function random_normal() returns a normally distributed pseudo-random
+	!  number with zero mean and unit variance.
+
+	!  The algorithm uses the ratio of uniforms method of A.J. Kinderman
+	!  and J.F. Monahan augmented with quadratic bounding curves.
+
+	REAL :: fn_val
+
+	!     Local variables
+	REAL     :: s = 0.449871, t = -0.386595, a = 0.19600, b = 0.25472,           &
+				r1 = 0.27597, r2 = 0.27846, u, v, x, y, q
+
+	!     Generate P = (u,v) uniform in rectangle enclosing acceptance region
+
+	DO
+	  CALL RANDOM_NUMBER(u)
+	  CALL RANDOM_NUMBER(v)
+	  v = 1.7156 * (v - half)
+
+	!     Evaluate the quadratic form
+	  x = u - s
+	  y = ABS(v) - t
+	  q = x**2 + y*(a*y - b*x)
+
+	!     Accept P if inside inner ellipse
+	  IF (q < r1) EXIT
+	!     Reject P if outside outer ellipse
+	  IF (q > r2) CYCLE
+	!     Reject P if outside acceptance region
+	  IF (v**2 < -4.0*LOG(u)*u**2) EXIT
+	END DO
+
+	!     Return ratio of P coordinates as the normal deviate
+	fn_val = v/u
+	RETURN
+
+	END FUNCTION random_normal
+
+!===============================================================
+
+	FUNCTION random_exponential() RESULT(fn_val)
+
+	! Adapted from Fortran 77 code from the book:
+	!     Dagpunar, J. 'Principles of random variate generation'
+	!     Clarendon Press, Oxford, 1988.   ISBN 0-19-852202-9
+
+	! FUNCTION GENERATES A RANDOM VARIATE IN [0,INFINITY) FROM
+	! A NEGATIVE EXPONENTIAL DlSTRIBUTION WlTH DENSITY PROPORTIONAL
+	! TO EXP(-random_exponential), USING INVERSION.
+
+	REAL  :: fn_val
+
+	!     Local variable
+	REAL  :: r
+
+	DO
+	  CALL RANDOM_NUMBER(r)
+	  IF (r > zero) EXIT
+	END DO
+
+	fn_val = -LOG(r)
+	RETURN
+
+	END FUNCTION random_exponential
+
+!===============================================================
+
+subroutine condensation_edmf(QT,THL,P,zagl,THV,QC)
+!
+! zero or one condensation for edmf: calculates THV and QC
+!
+real,intent(in)   :: QT,THL,P,zagl
+real,intent(out)  :: THV
+real,intent(inout):: QC
+
+integer :: niter,i
+real :: diff,exn,t,th,qs,qcold
+
+! constants used from module_model_constants.F
+! p1000mb
+! rcp ... Rd/cp
+! xlv ... latent heat for water (2.5e6)
+! cp
+! rvord .. rv/rd  (1.6) 
+
+
+! number of iterations
+  niter=50
+! minimum difference
+  diff=2.e-5
+
+  EXN=(P/p1000mb)**rcp
+  !QC=0.  !better first guess QC is incoming from lower level, do not set to zero
+  do i=1,NITER
+     T=EXN*THL + xlv/cp*QC        
+     QS=qsat_blend(T,P)
+     QCOLD=QC
+     QC=0.5*QC + 0.5*MAX((QT-QS),0.)
+     if (abs(QC-QCOLD)<Diff) exit
+  enddo
+
+  T=EXN*THL + xlv/cp*QC
+  QS=qsat_blend(T,P)
+  QC=max(QT-QS,0.)
+
+  !Do not allow saturation below 100 m
+  if(zagl < 100.)QC=0.
+
+  !THV=(THL+xlv/cp*QC).*(1+(1-rvovrd)*(QT-QC)-QC);
+  THV=(THL+xlv/cp*QC)*(1.+QT*(rvovrd-1.)-rvovrd*QC)
+  !THIS BASICALLY GIVE THE SAME RESULT AS THE PREVIOUS LINE
+  !TH = THL + xlv/cp/EXN*QC
+  !THV= TH*(1. + 0.608*QT)
+
+  !print *,'t,p,qt,qs,qc'
+  !print *,t,p,qt,qs,qc 
+
+
+end subroutine condensation_edmf
+
+!===============================================================
+
+SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
+
+    !---------------------------------------------------------------
+    !             NOTES ON SCALE-AWARE FORMULATION
+    !
+    !JOE: add scale-aware factor (Psig) here, taken from Honnert et al. (2011,
+    !     JAS) and/or from Hyeyum Hailey Shin and Song-You Hong (2013, JAS)
+    !
+    ! Psig_bl tapers local mixing
+    ! Psig_shcu tapers nonlocal mixing
+
+    REAL,INTENT(IN) :: dx,PBL1
+    REAL, INTENT(OUT) :: Psig_bl,Psig_shcu
+    REAL :: dxdh
+
+    Psig_bl=1.0
+    Psig_shcu=1.0
+    dxdh=MAX(dx,10.)/MIN(PBL1,3000.)
+    ! Honnert et al. 2011, TKE in PBL  *** original form used until 201605
+    !Psig_bl= ((dxdh**2) + 0.07*(dxdh**0.667))/((dxdh**2) + &
+    !         (3./21.)*(dxdh**0.67) + (3./42.))
+    ! Honnert et al. 2011, TKE in entrainment layer
+    !Psig_bl= ((dxdh**2) + (4./21.)*(dxdh**0.667))/((dxdh**2) + &
+     !        (3./20.)*(dxdh**0.67) + (7./21.))
+    ! New form to preseve parameterized mixing - only down 5% at dx = 750 m
+     Psig_bl= ((dxdh**2) + 0.106*(dxdh**0.667))/((dxdh**2) +0.066*(dxdh**0.667) + 0.071)
+
+    !assume a 500 m cloud depth for shallow-cu clods
+    dxdh=MAX(dx,10.)/MIN(PBL1+500.,3500.)
+    ! Honnert et al. 2011, TKE in entrainment layer *** original form used until 201605
+    !Psig_shcu= ((dxdh**2) + (4./21.)*(dxdh**0.667))/((dxdh**2) + &
+    !         (3./20.)*(dxdh**0.67) + (7./21.))
+
+    ! Honnert et al. 2011, TKE in cumulus
+    !Psig(i)= ((dxdh**2) + 1.67*(dxdh**1.4))/((dxdh**2) +1.66*(dxdh**1.4) +
+    !0.2)
+
+    ! Honnert et al. 2011, w'q' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) + 0.03*(dxdh**1.4) -
+    !(4./13.))/((dxdh**2) + 0.03*(dxdh**1.4) + (4./13.))
+    ! Honnert et al. 2011, w'q' in cumulus
+    !Psig(i)= ((dxdh**2) - 0.07*(dxdh**1.4))/((dxdh**2) -0.07*(dxdh**1.4) +
+    !0.02)
+
+    ! Honnert et al. 2011, q'q' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) + 0.25*(dxdh**0.667) -0.73)/((dxdh**2)
+    !-0.03*(dxdh**0.667) + 0.73)
+    ! Honnert et al. 2011, q'q' in cumulus
+    !Psig(i)= ((dxdh**2) - 0.34*(dxdh**1.4))/((dxdh**2) - 0.35*(dxdh**1.4)
+    !+ 0.37)
+
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, TKE in PBL (same as Honnert's above)
+    !Psig_shcu= ((dxdh**2) + 0.070*(dxdh**0.667))/((dxdh**2)
+    !+0.142*(dxdh**0.667) + 0.071)
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, TKE in entrainment zone  *** switch to this form 201605
+    Psig_shcu= ((dxdh**2) + 0.145*(dxdh**0.667))/((dxdh**2) +0.172*(dxdh**0.667) + 0.170)
+
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in PBL
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) -0.098)/((dxdh**2) + 0.106) 
+    ! Hyeyum Hailey Shin and Song-You Hong 2013, w'theta' in entrainment zone
+    !Psig(i)= 0.5 + 0.5*((dxdh**2) - 0.112*(dxdh**0.25) -0.071)/((dxdh**2)
+    !+ 0.054*(dxdh**0.25) + 0.10)
+
+    !print*,"in scale_aware; dx, dxdh, Psig(i)=",dx,dxdh,Psig(i)
+    !If(Psig_bl(i) < 0.0 .OR. Psig(i) > 1.)print*,"dx, dxdh, Psig(i)=",dx,dxdh,Psig_bl(i) 
+    If(Psig_bl > 1.0) Psig_bl=1.0
+    If(Psig_bl < 0.0) Psig_bl=0.0
+
+    If(Psig_shcu > 1.0) Psig_shcu=1.0
+    If(Psig_shcu < 0.0) Psig_shcu=0.0
+
+  END SUBROUTINE SCALE_AWARE
+
+! =====================================================================
+
+  FUNCTION esat_blend(t) 
+! JAYMES- added 22 Apr 2015
+! 
+! This calculates saturation vapor pressure.  Separate ice and liquid functions 
+! are used (identical to those in module_mp_thompson.F, v3.6).  Then, the 
+! final returned value is a temperature-dependant "blend".  Because the final 
+! value is "phase-aware", this formulation may be preferred for use throughout 
+! the module (replacing "svp").
+
+      IMPLICIT NONE
+      
+      REAL, INTENT(IN):: t
+      REAL :: esat_blend,XC,ESL,ESI,chi
+
+      XC=MAX(-80.,t-273.16)
+
+! For 253 < t < 273.16 K, the vapor pressures are "blended" as a function of temperature, 
+! using the approach of Chaboureau and Bechtold (2002), JAS, p. 2363.  The resulting 
+! values are returned from the function.
+      IF (t .GE. 273.16) THEN
+          esat_blend = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
+      ELSE IF (t .LE. 253.) THEN
+          esat_blend = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+      ELSE
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          chi  = (273.16-t)/20.16
+          esat_blend = (1.-chi)*ESL  + chi*ESI
+      END IF
+
+  END FUNCTION esat_blend
+
+! ====================================================================
+
+  FUNCTION qsat_blend(t, P)
+! JAYMES- this function extends function "esat" and returns a "blended"
+! saturation mixing ratio.
+
+      IMPLICIT NONE
+
+      REAL, INTENT(IN):: t, P
+      REAL :: qsat_blend,XC,ESL,ESI,RSLF,RSIF,chi
+
+      XC=MAX(-80.,t-273.16)
+
+      IF (t .GE. 273.16) THEN
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8))))))) 
+          qsat_blend = 0.622*ESL/(P-ESL) 
+      ELSE IF (t .LE. 253.) THEN
+          ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          qsat_blend = 0.622*ESI/(P-ESI)
+      ELSE
+          ESL  = J0+XC*(J1+XC*(J2+XC*(J3+XC*(J4+XC*(J5+XC*(J6+XC*(J7+XC*J8)))))))
+          ESI  = K0+XC*(K1+XC*(K2+XC*(K3+XC*(K4+XC*(K5+XC*(K6+XC*(K7+XC*K8)))))))
+          RSLF = 0.622*ESL/(P-ESL)
+          RSIF = 0.622*ESI/(P-ESI)
+          chi  = (273.16-t)/20.16
+          qsat_blend = (1.-chi)*RSLF + chi*RSIF
+      END IF
+
+  END FUNCTION qsat_blend
+
+! ===================================================================
+
+  FUNCTION xl_blend(t)
+! JAYMES- this function interpolates the latent heats of vaporization and
+! sublimation into a single, temperature-dependant, "blended" value, following
+! Chaboureau and Bechtold (2002), Appendix.
+
+      IMPLICIT NONE
+
+      REAL, INTENT(IN):: t
+      REAL :: xl_blend,xlvt,xlst,chi
+
+      IF (t .GE. 273.16) THEN
+          xl_blend = xlv + (cpv-cliq)*(t-273.16)  !vaporization/condensation
+      ELSE IF (t .LE. 253.) THEN
+          xl_blend = xls + (cpv-cice)*(t-273.16)  !sublimation/deposition
+      ELSE
+          xlvt = xlv + (cpv-cliq)*(t-273.16)  !vaporization/condensation
+          xlst = xls + (cpv-cice)*(t-273.16)  !sublimation/deposition
+          chi  = (273.16-t)/20.16
+          xl_blend = (1.-chi)*xlvt + chi*xlst     !blended
+      END IF
+
+  END FUNCTION xl_blend
+
+! ===================================================================
+! ===================================================================
+! This is the mass flux part of the TEMF scheme from module_bl_temf.F,
+! adapted for the MYNN context by Wayne Angevine June 2015.
+! Variable strategy:  TEMF external variables that have semantically
+! comfortable counterparts in the MYNN-EDMF context have been changed to
+! use those names.  Otherwise the TEMF variable names have been kept but
+! redefined as local variables.  Only "moist" vars are used, whether
+! updraft condenses or not.  Some former local vars are replaced with
+! externals.
+!
+! (Partial) list of conversions:
+!    wupd_temfx -> moist_w
+!    thup_temfx -> moist_thl
+!    qtup_temfx -> moist_qt
+!    qlup_temfx -> moist_qc
+!    cf3d_temfx -> cldfra_bl1d
+!    au -> moist_a
+
+  SUBROUTINE temf_mf(                        &
+                 & kts,kte,dt,zw,p,pi1d,     &
+                 & u,v,w,th,thl,thv,qt,qv,qc,&
+                 & qke,ust,flt,flq,flqv,flqc,&
+                 & hfx,qfx,tsk,              &
+                 & pblh,rho,dfh,dx,znt,ep_2, &
+            ! outputs - updraft properties
+                 & edmf_a,edmf_w,edmf_qt,    &
+                 & edmf_thl,edmf_ent,edmf_qc,&
+            ! outputs - variables needed for solver
+                 & s_aw,s_awthl,s_awqt,      &
+                 & s_awqv,s_awqc,            &
+                 & s_awu,s_awv,s_awqke,      &
+#if (WRF_CHEM == 1)
+                 & nchem,chem,s_awchem,      &
+#endif
+            ! in/outputs - subgrid scale clouds
+                 & qc_bl1d,cldfra_bl1d,      &
+            ! inputs - flags for moist arrays
+                 &F_QC,F_QI,psig,            &
+                 &spp_pbl,rstoch_col,        &
+                 &ii,jj,ids,ide,jds,jde)
+
+
+  ! inputs:
+     INTEGER, INTENT(IN) :: kts,kte,ii,jj,ids,ide,jds,jde
+     REAL,DIMENSION(kts:kte), INTENT(IN) :: u,v,w,th,thl,qt,qv,qc,thv,p,pi1d
+     REAL,DIMENSION(kts:kte), INTENT(IN) :: qke
+     REAL,DIMENSION(kts:kte+1), INTENT(IN) :: zw  !height at full-sigma
+     REAL,DIMENSION(kts:kte), INTENT(IN) :: rho  !density
+     REAL,DIMENSION(kts:kte), INTENT(IN) :: dfh  !diffusivity for heat
+     REAL, INTENT(IN) :: dt,ust,flt,flq,flqv,flqc,hfx,qfx,tsk,pblh,dx,znt,ep_2,psig
+     LOGICAL, OPTIONAL :: f_qc,f_qi
+
+  ! outputs - updraft properties
+     REAL,DIMENSION(kts:kte), INTENT(OUT) :: &
+                 & edmf_a,edmf_w,edmf_qt,    &
+                 & edmf_thl,edmf_ent,edmf_qc
+
+  ! outputs - variables needed for solver
+     REAL,DIMENSION(kts:kte+1) :: s_aw,      & !sum ai*wis_awphi
+                               s_awthl,      & !sum ai*wi*phii
+                                s_awqt,      &
+                                s_awqv,      &
+                                s_awqc,      &
+                                 s_awu,      &
+                                 s_awv,      &
+                                 s_awqke
+#if (WRF_CHEM == 1)
+     INTEGER, INTENT(IN) :: nchem
+     REAL,DIMENSION(kts:kte+1, nchem) :: chem
+     REAL,DIMENSION(kts:kte+1, nchem) :: s_awchem
+     INTEGER :: ic
+#endif
+
+     REAL,DIMENSION(kts:kte), INTENT(INOUT) :: qc_bl1d,cldfra_bl1d
+
+! Local variables
+!
+! EDMF constants
+   real, parameter :: CM = 0.03      ! Proportionality constant for subcloud MF
+   real, parameter :: Cdelt = 0.006  ! Prefactor for detrainment rate
+   real, parameter :: Cw = 0.5       ! Prefactor for surface wUPD
+   real, parameter :: Cc = 3.0       ! Prefactor for convective length scale
+   real, parameter :: lasymp = 200.0 ! Asymptotic length scale WA 11/20/09
+   real, parameter :: hmax = 4000.0  ! Max hd,hct WA 11/20/09
+   integer, parameter :: Nupd = 8    ! Number of updrafts
+!
+   integer :: i, k, kt, nu   ! Loop variable
+   integer::  h0idx
+   real::  h0
+   real::  wstr, ang, wm
+   real, dimension( Nupd) ::  hd,lcl,hct,ht
+   real::  convection_TKE_surface_src, sfcFTE
+   real::  sfcTHVF
+   real::  z0t
+   integer, dimension( Nupd) ::  hdidx,lclidx,hctidx,htidx
+   integer::  hmax_idx
+   integer::  tval
+   real, dimension( kts:kte) :: zm, zt, dzm, dzt
+   real, dimension( kts:kte) :: thetal, qtot
+   real, dimension( kts:kte) :: u_temf, v_temf
+   real, dimension( kts:kte) :: rv, rl, rt
+   real, dimension( kts:kte) :: chi_poisson, gam
+   real, dimension( kts:kte) :: dthdz
+   real, dimension( kts:kte) :: lepsmin
+   real, dimension( kts:kte) :: thetav
+   real, dimension( kts:kte) :: dmoist_qtdz
+   real, dimension( kts:kte) :: B, Bmoist
+   real, dimension( kts:kte, Nupd) :: epsmf, deltmf, dMdz
+   real, dimension( kts:kte, Nupd) :: UUPD, VUPD
+   real, dimension( kts:kte, Nupd) :: thetavUPD, qlUPD, TEUPD
+   real, dimension( kts:kte, Nupd) :: thetavUPDmoist, wUPD_dry
+   real, dimension( kts:kte, Nupd) :: dthUPDdz, dwUPDdz
+   real, dimension( kts:kte, Nupd) :: dwUPDmoistdz
+   real, dimension( kts:kte, Nupd) :: dUUPDdz, dVUPDdz, dTEUPDdz
+   real, dimension( kts:kte, Nupd) :: TUPD, rstUPD, rUPD, rlUPD, qstUPD
+   real, dimension( kts:kte, Nupd) :: MUPD, wUPD, qtUPD, thlUPD, qcUPD
+   real, dimension( kts:kte, Nupd) :: aUPD, cldfraUPD, aUPDt
+   real, dimension( kts:kte) :: N2, S, Ri, beta, ftau, fth, ratio
+   real, dimension( kts:kte) :: TKE, TE2
+   real, dimension( kts:kte) :: ustrtilde, linv, leps
+   real, dimension( kts:kte) :: km, kh
+   real, dimension( kts:kte) :: Fz, QFK, uwk, vwk
+   real, dimension( kts:kte) :: km_conv, kh_conv, lconv
+   real, dimension( kts:kte) :: alpha2, beta2   ! For thetav flux calculation
+   real, dimension( kts:kte) :: THVF, buoy_src, srcs
+   real, dimension( kts:kte) :: beta1 ! For saturation humidity calculations
+   real, dimension( kts:kte) :: MFCth
+   real Cepsmf    ! Prefactor for entrainment rate
+   real red_fact  ! for reducing MF components
+   real, dimension( kts:kte) :: edmf_u, edmf_v, edmf_qke ! Same format as registry vars, but not passed out
+   integer:: bdy_dist,taper_dist
+   real:: taper
+
+  ! Stochastic
+     INTEGER, INTENT(IN)   :: spp_pbl
+     REAL, DIMENSION(kts:kte), INTENT(in)   :: rstoch_col
+
+#if (WRF_CHEM == 1)
+   real,dimension( kts:kte+1, nchem, Nupd) :: chemUPD, dchemUPDdz
+   real,dimension( kts:kte+1, nchem)       :: edmf_chem
+#endif
+
+   ! Used to be TEMF external variables, now local
+   real, dimension( kts:kte, Nupd) :: &
+             shf_temfx, qf_temfx, uw_temfx, vw_temfx , &
+             mf_temfx
+   real, dimension( Nupd) :: hd_temfx, lcl_temfx, hct_temfx, cfm_temfx
+   logical is_convective
+   ! Vars for cloud fraction calculation
+   real, dimension( kts:kte) :: sigq, qst, satdef
+   real :: sigq2, rst, cldfra_sum, psig_w, maxw
+
+!----------------------------------------------------------------------
+! Grid staggering:  Matlab version has mass and turbulence levels.
+! WRF has full levels (with w) and half levels (u,v,theta,q*).  Both
+! sets of levels use the same indices (kts:kte).  See pbl_driver or
+! WRF Physics doc for (a few) details.
+! So *mass levels correspond to half levels.*
+! WRF full levels are ignored, we define our own turbulence levels
+! in order to put the first one below the first half level.
+! Another difference is that
+! the Matlab version (and the Mauritsen et al. paper) consider the
+! first mass level to be at z0 (effectively the surface).  WRF considers
+! the first half level to be above the effective surface.  The first half
+! level, at k=1, has nonzero values of u,v for example.  Here we convert
+! all incoming variables to internal ones with the correct indexing
+! in order to make the code consistent with the Matlab version.  We
+! already had to do this for thetal and qt anyway, so the only additional
+! overhead is for u and v.
+! I use suffixes m for mass and t for turbulence as in Matlab for things
+! like indices.
+! Note that zsrf is the terrain height ASL, from Registry variable ht.
+! Translations (Matlab to WRF):
+!     dzt -> calculated below
+!     dzm -> not supplied, calculated below
+!     k -> karman
+!     z0 -> znt
+!     z0t -> not in WRF, calculated below
+!     zt -> calculated below
+!     zm -> zw but NOTE zm(1) is now z0 (znt) and zm(2) is zw(1)
+!
+! Other notes:
+! - I have often used 1 instead of kts below, because the scheme demands
+!   to know where the surface is.  It won't work if kts .NE. 1.
+
+      IF ( debug_code ) THEN
+         print*,' MYNN; in TEMF_MF, beginning'
+      ENDIF
+
+      !JOE-initialize s_aw* variables
+      s_aw   = 0.
+      s_awthl= 0.
+      s_awqt = 0.
+      s_awqv = 0.
+      s_awqc = 0.
+      s_awu  = 0.
+      s_awv  = 0.
+      s_awqke= 0.
+      edmf_a = 0.
+      edmf_w = 0.
+      edmf_qt= 0. !qt
+      edmf_thl=0. !thl
+      edmf_ent=0.
+      edmf_qc= 0. !qc
+      edmf_u=0.
+      edmf_v=0.
+      edmf_qke=0.
+ 
+      z0t = znt
+
+      do k = kts,kte
+         rv(k) = qv(k) / (1.-qv(k))   ! Water vapor
+         rl(k) = qc(k) / (1.-qc(k))   ! Liquid water
+         rt(k) = qt(k)                ! Total water (without ice)
+         thetal(k) = thl(k)
+         qtot(k) = qt(k)
+         thetav(k) = thv(k)
+      end do
+
+      do k = kts,kte
+         u_temf(k) = u(k)
+         v_temf(k) = v(k)
+      end do
+
+      !taper off MF scheme when significant resolved-scale motions are present
+      !This function needs to be asymetric...
+      k      = 1
+      maxw   = 0.0
+      DO WHILE (ZW(k) < pblh + 500.)
+         maxw = MAX(maxw,ABS(W(k)))
+         k = k+1
+      ENDDO
+      maxw = MAX(0.,maxw - 0.5)         ! do nothing for small w, but
+      Psig_w = MAX(0.0, 1.0 - maxw/0.5) ! linearly taper off for w > 0.5 m/s
+      Psig_w = MIN(Psig_w, Psig)
+      !print*," maxw=", maxw," Psig_w=",Psig_w," Psig_shcu=",Psig_shcu
+
+      ! Get delta height at half (mass) levels
+      zm(1) = znt
+      dzt(1) = zw(2) - zm(1)
+      ! Get height and delta at turbulence levels
+      zt(1) = (zw(2) - znt) / 2.
+      do kt = kts+1,kte
+         zm(kt) = zw(kt) ! Convert indexing from WRF to TEMF
+         zt(kt) = (zm(kt) + zw(kt+1)) / 2.
+         dzm(kt) = zt(kt) - zt(kt-1)
+         dzt(kt) = zw(kt+1) - zw(kt)
+      end do
+      dzm(1) = dzm(2)
+
+      !print *,"In TEMF_MF zw = ", zw
+      !print *,"zm = ", zm
+      !print *,"zt = ", zt
+      !print *,"dzm = ", dzm
+      !print *,"dzt = ", dzt
+
+      ! Gradients at first level
+      dthdz(1) = (thetal(2)-thetal(1)) / (zt(1) * log10(zm(2)/z0t))
+
+      !print *,"In TEMF_MF dthdz(1),thetal(2,1),tsk,zt(1),zm(2),z0t = ", &
+      !             dthdz(1),thetal(2),thetal(1),tsk,zt(1),zm(2),z0t       
+
+      ! Surface thetaV flux from Stull p.147
+      sfcTHVF = hfx/(rho(1)*cp) * (1.+0.608*(qv(1)+qc(1))) + 0.608*thetav(1)*qfx
+
+      ! WA use hd_temf to calculate w* instead of finding h0 here????
+      ! Watch initialization!
+      h0idx = 1
+      h0 = zm(1)
+
+      lepsmin(kts) = 0.
+
+      ! WA 2/11/13 find index just above hmax for use below
+      hmax_idx = kte-1
+
+      do k = kts+1,kte-1
+         lepsmin(k) = 0.
+
+         ! Mean gradients
+         dthdz(k) = (thetal(k+1) - thetal(k)) / dzt(k)
+
+         ! Find h0 (should eventually be interpolated for smoothness)
+         if (thetav(k) > thetav(1) .AND. h0idx .EQ. 1) then
+         ! WA 9/28/11 limit h0 as for hd and hct
+            if (zm(k) < hmax) then
+               h0idx = k
+               h0 = zm(k)
+            else
+               h0idx = k
+               h0 = hmax
+            end if
+         end if
+         ! WA 2/11/13 find index just above hmax for use below
+         if (zm(k) > hmax) then
+            hmax_idx = min(hmax_idx,k)
+         end if
+      end do
+
+      ! Gradients at top level
+
+      dthdz(kte) = dthdz(kte-1)
+
+      if ( hfx > 0.) then
+         wstr = (g * h0 / thetav(2) * hfx/(rho(1)*cp) ) ** (1./3.)
+         bdy_dist = min( min((ii-ids),(ide-ii)) , min((jj-jds),(jde-jj)) )
+         taper_dist = 5
+         ! JSK - linearly taper w-star near lateral boundaries (within 5 grid columns)
+         if (bdy_dist .LE. taper_dist) then
+            taper = max(0., min( 1., real(bdy_dist) / real(taper_dist) ) )
+            wstr  = wstr * taper
+         end if
+      else
+         wstr = 0.
+      end if
+
+      !print *,"In TEMF_MF wstr,hfx,dthdz(1:2),h0 = ", wstr,hfx,dthdz(1),dthdz(2),h0
+      IF ( debug_code ) THEN
+         print*,' MYNN; in TEMF_MF: wstr,hfx,dtdz1,dtdz2,h0:', wstr,hfx,dthdz(1),dthdz(2),h0
+      ENDIF
+
+      ! Set flag convective or not for use below
+      is_convective = wstr > 0. .AND. dthdz(1)<0. .AND. dthdz(2)<0.  
+      ! WA 12/16/09 require two levels of negative (unstable) gradient
+
+      !*** Mass flux block starts here ***
+      ! WA WFIP 11/13/15 allow multiple updrafts, deterministic for now
+
+      if ( is_convective) then
+
+         IF ( debug_code ) THEN
+            print *,"In TEMF_MF is_convective, wstr = ", wstr
+         ENDIF
+
+         !Cepsmf = 2. / max(200.,h0)
+         Cepsmf = 1.0 / max(200.,h0) ! WA TEST reduce entrainment 
+         ! Cepsmf = max(Cepsmf,0.002)
+         ! Cepsmf = max(Cepsmf,0.0015)  ! WA TEST reduce max entrainment
+         ! Cepsmf = max(Cepsmf,0.0005)  ! WA TEST reduce min entrainment
+         Cepsmf = max(Cepsmf,0.0010)  ! WA TEST reduce min entrainment
+
+         do nu = 1,Nupd
+            do k = kts,kte
+               ! Calculate lateral entrainment fraction for subcloud layer
+               ! epsilon and delta are defined on mass grid (half levels)
+               ! epsmf(k,nu) = Cepsmf * (1+0.2*(floor(nu - Nupd/2.))) ! WA for three updrafts
+               ! epsmf(k,nu) = Cepsmf * (1+0.05*(floor(nu - Nupd/2.))) ! WA for ten updrafts
+               ! epsmf(k,nu) = Cepsmf * (1+0.0625*(floor(nu - Nupd/2.))) ! WA for eight updrafts
+               ! epsmf(k,nu) = Cepsmf * (1+0.03*(floor(nu - Nupd/2.))) ! WA for eight updrafts, less spread
+               epsmf(k,nu) = Cepsmf * (1+0.25*(nu-1)) ! WA for eight updrafts, much more eps for some plumes, per Neggers 2015 fig. 15 
+            end do
+
+            !IF ( debug_code ) THEN
+                print*,' MYNN; in TEMF_MF, Cepsmf, epsmf(1:13,nu)=', Cepsmf
+                print*,"    epsmf(1:13,nu)=",epsmf(1:13,nu)
+            !ENDIF
+
+            ! Initialize updraft
+            thlUPD(1,nu) = thetal(1) + Cw*wstr
+            qtUPD(1,nu) = qtot(1) + 0.0*qfx/wstr
+            rUPD(1,nu) = qtUPD(1,nu) / (1. - qtUPD(1,nu))
+            wUPD(1,nu) = Cw * wstr
+            wUPD_dry(1,nu) = Cw * wstr
+            UUPD(1,nu) = u_temf(1)
+            VUPD(1,nu) = v_temf(1)
+            thetavUPD(1,nu) = thlUPD(1,nu) * (1. + 0.608*qtUPD(1,nu))  ! WA Assumes no liquid
+            thetavUPDmoist(1,nu) = thetavUPD(1,nu)
+            TEUPD(1,nu) = qke(1) + g / thetav(1) * sfcTHVF
+            qlUPD(1,nu) = qc(1)  ! WA allow environment liquid
+            TUPD(1,nu) = thlUPD(1,nu) * pi1d(1)
+            !rstUPD(1,nu) = rsat_temf(p(1),TUPD(1,nu),ep_2)
+            rstUPD(1,nu) = qsat_blend(TUPD(1,nu),p(1)) ! get saturation water vapor mixing ratio at tl and p
+            rlUPD(1,nu) = 0.
+#if (WRF_CHEM == 1)
+            do ic = 1,nchem
+               chemUPD(1,ic,nu) = chem(1,ic)
+            enddo
+#endif
+
+            ! Calculate updraft parameters counting up
+            do k = 2,kte
+               ! WA 2/11/13 use hmax index to prevent oddness high up
+               if ( k < hmax_idx) then
+                  dthUPDdz(k-1,nu) = -epsmf(k,nu) * (thlUPD(k-1,nu) - thetal(k-1))
+                  thlUPD(k,nu) = thlUPD(k-1,nu) + dthUPDdz(k-1,nu) * dzm(k-1)
+                  dmoist_qtdz(k-1) = -epsmf(k,nu) * (qtUPD(k-1,nu) - qtot(k-1))
+                  qtUPD(k,nu) = qtUPD(k-1,nu) + dmoist_qtdz(k-1) * dzm(k-1)
+                  thetavUPD(k,nu) = thlUPD(k,nu) * (1. + 0.608*qtUPD(k,nu))  ! WA Assumes no liquid
+                  B(k-1) = g * (thetavUPD(k,nu) - thetav(k)) / thetav(k)
+                  if ( wUPD_dry(k-1,nu) < 1e-15 ) then
+                     wUPD_dry(k,nu) = 0.
+                  else
+                     dwUPDdz(k-1,nu) = -2. *epsmf(k,nu)*wUPD_dry(k-1,nu) + 0.33*B(k-1)/wUPD_dry(k-1,nu)
+                     wUPD_dry(k,nu) = wUPD_dry(k-1,nu) + dwUPDdz(k-1,nu) * dzm(k-1)
+                  end if
+                  dUUPDdz(k-1,nu) = -epsmf(k,nu) * (UUPD(k-1,nu) - u_temf(k-1))
+                  UUPD(k,nu) = UUPD(k-1,nu) + dUUPDdz(k-1,nu) * dzm(k-1)
+                  dVUPDdz(k-1,nu) = -epsmf(k,nu) * (VUPD(k-1,nu) - v_temf(k-1))
+                  VUPD(k,nu) = VUPD(k-1,nu) + dVUPDdz(k-1,nu) * dzm(k-1)
+                  dTEUPDdz(k-1,nu) = -epsmf(k,nu) * (TEUPD(k-1,nu) - qke(k-1))
+                  TEUPD(k,nu) = TEUPD(k-1,nu) + dTEUPDdz(k-1,nu) * dzm(k-1)
+                  ! Alternative updraft velocity based on moist thetav
+                  ! Need thetavUPDmoist, qlUPD
+                  rUPD(k,nu) = qtUPD(k,nu) / (1. - qtUPD(k,nu))
+                  ! WA Updraft temperature assuming no liquid
+                  TUPD(k,nu) = thlUPD(k,nu) * pi1d(k)
+                  ! Updraft saturation mixing ratio
+                  !rstUPD(k,nu) = rsat_temf(p(k-1),TUPD(k,nu),ep_2)
+                  rstUPD(k,nu) = qsat_blend(TUPD(k,nu),p(k-1))
+                  ! Correct to actual temperature (Sommeria & Deardorff 1977)
+                  beta1(k) = 0.622 * (xlv/(r_d*TUPD(k,nu))) * (xlv/(cp*TUPD(k,nu)))
+                  rstUPD(k,nu) = rstUPD(k,nu) * (1.0+beta1(k)*rUPD(k,nu)) / (1.0+beta1(k)*rstUPD(k,nu))
+                  qstUPD(k,nu) = rstUPD(k,nu) / (1. + rstUPD(k,nu))
+                  if (rUPD(k,nu) > rstUPD(k,nu)) then
+                     rlUPD(k,nu) = rUPD(k,nu) - rstUPD(k,nu)
+                     qlUPD(k,nu) = rlUPD(k,nu) / (1. + rlUPD(k,nu))
+                     thetavUPDmoist(k,nu) = (thlUPD(k,nu) + ((xlv/cp)*qlUPD(k,nu)/pi1d(k))) * &
+                                        (1. + 0.608*qstUPD(k,nu) - qlUPD(k,nu))
+                  else
+                     rlUPD(k,nu) = 0.
+                     qlUPD(k,nu) = qc(k-1)   ! WA 4/6/10 allow environment liquid
+                     thetavUPDmoist(k,nu) = thlUPD(k,nu) * (1. + 0.608*qtUPD(k,nu))
+                  end if
+                  Bmoist(k-1) = g * (thetavUPDmoist(k,nu) - thetav(k)) / thetav(k)
+                  if ( wUPD(k-1,nu) < 1e-15 ) then
+                     wUPD(k,nu) = 0.
+                  else
+                     dwUPDmoistdz(k-1,nu) = -2. *epsmf(k,nu)*wUPD(k-1,nu) + 0.33*Bmoist(k-1)/wUPD(k-1,nu)
+                     wUPD(k,nu) = wUPD(k-1,nu) + dwUPDmoistdz(k-1,nu) * dzm(k-1)
+                  end if
+#if (WRF_CHEM == 1)
+                  do ic = 1,nchem
+                     dchemUPDdz(k-1,ic,nu) = -epsmf(k,nu) * (chemUPD(k-1,ic,nu) - chem(k-1,ic))
+                     chemUPD(k,ic,nu) = chemUPD(k-1,ic,nu) + dchemUPDdz(k-1,ic,nu) * dzm(k-1)
+                  enddo
+#endif
+               else ! above hmax
+                  thlUPD(k,nu) = thetal(k)
+                  qtUPD(k,nu) = qtot(k)
+                  wUPD_dry(k,nu) = 0.
+                  UUPD(k,nu) = u_temf(k)
+                  VUPD(k,nu) = v_temf(k)
+                  TEUPD(k,nu) = qke(k)
+                  qlUPD(k,nu) = qc(k-1)
+                  wUPD(k,nu) = 0.
+#if (WRF_CHEM == 1)
+                  do ic = 1,nchem
+                     chemUPD(k,ic,nu) = chem(k-1,ic)
+                  enddo
+#endif
+               end if
+
+               IF ( debug_code ) THEN
+                 IF ( ABS(wUPD(k,nu))>10. ) THEN
+                   print*,' MYNN, in TEMF_MF, huge w at (nu,k):', nu,k
+                   print *,"     thlUPD(1:k,nu) = ", thlUPD(1:k,nu)
+                   print *,"     wUPD(1:k,nu)   = ", wUPD(1:k,nu)
+                   print *,"     Bmoist(1:k-1)  = ", Bmoist(1:k-1)
+                   print *,"     epsmf(1:k,nu)  = ", epsmf(1:k,nu)
+                 ENDIF
+               ENDIF
+
+            ENDDO !end-k
+
+            ! Find hd based on wUPD
+            if (wUPD_dry(1,nu) == 0.) then
+               hdidx(nu) = 1
+            else
+               hdidx(nu) = kte  ! In case wUPD <= 0 not found
+               do k = 2,kte
+                  if (wUPD_dry(k,nu) <= 0. .OR. zm(k) > hmax) then
+                     hdidx(nu) = k
+                     ! goto 100   ! FORTRAN made me do it!
+                     exit
+                  end if
+               end do
+            end if
+ 100                   hd(nu) = zm(hdidx(nu))
+
+            ! Find LCL, hct, and ht
+            lclidx(nu) = kte   ! In case LCL not found
+            do k = kts,kte
+               if ( k < hmax_idx .AND. rUPD(k,nu) > rstUPD(k,nu)) then
+                  lclidx(nu) = k
+                  ! goto 200
+                  exit
+               end if
+            end do
+ 200                   lcl(nu) = zm(lclidx(nu))
+
+            if (hd(nu) > lcl(nu)) then   ! Forced cloud (at least) occurs
+               ! Find hct based on wUPDmoist
+               if (wUPD(1,nu) == 0.) then
+                  hctidx(nu) = 1
+               else
+                  hctidx(nu) = kte  ! In case wUPD <= 0 not found
+                  do k = 2,kte
+                     if (wUPD(k,nu) <= 0. .OR. zm(k) > hmax) then
+                        hctidx(nu) = k
+                        ! goto 300   ! FORTRAN made me do it!
+                        exit
+                     end if
+                  end do
+               end if
+ 300                         hct(nu) = zm(hctidx(nu))
+               if (hctidx(nu) <= hdidx(nu)+1) then   ! No active cloud
+                  hct(nu) = hd(nu)
+                  hctidx(nu) = hdidx(nu)
+               else
+               end if
+            else   ! No cloud
+               hct(nu) = hd(nu)
+               hctidx(nu) = hdidx(nu)
+            end if
+            ht(nu) = max(hd(nu),hct(nu))
+            htidx(nu) = max(hdidx(nu),hctidx(nu))
+
+            ! Now truncate updraft at ht with taper
+            do k = 1,kte
+               if (zm(k) < 0.9*ht(nu)) then  ! Below taper region
+                   tval = 1
+               else if (zm(k) >= 0.9*ht(nu) .AND. zm(k) <= 1.0*ht(nu)) then
+                  ! Within taper region
+                  tval = 1. - ((zm(k) - 0.9*ht(nu)) / (1.0*ht(nu) - 0.9*ht(nu)))
+               else  ! Above taper region
+                  tval = 0.
+               end if
+               thlUPD(k,nu) = tval * thlUPD(k,nu) + (1-tval)*thetal(k)
+               thetavUPD(k,nu) = tval * thetavUPD(k,nu) + (1-tval)*thetav(k)
+               qtUPD(k,nu) = tval * qtUPD(k,nu) + (1-tval) * qtot(k)
+               if (k > 1) then
+                  qlUPD(k,nu) = tval * qlUPD(k,nu) + (1-tval) * qc(k-1)
+               end if
+               UUPD(k,nu) = tval * UUPD(k,nu) + (1-tval) * u_temf(k)
+               VUPD(k,nu) = tval * VUPD(k,nu) + (1-tval) * v_temf(k)
+               TEUPD(k,nu) = tval * TEUPD(k,nu) + (1-tval) * qke(k)
+               if (zm(k) > ht(nu)) then  ! WA this is just for cleanliness
+                  wUPD(k,nu) = 0.
+                  dwUPDmoistdz(k,nu) = 0.
+                  wUPD_dry(k,nu) = 0.
+                  dwUPDdz(k,nu) = 0.
+               end if
+#if (WRF_CHEM == 1)
+               do ic = 1,nchem
+                  chemUPD(k,ic,nu) = tval * chemUPD(k,ic,nu) + (1-tval) * chem(k,ic)
+               enddo
+#endif
+            end do
+
+            ! Calculate lateral detrainment rate for cloud layer
+            ! WA 8/5/15 constant detrainment
+            ! deltmf(1,nu) = Cepsmf
+            ! do k = 2,kte-1
+            !    deltmf(k,nu) = deltmf(k-1,nu)
+            ! end do
+            ! deltmf(kte,nu) = Cepsmf
+            deltmf(:,nu) = epsmf(:,nu)  ! WA TEST delt = eps everywhere 
+
+            ! Calculate mass flux (defined on turbulence levels)
+            mf_temfx(1,nu) = CM * wstr / Nupd
+            ! WA 3/2/16 limit max MF for stability
+            ! WA reduce the constant for improved numerical stability?
+            mf_temfx(1,nu) = min(mf_temfx(1,nu),0.2/Nupd)
+            do kt = 2,kte-1
+               dMdz(kt,nu) = (epsmf(kt,nu) - deltmf(kt,nu)) * mf_temfx(kt-1,nu) * dzt(kt)
+               mf_temfx(kt,nu) = mf_temfx(kt-1,nu) + dMdz(kt,nu)
+               ! WA TEST 6/14/16 don't allow <0
+               mf_temfx(kt,nu) = max(mf_temfx(kt,nu),0.0)
+               IF ( debug_code ) THEN
+                  IF ( mf_temfx(kt,nu)>=0.2/NUPD ) THEN
+                     print*,' MYNN, in TEMF_MF, huge MF at (nu,k):', nu,kt
+                     print*,"     mf_temfx(1:kt,nu)  = ", mf_temfx(1:kt,nu)
+                  ENDIF
+               ENDIF
+            end do
+            mf_temfx(kte,nu) = 0.
+
+            ! Calculate cloud fraction (on mass levels)
+            ! WA eventually replace this with the same saturation calculation
+            ! used in the MYNN code above for consistency.
+            ! WA TEST 6/14/16 make sure aUPD(1) is reasonable
+            aUPD(1,nu) = 0.06 / Nupd
+            do k = 2,kte
+               ! WA TEST 6/14/16 increase epsilon in test
+               ! if (wUPD(k-1,nu) >= 1.0e-15 .AND. wUPD(k,nu) >= 1.0e-15) then
+               if (wUPD(k-1,nu) >= 1.0e-5 .AND. wUPD(k,nu) >= 1.0e-5) then
+                  aUPD(k,nu) = ((mf_temfx(k-1,nu)+mf_temfx(k,nu))/2.0) / &
+                         ((wUPD(k-1,nu)+wUPD(k,nu))/2.0)  ! WA average before divide, is that best?
+               else
+                  aUPD(k,nu) = 0.0
+               end if
+               sigq2 = aUPD(k,nu) * (qtUPD(k,nu)-qtot(k))
+               if (sigq2 > 0.0) then
+                  sigq(k) = sqrt(sigq2)
+               else
+                  sigq(k) = 0.0
+               end if
+               !rst = rsat_temf(p(k-1),th(k-1)*pi1d(k-1),ep_2)
+               rst = qsat_blend(th(k-1)*pi1d(k-1),p(k-1))
+               qst(k) = rst / (1. + rst)
+               satdef(k) = qtot(k) - qst(k)
+               if (satdef(k) <= 0.0) then
+                  if (sigq(k) > 1.0e-15) then
+                     cldfraUPD(k,nu) = max(0.5 + 0.36 * atan(1.55*(satdef(k)/sigq(k))),0.0) / Nupd
+                  else
+                     cldfraUPD(k,nu) = 0.0
+                  end if
+               else
+                  cldfraUPD(k,nu) = 1.0 / Nupd
+               end if
+               if (zm(k) < lcl(nu)) then
+                  cldfraUPD(k,nu) = 0.0
+               end if
+            end do
+
+         end do  ! loop over nu updrafts
+
+         ! Add updraft areas into edmf_a, etc.
+         ! Add cloud fractions into cldfra_bl1d
+         !cldfra_bl1d(1) = 0.0
+         cfm_temfx = 0.0
+         do k = 2,kte
+            !cldfra_bl1d(k) = 0.0
+            cldfra_sum = 0.0
+            edmf_a(k) = 0.0
+            edmf_w(k) = 0.0
+            edmf_thl(k) = 0.0
+            edmf_qt(k) = 0.0
+            edmf_qc(k) = 0.0
+            edmf_u(k) = 0.0
+            edmf_v(k) = 0.0
+            edmf_qke(k) = 0.0
+            edmf_ent(k) = 0.0
+#if (WRF_CHEM == 1)
+            do ic = 1,nchem
+               edmf_chem(k,ic) = 0.0
+            enddo
+#endif
+            do nu = 1,Nupd
+               ! WA 7/5/16 put area on turbulence levels for consistency
+               aUPDt(k,nu) = mf_temfx(k,nu) / wUPD(k,nu)
+               if (aUPDt(k,nu) >= 1.0e-3 .AND. wUPD(k,nu) >= 1.0e-5) then
+                  edmf_a(k) = edmf_a(k) + aUPDt(k,nu)
+                  edmf_w(k) = edmf_w(k) + aUPDt(k,nu)*wUPD(k,nu)
+                  edmf_thl(k) = edmf_thl(k) + aUPDt(k,nu)*thlUPD(k,nu)
+                  edmf_qt(k) = edmf_qt(k) + aUPDt(k,nu)*qtUPD(k,nu)
+                  edmf_qc(k) = edmf_qc(k) + aUPDt(k,nu)*qlUPD(k,nu)
+                  edmf_u(k) = edmf_u(k) + aUPDt(k,nu)*UUPD(k,nu)
+                  edmf_v(k) = edmf_v(k) + aUPDt(k,nu)*VUPD(k,nu)
+                  edmf_qke(k) = edmf_qke(k) + aUPDt(k,nu)*TEUPD(k,nu)
+                  edmf_ent(k) = edmf_ent(k) + aUPDt(k,nu)*epsmf(k,nu)
+                  cldfra_sum = cldfra_sum + cldfraUPD(k,nu)
+#if (WRF_CHEM == 1)
+                  do ic = 1,nchem
+                     edmf_chem(k,ic) = edmf_chem(k,ic) + aUPDt(k,nu)*chemUPD(k,ic,nu)
+                  enddo
+#endif
+               end if
+            end do
+
+            IF ( debug_code ) THEN
+            !   print *,"In TEMF_MF edmf_w = ", edmf_w(1:10)
+            !   print *,"In TEMF_MF edmf_a = ", edmf_a(1:10)
+            !   print *,"In TEMF_MF edmf_thl = ", edmf_thl(1:10)
+            !   print *,"In TEMF_MF aUPD(2,:) = ", aUPD(2,:)
+            !   print *,"In TEMF_MF wUPD(2,:) = ", wUPD(2,:)
+            !   print *,"In TEMF_MF thlUPD(2,:) = ", thlUPD(2,:)
+            ENDIF
+
+            ! WA TEST 6/14/16 don't divide by very small updrafts
+            !if (edmf_a(k)>0.) then
+            if (edmf_a(k)>1.e-3) then
+               edmf_w(k)=edmf_w(k)/edmf_a(k)
+               edmf_qt(k)=edmf_qt(k)/edmf_a(k)
+               edmf_thl(k)=edmf_thl(k)/edmf_a(k)
+               edmf_ent(k)=edmf_ent(k)/edmf_a(k)
+               edmf_qc(k)=edmf_qc(k)/edmf_a(k)
+               edmf_u(k)=edmf_u(k)/edmf_a(k)
+               edmf_v(k)=edmf_v(k)/edmf_a(k)
+               edmf_qke(k)=edmf_qke(k)/edmf_a(k)
+#if (WRF_CHEM == 1)
+               do ic = 1,nchem
+                  edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a(k)
+               enddo
+#endif
+
+               if (edmf_qc(k) > 0.0) then
+                 IF (cldfra_sum > edmf_a(k)) THEN
+                   cldfra_bl1d(k) = cldfra_sum
+                   qc_bl1d(k) = edmf_qc(k)*edmf_a(k)/cldfra_sum
+                 ELSE
+                   cldfra_bl1d(k)=edmf_a(k)
+                   qc_bl1d(k) = edmf_qc(k)
+                 ENDIF
+               endif
+            endif
+
+            ! Put max value so far into cfm
+            if (zt(k) <= hmax) then
+               cfm_temfx = max(cldfra_bl1d(k),cfm_temfx)
+            end if
+         end do
+
+         !cldfra_bl1d(kte) = 0.0
+
+         ! Computing variables needed for solver
+
+         do k=kts,kte  ! do these in loop above
+            ! WA TEST 6/14/16 don't use very small updrafts to be consistent
+            ! with block above
+            if (edmf_a(k)>1.0e-3) then
+            s_aw(k)   = edmf_a(k)*edmf_w(k)*psig_w * (1.0+rstoch_col(k))
+            s_awthl(k)= edmf_a(k)*edmf_w(k)*edmf_thl(k)*psig_w * (1.0+rstoch_col(k)) 
+            s_awqt(k) = edmf_a(k)*edmf_w(k)*edmf_qt(k)*psig_w * (1.0+rstoch_col(k))
+            s_awqc(k) = edmf_a(k)*edmf_w(k)*edmf_qc(k)*psig_w * (1.0+rstoch_col(k))
+            s_awqv(k) = s_awqt(k) - s_awqc(k)
+            s_awu(k)  = edmf_a(k)*edmf_w(k)*edmf_u(k)*psig_w * (1.0+rstoch_col(k)) 
+            s_awv(k)  = edmf_a(k)*edmf_w(k)*edmf_v(k)*psig_w * (1.0+rstoch_col(k))
+            s_awqke(k) = edmf_a(k)*edmf_w(k)*edmf_qke(k)*psig_w * (1.0+rstoch_col(k))
+#if (WRF_CHEM == 1)
+            do ic = 1,nchem
+               s_awchem(k,ic) = edmf_w(k)*edmf_chem(k,ic)*psig_w * (1.0+rstoch_col(k))
+            enddo
+#endif
+            endif
+            !now reduce diagnostic output array by psig
+             edmf_a(k)=edmf_a(k)*psig_w 
+         enddo
+
+      ! end if   ! is_convective
+      ! Mass flux block ends here
+      else
+         edmf_a = 0.
+         edmf_w = 0.
+         edmf_qt = 0.
+         edmf_thl = 0.
+         edmf_ent = 0.
+         edmf_u = 0.
+         edmf_v = 0.
+         edmf_qke = 0.
+         s_aw   = 0.
+         s_awthl= 0.
+         s_awqt = 0.
+         s_awqv = 0.
+         s_awqc = 0.
+         s_awu  = 0.
+         s_awv  = 0.
+         s_awqke= 0.
+         edmf_qc(1) = qc(1)
+         !qc_bl1d(1) = qc(1)
+         do k = kts+1,kte-1
+            edmf_qc(k) = qc(k-1)
+            !qc_bl1d(k) = qc(k-1)
+         end do
+#if (WRF_CHEM == 1)
+         do ic = 1,nchem
+            s_awchem(:,ic) = 0.
+         enddo
+#endif
+      end if
+      !edmf_qc(kte) = qc(kte)
+      !qc_bl1d(kte) = qc(kte)
+
+      !IF ( debug_code ) THEN
+      !   print *,"After TEMF_MF, s_aw = ", s_aw(1:5)
+      !   print *,"After TEMF_MF, s_awthl = ", s_awthl(1:5)
+      !   print *,"After TEMF_MF, s_awqt = ", s_awqt(1:5)
+      !   print *,"After TEMF_MF, s_awqc = ", s_awqc(1:5)
+      !   print *,"After TEMF_MF, s_awqv = ", s_awqv(1:5)
+      !   print *,"After TEMF_MF, s_awu = ", s_awu(1:5)
+      !   print *,"After TEMF_MF, s_awv = ", s_awv(1:5)
+      !   print *,"After TEMF_MF, s_awqke = ", s_awqke(1:5)
+      !ENDIF
+
+END SUBROUTINE temf_mf
+
+!--------------------------------------------------------------------
+!
+   real function rsat_temf(p,T,ep2)
+
+!  Calculates the saturation mixing ratio with respect to liquid water
+!  Arguments are pressure (Pa) and absolute temperature (K)
+!  Uses the formula from the ARM intercomparison setup.
+!  Converted from Matlab by WA 7/28/08
+
+implicit none
+real p, T, ep2
+real temp, x
+real, parameter :: c0 = 0.6105851e+3
+real, parameter :: c1 = 0.4440316e+2
+real, parameter :: c2 = 0.1430341e+1
+real, parameter :: c3 = 0.2641412e-1
+real, parameter :: c4 = 0.2995057e-3
+real, parameter :: c5 = 0.2031998e-5
+real, parameter :: c6 = 0.6936113e-8
+real, parameter :: c7 = 0.2564861e-11
+real, parameter :: c8 = -0.3704404e-13
+
+temp = T - 273.15
+
+x =c0+temp*(c1+temp*(c2+temp*(c3+temp*(c4+temp*(c5+temp*(c6+temp*(c7+temp*c8)))))))
+rsat_temf = ep2*x/(p-x)
+
+return
+end function rsat_temf
+
+!=================================================================
 
 END MODULE module_bl_mynn

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_mynn.F
@@ -1,25 +1,14 @@
-!=================================================================================================================
-! copied for implementation in MPAS from WRF version 3.6.1.
-
-! modifications made to sourcecode:
-! * used preprocessing option to replace module_model_constants with mpas_atmphys_constants.
-!   Laura D. Fowler (laura@ucar.edu / 2014-09-25).
-! * used preprocessing option to include the actual mean distance between cell centers.
-!   Laura D. Fowler (laura@ucar.edu / 2015-01-06).
-! * used "dummy" variables in the call to mym_condensation.
-!   Laura D. Fowler (laura@ucar.edu / 2016-10-28).
-
-!=================================================================================================================
-
+!WRF:MODEL_LAYER:PHYSICS
+!
 MODULE module_sf_mynn
 
 !-------------------------------------------------------------------
 !Modifications implemented by Joseph Olson NOAA/GSD/AMB - CU/CIRES
-!for WRFv3.4 and WRFv3.4.1:
+!for WRFv3.4, v3.4.1, v3.5.1, v3.6, v3.7.1, and v3.9:
 !
 !   BOTH LAND AND WATER:
 !1) Calculation of stability parameter (z/L) taken from Li et al. (2010 BLM)
-!   for first iteration of first time step; afterwards, exact calculation.  
+!   for first iteration of first time step; afterwards, exact calculation.
 !2) Fixed isflux=0 option to turn off scalar fluxes, but keep momentum
 !   fluxes for idealized studies (credit: Anna Fitch).
 !3) Kinematic viscosity now varies with temperature
@@ -38,25 +27,35 @@ MODULE module_sf_mynn
 !
 !   WATER only:
 !1) isftcflx option is now available with the following options:
-!   (default) =0: z0, zt, and zq from COARE3.0 (Fairall et al 2003) 
-!             =1: z0 from Davis et al (2008), zt & zq from COARE3.0    
-!             =2: z0 from Davis et al (2008), zt & zq from Garratt (1992) 
-!             =3: z0 from Taylor and Yelland (2004), zt and zq from COARE3.0 
-!             =4: z0 from Zilitinkevich (2001), zt & zq from COARE3.0 
+!   (default) =0: z0, zt, and zq from the COARE algorithm. Set COARE_OPT (below) to
+!                 3.0 (Fairall et al. 2003, default)
+!                 3.5 (Edson et al 2013) 
+!             =1: z0 from Davis et al (2008), zt & zq from COARE 3.0/3.5
+!             =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
+!             =3: z0 from Taylor and Yelland (2004), zt and zq from COARE 3.0/3.5
+!             =4: z0 from Zilitinkevich (2001), zt & zq from COARE 3.0/3.5
 !
 !   SNOW/ICE only:
 !1) Added Andreas (2002) snow/ice parameterization for thermal and
-!   moisture roughness to help reduce the cool/moist bias in the arctic 
-!   region.
+!   moisture roughness to help reduce the cool/moist bias in the arctic
+!   region. Also added a z0 mod for snow (Andreas et al. 2005, BLM), which
+!
+! Misc:
+!   2) added a more elaborate diagnostic for u10 & V10 for high vertical resolution
+!      model configurations.
+!
+! New for v3.9:
+!   - option for stochastic parameter perturbations (SPP) 
 !
 !NOTE: This code was primarily tested in combination with the RUC LSM.
 !      Performance with the Noah (or other) LSM is relatively unknown.
 !-------------------------------------------------------------------
+ USE module_sf_sfclay, ONLY: sfclayinit
+ USE module_bl_mynn,   only: tv0, b1, b2, p608, ev, rd, & !, mym_condensation
+       &esat_blend, xl_blend, qsat_blend
 
 #if defined(mpas)
- use mpas_atmphys_constants,only: p1000mb => P0,cp,xlv,ep_2
- use module_bl_mynn,only: tv0,mym_condensation
- use module_sf_sfclay,only: sfclayinit
+ USE mpas_atmphys_constants,only: p1000mb => P0,cp,xlv,ep_2,cpv,g =>gravity,r_v,rcp
 
  implicit none
  private
@@ -65,23 +64,32 @@ MODULE module_sf_mynn
 
 #else
   USE module_model_constants, only: &
-       &p1000mb, cp, xlv, ep_2
+       &g, p1000mb, cp, xlv, ep_2, r_d, r_v, rcp, cpv 
 
-  USE module_sf_sfclay, ONLY: sfclayinit
-  USE module_bl_mynn,   only: tv0, mym_condensation
-  USE module_wrf_error
 !-------------------------------------------------------------------
   IMPLICIT NONE
 !-------------------------------------------------------------------
 #endif
 
-  REAL, PARAMETER :: xlvcp=xlv/cp, ep_3=1.-ep_2
- 
-  REAL, PARAMETER :: wmin=0.1    ! Minimum wind speed
-  REAL, PARAMETER :: VCONVC=1.0
-  REAL, PARAMETER :: SNOWZ0=0.012
+!For non-WRF
+!   REAL    , PARAMETER :: g            = 9.81
+!   REAL    , PARAMETER :: r_d          = 287.
+!   REAL    , PARAMETER :: cp           = 7.*r_d/2.
+!   REAL    , PARAMETER :: r_v          = 461.6
+!   REAL    , PARAMETER :: cpv          = 4.*r_v
+!   REAL    , PARAMETER :: rcp          = r_d/cp
+!   REAL    , PARAMETER :: XLV          = 2.5E6
+!   REAL    , PARAMETER :: XLF          = 3.50E5
+!   REAL    , PARAMETER :: p1000mb      = 100000.
+!   REAL    , PARAMETER :: EP_2         = r_d/r_v
 
-  REAL, DIMENSION(0:1000 ),SAVE          :: PSIMTB,PSIHTB
+  REAL, PARAMETER :: xlvcp=xlv/cp, ep_3=1.-ep_2 
+  REAL, PARAMETER :: wmin=0.1    ! Minimum wind speed
+  REAL, PARAMETER :: VCONVC=1.25
+  REAL, PARAMETER :: SNOWZ0=0.011
+  REAL, PARAMETER :: COARE_OPT=3.0  ! 3.0 or 3.5
+  !For debugging purposes:
+  LOGICAL, PARAMETER :: debug_code = .false.
 
 CONTAINS
 
@@ -94,12 +102,13 @@ CONTAINS
     !can be found in module_sf_sfclay.F. This subroutine returns
     !the forms from Dyer and Hicks (1974).
        
-    CALL sfclayinit(allowed_to_read)
+!    CALL sfclayinit(allowed_to_read)
 
   END SUBROUTINE mynn_sf_init_driver
 
 !-------------------------------------------------------------------
-   SUBROUTINE SFCLAY_mynn(U3D,V3D,T3D,QV3D,P3D,dz8w,               &
+   SUBROUTINE SFCLAY_mynn(                                         &
+                     U3D,V3D,T3D,QV3D,P3D,dz8w,                    &
                      CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,    &
                      ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
                      XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
@@ -108,17 +117,14 @@ CONTAINS
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
                      KARMAN,itimestep,ch,th3d,pi3d,qc3d,rho3d,     &
                      tsq,qsq,cov,sh3d,el_pbl,qcg,                  &
-!JOE-add output
-!                     z0zt_ratio,BulkRi,wstar,qstar,resist,logres,  &
-!JOE-end 
+                     icloud_bl,qc_bl,cldfra_bl,                    &
+                     spp_pbl,pattern_spp_pbl,                      &
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte,                    &
                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
-                     bl_mynn_cloudpdf                              &
-#if defined(mpas)
-                    ,dxCell                                        &
-#endif
+                     bl_mynn_cloudpdf,                             &
+                     dxCell                                        &
                          )
 !-------------------------------------------------------------------
       IMPLICIT NONE
@@ -138,7 +144,7 @@ CONTAINS
 !-- PSFCPA      surface pressure (Pa)
 !-- ZNT         roughness length (m)
 !-- UST         u* in similarity theory (m/s)
-!-- USTM        u* in similarity theory (m/s) w* added to WSPD. This is                                                                         
+!-- USTM        u* in similarity theory (m/s) w* added to WSPD. This is
 !               used to couple with TKE scheme but not in MYNN.
 !               (as of now, USTM = UST in this version)
 !-- PBLH        PBL height from previous time (m)
@@ -179,16 +185,16 @@ CONTAINS
 !-- EP2         constant for spec. hum. calc (Rd/Rv = 0.622) (dimensionless)
 !-- EP3         constant for spec. hum. calc (1 - Rd/Rv = 0.378 ) (dimensionless)
 !-- KARMAN      Von Karman constant
-!-- ck          enthalpy exchange coeff at 10 meters                                                                                           
-!-- cd          momentum exchange coeff at 10 meters                                                                                           
-!-- cka         enthalpy exchange coeff at the lowest model level                                                                              
-!-- cda         momentum exchange coeff at the lowest model level                                                                              
-!-- isftcflx    =0: z0, zt, and zq from COARE3.0 (Fairall et al 2003)
-!   (water      =1: z0 from Davis et al (2008), zt & zq from COARE3.0
+!-- ck          enthalpy exchange coeff at 10 meters
+!-- cd          momentum exchange coeff at 10 meters
+!-- cka         enthalpy exchange coeff at the lowest model level
+!-- cda         momentum exchange coeff at the lowest model level
+!-- isftcflx    =0: z0, zt, and zq from COARE3.0/3.5 (Fairall et al 2003/Edson et al 2013)
+!   (water      =1: z0 from Davis et al (2008), zt & zq from COARE3.0/3.5
 !    only)      =2: z0 from Davis et al (2008), zt & zq from Garratt (1992)
-!               =3: z0 from Taylor and Yelland (2004), zt and zq from COARE3.0                                                                 
-!               =4: z0 from Zilitinkevich (2001), zt & zq from COARE3.0
-!-- iz0tlnd     =0: Zilitinkevich (1995) with Czil=0.14, 
+!               =3: z0 from Taylor and Yelland (2004), zt and zq from COARE 3.0/3.5
+!               =4: z0 from Zilitinkevich (2001), zt & zq from COARE 3.0/3.5
+!-- iz0tlnd     =0: Zilitinkevich (1995) with Czil=0.10, 
 !   (land       =1: Czil_new (modified according to Chen & Zhang 2008)
 !    only)      =2: Modified Yang et al (2002, 2008) - generalized for all landuse
 !               =3: constant zt = z0/7.4 (Garratt 1992)
@@ -200,6 +206,9 @@ CONTAINS
 !-- cov         = T'q' from PBL scheme
 !-- tsq         = T'T' from PBL scheme
 !-- qsq         = q'q' from PBL scheme
+!-- icloud_bl  = namelist option for subgrid scale cloud/radiation feedback
+!-- qc_bl       = subgrid scale (bloundary layer) clouds
+!-- cldfra_bl   = subgridscale cloud fraction
 !
 !-- ids         start index for i in domain
 !-- ide         end index for i in domain
@@ -232,7 +241,10 @@ CONTAINS
 !NAMELIST OPTIONS:
       INTEGER,  INTENT(IN)   ::        ISFFLX
       INTEGER,  OPTIONAL,  INTENT(IN)   ::     ISFTCFLX, IZ0TLND,&
-                                                bl_mynn_cloudpdf
+                                                bl_mynn_cloudpdf,&
+                                                icloud_bl
+      INTEGER,  INTENT(IN),OPTIONAL    ::    spp_pbl
+
 !===================================
 ! 3D VARIABLES
 !===================================
@@ -243,7 +255,12 @@ CONTAINS
                                                               T3D, &
                                                              QC3D, &
                                                           U3D,V3D, &
-                             RHO3D,th3d,pi3d,tsq,qsq,cov,sh3d,el_pbl
+                          RHO3D,th3d,pi3d,tsq,qsq,cov,sh3d,el_pbl
+
+      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme ), OPTIONAL  ::  &
+                          qc_bl,cldfra_bl
+
+      REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN),OPTIONAL ::pattern_spp_pbl
 !===================================
 ! 2D VARIABLES
 !===================================
@@ -253,14 +270,10 @@ CONTAINS
                                                             XLAND, &
                                                               TSK, &
                                                               QCG, &
-                                                           PSFCPA , &
+                                                           PSFCPA ,&
                                                             SNOWH
 
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
       real,intent(in),dimension(ims:ime,jms:jme),optional:: dxCell
-!MPAS specific end.
-#endif
 
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(OUT  )               ::            U10,V10, &
@@ -298,16 +311,21 @@ CONTAINS
 !===================================
       REAL,     DIMENSION( its:ite ) ::                       U1D, &
                                                               V1D, &
+                                                        U1D2,V1D2, & !level2 winds
                                                              QV1D, &
                                                               P1D, &
                                                          T1D,QC1D, &
                                                             RHO1D, &
-                                                           dz8w1d
+                                                           dz8w1d, & !level 1 height
+                                                           dz2w1d    !level 2 height
+
+      REAL,     DIMENSION( its:ite ) ::                  rstoch1D
 
       ! VARIABLE FOR PASSING TO MYM_CONDENSATION
       REAL,     DIMENSION(kts:kts+1 ) :: dummy1,dummy2,dummy3,dummy4, &
                                          dummy5,dummy6,dummy7,dummy8, &
-                                         dummy9,dummy10
+                                         dummy9,dummy10,dummy11,      &
+                                         dummy12,dummy13,dummy14
 
       REAL,     DIMENSION( its:ite ) ::  vt1,vq1
       REAL,     DIMENSION(kts:kts+1) ::  thl, qw, vt, vq
@@ -323,20 +341,27 @@ CONTAINS
       DO J=jts,jte
         DO i=its,ite
            dz8w1d(I) = dz8w(i,kts,j)
+           dz2w1d(I) = dz8w(i,kts+1,j)
            U1D(i) =U3D(i,kts,j)
            V1D(i) =V3D(i,kts,j)
+           !2nd model level winds - for diags with high-res grids
+           U1D2(i) =U3D(i,kts+1,j)
+           V1D2(i) =V3D(i,kts+1,j)
            QV1D(i)=QV3D(i,kts,j)
            QC1D(i)=QC3D(i,kts,j)
            P1D(i) =P3D(i,kts,j)
            T1D(i) =T3D(i,kts,j)
            RHO1D(i)=RHO3D(i,kts,j)
+#if defined(wrfmodel)
+              if (spp_pbl==1) then
+                  rstoch1D(i)=pattern_spp_pbl(i,kts,j)
+              else
+                  rstoch1D(i)=0.0
+              endif
+#endif
         ENDDO
 
         IF (itimestep==1) THEN
-!          write(0,*)
-!          write(0,*) '--- sfc_mynn itimestep = ', itimestep
-!          write(0,*) '--- initialize vt1, vq1, ust, mol, qsfc, qstar'
-!          write(0,*)
            DO i=its,ite
               vt1(i)=0.
               vq1(i)=0.
@@ -346,41 +371,71 @@ CONTAINS
               qstar(i,j)=0.0
            ENDDO
         ELSE
-!          write(0,*)
-!          write(0,*) '--- sfc_mynn itimestep = ', itimestep
-!          write(0,*) '--- call mym_condensation:'
-!          write(0,*)
            DO i=its,ite
-              do k = kts,kts+1
+              DO k = kts,kts+1
                 ql = qc3d(i,k,j)/(1.+qc3d(i,k,j))
                 qw(k) = qv3d(i,k,j)/(1.+qv3d(i,k,j)) + ql
                 thl(k) = th3d(i,k,j)-xlvcp*ql/pi3d(i,k,j)
-                dummy1(k)  = dz8w(i,k,j)
-                dummy2(k)  = thl(k)
-                dummy3(k)  = qw(k)
-                dummy4(k)  = p3d(i,k,j)
-                dummy5(k)  = pi3d(i,k,j)
-                dummy6(k)  = tsq(i,k,j)
-                dummy7(k)  = qsq(i,k,j)
-                dummy8(k)  = cov(i,k,j)
-                dummy9(k)  = Sh3d(i,k,j)
-                dummy10(k) = el_pbl(i,k,j)
-              end do
+                dummy1(k)=dz8w(i,k,j)
+                dummy2(k)=thl(k)
+                dummy3(k)=qw(k)
+                dummy4(k)=p3d(i,k,j)
+                dummy5(k)=pi3d(i,k,j)
+                dummy6(k)=tsq(i,k,j)
+                dummy7(k)=qsq(i,k,j)
+                dummy8(k)=cov(i,k,j)
+                dummy9(k)=Sh3d(i,k,j)
+                dummy10(k)=el_pbl(i,k,j)
+                dummy14(k)=th3d(i,k,j)
+#if defined(wrfmodel)
+                if(icloud_bl > 0) then
+                  dummy11(k)=qc_bl(i,k,j)
+                  dummy12(k)=cldfra_bl(i,k,j)
+                else
+                  dummy11(k)=0.0
+                  dummy12(k)=0.0
+                endif
+#endif
+                dummy13(k)=0.0     !sgm
+              ENDDO
 
               ! NOTE: The last grid number is kts+1 instead of kte.
-              CALL mym_condensation (kts,kts+1, &
-                   &            dummy1,dummy2,dummy3, &
-                   &            dummy4,dummy5,dummy6, &
-                   &            dummy7,dummy8,dummy9, &
-                   &            dummy10,              &
-                   &            bl_mynn_cloudpdf,     &
-                   &            vt(kts:kts+1), vq(kts:kts+1))
+              CALL mym_condensation (kts,kts+1, dx,     &
+                   &            dummy1,dummy2,dummy3,   &
+                   &            dummy4,dummy5,dummy6,   &
+                   &            dummy7,dummy8,dummy9,   &
+                   &            dummy10,bl_mynn_cloudpdf,&
+                   &            dummy11,dummy12,        &
+                   &            PBLH(i,j),HFX(i,j),     &
+                   &            vt(kts:kts+1), vq(kts:kts+1), &
+                   &            dummy14,dummy13)
+
+!              ! NOTE: The last grid number is kts+1 instead of kte.
+!              CALL mym_condensation (kts,kts+1, dx,     &
+!                   &            dz8w(i,kts:kts+1,j),    &
+!                   &            thl(kts:kts+1),         &
+!                   &            qw(kts:kts+1),          &
+!                   &            p3d(i,kts:kts+1,j),     &
+!                   &            pi3d(i,kts:kts+1,j),    &
+!                   &            tsq(i,kts:kts+1,j),     &
+!                   &            qsq(i,kts:kts+1,j),     &
+!                   &            cov(i,kts:kts+1,j),     &
+!                   &            Sh3d(i,kts:kts+1,j),    & !JOE - cloud PDF testing
+!                   &            el_pbl(i,kts:kts+1,j),  & !JOE - cloud PDF testing
+!                   &            bl_mynn_cloudpdf,       & !JOE - cloud PDF testing
+!                   &            qc_bl2D(i,kts:kts+1),   & !JOE-subgrid BL clouds
+!                   &           cldfra_bl2D(i,kts:kts+1),& !JOE-subgrid BL clouds
+!                   &            PBLH(i,j),HFX(i,j),     & !JOE-subgrid BL clouds
+!                   &            vt(kts:kts+1), vq(kts:kts+1), &
+ !                  &            th,sgm)
               vt1(i) = vt(kts)
               vq1(i) = vq(kts)
            ENDDO
         ENDIF
 
-        CALL SFCLAY1D_mynn(J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,    &
+        CALL SFCLAY1D_mynn(                                        &
+                J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,               &
+                U1D2,V1D2,dz2w1d,                                  &
                 CP,G,ROVCP,R,XLV,PSFCPA(ims,j),CHS(ims,j),CHS2(ims,j),&
                 CQS2(ims,j),CPM(ims,j),PBLH(ims,j), RMOL(ims,j),   &
                 ZNT(ims,j),UST(ims,j),MAVAIL(ims,j),ZOL(ims,j),    &
@@ -391,24 +446,23 @@ CONTAINS
                 QGH(ims,j),QSFC(ims,j),LH(ims,j),                  &
                 GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
                 SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,               &
-                ch(ims,j),vt1,vq1,qc1d,qcg(ims,j),itimestep,       &
+                ch(ims,j),vt1,vq1,qc1d,qcg(ims,j),                 &
+                itimestep,                                         &
 !JOE-begin additional output
-                z0zt_ratio(ims,j),BulkRi(ims,j),wstar(ims,j),      &
+                z0zt_ratio(ims,j),wstar(ims,j),                    &
                 qstar(ims,j),resist(ims,j),logres(ims,j),          &
 !JOE-end
+                spp_pbl,rstoch1D,                                  &
                 ids,ide, jds,jde, kds,kde,                         &
                 ims,ime, jms,jme, kms,kme,                         &
                 its,ite, jts,jte, kts,kte                          &
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-                ,isftcflx,iz0tlnd,                                 &
-                USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
-                CD(ims,j),CDA(ims,j),dxCell(ims,j)                 &
-#else
                 ,isftcflx,iz0tlnd,                                 &
                 USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
                 CD(ims,j),CDA(ims,j)                               &
+#if defined(mpas)
+                ,dxCell(ims,j)                                     &
 #endif
+
                                                                    )
 
       ENDDO
@@ -416,27 +470,27 @@ CONTAINS
     END SUBROUTINE SFCLAY_MYNN
 
 !-------------------------------------------------------------------
-   SUBROUTINE SFCLAY1D_mynn(J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,   &
+   SUBROUTINE SFCLAY1D_mynn(                                       &
+                     J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,rho1d,          &
+                     U1D2,V1D2,dz2w1d,                             &
                      CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,    &
                      PBLH,RMOL,ZNT,UST,MAVAIL,ZOL,MOL,REGIME,      &
                      PSIM,PSIH,XLAND,HFX,QFX,TSK,                  &
                      U10,V10,TH2,T2,Q2,FLHC,FLQC,SNOWH,QGH,        &
                      QSFC,LH,GZ1OZ0,WSPD,BR,ISFFLX,DX,             &
                      SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
-                     KARMAN,ch,vt1,vq1,qc1d,qcg,itimestep,         &
+                     KARMAN,ch,vt1,vq1,qc1d,qcg,                   &
+                     itimestep,                                    &
 !JOE-additional output
-                     zratio,BRi,wstar,qstar,resist,logres,         &
+                     zratio,wstar,qstar,resist,logres,             &
 !JOE-end
+                     spp_pbl,rstoch1D,                             &
                      ids,ide, jds,jde, kds,kde,                    &
                      ims,ime, jms,jme, kms,kme,                    &
                      its,ite, jts,jte, kts,kte                     &
                      ,isftcflx, iz0tlnd,                           &
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
-                     ustm,ck,cka,cd,cda,dxCell                     &
-#else
-                     ustm,ck,cka,cd,cda                            &
-#endif
+                     ustm,ck,cka,cd,cda,                           &
+                     dxCell                                        &
                      )
 
 !-------------------------------------------------------------------
@@ -459,6 +513,7 @@ CONTAINS
 !-----------------------------
       INTEGER,  INTENT(IN) :: ISFFLX
       INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
+      INTEGER,  OPTIONAL,  INTENT(IN)             ::     spp_pbl
 
 !-----------------------------
 ! 1D ARRAYS
@@ -472,9 +527,10 @@ CONTAINS
                                                             SNOWH
 
       REAL,     DIMENSION( its:ite ), INTENT(IN)   ::     U1D,V1D, &
+                                                        U1D2,V1D2, &
                                                          QV1D,P1D, &
                                                          T1D,QC1d, &
-                                                           dz8w1d, &
+                                                    dz8w1d,dz2w1d, &
                                                             RHO1D, &
                                                           vt1,vq1
 
@@ -493,6 +549,7 @@ CONTAINS
                                                              WSPD, &
                                                                BR, &
                                                         PSIM,PSIH
+      REAL,     DIMENSION( its:ite ), INTENT(IN)   ::     rstoch1D
 
       ! DIAGNOSTIC OUTPUT
       REAL,     DIMENSION( ims:ime ), INTENT(OUT)   ::    U10,V10, &
@@ -502,7 +559,7 @@ CONTAINS
                 INTENT(OUT)     ::              ck,cka,cd,cda,ustm
 !--------------------------------------------
 !JOE-additinal output
-      REAL,     DIMENSION( ims:ime ) ::    zratio,BRi,wstar,qstar, &
+      REAL,     DIMENSION( ims:ime ) ::        zratio,wstar,qstar, &
                                                     resist,logres
 !JOE-end
 !----------------------------------------------------------------
@@ -512,6 +569,7 @@ CONTAINS
 
       REAL, DIMENSION(its:ite) :: &
                  ZA, &    !Height of lowest 1/2 sigma level(m)
+                ZA2, &    !Height of 2nd lowest 1/2 sigma level(m)
               THV1D, &    !Theta-v at lowest 1/2 sigma (K)
                TH1D, &    !Theta at lowest 1/2 sigma (K)
                TC1D, &    !T at lowest 1/2 sigma (Celsius)
@@ -521,6 +579,7 @@ CONTAINS
       PSIH10,PSIM10, &    !M-O stability functions at z=10 m
               WSPDI, & 
             z_t,z_q, &    !thermal & moisture roughness lengths
+           ZNTstoch, &
              GOVRTH, &    !g/theta
                THGB, &    !theta at ground
               THVGB, &    !theta-v at ground
@@ -532,8 +591,8 @@ CONTAINS
             GZ10OZt, &    !LOG((10.+z_t(i))/z_t(i))
              GZ1OZt       !LOG((ZA(I)+z_t(i))/z_t(i))
 
-      INTEGER ::  N,I,K,L,NZOL,NK,NZOL2,NZOL10, ITER
-      INTEGER, PARAMETER :: ITMAX=5
+      INTEGER ::  N,I,K,L,NZOL,NK,NZOL2,NZOL10, ITER, yesno
+      INTEGER, PARAMETER :: ITMAX=1
 
       REAL    ::  PL,THCON,TVCON,E1
       REAL    ::  DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL10
@@ -543,11 +602,7 @@ CONTAINS
       REAL    ::  restar,VISC,DQG,OLDUST,OLDTST
       REAL, PARAMETER :: psilim = -10.  ! ONLY AFFECTS z/L > 2.0
 
-#if defined(mpas)
-!MPAS specific (Laura D. Fowler - 2014-12-02):
       real,intent(in),dimension(ims:ime),optional:: dxCell
-!MPAS specific end.
-#endif
 
 !-------------------------------------------------------------------
 
@@ -566,10 +621,11 @@ CONTAINS
          QVSH(I)=QV1D(I)/(1.+QV1D(I))        !CONVERT TO SPEC HUM (kg/kg)
          TVCON=(1.+EP1*QVSH(I))
          THV1D(I)=TH1D(I)*TVCON                 !(K)
-         TV1D(I)=T1D(I)*TVCON                   !(K)
+         TV1D(I)=T1D(I)*TVCON   !(K)
 
          !RHO1D(I)=PSFCPA(I)/(R*TV1D(I)) !now using value calculated in sfc driver
          ZA(I)=0.5*dz8w1d(I)             !height of first half-sigma level 
+         ZA2(I)=dz8w1d(I) + 0.5*dz2w1d(I)    !height of 2nd half-sigma level
          GOVRTH(I)=G/TH1D(I)
       ENDDO
 
@@ -633,30 +689,10 @@ CONTAINS
          !  subgrid-scale velocity (VSGD) following Beljaars (1995, QJRMS) 
          !  and Mahrt and Sun (1995, MWR), respectively
          !-------------------------------------------------------
-         !       VCONV = 0.25*sqrt(g/THVGB(I)*pblh(i)*dthvm)
-         !  Use Beljaars over land, old MM5 (Wyngaard) formula over water
-         IF (xland(i).lt.1.5) then     !LAND (xland == 1)
-
-            fluxc = max(hfx(i)/RHO1D(i)/cp                    &
-            &    + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
-            WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**.33
-
-         ELSE                          !WATER (xland == 2)
-
-            !JOE-the Wyngaard formula is ~3 times larger than the Beljaars 
-            !formula, so switch to Beljaars for water, but use VCONVC = 1.25,
-            !as in the COARE3.0 bulk parameterizations.
-            !IF(-DTHVDZ.GE.0)THEN
-            !   DTHVM=-DTHVDZ
-            !ELSE
-            !   DTHVM=0.
-            !ENDIF
-            !WSTAR(I) = 2.*SQRT(DTHVM)
-            fluxc = max(hfx(i)/RHO1D(i)/cp                    &
-            &     + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
-            WSTAR(I) = 1.25*(g/TSK(i)*pblh(i)*fluxc)**.33
-
-         ENDIF
+         !  Use Beljaars over land and water
+         fluxc = max(hfx(i)/RHO1D(i)/cp                    &
+         &    + ep1*THVGB(I)*qfx(i)/RHO1D(i),0.)
+         WSTAR(I) = vconvc*(g/TSK(i)*pblh(i)*fluxc)**.33
 
          !--------------------------------------------------------
          ! Mahrt and Sun low-res correction
@@ -678,11 +714,9 @@ CONTAINS
          !--------------------------------------------------------
          BR(I)=GOVRTH(I)*ZA(I)*DTHVDZ/(WSPD(I)*WSPD(I))
          !SET LIMITS ACCORDING TO Li et al. (2010) Boundary-Layer Meteorol (p.158)
-         !JOE: defying limits: BR(I)=MAX(BR(I),-2.0)
          BR(I)=MAX(BR(I),-20.0)
          BR(I)=MIN(BR(I),2.0)
-         BRi(I)=BR(I)  !new variable for output - BR is not a "state" variable.
-               
+                
          ! IF PREVIOUSLY UNSTABLE, DO NOT LET INTO REGIMES 1 AND 2 (STABLE)
          !if (itimestep .GT. 1) THEN
          !    IF(MOL(I).LT.0.)BR(I)=MIN(BR(I),0.0)
@@ -722,96 +756,200 @@ CONTAINS
           !--------------------------------------
           IF ( PRESENT(ISFTCFLX) ) THEN
              IF ( ISFTCFLX .EQ. 0 ) THEN
-                !NAME OF SUBROUTINE IS MISLEADING - ACTUALLY VARIABLE CHARNOCK
-                !PARAMETER FROM COARE3.0:
-                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
+                IF (COARE_OPT .EQ. 3.0) THEN
+                  !COARE 3.0 (MISLEADING SUBROUTINE NAME)
+                  CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+                ELSE
+                  !COARE 3.5
+                  CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+                ENDIF
              ELSEIF ( ISFTCFLX .EQ. 1 .OR. ISFTCFLX .EQ. 2 ) THEN
                 CALL davis_etal_2008(ZNT(i),UST(i))
              ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
-                CALL Taylor_Yelland_2001(ZNT(i),UST(i),WSPD(i))                                                      
+                CALL Taylor_Yelland_2001(ZNT(i),UST(i),WSPD(i))
              ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
-                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
+                IF (COARE_OPT .EQ. 3.0) THEN
+                  !COARE 3.0 (MISLEADING SUBROUTINE NAME)
+                  CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+                ELSE
+                  !COARE 3.5
+                  CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+                ENDIF
              ENDIF
           ELSE
-             !DEFAULT TO COARE 3.0
-             CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc)
+             !DEFAULT TO COARE 3.0/3.5
+             IF (COARE_OPT .EQ. 3.0) THEN
+                !COARE 3.0
+                CALL charnock_1955(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+             ELSE
+                !COARE 3.5
+                CALL edson_etal_2013(ZNT(i),UST(i),WSPD(i),visc,ZA(I))
+             ENDIF
           ENDIF
+
+#if defined(wrfmodel)
+          ! add stochastic perturbaction of ZNT
+             if (spp_pbl==1) then
+                ZNTstoch(I)  = MAX(ZNT(I) + 1.5 * ZNT(I) * rstoch1D(i), 1e-6)
+             else
+                ZNTstoch(I)  = ZNT(I)
+             endif
+#endif
 
           !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING NEW ZNT
           ! AHW: Garrattt formula: Calculate roughness Reynolds number
           !      Kinematic viscosity of air (linear approx to
           !      temp dependence at sea level)
+#if defined(mpas)
           restar=MAX(ust(i)*ZNT(i)/visc, 0.1)
+#else
+          restar=MAX(ust(i)*ZNTstoch(i)/visc, 0.1)
+#endif
 
           !--------------------------------------
           !CALCULATE z_t and z_q
           !--------------------------------------
           IF ( PRESENT(ISFTCFLX) ) THEN
              IF ( ISFTCFLX .EQ. 0 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
+                IF (COARE_OPT .EQ. 3.0) THEN
+                   CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc)
+                ELSE
+                   !presumably, this will be published soon, but hasn't yet
+                   CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+                ENDIF
              ELSEIF ( ISFTCFLX .EQ. 1 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
+                IF (COARE_OPT .EQ. 3.0) THEN
+                   CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc)
+                ELSE
+                   CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+                ENDIF
              ELSEIF ( ISFTCFLX .EQ. 2 ) THEN
+#if defined(mpas)
                 CALL garratt_1992(z_t(i),z_q(i),ZNT(i),restar,XLAND(I))
+#else
+                CALL garratt_1992(z_t(i),z_q(i),ZNTstoch(i),restar,XLAND(I))
+#endif
              ELSEIF ( ISFTCFLX .EQ. 3 ) THEN
-                CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
+                IF (COARE_OPT .EQ. 3.0) THEN
+                   CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc)
+                ELSE
+                   CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+                ENDIF
              ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
+#if defined(mpas)
                 CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
                                    UST(I),KARMAN,XLAND(I),IZ0TLND)
+#else
+                CALL zilitinkevich_1995(ZNTstoch(i),z_t(i),z_q(i),restar,&
+                                   UST(I),KARMAN,XLAND(I),IZ0TLND,spp_pbl,rstoch1D(i))
+#endif
              ENDIF
           ELSE
-             !DEFAULT TO COARE 3.0 
-             CALL fairall_2001(z_t(i),z_q(i),restar,UST(i),visc)
+             !DEFAULT TO COARE 3.0/3.5
+             IF (COARE_OPT .EQ. 3.0) THEN
+                CALL fairall_etal_2003(z_t(i),z_q(i),restar,UST(i),visc)
+             ELSE
+                CALL fairall_etal_2014(z_t(i),z_q(i),restar,UST(i),visc,rstoch1D(i),spp_pbl)
+             ENDIF
           ENDIF
  
        ELSE
+
+#if defined(wrfmodel)
+          ! add stochastic perturbaction of ZNT
+             if (spp_pbl==1) then
+                ZNTstoch(I)  = MAX(ZNT(I) + 1.5 * ZNT(I) * rstoch1D(i), 1e-6)
+             else
+                ZNTstoch(I)  = ZNT(I)
+             endif
+#endif
 
           !--------------------------------------
           ! LAND
           !--------------------------------------
           !COMPUTE ROUGHNESS REYNOLDS NUMBER (restar) USING DEFAULT ZNT
+#if defined(mpas)
           restar=MAX(ust(i)*ZNT(i)/visc, 0.1)
+#else
+          restar=MAX(ust(i)*ZNTstoch(i)/visc, 0.1)
+#endif
 
           !--------------------------------------
           !GET z_t and z_q
           !--------------------------------------
           !CHECK FOR SNOW/ICE POINTS OVER LAND
-          !IF ( ZNT(i) .LE. SNOWZ0  .AND.  TSK(I) .LE. 273.15 ) THEN
+          !IF ( ZNTSTOCH(i) .LE. SNOWZ0  .AND.  TSK(I) .LE. 273.15 ) THEN
           IF ( SNOWH(i) .GE. 0.1) THEN
-             CALL Andreas_2002(ZNT(i),restar,z_t(i),z_q(i))
+#if defined(mpas)
+             CALL Andreas_2002(ZNT(i),visc,ust(i),z_t(i),z_q(i))
+#else
+             CALL Andreas_2002(ZNTSTOCH(i),visc,ust(i),z_t(i),z_q(i))
+#endif
           ELSE
              IF ( PRESENT(IZ0TLND) ) THEN
                 IF ( IZ0TLND .LE. 1 .OR. IZ0TLND .EQ. 4) THEN
                    !IF IZ0TLND==4, THEN PSIQ WILL BE RECALCULATED USING
                    !PAN ET AL (1994), but PSIT FROM ZILI WILL BE USED.
+#if defined(mpas)
                    CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
                                   UST(I),KARMAN,XLAND(I),IZ0TLND)
+#else
+                   CALL zilitinkevich_1995(ZNTSTOCH(i),z_t(i),z_q(i),restar,&
+                                  UST(I),KARMAN,XLAND(I),IZ0TLND,spp_pbl,rstoch1D(i))
+#endif
                 ELSEIF ( IZ0TLND .EQ. 2 ) THEN
+#if defined(mpas)
                    CALL Yang_2008(ZNT(i),z_t(i),z_q(i),UST(i),MOL(I),&
                                   qstar(I),restar,visc,XLAND(I))
+#else
+                   CALL Yang_2008(ZNTSTOCH(i),z_t(i),z_q(i),UST(i),MOL(I),&
+                                  qstar(I),restar,visc,XLAND(I))
+#endif
                 ELSEIF ( IZ0TLND .EQ. 3 ) THEN
-                   !Original MYNN in WRF-ARW used this form:
+#if defined(mpas)
                    CALL garratt_1992(z_t(i),z_q(i),ZNT(i),restar,XLAND(I))
+#else
+                   !Original MYNN in WRF-ARW used this form:
+                   CALL garratt_1992(z_t(i),z_q(i),ZNTSTOCH(i),restar,XLAND(I))
+#endif
                 ENDIF
              ELSE
                 !DEFAULT TO ZILITINKEVICH
+#if defined(mpas)
                 CALL zilitinkevich_1995(ZNT(i),z_t(i),z_q(i),restar,&
                                         UST(I),KARMAN,XLAND(I),0)
+#else
+                CALL zilitinkevich_1995(ZNTSTOCH(i),z_t(i),z_q(i),restar,&
+                                        UST(I),KARMAN,XLAND(I),0,spp_pbl,rstoch1D(i))
+#endif
              ENDIF
           ENDIF
 
        ENDIF
+#if defined(mpas)
        zratio(i)=znt(i)/z_t(i)
+#else
+       zratio(i)=zntstoch(i)/z_t(i)
+#endif
 
        !ADD RESISTANCE (SOMEWHAT FOLLOWING JIMENEZ ET AL. (2012)) TO PROTECT AGAINST
        !EXCESSIVE FLUXES WHEN USING A LOW FIRST MODEL LEVEL (ZA < 10 m).        
-       !Formerly: GZ1OZ0(I)= LOG(ZA(I)/ZNT(I))
+       !Formerly for WRF (and still for MPAS): GZ1OZ0(I)= LOG(ZA(I)/ZNTstoch(I))
+#if defined(mpas)
        GZ1OZ0(I)= LOG((ZA(I)+ZNT(I))/ZNT(I))
-       GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))           
-       GZ2OZ0(I)= LOG((2.0+ZNT(I))/ZNT(I))                                        
-       GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))                                        
+       GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))     
+       GZ2OZ0(I)= LOG((2.0+ZNT(I))/ZNT(I))     
+       GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))     
        GZ10OZ0(I)=LOG((10.+ZNT(I))/ZNT(I)) 
        GZ10OZt(I)=LOG((10.+z_t(i))/z_t(i)) 
+#else
+       GZ1OZ0(I)= LOG((ZA(I)+ZNTstoch(I))/ZNTstoch(I))
+       GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))           
+       GZ2OZ0(I)= LOG((2.0+ZNTstoch(I))/ZNTstoch(I))                                        
+       GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))                                        
+       GZ10OZ0(I)=LOG((10.+ZNTstoch(I))/ZNTstoch(I)) 
+       GZ10OZt(I)=LOG((10.+z_t(i))/z_t(i)) 
+#endif
 
      !--------------------------------------------------------------------      
      !--- DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATE STABILITY CLASS:
@@ -844,14 +982,18 @@ CONTAINS
         ENDIF
 
         !COMPUTE z/L
-        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
+        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+!        IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
+#if defined(mpas)
            CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        ELSE
-           ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I),0.001)**2)
-           ZOL(I)=MAX(ZOL(I),0.0)
-           ZOL(I)=MIN(ZOL(I),2.)
-        ENDIF
+#else
+           CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+#endif
+!        ELSE
+!           ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I)*UST(I),0.0001))
+!           ZOL(I)=MAX(ZOL(I),0.0)
+!           ZOL(I)=MIN(ZOL(I),2.)
+!        ENDIF
  
         !COMPUTE PSIM and PSIH
         IF((XLAND(I)-1.5).GE.0)THEN                                            
@@ -859,22 +1001,31 @@ CONTAINS
            !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
            !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
            !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+#if defined(mpas)
            CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
+#else
+           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+#endif
         ELSE
            ! LAND  
            !CALL PSI_Beljaars_Holtslag_1991(PSIM(I),PSIH(I),ZOL(I))
            !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
            !CALL PSI_Zilitinkevich_Esau_2007(PSIM(I),PSIH(I),ZOL(I))
-           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
+#if defined(mpas)
+            CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
+#else
+           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+#endif
         ENDIF              
 
         ! LOWER LIMIT ON PSI IN STABLE CONDITIONS
-        PSIM(I)=MAX(PSIM(I),psilim)
-        PSIH(I)=MAX(PSIH(I),psilim)                                     
         PSIM10(I)=MAX(10./ZA(I)*PSIM(I), psilim)
         PSIH10(I)=MAX(10./ZA(I)*PSIH(I), psilim)
         PSIM2(I)=MAX(2./ZA(I)*PSIM(I), psilim)
         PSIH2(I)=MAX(2./ZA(I)*PSIH(I), psilim)
+        PSIM(I)=MAX(PSIM(I),psilim)
+        PSIH(I)=MAX(PSIH(I),psilim)                                     
+
         ! 1.0 over Monin-Obukhov length
         RMOL(I)= ZOL(I)/ZA(I)
 
@@ -884,45 +1035,49 @@ CONTAINS
         !=========================================================
         REGIME(I)=3.
 
-        PSIM(I)=0.0                                                              
-        PSIH(I)=PSIM(I)                                                          
-        PSIM10(I)=0.                                                   
-        PSIH10(I)=PSIM10(I)                                           
-        PSIM2(I)=0.                                                  
-        PSIH2(I)=PSIM2(I)                                           
-                                           
-        !ZOL(I)=0.                                             
-        IF(UST(I) .LT. 0.01)THEN                                                 
-          ZOL(I)=BR(I)*GZ1OZ0(I)                                               
-        ELSE                                                                     
-          ZOL(I)=KARMAN*GOVRTH(I)*ZA(I)*MOL(I)/(UST(I)*UST(I)) 
-        ENDIF                                                                    
-        RMOL(I) = ZOL(I)/ZA(I)  
+        PSIM(I)=0.0
+        PSIH(I)=PSIM(I)
+        PSIM10(I)=0.
+        PSIH10(I)=PSIM10(I)
+        PSIM2(I)=0.
+        PSIH2(I)=PSIM2(I)
 
-     ELSEIF(BR(I) .LT. 0.)THEN            
+        !ZOL(I)=0.
+        IF(UST(I) .LT. 0.01)THEN
+          ZOL(I)=BR(I)*GZ1OZ0(I)
+        ELSE
+          ZOL(I)=KARMAN*GOVRTH(I)*ZA(I)*MOL(I)/(MAX(UST(I)*UST(I),0.001))
+        ENDIF
+        RMOL(I) = ZOL(I)/ZA(I)
+
+     ELSEIF(BR(I) .LT. 0.)THEN
         !==========================================================
         !-----CLASS 4; FREE CONVECTION:                                                  
         !==========================================================
         REGIME(I)=4.
 
         !COMPUTE z/L
-        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
+        !CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+        !IF (ITER .EQ. 1 .AND. itimestep .LE. 1) THEN
+#if defined(mpas)
            CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNT(I),zratio(I))
-        ELSE
-           ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I),0.001)**2)
-           ZOL(I)=MAX(ZOL(I),-9.999)
-           ZOL(I)=MIN(ZOL(I),0.0)
-        ENDIF
+#else
+           CALL Li_etal_2010(ZOL(I),BR(I),ZA(I)/ZNTstoch(I),zratio(I))
+#endif
+        !ELSE
+        !   ZOL(I)=ZA(I)*KARMAN*G*MOL(I)/(TH1D(I)*MAX(UST(I)*UST(I),0.001))
+        !   ZOL(I)=MAX(ZOL(I),-19.999)
+        !   ZOL(I)=MIN(ZOL(I),0.0)
+        !ENDIF
 
         ZOL10=10./ZA(I)*ZOL(I)
         ZOL2=2./ZA(I)*ZOL(I)
         ZOL(I)=MIN(ZOL(I),0.)
-        ZOL(I)=MAX(ZOL(I),-9.9999)
+        ZOL(I)=MAX(ZOL(I),-19.9999)
         ZOL10=MIN(ZOL10,0.)
-        ZOL10=MAX(ZOL10,-9.9999)
+        ZOL10=MAX(ZOL10,-19.9999)
         ZOL2=MIN(ZOL2,0.)
-        ZOL2=MAX(ZOL2,-9.9999)
+        ZOL2=MAX(ZOL2,-19.9999)
         NZOL=INT(-ZOL(I)*100.)
         RZOL=-ZOL(I)*100.-NZOL
         NZOL10=INT(-ZOL10*100.)
@@ -934,25 +1089,30 @@ CONTAINS
         IF((XLAND(I)-1.5).GE.0)THEN                                            
            ! WATER
            !CALL PSI_Suselj_Sood_2010(PSIM(I),PSIH(I),ZOL(I))
-           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNT(I), ZA(I))
+           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNTstoch(I), ZA(I))
            !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+#if defined(mpas)
            CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
+           CALL PSI_DyerHicks(PSIM2(I),PSIH2(I),ZOL2,z_t(I),ZNT(I),2.)
+#else
+           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+           CALL PSI_DyerHicks(PSIM2(I),PSIH2(I),ZOL2,z_t(I),ZNTstoch(I),2.)
+#endif
         ELSE           
            ! LAND  
-           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNT(I), ZA(I))
+           !CALL PSI_Hogstrom_1996(PSIM(I),PSIH(I),ZOL(I), z_t(I), ZNTstoch(I), ZA(I))
            !CALL PSI_Businger_1971(PSIM(I),PSIH(I),ZOL(I))
+#if defined(mpas)
            CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNT(I),ZA(I))
+           CALL PSI_DyerHicks(PSIM2(I),PSIH2(I),ZOL2,z_t(I),ZNT(I),2.)
+#else
+           CALL PSI_DyerHicks(PSIM(I),PSIH(I),ZOL(I),z_t(I),ZNTstoch(I),ZA(I))
+           CALL PSI_DyerHicks(PSIM2(I),PSIH2(I),ZOL2,z_t(I),ZNTstoch(I),2.)
+#endif
         ENDIF              
 
-!!!!!JOE-test:avoid using psi tables in entirety
-!        PSIM10(I)=PSIMTB(NZOL10)+RZOL10*(PSIMTB(NZOL10+1)-PSIMTB(NZOL10))
-!        PSIH10(I)=PSIHTB(NZOL10)+RZOL10*(PSIHTB(NZOL10+1)-PSIHTB(NZOL10))
-!        PSIM2(I)=PSIMTB(NZOL2)+RZOL2*(PSIMTB(NZOL2+1)-PSIMTB(NZOL2))
-!        PSIH2(I)=PSIHTB(NZOL2)+RZOL2*(PSIHTB(NZOL2+1)-PSIHTB(NZOL2))
         PSIM10(I)=10./ZA(I)*PSIM(I)
         PSIH10(I)=10./ZA(I)*PSIH(I)
-        PSIM2(I)=2./ZA(I)*PSIM(I)
-        PSIH2(I)=2./ZA(I)*PSIH(I)
 
         !---LIMIT PSIH AND PSIM IN THE CASE OF THIN LAYERS AND
         !---HIGH ROUGHNESS.  THIS PREVENTS DENOMINATOR IN FLUXES
@@ -973,9 +1133,7 @@ CONTAINS
      !------------------------------------------------------------
      !-----COMPUTE THE FRICTIONAL VELOCITY:                                           
      !------------------------------------------------------------
-     !     ZA(1982) EQS(2.60),(2.61).                                                 
-      GZ1OZ0(I) =LOG((ZA(I)+ZNT(I))/ZNT(I))
-      GZ10OZ0(I)=LOG((10.+ZNT(I))/ZNT(I)) 
+     !     ZA(1982) EQS(2.60),(2.61).
       PSIX=GZ1OZ0(I)-PSIM(I)
       PSIX10=GZ10OZ0(I)-PSIM10(I)
       ! TO PREVENT OSCILLATIONS AVERAGE WITH OLD VALUE 
@@ -990,7 +1148,7 @@ CONTAINS
       ENDIF
 
       IF ((XLAND(I)-1.5).LT.0.) THEN        !LAND
-         UST(I)=MAX(UST(I),0.01)  !JOE:Relaxing this limit
+         UST(I)=MAX(UST(I),0.005)  !Further relaxing this limit - no need to go lower
          !Keep ustm = ust over land.
          IF ( PRESENT(USTM) ) USTM(I)=UST(I)
       ENDIF
@@ -1003,14 +1161,13 @@ CONTAINS
       GZ1OZt(I)= LOG((ZA(I)+z_t(i))/z_t(i))           
       GZ2OZt(I)= LOG((2.0+z_t(i))/z_t(i))                                        
 
-      !PSIT=MAX(GZ1OZ0(I)-PSIH(I),2.)
-      PSIT=MAX(LOG((ZA(I)+z_t(i))/z_t(i))-PSIH(I) ,2.0)
-      PSIT2=MAX(LOG((2.0+z_t(i))/z_t(i))-PSIH2(I) ,2.0)                                    
+      PSIT =MAX(GZ1OZt(I)-PSIH(I) ,1.)
+      PSIT2=MAX(GZ2OZt(I)-PSIH2(I),1.)
       resist(I)=PSIT
       logres(I)=GZ1OZt(I)
 
-      PSIQ=MAX(LOG((za(i)+z_q(i))/z_q(I))-PSIH(I) ,2.0)   
-      PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,2.0) 
+      PSIQ=MAX(LOG((ZA(I)+z_q(i))/z_q(I))-PSIH(I) ,1.0)
+      PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,1.0)
 
       IF((XLAND(I)-1.5).LT.0)THEN    !Land only
          IF ( IZ0TLND .EQ. 4 ) THEN
@@ -1022,7 +1179,8 @@ CONTAINS
       !----------------------------------------------------
       !COMPUTE THE TEMPERATURE SCALE (or FRICTION TEMPERATURE, T*)
       !----------------------------------------------------
-      DTG=TH1D(I)-THGB(I)                                                   
+      !DTG=TH1D(I)-THGB(I) !SWITCH TO THETA-V                                                   
+      DTG=THV1D(I)-THVGB(I)
       OLDTST=MOL(I)
       MOL(I)=KARMAN*DTG/PSIT/PRT
       !t_star(I) = -HFX(I)/(UST(I)*CPM(I)*RHO1D(I))
@@ -1032,42 +1190,6 @@ CONTAINS
       DQG=(QVSH(i)-qsfc(i))*1000.   !(kg/kg -> g/kg)
       qstar(I)=KARMAN*DQG/PSIQ/PRT
 
-      !-----------------------------------------------------
-      !COMPUTE DIAGNOSTICS
-      !-----------------------------------------------------
-      !COMPUTE 10 M WNDS
-      !-----------------------------------------------------
-      ! If the lowest model level is close to 10-m, use it 
-      ! instead of the flux-based diagnostic formula.
-      if (ZA(i) .gt. 7.0 .and. ZA(i) .lt. 13.0) then
-         U10(I)=U1D(I)
-         V10(I)=V1D(I)
-      else                                 
-         U10(I)=U1D(I)*PSIX10/PSIX                                    
-         V10(I)=V1D(I)*PSIX10/PSIX     
-      endif
-
-      !-----------------------------------------------------
-      !COMPUTE 2m T, TH, AND Q
-      !THESE WILL BE OVERWRITTEN FOR LAND POINTS IN THE LSM 
-      !-----------------------------------------------------
-      TH2(I)=THGB(I)+DTG*PSIT2/PSIT
-      !***  BE CERTAIN THAT THE 2-M THETA IS BRACKETED BY
-      !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
-!      IF ((TH1D(I)>THGB(I) .AND. (TH2(I)<THGB(I) .OR. TH2(I)>TH1D(I))) .OR. &
-!          (TH1D(I)<THGB(I) .AND. (TH2(I)>THGB(I) .OR. TH2(I)<TH1D(I)))) THEN
-!          TH2(I)=THGB(I) + 2.*(TH1D(I)-THGB(I))/ZA(I)
-!      ENDIF
-      T2(I)=TH2(I)*(PSFC(I)/100.)**ROVCP
-
-      Q2(I)=QSFCMR(I)+(QV1D(I)-QSFCMR(I))*PSIQ2/PSIQ
-      !***  BE CERTAIN THAT THE 2-M MIXING RATIO IS BRACKETED BY
-      !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
-      IF ((QV1D(I)>QSFCMR(I) .AND. (Q2(I)<QSFCMR(I) .OR. Q2(I)>QV1D(I))) .OR. &
-          (QV1D(I)<QSFCMR(I) .AND. (Q2(I)>QSFCMR(I) .OR. Q2(I)<QV1D(I)))) THEN
-          Q2(I)=QSFCMR(I) + 2.*(QV1D(I)-QSFCMR(I))/ZA(I)
-      ENDIF
-
       !CHECK FOR CONVERGENCE
       IF (ITER .GE. 2) THEN
          !IF (ABS(OLDUST-UST(I)) .lt. 0.01) THEN
@@ -1075,14 +1197,14 @@ CONTAINS
             ITER = ITER+ITMAX
          ENDIF
 
-         !IF (I .eq. 2) THEN
+         !IF () THEN
          !  print*,"ITER:",ITER
          !  write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I)," Tstar:",MOL(I)
          !  write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I)," DTHV:",THV1D(I)-THVGB(I)
          !  write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
-         !  write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNT(I)," Zt:",z_t(I)," za:",za(I)
+         !  write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNTstoch(I)," Zt:",z_t(I)," za:",za(I)
          !  write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",QSFC(I)," QVSH(I):",QVSH(I)
-         !  print*,"VISC=",VISC," Z0:",ZNT(I)," T1D(i):",T1D(i)
+         !  print*,"VISC=",VISC," Z0:",ZNTstoch(I)," T1D(i):",T1D(i)
          !  write(*,*)"============================================="
          !ENDIF
       ENDIF
@@ -1105,7 +1227,20 @@ CONTAINS
       !----------------------------------------------------------
  DO I=its,ite
 
-   IF (ISFFLX .LT. 1) THEN                                                
+    !For computing the diagnostics and fluxes (below), whether the fluxes
+    !are turned off or on, we need the following:
+    PSIX=GZ1OZ0(I)-PSIM(I)
+    PSIX10=GZ10OZ0(I)-PSIM10(I)
+
+    PSIT =MAX(GZ1OZt(I)-PSIH(I), 1.0)
+    PSIT2=MAX(GZ2OZt(I)-PSIH2(I),1.0)
+    PSIT10=MAX(GZ10OZ0(I)-PSIH10(I), 1.0)
+  
+    PSIQ=MAX(LOG((ZA(I)+z_q(i))/z_q(I))-PSIH(I) ,1.0)
+    PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,1.0)
+    PSIQ10=MAX(GZ10OZ0(I)-PSIH10(I),1.0)
+
+    IF (ISFFLX .LT. 1) THEN                                                
 
        QFX(i)  = 0.                                                              
        HFX(i)  = 0.    
@@ -1123,18 +1258,7 @@ CONTAINS
            Cka(I)= 0.
            Cda(I)= 0.
        ENDIF
-   ELSE
-
-      PSIX=GZ1OZ0(I)-PSIM(I)
-      PSIX10=GZ10OZ0(I)-PSIM10(I)
-
-      PSIT=MAX(LOG((ZA(I)+z_t(i))/z_t(i))-PSIH(I) ,2.0)
-      PSIT2=MAX(LOG((2.0+z_t(i))/z_t(i))-PSIH2(I) ,2.0)        
-      PSIT10=MAX(LOG((10.0+z_t(i))/z_t(i))-PSIH10(I) ,2.0)
-
-      PSIQ=MAX(LOG((za(i)+z_q(i))/z_q(I))-PSIH(I) ,2.0)   
-      PSIQ2=MAX(LOG((2.0+z_q(i))/z_q(I))-PSIH2(I) ,2.0) 
-      PSIQ10=MAX(LOG((10.0+z_q(i))/z_q(I))-PSIH10(I) ,2.0)
+    ELSE
 
       IF((XLAND(I)-1.5).LT.0)THEN !LAND Only  
          IF ( IZ0TLND .EQ. 4 ) THEN
@@ -1148,18 +1272,18 @@ CONTAINS
       ! AND MOISTURE (FLQC)
       !------------------------------------------
       FLQC(I)=RHO1D(I)*MAVAIL(I)*UST(I)*KARMAN/PSIQ
-
-      DTTHX=ABS(TH1D(I)-THGB(I))                                            
-      IF(DTTHX.GT.1.E-5)THEN                                                   
-         FLHC(I)=CPM(I)*RHO1D(I)*UST(I)*MOL(I)/(TH1D(I)-THGB(I))          
-      ELSE                                                                     
-         FLHC(I)=0.                                                             
-      ENDIF   
+      FLHC(I)=RHO1D(I)*CPM(I)*UST(I)*KARMAN/PSIT
+      !OLD WAY:
+      !DTTHX=ABS(TH1D(I)-THGB(I))                                            
+      !IF(DTTHX.GT.1.E-5)THEN                                                   
+      !   FLHC(I)=CPM(I)*RHO1D(I)*UST(I)*MOL(I)/(TH1D(I)-THGB(I))          
+      !ELSE                                                                     
+      !   FLHC(I)=0.                                                             
+      !ENDIF   
 
       !----------------------------------
       ! COMPUTE SURFACE MOISTURE FLUX:
       !----------------------------------
-
       QFX(I)=FLQC(I)*(QSFCMR(I)-QV1D(I))          
       !JOE: QFX(I)=MAX(QFX(I),0.)   !originally did not allow neg QFX           
       QFX(I)=MAX(QFX(I),-0.02)      !allows small neg QFX, like MYJ  
@@ -1170,12 +1294,12 @@ CONTAINS
       !----------------------------------
       IF(XLAND(I)-1.5.GT.0.)THEN      !WATER                                           
          HFX(I)=FLHC(I)*(THGB(I)-TH1D(I))                                
-!        IF ( PRESENT(ISFTCFLX) ) THEN
-!           IF ( ISFTCFLX.NE.0 ) THEN
-!              ! AHW: add dissipative heating term (commented out in 3.6.1
-!              HFX(I)=HFX(I)+RHO1D(I)*USTM(I)*USTM(I)*WSPDI(I)
-!           ENDIF
-!        ENDIF
+         IF ( PRESENT(ISFTCFLX) ) THEN
+            IF ( ISFTCFLX.NE.0 ) THEN
+               ! AHW: add dissipative heating term
+               HFX(I)=HFX(I)+RHO1D(I)*USTM(I)*USTM(I)*WSPDI(I)
+            ENDIF
+         ENDIF
       ELSEIF(XLAND(I)-1.5.LT.0.)THEN  !LAND                               
          HFX(I)=FLHC(I)*(THGB(I)-TH1D(I))                                
          HFX(I)=MAX(HFX(I),-250.)                                       
@@ -1206,39 +1330,138 @@ CONTAINS
 
    ENDIF !end ISFFLX option
 
-!   IF ( wrf_at_debug_level(3000) ) THEN
-!   IF (HFX(I) > 1200. .OR. HFX(I) < -500. .OR. &
-!      &LH(I)  > 1200. .OR. LH(I)  < -500. .OR. &
-!      &UST(I) < 0.0 .OR. UST(I) > 4.0 .OR. &
-!      &WSTAR(I)<0.0 .OR. WSTAR(I) > 6.0 .OR. &
-!      &RHO1D(I)<0.0 .OR. RHO1D(I) > 1.6 .OR. &
-!      &QSFC(I)*1000. <0.0 .OR. QSFC(I)*1000. >38. .OR. &
-!      &PBLH(I)>6000.) THEN
-!      print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
-!            ITER-ITMAX," ITERATIONS",I,J
-!      write(*,1000)"HFX: ",HFX(I)," LH:",LH(I)," CH:",CH(I),&
-!            " PBLH:",PBLH(I)
-!      write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I),&
-!            " Tstar:",MOL(I)
-!      write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I),&
-!            " DTHV:",THV1D(I)-THVGB(I)
-!      write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",&
-!            ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
-!      write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNT(I)," Zt:",z_t(I),&
-!            " za:",za(I)
-!      write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",&
-!            QSFC(I)," QVSH(I):",QVSH(I)
-!      print*,"PSIX=",PSIX," Z0:",ZNT(I)," T1D(i):",T1D(i)
-!      write(*,*)"============================================="
-!   ENDIF
-!   ENDIF
+   !-----------------------------------------------------
+   !COMPUTE DIAGNOSTICS
+   !-----------------------------------------------------
+   !COMPUTE 10 M WNDS
+   !-----------------------------------------------------
+   ! If the lowest model level is close to 10-m, use it
+   ! instead of the flux-based diagnostic formula.
+   if (ZA(i) .le. 7.0) then
+      ! high vertical resolution
+      if(ZA2(i) .gt. 7.0 .and. ZA2(i) .lt. 13.0) then
+         !use 2nd model level
+         U10(I)=U1D2(I)
+         V10(I)=V1D2(I)
+      else
+#if defined(mpas)
+         U10(I)=U1D(I)*log(10./ZNT(I))/log(ZA(I)/ZNT(I))
+         V10(I)=V1D(I)*log(10./ZNT(I))/log(ZA(I)/ZNT(I))
+#else
+         U10(I)=U1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+         V10(I)=V1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+#endif
+      endif
+   elseif(ZA(i) .gt. 7.0 .and. ZA(i) .lt. 13.0) then
+      !moderate vertical resolution
+      !U10(I)=U1D(I)*PSIX10/PSIX
+      !V10(I)=V1D(I)*PSIX10/PSIX
+      !use neutral-log:
+#if defined(mpas)
+      U10(I)=U1D(I)*log(10./ZNT(I))/log(ZA(I)/ZNT(I))
+      V10(I)=V1D(I)*log(10./ZNT(I))/log(ZA(I)/ZNT(I))
+#else
+      U10(I)=U1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+      V10(I)=V1D(I)*log(10./ZNTstoch(I))/log(ZA(I)/ZNTstoch(I))
+#endif
+   else
+      ! very coarse vertical resolution
+      U10(I)=U1D(I)*PSIX10/PSIX
+      V10(I)=V1D(I)*PSIX10/PSIX
+   endif
+
+   !-----------------------------------------------------
+   !COMPUTE 2m T, TH, AND Q
+   !THESE WILL BE OVERWRITTEN FOR LAND POINTS IN THE LSM
+   !-----------------------------------------------------
+   DTG=TH1D(I)-THGB(I) 
+   TH2(I)=THGB(I)+DTG*PSIT2/PSIT
+   !***  BE CERTAIN THAT THE 2-M THETA IS BRACKETED BY
+   !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
+   IF ((TH1D(I)>THGB(I) .AND. (TH2(I)<THGB(I) .OR. TH2(I)>TH1D(I))) .OR. &
+       (TH1D(I)<THGB(I) .AND. (TH2(I)>THGB(I) .OR. TH2(I)<TH1D(I)))) THEN
+       TH2(I)=THGB(I) + 2.*(TH1D(I)-THGB(I))/ZA(I)
+   ENDIF
+   T2(I)=TH2(I)*(PSFC(I)/100.)**ROVCP
+
+   Q2(I)=QSFCMR(I)+(QV1D(I)-QSFCMR(I))*PSIQ2/PSIQ
+   !***  BE CERTAIN THAT THE 2-M MIXING RATIO IS BRACKETED BY
+   !***  THE VALUES AT THE SURFACE AND LOWEST MODEL LEVEL.
+   IF ((QV1D(I)>QSFCMR(I) .AND. (Q2(I)<QSFCMR(I) .OR. Q2(I)>QV1D(I))) .OR. &
+       (QV1D(I)<QSFCMR(I) .AND. (Q2(I)>QSFCMR(I) .OR. Q2(I)<QV1D(I)))) THEN
+       Q2(I)=QSFCMR(I) + 2.*(QV1D(I)-QSFCMR(I))/ZA(I)
+   ENDIF
+
+   IF ( debug_code ) THEN
+      yesno = 0
+      IF (HFX(I) > 1200. .OR. HFX(I) < -700.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            ITER-ITMAX," ITERATIONS",I,J, "HFX: ",HFX(I)
+            yesno = 1
+      ENDIF
+      IF (LH(I)  > 1200. .OR. LH(I)  < -700.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            ITER-ITMAX," ITERATIONS",I,J, "LH: ",LH(I)
+            yesno = 1
+      ENDIF
+      IF (UST(I) < 0.0 .OR. UST(I) > 4.0 )THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&                                                                     
+            ITER-ITMAX," ITERATIONS",I,J, "UST: ",UST(I)
+            yesno = 1
+      ENDIF
+      IF (WSTAR(I)<0.0 .OR. WSTAR(I) > 6.0)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            ITER-ITMAX," ITERATIONS",I,J, "WSTAR: ",WSTAR(I)
+            yesno = 1
+      ENDIF
+      IF (RHO1D(I)<0.0 .OR. RHO1D(I) > 1.6 )THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            ITER-ITMAX," ITERATIONS",I,J, "rho: ",RHO1D(I)
+            yesno = 1
+      ENDIF
+      IF (QSFC(I)*1000. <0.0 .OR. QSFC(I)*1000. >40.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&
+            ITER-ITMAX," ITERATIONS",I,J, "QSFC: ",QSFC(I)
+            yesno = 1
+      ENDIF
+      IF (PBLH(I)<0. .OR. PBLH(I)>6000.)THEN
+            print*,"SUSPICIOUS VALUES IN MYNN SFCLAYER",&                                                              
+            ITER-ITMAX," ITERATIONS",I,J, "PBLH: ",PBLH(I)
+            yesno = 1
+      ENDIF
+
+      IF (yesno == 1) THEN
+        print*," OTHER INFO:"
+        write(*,1001)"REGIME:",REGIME(I)," z/L:",ZOL(I)," U*:",UST(I),&
+              " Tstar:",MOL(I)
+        write(*,1002)"PSIM:",PSIM(I)," PSIH:",PSIH(I)," W*:",WSTAR(I),&
+              " DTHV:",THV1D(I)-THVGB(I)
+        write(*,1003)"CPM:",CPM(I)," RHO1D:",RHO1D(I)," L:",&
+              ZOL(I)/ZA(I)," DTH:",TH1D(I)-THGB(I)
+#if defined(mpas)
+        write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNT(I)," Zt:",z_t(I),&
+              " za:",za(I)
+#else
+        write(*,1004)"Z0/Zt:",zratio(I)," Z0:",ZNTstoch(I)," Zt:",z_t(I),&
+              " za:",za(I)
+#endif
+        write(*,1005)"Re:",restar," MAVAIL:",MAVAIL(I)," QSFC(I):",&
+              QSFC(I)," QVSH(I):",QVSH(I)
+#if defined(mpas)
+        print*,"PSIX=",PSIX," Z0:",ZNT(I)," T1D(i):",T1D(i)
+#else
+        print*,"PSIX=",PSIX," Z0:",ZNTstoch(I)," T1D(i):",T1D(i)
+#endif
+        write(*,*)"============================================="
+      ENDIF
+   ENDIF
 
  ENDDO !end i-loop
 
 END SUBROUTINE SFCLAY1D_mynn
 !-------------------------------------------------------------------          
    SUBROUTINE zilitinkevich_1995(Z_0,Zt,Zq,restar,ustar,KARMAN,&
-       & landsea,IZ0TLND2)
+       & landsea,IZ0TLND2,spp_pbl,rstoch)
 
        ! This subroutine returns the thermal and moisture roughness lengths
        ! from Zilitinkevich (1995) and Zilitinkevich et al. (2001) over
@@ -1256,6 +1479,9 @@ END SUBROUTINE SFCLAY1D_mynn
        REAL :: CZIL  !=0.100 in Chen et al. (1997)
                      !=0.075 in Zilitinkevich (1995)
                      !=0.500 in Lemone et al. (2008)
+       INTEGER, OPTIONAL,  INTENT(IN)  ::    spp_pbl
+       REAL, OPTIONAL,  INTENT(IN)  ::    rstoch
+
 
        IF (landsea-1.5 .GT. 0) THEN    !WATER
 
@@ -1283,7 +1509,7 @@ END SUBROUTINE SFCLAY1D_mynn
           IF ( IZ0TLND2 .EQ. 1 ) THEN
              CZIL = 10.0 ** ( -0.40 * ( Z_0 / 0.07 ) )
           ELSE
-             CZIL = 0.10
+             CZIL = 0.075 !0.10
           END IF
 
           Zt = Z_0*EXP(-KARMAN*CZIL*SQRT(restar))
@@ -1292,7 +1518,18 @@ END SUBROUTINE SFCLAY1D_mynn
           Zq = Z_0*EXP(-KARMAN*CZIL*SQRT(restar))
           Zq = MIN( Zq, Z_0/2.)
 
-          !Zq = Zt
+! perturb thermal and moisture roughness lenth by +/-50%
+! uses same perturbation pattern for perturbing cloud fraction 
+! and turbulent mixing length (module_sf_mynn.F), but 
+! twice the amplitude; 
+! multiplication with -1.0 anticorrelates patterns
+#if defined(wrfmodel)
+             if (spp_pbl==1) then
+                Zt = Zt + Zt * 2.0 * rstoch
+                Zt = MAX(Zt, 0.001)
+                Zq = Zt
+             endif
+#endif
        ENDIF
                    
        return
@@ -1336,6 +1573,7 @@ END SUBROUTINE SFCLAY1D_mynn
 !--------------------------------------------------------------
    SUBROUTINE davis_etal_2008(Z_0,ustar)
 
+    !a.k.a. : Donelan et al. (2004)
     !This formulation for roughness length was designed to match 
     !the labratory experiments of Donelan et al. (2004).
     !This is an update version from Davis et al. 2008, which
@@ -1389,7 +1627,7 @@ END SUBROUTINE SFCLAY1D_mynn
 
    END SUBROUTINE Taylor_Yelland_2001
 !--------------------------------------------------------------------
-   SUBROUTINE charnock_1955(Z_0,ustar,wsp10,visc)
+   SUBROUTINE charnock_1955(Z_0,ustar,wsp10,visc,zu)
  
     !This version of Charnock's relation employs a varying
     !Charnock parameter, similar to COARE3.0 [Fairall et al. (2003)].
@@ -1397,13 +1635,16 @@ END SUBROUTINE SFCLAY1D_mynn
     !between 10-m wsp = 10 and 18. 
 
        IMPLICIT NONE
-       REAL, INTENT(IN)  :: ustar, visc, wsp10
+       REAL, INTENT(IN)  :: ustar, visc, wsp10, zu
        REAL, INTENT(OUT) :: Z_0
        REAL, PARAMETER   :: G=9.81, CZO2=0.011
        REAL              :: CZC    !variable charnock "constant"   
+       REAL              :: wsp10m ! logarithmically calculated 10 m
 
-       CZC = CZO2 + 0.007*MIN(MAX((wsp10-10.)/8., 0.), 1.0)
-       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.1))
+       wsp10m = wsp10*log(10./1e-4)/log(zu/1e-4)
+       CZC = CZO2 + 0.007*MIN(MAX((wsp10m-10.)/8., 0.), 1.0)
+
+       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.05))
        Z_0 = MAX( Z_0, 1.27e-7)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3)  !Davis et al. (2008)
 
@@ -1411,9 +1652,37 @@ END SUBROUTINE SFCLAY1D_mynn
 
    END SUBROUTINE charnock_1955
 !--------------------------------------------------------------------
+   SUBROUTINE edson_etal_2013(Z_0,ustar,wsp10,visc,zu)
+
+     !This version of Charnock's relation employs a varying
+     !Charnock parameter, taken from COARE 3.5 [Edson et al. (2001, JPO)].
+     !The Charnock parameter CZC is varied from about .005 to .028
+     !between 10-m wind speeds of 6 and 19 m/s.
+
+       IMPLICIT NONE
+       REAL, INTENT(IN)  :: ustar, visc, wsp10, zu
+       REAL, INTENT(OUT) :: Z_0
+       REAL, PARAMETER   :: G=9.81
+       REAL, PARAMETER   :: m=0.017, b=-0.005
+       REAL              :: CZC    ! variable charnock "constant"
+       REAL              :: wsp10m ! logarithmically calculated 10 m
+
+       wsp10m = wsp10*log(10/1e-4)/log(zu/1e-4)
+       wsp10m = MIN(19., wsp10m)
+       CZC    = m*wsp10m + b
+       CZC    = MAX(CZC, 0.0)
+
+       Z_0 = CZC*ustar*ustar/G + (0.11*visc/MAX(ustar,0.07))
+       Z_0 = MAX( Z_0, 1.27e-7)  !These max/mins were suggested by
+       Z_0 = MIN( Z_0, 2.85e-3)  !Davis et al. (2008)
+
+       return
+
+   END SUBROUTINE edson_etal_2013
+!--------------------------------------------------------------------
    SUBROUTINE garratt_1992(Zt,Zq,Z_0,Ren,landsea)
 
-    !This formulation for the thermal and moisture roughness lengths 
+    !This formulation for the thermal and moisture roughness lengths
     !(Zt and Zq) relates them to Z0 via the roughness Reynolds number (Ren).
     !This formula comes from Fairall et al. (2003). It is modified from
     !the original Garratt-Brutsaert model to better fit the COARE/HEXMAX
@@ -1444,20 +1713,15 @@ END SUBROUTINE SFCLAY1D_mynn
 
     END SUBROUTINE garratt_1992
 !--------------------------------------------------------------------
-    SUBROUTINE fairall_2001(Zt,Zq,Ren,ustar,visc)
+    SUBROUTINE fairall_etal_2003(Zt,Zq,Ren,ustar,visc)
 
-    !This formulation for thermal and moisture roughness length (Zt and Zq) 
-    !as a function of the roughness Reynolds number (Ren) comes from the 
+    !This formulation for thermal and moisture roughness length (Zt and Zq)
+    !as a function of the roughness Reynolds number (Ren) comes from the
     !COARE3.0 formulation, empirically derived from COARE and HEXMAX data
     ![Fairall et al. (2003)]. Edson et al. (2004; JGR) suspected that this
-    !relationship overestimated roughness lengths for low Reynolds number 
-    !flows, so a smooth flow relationship, taken from Garrattt (1992, p. 102),
-    !is used for flows with Ren < 2. 
-    !
-    !Note that this formulation should not be used with the Davis et al. 
-    !(2008) formulation for Zo, because that formulation produces much 
-    !smaller u* (Ren), resulting in a large Zt and Zq. It works best with
-    !the Charnock or the Taylor and Yelland relationships.
+    !relationship overestimated the scalar roughness lengths for low Reynolds
+    !number flows, so an optional smooth flow relationship, taken from Garratt
+    !(1992, p. 102), is available for flows with Ren < 2.
     !
     !This is for use over water only.
 
@@ -1469,27 +1733,58 @@ END SUBROUTINE SFCLAY1D_mynn
 
           Zt = (5.5e-5)*(Ren**(-0.60))
           Zq = Zt
-          !FOR SMOOTH SEAS, USE GARRATT
+          !FOR SMOOTH SEAS, CAN USE GARRATT
           !Zq = 0.2*visc/MAX(ustar,0.1)
           !Zq = 0.3*visc/MAX(ustar,0.1)
 
        ELSE
-          
-          !FOR ROUGH SEAS, USE FAIRALL
+
+          !FOR ROUGH SEAS, USE COARE
           Zt = (5.5e-5)*(Ren**(-0.60))
           Zq = Zt
- 
+
        ENDIF
 
        Zt = MIN(Zt,1.0e-4)
        Zt = MAX(Zt,2.0e-9)
 
        Zq = MIN(Zt,1.0e-4)
-       Zq = MAX(Zt,2.0e-9) 
-                   
+       Zq = MAX(Zt,2.0e-9)
+
        return
 
-    END SUBROUTINE fairall_2001
+    END SUBROUTINE fairall_etal_2003
+!--------------------------------------------------------------------
+    SUBROUTINE fairall_etal_2014(Zt,Zq,Ren,ustar,visc,rstoch,spp_pbl)
+
+    !This formulation for thermal and moisture roughness length (Zt and Zq)
+    !as a function of the roughness Reynolds number (Ren) comes from the
+    !COARE 3.5/4.0 formulation, empirically derived from COARE and HEXMAX data
+    ![Fairall et al. (2014? coming soon, not yet published as of July 2014)].
+    !This is for use over water only.
+
+       IMPLICIT NONE
+       REAL, INTENT(IN)  :: Ren,ustar,visc,rstoch
+       INTEGER, OPTIONAL, INTENT(IN):: spp_pbl
+       REAL, INTENT(OUT) :: Zt,Zq
+
+       !Zt = (5.5e-5)*(Ren**(-0.60))
+       Zt = MIN(1.6E-4, 5.8E-5/(Ren**0.72))
+       Zq = Zt
+
+#if defined(wrfmodel)
+          IF (spp_pbl ==1) THEN
+             Zt = MAX(Zt + Zt*2.0*rstoch,2.0e-9)
+             Zq = MAX(Zt + Zt*2.0*rstoch,2.0e-9)
+          ELSE
+             Zt = MAX(Zt,2.0e-9)
+             Zq = MAX(Zt,2.0e-9)
+          ENDIF
+#endif
+
+       return
+
+    END SUBROUTINE fairall_etal_2014
 !--------------------------------------------------------------------
     SUBROUTINE Yang_2008(Z_0,Zt,Zq,ustar,tstar,qst,Ren,visc,landsea)
 
@@ -1508,44 +1803,57 @@ END SUBROUTINE SFCLAY1D_mynn
     !to 7.2 (in 2008 paper). Their form typically varies the
     !ratio Z0/Zt by a few orders of magnitude (1-1E4).
     !
-    !This modified form uses beta = 0.5 and Renc = 350, so zt generally 
-    !varies similarly to the Zilitinkevich form for small/moderate heat 
-    !fluxes but can become ~O(1/2 Zilitinkevich) for very large negative T*.
-    !Also, the exponent (0.25) on tstar was changed to 1.0, since we found                                      
-    !Zt was reduced too much for low-moderate positive heat fluxes.                                             
+    !This modified form uses beta = 1.5 and a variable Renc (function of Z_0),
+    !so zt generally varies similarly to the Zilitinkevich form (with Czil = 0.1)
+    !for very small or negative surface heat fluxes but can become close to the
+    !Zilitinkevich with Czil = 0.2 for very large HFX (large negative T*).
+    !Also, the exponent (0.25) on tstar was changed to 1.0, since we found
+    !Zt was reduced too much for low-moderate positive heat fluxes.
     !
     !This should only be used over land!
 
        IMPLICIT NONE
        REAL, INTENT(IN)  :: Z_0, Ren, ustar, tstar, qst, visc, landsea
-       REAL              :: ht, tstar2
+       REAL              :: ht,     &! roughness height at critical Reynolds number
+                            tstar2, &! bounded T*, forced to be non-positive
+                            qstar2, &! bounded q*, forced to be non-positive
+                            Z_02,   &! bounded Z_0 for variable Renc2 calc
+                            Renc2    ! variable Renc, function of Z_0
        REAL, INTENT(OUT) :: Zt,Zq
-       REAL, PARAMETER  :: Renc=350., beta=0.5, e=2.71828183
+       REAL, PARAMETER  :: Renc=300., & !old constant Renc
+                           beta=1.5,  & !important for diurnal variation
+                           m=170.,    & !slope for Renc2 function
+                           b=691.       !y-intercept for Renc2 function
 
-       ht     = Renc*visc/MAX(ustar,0.01)
+       Z_02 = MIN(Z_0,0.5)
+       Z_02 = MAX(Z_02,0.04)
+       Renc2= b + m*log(Z_02)
+       ht     = Renc2*visc/MAX(ustar,0.01)
        tstar2 = MIN(tstar, 0.0)
+       qstar2 = MIN(qst,0.0)
 
        Zt     = ht * EXP(-beta*(ustar**0.5)*(ABS(tstar2)**1.0))
-       !Zq     = ht * EXP(-beta*(ustar**0.5)*(ABS(qst)**1.0))
-       Zq     = Zt
-                   
-       Zt = MIN(Zt, Z_0/2.0)  !(e**2.))   !limit from Garratt (1980,1992)
-       Zq = MIN(Zq, Z_0/2.0)  !(e**2.))   !limit from Garratt (1980,1992)
+       Zq     = ht * EXP(-beta*(ustar**0.5)*(ABS(qstar2)**1.0))
+       !Zq     = Zt
+
+       Zt = MIN(Zt, Z_0/2.0)
+       Zq = MIN(Zq, Z_0/2.0)
 
        return
 
     END SUBROUTINE Yang_2008
 !--------------------------------------------------------------------
-    SUBROUTINE Andreas_2002(Z_0,Ren,Zt,Zq)
+    SUBROUTINE Andreas_2002(Z_0,bvisc,ustar,Zt,Zq)
 
-    !This is taken from Andreas (2002; J. of Hydromet).
+    ! This is taken from Andreas (2002; J. of Hydromet) and 
+    ! Andreas et al. (2005; BLM).
     !
-    !This should only be used over snow/ice!
+    ! This should only be used over snow/ice!
 
        IMPLICIT NONE
-       REAL, INTENT(IN)  :: Z_0, Ren
+       REAL, INTENT(IN)  :: Z_0, bvisc, ustar
        REAL, INTENT(OUT) :: Zt, Zq
-       REAL :: Ren2 
+       REAL :: Ren2, zntsno
 
        REAL, PARAMETER  :: bt0_s=1.25,  bt0_t=0.149,  bt0_r=0.317,  &
                            bt1_s=0.0,   bt1_t=-0.55,  bt1_r=-0.565, &
@@ -1554,26 +1862,31 @@ END SUBROUTINE SFCLAY1D_mynn
        REAL, PARAMETER  :: bq0_s=1.61,  bq0_t=0.351,  bq0_r=0.396,  &
                            bq1_s=0.0,   bq1_t=-0.628, bq1_r=-0.512, &
                            bq2_s=0.0,   bq2_t=0.0,    bq2_r=-0.180
-          
-       Ren2 = Ren
+
+      !Calculate zo for snow (Andreas et al. 2005, BLM)                                                                     
+       zntsno = 0.135*bvisc/ustar + &
+               (0.035*(ustar*ustar)/9.8) * &
+               (5.*exp(-1.*(((ustar - 0.18)/0.1)*((ustar - 0.18)/0.1))) + 1.)                                                
+       Ren2 = ustar*zntsno/bvisc
+
        ! Make sure that Re is not outside of the range of validity
        ! for using their equations
        IF (Ren2 .gt. 1000.) Ren2 = 1000. 
 
        IF (Ren2 .le. 0.135) then
 
-          Zt = Z_0*EXP(bt0_s + bt1_s*LOG(Ren2) + bt2_s*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_s + bq1_s*LOG(Ren2) + bq2_s*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_s + bt1_s*LOG(Ren2) + bt2_s*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_s + bq1_s*LOG(Ren2) + bq2_s*LOG(Ren2)**2)
 
        ELSE IF (Ren2 .gt. 0.135 .AND. Ren2 .lt. 2.5) then
 
-          Zt = Z_0*EXP(bt0_t + bt1_t*LOG(Ren2) + bt2_t*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_t + bq1_t*LOG(Ren2) + bq2_t*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_t + bt1_t*LOG(Ren2) + bt2_t*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_t + bq1_t*LOG(Ren2) + bq2_t*LOG(Ren2)**2)
 
        ELSE
 
-          Zt = Z_0*EXP(bt0_r + bt1_r*LOG(Ren2) + bt2_r*LOG(Ren2)**2)
-          Zq = Z_0*EXP(bq0_r + bq1_r*LOG(Ren2) + bq2_r*LOG(Ren2)**2)
+          Zt = zntsno*EXP(bt0_r + bt1_r*LOG(Ren2) + bt2_r*LOG(Ren2)**2)
+          Zq = zntsno*EXP(bq0_r + bq1_r*LOG(Ren2) + bq2_r*LOG(Ren2)**2)
 
        ENDIF
 
@@ -1843,6 +2156,393 @@ END SUBROUTINE SFCLAY1D_mynn
        return
 
     END SUBROUTINE Li_etal_2010
-!--------------------------------------------------------------------
+
+!-------------------------------------------------------------------
+!---- add pbl modules so they can be optimized in pbl code
+!-------------------------------------------------------------------
+  SUBROUTINE  mym_condensation (kts,kte,  &
+    &            dx, dz,                  &
+    &            thl, qw,                 &
+    &            p,exner,                 &
+    &            tsq, qsq, cov,           &
+    &            Sh, el, bl_mynn_cloudpdf,&
+    &            qc_bl1D, cldfra_bl1D,    &
+    &            PBLH1,HFX1,              &
+    &            Vt, Vq, th, sgm)
+
+!-------------------------------------------------------------------
+
+    INTEGER, INTENT(IN)   :: kts,kte, bl_mynn_cloudpdf
+    REAL, INTENT(IN)      :: dx,PBLH1,HFX1
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner, thl, qw, &
+         &tsq, qsq, cov, th
+
+    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: vt,vq,sgm
+
+    REAL, DIMENSION(kts:kte) :: qmq,alp,a,bet,b,ql,q1,cld,RH
+    REAL, DIMENSION(kts:kte), INTENT(OUT) :: qc_bl1D,cldfra_bl1D
+    DOUBLE PRECISION :: t3sq, r3sq, c3sq
+
+    REAL :: qsl,esat,qsat,tlk,qsat_tl,dqsl,cld0,q1k,eq1,qll,&
+         &q2p,pt,rac,qt,t,xl,rsl,cpm,cdhdz,Fng,qww,alpha,beta,bb,ls_min,ls,wt
+    INTEGER :: i,j,k
+
+    REAL :: erf
+
+    !JOE: NEW VARIABLES FOR ALTERNATE SIGMA
+    REAL::dth,dtl,dqw,dzk
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: Sh,el
+
+    !JOE: variables for BL clouds
+    REAL::zagl,cld9,damp,edown,RHcrit,RHmean,RHsum,RHnum,Hshcu,PBLH2,ql_limit
+    REAL, PARAMETER :: Hfac = 3.0     !cloud depth factor for HFX (m^3/W)
+    REAL, PARAMETER :: HFXmin = 50.0  !min W/m^2 for BL clouds
+    REAL            :: RH_00L, RH_00O, phi_dz, lfac
+    REAL, PARAMETER :: cdz = 2.0
+    REAL, PARAMETER :: mdz = 1.5
+
+    !JAYMES:  variables for tropopause-height estimation
+    REAL            :: theta1, theta2, ht1, ht2
+    INTEGER         :: k_tropo
+
+    REAL, PARAMETER :: rr2=0.7071068, rrp=0.3989423
+
+    k_tropo=5
+
+    zagl = 0.
+
+    SELECT CASE(bl_mynn_cloudpdf)
+
+      CASE (0) ! ORIGINAL MYNN PARTIAL-CONDENSATION SCHEME
+
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           !NOTE: negative bl_mynn_cloudpdf will zero-out the stratus subgrid clouds
+           !      at the end of this subroutine.
+           !Sommeria and Deardorff (1977) scheme, as implemented
+           !in Nakanishi and Niino (2009), Appendix B
+           t3sq = MAX( tsq(k), 0.0 )
+           r3sq = MAX( qsq(k), 0.0 )
+           c3sq =      cov(k)
+           c3sq = SIGN( MIN( ABS(c3sq), SQRT(t3sq*r3sq) ), c3sq )
+           r3sq = r3sq +bet(k)**2*t3sq -2.0*bet(k)*c3sq
+           !DEFICIT/EXCESS WATER CONTENT
+           qmq(k) = qw(k) -qsl
+           !ORIGINAL STANDARD DEVIATION: limit e-6 produces ~10% more BL clouds
+           !than e-10
+           sgm(k) = SQRT( MAX( r3sq, 1.0d-10 ))
+           !NORMALIZED DEPARTURE FROM SATURATION
+           q1(k)   = qmq(k) / sgm(k)
+           !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
+           cld(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+
+        END DO
+
+      CASE (1, -1) !ALTERNATIVE FORM (Nakanishi & Niino 2004 BLM, eq. B6, and
+                       !Kuwano-Yoshida et al. 2010 QJRMS, eq. 7):
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           if (k .eq. kts) then
+             dzk = 0.5*dz(k)
+           else
+             dzk = 0.5*( dz(k) + dz(k-1) )
+           end if
+           dth = 0.5*(thl(k+1)+thl(k)) - 0.5*(thl(k)+thl(MAX(k-1,kts)))
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+           sgm(k) = SQRT( MAX( (alp(k)**2 * MAX(el(k)**2,0.1) * &
+                             b2 * MAX(Sh(k),0.03))/4. * &
+                      (dqw/dzk - bet(k)*(dth/dzk ))**2 , 1.0e-10) )
+           qmq(k) = qw(k) -qsl
+           q1(k)   = qmq(k) / sgm(k)
+           cld(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
+        END DO
+
+      CASE (2, -2)
+          !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
+          !JAYMES- this added 27 Apr 2015
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           qsl=ep_2*esat/(p(k)-ep_3*esat)
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
+
+           xl = xl_blend(t)                    ! obtain latent heat
+
+           tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
+           qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
+                                               !   at tl and p
+
+           rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
+                                               ! CB02, Eqn. 4
+
+           cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
+
+           a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
+
+           qmq(k) = a(k) * (qw(k) - qsat_tl) ! saturation deficit/excess;
+                                               !   the numerator of Q1
+
+           b(k) = a(k)*rsl                     ! CB02 variable "b"
+
+           dtl =    0.5*(thl(k+1)*(p(k+1)/p1000mb)**rcp + tlk) &
+               & - 0.5*(tlk + thl(MAX(k-1,kts))*(p(MAX(k-1,kts))/p1000mb)**rcp)
+
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+
+           if (k .eq. kts) then
+             dzk = 0.5*dz(k)
+           else
+             dzk = 0.5*( dz(k) + dz(k-1) )
+           end if
+
+           cdhdz = dtl/dzk + (g/cpm)*(1.+qw(k))  ! expression below Eq. 9
+                                                 ! in CB02
+           zagl = zagl + dz(k)
+           ls_min = MIN(MAX(zagl,25.),300.) ! Let this be the minimum possible length scale:
+                                        !   25 m < ls_min(=zagl) < 300 m
+           lfac=MIN(4.25+dx/4000.,6.)   ! A dx-dependent multiplier for the master length scale:
+                                        !   lfac(750 m) = 4.4
+                                        !   lfac(3 km)  = 5.0
+                                        !   lfac(13 km) = 6.0
+
+           ls = MAX(MIN(lfac*el(k),900.),ls_min)  ! Bounded:  ls_min < ls < 900 m
+                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale.
+                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the
+                   ! MYNN master length scale (el) must exceed 60 m before ls
+                   ! becomes responsive to el, otherwise ls = ls_min = 300 m.
+
+           sgm(k) = MAX(1.e-10, 0.225*ls*SQRT(MAX(0., & ! Eq. 9 in CB02:
+                   & (a(k)*dqw/dzk)**2              & ! < 1st term in brackets,
+                   & -2*a(k)*b(k)*cdhdz*dqw/dzk     & ! < 2nd term,
+                   & +b(k)**2 * cdhdz**2)))           ! < 3rd term
+                   ! CB02 use a multiplier of 0.2, but 0.225 is chosen
+                   ! based on tests
+
+           q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
+
+           cld(k) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
+
+         END DO
+    END SELECT
+
+    zagl = 0.
+    RHsum=0.
+    RHnum=0.
+    RHmean=0.1 !initialize with small value for small PBLH cases
+    damp =0
+    PBLH2=MAX(10.,PBLH1)
+
+    SELECT CASE(bl_mynn_cloudpdf)
+
+      CASE (-1 : 1) ! ORIGINAL MYNN PARTIAL-CONDENSATION SCHEME
+                    ! OR KUWANO ET AL.
+        DO k = kts,kte-1
+           t    = th(k)*exner(k)
+           q1k  = q1(k)
+           zagl = zagl + dz(k)
+           !q1=0.
+           !cld(k)=0.
+
+           !COMPUTE MEAN RH IN PBL (NOT PRESSURE WEIGHTED). 
+           IF (zagl < PBLH2 .AND. PBLH2 > 400.) THEN
+              RHsum=RHsum+RH(k)
+              RHnum=RHnum+1.0
+              RHmean=RHsum/RHnum
+           ENDIF
+           RHcrit = 1. - 0.35*(1.0 - (MAX(250.- MAX(HFX1,HFXmin),0.0)/200.)**2)
+           if (HFX1 > HFXmin) then
+              cld9=MIN(MAX(0., (rh(k)-RHcrit)/(1.1-RHcrit)), 1.)**2
+           else
+              cld9=0.0
+           endif
+
+           edown=PBLH2*.1
+           !Vary BL cloud depth (Hshcu) by mean RH in PBL and HFX
+           !(somewhat following results from Zhang and Klein (2013, JAS))
+           Hshcu=200. + (RHmean+0.5)**1.5*MAX(HFX1,0.)*Hfac
+           if (zagl < PBLH2-edown) then
+              damp=MIN(1.0,exp(-ABS(((PBLH2-edown)-zagl)/edown)))
+           elseif(zagl >= PBLH2-edown .AND. zagl < PBLH2+Hshcu)then
+              damp=1.
+           elseif (zagl >= PBLH2+Hshcu)then
+              damp=MIN(1.0,exp(-ABS((zagl-(PBLH2+Hshcu))/500.)))
+           endif
+           cldfra_bl1D(k)=cld9*damp
+           !cldfra_bl1D(k)=cld(k) ! JAYMES: use this form to retain the Sommeria-Deardorff value
+
+           !use alternate cloud fraction to estimate qc for use in BL clouds-radiation
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cldfra_bl1D(k)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql (k) = alp(k)*sgm(k)*qll
+           if(cldfra_bl1D(k)>0.01 .and. ql(k)<1.E-6)ql(k)=1.E-6
+           qc_bl1D(k)=ql(k)*damp
+           !now recompute estimated lwc for PBL scheme's use
+           !qll IS THE NORMALIZED LIQUID WATER CONTENT (Sommeria and
+           !Deardorff (1977, eq 29a). rrp = 1/(sqrt(2*pi)) = 0.3989
+           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           qll  = MAX( cld(k)*q1k + eq1, 0.0 )
+           !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
+           ql (k) = alp(k)*sgm(k)*qll
+
+           q2p = xlvcp/exner(k)
+           pt = thl(k) +q2p*ql(k) ! potential temp
+
+           !qt is a THETA-V CONVERSION FOR TOTAL WATER (i.e., THETA-V = qt*THETA)
+           qt   = 1.0 +p608*qw(k) -(1.+p608)*ql(k)
+           rac  = alp(k)*( cld(k)-qll*eq1 )*( q2p*qt-(1.+p608)*pt )
+
+           !BUOYANCY FACTORS: wherever vt and vq are used, there is a
+           !"+1" and "+tv0", respectively, so these are subtracted out here.
+           !vt is unitless and vq has units of K.
+           vt(k) =      qt-1.0 -rac*bet(k)
+           vq(k) = p608*pt-tv0 +rac
+
+           !To avoid FPE in radiation driver, when these two quantities are multiplied by eachother,
+           ! add limit to qc_bl and cldfra_bl:
+           IF (QC_BL1D(k) < 1E-6 .AND. ABS(CLDFRA_BL1D(k)) > 0.01) QC_BL1D(k)= 1E-6
+           IF (CLDFRA_BL1D(k) < 1E-2)THEN
+              CLDFRA_BL1D(k)=0.
+              QC_BL1D(k)=0.
+           ENDIF
+
+        END DO
+      CASE ( 2, -2)
+        ! JAYMES- this option added 8 May 2015
+        ! The cloud water formulations are taken from CB02, Eq. 8.
+        ! "fng" represents the non-Gaussian contribution to the liquid
+        ! water flux; these formulations are from Cuijpers and Bechtold
+        ! (1995), Eq. 7.  CB95 also draws from Bechtold et al. 1995,
+        ! hereafter BCMT95
+        DO k = kts,kte-1
+           t    = th(k)*exner(k)
+           q1k  = q1(k)
+           zagl = zagl + dz(k)
+           IF (q1k < 0.) THEN
+              ql (k) = sgm(k)*EXP(1.2*q1k-1)
+           ELSE IF (q1k > 2.) THEN
+              ql (k) = sgm(k)*q1k
+           ELSE
+              ql (k) = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
+           ENDIF
+
+           !Next, adjust our initial estimates of cldfra and ql based
+           !on tropopause-height and PBLH considerations
+           !JAYMES:  added 4 Nov 2016
+           if ((cld(k) .gt. 0.) .or. (ql(k) .gt. 0.))  then
+              if (k .le. k_tropo) then
+                 !At and below tropopause: impose an upper limit on ql; assume that
+                 !a maximum of 0.5 percent supersaturation in water vapor can be
+                 !available for cloud production
+                 ql_limit = 0.005 * qsat_blend( th(k)*exner(k), p(k) )
+                 ql(k) = MIN( ql(k), ql_limit )
+              else
+                 !Above tropopause:  eliminate subgrid clouds from CB scheme
+                 cld(k) = 0.
+                 ql(k) = 0.
+              endif
+           endif
+
+           !Buoyancy-flux-related calculations follow...
+           ! "Fng" represents the non-Gaussian transport factor
+           ! (non-dimensional) from from Bechtold et al. 1995
+           ! (hereafter BCMT95), section 3(c).  Their suggested
+           ! forms for Fng (from their Eq. 20) are:
+           ! For purposes of the buoyancy flux in stratus, we will use Fng = 1
+           Fng = 1.
+
+           xl    = xl_blend(t)
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from
+                             ! "b" in CB02 (i.e., b(k) above) by a factor
+                             ! of T/theta.  Strictly, b(k) above is formulated in
+                             ! terms of sat. mixing ratio, but bb in BCMT95 is
+                             ! cast in terms of sat. specific humidity.  The
+                             ! conversion is neglected here.
+           qww   = 1.+0.61*qw(k)
+           alpha = 0.61*th(k)
+           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+
+           vt(k) = qww   - cld(k)*beta*bb*Fng   - 1.
+           vq(k) = alpha + cld(k)*beta*a(k)*Fng - tv0
+           ! vt and vq correspond to beta-theta and beta-q, respectively,
+           ! in NN09, Eq. B8.  They also correspond to the bracketed
+           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+           ! The "-1" and "-tv0" terms are included for consistency with
+           ! the legacy vt and vq formulations (above).
+
+           ! increase the cloud fraction estimate below PBLH+1km
+           if (zagl .lt. PBLH2+1000.) cld(k) = MIN( 1., 1.8*cld(k) )
+           ! return a cloud condensate and cloud fraction for icloud_bl option:
+           cldfra_bl1D(k) = cld(k)
+           qc_bl1D(k) = ql(k)
+
+           !To avoid FPE in radiation driver, when these two quantities are multiplied by eachother,
+           ! add limit to qc_bl and cldfra_bl:
+           IF (QC_BL1D(k) < 1E-6 .AND. ABS(CLDFRA_BL1D(k)) > 0.01) QC_BL1D(k)= 1E-6
+           IF (CLDFRA_BL1D(k) < 1E-2)THEN
+              CLDFRA_BL1D(k)=0.
+              QC_BL1D(k)=0.
+           ENDIF
+
+         END DO
+
+      END SELECT !end cloudPDF option
+
+      !FOR TESTING PURPOSES ONLY, ISOLATE ON THE MASS-CLOUDS.
+      IF (bl_mynn_cloudpdf .LT. 0) THEN
+         DO k = kts,kte-1
+              cldfra_bl1D(k) = 0.0
+              qc_bl1D(k) = 0.0
+         END DO
+      ENDIF
+
+      cld(kte) = cld(kte-1)
+      ql(kte) = ql(kte-1)
+      vt(kte) = vt(kte-1)
+      vq(kte) = vq(kte-1)
+      qc_bl1D(kte)=0.
+      cldfra_bl1D(kte)=0.
+
+    RETURN
+
+  END SUBROUTINE mym_condensation
+
+! ==================================================================
+
 
 END MODULE module_sf_mynn
+


### PR DESCRIPTION
Toward the effort to unify physics schemes between the MPAS and WRF models, the MYNN surface and PBL schemes were modified to include changes necessary to allow them to run in both models. In areas where the models differ (e.g., in their handling of 'dx'), there are if-defs put around the code to ensure that it's handled correctly for the model in which it is running. Additionally, it was necessary to make some mods to the MPAS PBL driver (mpas_atmphys_driver_pbl.F) to incorporate some of the mods. Results before and after are NOT bit-for-bit, however, as this update includes some updates to the actual physics - in order to bring MPAS physics up-to-date with recently modified WRF physics.