### PR TITLE
Bug fix to the seaice warning system.

### DIFF
--- a/src/core_seaice/column/ice_warnings.F90
+++ b/src/core_seaice/column/ice_warnings.F90
@@ -28,7 +28,7 @@ contains
 
   subroutine add_warning(warning)
 
-    character(len=*), intent(in) :: &
+    character(len=char_len_long), intent(in) :: &
          warning ! warning to add to array of warnings
 
     ! number of array elements to increase size of warnings array if that array has run out of space


### PR DESCRIPTION
Corrects the passing of warnings from the column package.
In stand alone runs on IC machines (grizzly), column warnings failed to write to the sea ice log. 
