### PR TITLE
Update ISOMIP+ test case and add new parameter studies

### DIFF
--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_adjust_ssh.xml
@@ -13,6 +13,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_driver.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_driver.xml
@@ -8,7 +8,15 @@
 	<case name="adjust_ssh">
 		<step executable="./run.py" quiet="true" pre_message=" * Running adjust_ssh" post_message="     Complete"/>
 	</case>
-	<case name="forward">
-		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	<case name="forward_short">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward_short" post_message="     Complete"/>
 	</case>
+	<validation>
+		<compare_fields file1="forward_short/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+		<compare_fields file1="forward_short/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
 </driver_script>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_driver.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_driver.xml
@@ -8,15 +8,7 @@
 	<case name="adjust_ssh">
 		<step executable="./run.py" quiet="true" pre_message=" * Running adjust_ssh" post_message="     Complete"/>
 	</case>
-	<case name="forward_short">
-		<step executable="./run.py" quiet="true" pre_message=" * Running forward_short" post_message="     Complete"/>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
 	</case>
-	<validation>
-		<compare_fields file1="forward_short/output.nc">
-			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
-		</compare_fields>
-		<compare_fields file1="forward_short/land_ice_fluxes.nc">
-			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
-		</compare_fields>
-	</validation>
 </driver_script>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward.xml
@@ -24,15 +24,8 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">64</argument>
+			<argument flag="graph.info">136</argument>
 		</step>
-		<model_run procs="64" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
-		<step executable="./update_evaporationFlux.py">
-			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
-			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
-			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
-			<argument flag="--out_forcing_link">forcing_data.nc</argument>
-			<argument flag="--avg_years">0.25</argument>
-		</step>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward.xml
@@ -27,5 +27,11 @@
 			<argument flag="graph.info">136</argument>
 		</step>
 		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./update_evaporationFlux.py">
+			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
+			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
+			<argument flag="--out_forcing_link">forcing_data.nc</argument>
+			<argument flag="--avg_months">3</argument>
+		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward_short.xml
@@ -21,7 +21,9 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="land_ice_fluxes">
+			<attribute name="clobber_mode">overwrite</attribute>
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
 		<stream name="globalStatsOutput">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_forward_short.xml
@@ -12,6 +12,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_run_duration">'0000-00-00_01:00:00'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -50,6 +51,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_adjust_ssh.xml
@@ -13,6 +13,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward.xml
@@ -24,15 +24,14 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">64</argument>
+			<argument flag="graph.info">136</argument>
 		</step>
-		<model_run procs="64" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./update_evaporationFlux.py">
-			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
 			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
 			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
 			<argument flag="--out_forcing_link">forcing_data.nc</argument>
-			<argument flag="--avg_years">0.25</argument>
+			<argument flag="--avg_months">3</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward_short.xml
@@ -21,7 +21,9 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="land_ice_fluxes">
+			<attribute name="clobber_mode">overwrite</attribute>
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
 		<stream name="globalStatsOutput">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_forward_short.xml
@@ -12,6 +12,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_run_duration">'0000-00-00_01:00:00'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -50,6 +51,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_adjust_ssh.xml
@@ -13,6 +13,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward.xml
@@ -24,15 +24,14 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">64</argument>
+			<argument flag="graph.info">136</argument>
 		</step>
-		<model_run procs="64" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./update_evaporationFlux.py">
-			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
 			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
 			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
 			<argument flag="--out_forcing_link">forcing_data.nc</argument>
-			<argument flag="--avg_years">0.25</argument>
+			<argument flag="--avg_months">3</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward_short.xml
@@ -21,7 +21,9 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
 		<stream name="land_ice_fluxes">
+			<attribute name="clobber_mode">overwrite</attribute>
 			<attribute name="output_interval">0000_01:00:00</attribute>
 		</stream>
 		<stream name="globalStatsOutput">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_forward_short.xml
@@ -12,6 +12,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_run_duration">'0000-00-00_01:00:00'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -52,6 +53,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_adjust_ssh.xml
@@ -14,6 +14,8 @@
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_forward.xml
@@ -17,6 +17,8 @@
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="template_forward.xml" path_base="script_resolution_dir"/>
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">16</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
@@ -26,15 +28,14 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">4</argument>
+			<argument flag="graph.info">16</argument>
 		</step>
-		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./update_evaporationFlux.py">
-			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
 			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
 			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
 			<argument flag="--out_forcing_link">forcing_data.nc</argument>
-			<argument flag="--avg_years">0.25</argument>
+			<argument flag="--avg_months">3</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -50,6 +51,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -50,6 +51,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
@@ -17,6 +17,7 @@
 	<add_executable source="cell_culler" dest="MpasCellCuller.x"/>
 	<add_executable source="mesh_converter" dest="MpasMeshConverter.x"/>
 	<add_link source_path="script_configuration_dir" source="processInputGeometry.py" dest="processInputGeometry.py"/>
+	<add_link source_path="script_configuration_dir" source="removePeriodic.py" dest="removePeriodic.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
@@ -52,6 +53,9 @@
 
 		<step executable="./MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>
+		</step>
+		<step executable="./removePeriodic.py">
+			<argument flag="">culled_mesh.nc</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/template_forward.xml
@@ -17,6 +17,7 @@
 		<option name="config_cvmix_convective_diffusion">1.0</option>
 		<option name="config_cvmix_convective_viscosity">1.0</option>
 		<option name="config_use_cvmix_shear">.true.</option>
+		<option name="config_cvmix_use_BLD_smoothing">.true.</option>
 		<option name="config_cvmix_shear_mixing_scheme">'KPP'</option>
 		<option name="config_use_bulk_thickness_flux">.true.</option>
 		<option name="config_land_ice_flux_mode">'standalone'</option>

--- a/testing_and_setup/compass/ocean/isomip_plus/removePeriodic.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/removePeriodic.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from netCDF4 import Dataset
+from optparse import OptionParser
+
+parser = OptionParser()
+
+options, args = parser.parse_args()
+fileName=args[0]
+
+nc = Dataset(fileName,'r+')
+nc.setncattr('is_periodic', 'NO')
+nc.close()
+

--- a/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BL20.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BL20.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+Sets up a paramter study that varies GammaT and GammaS (the
+heat and salt transfer coefficients) according to the
+specification of the ISOMIP+ Ocean0 experiment
+"""
+
+import numpy
+import subprocess
+
+gammaTs = numpy.array(
+    [0.01, 0.02, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11,
+     0.12, 0.15, 0.2])
+gammaSs = gammaTs/35.
+
+GammaTStrings = ['{:g}'.format(GammaT) for GammaT in gammaTs.ravel()]
+GammaSStrings = ['{:g}'.format(GammaS) for GammaS in gammaSs.ravel()]
+
+args = ['../../utility_scripts/make_parameter_study_configs.py', '-t', 
+        'template_Gwyther_GammaT_BL20.xml', '-o', '2km/Ocean0/config_GammaT_BL20',
+        '-p', 'GammaT={}'.format(','.join(GammaTStrings)),
+        'GammaS={}'.format(','.join(GammaSStrings))]
+        
+print 'running {}'.format(' '.join(args))
+subprocess.check_call(args)

--- a/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BLFlux.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BLFlux.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Sets up a paramter study that varies GammaT and GammaS (the
+heat and salt transfer coefficients) according to the
+specification of the ISOMIP+ Ocean0 experiment
+"""
+
+import numpy
+import subprocess
+
+gammaTs = numpy.array(
+    [0.01, 0.02, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11,
+     0.12, 0.15, 0.2])
+#gammaTs = numpy.array([0.01])
+gammaSs = gammaTs/35.
+
+blFlux = numpy.array([2., 5., 10., 15., 20., 25., 30., 35., 40.])
+#blFlux = numpy.array([2.])
+
+GammaTs, BLFluxs = numpy.meshgrid(gammaTs, blFlux)
+GammaSs, _ = numpy.meshgrid(gammaSs, blFlux)
+
+GammaTStrings = ['{:g}'.format(GammaT) for GammaT in GammaTs.ravel()]
+GammaSStrings = ['{:g}'.format(GammaS) for GammaS in GammaSs.ravel()]
+BLFluxStrings = ['{:g}'.format(depth) for depth in BLFluxs.ravel()]
+
+args = ['../../utility_scripts/make_parameter_study_configs.py', '-t', 
+        'template_Gwyther_GammaT_BLFlux.xml', '-o', '2km/Ocean0/config_GammaT_BLFlux',
+        '-p', 'GammaT={}'.format(','.join(GammaTStrings)),
+        'GammaS={}'.format(','.join(GammaSStrings)), 
+         'blFlux={}'.format(','.join(BLFluxStrings))]
+        
+print 'running {}'.format(' '.join(args))
+subprocess.check_call(args)

