### PR TITLE
PIO version compatibility check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,32 +424,51 @@ llvm:
 CPPINCLUDES = 
 FCINCLUDES = 
 LIBS = 
-ifneq ($(wildcard $(PIO)/lib), ) # Check for newer PIO version
+
+#
+# If user has indicated a PIO2 library, define USE_PIO2 pre-processor macro
+#
 ifeq "$(USE_PIO2)" "true"
-	FCINCLUDES = -I$(PIO)/include
 	override CPPFLAGS += -DUSE_PIO2
-	LIBS = -L$(PIO)/lib -lpiof -lpioc
-ifneq ($(wildcard $(PIO)/lib/libgptl.a), ) # Check for GPTL library for PIO2
+endif
+
+#
+# Regardless of PIO library version, look for a lib subdirectory of PIO path
+# NB: PIO_LIB is used later, so we don't just set LIBS directly
+#
+ifneq ($(wildcard $(PIO)/lib), )
+	PIO_LIB = $(PIO)/lib
+else
+	PIO_LIB = $(PIO)
+endif
+LIBS = -L$(PIO_LIB)
+
+#
+# Regardless of PIO library version, look for an include subdirectory of PIO path
+#
+ifneq ($(wildcard $(PIO)/include), )
+	CPPINCLUDES += -I$(PIO)/include
+	FCINCLUDES += -I$(PIO)/include
+else
+	CPPINCLUDES += -I$(PIO)
+	FCINCLUDES += -I$(PIO)
+endif
+
+#
+# Depending on PIO version, libraries may be libpio.a, or libpiof.a and libpioc.a
+# Keep open the possibility of shared libraries in future with, e.g., .so suffix
+#
+ifneq ($(wildcard $(PIO_LIB)/libpio\.*), )
+	LIBS += -lpio
+endif
+ifneq ($(wildcard $(PIO_LIB)/libpiof\.*), )
+	LIBS += -lpiof
+endif
+ifneq ($(wildcard $(PIO_LIB)/libpioc\.*), )
+	LIBS += -lpioc
+endif
+ifneq ($(wildcard $(PIO_LIB)/libgptl\.*), )
 	LIBS += -lgptl
-endif
-else
-	CPPINCLUDES = -I$(PIO)/include
-	FCINCLUDES = -I$(PIO)/include
-	LIBS = -L$(PIO)/lib -lpio
-endif
-else
-ifeq "$(USE_PIO2)" "true"
-	FCINCLUDES = -I$(PIO)/include
-	override CPPFLAGS += -DUSE_PIO2
-	LIBS = -L$(PIO) -lpiof -lpioc
-ifneq ($(wildcard $(PIO)/libgptl.a), ) # Check for GPTL library for PIO2
-	LIBS += -lgptl
-endif
-else
-	CPPINCLUDES = -I$(PIO)
-	FCINCLUDES = -I$(PIO)
-	LIBS = -L$(PIO) -lpio
-endif
 endif
 
 ifneq "$(PNETCDF)" ""

--- a/Makefile
+++ b/Makefile
@@ -471,12 +471,6 @@ ifneq ($(wildcard $(PIO_LIB)/libgptl\.*), )
 	LIBS += -lgptl
 endif
 
-ifneq "$(PNETCDF)" ""
-	CPPINCLUDES += -I$(PNETCDF)/include
-	FCINCLUDES += -I$(PNETCDF)/include
-	LIBS += -L$(PNETCDF)/lib -lpnetcdf
-endif
-
 ifneq "$(NETCDF)" ""
 	CPPINCLUDES += -I$(NETCDF)/include
 	FCINCLUDES += -I$(NETCDF)/include
@@ -492,6 +486,13 @@ ifneq "$(NETCDF)" ""
 		LIBS += $(NCLIBF)
 	endif
 	LIBS += $(NCLIB)
+endif
+
+
+ifneq "$(PNETCDF)" ""
+	CPPINCLUDES += -I$(PNETCDF)/include
+	FCINCLUDES += -I$(PNETCDF)/include
+	LIBS += -L$(PNETCDF)/lib -lpnetcdf
 endif
 
 RM = rm -f


### PR DESCRIPTION
This commit adds a conditional check in the Makefile to check to see if the
user has the correct version of PIO insatalled against the one which was
specified in the make command and gives an error message and suggestions for
fixes if a mismatch is found.

First, it checks to see if either PIO1 or PIO2 are installed and reports an
error if neither of them are installed. It then checks PIO1 or PIO2 depending
on whether or not USE_PIO2 is set to true.

--

@mgduda, let me know if you have any suggestions, additions/edits to the help messages if you have any! I included a few, but I'm sure I missed one that we talked about earlier.

As well, if anyone has any suggestions to the shell commands please let me know, I'm not too fluent in it still!
