### PR TITLE
add constant for E3SM coupled simulation (follow up on PR#63) 

### DIFF
--- a/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
@@ -84,8 +84,9 @@
 !tcx note cice snowpatch = 0.02
 
       integer (kind=int_kind), parameter :: & 
-         nspint = 3                ! number of solar spectral intervals
-                    
+         nspint = 3             ,& ! number of solar spectral intervals
+         nspint_5bd = 5            ! number of solar spectral intervals with config_use_snicar           
+      
       ! weights for albedos 
       ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
       ! in a summer polar atmosphere with 1.5m bare sea ice surface:


### PR DESCRIPTION
This merge is a follow-up to the Pull Request #63 snow/sea ice shortwave radiative transfer harmonization. The new parameter nspint_5bd is added to cime constant file, which is needed for E3SM coupled simulation.