### PR TITLE
Ocean/fix mld for land ice

### DIFF
--- a/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
+++ b/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
@@ -78,7 +78,7 @@
 		/>
 	</var_struct>
 <var_struct name="mixedLayerDepthAMScratch" time_levs="1">
-▸\▸\<var name="workArrayPressure"
+▸\▸\<var name="pressureAdjustedForLandIceScratch"
 ▸\▸\▸\ persistence="scratch"
 ▸\▸\▸\ type="real"
 ▸\▸\▸\ dimensions="nVertLevels nCells Time"

--- a/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
+++ b/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
@@ -78,7 +78,7 @@
 		/>
 	</var_struct>
 <var_struct name="mixedLayerDepthAMScratch" time_levs="1">
-▸\▸\<var name="pressureAdjustedForLandIceScratch"
+  <var name="pressureAdjustedForLandIceScratch"
 ▸\▸\▸\ persistence="scratch"
 ▸\▸\▸\ type="real"
 ▸\▸\▸\ dimensions="nVertLevels nCells Time"

--- a/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
+++ b/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
@@ -77,7 +77,16 @@
 			 description="mixed layer depth based on gradient of density"
 		/>
 	</var_struct>
-	<streams>
+<var_struct name="mixedLayerDepthAMScratch" time_levs="1">
+▸\▸\<var name="workArrayPressure"
+▸\▸\▸\ persistence="scratch"
+▸\▸\▸\ type="real"
+▸\▸\▸\ dimensions="nVertLevels nCells Time"
+▸\▸\▸\ units="various"
+▸\▸\▸\ description="temporary array to hold pressure " 
+▸\▸\/>
+</var_struct>
+  <streams>
 		<stream name="mixedLayerDepthsOutput" type="output"
 				mode="forward;analysis"
 				filename_template="analysis_members/mixedLayerDepths.$Y-$M-$D.nc"

--- a/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
+++ b/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
@@ -77,16 +77,16 @@
 			 description="mixed layer depth based on gradient of density"
 		/>
 	</var_struct>
-<var_struct name="mixedLayerDepthAMScratch" time_levs="1">
-  <var name="pressureAdjustedForLandIceScratch"
-▸\▸\▸\ persistence="scratch"
-▸\▸\▸\ type="real"
-▸\▸\▸\ dimensions="nVertLevels nCells Time"
-▸\▸\▸\ units="various"
-▸\▸\▸\ description="temporary array to hold pressure " 
-▸\▸\/>
-</var_struct>
-  <streams>
+	<var_struct name="mixedLayerDepthAMScratch" time_levs="1">
+		<var name="pressureAdjustedForLandIceScratch"
+			persistence="scratch"
+			type="real"
+			dimensions="nVertLevels nCells Time"
+			units="various"
+			description="temporary array to hold pressure " 
+		/>
+	</var_struct>
+  	<streams>
 		<stream name="mixedLayerDepthsOutput" type="output"
 				mode="forward;analysis"
 				filename_template="analysis_members/mixedLayerDepths.$Y-$M-$D.nc"

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -177,8 +177,8 @@ contains
       type(field2DReal), pointer :: pressureAdjustedForLandIceField
       real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
-      real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD, landIceDraft
-      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
+      real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
+      real (kind=RKIND), dimension(:), pointer :: dThreshMLD, dGradientMLD, landIcePressure
       integer, dimension(:), pointer :: landIceMask 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       real (kind=RKIND), dimension(:,:), pointer :: zTop, zMid, pressure
@@ -263,7 +263,7 @@ contains
          endif
 
          if(tThresholdFlag) then
-            call mpas_pool_get_array(mixedLayerDepthsAMPool, 'tThreshMLD',tThresholdMLD)
+            call mpas_pool_get_array(mixedLayerDepthsAMPool, 'tThreshMLD',tThreshMLD)
             do iCell = 1,nCellsSolve
 
                !Initialize RefIndex for cases of very shallow columns
@@ -294,26 +294,26 @@ contains
                         call interp_bw_levels(localVals(2),localVals(3), dV, dVp1, tempThresh,     &
                                    interp_local, mldTemp)!,dVm1, localVals(1))
                         mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)
-                        tThresholdMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
+                        tThreshMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
                         found_temp_mld = .true.
                         exit
                      endif
                 enddo
 
 ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
