### PR TITLE
Fix bug in Dirichlet b.c. and update HO tests

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1440,7 +1440,8 @@ void extendMaskByOneLayer(int const* verticesMask_F,
 void import2DFields(std::map<int, int> bdExtensionMap, double const* bedTopography_F, double const * lowerSurface_F, double const * thickness_F,
     double const * beta_F, double const* stiffnessFactor_F, 
     double const * temperature_F, double const * smb_F, double eps) {
-        
+
+  int vertexLayerShift = (Ordering == 0) ? 1 : nLayers + 1;
   elevationData.assign(nVertices, 1e10);
   thicknessData.assign(nVertices, 1e10);
   bedTopographyData.assign(nVertices, 1e10);
@@ -1551,11 +1552,16 @@ void import2DFields(std::map<int, int> bdExtensionMap, double const* bedTopograp
          // which is unphysical and can cause large slopes and other issues.
          if (bedTopographyData[iV] < 0.0) {
             //std::cout<<"non-floating boundary below sea level at iV="<<iV<<std::endl;
+            if (std::find(dirichletNodesIDs.begin(), dirichletNodesIDs.end(), iV*vertexLayerShift) == dirichletNodesIDs.end()) { // Don't do this if location is a Dirichlet node!
+               //std::cout<<"  non-floating boundary below sea level node is Dirichlet so skipping. iV="<<iV<<std::endl;
+            } else {
+            //for (int i = 0; i < dirichletNodesIDs.size(); i++)
+            //            std::cout << dirichletNodesIDs.at(i) << ' ';  // print entire list of Diri nodes for debugging.
             thicknessData[iV] = eps*2.0; // insert special small value here to make identifying these points easier in exo output
             elevationData[iV] = (rho_ocean / rho_ice - 1.0) * thicknessData[iV];  // floating surface
             betaData[iV] = 0.0; // free slip under floating ice
+            }
          } // if below sea level
-
       }  // floating or not
     } // is boundary
   }  // vertex loop

--- a/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_driver.xml
+++ b/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="setup_and_run_testcase.py">
+        <case name="setup_mesh">
+                <step executable="./setup_mesh.py" quiet="false" pre_message=" * Running setup_mesh step" post_message="     Complete"/>
+        </case>
+        <case name="full_run">
+                <step executable="./full_run.py" quiet="false" pre_message=" * Running full_run step" post_message="     Complete"/>
+        </case>
+        <case name="restart_run">
+                <step executable="./restart_run.py" quiet="false" pre_message=" * Running restart_run step" post_message="     Complete"/>
+        </case>
+        <validation>
+                <compare_fields file1="full_run/output_00000.nc" file2="restart_run/output_00000.nc">
+                        <template file="output_comparison.xml" path_base="script_test_dir"/>
+                </compare_fields>
+        </validation>
+</driver_script>
+

--- a/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_full_run_step.xml
+++ b/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_full_run_step.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<config case="full_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/landice_grid.nc" dest="landice_grid.nc"/>
+        <add_link source="../setup_mesh/graph.info" dest="graph.info"/>
+        <add_link source_path="script_configuration_dir" source="albany_input.xml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <add_executable source="metis" dest="metis"/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_start_time">0000-01-01_00:00:00</option>
+                <option name="config_run_duration">'0002-00-00_00:00:00'</option>
+                <option name="config_dt">'0001-00-00_00:00:00'</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                        <attribute name="reference_time">0000-01-01_00:00:00</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.$M.$D.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <run_script name="full_run.py">
+
+                <!-- Set up needed graph file -->
+                <step executable="./metis" pre_message="\n\n### Creating graph.info.part file\n\n" post_message="\n\n### graph.info.part file creation complete\n\n">
+                        <argument flag="graph.info">4</argument>
+                </step>
+
+                <!-- Run the model -->
+                <model_run procs="4" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+        </run_script>
+</config>
+

