### PR TITLE
New Tiedtke Cumulus Scheme Unified with WRFV4.0

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -1,15 +1,3 @@
-!=================================================================================================================
-! copied for implementation in MPAS from WRF version 3.8.1:
-
-! modifications made to sourcecode:
-! * used preprocessing option to replace module_model_constants with mpas_atmphys_constants; used preprocessing
-!   option to include the horizontal dependence of the array znu.
-!   Laura D. Fowler (laura@ucar.edu) / 2016-09-19.
-! * added the three corrections available from module_cu_ntiedtke.F available in the WRF github repository Z(not
-!   in the released version WRF 3.8.1.
-!   Laura D. Fowler (laura@ucar.edu) / 2016-10-18.
-
-!=================================================================================================================
 !-----------------------------------------------------------------------
 !
 !wrf:model_layer:physics
@@ -19,7 +7,7 @@
 !    j.morcrette                    1992
 !--------------------------------------------    
 !    modifications
-!    C. zhang & Yuqing Wang         2011-2014
+!    C. zhang & Yuqing Wang         2011-2017
 !
 !   modified from IPRC IRAM - yuqing wang, university of hawaii
 !               & ICTP REGCM4.4
@@ -41,6 +29,18 @@
 !   other refenrence: tiedtke (1989, mwr, 117, 1779-1800)
 !                     IFS documentation - cy33r1, cy37r2, cy38r1, cy40r1
 !
+!===========================================================
+!  Note for climate simulation of Tropical Cyclones
+!  This version of Tiedtke scheme was tested with YSU PBL scheme, RRTMG radation
+!  schemes, and WSM6 microphysics schemes, at horizontal resolution around 20 km
+!  Set: momtrans = 2. 
+!       pgcoef   = 0.7 to 1.0 is good depends on the basin 
+!       nonequil = .false.
+!===========================================================
+!  Note for the diurnal simulation of precipitaton
+!  When nonequil = .true., the CAPE is relaxed toward to a value from PBL
+!  It can improve the diurnal precipitation over land. 
+!===========================================================
 !###########################################################
 
 module module_cu_ntiedtke
@@ -51,18 +51,19 @@ module module_cu_ntiedtke
    &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, g=>gravity
 #else
      use module_model_constants, only:rd=>r_d, rv=>r_v, &
-   &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, g              
+   &       cpd=>cp, alv=>xlv, als=>xls, alf=>xlf, g
 #endif
 
      implicit none
-     real,private :: rcpd,vtmpc1,tmelt,                &
+     real,private :: t13,rcpd,vtmpc1,tmelt,            &
              c1es,c2es,c3les,c3ies,c4les,c4ies,c5les,c5ies,zrg
 
      real,private :: r5alvcp,r5alscp,ralvdcp,ralsdcp,ralfdcp,rtwat,rtber,rtice 
-     real,private :: entrdd,cmfcmax,cmfcmin,cmfdeps,zdnoprc,cprcon
+     real,private :: entrdd,cmfcmax,cmfcmin,cmfdeps,zdnoprc,cprcon,pgcoef
      integer,private :: momtrans
 
      parameter(         &
+      t13=1.0/3.0,      &
       rcpd=1.0/cpd,     &
       tmelt=273.16,     &
       zrg=1.0/g,        &
@@ -120,11 +121,17 @@ module module_cu_ntiedtke
       parameter(momtrans = 2 )
 !     -------
 !
-      logical :: isequil
-!     isequil: representing equilibrium and nonequilibrium convection
-!     ( .false. [default]; .true. [experimental]. Ref. Bechtold et al. 2014 JAS )
+!     coefficient for pressure gradient intensity
+!     (0.7 - 1.0 is recommended in this vesion of Tiedtke scheme) 
+      parameter(pgcoef=0.7)
+!     -------
+!
+      logical :: nonequil
+!     nonequil: representing equilibrium and nonequilibrium convection
+!     ( .false. [equilibrium: removing all CAPE]; .true. [nonequilibrium: relaxing CAPE toward CAPE from PBL]. 
+!       Ref. Bechtold et al. 2014 JAS )
 ! 
-      parameter(isequil = .true. )
+      parameter(nonequil = .true. )
 !
 !--------------------
 !     switches for deep, mid, shallow convections, downdraft, and momentum transport
@@ -212,8 +219,12 @@ contains
 
       real,    intent(in) ::                                            &
                                         dt
+#if defined(mpas)
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         dx
+#elif defined(wrfmodel)
+      real,    intent(in) ::            dx
+#endif
 
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         xland
@@ -278,7 +289,9 @@ contains
                                         rcs,                            &
                                         rn,                             &
                                         evap,                           &
-                                        heatflux                       
+                                        heatflux,                       &
+                                        dx2d
+
       integer  , dimension(its:ite) ::  slimsk
 
 
@@ -319,7 +332,7 @@ contains
                                         kx1
 
 !-------other local variables----
-      integer                      :: zz
+      integer                      :: zz, pp
 !-----------------------------------------------------------------------
 !
 !
@@ -365,6 +378,16 @@ contains
         slimsk(i)=int(abs(xland(i,j)-2.))
       enddo
 
+#if defined(mpas)
+      do i=its,ite
+         dx2d(i) = dx(i,j)
+      enddo
+#else
+      do i=its,ite
+         dx2d(i) = dx
+      enddo
+#endif
+
       do k=kts,kte
         kp=k+1
         do i=its,ite
@@ -372,8 +395,9 @@ contains
         enddo
       enddo
 
+      pp = 0
       do k=kts,kte
-        zz = kte+1-k
+        zz = kte-pp
         do i=its,ite
           u1(i,zz)=u3d(i,k,j)
           v1(i,zz)=v3d(i,k,j)
@@ -392,14 +416,17 @@ contains
           ghtl(i,zz)=zl(i,k)
           prsl(i,zz) = pcps(i,k,j)
         enddo
+        pp = pp + 1
       enddo
 
+      pp = 0
       do k=kts,kte+1
-        zz = kte+2-k
+        zz = kte+1-pp
         do i=its,ite
           ghti(i,zz) = zi(i,k)
           prsi(i,zz) = p8w(i,k,j) 
         enddo
+        pp = pp + 1
       enddo
 !
       do i=its,ite
@@ -409,41 +436,47 @@ contains
 !
 !########################################################################
       call tiecnvn(u1,v1,t1,q1,q2,q3,q1b,t1b,ghtl,ghti,omg,prsl,prsi,evap,heatflux,  &
-                  rn,slimsk,im,kx,kx1,delt,dx)
+                  rn,slimsk,im,kx,kx1,delt,dx2d)
 
       do i=its,ite
          raincv(i,j)=rn(i)/stepcu
          pratec(i,j)=rn(i)/(stepcu * dt)
       enddo
 
+      pp = 0
       do k=kts,kte
-        zz = kte+1-k
+        zz = kte-pp
         do i=its,ite
           rthcuten(i,k,j)=(t1(i,zz)-t3d(i,k,j))/pi3d(i,k,j)*rdelt
           rqvcuten(i,k,j)=(q1(i,zz)-qv3d(i,k,j))*rdelt
           rucuten(i,k,j) =(u1(i,zz)-u3d(i,k,j))*rdelt
           rvcuten(i,k,j) =(v1(i,zz)-v3d(i,k,j))*rdelt
         enddo
+        pp = pp + 1
       enddo
 
       if(present(rqccuten))then
         if ( f_qc ) then
+          pp = 0
           do k=kts,kte
-            zz = kte+1-k
+            zz = kte-pp
             do i=its,ite
               rqccuten(i,k,j)=(q2(i,zz)-qc3d(i,k,j))*rdelt
             enddo
+            pp = pp + 1
           enddo
         endif
       endif
 
       if(present(rqicuten))then
         if ( f_qi ) then
+          pp = 0
           do k=kts,kte
-            zz = kte+1-k
+            zz = kte-pp
             do i=its,ite
               rqicuten(i,k,j)=(q3(i,zz)-qi3d(i,k,j))*rdelt
             enddo
+            pp = pp + 1
           enddo
         endif
       endif
@@ -670,7 +703,7 @@ contains
      &     pssfc,    ldcum,                              &
      &     ktype,    kcbot,    kctop,    ptu,      pqu,&
      &     plu,      plude,    pmfu,     pmfd,     prain,&
-     &     pcte,     phhfl,    lndj,     zgeoh,   dx)
+     &     pcte,     phhfl,    lndj,     zgeoh,    dx)
       implicit none
 !
 !***cumastrn*  master routine for cumulus massflux-scheme