--- a/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BLTracer.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/setup_Gwyther_GammaT_BLTracer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Sets up a paramter study that varies GammaT and GammaS (the
+heat and salt transfer coefficients) according to the
+specification of the ISOMIP+ Ocean0 experiment
+"""
+
+import numpy
+import subprocess
+
+gammaTs = numpy.array(
+    [0.01, 0.02, 0.03, 0.04, 0.05, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11,
+     0.12, 0.15, 0.2])
+#gammaTs = numpy.array([0.01])
+gammaSs = gammaTs/35.
+
+blTracer = numpy.array([2., 5., 10., 15., 20., 25., 30., 35., 40.])
+#blTracer = numpy.array([2.])
+
+GammaTs, BLTracers = numpy.meshgrid(gammaTs, blTracer)
+GammaSs, _ = numpy.meshgrid(gammaSs, blTracer)
+
+GammaTStrings = ['{:g}'.format(GammaT) for GammaT in GammaTs.ravel()]
+GammaSStrings = ['{:g}'.format(GammaS) for GammaS in GammaSs.ravel()]
+BLTracerStrings = ['{:g}'.format(depth) for depth in BLTracers.ravel()]
+
+args = ['../../utility_scripts/make_parameter_study_configs.py', '-t', 
+        'template_Gwyther_GammaT_BLTracer.xml', '-o', '2km/Ocean0/config_GammaT_BLTracer',
+        '-p', 'GammaT={}'.format(','.join(GammaTStrings)),
+        'GammaS={}'.format(','.join(GammaSStrings)), 
+         'blTracer={}'.format(','.join(BLTracerStrings))]
+        
+print 'running {}'.format(' '.join(args))
+subprocess.check_call(args)

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BL20.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BL20.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="forward_GammaT_@GammaT_blFlux_20_blTracer_20">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../adjust_ssh/init.nc" dest="init.nc"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data_init.nc"/>
+	<add_link source="forcing_data_init.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<add_link source_path="script_configuration_dir" source="viz" dest="viz"/>
+	<add_link source_path="script_configuration_dir" source="update_evaporationFlux.py" dest="update_evaporationFlux.py"/>
+	<add_link source_path="utility_scripts" source="setup_restart.py" dest="setup_restart.py"/>
+	<add_link source_path="utility_scripts" source="check_progress.py" dest="check_progress.py"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">@GammaT</option>
+		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
+		<option name="config_land_ice_flux_boundaryLayerThickness">20.0</option>
+		<option name="config_land_ice_flux_attenuation_coefficient">20.0</option>
+		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_pio_num_iotasks">2</option>
+		<option name="config_pio_stride">68</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">136</argument>
+		</step>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BL20.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BL20.xml
@@ -20,7 +20,9 @@
 		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
 		<option name="config_land_ice_flux_boundaryLayerThickness">20.0</option>
 		<option name="config_land_ice_flux_attenuation_coefficient">20.0</option>
-		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:05'</option>
+		<option name="config_run_duration">'0000-01-00_00:00:00'</option>
 		<option name="config_pio_num_iotasks">2</option>
 		<option name="config_pio_stride">68</option>
 	</namelist>
@@ -34,5 +36,11 @@
 			<argument flag="graph.info">136</argument>
 		</step>
 		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./update_evaporationFlux.py">
+			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
+			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
+			<argument flag="--out_forcing_link">forcing_data.nc</argument>
+			<argument flag="--avg_months">3</argument>
+		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLFlux.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLFlux.xml
@@ -20,7 +20,9 @@
 		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
 		<option name="config_land_ice_flux_boundaryLayerThickness">2.0</option>
 		<option name="config_land_ice_flux_attenuation_coefficient">@blFlux</option>
-		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:05'</option>
+		<option name="config_run_duration">'0000-01-00_00:00:00'</option>
 		<option name="config_pio_num_iotasks">2</option>
 		<option name="config_pio_stride">68</option>
 	</namelist>
@@ -34,5 +36,11 @@
 			<argument flag="graph.info">136</argument>
 		</step>
 		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./update_evaporationFlux.py">
+			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
+			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
+			<argument flag="--out_forcing_link">forcing_data.nc</argument>
+			<argument flag="--avg_months">3</argument>
+		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLFlux.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLFlux.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="forward_GammaT_@GammaT_blFlux_@blFlux">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../adjust_ssh/init.nc" dest="init.nc"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data_init.nc"/>
+	<add_link source="forcing_data_init.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<add_link source_path="script_configuration_dir" source="viz" dest="viz"/>
+	<add_link source_path="script_configuration_dir" source="update_evaporationFlux.py" dest="update_evaporationFlux.py"/>
+	<add_link source_path="utility_scripts" source="setup_restart.py" dest="setup_restart.py"/>
+	<add_link source_path="utility_scripts" source="check_progress.py" dest="check_progress.py"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">@GammaT</option>
+		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
+		<option name="config_land_ice_flux_boundaryLayerThickness">2.0</option>
+		<option name="config_land_ice_flux_attenuation_coefficient">@blFlux</option>
+		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_pio_num_iotasks">2</option>
+		<option name="config_pio_stride">68</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">136</argument>
+		</step>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLTracer.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLTracer.xml
@@ -20,7 +20,9 @@
 		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
 		<option name="config_land_ice_flux_boundaryLayerThickness">@blTracer</option>
 		<option name="config_land_ice_flux_attenuation_coefficient">2.0</option>
-		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:05'</option>
+		<option name="config_run_duration">'0000-01-00_00:00:00'</option>
 		<option name="config_pio_num_iotasks">2</option>
 		<option name="config_pio_stride">68</option>
 	</namelist>
@@ -34,5 +36,11 @@
 			<argument flag="graph.info">136</argument>
 		</step>
 		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./update_evaporationFlux.py">
+			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
+			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
+			<argument flag="--out_forcing_link">forcing_data.nc</argument>
+			<argument flag="--avg_months">3</argument>
+		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLTracer.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Gwyther_GammaT_BLTracer.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="forward_GammaT_@GammaT_blTracer_@blTracer">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../adjust_ssh/init.nc" dest="init.nc"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data_init.nc"/>
+	<add_link source="forcing_data_init.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+	<add_executable source="metis" dest="metis"/>
+
+	<add_link source_path="script_configuration_dir" source="viz" dest="viz"/>
+	<add_link source_path="script_configuration_dir" source="update_evaporationFlux.py" dest="update_evaporationFlux.py"/>
+	<add_link source_path="utility_scripts" source="setup_restart.py" dest="setup_restart.py"/>
+	<add_link source_path="utility_scripts" source="check_progress.py" dest="check_progress.py"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">@GammaT</option>
+		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
+		<option name="config_land_ice_flux_boundaryLayerThickness">@blTracer</option>
+		<option name="config_land_ice_flux_attenuation_coefficient">2.0</option>
+		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_pio_num_iotasks">2</option>
+		<option name="config_pio_stride">68</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./metis">
+			<argument flag="graph.info">136</argument>
+		</step>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Ocean0_param_study.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Ocean0_param_study.xml
@@ -18,7 +18,7 @@
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">@GammaT</option>
 		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
-		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_run_duration">'0000-01-00_00:00:00'</option>
 		<option name="config_pio_num_iotasks">2</option>
 		<option name="config_pio_stride">68</option>
 	</namelist>
@@ -33,11 +33,10 @@
 		</step>
 		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./update_evaporationFlux.py">
-			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
 			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
 			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
 			<argument flag="--out_forcing_link">forcing_data.nc</argument>
-			<argument flag="--avg_years">0.25</argument>
+			<argument flag="--avg_months">3</argument>
 		</step>
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_Ocean0_param_study.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_Ocean0_param_study.xml
@@ -18,6 +18,9 @@
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">@GammaT</option>
 		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">@GammaS</option>
+		<option name="config_run_duration">'0001-00-00_00:00:00'</option>
+		<option name="config_pio_num_iotasks">2</option>
+		<option name="config_pio_stride">68</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">
@@ -26,9 +29,9 @@
 
 	<run_script name="run.py">
 		<step executable="./metis">
-			<argument flag="graph.info">64</argument>
+			<argument flag="graph.info">136</argument>
 		</step>
-		<model_run procs="64" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./update_evaporationFlux.py">
 			<argument flag="--in_fluxes_file">land_ice_fluxes.nc</argument>
 			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_adjust_ssh.xml
@@ -6,6 +6,7 @@
 		<option name="config_use_activeTracers_surface_bulk_forcing">.false.</option>
 		<option name="config_use_bulk_thickness_flux">.false.</option>
 		<option name="config_AM_globalStats_enable">.false.</option>
+		<option name="config_AM_timeSeriesStatsMonthly_enable">.false.</option>
 	</namelist>
 	<streams>
 		<stream name="mesh">

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -18,7 +18,8 @@
 		<option name="config_use_cvmix_convection">.true.</option>
 		<option name="config_cvmix_convective_diffusion">0.1</option>
 		<option name="config_cvmix_convective_viscosity">0.1</option>
-		<option name="config_use_cvmix_shear">.true.</option>
+		<option name="config_use_cvmix_shear">.false.</option>
+		<option name="config_cvmix_use_BLD_smoothing">.false.</option>
 		<option name="config_use_bulk_thickness_flux">.true.</option>
 		<option name="config_land_ice_flux_mode">'standalone'</option>
 		<option name="config_land_ice_flux_attenuation_coefficient">10.0</option>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -39,6 +39,8 @@
 		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
 		<option name="config_check_ssh_consistency">.false.</option>
 		<option name="config_AM_timeSeriesStatsMonthly_enable">.true.</option>
+		<option name="config_pio_num_iotasks">2</option>
+		<option name="config_pio_stride">68</option>
 	</namelist>
 
 	<streams>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -25,8 +25,8 @@
 		<option name="config_land_ice_flux_boundaryLayerThickness">10.0</option>
 		<option name="config_land_ice_flux_topDragCoeff">2.5e-3</option>
 		<option name="config_land_ice_flux_rms_tidal_velocity">1e-2</option>
-		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">0.0146</option>
-		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">0.00041785579</option>
+		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">0.0184</option>
+		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">0.00052478511</option>
 		<option name="config_implicit_bottom_drag_coeff">2.5e-3</option>
 		<option name="config_eos_type">'linear'</option>
 		<option name="config_eos_linear_alpha">0.03836</option>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -81,23 +81,32 @@
 			<attribute name="output_interval">00-01-00_00:00:00</attribute>
 			<add_contents>
 				<member name="daysSinceStartOfSim" type="var"/>
-				<member name="tracersSurfaceValue" type="var_array"/>
-				<member name="surfaceVelocity" type="var_array"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="layerThickness" type="var"/>
+				<member name="density" type="var"/>
+				<member name="potentialDensity" type="var"/>
 				<member name="ssh" type="var"/>
 				<member name="normalVelocity" type="var"/>
-				<member name="velocityZonal" type="var"/>
-				<member name="velocityMeridional" type="var"/>
+				<member name="velocityX" type="var"/>
+				<member name="velocityY" type="var"/>
 				<member name="vertVelocityTop" type="var"/>
-				<member name="normalTransportVelocity" type="var"/>
-				<member name="transportVelocityZonal" type="var"/>
-				<member name="transportVelocityMeridional" type="var"/>
-				<member name="vertTransportVelocityTop" type="var"/>
-				<member name="tThreshMLD" type="var"/>
-				<member name="dThreshMLD" type="var"/>
 				<member name="landIceFreshwaterFlux" type="var"/>
 				<member name="landIceHeatFlux" type="var"/>
 				<member name="heatFluxToLandIce" type="var"/>
 				<member name="areaCellGlobal" type="var"/>
+				<member name="CFLNumberGlobal" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="landIcePressure" type="var"/>
+				<member name="landIceDraft" type="var"/>
+				<member name="landIceFraction" type="var"/>
+				<member name="landIceMask" type="var"/>
+				<member name="landIceFrictionVelocity" type="var"/>
+				<member name="topDrag" type="var"/>
+				<member name="topDragMagnitude" type="var"/>
+				<member name="landIceBoundaryLayerTracers" type="var_array"/>
+				<member name="landIceInterfaceTracers" type="var_array"/>
+				<member name="accumulatedLandIceMass" type="var"/>
+                                <member name="accumulatedLandIceHeat" type="var"/>
 			</add_contents>
 		</stream>
 		<stream name="timeSeriesStatsMonthlyRestart">

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -39,6 +39,7 @@
 		<option name="config_use_activeTracers_interior_restoring">.true.</option>
 		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
 		<option name="config_check_ssh_consistency">.false.</option>
+		<option name="config_AM_globalStats_text_file">.false.</option>
 		<option name="config_AM_timeSeriesStatsMonthly_enable">.true.</option>
 		<option name="config_AM_timeSeriesStatsMonthly_restart_stream">'none'</option>
 		<option name="config_pio_num_iotasks">2</option>
@@ -109,20 +110,6 @@
 				<member name="landIceInterfaceTracers" type="var_array"/>
 				<member name="accumulatedLandIceMass" type="var"/>
                                 <member name="accumulatedLandIceHeat" type="var"/>
-			</add_contents>
-		</stream>
-		<stream name="timeSeriesStatsMonthlyRestart">
-			<attribute name="name">timeSeriesStatsMonthlyRestart</attribute>
-			<attribute name="filename_interval">output_interval</attribute>
-			<attribute name="clobber_mode">truncate</attribute>
-			<attribute name="reference_time">0001-01-01_00:00:00</attribute>
-			<attribute name="output_interval">none</attribute>
-			<attribute name="filename_template">restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc</attribute>
-			<attribute name="input_interval">initial_only</attribute>
-			<attribute name="type">input;output</attribute>
-			<attribute name="immutable">true</attribute>
-			<attribute name="io_type">pnetcdf</attribute>
-			<add_contents>
 			</add_contents>
 		</stream>
 

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -139,7 +139,6 @@
 				<member name="layerThickness" type="var"/>
 				<member name="zMid" type="var"/>
 				<member name="ssh" type="var"/>
-				<member name="landIcePressure" type="var"/>
 				<member name="seaIcePressure" type="var"/>
 				<member name="atmosphericPressure" type="var"/>
 				<member name="tracersSurfaceValue" type="var_array"/>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -26,8 +26,8 @@
 		<option name="config_land_ice_flux_boundaryLayerThickness">10.0</option>
 		<option name="config_land_ice_flux_topDragCoeff">2.5e-3</option>
 		<option name="config_land_ice_flux_rms_tidal_velocity">1e-2</option>
-		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">0.0184</option>
-		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">0.00052478511</option>
+		<option name="config_land_ice_flux_jenkins_heat_transfer_coefficient">0.0194</option>
+		<option name="config_land_ice_flux_jenkins_salt_transfer_coefficient">0.00055428571</option>
 		<option name="config_implicit_bottom_drag_coeff">2.5e-3</option>
 		<option name="config_eos_type">'linear'</option>
 		<option name="config_eos_linear_alpha">0.03836</option>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -40,6 +40,7 @@
 		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
 		<option name="config_check_ssh_consistency">.false.</option>
 		<option name="config_AM_timeSeriesStatsMonthly_enable">.true.</option>
+		<option name="config_AM_timeSeriesStatsMonthly_restart_stream">'none'</option>
 		<option name="config_pio_num_iotasks">2</option>
 		<option name="config_pio_stride">68</option>
 	</namelist>
@@ -115,11 +116,12 @@
 			<attribute name="filename_interval">output_interval</attribute>
 			<attribute name="clobber_mode">truncate</attribute>
 			<attribute name="reference_time">0001-01-01_00:00:00</attribute>
-			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="output_interval">none</attribute>
 			<attribute name="filename_template">restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc</attribute>
 			<attribute name="input_interval">initial_only</attribute>
 			<attribute name="type">input;output</attribute>
 			<attribute name="immutable">true</attribute>
+			<attribute name="io_type">pnetcdf</attribute>
 			<add_contents>
 			</add_contents>
 		</stream>

--- a/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/template_forward.xml
@@ -38,6 +38,7 @@
 		<option name="config_use_activeTracers_interior_restoring">.true.</option>
 		<option name="config_use_activeTracers_surface_bulk_forcing">.true.</option>
 		<option name="config_check_ssh_consistency">.false.</option>
+		<option name="config_AM_timeSeriesStatsMonthly_enable">.true.</option>
 	</namelist>
 
 	<streams>
@@ -65,10 +66,56 @@
 				<member name="atmosphericPressure" type="var"/>
 			</add_contents>
 		</stream>
+
+		<stream name="timeSeriesStatsMonthlyOutput">
+			<attribute name="name">timeSeriesStatsMonthlyOutput</attribute>
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">timeSeriesStatsMonthly.$Y-$M-$D.nc</attribute>
+			<attribute name="filename_interval">00-01-00_00:00:00</attribute>
+			<attribute name="reference_time">0001-01-01_00:00:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="io_type">pnetcdf</attribute>
+			<attribute name="packages">timeSeriesStatsMonthlyAMPKG</attribute>
+			<attribute name="output_interval">00-01-00_00:00:00</attribute>
+			<add_contents>
+				<member name="daysSinceStartOfSim" type="var"/>
+				<member name="tracersSurfaceValue" type="var_array"/>
+				<member name="surfaceVelocity" type="var_array"/>
+				<member name="ssh" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="vertVelocityTop" type="var"/>
+				<member name="normalTransportVelocity" type="var"/>
+				<member name="transportVelocityZonal" type="var"/>
+				<member name="transportVelocityMeridional" type="var"/>
+				<member name="vertTransportVelocityTop" type="var"/>
+				<member name="tThreshMLD" type="var"/>
+				<member name="dThreshMLD" type="var"/>
+				<member name="landIceFreshwaterFlux" type="var"/>
+				<member name="landIceHeatFlux" type="var"/>
+				<member name="heatFluxToLandIce" type="var"/>
+				<member name="areaCellGlobal" type="var"/>
+			</add_contents>
+		</stream>
+		<stream name="timeSeriesStatsMonthlyRestart">
+			<attribute name="name">timeSeriesStatsMonthlyRestart</attribute>
+			<attribute name="filename_interval">output_interval</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="reference_time">0001-01-01_00:00:00</attribute>
+			<attribute name="output_interval">stream:restart:output_interval</attribute>
+			<attribute name="filename_template">restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc</attribute>
+			<attribute name="input_interval">initial_only</attribute>
+			<attribute name="type">input;output</attribute>
+			<attribute name="immutable">true</attribute>
+			<add_contents>
+			</add_contents>
+		</stream>
+
 		<stream name="output">
 			<attribute name="type">output</attribute>
 			<attribute name="filename_template">output.nc</attribute>
-			<attribute name="output_interval">0000-00-05_00:00:00</attribute>
+			<attribute name="output_interval">0001-00-00_00:00:00</attribute>
 			<attribute name="clobber_mode">overwrite</attribute>
 			<add_contents>
 				<member name="tracers" type="var_struct"/>
@@ -92,12 +139,6 @@
 				<member name="velocityX" type="var"/>
 				<member name="velocityY" type="var"/>
 			</add_contents>
-		</stream>
-
-		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
-		<stream name="land_ice_fluxes">
-			<attribute name="clobber_mode">overwrite</attribute>
-			<attribute name="output_interval">0000-00-05_00:00:00</attribute>
 		</stream>
 
 		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/computeBarotropicStreamfunction.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/computeBarotropicStreamfunction.py
@@ -9,151 +9,149 @@ import scipy.sparse
 import scipy.sparse.linalg
 import os.path
 
+import glob
+
 
 def computeTransport():
-  transport = numpy.zeros(nEdges)
-  innerEdges = numpy.logical_and(cellsOnEdge[:,0] >= 0,cellsOnEdge[:,1] >= 0)
-  innerEdges = numpy.nonzero(innerEdges)[0]
-  for iEdge in innerEdges:
-    cell0 = cellsOnEdge[iEdge,0]
-    cell1 = cellsOnEdge[iEdge,1]
-    layerThicknessEdge = 0.5*(layerThickness[cell0,:] + layerThickness[cell1,:])
-    transport[iEdge] = dvEdge[iEdge]*numpy.sum(layerThicknessEdge*normalVelocity[iEdge,:])
+    transport = numpy.zeros(nEdges)
+    innerEdges = numpy.logical_and(cellsOnEdge[:,0] >= 0,cellsOnEdge[:,1] >= 0)
+    innerEdges = numpy.nonzero(innerEdges)[0]
+    for iEdge in innerEdges:
+        cell0 = cellsOnEdge[iEdge,0]
+        cell1 = cellsOnEdge[iEdge,1]
+        layerThicknessEdge = 0.5*(layerThickness[cell0,:] + layerThickness[cell1,:])
+        transport[iEdge] = dvEdge[iEdge]*numpy.sum(layerThicknessEdge*normalVelocity[iEdge,:])
 
-  return (innerEdges,transport)
+    return (innerEdges,transport)
   
 def computeBSF():
-  boundaryVertices = numpy.logical_or(cellsOnVertex[:,0] ==-1,cellsOnVertex[:,1] ==-1)
-  boundaryVertices = numpy.logical_or(boundaryVertices,cellsOnVertex[:,2] ==-1)
-  boundaryVertices = numpy.nonzero(boundaryVertices)[0]
-  nBoundaryVertices = len(boundaryVertices)
-  nInnerEdges = len(innerEdges)
+    boundaryVertices = numpy.logical_or(cellsOnVertex[:,0] ==-1,cellsOnVertex[:,1] ==-1)
+    boundaryVertices = numpy.logical_or(boundaryVertices,cellsOnVertex[:,2] ==-1)
+    boundaryVertices = numpy.nonzero(boundaryVertices)[0]
+    nBoundaryVertices = len(boundaryVertices)
+    nInnerEdges = len(innerEdges)
   
-  rhs = numpy.zeros(nInnerEdges+nBoundaryVertices,dtype=float)
-  indices = numpy.zeros((2,2*nInnerEdges+nBoundaryVertices),dtype=int)
-  data = numpy.zeros(2*nInnerEdges+nBoundaryVertices,dtype=float)
-  for index in range(nInnerEdges):
+    rhs = numpy.zeros(nInnerEdges+nBoundaryVertices,dtype=float)
+    indices = numpy.zeros((2,2*nInnerEdges+nBoundaryVertices),dtype=int)
+    data = numpy.zeros(2*nInnerEdges+nBoundaryVertices,dtype=float)
+    for index in range(nInnerEdges):
   
-    iEdge = innerEdges[index]
-    v0 = verticesOnEdge[iEdge,0]
-    v1 = verticesOnEdge[iEdge,1]
+        iEdge = innerEdges[index]
+        v0 = verticesOnEdge[iEdge,0]
+        v1 = verticesOnEdge[iEdge,1]
     
-    indices[0,2*index] = index
-    indices[1,2*index] = v1
-    data[2*index] = 1.
-    indices[0,2*index+1] = index
-    indices[1,2*index+1] = v0
-    data[2*index+1] = -1.
+        indices[0,2*index] = index
+        indices[1,2*index] = v1
+        data[2*index] = 1.
+        indices[0,2*index+1] = index
+        indices[1,2*index+1] = v0
+        data[2*index+1] = -1.
     
-    rhs[index] = transport[iEdge]*1e-6 #in Sv
+        rhs[index] = transport[iEdge]*1e-6 #in Sv
   
-  for index in range(nBoundaryVertices):
-    iVertex = boundaryVertices[index]
-    indices[0,2*nInnerEdges+index] = nInnerEdges+index
-    indices[1,2*nInnerEdges+index] = iVertex
-    data[2*nInnerEdges+index] = 1. 
-    rhs[nInnerEdges+index] = 0. # bsf is zero at the boundaries
+    for index in range(nBoundaryVertices):
+        iVertex = boundaryVertices[index]
+        indices[0,2*nInnerEdges+index] = nInnerEdges+index
+        indices[1,2*nInnerEdges+index] = iVertex
+        data[2*nInnerEdges+index] = 1. 
+        rhs[nInnerEdges+index] = 0. # bsf is zero at the boundaries
   
-  M = scipy.sparse.csr_matrix((data,indices),shape=(nInnerEdges+nBoundaryVertices,nVertices))
+    M = scipy.sparse.csr_matrix((data,indices),shape=(nInnerEdges+nBoundaryVertices,nVertices))
   
-  solution = scipy.sparse.linalg.lsqr(M,rhs)
+    solution = scipy.sparse.linalg.lsqr(M,rhs)
   
-  bsf = -solution[0]
-  return bsf
+    bsf = -solution[0]
+    return bsf
 
  
 def computeBSFCell(bsf):
-  bsfCell = numpy.zeros(nCells)
-  for iCell in range(nCells):
-    edgeCount = nEdgesOnCell[iCell]
-    edges = edgesOnCell[iCell,0:edgeCount]
-    verts = verticesOnCell[iCell,0:edgeCount]
-    areaEdge = dcEdge[edges]*dvEdge[edges]
-    indexM1 = numpy.mod(numpy.arange(-1,edgeCount-1),edgeCount)
-    areaVert = 0.5*(areaEdge+areaEdge[indexM1])
-    bsfCell[iCell] = numpy.sum(areaVert*bsf[verts])/numpy.sum(areaVert)
+    bsfCell = numpy.zeros(nCells)
+    for iCell in range(nCells):
+        edgeCount = nEdgesOnCell[iCell]
+        edges = edgesOnCell[iCell,0:edgeCount]
+        verts = verticesOnCell[iCell,0:edgeCount]
+        areaEdge = dcEdge[edges]*dvEdge[edges]
+        indexM1 = numpy.mod(numpy.arange(-1,edgeCount-1),edgeCount)
+        areaVert = 0.5*(areaEdge+areaEdge[indexM1])
+        bsfCell[iCell] = numpy.sum(areaVert*bsf[verts])/numpy.sum(areaVert)
   
-  return bsfCell
+    return bsfCell
+
 
 parser = OptionParser()
            
 options, args = parser.parse_args()
 
-folder=args[0]
+if len(args) > 0:
+    folder = args[0]
+else:
+    folder = '.'
 
-inFile = Dataset('%s/output.nc'%folder,'r')
+inFileNames = sorted(glob.glob('%s/timeSeriesStatsMonthly.*.nc'%folder))
+
+initFile = Dataset('{}/init.nc'.format(folder), 'r')
 outFileName = '%s/barotropicStreamfunction.nc'%folder
 continueOutput = os.path.exists(outFileName)
 if(continueOutput):
-  outFile = Dataset(outFileName,'r+',format='NETCDF4')
+    outFile = Dataset(outFileName,'r+',format='NETCDF4')
 else:
-  outFile = Dataset(outFileName,'w',format='NETCDF4')
+    outFile = Dataset(outFileName,'w',format='NETCDF4')
 
-  #Copy dimensions
-  for dimName, dimension in inFile.dimensions.iteritems():
-    print dimName, len(dimension)
-    outFile.createDimension(dimName, len(dimension) if not dimension.isunlimited() else None)
- 
- 
-  # Copy variables
-  for varName, inVar in inFile.variables.iteritems():
-    if(inVar.dimensions[0] == 'Time'):
-      continue
-    outVar = outFile.createVariable(varName, inVar.datatype, inVar.dimensions)
-    print varName, inVar.dimensions, inVar.datatype
-  
-    # Copy variable attributes
-    outVar.setncatts({k: inVar.getncattr(k) for k in inVar.ncattrs()})
-  
-    outVar[:] = inVar[:]
+    outFile.createDimension('Time', None)
+    for dimName in ['nCells', 'nVertices']:
+        outFile.createDimension(dimName, len(initFile.dimensions[dimName]))
 
-nVertices = len(inFile.dimensions['nVertices'])
-nCells = len(inFile.dimensions['nCells'])
-nEdges = len(inFile.dimensions['nEdges'])
-nVertLevels = len(inFile.dimensions['nVertLevels'])
-nTimeIn = len(inFile.dimensions['Time'])
+nVertices = len(initFile.dimensions['nVertices'])
+nCells = len(initFile.dimensions['nCells'])
+nEdges = len(initFile.dimensions['nEdges'])
+nVertLevels = len(initFile.dimensions['nVertLevels'])
+nTimeIn = len(inFileNames)
 if(continueOutput):
-  nTimeOut = len(outFile.dimensions['Time'])
+    nTimeOut = len(outFile.dimensions['Time'])
 else:
-  nTimeOut = 0
+    nTimeOut = 0
 
-verticesOnEdge = inFile.variables['verticesOnEdge'][:]-1 # change to zero-based indexing
-cellsOnEdge = inFile.variables['cellsOnEdge'][:]-1 # change to zero-based indexing
-dvEdge = inFile.variables['dvEdge'][:]
-dcEdge = inFile.variables['dcEdge'][:]
-cellsOnVertex = inFile.variables['cellsOnVertex'][:]-1 # change to zero-based indexing
-nEdgesOnCell = inFile.variables['nEdgesOnCell'][:]
-edgesOnCell = inFile.variables['edgesOnCell'][:]-1
-verticesOnCell = inFile.variables['verticesOnCell'][:]-1
-xEdge = inFile.variables['xEdge'][:]
-yEdge = inFile.variables['yEdge'][:]
-xVertex = inFile.variables['xVertex'][:]
-yVertex = inFile.variables['yVertex'][:]
+verticesOnEdge = initFile.variables['verticesOnEdge'][:]-1 # change to zero-based indexing
+cellsOnEdge = initFile.variables['cellsOnEdge'][:]-1 # change to zero-based indexing
+dvEdge = initFile.variables['dvEdge'][:]
+dcEdge = initFile.variables['dcEdge'][:]
+cellsOnVertex = initFile.variables['cellsOnVertex'][:]-1 # change to zero-based indexing
+nEdgesOnCell = initFile.variables['nEdgesOnCell'][:]
+edgesOnCell = initFile.variables['edgesOnCell'][:]-1
+verticesOnCell = initFile.variables['verticesOnCell'][:]-1
+xEdge = initFile.variables['xEdge'][:]
+yEdge = initFile.variables['yEdge'][:]
+xVertex = initFile.variables['xVertex'][:]
+yVertex = initFile.variables['yVertex'][:]
+initFile.close()
 
 if(continueOutput):
-  outBSF = outFile.variables['barotropicStreamfunction']
-  outBSFCell = outFile.variables['barotropicStreamfunctionCell']
+    outBSF = outFile.variables['barotropicStreamfunction']
+    outBSFCell = outFile.variables['barotropicStreamfunctionCell']
 else:
-  outBSF = outFile.createVariable('barotropicStreamfunction',float,['Time','nVertices'])
-  outBSFCell = outFile.createVariable('barotropicStreamfunctionCell',float,['Time','nCells'])
+    outBSF = outFile.createVariable('barotropicStreamfunction',float,['Time','nVertices'])
+    outBSFCell = outFile.createVariable('barotropicStreamfunctionCell',float,['Time','nCells'])
 
 print nTimeOut, nTimeIn
 for tIndex in range(nTimeOut,nTimeIn):
-  print tIndex, nTimeIn
-  normalVelocity = inFile.variables['normalVelocity'][tIndex,:,:]
-  layerThickness = inFile.variables['layerThickness'][tIndex,:,:]
+    print tIndex, nTimeIn
+    inFile = Dataset(inFileNames[tIndex], 'r')
+    normalVelocity = \
+        inFile.variables['timeMonthly_avg_normalVelocity'][0,:,:]
+    layerThickness = \
+        inFile.variables['timeMonthly_avg_layerThickness'][0,:,:]
+    inFile.close()
   
 
-  (innerEdges,transport) = computeTransport()
+    (innerEdges,transport) = computeTransport()
   
-  bsf = computeBSF()
+    bsf = computeBSF()
   
-  bsfCell = computeBSFCell(bsf)
+    bsfCell = computeBSFCell(bsf)
   
   
-  outBSF[tIndex,:] = bsf
-  outBSFCell[tIndex,:] = bsfCell
+    outBSF[tIndex, :] = bsf
+    outBSFCell[tIndex, :] = bsfCell
 
 outFile.close()
-inFile.close()
 

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/computeOverturningStreamfunction.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/computeOverturningStreamfunction.py
@@ -10,287 +10,294 @@ import shapely.geometry
 
 from progressbar import ProgressBar, Percentage, Bar, ETA
 
+import glob
+
+
 def computeSectionEdgeIndices(point1,point2):
-  #print 'section at between', point1, point2
+    shapelySection = shapely.geometry.LineString([point1,point2])
+
+
+    edgeIndices = []
+    for iEdge in range(nEdges):
+        if shapelySection.intersects(shapelyEdges[iEdge]):
+            edgeIndices.append(iEdge)
+    if(len(edgeIndices) == 0):
+        return (numpy.array(edgeIndices),numpy.array([]))
+
+    # favor larger x and y in a tie
+    edgeIndices = numpy.array(edgeIndices)[numpy.argsort(xEdge[edgeIndices] + yEdge[edgeIndices])[::-1]]
+    distanceSquared = (xEdge[edgeIndices] - point1[0])**2 + (yEdge[edgeIndices] - point1[1])**2
+    currentEdge = edgeIndices[numpy.argmin(distanceSquared)]
+    distanceSquared = (xEdge[edgeIndices] - point2[0])**2 + (yEdge[edgeIndices] - point2[1])**2
+    endEdge = edgeIndices[numpy.argmin(distanceSquared)]
+    xEnd = point2[0] #xEdge[endEdge]
+    yEnd = point2[1] #yEdge[endEdge]
+
+
+    # first vertex is the one closer to the end point
+    vertices = verticesOnEdge[currentEdge,:]
+    distances = (xVertex[vertices] - xEnd)**2 + (yVertex[vertices] - yEnd)**2
+    iVertex = vertices[numpy.argmin(distances)]
   
-  shapelySection = shapely.geometry.LineString([point1,point2])
-
-
-  edgeIndices = []
-  for iEdge in range(nEdges):
-    if shapelySection.intersects(shapelyEdges[iEdge]):
-      edgeIndices.append(iEdge)
-  if(len(edgeIndices) == 0):
-    return (numpy.array(edgeIndices),numpy.array([]))
-
-  # favor larger x and y in a tie
-  edgeIndices = numpy.array(edgeIndices)[numpy.argsort(xEdge[edgeIndices] + yEdge[edgeIndices])[::-1]]
-  distanceSquared = (xEdge[edgeIndices] - point1[0])**2 + (yEdge[edgeIndices] - point1[1])**2
-  currentEdge = edgeIndices[numpy.argmin(distanceSquared)]
-  distanceSquared = (xEdge[edgeIndices] - point2[0])**2 + (yEdge[edgeIndices] - point2[1])**2
-  endEdge = edgeIndices[numpy.argmin(distanceSquared)]
-  xEnd = point2[0] #xEdge[endEdge]
-  yEnd = point2[1] #yEdge[endEdge]
-
-
-  # first vertex is the one closer to the end point
-  vertices = verticesOnEdge[currentEdge,:]
-  distances = (xVertex[vertices] - xEnd)**2 + (yVertex[vertices] - yEnd)**2
-  iVertex = vertices[numpy.argmin(distances)]
-  
-  edgeIndices = [currentEdge]
-  if(vertices[0] == iVertex):
-    edgeSigns = [1]
-  else:
-    assert(vertices[1] == iVertex)
-    edgeSigns = [-1]
-
-  while(currentEdge != endEdge):
-    edges = edgesOnVertex[iVertex,:]
-    if(endEdge in edges):
-      currentEdge = endEdge
+    edgeIndices = [currentEdge]
+    if(vertices[0] == iVertex):
+        edgeSigns = [1]
     else:
-      # favor larger x and y in a tie
-      edges = edges[numpy.argsort(xEdge[edges] + yEdge[edges])[::-1]]
-      minDistance = 1e30
-      currentEdge = -1
-      for iEdge in edges:
-        if iEdge < 0:
-          continue
-        if iEdge in edgeIndices:
-          continue
+        assert(vertices[1] == iVertex)
+        edgeSigns = [-1]
+
+    while(currentEdge != endEdge):
+        edges = edgesOnVertex[iVertex,:]
+        if(endEdge in edges):
+            currentEdge = endEdge
+        else:
+            # favor larger x and y in a tie
+            edges = edges[numpy.argsort(xEdge[edges] + yEdge[edges])[::-1]]
+            minDistance = 1e30
+            currentEdge = -1
+            for iEdge in edges:
+                if iEdge < 0:
+                    continue
+                if iEdge in edgeIndices:
+                    continue
         
-        distance = (xEdge[iEdge] - xEnd)**2 + (yEdge[iEdge] - yEnd)**2
-        if(distance < minDistance):
-          minDistance = distance
-          currentEdge = iEdge
+                distance = (xEdge[iEdge] - xEnd)**2 + (yEdge[iEdge] - yEnd)**2
+                if(distance < minDistance):
+                    minDistance = distance
+                    currentEdge = iEdge
 
-    if(currentEdge < 0):
-      print "Warning: endEdge not found!"
-      print xEdge[edgeIndices], yEdge[edgeIndices]
-      print xEdge[endEdge], yEdge[endEdge]
-      # we must be done done
-      break
+        if(currentEdge < 0):
+            print "Warning: endEdge not found!"
+            print xEdge[edgeIndices], yEdge[edgeIndices]
+            print xEdge[endEdge], yEdge[endEdge]
+            # we must be done done
+            break
     
-    edgeIndices.append(currentEdge)
-    vertex1 = verticesOnEdge[currentEdge,0]
-    vertex2 = verticesOnEdge[currentEdge,1]
-    if(vertex1 == iVertex):
-      iVertex = vertex2
-      edgeSigns.append(1)
-    else:
-      assert(vertex2 == iVertex)
-      iVertex = vertex1
-      edgeSigns.append(-1)
+        edgeIndices.append(currentEdge)
+        vertex1 = verticesOnEdge[currentEdge,0]
+        vertex2 = verticesOnEdge[currentEdge,1]
+        if(vertex1 == iVertex):
+            iVertex = vertex2
+            edgeSigns.append(1)
+        else:
+            assert(vertex2 == iVertex)
+            iVertex = vertex1
+            edgeSigns.append(-1)
   
-  return (numpy.array(edgeIndices),numpy.array(edgeSigns))
+    return (numpy.array(edgeIndices),numpy.array(edgeSigns))
 
                        
 parser = OptionParser()
            
 options, args = parser.parse_args()
 
-folder = args[0]
+if len(args) > 0:
+    folder = args[0]
+else:
+    folder = '.'
 
-inFile = Dataset('%s/output.nc'%folder,'r')
+inFileNames = sorted(glob.glob('%s/timeSeriesStatsMonthly.*.nc'%folder))
+
+initFile = Dataset('%s/init.nc'%folder,'r')
 outFileName = '%s/overturningStreamfunction.nc'%folder
 continueOutput = os.path.exists(outFileName)
 if(continueOutput):
-  outFile = Dataset(outFileName,'r+',format='NETCDF4')
+    outFile = Dataset(outFileName,'r+',format='NETCDF4')
 else:
-  outFile = Dataset(outFileName,'w',format='NETCDF4')
+    outFile = Dataset(outFileName,'w',format='NETCDF4')
 
-nVertices = len(inFile.dimensions['nVertices'])
-nCells = len(inFile.dimensions['nCells'])
-nEdges = len(inFile.dimensions['nEdges'])
-nVertLevels = len(inFile.dimensions['nVertLevels'])
-nTimeIn = len(inFile.dimensions['Time'])
+nVertices = len(initFile.dimensions['nVertices'])
+nCells = len(initFile.dimensions['nCells'])
+nEdges = len(initFile.dimensions['nEdges'])
+nVertLevels = len(initFile.dimensions['nVertLevels'])
+nTimeIn = len(inFileNames)
 if(continueOutput):
-  nTimeOut = len(outFile.dimensions['Time'])
+    nTimeOut = len(outFile.dimensions['Time'])
 else:
-  nTimeOut = 0
+    nTimeOut = 0
 
 
-verticesOnEdge = inFile.variables['verticesOnEdge'][:,:]-1 # change to zero-based indexing
-cellsOnEdge = inFile.variables['cellsOnEdge'][:,:]-1 # change to zero-based indexing
-dvEdge = inFile.variables['dvEdge'][:]
-dcEdge = inFile.variables['dcEdge'][:]
-cellsOnVertex = inFile.variables['cellsOnVertex'][:,:]-1 # change to zero-based indexing
-nEdgesOnCell = inFile.variables['nEdgesOnCell'][:]
-edgesOnCell = inFile.variables['edgesOnCell'][:,:]-1
-edgesOnVertex = inFile.variables['edgesOnVertex'][:,:]-1
-verticesOnCell = inFile.variables['verticesOnCell'][:,:]-1
-maxLevelCell = inFile.variables['maxLevelCell'][:]-1
-xEdge = inFile.variables['xEdge'][:]
-yEdge = inFile.variables['yEdge'][:]
-xVertex = inFile.variables['xVertex'][:]
-yVertex = inFile.variables['yVertex'][:]
-xCell = inFile.variables['xCell'][:]
-yCell = inFile.variables['yCell'][:]
+verticesOnEdge = initFile.variables['verticesOnEdge'][:,:]-1 # change to zero-based indexing
+cellsOnEdge = initFile.variables['cellsOnEdge'][:,:]-1 # change to zero-based indexing
+dvEdge = initFile.variables['dvEdge'][:]
+dcEdge = initFile.variables['dcEdge'][:]
+cellsOnVertex = initFile.variables['cellsOnVertex'][:,:]-1 # change to zero-based indexing
+nEdgesOnCell = initFile.variables['nEdgesOnCell'][:]
+edgesOnCell = initFile.variables['edgesOnCell'][:,:]-1
+edgesOnVertex = initFile.variables['edgesOnVertex'][:,:]-1
+verticesOnCell = initFile.variables['verticesOnCell'][:,:]-1
+maxLevelCell = initFile.variables['maxLevelCell'][:]-1
+xEdge = initFile.variables['xEdge'][:]
+yEdge = initFile.variables['yEdge'][:]
+xVertex = initFile.variables['xVertex'][:]
+yVertex = initFile.variables['yVertex'][:]
+xCell = initFile.variables['xCell'][:]
+yCell = initFile.variables['yCell'][:]
 
 
 if(continueOutput):
-  outOSF = outFile.variables['overturningStreamfunction']
-  sectionIndicesArray = outFile.variables['sectionEdgeIndices'][:,:]
-  sectionSignArray = outFile.variables['sectionEdgeSigns'][:,:]
-  sectionEdgeIndices = []
-  sectionEdgeSigns = []
-  for xIndex in range(sectionIndicesArray.shape[0]):
-    mask = sectionIndicesArray.mask[xIndex,:] == False
-    sectionEdgeIndices.append(sectionIndicesArray[xIndex,:][mask])
-    sectionEdgeSigns.append(sectionSignArray[xIndex,:][mask])
-  x = outFile.variables['x'][0,:]
-  z = outFile.variables['z'][:,0]
-  nx = len(x)
-  nz = len(z)
+    outOSF = outFile.variables['overturningStreamfunction']
+    sectionIndicesArray = outFile.variables['sectionEdgeIndices'][:,:]
+    sectionSignArray = outFile.variables['sectionEdgeSigns'][:,:]
+    sectionEdgeIndices = []
+    sectionEdgeSigns = []
+    for xIndex in range(sectionIndicesArray.shape[0]):
+        mask = sectionIndicesArray.mask[xIndex,:] == False
+        sectionEdgeIndices.append(sectionIndicesArray[xIndex,:][mask])
+        sectionEdgeSigns.append(sectionSignArray[xIndex,:][mask])
+    x = outFile.variables['x'][0,:]
+    z = outFile.variables['z'][:,0]
+    nx = len(x)
+    nz = len(z)
     
 else:
-  #xMin = numpy.amin(xVertex)
-  #xMax = numpy.amax(xVertex)
-  yMin = numpy.amin(yVertex)
-  yMax = numpy.amax(yVertex)
-  xMin = 320e3
-  xMax = 800e3
-  dx = 2e3 # 2 km
-  nx = int((xMax-xMin)/dx)+1
-  x = numpy.linspace(xMin,xMax,nx)
+    #xMin = numpy.amin(xVertex)
+    #xMax = numpy.amax(xVertex)
+    yMin = numpy.amin(yVertex)
+    yMax = numpy.amax(yVertex)
+    xMin = 320e3
+    xMax = 800e3
+    dx = 2e3 # 2 km
+    nx = int((xMax-xMin)/dx)+1
+    x = numpy.linspace(xMin,xMax,nx)
   
-  zMin = -720.0
-  zMax = 0.0
-  dz = 5.0
-  nz = int((zMax-zMin)/dz)+1
-  z = numpy.linspace(zMax,zMin,nz)
+    zMin = -720.0
+    zMax = 0.0
+    dz = 5.0
+    nz = int((zMax-zMin)/dz)+1
+    z = numpy.linspace(zMax,zMin,nz)
 
-  #print "Building shapely edges"
-  shapelyEdges = []
-  for iEdge in range(nEdges):
-    points = []
-    for v in verticesOnEdge[iEdge,:]:
-      points.append((xVertex[v],yVertex[v]))
-    shapelyEdges.append(shapely.geometry.LineString(points))
+    #print "Building shapely edges"
+    shapelyEdges = []
+    for iEdge in range(nEdges):
+        points = []
+        for v in verticesOnEdge[iEdge,:]:
+            points.append((xVertex[v],yVertex[v]))
+        shapelyEdges.append(shapely.geometry.LineString(points))
 
-  #print "Finding section indices"
-  maxSectionLength = 0
-  sectionEdgeIndices = []
-  sectionEdgeSigns = []
-  pbar = ProgressBar(widgets=[Percentage(), Bar(), ETA()], maxval=len(x)).start()
-  for xIndex in range(len(x)):
-    #print xIndex, '/', len(x)-1
-    xSection = x[xIndex]
-    (edgeIndices, edgeSigns) = computeSectionEdgeIndices((xSection,yMin),(xSection,yMax))
-    if(len(edgeIndices) != 0):
-      xMean = numpy.mean(xEdge[edgeIndices])
-      x[xIndex] = xMean
+    #print "Finding section indices"
+    maxSectionLength = 0
+    sectionEdgeIndices = []
+    sectionEdgeSigns = []
+    pbar = ProgressBar(widgets=[Percentage(), Bar(), ETA()], maxval=len(x)).start()
+    for xIndex in range(len(x)):
+        #print xIndex, '/', len(x)-1
+        xSection = x[xIndex]
+        (edgeIndices, edgeSigns) = computeSectionEdgeIndices((xSection,yMin),(xSection,yMax))
+        if(len(edgeIndices) != 0):
+            xMean = numpy.mean(xEdge[edgeIndices])
+            x[xIndex] = xMean
 
-    sectionEdgeIndices.append(edgeIndices)
-    sectionEdgeSigns.append(edgeSigns)
-    maxSectionLength = max(maxSectionLength,len(edgeIndices))
-    pbar.update(xIndex+1)
-  pbar.finish()
+        sectionEdgeIndices.append(edgeIndices)
+        sectionEdgeSigns.append(edgeSigns)
+        maxSectionLength = max(maxSectionLength,len(edgeIndices))
+        pbar.update(xIndex+1)
+    pbar.finish()
     
-  sectionIndicesArray = numpy.ma.masked_all((nx,maxSectionLength),int)
-  sectionSignsArray = numpy.ma.masked_all((nx,maxSectionLength),int)
-  for xIndex in range(len(x)):
-    count = len(sectionEdgeIndices[xIndex])
-    sectionIndicesArray[xIndex,0:count] = sectionEdgeIndices[xIndex]
-    sectionSignsArray[xIndex,0:count] = sectionEdgeSigns[xIndex]
+    sectionIndicesArray = numpy.ma.masked_all((nx,maxSectionLength),int)
+    sectionSignsArray = numpy.ma.masked_all((nx,maxSectionLength),int)
+    for xIndex in range(len(x)):
+        count = len(sectionEdgeIndices[xIndex])
+        sectionIndicesArray[xIndex,0:count] = sectionEdgeIndices[xIndex]
+        sectionSignsArray[xIndex,0:count] = sectionEdgeSigns[xIndex]
 
-  outFile.createDimension('nx',nx)
-  outFile.createDimension('nz',nz)
-  outFile.createDimension('maxSectionLength',maxSectionLength)
-  outFile.createDimension('Time',None)
-  outOSF = outFile.createVariable('overturningStreamfunction',float,['Time','nz','nx'])
-  outX = outFile.createVariable('x',float,['nz','nx'])
-  outZ = outFile.createVariable('z',float,['nz','nx'])
-  (X,Z) = numpy.meshgrid(x,z)
-  outX[:,:] = X
-  outZ[:,:] = Z
-  outSectionIndices = outFile.createVariable('sectionEdgeIndices',int,['nx','maxSectionLength'])
-  outSectionIndices[:,:] = sectionIndicesArray
-  outSectionSigns = outFile.createVariable('sectionEdgeSigns',int,['nx','maxSectionLength'])
-  outSectionSigns[:,:] = sectionSignsArray
+    outFile.createDimension('nx',nx)
+    outFile.createDimension('nz',nz)
+    outFile.createDimension('maxSectionLength',maxSectionLength)
+    outFile.createDimension('Time',None)
+    outOSF = outFile.createVariable('overturningStreamfunction',float,['Time','nz','nx'])
+    outX = outFile.createVariable('x',float,['nz','nx'])
+    outZ = outFile.createVariable('z',float,['nz','nx'])
+    (X,Z) = numpy.meshgrid(x,z)
+    outX[:,:] = X
+    outZ[:,:] = Z
+    outSectionIndices = outFile.createVariable('sectionEdgeIndices',int,['nx','maxSectionLength'])
+    outSectionIndices[:,:] = sectionIndicesArray
+    outSectionSigns = outFile.createVariable('sectionEdgeSigns',int,['nx','maxSectionLength'])
+    outSectionSigns[:,:] = sectionSignsArray
 
-bottomDepth = inFile.variables['bottomDepth'][:]
+bottomDepth = initFile.variables['bottomDepth'][:]
 
 #print "Building maxLevelEdgeTop"
 maxLevelEdgeTop = -1*numpy.ones(nEdges,int)
 for iEdge in range(nEdges):
-  cell1 = cellsOnEdge[iEdge,0]
-  cell2 = cellsOnEdge[iEdge,1]
-  if(cell1 >= 0 and cell2 >= 0):
-    maxLevelEdgeTop[iEdge] = min(maxLevelCell[cell1],maxLevelCell[cell2])
+    cell1 = cellsOnEdge[iEdge,0]
+    cell2 = cellsOnEdge[iEdge,1]
+    if(cell1 >= 0 and cell2 >= 0):
+        maxLevelEdgeTop[iEdge] = min(maxLevelCell[cell1],maxLevelCell[cell2])
 
 pbar = ProgressBar(widgets=[Percentage(), Bar(), ETA()], maxval=nTimeIn*nx).start()
 for tIndex in range(nTimeOut,nTimeIn):
-  #print "Time: ", ''.join(inFile.variables['xtime'][tIndex,:]).rstrip()
+    inFile = Dataset(inFileNames[tIndex], 'r')
 
-  layerThickness = inFile.variables['layerThickness'][tIndex,:,:]
-  normalVelocity = inFile.variables['normalVelocity'][tIndex,:,:]
+    normalVelocity = \
+        inFile.variables['timeMonthly_avg_normalVelocity'][0,:,:]
+    layerThickness = \
+        inFile.variables['timeMonthly_avg_layerThickness'][0,:,:]
 
+    inFile.close()
 
-  zInterfaceCell = numpy.zeros((nCells,nVertLevels+1))
-  zInterfaceCell[:,-1] = -bottomDepth
-  for levelIndex in range(nVertLevels-1,-1,-1):
-    mask = levelIndex <= maxLevelCell
-    zInterfaceCell[:,levelIndex] = zInterfaceCell[:,levelIndex+1] + mask*layerThickness[:,levelIndex]
+    zInterfaceCell = numpy.zeros((nCells,nVertLevels+1))
+    zInterfaceCell[:,-1] = -bottomDepth
+    for levelIndex in range(nVertLevels-1,-1,-1):
+        mask = levelIndex <= maxLevelCell
+        zInterfaceCell[:,levelIndex] = zInterfaceCell[:,levelIndex+1] + mask*layerThickness[:,levelIndex]
   
         
-  #print "Computing transport over sections"
-  transportSection = numpy.zeros((nz-1,nx))
-  transportSectionArea = numpy.zeros((nz-1,nx))
-  for xIndex in range(nx):
-    for sIndex in range(len(sectionEdgeIndices[xIndex])):
-      iEdge = sectionEdgeIndices[xIndex][sIndex]
-      sign = sectionEdgeSigns[xIndex][sIndex]
+    #print "Computing transport over sections"
+    transportSection = numpy.zeros((nz-1,nx))
+    transportSectionArea = numpy.zeros((nz-1,nx))
+    for xIndex in range(nx):
+        for sIndex in range(len(sectionEdgeIndices[xIndex])):
+            iEdge = sectionEdgeIndices[xIndex][sIndex]
+            sign = sectionEdgeSigns[xIndex][sIndex]
 
-      cell1 = cellsOnEdge[iEdge,0]
-      cell2 = cellsOnEdge[iEdge,1]
-      levelIndex = maxLevelEdgeTop[iEdge]
-      zBot = 0.5*(zInterfaceCell[cell1,levelIndex+1] + zInterfaceCell[cell2,levelIndex+1])
-      layerThicknessEdge = 0.5*(layerThickness[cell1,levelIndex]
-                              + layerThickness[cell2,levelIndex])
-      zTop = zBot + layerThicknessEdge
-      for zIndex in range(nz-2,-1,-1):
-        #print zIndex
-        # sum the fluxes (if any) within this level on the output grid
-        while (levelIndex >= 0) and (zBot < z[zIndex]):
-          #print zIndex, levelIndex, z[zIndex], zBot
-          v = normalVelocity[iEdge,levelIndex]
-          if(zTop <= z[zIndex]):
-            dz = zTop - zBot
-            zBot = zTop
+            cell1 = cellsOnEdge[iEdge,0]
+            cell2 = cellsOnEdge[iEdge,1]
+            levelIndex = maxLevelEdgeTop[iEdge]
+            zBot = 0.5*(zInterfaceCell[cell1,levelIndex+1] + zInterfaceCell[cell2,levelIndex+1])
             layerThicknessEdge = 0.5*(layerThickness[cell1,levelIndex]
-                                    + layerThickness[cell2,levelIndex])
-            zTop += layerThicknessEdge
-            levelIndex -= 1
-          else:
-            dz = z[zIndex] - zBot
-            zBot = z[zIndex]
-          area = dvEdge[iEdge]*dz
-          transportSection[zIndex,xIndex] += sign*area*v
-          transportSectionArea[zIndex,xIndex] += area
-    pbar.update(tIndex*nx+xIndex+1)
+                              + layerThickness[cell2,levelIndex])
+            zTop = zBot + layerThicknessEdge
+            for zIndex in range(nz-2,-1,-1):
+                #print zIndex
+                # sum the fluxes (if any) within this level on the output grid
+                while (levelIndex >= 0) and (zBot < z[zIndex]):
+                    #print zIndex, levelIndex, z[zIndex], zBot
+                    v = normalVelocity[iEdge,levelIndex]
+                    if(zTop <= z[zIndex]):
+                        dz = zTop - zBot
+                        zBot = zTop
+                        layerThicknessEdge = \
+                            0.5*(layerThickness[cell1,levelIndex]
+                                 + layerThickness[cell2,levelIndex])
+                        zTop += layerThicknessEdge
+                        levelIndex -= 1
+                    else:
+                        dz = z[zIndex] - zBot
+                        zBot = z[zIndex]
+                    area = dvEdge[iEdge]*dz
+                    transportSection[zIndex,xIndex] += sign*area*v
+                    transportSectionArea[zIndex,xIndex] += area
+        pbar.update(tIndex*nx+xIndex+1)
     
-  transportMask = 1.0*(transportSectionArea > 0.0)
+    transportMask = 1.0*(transportSectionArea > 0.0)
 
-  #print "Computing overturning streamfunction"
-  # As transport betwee two points is the difference between OSF at these 
-  # locations, OSF is the cumulative sum of transport
-  osf = numpy.zeros((nz,nx))
-  osf[1:,:] = 1e-6*numpy.cumsum(transportSection,axis=0) # in Sv
-  # OSF is valid as long as there is valid transport on one side or the other
-  osfMask = numpy.zeros((nz,nx))
-  osfMask[0:-1,:] = transportMask
-  osfMask[1:,:] = numpy.logical_or(osfMask[1:,:],transportMask)
+    #print "Computing overturning streamfunction"
+    # As transport betwee two points is the difference between OSF at these 
+    # locations, OSF is the cumulative sum of transport
+    osf = numpy.zeros((nz,nx))
+    osf[1:,:] = 1e-6*numpy.cumsum(transportSection,axis=0) # in Sv
+    # OSF is valid as long as there is valid transport on one side or the other
+    osfMask = numpy.zeros((nz,nx))
+    osfMask[0:-1,:] = transportMask
+    osfMask[1:,:] = numpy.logical_or(osfMask[1:,:],transportMask)
   
-  # make OSF a masked array for plotting
-  osf = numpy.ma.masked_array(osf,osfMask == 0.0)
+    # make OSF a masked array for plotting
+    osf = numpy.ma.masked_array(osf,osfMask == 0.0)
 
-  outOSF[tIndex,:,:] = osf
+    outOSF[tIndex,:,:] = osf
 
 pbar.finish()
-
-
 outFile.close()
-inFile.close()
 

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/computeOverturningStreamfunction.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/computeOverturningStreamfunction.py
@@ -112,7 +112,7 @@ nEdges = len(initFile.dimensions['nEdges'])
 nVertLevels = len(initFile.dimensions['nVertLevels'])
 nTimeIn = len(inFileNames)
 if(continueOutput):
-    nTimeOut = len(outFile.dimensions['Time'])
+    nTimeOut = len(outFile.dimensions['nTime'])
 else:
     nTimeOut = 0
 
@@ -145,8 +145,8 @@ if(continueOutput):
         mask = sectionIndicesArray.mask[xIndex,:] == False
         sectionEdgeIndices.append(sectionIndicesArray[xIndex,:][mask])
         sectionEdgeSigns.append(sectionSignArray[xIndex,:][mask])
-    x = outFile.variables['x'][0,:]
-    z = outFile.variables['z'][:,0]
+    x = outFile.variables['x'][:]
+    z = outFile.variables['z'][:]
     nx = len(x)
     nz = len(z)
     


### PR DESCRIPTION
Variables are now averaged with `timeSeriesStatsMonthlyOutput` to ISOMIP+ test cases.  Evaporation rates are computed based on monthly mean melt rates.  Visualization and output for MISOMIP are computed from this output as well.

New default parameter values are used in ISOMIP+ based on redoing the Ocean0 parameter study (varying the heat and salt transfer coefficients and finding the value that gives 30 m/yr mean melt rate for `landIceDraft < -300`).

Scripts have been added for generating 3 different parameter studies that will be used in Gwyther et al., "The importance of vertical processes and resolution on simulated basal melt of an ice shelf: a multi-model study within the ISOMIP+ framework", in prep.
