### PR TITLE
Add variable-resolution gm bolus parameter

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2583,6 +2583,10 @@
 			 description="GM stream function"
 			 packages="forwardMode;analysisMode"
 		/>
+		<var name="gmBolusKappa" type="real" dimensions="nEdges" units="m^2 s^{-1}"
+			 description="GM Bolus Kappa value.  This is constant in time, and set at init based on the constant or ramp fuction."
+			 packages="gm"
+		/>
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of surface fluxes. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -395,22 +395,22 @@
 					description="Control what type of function is used for GM Bolus kappa"
 					possible_values="'constant' and 'ramp'"
 		/>
-		<nml_option name="config_standardGM_tracer_kappa" type="real" default_value="0.0" units="m^2 s^{-1}"
+		<nml_option name="config_standardGM_tracer_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_Bolus_kappa_function is set to constant."
 		/>
 		<nml_option name="config_GM_Bolus_kappa_min" type="real" default_value="0.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Bolus_kappa_max" type="real" default_value="0.0" units="m^2 s^{-1}"
+		<nml_option name="config_GM_Bolus_kappa_max" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Bolus_cell_size_min" type="real" default_value="0.0" units="m"
+		<nml_option name="config_GM_Bolus_cell_size_min" type="real" default_value="20000.0" units="m"
 					description="Minimum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Bolus_cell_size_max" type="real" default_value="0.0" units="m"
+		<nml_option name="config_GM_Bolus_cell_size_max" type="real" default_value="30000.0" units="m"
 					description="Maximum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge"
 					possible_values="Any positive real value."
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1223,6 +1223,7 @@
 		<package name="initMode" description="This package controls variables that are intended to be used within the init run mode of the ocean model."/>
 		<package name="cullCells" description="This package controls variables that provide information on what cells should be culled."/>
 		<package name="tracerBudget" description="This package controls variables that record the tracer budget."/>
+		<package name="gm" description="This package is for GM variables, which are only needed at lower resolutions."/>
 	</packages>
 
 	<streams>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -406,11 +406,11 @@
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Bolus_cell_size_min" type="real" default_value="20000.0" units="m"
+		<nml_option name="config_GM_Bolus_cell_size_min" type="real" default_value="20e3" units="m"
 					description="Minimum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Bolus_cell_size_max" type="real" default_value="30000.0" units="m"
+		<nml_option name="config_GM_Bolus_cell_size_max" type="real" default_value="30e3" units="m"
 					description="Maximum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge"
 					possible_values="Any positive real value."
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -391,8 +391,27 @@
 					description="Vertical component of Redi mixing limited in bottom config_Redi_surface_layer_tapering_depth"
 					possible_values="Any positive real value, typically between 100 and 500 m."
 		/>
+		<nml_option name="config_GM_Bolus_kappa_function" type="character" default_value="constant" units="unitless"
+					description="Control what type of function is used for GM Bolus kappa"
+					possible_values="'constant' and 'ramp'"
+		/>
 		<nml_option name="config_standardGM_tracer_kappa" type="real" default_value="0.0" units="m^2 s^{-1}"
-					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$"
+					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_Bolus_kappa_function is set to constant."
+		/>
+		<nml_option name="config_GM_Bolus_kappa_min" type="real" default_value="0.0" units="m^2 s^{-1}"
+					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_GM_Bolus_kappa_max" type="real" default_value="0.0" units="m^2 s^{-1}"
+					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$, min value in ramp as a function of dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_GM_Bolus_cell_size_min" type="real" default_value="0.0" units="m"
+					description="Minimum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_Bolus_kappa_function is set to ramp."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_GM_Bolus_cell_size_max" type="real" default_value="0.0" units="m"
+					description="Maximum value in grid cell size for GM $kappa$ ramp function.  Here cell size refers to dcEdge"
 					possible_values="Any positive real value."
 		/>
 		<nml_option name="config_Redi_kappa" type="real" default_value="0.0" units="m^2 s^{-1}"

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -121,6 +121,7 @@ module ocn_core_interface
       logical, pointer :: frazilIceActive
       logical, pointer :: inSituEOSActive
       logical, pointer :: variableShortwaveActive
+      logical, pointer :: gmActive
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -143,6 +144,7 @@ module ocn_core_interface
 
       logical, pointer :: config_use_freq_filtered_thickness
       logical, pointer :: config_use_frazil_ice_formation
+      logical, pointer :: config_use_standardGM
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
       character (len=StrKIND), pointer :: config_pressure_gradient_type
@@ -275,6 +277,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_pressure_gradient_type', config_pressure_gradient_type)
       if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
          inSituEOSActive = .true.
