### PR TITLE
Update default 'config_geog_data_path' for current NWSC Glade filesystem

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -108,7 +108,7 @@
 
         <nml_record name="data_sources" in_defaults="true">
 
-                <nml_option name="config_geog_data_path"        type="character"     default_value="/glade/p/work/wrfhelp/WPS_GEOG/"
+                <nml_option name="config_geog_data_path"        type="character"     default_value="/glade/work/wrfhelp/WPS_GEOG/"
                      units="-"
                      description="Path to the WPS static data files (case 7 only)"
                      possible_values="Any valid path"/>


### PR DESCRIPTION
This merge updates the default path of the WPS geographical data to match the current path on
the NWSC Glade filesystem. The data were previously in `/glade/p/work/`, which no longer exists.
This commit updates the default to `/glade/work/wrfhelp/WPS_GEOG`.