### PR TITLE
Add Langmuir mixing parameterization via CVMix

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -515,7 +515,7 @@
 					possible_values="any integer"
 		/>
 		<nml_option name="config_cvmix_use_BLD_smoothing" type="logical" default_value=".true." units="NA"
-					description="If true KPP bld is smoothed with a laplacian filter" 
+					description="If true KPP bld is smoothed with a laplacian filter"
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_cvmix_shear_mixing_scheme" type="character" default_value="PP" units="NA"
@@ -609,6 +609,18 @@
 		<nml_option name="config_cvmix_kpp_nonlocal_with_implicit_mix" type="logical" default_value=".false." units="none"
 					description="flag that moves the non-local computation and application of tendency to after main timestep loop"
 					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_cvmix_kpp_use_theory_wave" type="logical" default_value=".false." units="NA"
+					description="Flag for use of theory-wave in Li et al. (2017) to approximate the Langmuir number and enhancement factor"
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_cvmix_kpp_langmuir_mixing_opt" type="character" default_value="NONE" units="NA"
+					description="Option of Langmuir enhanced mixing parameterization"
+					possible_values="NONE, LWF16, RWHGK16"
+		/>
+		<nml_option name="config_cvmix_kpp_langmuir_entrainment_opt" type="character" default_value="NONE" units="NA"
+					description="Option of Langmuir enhanced entrainment parameterization"
+					possible_values="NONE, LWF16, LF17, RWHGK16"
 		/>
 	</nml_record>
 	<nml_record name="vmix_const" mode="forward">
@@ -1711,6 +1723,7 @@
 			<var name="rainFlux"/>
 			<var name="snowFlux"/>
 			<var name="iceFraction"/>
+			<var name="windSpeed10m"/>
 			<var name="nAccumulatedCoupled"/>
 			<var name="thermalExpansionCoeff"/>
 			<var name="salineContractionCoeff"/>
@@ -2718,7 +2731,7 @@
 		<var name="nForcingGroupCounter"		type="integer"	dimensions="Time"/>
 		<var name="forcingGroupNames"			type="text"	dimensions="nForcingGroupsMax Time"/>
 		<var name="forcingGroupRestartTimes"		type="text"	dimensions="nForcingGroupsMax Time"/>
-	
+
 		<!-- *********************************************************************
 
 				The fields listed below are constituent fields for coupling.
@@ -2835,6 +2848,9 @@
 		<!-- Misc. coupling fields -->
 		<var name="iceFraction" type="real" dimensions="nCells Time" units="fractional"
 			 description="Fraction of sea ice coverage at cell centers from coupler. Positive into the ocean."
+		/>
+        <var name="windSpeed10m" type="real" dimensions="nCells Time" units="m s^{-1}"
+			 description="Wind speed at 10 meter."
 		/>
 
 		<!-- Output fields for coupling -->

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=lt_v1.3
+CVMIX_TAG=v0.94b-beta
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 
 ## Available protocols for acquiring CVMix source code
-CVMIX_GIT_HTTP_ADDRESS=https://github.com/qingli411/CVMix-src.git
-CVMIX_GIT_SSH_ADDRESS=git@github.com:qingli411/CVMix-src.git
-CVMIX_SVN_ADDRESS=https://github.com/qingli411/CVMix-src/tags
-CVMIX_WEB_ADDRESS=https://github.com/qingli411/CVMix-src/archive
+CVMIX_GIT_HTTP_ADDRESS=https://github.com/CVMix/CVMix-src.git
+CVMIX_GIT_SSH_ADDRESS=git@github.com:CVMix/CVMix-src.git
+CVMIX_SVN_ADDRESS=https://github.com/CVMix/CVMix-src/tags
+CVMIX_WEB_ADDRESS=https://github.com/CVMix/CVMix-src/archive
 
 GIT=`which git`
 SVN=`which svn`

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=v0.84-beta
+CVMIX_TAG=lt_v1.3
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 
 ## Available protocols for acquiring CVMix source code
