### PR TITLE
Fix parallel build of MPAS-A physics

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -48,7 +48,7 @@ OBJS = \
 lookup_tables:
 	./checkout_data_files.sh
 
-core_physics_wrf:
+core_physics_wrf: core_physics_init
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)


### PR DESCRIPTION
This merge adds a missing dependency in the MPAS-A physics Makefile to fix
parallel builds.

The 'all' target in the src/core_atmosphere/physics/Makefile depends on both
'core_physics_wrf' and 'core_physics_init', among others. 'make' can choose
to process these in any order (subject to dependencies), so it could happen that
'core_physics_wrf' was processed in parallel with 'core_physics_init'. However,
some objects in 'core_physics_wrf' depend on objects in 'core_physics_init'
(e.g., module_mp_radar.F depends on mpas_atmphys_utilities.F), so we need to add
a dependency on 'core_physics_init' to the 'core_physics_wrf' target to ensure
correct parallel builds.