--- a/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_restart_run_step.xml
+++ b/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_restart_run_step.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<config case="restart_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/landice_grid.nc" dest="landice_grid.nc"/>
+        <add_link source="../setup_mesh/graph.info" dest="graph.info"/>
+        <add_link source_path="script_configuration_dir" source="albany_input.xml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <add_executable source="metis" dest="metis"/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_start_time">0000-01-01_00:00:00</option>
+                <option name="config_run_duration">'0001-00-00_00:00:00'</option>
+                <option name="config_dt">'0001-00-00_00:00:00'</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+        </namelist>
+
+        <namelist name="namelist.landice.rst" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_start_time">0001-01-01_00:00:00</option>
+                <option name="config_run_duration">'0001-00-00_00:00:00'</option>
+                <option name="config_dt">'0001-00-00_00:00:00'</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.true.</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                        <attribute name="reference_time">0000-01-01_00:00:00</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.$M.$D.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <streams name="streams.landice.rst" keep="immutable" mode="forward">
+                <template file="mismip+_template.xml" path_base="script_configuration_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">overwrite</attribute>
+                        <attribute name="reference_time">0000-01-01_00:00:00</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.$M.$D.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">0001-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+
+        <run_script name="restart_run.py">
+
+                <!-- Set up needed graph file -->
+                <step executable="./metis" pre_message="\n\n### Creating graph.info.part file\n\n" post_message="\n\n### graph.info.part file creation complete\n\n">
+                        <argument flag="graph.info">4</argument>
+                </step>
+
+                <!-- Run the first part of the run -->
+                <model_run procs="4" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+                <!-- Run the restart part of the run -->
+                <model_run procs="4" threads="1" namelist="namelist.landice.rst" streams="streams.landice.rst"/>
+        </run_script>
+</config>
+

--- a/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_setup_mesh_step.xml
+++ b/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/config_setup_mesh_step.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<config case="setup_mesh">
+        <!-- Set up needed files and executables -->
+        <add_executable source="periodic_hex" dest="periodic_grid"/>
+        <add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
+        <add_executable source="cell_culler" dest="MpasCellCuller.x"/>
+        <add_executable source="grid_to_li_grid" dest="create_landice_grid_from_generic_MPAS_grid.py"/>
+        <add_executable source="model" dest="landice_model"/>
+        <add_executable source="metis" dest="metis"/>
+        <add_link source_path="script_configuration_dir" source="cull_cells_for_MISMIP.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="setup_mismip+_initial_conditions.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="setup_mismip+_subdirectories.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="mismip+WriteGL.py" dest="."/> -->
+        <add_link source_path="script_configuration_dir" source="mismip+PlotGL.py" dest="."/> -->
+        <add_link source_path="script_configuration_dir" source="albany_input.xml" dest="."/>
+        <add_link source_path="script_test_dir" source="namelist.input" dest="namelist.input"/>
+        <add_link source_path="work_case_dir" source="culled_graph.info" dest="graph.info"/>
+
+
+
+
+        <run_script name="setup_mesh.py">
+
+                <!-- make base mesh -->
+                <step executable="./periodic_grid" pre_message="\n\n### Creating periodic_hex mesh\n\n" post_message="\n\n### periodic_hex mesh creation complete\n\n">
+                </step>
+
+                <!-- mark cells for culling -->
+                <step executable="./cull_cells_for_MISMIP.py" >
+                        <argument flag="-f">grid.nc</argument>
+                </step>
+
+                <!-- cull cells -->
+                <step executable="./MpasCellCuller.x" >
+                        <argument flag="">grid.nc</argument>
+                        <argument flag="">culled_grid.nc</argument>
+                </step>
+
+                <!-- Convert from basic MPAS mesh to MPASLI mesh -->
+                <step executable="./create_landice_grid_from_generic_MPAS_grid.py" pre_message="\n\n### Creating LI mesh\n\n" post_message="\n\n### LI mesh creation complete\n\n">
+                        <argument flag="-i">culled_grid.nc</argument>
+                        <argument flag="-o">landice_grid.nc</argument>
+                        <argument flag="-l">10</argument>
+                        <argument flag="--diri"></argument>
+                        <argument flag="--beta"></argument>
+                        <argument flag="--thermal"></argument>
+                </step>
+
+                <!-- Set up initial condition on to landice mesh -->
+                <step executable="./setup_mismip+_initial_conditions.py" pre_message="\n\n### Setting up initial condition\n\n" post_message="\n\n### Initial condition setup complete\n\n">
+                        <argument flag="-f">landice_grid.nc</argument>
+                </step>
+
+                <!-- Set up needed graph file -->
+                <step executable="./metis" pre_message="\n\n### Creating graph.info.part file\n\n" post_message="\n\n### graph.info.part file creation complete\n\n">
+                        <argument flag="graph.info">16</argument>
+                </step>
+
+        </run_script>
+
+
+</config>
+

