### PR TITLE
Add support for MPAS as a lib used in an external program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,11 +611,11 @@ else
 endif # END IF BUILT CORE CHECK
 
 ifeq "$(SHARELIB)" "true"
-	FFLAGS += "-fPIC"
-	CFLAGS += "-fPIC"
-	CXXFLAGS += "-fPIC"
-	override CPPFLAGS += "-fPIC"
-	LDFLAGS += "-fPIC"
+	FFLAGS += -fPIC
+	CFLAGS += -fPIC
+	CXXFLAGS += -fPIC
+	override CPPFLAGS += -fPIC
+	LDFLAGS += -fPIC
 endif #SHARELIB IF
 
 ifneq ($(wildcard namelist.$(NAMELIST_SUFFIX)), ) # Check for generated namelist file.

--- a/Makefile
+++ b/Makefile
@@ -610,6 +610,14 @@ else
 	CONTINUE=true
 endif # END IF BUILT CORE CHECK
 
+ifeq "$(SHARELIB)" "true"
+	FFLAGS += "-fPIC"
+	CFLAGS += "-fPIC"
+	CXXFLAGS += "-fPIC"
+	override CPPFLAGS += "-fPIC"
+	LDFLAGS += "-fPIC"
+endif #SHARELIB IF
+
 ifneq ($(wildcard namelist.$(NAMELIST_SUFFIX)), ) # Check for generated namelist file.
 	NAMELIST_MESSAGE="A default namelist file (namelist.$(NAMELIST_SUFFIX).defaults) has been generated, but namelist.$(NAMELIST_SUFFIX) has not been modified."
 else

--- a/src/driver/mpas.F
+++ b/src/driver/mpas.F
@@ -14,11 +14,11 @@ program mpas
    type (core_type), pointer :: corelist
    type (domain_type), pointer :: domain_ptr
 
-   call mpas_init(corelist,domain_ptr)
+   call mpas_init(corelist, domain_ptr)
 
    call mpas_run(domain_ptr) 
 
-   call mpas_finalize(corelist,domain_ptr)
+   call mpas_finalize(corelist, domain_ptr)
 
    stop
 

--- a/src/driver/mpas.F
+++ b/src/driver/mpas.F
@@ -11,11 +11,14 @@ program mpas
 
    implicit none
 
-   call mpas_init()
+   type (core_type), pointer :: corelist
+   type (domain_type), pointer :: domain_ptr
 
-   call mpas_run() 
+   call mpas_init(corelist,domain_ptr)
 
-   call mpas_finalize()
+   call mpas_run(domain_ptr) 
+
+   call mpas_finalize(corelist,domain_ptr)
 
    stop
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -154,8 +154,8 @@ module mpas_subdriver
 
       call mpas_allocate_domain(domain_ptr)
 
-      if (present(mpi_comm)) domainID = domainID + 1
-      domain_ptr % domainID = domainID + 1
+      domainID = domainID + 1
+      domain_ptr % domainID = domainID
 
       !
       ! Initialize infrastructure
@@ -362,7 +362,7 @@ module mpas_subdriver
    end subroutine mpas_run
 
 
-   subroutine mpas_finalize(corelist,domain_ptr)
+   subroutine mpas_finalize(corelist, domain_ptr)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
       use mpas_log, only : mpas_log_finalize, mpas_log_info

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -35,14 +35,12 @@ module mpas_subdriver
    use test_core_interface
 #endif
 
-   type (core_type), pointer :: corelist => null()
    type (dm_info), pointer :: dminfo
-   type (domain_type), pointer :: domain_ptr
 
    contains
 
 
-   subroutine mpas_init()
+   subroutine mpas_init(corelist, domain_ptr, mpi_comm)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_init, MPAS_build_stream_filename, MPAS_stream_mgr_validate_streams
       use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
@@ -52,6 +50,10 @@ module mpas_subdriver
       use mpas_log
  
       implicit none
+
+      type (core_type), intent(out), pointer :: corelist
+      type (domain_type), intent(out), pointer :: domain_ptr
+      integer, intent(in), optional :: mpi_comm
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -81,6 +83,7 @@ module mpas_subdriver
       character(len=StrKIND) :: iotype
       logical :: streamsExists
       integer :: mesh_iotype
+      integer, save :: domainID = -1
 
       interface
          subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
@@ -151,10 +154,13 @@ module mpas_subdriver
 
       call mpas_allocate_domain(domain_ptr)
 
+      if (present(mpi_comm)) domainID = domainID + 1
+      domain_ptr % domainID = domainID + 1
+
       !
       ! Initialize infrastructure
       !
