### PR TITLE
Data iceberg forcing restart bug fix.

### DIFF
--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -582,6 +582,7 @@ module seaice_core_interface
 
      logical, pointer :: &
           config_use_forcing, &
+          config_use_data_icebergs, &
           config_testing_system_test, &
           config_use_snicar
 
@@ -597,11 +598,12 @@ module seaice_core_interface
      ! pkgForcing
 
      call MPAS_pool_get_config(configPool, "config_use_forcing", config_use_forcing)
+     call MPAS_pool_get_config(configPool, "config_use_data_icebergs", config_use_data_icebergs)
 
      call MPAS_pool_get_package(packagePool, "pkgForcingActive", pkgForcingActive)
 
      ! see if we are using the forcing system
-     if (config_use_forcing) then
+     if (config_use_forcing .or. config_use_data_icebergs) then
 
         pkgForcingActive = .true.
 

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -345,9 +345,7 @@ contains
 
        call data_iceberg_forcing(&
             streamManager, &
-            domain, &
-            simulationClock, &
-            firstTimeStep)
+            domain)
 
     endif
 
@@ -1700,21 +1698,16 @@ contains
 
   subroutine data_iceberg_forcing(&
        streamManager, &
-       domain, &
-       simulationClock, &
-       firstTimeStep)
+       domain)
 
     type (MPAS_streamManager_type), intent(inout) :: streamManager
 
     type (domain_type) :: domain
 
-    type (MPAS_clock_type) :: simulationClock
-
-    logical, intent(in) :: firstTimeStep
-
     type (MPAS_time_type) :: currentForcingTime
 
-    character(len=strKIND) :: currentForcingTimeStr
+    ! for debugging
+    ! character(len=strKIND) :: currentForcingTimeStr
 
     logical, pointer :: &
          config_do_restart
@@ -1723,7 +1716,6 @@ contains
          config_dt
 
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
-    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
     ! get the current time
     call MPAS_forcing_get_forcing_time(&
@@ -1731,8 +1723,9 @@ contains
        "seaice_data_iceberg_forcing_monthly", &
        currentForcingTime)
 