+      end if
+
+      !
+      ! test for use of gm
+      !
+      call mpas_pool_get_package(packagePool, 'gmActive', gmActive)
+      call mpas_pool_get_config(configPool, 'config_use_standardGM', config_use_standardGM)
+      if (config_use_standardGM) then
+         gmActive = .true.
       end if
 
       !

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -228,7 +228,7 @@ module ocn_forward_mode
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_short_wave_absorption_init(domain,err_tmp)
       ierr = ior(ierr,err_tmp)
-      call ocn_gm_init(err_tmp)
+      call ocn_gm_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_nonlocalflux_init(err_tmp)
       ierr = ior(ierr,err_tmp)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -739,7 +739,6 @@ contains
       if (.not.config_use_standardGM) return
 
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM',config_use_standardGM)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
       call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_function',config_GM_Bolus_kappa_function)
       call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_min',config_GM_Bolus_kappa_min)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -43,7 +43,6 @@ module ocn_gm
 
    ! Config options
    real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc
-   real (kind=RKIND), pointer :: config_standardGM_tracer_kappa
    real (kind=RKIND), pointer :: config_max_relative_slope
    real (kind=RKIND), pointer :: config_Redi_kappa
    logical, pointer :: config_disable_redi_k33
@@ -717,11 +716,21 @@ contains
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: error flag
+      character (len=StrKIND), pointer :: config_GM_Bolus_kappa_function
+      real (kind=RKIND), pointer :: config_standardGM_tracer_kappa
+      real (kind=RKIND), pointer :: config_GM_Bolus_kappa_min
+      real (kind=RKIND), pointer :: config_GM_Bolus_kappa_max
+      real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_min
+      real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_max
 
       err = 0
 
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
+      call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_min',config_GM_Bolus_kappa_min)
+      call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_max',config_GM_Bolus_kappa_max)
+      call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_cell_size_min',config_GM_Bolus_cell_size_min)
+      call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_cell_size_max',config_GM_Bolus_cell_size_max)
       call mpas_pool_get_config(ocnConfigs, 'config_max_relative_slope',config_max_relative_slope)
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_kappa', config_Redi_kappa)
       call mpas_pool_get_config(ocnConfigs, 'config_disable_redi_k33',config_disable_redi_k33)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -715,6 +715,8 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
+      real (kind=RKIND) :: avgCellDiameter, sqrtPiInv
+
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: diagnosticsPool
@@ -724,11 +726,12 @@ contains
       real (kind=RKIND), pointer :: config_GM_Bolus_kappa_max
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_min
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_max
+      real (kind=RKIND), dimension(:), pointer :: areaCell
 
       integer :: iEdge
       integer, pointer :: nEdges
-      real(kind=RKIND), dimension(:), pointer   :: dcEdge
       real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
+      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOncell, edgeSignOnCell
 
       err = 0
 
@@ -757,8 +760,9 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-         call mpas_pool_get_array(meshPool, 'dcEdge',  dcEdge)
+         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
          ! initialize Bolus kappa array
          if (config_GM_Bolus_kappa_function == 'constant') then
@@ -768,17 +772,19 @@ contains
             end do
             !$omp end do
          else if (config_GM_Bolus_kappa_function == 'ramp') then
+            sqrtPiInv = 1.0_RKIND / sqrt(pii)
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
-               if (dcEdge(iEdge) <= config_GM_Bolus_cell_size_min) then
+               avgCellDiameter = sqrtPiInv*(sqrt(areaCell(cellsOnEdge(1,iEdge))) + sqrt(areaCell(cellsOnEdge(2,iEdge))))
+               if (avgCellDiameter <= config_GM_Bolus_cell_size_min) then
                   gmBolusKappa(iEdge) = config_GM_Bolus_kappa_min
-               else if (dcEdge(iEdge) >= config_GM_Bolus_cell_size_max) then
+               else if (avgCellDiameter >= config_GM_Bolus_cell_size_max) then
                   gmBolusKappa(iEdge) = config_GM_Bolus_kappa_max
                else
                   gmBolusKappa(iEdge) = config_GM_Bolus_kappa_min + &
                       (config_GM_Bolus_kappa_max - config_GM_Bolus_kappa_min) &
                      /(config_GM_Bolus_cell_size_max - config_GM_Bolus_cell_size_min) &
-                     *(dcEdge(iEdge) - config_GM_Bolus_cell_size_min)
+                     *(avgCellDiameter - config_GM_Bolus_cell_size_min)
                end if
             end do
             !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -45,6 +45,7 @@ module ocn_gm
    real (kind=RKIND), pointer :: config_gravWaveSpeed_trunc
    real (kind=RKIND), pointer :: config_max_relative_slope
    real (kind=RKIND), pointer :: config_Redi_kappa
+   logical, pointer :: config_use_standardGM
    logical, pointer :: config_disable_redi_k33
    logical, pointer :: config_use_Redi_surface_layer_tapering
    logical, pointer :: config_use_Redi_bottom_layer_tapering