--- a/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/MISMIP+/standard_resolution/restart_test/output_comparison.xml
@@ -1,0 +1,9 @@
+<template>
+        <validation>
+                <compare_fields>
+                        <field name="thickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="surfaceSpeed" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                </compare_fields>
+        </validation>
+</template>
+

--- a/testing_and_setup/compass/landice/circular-shelf/1250m/decomposition_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/circular-shelf/1250m/decomposition_test/output_comparison.xml
@@ -1,9 +1,9 @@
 <template>
         <validation>
                 <compare_fields>
-                        <field name="normalVelocity" l2_norm="1.0e-27"/>
-                        <field name="uReconstructX" l2_norm="2.0e-27"/>
-                        <field name="uReconstructY" l2_norm="1.0e-27"/>
+                        <field name="normalVelocity" l2_norm="1.0e-3"/>
+                        <field name="uReconstructX" l2_norm="1.0e-3"/>
+                        <field name="uReconstructY" l2_norm="1.0e-3"/>
                 </compare_fields>
         </validation>
 </template>

--- a/testing_and_setup/compass/landice/dome/2000m/ho_decomposition_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/dome/2000m/ho_decomposition_test/output_comparison.xml
@@ -1,7 +1,7 @@
 <template>
         <validation>
                 <compare_fields>
-                        <field name="normalVelocity" l2_norm="1.0e-14"/>
+                        <field name="normalVelocity" l2_norm="1.0e-13"/>
                         <!-- HO decomp is not BFB, but should be small -->
                 </compare_fields>
         </validation>

--- a/testing_and_setup/compass/landice/dome/variable_resolution/ho_decomposition_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/dome/variable_resolution/ho_decomposition_test/output_comparison.xml
@@ -1,7 +1,7 @@
 <template>
         <validation>
                 <compare_fields>
-                        <field name="normalVelocity" l2_norm="1.0e-14"/>
+                        <field name="normalVelocity" l2_norm="1.0e-13"/>
                         <!-- HO decomp is not BFB, but should be small -->
                 </compare_fields>
         </validation>

--- a/testing_and_setup/compass/landice/regression_suites/ho_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/ho_integration_test_suite.xml
@@ -28,5 +28,9 @@
                 <script name="setup_and_run_testcase.py"/>
         </test>
 
+        <test name="MISMIP+ restart test" core="landice" configuration="MISMIP+" resolution="standard_resolution" test="restart_test">
+                <script name="setup_and_run_testcase.py"/>
+        </test>
+
 </regression_suite>
 


### PR DESCRIPTION
This merge fixed a bug in Dirichlet boundary conditions, where Dirichlet locations were being ignored at non-floating boundaries below sea level due to a change last year in how b.c. are applied at those locations.  The bug was introduced in bd1d1c012417a3a34c689a6ddddbda2974b03176 (June 2017).

This merge also adds a short test of MISMIP+ to the regression suite to hopefully catch changes to Dirichlet/free-slip boundary conditions.

Finally, this merge decreases the tolerance of higher order decomposition tests to allow those tests to continue being useful as regression tests.