-    call MPAS_get_time(currentForcingTime, dateTimeString=currentForcingTimeStr)
-    call MPAS_log_write('Get Data icebergs at: '//trim(currentForcingTimeStr))
+    ! for debugging
+    ! call MPAS_get_time(currentForcingTime, dateTimeString=currentForcingTimeStr)
+    ! call MPAS_log_write('Get Data icebergs at: '//trim(currentForcingTimeStr))
 
     ! use the forcing layer to get
     call MPAS_forcing_get_forcing(&

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1704,9 +1704,8 @@ contains
 
     type (domain_type) :: domain
 
-    type (MPAS_time_type) :: currentForcingTime
-
     ! for debugging
+    ! type (MPAS_time_type) :: currentForcingTime
     ! character(len=strKIND) :: currentForcingTimeStr
 
     logical, pointer :: &
@@ -1717,13 +1716,13 @@ contains
 
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
 
-    ! get the current time
-    call MPAS_forcing_get_forcing_time(&
-       seaiceForcingGroups, &
-       "seaice_data_iceberg_forcing_monthly", &
-       currentForcingTime)
-
     ! for debugging
+    ! ! get the current time
+    ! call MPAS_forcing_get_forcing_time(&
+    !    seaiceForcingGroups, &
+    !    "seaice_data_iceberg_forcing_monthly", &
+    !    currentForcingTime)
+
     ! call MPAS_get_time(currentForcingTime, dateTimeString=currentForcingTimeStr)
     ! call MPAS_log_write('Get Data icebergs at: '//trim(currentForcingTimeStr))
 

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1704,20 +1704,19 @@ contains
 
     type (domain_type) :: domain
 
-    ! for debugging
+    ! Arguments for verbose debugging
     ! type (MPAS_time_type) :: currentForcingTime
     ! character(len=strKIND) :: currentForcingTimeStr
-
-    logical, pointer :: &
-         config_do_restart
 
     real(kind=RKIND), pointer :: &
          config_dt
 
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
 
-    ! for debugging
-    ! ! get the current time
+    ! For verbose debugging.
+    ! Uncomment the lines below and the arguments above to print the forcing time
+    ! to the log file, to ensure the forcing times match the simulation times.
+
     ! call MPAS_forcing_get_forcing_time(&
     !    seaiceForcingGroups, &
     !    "seaice_data_iceberg_forcing_monthly", &

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -1640,7 +1640,6 @@ contains
          forcingIntervalMonthly, &
          forcingReferenceTimeMonthly
 
-    ! type (MPAS_clock_type) :: simulationClock
     type (MPAS_Time_Type) :: currTime
     character(len=strKIND) :: timeStamp
     integer :: ierr
@@ -1651,7 +1650,6 @@ contains
     forcingIntervalMonthly = "00-01-00_00:00:00"
     forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
 
-!    currTime = mpas_get_clock_time(simulationClock, MPAS_NOW, ierr)
     currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
     call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
     timeStamp = '0000'//trim(timeStamp(5:))
@@ -1710,7 +1708,7 @@ contains
 
     type (domain_type) :: domain
 
-    type (MPAS_clock_type) :: simulationClock ! dc is this being used?
+    type (MPAS_clock_type) :: simulationClock
 
     logical, intent(in) :: firstTimeStep
 
@@ -1729,8 +1727,8 @@ contains
 
     ! get the current time
     call MPAS_forcing_get_forcing_time(&
-        seaiceForcingGroups, &
-        "seaice_data_iceberg_forcing_monthly", &
+       seaiceForcingGroups, &
+       "seaice_data_iceberg_forcing_monthly", &
        currentForcingTime)
 
     call MPAS_get_time(currentForcingTime, dateTimeString=currentForcingTimeStr)

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -346,7 +346,8 @@ contains
        call data_iceberg_forcing(&
             streamManager, &
             domain, &
-            simulationClock)
+            simulationClock, &
+            firstTimeStep)
 
     endif
 
@@ -1639,10 +1640,10 @@ contains
          forcingIntervalMonthly, &
          forcingReferenceTimeMonthly
 
-!     type (MPAS_clock_type) :: simulationClock
-     type (MPAS_Time_Type) :: currTime
-     character(len=strKIND) :: timeStamp
-     integer :: ierr
+    ! type (MPAS_clock_type) :: simulationClock
+    type (MPAS_Time_Type) :: currTime
+    character(len=strKIND) :: timeStamp
+    integer :: ierr
 
     ! get configuration options
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
@@ -1702,7 +1703,8 @@ contains
   subroutine data_iceberg_forcing(&
        streamManager, &
        domain, &
-       simulationClock)
+       simulationClock, &
+       firstTimeStep)
 
     type (MPAS_streamManager_type), intent(inout) :: streamManager
 
@@ -1710,12 +1712,31 @@ contains
 
     type (MPAS_clock_type) :: simulationClock ! dc is this being used?
 
+    logical, intent(in) :: firstTimeStep
+
+    type (MPAS_time_type) :: currentForcingTime
+
+    character(len=strKIND) :: currentForcingTimeStr
+
+    logical, pointer :: &
+         config_do_restart
+
     real(kind=RKIND), pointer :: &
          config_dt
 
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
-    ! use the forcing layer to get data
+    ! get the current time
+    call MPAS_forcing_get_forcing_time(&
+        seaiceForcingGroups, &
+        "seaice_data_iceberg_forcing_monthly", &
+       currentForcingTime)
+
+    call MPAS_get_time(currentForcingTime, dateTimeString=currentForcingTimeStr)
+    call MPAS_log_write('Get Data icebergs at: '//trim(currentForcingTimeStr))
+
+    ! use the forcing layer to get
     call MPAS_forcing_get_forcing(&
        seaiceForcingGroups, &
        "seaice_data_iceberg_forcing_monthly", &
@@ -2087,11 +2108,13 @@ contains
     type(domain_type) :: domain
 
     logical, pointer :: &
-         config_use_forcing
+         config_use_forcing, &
+         config_use_data_icebergs
 
     call MPAS_pool_get_config(domain % configs, "config_use_forcing", config_use_forcing)
+    call MPAS_pool_get_config(domain % configs, "config_use_data_icebergs", config_use_data_icebergs)
 
-    if (config_use_forcing) then
+    if (config_use_forcing .or. config_use_data_icebergs) then
 
        call MPAS_forcing_write_restart_times(seaiceForcingGroups)
 

--- a/src/core_seaice/shared/mpas_seaice_forcing.F
+++ b/src/core_seaice/shared/mpas_seaice_forcing.F
@@ -13,6 +13,8 @@
 
 module seaice_forcing
 
+  use mpas_kind_types
+  use mpas_timer
   use mpas_derived_types
   use mpas_pool_routines
   use mpas_timekeeping
@@ -63,9 +65,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_forcing_init(domain)
+  subroutine seaice_forcing_init(domain, clock)
 
     type (domain_type) :: domain
+
+    type (MPAS_Clock_type) :: clock
 
     logical, pointer :: &
          config_use_forcing, &
@@ -85,7 +89,7 @@ contains
     endif
 
     ! init the data iceberg forcing
-    if (config_use_data_icebergs) call init_data_iceberg_forcing(domain)
+    if (config_use_data_icebergs) call init_data_iceberg_forcing(domain, clock)
 
   end subroutine seaice_forcing_init
 
@@ -1622,9 +1626,11 @@ contains
 !>
 !-----------------------------------------------------------------------
 
-  subroutine init_data_iceberg_forcing(domain)
+  subroutine init_data_iceberg_forcing(domain, clock)
 
     type (domain_type) :: domain
+
+    type (MPAS_Clock_type) :: clock
 
     logical, pointer :: &
          config_do_restart
@@ -1633,18 +1639,28 @@ contains
          forcingIntervalMonthly, &
          forcingReferenceTimeMonthly
 
+!     type (MPAS_clock_type) :: simulationClock
+     type (MPAS_Time_Type) :: currTime
+     character(len=strKIND) :: timeStamp
+     integer :: ierr
+
     ! get configuration options
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
     forcingIntervalMonthly = "00-01-00_00:00:00"
     forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
 
+!    currTime = mpas_get_clock_time(simulationClock, MPAS_NOW, ierr)
+    currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
+    call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
+    timeStamp = '0000'//trim(timeStamp(5:))
+
     ! create own data iceberg forcing group
     call MPAS_forcing_init_group(&
          seaiceForcingGroups, &
          "seaice_data_iceberg_forcing_monthly", &
          domain, &
-         '0000-01-01_00:00:00', &
+         timeStamp, &
          '0000-01-01_00:00:00', &
          '0001-00-00_00:00:00', &
          config_do_restart)

--- a/src/core_seaice/shared/mpas_seaice_initialize.F
+++ b/src/core_seaice/shared/mpas_seaice_initialize.F
@@ -96,7 +96,7 @@ contains
 
     ! initialize forcing
     call mpas_log_write(" Initialize forcing...")
-    call seaice_forcing_init(domain)
+    call seaice_forcing_init(domain, clock)
 
     ! init dynamics
     call mpas_log_write(" Initialize velocity solver...")


### PR DESCRIPTION
The current implementation of data icebergs passes testing in MPAS-Seaice standalone, including restartability, however in E3SM the model dies on a restart initialization due to data icebergs. Compsets without data icebergs active do not seem to be affected.

This PR is a work-in-progress, opened for visibility. Currently this branch passes testing in MPAS-Seaice standalone, runs in E3SM for an initial run, and fails on a restart run.