-                   if(.not. found_temp_mld) tThresholdMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
+                   if(.not. found_temp_mld) tThreshMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
                enddo !iCell
 
                if (associated(landIceMask) ) THEN
                   do iCell = 1, nCellsSolve
-                     tThresholdMLD(iCell) = tThresholdMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                   enddo
                endif
 
           endif !end tThresh MLD search
 
          if(dThresholdFlag) then
-            call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD',dThresholdMLD)
+            call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD',dThreshMLD)
 
             do iCell = 1,nCellsSolve
 
@@ -343,7 +343,7 @@ contains
                         call interp_bw_levels(localVals(2),localVals(3), dV, dVp1, denThresh,     &
                                    interp_local, mldTemp)!, dVm1, localVals(1))
                         mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)
-                        dThresholdMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
+                        dThreshMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
                         found_den_mld = .true.
                         exit
                      endif
@@ -351,13 +351,13 @@ contains
 
 ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
 
-                    if(.not. found_den_mld) dThresholdMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
+                    if(.not. found_den_mld) dThreshMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
 
              enddo !iCell
 
              if (associated(landIceMask) ) THEN
                do iCell = 1, nCellsSolve
-                  dThresholdMLD(iCell) = dThresholdMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+                  dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                enddo
 
 

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -162,6 +162,7 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: mixedLayerDepthsAM
       type (mpas_pool_type), pointer :: forcingPool
+      type (mpas_pool_type), pointer :: scratchPool
 
       ! Here are some example variables which may be needed for your analysis member
       integer, pointer :: nVertLevels, nCellsSolve
@@ -173,6 +174,9 @@ contains
       logical,pointer :: tThresholdFlag, dThresholdFlag
       logical,pointer :: tGradientFlag, dGradientFlag
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
+      type(field2DReal), pointer :: workArrayField
+      real (kind=RKIND), dimension(:,:), pointer :: workArray
+
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
       real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
@@ -221,6 +225,12 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAM', mixedLayerDepthsAMPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
+         !Use work array for storing of pressure, potentially modified by landIce
+         call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAMScratch', scratchPool)
+         call mpas_pool_get_field(scratchPool, 'workArrayPressure', workArrayField)
+         call mpas_allocate_scratch_field(workArrayField, .true.)
+         workArray => workArrayField % array
+
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
 
@@ -238,10 +248,13 @@ contains
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
+         workArray(:,:) = pressure(:,:)
          !If landice cavity remove land ice pressure to search for ML depth
          if ( associated(landIcePressure) ) THEN
            do iCell = 1,nCellsSolve
-             pressure(1,iCell) = pressure(1,iCell) - landIcePressure(iCell)
+             do k = 1,maxLevelCell(iCell)
+                workArray(k,iCell) = workArray(k,iCell) - landIcePressure(iCell)
+             enddo
            enddo
          endif
 
@@ -255,9 +268,9 @@ contains
                found_temp_mld = .false.
 
                do k=1, maxLevelCell(iCell)-1
-                  if(pressure(k+1,iCell) > refPress) then
+                  if(workArray(k+1,iCell) > refPress) then
                      localvals(2:3)=tracers(index_temperature,k:k+1,iCell)