@@ -998,7 +1031,7 @@ contains
            ztau = max(ztmst,ztau)
            ztau = max(360.,ztau)
            ztau = min(10800.,ztau)
-           if(isequil) then
+           if(nonequil) then
              zcape2(jl)= max(0.,zcape2(jl))
              zcape(jl) = max(0.,min(zcape1(jl)-zcape2(jl),5000.))
            else
@@ -1276,15 +1309,10 @@ contains
               zvu(jl,jk) = (zvu(jl,ik)*pmfu(jl,ik) + &
                 zerate*pven(jl,jk)-zderate*zvu(jl,ik))*zmfa
             else
-              if(ktype(jl) == 1 .or. ktype(jl) == 3) then
-                pgf_u   =  -0.7*0.5*(pmfu(jl,ik)*(puen(jl,ik)-puen(jl,jk))+&
+              pgf_u = -pgcoef*0.5*(pmfu(jl,ik)*(puen(jl,ik)-puen(jl,jk))+&
                                    pmfu(jl,jk)*(puen(jl,jk)-puen(jl,jk-1)))
-                pgf_v   =  -0.7*0.5*(pmfu(jl,ik)*(pven(jl,ik)-pven(jl,jk))+&
+              pgf_v = -pgcoef*0.5*(pmfu(jl,ik)*(pven(jl,ik)-pven(jl,jk))+&
                                    pmfu(jl,jk)*(pven(jl,jk)-pven(jl,jk-1)))
-              else
-                pgf_u   = 0.
-                pgf_v   = 0.
-              end if
               zerate = pmfu(jl,jk) - pmfu(jl,ik) + pmfude_rate(jl,jk)
               zderate = pmfude_rate(jl,jk)
               zmfa = 1./max(cmfcmin,pmfu(jl,jk))
@@ -1629,7 +1657,7 @@ contains
       real     fscale,crirh1,pp
       real     atop1,atop2,abot
       real     tmix,zmix,qmix,pmix
-      real     zlglac,dp,t13
+      real     zlglac,dp
       integer  nk,is,ikb,ikt
 
       real     zqsu,zcor,zdp,zesdp,zalfaw,zfacw,zfaci,zfac,zdsdp,zdqsdt,zdtdp
@@ -1638,8 +1666,6 @@ contains
       integer  jl,jk,ik,icall,levels
       logical  needreset, lldcum(klon)
 !--------------------------------------------------------------
-      t13 = 1.0/3.0
-!
       do jl=1,klon
         kcbot(jl)=klev
         kctop(jl)=klev
@@ -1795,10 +1821,12 @@ contains
             else
               lldcum(jl) = .false.
             end if
-          else if(plu(jl,jk) .gt. 0.)then
+          else 
+            if(plu(jl,jk) .gt. 0.)then
               klab(jl,jk)=2
-          else
+            else
               klab(jl,jk)=1
+            end if
           end if
         end if
       end do
@@ -1856,7 +1884,7 @@ contains
        end do
       end do
 
-      do levels=klevm1-1,klev/2,-1 ! loop starts
+      do levels=klevm1-1,klev/2+1,-1 ! loop starts
         do jk=1,klev
           do jl=1,klon
              plu(jl,jk)=0.0  ! parcel liquid water
@@ -2014,10 +2042,12 @@ contains
             else
               lldcum(jl) = .false.
             end if
-          else if(plu(jl,jk) .gt. 0.)then
+          else 
+            if(plu(jl,jk) .gt. 0.)then
               klab(jl,jk)=2
-          else
+            else
               klab(jl,jk)=1
+            end if
           end if
         end if
       end do
@@ -2457,7 +2487,7 @@ contains
                 plude(jl,jk) = plu(jl,jk+1)*zdmfde(jl)
                 pmfu(jl,jk) = pmfu(jl,jk+1) + zdmfen(jl) - zdmfde(jl)
               end if
-              if ( zbuo(jl,jk) > 0.  ) then
+              if ( zbuo(jl,jk) > -0.2  ) then
                 ikb = kcbot(jl)
                 zoentr(jl) = 1.75e-3*(0.3-(min(1.,pqen(jl,jk-1) /    &
                   pqsen(jl,jk-1))-1.))*(pgeoh(jl,jk-1)-pgeoh(jl,jk)) * &
@@ -2505,7 +2535,6 @@ contains
               zdshrd = 3.e-4
             end if
             ikb=kcbot(jl)
-!            if((paph(jl,ikb)-paph(jl,jk))>zdnoprc) then
             if ( plu(jl,jk) > zdshrd )then
               zwu = min(15.0,sqrt(2.*max(0.1,kup(jl,jk+1))))
               zprcon = zprcdgw/(0.75*zwu)
@@ -3383,8 +3412,6 @@ contains
 ! local variables
     integer  jk , ik , jl
     real     zalv , zzp
-    real     zmfus(klon,klev) , zmfuq(klon,klev) 
-    real     zmfds(klon,klev) , zmfdq(klon,klev)
     real     zdtdt(klon,klev) , zdqdt(klon,klev) , zdp(klon,klev)
     !*    1.0          SETUP AND INITIALIZATIONS
     ! -------------------------
@@ -3392,10 +3419,6 @@ contains
       do jl = 1, klon
         if ( ldcum(jl) ) then
           zdp(jl,jk) = g/(paph(jl,jk+1)-paph(jl,jk))
-          zmfus(jl,jk) = pmfus(jl,jk)
-          zmfds(jl,jk) = pmfds(jl,jk)
-          zmfuq(jl,jk) = pmfuq(jl,jk)
-          zmfdq(jl,jk) = pmfdq(jl,jk)
         end if
       end do
     end do
@@ -3408,11 +3431,11 @@ contains
           if ( ldcum(jl) ) then
             zalv = foelhm(pten(jl,jk))
             zdtdt(jl,jk) = zdp(jl,jk)*rcpd * &
-              (zmfus(jl,jk+1)-zmfus(jl,jk)+zmfds(jl,jk+1) - &
-               zmfds(jl,jk)+alf*plglac(jl,jk)-alf*pdpmel(jl,jk) - &
+              (pmfus(jl,jk+1)-pmfus(jl,jk)+pmfds(jl,jk+1) - &
+               pmfds(jl,jk)+alf*plglac(jl,jk)-alf*pdpmel(jl,jk) - &
                zalv*(pmful(jl,jk+1)-pmful(jl,jk)-plude(jl,jk)-pdmfup(jl,jk)-pdmfdp(jl,jk)))
-            zdqdt(jl,jk) = zdp(jl,jk)*(zmfuq(jl,jk+1) - &
-              zmfuq(jl,jk)+zmfdq(jl,jk+1)-zmfdq(jl,jk)+pmful(jl,jk+1) - &
+            zdqdt(jl,jk) = zdp(jl,jk)*(pmfuq(jl,jk+1) - &
+              pmfuq(jl,jk)+pmfdq(jl,jk+1)-pmfdq(jl,jk)+pmful(jl,jk+1) - &
               pmful(jl,jk)-plude(jl,jk)-pdmfup(jl,jk)-pdmfdp(jl,jk))
           end if
         end do
@@ -3421,10 +3444,10 @@ contains
           if ( ldcum(jl) ) then
             zalv = foelhm(pten(jl,jk))
             zdtdt(jl,jk) = -zdp(jl,jk)*rcpd * &
-              (zmfus(jl,jk)+zmfds(jl,jk)+alf*pdpmel(jl,jk) - &
-               zalv*(pmful(jl,jk)+pdmfup(jl,jk)+pdmfdp(jl,jk)))
-            zdqdt(jl,jk) = -zdp(jl,jk)*(zmfuq(jl,jk) + &
-              zmfdq(jl,jk)+(pmful(jl,jk)+pdmfup(jl,jk)+pdmfdp(jl,jk)))
+              (pmfus(jl,jk)+pmfds(jl,jk)+alf*pdpmel(jl,jk) - &
+               zalv*(pmful(jl,jk)+pdmfup(jl,jk)+pdmfdp(jl,jk)+plude(jl,jk)))
+            zdqdt(jl,jk) = -zdp(jl,jk)*(pmfuq(jl,jk) + plude(jl,jk) + &
+              pmfdq(jl,jk)+(pmful(jl,jk)+pdmfup(jl,jk)+pdmfdp(jl,jk)))
           end if
         end do
       end if
@@ -3858,3 +3881,4 @@ contains
       end function  foeldcpm
 
 end module module_cu_ntiedtke
+


### PR DESCRIPTION
Toward the effort to unify physics schemes between the MPAS and WRF models, the New Tiedtke routine was modified to include changes necessary to allow it to run in both models. In areas where the models differ (e.g., in their handling of 'dx'), there are if-defs put around the code to ensure that it's handled correctly for the model in which it is running. Results before and after are NOT bit-for-bit, however, as this update includes some updates to the actual physics. The original MPAS version of New Tiedtke was updated to V3.8.1 of WRF, and then was modified by @weiwangncar to update to WRFV3.9. The mods I made stemmed from those.
