### PR TITLE
Zero-out physics tendencies if MPAS-A was not built with physics

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -419,6 +419,13 @@ module atm_time_integration
          block => block % next
       end do
       call mpas_timer_stop('physics_get_tend')
+#else
+      !
+      ! If no physics are being used, simply zero-out the physics tendency fields
+      !
+      tend_ru_physics(:,:) = 0.0_RKIND
+      tend_rtheta_physics(:,:) = 0.0_RKIND
+      tend_rho_physics(:,:) = 0.0_RKIND
 #endif
 
       !


### PR DESCRIPTION
This merge adds code to zero-out physics tendencies if MPAS-A was not built
with physics. Setting the ru, rtheta, and rho tendency arrays to zero in place of
a call to physics_get_tend if MPAS-A was compiled without -DDO_PHYSICS
is needed to obtain correct results.