-CVMIX_GIT_HTTP_ADDRESS=https://github.com/CVMix/CVMix-src.git
-CVMIX_GIT_SSH_ADDRESS=git@github.com:CVMix/CVMix-src.git
-CVMIX_SVN_ADDRESS=https://github.com/CVMix/CVMix-src/tags
-CVMIX_WEB_ADDRESS=https://github.com/CVMix/CVMix-src/archive
+CVMIX_GIT_HTTP_ADDRESS=https://github.com/qingli411/CVMix-src.git
+CVMIX_GIT_SSH_ADDRESS=git@github.com:qingli411/CVMix-src.git
+CVMIX_SVN_ADDRESS=https://github.com/qingli411/CVMix-src/tags
+CVMIX_WEB_ADDRESS=https://github.com/qingli411/CVMix-src/archive
 
 GIT=`which git`
 SVN=`which svn`
@@ -38,36 +38,36 @@ fi
 
 # CVmix Doesn't exist, need to acquire souce code
 # If might have been flushed from the above if, in the case where it was svn or wget that acquired the source.
-if [ ! -d cvmix ]; then 
+if [ ! -d cvmix ]; then
 	if [ -d .cvmix_all ]; then
 		rm -rf .cvmix_all
 	fi
 
-	if [ "${GIT}" != "" ]; then 
+	if [ "${GIT}" != "" ]; then
 		echo " ** Using git to acquire cvmix source. ** "
 		PROTOCOL="git ssh"
 		git clone ${CVMIX_GIT_SSH_ADDRESS} .cvmix_all &> /dev/null
-		if [ -d .cvmix_all ]; then 
-			cd .cvmix_all 
+		if [ -d .cvmix_all ]; then
+			cd .cvmix_all
 			git checkout ${CVMIX_TAG} &> /dev/null
-			cd ../ 
-			ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix 
-		else 
+			cd ../
+			ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix
+		else
 			git clone ${CVMIX_GIT_HTTP_ADDRESS} .cvmix_all &> /dev/null
 			PROTOCOL="git http"
-			if [ -d .cvmix_all ]; then 
-				cd .cvmix_all 
+			if [ -d .cvmix_all ]; then
+				cd .cvmix_all
 				git checkout ${CVMIX_TAG} &> /dev/null
-				cd ../ 
-				ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix 
-			fi 
-		fi 
-	elif [ "${SVN}" != "" ]; then 
+				cd ../
+				ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix
+			fi
+		fi
+	elif [ "${SVN}" != "" ]; then
 		echo " ** Using svn to acquire cvmix source. ** "
 		PROTOCOL="svn"
 		svn co ${CVMIX_SVN_ADDRESS}/${CVMIX_TAG} .cvmix_all &> /dev/null
 		ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix
-	else 
+	else
 		echo " ** Using wget to acquire cvmix source. ** "
 		PROTOCOL="svn"
 		CVMIX_ZIP_DIR=`echo ${CVMIX_TAG} | sed 's/v//g'`
@@ -77,9 +77,9 @@ if [ ! -d cvmix ]; then
 		fi
 		unzip ${CVMIX_TAG}.zip &> /dev/null
 		mv ${CVMIX_TAG}.zip .${CVMIX_TAG}.zip
-		mv ${CVMIX_ZIP_DIR} .cvmix_all 
-		ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix 
-	fi 
+		mv ${CVMIX_ZIP_DIR} .cvmix_all
+		ln -sf .cvmix_all/${CVMIX_SUBDIR} cvmix
+	fi
 fi
 
 if [ ! -d cvmix ]; then

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -623,18 +623,6 @@ contains
      endif !kpp stage 1 -- boundary layer compute
 
      if (kpp_stage == 2) then
-            ! update Langmuir enhancement factor
-            ! TODO: theory-wave is the only option to get Langmuir number and enhancement factor for now <06-09-18, Qing Li> !
-            if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
-               langmuirEnhancementFactor =  &
-                       cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
-                                               surfaceFrictionVelocity(iCell), &
-                                               boundaryLayerDepth(iCell), &
-                                               cvmix_global_params)
-            else
-               langmuirEnhancementFactor = 1.0_RKIND
-            end if
-
             ! copy data into cvmix_variables
             do k = 1, maxLevelCell(iCell) + 1
               cvmix_variables % Mdiff_iface(k) = vertViscTopOfCell(k, iCell)
