### PR TITLE
Fixes for bfb restart and partitions tests in E3SM

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1769,6 +1769,20 @@ module ocn_time_integration_split
         ! implicit vmix routine that follows.
         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
+        block => block % next
+      end do
+      call mpas_threading_barrier()
+
+      call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
+
+      block => domain % blocklist
+      do while(associated(block))
+        call mpas_pool_get_subpool(block % structs, 'state', statePool)
+        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+        call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+        call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
         ! Compute normalGMBolusVelocity; it will be added to the baroclinic modes in Stage 2 above.
         if (config_use_standardGM) then
            call ocn_gm_compute_Bolus_velocity(diagnosticsPool, meshPool, scratchPool)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -313,8 +313,8 @@ contains
       end do
       !$omp end do
 
-      ! Need 0 and 1 halo cells
-      nCells = nCellsArray( 2 )
+      ! Need 0,1,2 halo cells
+      nCells = nCellsArray( 3 )
       !
       ! Compute divergence, kinetic energy, and vertical velocity
       !
@@ -379,8 +379,8 @@ contains
       end do
       !$omp end do
 
-      nCells = nCellsArray( size(nCellsArray) )
-
+      ! Need 0,1,2 halo cells
+      nCells = nCellsArray( 3 )
       !
       ! Compute kinetic energy
       !

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -394,8 +394,8 @@ contains
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      integer :: iCell
-      integer, pointer :: nCellsSolve
+      integer :: iCell, nCells
+      integer, dimension(:), pointer :: nCellsArray
 
       real (kind=RKIND), pointer :: config_land_ice_flux_ISOMIP_gammaT
 
@@ -428,7 +428,6 @@ contains
                                      freezeInterfaceSalinityField, freezeInterfaceTemperatureField, &
                                      freezeFreshwaterFluxField, freezeHeatFluxField, &
                                      freezeIceHeatFluxField
-
       err = 0
 
       if ( .not. standaloneOn ) return
@@ -439,7 +438,7 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_useHollandJenkinsAdvDiff', &
                                 config_land_ice_flux_useHollandJenkinsAdvDiff)
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
       call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
 
@@ -489,9 +488,11 @@ contains
          freezeIceHeatFlux => freezeIceHeatFluxField % array
       end if
 
+      nCells = nCellsArray( size(nCellsArray) )
+
       if(isomipOn) then
          !$omp do schedule(runtime) private(heatFlux)
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCells
             if (landIceMask(iCell) == 0) cycle
 
             ! linearized equaiton for the S and p dependent potential freezing temperature
@@ -538,7 +539,7 @@ contains
                landIceFreshwaterFlux, &
                landIceHeatFlux, &
                heatFluxToLandIce, &
-               nCellsSolve, &
+               nCells, &
                err)
             if(err .ne. 0) then
                call mpas_log_write( &
@@ -559,7 +560,7 @@ contains
                freezeFreshwaterFlux, &
                freezeHeatFlux, &
                freezeIceHeatFlux, &
-               nCellsSolve, &
+               nCells, &
                err)
             if(err .ne. 0) then
                call mpas_log_write( &
@@ -567,7 +568,7 @@ contains
                   MPAS_LOG_CRIT)
             end if
 
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCells
                if ((landIceMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
 
                landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
@@ -589,7 +590,7 @@ contains
                landIceFreshwaterFlux, &
                landIceHeatFlux, &
                heatFluxToLandIce, &
-               nCellsSolve, &
+               nCells, &
                err)
             if(err .ne. 0) then
                call mpas_log_write( &
@@ -599,7 +600,7 @@ contains
          end if
 
          ! modulate the fluxes by the landIceFraction
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCells
             if (landIceMask(iCell) == 0) cycle
 
             landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*landIceFreshwaterFlux(iCell)
@@ -618,7 +619,7 @@ contains
       end if
 
       ! accumulate land-ice mass and heat
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
         accumulatedLandIceMassNew(iCell) = accumulatedLandIceMassOld(iCell) - dt*landIceFreshwaterFlux(iCell)
         accumulatedLandIceHeatNew(iCell) = accumulatedLandIceHeatOld(iCell) + dt*heatFluxToLandIce(iCell)
       end do


### PR DESCRIPTION
There are three changes.  
1. Widen halo computation ring for kinetic energy.
2. Widen halo computation ring for melt fluxes.
3. Add halo exchange for surfaceFrictionVelocity

When running E3SM with melt fluxes on, the first is needed for bfb restarts (https://github.com/E3SM-Project/E3SM/issues/2702) and all three for bfb partition tests (https://github.com/E3SM-Project/E3SM/issues/2739).