### PR TITLE
Increase AM dimension from 32 to 36

### DIFF
--- a/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
@@ -1,5 +1,5 @@
 	<dims>
-		<dim name="nLayerVolWeightedAvgFields" definition="32" units="unitless"
+		<dim name="nLayerVolWeightedAvgFields" definition="36" units="unitless"
 			 description="A number equal to or greater than the number of var arrays in the layerVolumeWeightedAverageAM var structure below."
 		/>
 		<dim name="nOceanRegionsTmp" definition="7" units="unitless"

--- a/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
@@ -1,5 +1,5 @@
 	<dims>
-		<dim name="nSfcAreaWeightedAvgFields" definition="32" units="unitless"
+		<dim name="nSfcAreaWeightedAvgFields" definition="36" units="unitless"
 			 description="A number equal to or greater than the number of var arrays in the surfaceAreaWeightedAveragesAM var structure below."
 		/>
 		<dim name="nOceanRegions" definition="7" units="unitless"


### PR DESCRIPTION
This is a bug fix for running with additional flux fields in two analysis members.