@@ -650,8 +638,19 @@ contains
                           zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
                           OBL_depth = boundaryLayerDepth(iCell) )
 
+            ! update Langmuir enhancement factor
+            ! TODO: theory-wave is the only option to get Langmuir number and enhancement factor for now <06-09-18, Qing Li> !
+            if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+               langmuirEnhancementFactor =  &
+                       cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
+                                               surfaceFrictionVelocity(iCell), &
+                                               boundaryLayerDepth(iCell), &
+                                               cvmix_global_params)
+            else
+               langmuirEnhancementFactor = 1.0_RKIND
+            end if
 
-             !           call mpas_timer_start('cvmix coeffs kpp', .false.)
+!           call mpas_timer_start('cvmix coeffs kpp', .false.)
             call cvmix_coeffs_kpp(                                              &
                           Mdiff_out = cvmix_variables % Mdiff_iface(1:maxLevelCell(iCell)+1),       &
                           Tdiff_out = cvmix_variables % Tdiff_iface(1:maxLevelCell(iCell)+1),       &
@@ -1028,6 +1027,29 @@ contains
            call mpas_log_write( &
               "Unknown value for config_cvmix_kpp_matching., supported values are:" // &
               "         SimpleShapes or MatchBoth", &
+              MPAS_LOG_CRIT)
+           err = 1
+           return
+        endif
+
+        if (trim(config_cvmix_kpp_langmuir_mixing_opt) .ne. "NONE" .and. &
+            trim(config_cvmix_kpp_langmuir_mixing_opt) .ne. "LWF16" .and. &
+            trim(config_cvmix_kpp_langmuir_mixing_opt) .ne. "RWHGK16") then
+           call mpas_log_write( &
+              "Unknown value for config_cvmix_kpp_langmuir_mixing_opt, supported values are:" // &
+              "         NONE or LWF16 or RWHGK16", &
+              MPAS_LOG_CRIT)
+           err = 1
+           return
+        endif
+
+        if (trim(config_cvmix_kpp_langmuir_entrainment_opt) .ne. "NONE" .and. &
+            trim(config_cvmix_kpp_langmuir_entrainment_opt) .ne. "LWF16" .and. &
+            trim(config_cvmix_kpp_langmuir_entrainment_opt) .ne. "LF17" .and. &
+            trim(config_cvmix_kpp_langmuir_entrainment_opt) .ne. "RWHGK16") then
+           call mpas_log_write( &
+              "Unknown value for config_cvmix_kpp_langmuir_entrainment_opt, supported values are:" // &
+              "         NONE or LWF16 or LF17 or RWHGK16", &
               MPAS_LOG_CRIT)
            err = 1
            return

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -131,7 +131,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: &
         latCell, lonCell, bottomDepth, surfaceBuoyancyForcing, surfaceFrictionVelocity, fCell, &
         boundaryLayerDepth, ssh, indexBoundaryLayerDepth, dcEdge, dvEdge, areaCell, iceFraction, &
-        boundaryLayerDepthSmooth
+        boundaryLayerDepthSmooth, windSpeed10m
 
       real (kind=RKIND), dimension(:,:), pointer :: &
         vertViscTopOfCell, vertDiffTopOfCell, layerThickness, &
@@ -166,6 +166,8 @@ contains
       logical :: bulkRichardsonFlag
 
       real (kind=RKIND), pointer :: config_cvmix_background_viscosity, config_cvmix_background_diffusion
+      real (kind=RKIND) :: langmuirEnhancementFactor, langmuirNumber
+      logical, pointer :: config_cvmix_kpp_use_theory_wave
 
       !-----------------------------------------------------------------
       !
@@ -211,6 +213,7 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_use_BLD_smoothing', config_cvmix_use_BLD_smoothing)
       call mpas_pool_get_config(ocnConfigs, 'configure_cvmix_kpp_minimum_OBL_under_sea_ice', &
                                 configure_cvmix_kpp_minimum_OBL_under_sea_ice)
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', nVertLevelsP1)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
@@ -262,6 +265,7 @@ contains
       ! set pointers for fields related to ocean forcing state
       !
       call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
+      call mpas_pool_get_array(forcingPool, 'windSpeed10m', windSpeed10m)
 
       !
       ! set pointers for fields related forcing at ocean surface
@@ -462,6 +466,24 @@ contains
               k=min(maxLevelCell(iCell)+1,nVertLevels)
               Nsqr_iface(k:maxLevelCell(iCell)+1) = Nsqr_iface(k-1)
 
+              ! compute Langmuir number and Langmuir enhancement factor
+              ! TODO: theory-wave is the only option to get Langmuir number and enhancement factor for now <06-09-18, Qing Li> !
+              if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+                 langmuirNumber =  sqrt(surfaceFrictionVelocity(iCell) / &
+                         cvmix_kpp_ustokes_SL_model(windSpeed10m(iCell), &
+                                                    boundaryLayerDepth(iCell), &
+                                                    cvmix_global_params))
+                 langmuirEnhancementFactor =  &
+                         cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
+                                                 surfaceFrictionVelocity(iCell), &
+                                                 boundaryLayerDepth(iCell), &
+                                                 cvmix_global_params)
+              else
+                 ! arbitrarily large Langmuir number
+                 langmuirNumber = 1.e10_RKIND
+                 langmuirEnhancementFactor = 1.0_RKIND
+              end if
+
               ! compute bulk Richardson number
               ! assume boundary layer depth is at bottom of every kIndexOBL cell
               bulkRichardsonNumberStop = config_cvmix_kpp_stop_OBL_search * config_cvmix_kpp_criticalBulkRichardsonNumber
