### PR TITLE
Update to fix salinity restoring time interval

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
@@ -211,7 +211,7 @@ contains
         character(len=strKind) :: timeStamp
 
         logical, intent(in) :: firstTimeStep
-        character(len=strKind), pointer :: config_dt
+        character(len=strKind), pointer :: config_surface_salinity_monthly_restoring_compute_interval
         real(kind=RKIND) :: dt, sumAreaDeltaS, sumArea, avgDeltaS, deltaS, sumAreaDeltaSGlobal, sumAreaGlobal
         real(kind=RKIND) :: avgDeltaS1
         type (block_type), pointer :: block
@@ -292,29 +292,25 @@ contains
            return
         endif  !  first timestep
 
-        call MPAS_pool_get_config(domain%configs, 'config_dt', config_dt)
+        call MPAS_pool_get_config(domain%configs, 'config_surface_salinity_monthly_restoring_compute_interval', &
+                                                   config_surface_salinity_monthly_restoring_compute_interval)
         call MPAS_pool_get_config(domain%configs, 'config_salinity_restoring_max_difference',  &
                                                           salinity_restoring_max_difference)
-
-        call mpas_pool_get_config(domain%configs, 'config_salinity_restoring_under_sea_ice', &
+        call MPAS_pool_get_config(domain%configs, 'config_salinity_restoring_under_sea_ice', &
                                                    config_salinity_restoring_under_sea_ice)
         call MPAS_pool_get_config(domain%configs, 'config_salinity_restoring_constant_piston_velocity',  &
-                                                   salinity_restoring_constant_piston_velocity)
-        call mpas_set_timeInterval(timeStepSurfaceSalinity,timeString=config_dt)
-        call mpas_get_timeInterval(timeStepSurfaceSalinity,dt=dt)
+                                                          salinity_restoring_constant_piston_velocity)
 
-        call mpas_pool_get_subpool(domain % blocklist % structs, 'surfaceSalinityMonthlyForcing',  &
+        call MPAS_set_timeInterval(timeStepSurfaceSalinity,timeString=config_surface_salinity_monthly_restoring_compute_interval)
+        call MPAS_get_timeInterval(timeStepSurfaceSalinity,dt=dt)
+
+        call MPAS_pool_get_subpool(domain % blocklist % structs, 'surfaceSalinityMonthlyForcing',  &
                                                                   surfaceSalinityMonthlyForcing)
-        call mpas_pool_get_array(surfaceSalinityMonthlyForcing, 'surfaceSalinityMonthlyClimatologyValue',   &
+        call MPAS_pool_get_array(surfaceSalinityMonthlyForcing, 'surfaceSalinityMonthlyClimatologyValue',   &
                                                                  surfaceSalinityMonthlyClimatologyValue)
 
-        if(firstTimestep .and. config_do_restart) then
-           call MPAS_forcing_get_forcing(forcingGroupHead, &
-                'surfaceSalinityMonthlyClimatology', streamManager, 0.0_RKIND)
-        else
-           call MPAS_forcing_get_forcing(forcingGroupHead, &
-                'surfaceSalinityMonthlyClimatology', streamManager, dt)
-        end if
+        call MPAS_forcing_get_forcing(forcingGroupHead, &
+             'surfaceSalinityMonthlyClimatology', streamManager, dt)
 
       sumAreaDeltaS = 0.0_RKIND
       sumArea = 0.0_RKIND


### PR DESCRIPTION
This PR updates the salinity restoring code to use the config_surface_salinity_monthly_restoring_compute_interval for the forcing time interval instead of config_dt. It does some minor clean-up and removes some unused code.

Tested with:
* ERS.T62_oEC60to30v3.GMPAS-IAF.anvil_intel

To work inside E3SM, it will require a corresponding modification to the ocn_comp_mct driver as well.

@maltrud , @vanroekel - I have a version that prints the time of the forcing update to the ocn log, if that would be an improvement. I should point out that not much goes to the log by default, so I'm hesitant to start filling it up...