-                     localvals(5:6)=pressure(k:k+1,iCell)
+                     localvals(5:6)=workArray(k:k+1,iCell)
 
                      call interp_bw_levels(localVals(2),localVals(3), &
                                    localVals(5),localVals(6),refPress,interp_local,                &
@@ -298,9 +311,9 @@ contains
                found_den_mld = .false.
 
                do k=1, maxLevelCell(iCell)-1
-                  if(pressure(k+1,iCell) > refPress) then
+                  if(workArray(k+1,iCell) > refPress) then
                      localvals(2:3)=potentialDensity(k:k+1,iCell)
-                     localvals(5:6)=pressure(k:k+1,iCell)
+                     localvals(5:6)=workArray(k:k+1,iCell)
 
                      call interp_bw_levels(localVals(2),localVals(3), &
                                    localVals(5),localVals(6),refPress,interp_local,                &
@@ -348,7 +361,7 @@ contains
                found_temp_mld=.false.
 
                do k=2,maxLevelCell(iCell)-1
-                     dz=abs(pressure(k-1,iCell)-pressure(k,iCell))
+                     dz=abs(workArray(k-1,iCell)-workArray(k,iCell))
                      temperatureGradient(k,1) = abs(tracers(index_temperature,k-1,iCell) - tracers(index_temperature,k,iCell)) / dz
                      temperatureGradient(k,2) = k
                enddo
@@ -399,7 +412,7 @@ contains
                found_den_mld=.false.
 
                do k=2,maxLevelCell(iCell)-1
-                     dz=abs(pressure(k-1,iCell)-pressure(k,iCell))
+                     dz=abs(workArray(k-1,iCell)-workArray(k,iCell))
                      densityGradient(k,1) = abs(potentialDensity(k-1,iCell)-potentialDensity(k,iCell)) / dz
                      densityGradient(k,2) = k
                enddo
@@ -434,14 +447,7 @@ contains
          deallocate(densityGradient)
        endif !if(densitygradientflag)
 
-       !If landice cavity add land ice pressure back in for rest of code.
-         if ( associated(landIcePressure) ) THEN
-           do iCell = 1,nCellsSolve
-             pressure(1,iCell) = pressure(1,iCell) + landIcePressure(iCell)
-           enddo
-         endif
-
-
+         call mpas_deallocate_scratch_field(workArrayField, .true.)
          block => block % next
       end do
 

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -174,7 +174,7 @@ contains
       logical,pointer :: tThresholdFlag, dThresholdFlag
       logical,pointer :: tGradientFlag, dGradientFlag
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
-      type(field2DReal), pointer :: workArrayField
+      type(field2DReal), pointer :: pressureAdjustedForLandIceScratchField
       real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
@@ -227,9 +227,9 @@ contains
 
          !Use work array for storing of pressure, potentially modified by landIce
          call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAMScratch', scratchPool)
-         call mpas_pool_get_field(scratchPool, 'workArrayPressure', workArrayField)
-         call mpas_allocate_scratch_field(workArrayField, .true.)
-         pressureAdjustedForLandIce => workArrayField % array
+         call mpas_pool_get_field(scratchPool, 'pressureAdjustedForLandIceScratch', pressureAdjustedForLandIceField)
+         call mpas_allocate_scratch_field(pressureAdjustedForLandIceField, .true.)
+         pressureAdjustedForLandIce => pressureAdjustedForLandIceField % array
 
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
@@ -448,7 +448,7 @@ contains
          deallocate(densityGradient)
        endif !if(densitygradientflag)
 
-         call mpas_deallocate_scratch_field(workArrayField, .true.)
+         call mpas_deallocate_scratch_field(pressureAdjustedForLandIceField, .true.)
          block => block % next
       end do
 

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -437,7 +437,7 @@ contains
        !If landice cavity add land ice pressure back in for rest of code.
          if ( associated(landIcePressure) ) THEN
            do iCell = 1,nCellsSolve
-             pressure(1,iCell) = pressure(1,iCell) - landIcePressure(iCell)
+             pressure(1,iCell) = pressure(1,iCell) + landIcePressure(iCell)
            enddo
          endif
 

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -177,8 +177,9 @@ contains
       type(field2DReal), pointer :: pressureAdjustedForLandIceField
       real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
-      real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
-      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure,modifySSHMask
+      real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD, landIceDraft
+      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
+      integer, dimension(:), pointer :: landIceMask 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       real (kind=RKIND), dimension(:,:), pointer :: zTop, zMid, pressure
       real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
@@ -243,7 +244,8 @@ contains
                         potentialDensity)
          call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'modifySSHMask', modifySSHMask)
+         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
@@ -302,9 +304,9 @@ contains
                    if(.not. found_temp_mld) tThresholdMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
                enddo !iCell
 
-               if (associated(modifySSHMask) ) THEN
+               if (associated(landIceMask) ) THEN
                   do iCell = 1, nCellsSolve
-                     tThresholdMLD(iCell) = tThresholdMLD(iCell) - abs(zTop(1,iCell))*modifySSHMask(iCell)
+                     tThresholdMLD(iCell) = tThresholdMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                   enddo
                endif
 
@@ -355,8 +357,10 @@ contains
 
              if (associated(landIceMask) ) THEN
                do iCell = 1, nCellsSolve
-                  dThresholdMLD(iCell) = dThresholdMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+                  dThresholdMLD(iCell) = dThresholdMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                enddo
+
+
              endif
 
 
@@ -414,7 +418,7 @@ contains
          !normalize MLD to top of ice cavity
          if (associated(landIceMask) ) THEN
            do iCell = 1, nCellsSolve
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
            enddo
          endif
 