@@ -102,7 +103,7 @@ contains
          gradZMidTopOfEdge, relativeSlopeTopOfEdge, relativeSlopeTopOfCell, k33, gmStreamFuncTopOfEdge, BruntVaisalaFreqTop, &
          gmStreamFuncTopOfCell, dDensityDzTopOfEdge, dDensityDzTopOfCell, relativeSlopeTapering, relativeSlopeTaperingCell, &
          areaCellSum
-      real(kind=RKIND), dimension(:), pointer   :: boundaryLayerDepth
+      real(kind=RKIND), dimension(:), pointer   :: boundaryLayerDepth, gmBolusKappa
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
       integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell
@@ -135,6 +136,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
       call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
       call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
 
       if (config_use_Redi_surface_layer_tapering) call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', &
           boundaryLayerDepth)
@@ -538,7 +540,7 @@ contains
                           * layerThicknessEdge(k,iEdge)) - BruntVaisalaFreqTopEdge
             tridiagC(k-1) = 2.0_RKIND * config_gravWaveSpeed_trunc**2 / layerThicknessEdge(k, iEdge) &
                           / (layerThicknessEdge(k-1, iEdge) + layerThicknessEdge(k, iEdge))
-            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
+            rightHandSide(k-1) = gmBolusKappa(iEdge) * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
 
             ! Second to next to the last rows
             do k = 3, maxLevelEdgeTop(iEdge)-1
@@ -550,7 +552,7 @@ contains
                              * layerThicknessEdge(k, iEdge) ) - BruntVaisalaFreqTopEdge
                tridiagC(k-1) = 2.0_RKIND * config_gravWaveSpeed_trunc**2 / layerThicknessEdge(k, iEdge) &
                              / (layerThicknessEdge(k-1, iEdge) + layerThicknessEdge(k, iEdge))
-               rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
+               rightHandSide(k-1) = gmBolusKappa(iEdge) * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
             end do
 
             ! Last row