@@ -546,7 +568,12 @@ contains
                    delta_buoy_cntr = bulkRichardsonNumberBuoy(1:maxLevelCell(iCell),iCell), &
                    delta_Vsqr_cntr = bulkRichardsonNumberShear(1:maxLevelCell(iCell),iCell), &
                    ws_cntr = turbulentScalarVelocityScale(:), &
-                   Nsqr_iface = Nsqr_iface(1:maxLevelCell(iCell)+1) )
+                   Nsqr_iface = Nsqr_iface(1:maxLevelCell(iCell)+1), &
+                   EFactor = langmuirEnhancementFactor, &
+                   LaSL = langmuirNumber, &
+                   bfsfc = cvmix_variables%SurfaceBuoyancyForcing, &
+                   ustar = cvmix_variables%SurfaceFriction )
+              ! TODO: the surface buoyancy forcing here does not include penetrative solar radiation? <05-09-18, Qing Li> !
 
               ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
 
@@ -596,6 +623,18 @@ contains
      endif !kpp stage 1 -- boundary layer compute
 
      if (kpp_stage == 2) then
+            ! update Langmuir enhancement factor
+            ! TODO: theory-wave is the only option to get Langmuir number and enhancement factor for now <06-09-18, Qing Li> !
+            if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
+               langmuirEnhancementFactor =  &
+                       cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
+                                               surfaceFrictionVelocity(iCell), &
+                                               boundaryLayerDepth(iCell), &
+                                               cvmix_global_params)
+            else
+               langmuirEnhancementFactor = 1.0_RKIND
+            end if
+
             ! copy data into cvmix_variables
             do k = 1, maxLevelCell(iCell) + 1
               cvmix_variables % Mdiff_iface(k) = vertViscTopOfCell(k, iCell)
@@ -629,7 +668,8 @@ contains
                           surf_fric = cvmix_variables%SurfaceFriction,                      &
                           surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
                           nlev = maxLevelCell(iCell),                                  &
-                          max_nlev = nVertLevels)
+                          max_nlev = nVertLevels,                                      &
+                          Langmuir_EFactor = langmuirEnhancementFactor )
 !           call mpas_timer_stop('cvmix coeffs kpp')
 
             ! intent out of BoundaryLayerDepth is boundary layer depth measured in meters and vertical index
@@ -737,7 +777,7 @@ contains
              boundaryLayerDepth(iCell) = boundaryLayerDepthSmooth(iCell)
           enddo
          !$omp end do