@@ -470,7 +474,7 @@ contains
 
          if (associated(landIceMask) ) THEN
            do iCell = 1, nCellsSolve
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
            enddo
          endif
 

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -175,7 +175,7 @@ contains
       logical,pointer :: tGradientFlag, dGradientFlag
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
       type(field2DReal), pointer :: workArrayField
-      real (kind=RKIND), dimension(:,:), pointer :: workArray
+      real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
       real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
@@ -229,7 +229,7 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAMScratch', scratchPool)
          call mpas_pool_get_field(scratchPool, 'workArrayPressure', workArrayField)
          call mpas_allocate_scratch_field(workArrayField, .true.)
-         workArray => workArrayField % array
+         pressureAdjustedForLandIce => workArrayField % array
 
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
@@ -248,12 +248,13 @@ contains
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
-         workArray(:,:) = pressure(:,:)
+         pressureAdjustedForLandIce(:,:) = pressure(:,:)
          !If landice cavity remove land ice pressure to search for ML depth
          if ( associated(landIcePressure) ) THEN
            do iCell = 1,nCellsSolve
              do k = 1,maxLevelCell(iCell)
-                workArray(k,iCell) = workArray(k,iCell) - landIcePressure(iCell)
+                pressureAdjustedForLandIce(k,iCell) = pressureAdjustedForLandIce(k,iCell)   &
+                                                        - landIcePressure(iCell)
              enddo
            enddo
          endif
@@ -268,9 +269,9 @@ contains
                found_temp_mld = .false.
 
                do k=1, maxLevelCell(iCell)-1
-                  if(workArray(k+1,iCell) > refPress) then
+                  if(pressureAdjustedForLandIce(k+1,iCell) > refPress) then
                      localvals(2:3)=tracers(index_temperature,k:k+1,iCell)