-      call mpas_framework_init_phase1(domain_ptr % dminfo)
+      call mpas_framework_init_phase1(domain_ptr % dminfo, mpi_comm)
 
 
 #ifdef CORE_ATMOSPHERE
@@ -338,11 +344,15 @@ module mpas_subdriver
    end subroutine mpas_init
 
 
-   subroutine mpas_run()
+   subroutine mpas_run(domain_ptr)
+      use mpas_log, only: mpas_log_info
 
       implicit none
 
+      type (domain_type), intent(inout), pointer :: domain_ptr
       integer :: iErr
+
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
 
       iErr = domain_ptr % core % core_run(domain_ptr)
       if ( iErr /= 0 ) then
@@ -352,12 +362,15 @@ module mpas_subdriver
    end subroutine mpas_run
 
 
-   subroutine mpas_finalize()
+   subroutine mpas_finalize(corelist,domain_ptr)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
-      use mpas_log, only : mpas_log_finalize
+      use mpas_log, only : mpas_log_finalize, mpas_log_info
 
       implicit none
+
+      type (core_type), intent(inout), pointer :: corelist
+      type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
 
@@ -383,6 +396,8 @@ module mpas_subdriver
       ! Print out log stats and close log file
       !   (Do this after timer stats are printed and stream mgr finalized,
       !    but before framework is finalized because domain is destroyed there.)
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
+
       call mpas_log_finalize(iErr)
       if ( iErr /= 0 ) then
          call mpas_dmpar_global_abort('ERROR: Log finalize failed for core ' // trim(domain_ptr % core % coreName))

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -83,7 +83,7 @@ module mpas_subdriver
       character(len=StrKIND) :: iotype
       logical :: streamsExists
       integer :: mesh_iotype
-      integer, save :: domainID = -1
+      integer, save :: domainID = 0
 
       interface
          subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
@@ -154,8 +154,8 @@ module mpas_subdriver
 
       call mpas_allocate_domain(domain_ptr)
 
-      domainID = domainID + 1
       domain_ptr % domainID = domainID
+      domainID = domainID + 1
 
       !
       ! Initialize infrastructure

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -349,7 +349,9 @@ include 'mpif.h'
 #ifdef _MPI
       integer :: mpi_ierr, mpi_errcode
 
-      call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      if ( dminfo % initialized_mpi ) then
+         call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      end if
 #endif
 
       stop

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -34,4 +34,7 @@
 
       ! Domain_type is a linked list
       type (domain_type), pointer :: next => null()
+
+      ! Unique global ID number for this domain
+      integer :: domainID
    end type domain_type

--- a/src/framework/mpas_io_units.F
+++ b/src/framework/mpas_io_units.F
@@ -21,8 +21,14 @@ module mpas_io_units
 
    use mpas_kind_types
 
-   integer, parameter, private :: maxUnits = 99
-   logical, dimension(0:maxUnits), private, save :: unitsInUse
+   implicit none
+
+   private
+
+   integer, parameter :: maxUnits = 99
+   logical, dimension(0:maxUnits), save :: unitsInUse
+
+   public :: mpas_new_unit, mpas_release_unit
 
    contains
 
@@ -45,6 +51,7 @@ module mpas_io_units
 
         logical :: opened
 
+        newUnit = -1
         do i = 1, maxUnits
             if (.not. unitsInUse(i)) then
                 inquire(i, opened=opened)
@@ -74,7 +81,8 @@ module mpas_io_units
     subroutine mpas_release_unit(releasedUnit)!{{{
         integer, intent(in) :: releasedUnit
 
-        unitsInUse(releasedUnit) = .false.
+        if ( 0 <= releasedUnit .and. releasedUnit <= maxUnits) &
+           unitsInUse(releasedUnit) = .false.
 
     end subroutine mpas_release_unit!}}}
 

--- a/src/framework/mpas_io_units.F
+++ b/src/framework/mpas_io_units.F
@@ -28,7 +28,7 @@ module mpas_io_units
    integer, parameter :: maxUnits = 99
    logical, dimension(0:maxUnits), save :: unitsInUse
    integer, parameter :: unformatted_min = 95
-   integer, parameter :: unformatted_max = 99
+   integer, parameter :: unformatted_max = maxUnits
 
    public :: mpas_new_unit, mpas_release_unit
 
@@ -56,16 +56,13 @@ module mpas_io_units
 
         newUnit = -1
 
-        limit_type = 1
+        minsearch = 1
+        maxsearch = unformatted_min - 1
         if ( present(unformatted) ) then
-           if ( unformatted ) limit_type = 2
-        end if
-        if ( limit_type == 2 ) then
-           minsearch = unformatted_min
-           maxsearch = unformatted_max
-        else
-           minsearch = 1
-           maxsearch = maxUnits
+           if ( unformatted ) then
+              minsearch = unformatted_min
+              maxsearch = unformatted_max
+           end if
         end if
 
         do i = minsearch, maxsearch

--- a/src/framework/mpas_io_units.F
+++ b/src/framework/mpas_io_units.F
@@ -27,6 +27,8 @@ module mpas_io_units
 
    integer, parameter :: maxUnits = 99
    logical, dimension(0:maxUnits), save :: unitsInUse
+   integer, parameter :: unformatted_min = 95
+   integer, parameter :: unformatted_max = 99
 
    public :: mpas_new_unit, mpas_release_unit
 
@@ -44,15 +46,29 @@ module mpas_io_units
 !> the unit number
 !
 !-----------------------------------------------------------------------
-    subroutine mpas_new_unit(newUnit)!{{{
+    subroutine mpas_new_unit(newUnit, unformatted)!{{{
         integer, intent(inout) :: newUnit
+        logical, optional, intent(in) :: unformatted
 
-        integer :: i
+        integer :: i, minsearch, maxsearch, limit_type
 
         logical :: opened
 
         newUnit = -1
-        do i = 1, maxUnits
+
+        limit_type = 1
+        if ( present(unformatted) ) then
+           if ( unformatted ) limit_type = 2
+        end if
+        if ( limit_type == 2 ) then
+           minsearch = unformatted_min
+           maxsearch = unformatted_max
+        else
+           minsearch = 1
+           maxsearch = maxUnits
+        end if
+
+        do i = minsearch, maxsearch
             if (.not. unitsInUse(i)) then
                 inquire(i, opened=opened)
                 if (opened) then

--- a/src/framework/mpas_io_units.F
+++ b/src/framework/mpas_io_units.F
@@ -50,7 +50,7 @@ module mpas_io_units
         integer, intent(inout) :: newUnit
         logical, optional, intent(in) :: unformatted
 
-        integer :: i, minsearch, maxsearch, limit_type
+        integer :: i, minsearch, maxsearch
 
         logical :: opened
 

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -176,10 +176,13 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
-      ! Store the domain number
-      !   This will be used to decide whether to abort MPI
+      ! Store the domain number and initialized_mpi
+      !   This will be used to number the log files
       mpas_log_info % domainID = domain % domainID
       write(domainString, '(i4.4)') mpas_log_info % domainID
+
+      !   This will be used to decide whether to abort MPI
+      mpas_log_info % initialized_mpi = domain % dminfo % initialized_mpi
 
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
@@ -281,8 +284,9 @@ module mpas_log
          mpas_log_info % outputLog % unitNum = unitNumber
          call mpas_new_unit(unitNumber)
          mpas_log_info % errorLog % unitNum = unitNumber
-         if ( unitNumber < 0 ) &
+         if ( unitNumber < 0 ) then
             call mpas_dmpar_global_abort('ERROR: All file units are taken.  Change maxUnits in mpas_io_units.F')
+         end if
 
       endif
 
@@ -432,9 +436,10 @@ module mpas_log
          write(unitNumber, '(a)') '----------------------------------------------------------------------'
          write(unitNumber, '(a,a,a,a,a,i7.1,a,i7.1)') 'Beginning MPAS-', trim(mpas_log_info % coreName), ' ', &
             trim(logTypeString), ' Log File for task ', mpas_log_info % taskID, ' of ', mpas_log_info % nTasks
-         if ( mpas_log_info % domainID > 0 ) &
+         if ( mpas_log_info % domainID > 0 ) then
             write(unitNumber, '(a,i7.1)') &
                ' for domain number ',  mpas_log_info % domainID
+         end if
          call date_and_time(date,time)
          write(unitNumber, '(a)') '    Opened at ' // date(1:4)//'/'//date(5:6)//'/'//date(7:8) // &
             ' ' // time(1:2)//':'//time(3:4)//':'//time(5:6)
@@ -846,8 +851,9 @@ module mpas_log
       deallocate(mpas_log_info)
 
 #ifdef _MPI
-      if ( mpas_log_info % domainID == 0 ) &
+      if ( mpas_log_info % initialized_mpi ) then
          call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+      end if
 #else
       stop
 #endif

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -41,6 +41,7 @@ module mpas_log
 
    use mpas_derived_types
    use mpas_abort, only : mpas_dmpar_global_abort
+   use mpas_io_units
 
    implicit none
    private
@@ -97,8 +98,6 @@ module mpas_log
 
    subroutine mpas_log_init(coreLogInfo, domain, unitNumbers, err)
 
-      use mpas_io_units
-
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -120,6 +119,7 @@ module mpas_log
       ! local variables
       !-----------------------------------------------------------------
       character(len=16) :: taskString  !< variable to build the task number as a string with appropriate zero padding
+      character(len=4) :: domainString  !< variable to store the domain number as a string with appropriate zero padding
       integer :: unitNumber !< local variable used to get a unit number
       character(len=strKind) :: proposedLogFileName, proposedErrFileName
       logical :: isOpen
@@ -176,6 +176,11 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
+      ! Store the domain number
+      !   This will be used to decide whether to abort MPI
+      mpas_log_info % domainID = domain % domainID
+      write(domainString, '(i4.4)') mpas_log_info % domainID
+
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
       !   * Debug build: All tasks active
@@ -209,6 +214,11 @@ module mpas_log
       end if
       write(proposedLogFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".out"
       write(proposedErrFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".err"
+
+      if ( mpas_log_info % domainID > 0 ) then
+         write(proposedLogFileName, fmt='(a, a, a)') trim(proposedLogFileName),".d", trim(domainString)
+         write(proposedErrFileName, fmt='(a, a, a)') trim(proposedErrFileName),".d", trim(domainString)
+      end if
 
       ! Set the log and err file names and unit numbers
       if (present(unitNumbers)) then
@@ -271,6 +281,8 @@ module mpas_log
          mpas_log_info % outputLog % unitNum = unitNumber
          call mpas_new_unit(unitNumber)
          mpas_log_info % errorLog % unitNum = unitNumber
+         if ( unitNumber < 0 ) &
+            call mpas_dmpar_global_abort('ERROR: All file units are taken.  Change maxUnits in mpas_io_units.F')
 
       endif
 
@@ -420,6 +432,9 @@ module mpas_log
          write(unitNumber, '(a)') '----------------------------------------------------------------------'
          write(unitNumber, '(a,a,a,a,a,i7.1,a,i7.1)') 'Beginning MPAS-', trim(mpas_log_info % coreName), ' ', &
             trim(logTypeString), ' Log File for task ', mpas_log_info % taskID, ' of ', mpas_log_info % nTasks
+         if ( mpas_log_info % domainID > 0 ) &
+            write(unitNumber, '(a,i7.1)') &
+               ' for domain number ',  mpas_log_info % domainID
          call date_and_time(date,time)
          write(unitNumber, '(a)') '    Opened at ' // date(1:4)//'/'//date(5:6)//'/'//date(7:8) // &
             ' ' // time(1:2)//':'//time(3:4)//':'//time(5:6)
@@ -694,6 +709,7 @@ module mpas_log
       !   2) the log mgr opened the file (otherwise the driver that opened it should close it)
       if (mpas_log_info % outputLog % isActive .and. mpas_log_info % outputLog % openedByLogModule) then
          close(mpas_log_info % outputLog % unitNum, iostat = err)
+         call mpas_release_unit(mpas_log_info % outputLog % unitNum)
       endif
 
       ! Note: should not need to close an err file.  If these are open, they are intended to quickly lead to abort
@@ -823,13 +839,15 @@ module mpas_log
 
       ! Close the err log to be clean
       close(mpas_log_info % errorLog % unitNum)
+      call mpas_release_unit(mpas_log_info % errorLog % unitNum)
 
       deallocate(mpas_log_info % errorLog)
       deallocate(mpas_log_info % outputLog)
       deallocate(mpas_log_info)
 
 #ifdef _MPI
-      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+      if ( mpas_log_info % domainID == 0 ) &
+         call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
 #else
       stop
 #endif

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -27,6 +27,7 @@
       integer :: nTasks !<  number of total tasks associated with this instance
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
+      integer :: domainID !< domain number for this instance of the log manager
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -28,6 +28,7 @@
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
       integer :: domainID !< domain number for this instance of the log manager
+      logical :: initialized_mpi
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run


### PR DESCRIPTION
This is the first of several PR's for interfacing MPAS with the JEDI data assimilation framework. 
 There are multiple modifications to enable an external program to call top-level MPAS subroutines as part of a shared library, including  (1) the MPI communicator can be initialized and destroyed outside of MPAS, (2) multiple instances of the domain and corelist can be used, and (3) the mpas_log_info pointer is associated with the appropriate domain % logInfo before it is used in lower level subroutines.

The new SHARELIB option in the top-level Makefile enables users to build a shared library with Position Independent Code.

This code has been tested within JEDI with code that will be submitted in several other pull requests (#107 and #108).  There should be no impact to non-JEDI applications, but I have no method to test that fact at this time.