-     
+
        endif !stage 1 BLD smoothing
       end do ! kpp_stage
       call mpas_timer_stop('cvmix cell loop')
@@ -836,6 +876,11 @@ contains
       real (kind=RKIND), pointer :: config_cvmix_kpp_criticalBulkRichardsonNumber, &
                                     config_cvmix_kpp_surface_layer_extent, &
                                     config_cvmix_kpp_stop_OBL_search
+
+      ! Langmuir turbulence
+      character (len=StrKIND), pointer :: config_cvmix_kpp_langmuir_mixing_opt, &
+                                          config_cvmix_kpp_langmuir_entrainment_opt
+
       !
       ! assume no errors during initialization and set to 1 when error is encountered
       !
@@ -872,6 +917,9 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_convective_diffusion', config_cvmix_convective_diffusion)
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_convective_viscosity', config_cvmix_convective_viscosity)
       call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_use_enhanced_diff', config_cvmix_kpp_use_enhanced_diff)
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_langmuir_mixing_opt', config_cvmix_kpp_langmuir_mixing_opt)
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_langmuir_entrainment_opt', &
+                                config_cvmix_kpp_langmuir_entrainment_opt)
       cvmixOn = config_use_cvmix
       cvmixBackgroundOn = config_use_cvmix_background
       backgroundVisc = config_cvmix_background_viscosity
@@ -900,6 +948,7 @@ contains
       !
       call cvmix_put(cvmix_global_params,  'max_nlev', nVertLevels)
       call cvmix_put(cvmix_global_params,  'prandtl',  config_cvmix_prandtl_number)
+      call cvmix_put(cvmix_global_params,  'Gravity',  gravity)
 
       !
       ! initialize background mixing
@@ -992,6 +1041,8 @@ contains
                lMonOb = config_cvmix_kpp_MonObOBL, &
                MatchTechnique = config_cvmix_kpp_matching, &
                surf_layer_ext = config_cvmix_kpp_surface_layer_extent, &
+               langmuir_mixing_str = config_cvmix_kpp_langmuir_mixing_opt, &
+               langmuir_entrainment_str = config_cvmix_kpp_langmuir_entrainment_opt, &
                lenhanced_diff = config_cvmix_kpp_use_enhanced_diff)
       endif
 


### PR DESCRIPTION
This merge adds Langmuir mixing parameterization via CVMix

1. Change the CVMix repository to use the 'theory-wave' approximation of Li et al., 2017 to estimate the Langmuir enhancement factor from 10-meter wind, surface friction velocity and boundary layer depth
2. New entries in mpaso namelist allowing different options of Langmuir mixing parameterization


MPAS-Analysis:

[G-case without Langmuir turbulence parameterization](http://portal.nersc.gov/project/acme/qingli/GMPAS-IAF_T62_oEC60to30v3_CTRL/)
```
config_cvmix_kpp_langmuir_mixing_opt = 'NONE'
config_cvmix_kpp_langmuir_entrainment_opt = 'NONE'
```

[G-case with Langmuir (LWF16)](http://portal.nersc.gov/project/acme/qingli/GMPAS-IAF_T62_oEC60to30v3_TWAV/)
```
config_cvmix_kpp_langmuir_mixing_opt = 'LWF16'
config_cvmix_kpp_langmuir_entrainment_opt = 'LWF16'
```

[G-case with Langmuir (LF17)](http://portal.nersc.gov/project/acme/qingli/GMPAS-IAF_T62_oEC60to30v3_LF17/)
```
config_cvmix_kpp_langmuir_mixing_opt = 'LWF16'
config_cvmix_kpp_langmuir_entrainment_opt = 'LF17'
```

[B-case with Langmuir (LF17, 40 years)](http://portal.nersc.gov/project/acme/qingli/20181129.Langmuir-LF17.A_WCYCL1850S.ne30_oECv3_ICG.anvil_years1-40/)
```
config_cvmix_kpp_langmuir_mixing_opt = 'LWF16'
config_cvmix_kpp_langmuir_entrainment_opt = 'LF17'
```