-                     localvals(5:6)=workArray(k:k+1,iCell)
+                     localvals(5:6)=pressureAdjustedForLandIce(k:k+1,iCell)
 
                      call interp_bw_levels(localVals(2),localVals(3), &
                                    localVals(5),localVals(6),refPress,interp_local,                &
@@ -311,9 +312,9 @@ contains
                found_den_mld = .false.
 
                do k=1, maxLevelCell(iCell)-1
-                  if(workArray(k+1,iCell) > refPress) then
+                  if(pressureAdjustedForLandIce(k+1,iCell) > refPress) then
                      localvals(2:3)=potentialDensity(k:k+1,iCell)
-                     localvals(5:6)=workArray(k:k+1,iCell)
+                     localvals(5:6)=pressureAdjustedForLandIce(k:k+1,iCell)
 
                      call interp_bw_levels(localVals(2),localVals(3), &
                                    localVals(5),localVals(6),refPress,interp_local,                &
@@ -361,7 +362,7 @@ contains
                found_temp_mld=.false.
 
                do k=2,maxLevelCell(iCell)-1
-                     dz=abs(workArray(k-1,iCell)-workArray(k,iCell))
+                     dz=abs(pressureAdjustedForLandIce(k-1,iCell)-pressureAdjustedForLandIce(k,iCell))
                      temperatureGradient(k,1) = abs(tracers(index_temperature,k-1,iCell) - tracers(index_temperature,k,iCell)) / dz
                      temperatureGradient(k,2) = k
                enddo
@@ -412,7 +413,7 @@ contains
                found_den_mld=.false.
 
                do k=2,maxLevelCell(iCell)-1
-                     dz=abs(workArray(k-1,iCell)-workArray(k,iCell))
+                     dz=abs(pressureAdjustedForLandIce(k-1,iCell)-pressureAdjustedForLandIce(k,iCell))
                      densityGradient(k,1) = abs(potentialDensity(k-1,iCell)-potentialDensity(k,iCell)) / dz
                      densityGradient(k,2) = k
                enddo

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -174,7 +174,7 @@ contains
       logical,pointer :: tThresholdFlag, dThresholdFlag
       logical,pointer :: tGradientFlag, dGradientFlag
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
-      type(field2DReal), pointer :: pressureAdjustedForLandIceScratchField
+      type(field2DReal), pointer :: pressureAdjustedForLandIceField
       real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
@@ -226,7 +226,7 @@ contains
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
          !Use work array for storing of pressure, potentially modified by landIce
-         call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAMScratch', scratchPool)
+         call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthAMScratch', scratchPool)
          call mpas_pool_get_field(scratchPool, 'pressureAdjustedForLandIceScratch', pressureAdjustedForLandIceField)
          call mpas_allocate_scratch_field(pressureAdjustedForLandIceField, .true.)
          pressureAdjustedForLandIce => pressureAdjustedForLandIceField % array

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -178,7 +178,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: pressureAdjustedForLandIce 
 
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
-      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
+      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure,modifySSHMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       real (kind=RKIND), dimension(:,:), pointer :: zTop, zMid, pressure
       real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
@@ -243,6 +243,7 @@ contains
                         potentialDensity)
          call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array(forcingPool, 'modifySSHMask', modifySSHMask)
          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
@@ -300,6 +301,13 @@ contains
 ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
                    if(.not. found_temp_mld) tThresholdMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
                enddo !iCell
+
+               if (associated(modifySSHMask) ) THEN
+                  do iCell = 1, nCellsSolve
+                     tThresholdMLD(iCell) = tThresholdMLD(iCell) - abs(zTop(1,iCell))*modifySSHMask(iCell)
+                  enddo
+               endif
+
           endif !end tThresh MLD search
 
          if(dThresholdFlag) then
@@ -344,6 +352,13 @@ contains
                     if(.not. found_den_mld) dThresholdMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
 
              enddo !iCell
+
+             if (associated(landIceMask) ) THEN
+               do iCell = 1, nCellsSolve
+                  dThresholdMLD(iCell) = dThresholdMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+               enddo
+             endif
+
 
         endif !end dThresh MLD search
 
@@ -396,6 +411,14 @@ contains
 
          enddo !icell
 
+         !normalize MLD to top of ice cavity
+         if (associated(landIceMask) ) THEN
+           do iCell = 1, nCellsSolve
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+           enddo
+         endif
+
+
          deallocate(temperatureGradient)
 
        endif !if(temperaturegradientflag)
@@ -445,13 +468,18 @@ contains
 
          enddo !icell
 
+         if (associated(landIceMask) ) THEN
+           do iCell = 1, nCellsSolve
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(zTop(1,iCell))*landIceMask(iCell)
+           enddo
+         endif
+
          deallocate(densityGradient)
        endif !if(densitygradientflag)
 
          call mpas_deallocate_scratch_field(pressureAdjustedForLandIceField, .true.)
          block => block % next
       end do
-
 
       ! Even though some variables do not include an index that is decomposed amongst
       ! domain partitions, we assign them within a block loop so that all blocks have the

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -161,6 +161,7 @@ contains
       type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: mixedLayerDepthsAM
+      type (mpas_pool_type), pointer :: forcingPool
 
       ! Here are some example variables which may be needed for your analysis member
       integer, pointer :: nVertLevels, nCellsSolve
@@ -173,7 +174,7 @@ contains
       logical,pointer :: tGradientFlag, dGradientFlag
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:), pointer :: tThresholdMLD, tGradientMLD
-      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD
+      real (kind=RKIND), dimension(:), pointer :: dThresholdMLD, dGradientMLD, landIcePressure
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       real (kind=RKIND), dimension(:,:), pointer :: zTop, zMid, pressure
       real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
@@ -216,6 +217,7 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAM', mixedLayerDepthsAMPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
@@ -230,11 +232,18 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
                         potentialDensity)
          call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
+         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
+         !If landice cavity remove land ice pressure to search for ML depth
+         if ( associated(landIcePressure) ) THEN
+           do iCell = 1,nCellsSolve
+             pressure(1,iCell) = pressure(1,iCell) - landIcePressure(iCell)
+           enddo
+         endif
 
          if(tThresholdFlag) then
             call mpas_pool_get_array(mixedLayerDepthsAMPool, 'tThreshMLD',tThresholdMLD)
@@ -424,6 +433,14 @@ contains
 
          deallocate(densityGradient)
        endif !if(densitygradientflag)
+
+       !If landice cavity add land ice pressure back in for rest of code.
+         if ( associated(landIcePressure) ) THEN
+           do iCell = 1,nCellsSolve
+             pressure(1,iCell) = pressure(1,iCell) - landIcePressure(iCell)
+           enddo
+         endif
+
 
          block => block % next
       end do


### PR DESCRIPTION
This fixes MLD for land ice cavities. IN the original code pressure is used to find a reference depth above 10 deci-bars, which does not work under land ice cavities and results in large MLD.  This commit subtracts land ice pressure at the start of the analysis and adds it back at the end.