@@ -561,7 +563,7 @@ contains
                           / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge))
             tridiagB(k-1) = - 2.0_RKIND * config_gravWaveSpeed_trunc**2 / (layerThicknessEdge(k-1, iEdge) &
                           * layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-            rightHandSide(k-1) = config_standardGM_tracer_kappa * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
+            rightHandSide(k-1) = gmBolusKappa(iEdge) * gravity / rho_sw * gradDensityConstZTopOfEdge(k,iEdge)
 
             ! Total number of rows
             N = maxLevelEdgeTop(iEdge) - 1
@@ -707,12 +709,15 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_gm_init(err)!{{{
+   subroutine ocn_gm_init(domain, err)!{{{
 
-      type (domain_type) :: domain
+      type (domain_type), intent(in) :: domain
 
       integer, intent(out) :: err !< Output: error flag
 
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: diagnosticsPool
       character (len=StrKIND), pointer :: config_GM_Bolus_kappa_function
       real (kind=RKIND), pointer :: config_standardGM_tracer_kappa
       real (kind=RKIND), pointer :: config_GM_Bolus_kappa_min
@@ -720,14 +725,20 @@ contains
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_min
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_max
 
-      integer                          :: iEdge, nEdges
+      integer :: iEdge
+      integer, pointer :: nEdges
       real(kind=RKIND), dimension(:), pointer   :: dcEdge
       real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
 
       err = 0
 
+      call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM',config_use_standardGM)
+      if (.not.config_use_standardGM) return
+
       call mpas_pool_get_config(ocnConfigs, 'config_gravWaveSpeed_trunc',config_gravWaveSpeed_trunc)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_standardGM',config_use_standardGM)
       call mpas_pool_get_config(ocnConfigs, 'config_standardGM_tracer_kappa',config_standardGM_tracer_kappa)
+      call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_function',config_GM_Bolus_kappa_function)
       call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_min',config_GM_Bolus_kappa_min)
       call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_kappa_max',config_GM_Bolus_kappa_max)
       call mpas_pool_get_config(ocnConfigs, 'config_GM_Bolus_cell_size_min',config_GM_Bolus_cell_size_min)
@@ -740,14 +751,14 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_surface_layer_tapering_extent',config_Redi_surface_layer_tapering_extent)
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_bottom_layer_tapering_depth',config_Redi_bottom_layer_tapering_depth)
 
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_array(meshPool, 'dcEdge',  dcEdge)
-      call mpas_pool_get_array(meshPool, 'gmBolusKappa', gmBolusKappa)
-
-      ! do I need a block loop here? mrp
 
       block => domain % blocklist
       do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+         call mpas_pool_get_array(meshPool, 'dcEdge',  dcEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
 
          ! initialize Bolus kappa array
          if (config_GM_Bolus_kappa_function == 'constant') then
@@ -759,21 +770,21 @@ contains
          else if (config_GM_Bolus_kappa_function == 'ramp') then
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
-               if (dcEdge(iEdge) < config_GM_Bolus_cell_size_min) then
-                  gmBolusKappa(iEdge) = config_GM_Bolus_cell_size_min
-               else if (dcEdge(iEdge) > config_GM_Bolus_cell_size_max) then
-                  gmBolusKappa(iEdge) = config_GM_Bolus_cell_size_max
+               if (dcEdge(iEdge) <= config_GM_Bolus_cell_size_min) then
+                  gmBolusKappa(iEdge) = config_GM_Bolus_kappa_min
+               else if (dcEdge(iEdge) >= config_GM_Bolus_cell_size_max) then
+                  gmBolusKappa(iEdge) = config_GM_Bolus_kappa_max
                else
                   gmBolusKappa(iEdge) = config_GM_Bolus_kappa_min + &
                       (config_GM_Bolus_kappa_max - config_GM_Bolus_kappa_min) &
-                     /(config_GM_Bolus_cell_size_max - config_GM_Bolus_kappa_min) &
-                     *(dcEdge(iEdge) - config_GM_Bolus_kappa_min)
+                     /(config_GM_Bolus_cell_size_max - config_GM_Bolus_cell_size_min) &
+                     *(dcEdge(iEdge) - config_GM_Bolus_cell_size_min)
                end if
             end do
             !$omp end do
          else
             call mpas_log_write( 'Invalid choice of config_GM_Bolus_kappa_function.', MPAS_LOG_CRIT)
-            iErr = 1
+            err = 1
             call mpas_dmpar_finalize(domain % dminfo)
          end if
 

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -709,19 +709,20 @@ contains
 
    subroutine ocn_gm_init(err)!{{{
 
-      !-----------------------------------------------------------------
-      !
-      ! Output Variables
-      !
-      !-----------------------------------------------------------------
+      type (domain_type) :: domain
 
       integer, intent(out) :: err !< Output: error flag
+
       character (len=StrKIND), pointer :: config_GM_Bolus_kappa_function
       real (kind=RKIND), pointer :: config_standardGM_tracer_kappa
       real (kind=RKIND), pointer :: config_GM_Bolus_kappa_min
       real (kind=RKIND), pointer :: config_GM_Bolus_kappa_max
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_min
       real (kind=RKIND), pointer :: config_GM_Bolus_cell_size_max
+
+      integer                          :: iEdge, nEdges
+      real(kind=RKIND), dimension(:), pointer   :: dcEdge
+      real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
 
       err = 0
 
@@ -739,6 +740,45 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_surface_layer_tapering_extent',config_Redi_surface_layer_tapering_extent)
       call mpas_pool_get_config(ocnConfigs, 'config_Redi_bottom_layer_tapering_depth',config_Redi_bottom_layer_tapering_depth)
 
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_array(meshPool, 'dcEdge',  dcEdge)
+      call mpas_pool_get_array(meshPool, 'gmBolusKappa', gmBolusKappa)
+
+      ! do I need a block loop here? mrp
+
+      block => domain % blocklist
+      do while (associated(block))
+
+         ! initialize Bolus kappa array
+         if (config_GM_Bolus_kappa_function == 'constant') then
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               gmBolusKappa(iEdge) = config_standardGM_tracer_kappa
+            end do
+            !$omp end do
+         else if (config_GM_Bolus_kappa_function == 'ramp') then
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               if (dcEdge(iEdge) < config_GM_Bolus_cell_size_min) then
+                  gmBolusKappa(iEdge) = config_GM_Bolus_cell_size_min
+               else if (dcEdge(iEdge) > config_GM_Bolus_cell_size_max) then
+                  gmBolusKappa(iEdge) = config_GM_Bolus_cell_size_max
+               else
+                  gmBolusKappa(iEdge) = config_GM_Bolus_kappa_min + &
+                      (config_GM_Bolus_kappa_max - config_GM_Bolus_kappa_min) &
+                     /(config_GM_Bolus_cell_size_max - config_GM_Bolus_kappa_min) &
+                     *(dcEdge(iEdge) - config_GM_Bolus_kappa_min)
+               end if
+            end do
+            !$omp end do
+         else
+            call mpas_log_write( 'Invalid choice of config_GM_Bolus_kappa_function.', MPAS_LOG_CRIT)
+            iErr = 1
+            call mpas_dmpar_finalize(domain % dminfo)
+         end if
+
+         block => block % next
+      end do
    end subroutine ocn_gm_init!}}}
 
 !***********************************************************************


### PR DESCRIPTION
Currently the GM bolus parameter is a constant.  This adds a ramp function that depends on dcEdge.  Constant remains the default, so this is a bit-for-bit change.

