### PR TITLE
Update ocean BGC threading

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -439,7 +439,6 @@ module ocn_time_integration_rk4
                     * highFreqThicknessTend(:, iCell)
               end do
               !$omp end do
-              call mpas_threading_barrier()
               block => block % next
            end do
 
@@ -642,7 +641,6 @@ module ocn_time_integration_rk4
             normalTransportVelocity(:, iEdge) = normalVelocityNew(:, iEdge)
          end do
          !$omp end do
-         call mpas_threading_barrier()
 
          ! Compute normalGMBolusVelocity and the tracer transport velocity
          if (config_use_standardGM) then
@@ -1161,7 +1159,6 @@ module ocn_time_integration_rk4
          normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
       end do
       !$omp end do
-      call mpas_threading_barrier()
 
       ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
       if (config_use_standardGM) then
@@ -1176,7 +1173,6 @@ module ocn_time_integration_rk4
          end do
          !$omp end do
       end if
-      call mpas_threading_barrier()
       ! ------------------------------------------------------------------
       ! End: Accumulating various parametrizations of the transport velocity
       ! ------------------------------------------------------------------

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -560,7 +560,7 @@ module ocn_time_integration_split
 
                allocate(uTemp(nVertLevels))
 
-               !$omp do schedule(runtime) private(cell1, cell2, k, normalThicknessFluxSum, thicknessSum)
+               !$omp do schedule(runtime)
                do iEdge = 1, nEdges
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
@@ -813,7 +813,7 @@ module ocn_time_integration_split
                      nEdges = nEdgesPtr
                      nEdges = nEdgesArray( edgeHaloComputeCounter )
 
-                     !$omp do schedule(runtime) private(cell1, cell2, CoriolisTerm, i, eoe)
+                     !$omp do schedule(runtime)
                      do iEdge = 1, nEdges
 
                         temp_mask = edgeMask(1, iEdge)
@@ -1025,7 +1025,7 @@ module ocn_time_integration_split
 
                    nEdges = nEdgesArray( edgeHaloComputeCounter )
 
-                   !$omp do schedule(runtime) private(cell1, cell2, eoe, CoriolisTerm, i, sshCell1, sshCell2)
+                   !$omp do schedule(runtime)
                    do iEdge = 1, nEdges
 
                      ! asarje: added to avoid redundant computations based on mask
@@ -1338,7 +1338,7 @@ module ocn_time_integration_split
                   useVelocityCorrection = 0
                endif
 
-               !$omp do schedule(runtime) private(k, normalThicknessFluxSum, thicknessSum, normalVelocityCorrection)
+               !$omp do schedule(runtime)
                do iEdge = 1, nEdges
 
                   ! velocity for normalVelocityCorrectionection is normalBarotropicVelocity + normalBaroclinicVelocity + uBolus

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -285,12 +285,13 @@ contains
       !    used -1e34 so error clearly occurs if these values are used.
       !
 
-      !$omp single
+      !$omp master
       normalVelocity(:,nEdges+1) = -1e34
       layerThickness(:,nCells+1) = -1e34
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
-      !$omp end single
+      !$omp end master
+      call mpas_threading_barrier()
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
@@ -320,7 +321,7 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
-      !$omp do schedule(runtime) private(invAreaCell1, iEdge, r_tmp, i, k)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -364,7 +365,7 @@ contains
 
       nEdges = nEdgesArray( 2 )
 
-      !$omp do schedule(runtime) private(eoe, i, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -621,7 +622,7 @@ contains
 
         allocate(pTop(nVertLevels))
 
-        !$omp do schedule(runtime) private(k)
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
 
            ! assume atmospheric pressure at the surface is zero for now.
@@ -752,7 +753,7 @@ contains
 
         nCells = nCellsArray( 1 )
 
-        !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        !$omp do schedule(runtime)
         do iCell=1,nCells
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
@@ -1168,7 +1169,7 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1188,8 +1189,6 @@ contains
         enddo
       enddo ! iEdge
       !$omp end do
-
-      call mpas_threading_barrier()
 
       call mpas_timer_stop("ocn_filter_btr_mode_vel")
 
@@ -1239,7 +1238,7 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, vertSum, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1450,8 +1449,7 @@ contains
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
-      !$omp do schedule(runtime) private(invAreaCell, deltaVelocitySquared, i, iEdge, factor, delU2, fracAbsorbed, &
-      !$omp                              fracAbsorbedRunoff)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
        invAreaCell = 1.0_RKIND / areaCell(iCell)
 
@@ -1513,8 +1511,6 @@ contains
 
       enddo
       !$omp end do
-
-      call mpas_threading_barrier()
 
       ! deallocate scratch space
       call mpas_deallocate_scratch_field(thermalExpansionCoeffField, .true.)
@@ -1740,7 +1736,7 @@ contains
 
 
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
-      !$omp do schedule(runtime) private(blThickness, iLevel, dz)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -309,7 +309,7 @@ contains
          enddo
       endif
 
-      !$omp do schedule(runtime) private(k, DRDT0, DKDT, DRHODT, DRDS0, DKDS, DRHODS)
+      !$omp do schedule(runtime)
       do iCell=1,nCells
          if (displacement_type == 'surfaceDisplaced') then
            if(present(tracersSurfaceLayerValue)) then

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -451,9 +451,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! loop over all columns
-      !$omp do schedule(runtime) private(kBottomFrazil, k, columnTemperatureMin, sumNewFrazilIceThickness, &
-      !$omp                              oceanFreezingTemperature, potential, freezingEnergy, meltingEnergy, &
-      !$omp                              newFrazilIceThickness, meltedFrazilIceThickness)
+      !$omp do schedule(runtime)
       do iCell=1,nCells
 
         underLandIce = .false.

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -418,11 +418,10 @@ contains
       ! use relativeSlopeTaperingCell as a temporary space for smoothing of relativeSlopeTopOfCell
       relativeSlopeTaperingCell = relativeSlopeTopOfCell
       do iter = 1, 5
-         !$omp barrier
 
          nCells = nCellsArray( 2 )
 
-         !$omp do schedule(runtime) private(k, rtmp)
+         !$omp do schedule(runtime)
          do iCell=1,nCells
            relativeSlopeTaperingCell(1, iCell) = 0.0_RKIND
            relativeSlopeTaperingCell(maxLevelCell(iCell):nVertLevels, iCell) = 0.0_RKIND
@@ -523,7 +522,7 @@ contains
 
       nEdges = nEdgesArray( 3 )
 
-      !$omp do schedule(runtime) private(cell1, cell2, k, BruntVaisalaFreqTopEdge, N)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_sea_ice.F
@@ -135,8 +135,7 @@ contains
 
       density_ice = rho_ice
 
-      !$omp do schedule(runtime) private(maxLevel, netEnergyChange, k, freezingTemp, availableEnergyChange, energyChange, &
-      !$omp                              temperatureChange, thicknessChange, iceThicknessChange, iTracer)
+      !$omp do schedule(runtime)
       do iCell = 1, nCellsSolve ! Check performance of these two loop definitions
 !     do iCell = nCellsSolve, 1, -1
          maxLevel = min(maxLevelCell(iCell), verticalLevelCap)

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -491,7 +491,7 @@ contains
       nCells = nCellsArray( size(nCellsArray) )
 
       if(isomipOn) then
-         !$omp do schedule(runtime) private(heatFlux)
+         !$omp do schedule(runtime)
          do iCell = 1, nCells
             if (landIceMask(iCell) == 0) cycle
 
@@ -795,7 +795,7 @@ contains
             .and. present(kappa_land_ice)
     Tlatent = latent_heat_fusion_mks/cp_sw
 
-    !$omp do schedule(runtime) private(iceHeatFluxCoeff, nu, iceDeltaT, T0, transferVelocityRatio, a, b, c)
+    !$omp do schedule(runtime)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 
@@ -952,7 +952,7 @@ contains
 
     err = 0
     cpRatio = cp_land_ice/cp_sw
-    !$omp do schedule(runtime) private(T0, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c)
+    !$omp do schedule(runtime) reduction(+:err)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 
@@ -975,9 +975,7 @@ contains
       outInterfaceSalinity(iCell) = (-b + sqrt(b**2 - 4.0_RKIND*a*c*oceanSalinity(iCell)))/(2.0_RKIND*a)
       if (outInterfaceSalinity(iCell) .le. 0.0_RKIND) then
          err = 1
-         call mpas_log_write( &
-            'interfaceSalinity is negative.', &
-            MPAS_LOG_CRIT)
+         call mpas_log_write('interfaceSalinity is negative.', MPAS_LOG_CRIT)
       end if
       outInterfaceTemperature(iCell) = dTf_dS*outInterfaceSalinity(iCell)+T0
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -628,6 +628,9 @@ contains
                                                         tracerGroupSurfaceFluxRemoved, dt, layerThickness, err)
                end if
 
+
+               !$omp master
+
                !
                ! compute ecosystem source-sink tendencies and net surface fluxes
                ! NOTE: must be called before ocn_tracer_surface_flux_tend
@@ -672,6 +675,9 @@ contains
                   call ocn_tracer_MacroMolecules_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &
                      nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                endif
+
+               !$omp end master
+               call mpas_threading_barrier()
 
                !
                ! ocean surface restoring
@@ -974,7 +980,7 @@ contains
 
       allocate(div_hu(nVertLevels))
 
-      !$omp do schedule(runtime) private(div_hu_btr, invAreaCell, i, iEdge, k, totalThickness, flux)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
         tend_lowFreqDivergence(:, iCell) = 0.0_RKIND
         tend_highFreqThickness(:, iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -147,7 +147,7 @@ contains
       !
       ! ALE thickness alteration due to SSH (z-star)
       !
-      !$omp do schedule(runtime) private(kMax, thicknessSum, k)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          kMax = maxLevelCell(iCell)
 
@@ -182,7 +182,7 @@ contains
       !
       if (config_use_min_max_thickness) then
 
-         !$omp do schedule(runtime) private(kMax, remainder, k, newThickness)
+         !$omp do schedule(runtime)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -304,8 +304,7 @@ module ocn_tracer_advection_mono
 #endif
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
-        !$omp do schedule(runtime) private(k, tracer_max_new, tracer_min_new, tracer_upwind_new, scale_factor, invAreaCell1, i, &
-        !$omp                              iEdge, cell1, cell2, signedFactor)
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -381,7 +380,7 @@ module ocn_tracer_advection_mono
 
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
-        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, flux, k)
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -495,7 +494,7 @@ module ocn_tracer_advection_mono
         ! Need all owned and 1 halo cells
         nCells = nCellsArray( 2 )
         !  Compute the high and low order vertical fluxes. Also determine bounds on tracer_cur.
-        !$omp do schedule(runtime) private(k, verticalWeightK, verticalWeightKm1, i)
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
 
           ! Operate on top cell in column
@@ -583,7 +582,7 @@ module ocn_tracer_advection_mono
 #endif
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
-        !$omp do schedule(runtime) private(k, tracer_max_new, tracer_min_new, tracer_upwind_new, scale_factor, i)
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
 
           ! Build the factors for the FCT
@@ -660,7 +659,7 @@ module ocn_tracer_advection_mono
         if (monotonicityCheck) then
           nCells = nCellsArray( 1 )
           ! Check for monotonicity of new tracer value
-          !$omp do schedule(runtime) private(k)
+          !$omp do schedule(runtime)
           do iCell = 1, nCells
             do k = 1, maxLevelCell(iCell)
               ! work_tend on the RHS is the total vertical advection tendency

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -152,7 +152,7 @@ contains
       !
       ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
       !
-      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, iTracer, tracer_turb_flux, flux)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
@@ -232,7 +232,6 @@ contains
       end do
       !$omp end do
 
-      call mpas_threading_barrier()
       call mpas_deallocate_scratch_field(delsq_tracerField, .true.)
 
       call mpas_timer_stop("tracer del4")

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -221,7 +221,7 @@ contains
       if(.not.config_disable_redi_horizontal_term1) then
 
          nCells = nCellsArray( 1 )
-         !$omp do schedule(runtime) private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, s_tmp, iTracer, tracer_turb_flux, flux)
+         !$omp do schedule(runtime)
          do iCell = 1, nCells
             invAreaCell = 1.0_RKIND / areaCell(iCell)
             do i = 1, nEdgesOnCell(iCell)
@@ -257,7 +257,7 @@ contains
          call mpas_threading_barrier()
 
          nCells = nCellsArray( 2 )
-         !$omp do schedule(runtime) private(k)
+         !$omp do schedule(runtime)
          do iCell = 1, nCells
             do k = 2, maxLevelCell(iCell)
                dTracerdZTopOfCell(k,iCell) = (tracers(iTracer,k-1,iCell) - tracers(iTracer,k,iCell)) &
@@ -275,7 +275,7 @@ contains
          nEdges = nEdgesArray( 2 )
          ! Compute tracer gradient (gradTracerEdge) along the constant coordinate surface.
          ! The computed variables lives at edge and mid-layer depth
-         !$omp do schedule(runtime) private(cell1, cell2, k)
+         !$omp do schedule(runtime)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -288,7 +288,7 @@ contains
 
          nEdges = nEdgesArray( 2 )
          ! Interpolate dTracerdZTopOfCell to edge and top of layer
-         !$omp do schedule(runtime) private(cell1, cell2, k)
+         !$omp do schedule(runtime)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -301,7 +301,7 @@ contains
 
          nEdges = nEdgesArray( 2 )
          ! Interpolate gradTracerEdge to edge and top of layer
-         !$omp do schedule(runtime) private(k, h1, h2)
+         !$omp do schedule(runtime)
          do iEdge = 1, nEdges
             do k = 2, maxLevelEdgeTop(iEdge)
                h1 = layerThicknessEdge(k-1,iEdge)
@@ -321,7 +321,7 @@ contains
          ! Compute \nabla\cdot(relativeSlope d\phi/dz)
          if(.not.config_disable_redi_horizontal_term2) then
             nCells = nCellsArray( 1 )
-            !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, s_tmpU, s_tmpD, flux)
+            !$omp do schedule(runtime)
             do iCell = 1, nCells
                invAreaCell = 1.0_RKIND / areaCell(iCell)
                do i = 1, nEdgesOnCell(iCell)
@@ -346,7 +346,7 @@ contains
          ! Compute relativeSlope\cdot\nabla\phi (variable gradHTracerSlopedTopOfCell) at non-boundary edges
 
          nCells = nCellsArray( 1 )
-         !$omp do schedule(runtime) private(i, iedge, areaEdge, k, r_tmp)
+         !$omp do schedule(runtime)
          do iCell = 1, nCells
             areaCellSum(:, iCell) = 1.0e-34_RKIND
             gradHTracerSlopedTopOfCell(:, iCell) = 0.0_RKIND
@@ -364,7 +364,7 @@ contains
          !$omp end do
 
          nCells = nCellsArray( 1 )
-         !$omp do schedule(runtime) private(k)
+         !$omp do schedule(runtime)
          do iCell=1,nCells
             do k = 1, maxLevelCell(iCell)
                gradHTracerSlopedTopOfCell(k,iCell) = gradHTracerSlopedTopOfCell(k,iCell)/areaCellSum(k,iCell)
@@ -374,7 +374,7 @@ contains
 
          if(.not.config_disable_redi_horizontal_term3) then
             nCells = nCellsArray( 1 )
-            !$omp do schedule(runtime) private(k, s_tmp)
+            !$omp do schedule(runtime)
             do iCell = 1, nCells
                ! impose no-flux boundary conditions at top and bottom of column
                gradHTracerSlopedTopOfCell(1,iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -145,7 +145,7 @@ contains
 
       nCells = nCellsArray( 3 )
 
-      !$omp do schedule(runtime) private(depth, k, depLev)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          depth = 0.0_RKIND
          do k = 1, maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -156,7 +156,7 @@ contains
 
       nCells = nCellsArray( 3 )
 
-      !$omp do schedule(runtime) private(depth, k, cloudRatio, depLev)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
         depth = 0.0_RKIND
         cloudRatio = min(1.0_RKIND, 1.0_RKIND - penetrativeTemperatureFlux(iCell)/(hflux_factor*(1.0E-15_RKIND + &

--- a/src/core_ocean/shared/mpas_ocn_vel_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_coriolis.F
@@ -146,7 +146,7 @@ contains
 
       allocate( qArr(nVertLevels) )
 
-      !$omp do schedule(runtime) private(cell1, cell2, invLength, k, j, eoe, workVorticity)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -143,8 +143,7 @@ contains
 
       nEdges = nEdgesArray ( 1 )
 
-      !$omp do schedule(runtime) private(zTop, transmissionCoeffBot, remainingStress, k, transmissionCoeffTop, &
-      !$omp                              cell1, cell2, attenuationCoeff, zBot)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         zTop = 0.0_RKIND
         cell1 = cellsOnEdge(1,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -189,7 +189,7 @@ contains
       nEdges = nEdgesArray( 3 )
 
       !Compute delsq_u
-      !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          delsq_u(:, iEdge) = 0.0_RKIND
          cell1 = cellsOnEdge(1,iEdge)
@@ -212,7 +212,7 @@ contains
       nVertices = nVerticesArray( 2 )
 
       ! Compute delsq_relativeVorticity
-      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k)
+      !$omp do schedule(runtime)
       do iVertex = 1, nVertices
          delsq_relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -229,7 +229,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! Compute delsq_divergence
-      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          delsq_divergence(:, iCell) = 0.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -247,7 +247,7 @@ contains
 
       ! Compute - \kappa \nabla^4 u
       ! as  \nabla div(\nabla^2 u) + k \times \nabla ( k \cross curl(\nabla^2 u) )
-      !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, r_tmp, u_diffusion, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -218,7 +218,7 @@ contains
 
          allocate(JacobianDxDs(nVertLevels))
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k, pGrad)
+         !$omp do schedule(runtime)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -256,7 +256,7 @@ contains
          allocate(JacobianDxDs(nVertLevels),JacobianTz(nVertLevels),JacobianSz(nVertLevels), T1(nVertLevels))
          allocate(T2(nVertLevels), S1(nVertLevels), S2(nVertLevels))
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, kMax, k, pGrad, alpha, beta)
+         !$omp do schedule(runtime)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -137,7 +137,7 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
-      !$omp do schedule(runtime) private(cell1, cell2, k, vertAleTransportTopEdge)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -273,7 +273,7 @@ contains
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
       A(1)=0
 
-      !$omp do schedule(runtime) private(N, cell1, cell2, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -415,7 +415,7 @@ contains
       nCells = nCellsArray( 1 )
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
-      !$omp do schedule(runtime) private(N, k)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
          N = maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -349,7 +349,7 @@ contains
 
       call mpas_timer_start('cvmix cell loop', .false.)
       do kpp_stage = 1,2
-      !$omp do schedule(runtime) private(k, bulkRichardsonNumberStop, kIndexOBL, bulkRichardsonFlag)
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND / areaCell(iCell)
 
@@ -707,6 +707,7 @@ contains
  endif ! kpp stage 2 convection calc
       end do  ! do iCell=1,mesh%nCells
       !$omp end do
+
       if (kpp_stage == 1 .and. config_cvmix_use_BLD_smoothing) then ! smooth boundary layer
          nCells = nCellsArray(2)
 


### PR DESCRIPTION
Update ocean BGC threading to make multi-threaded runs BFB with single-threaded runs in coupled E3SM cases.

Checked with E3SM test `SMS.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.anvil_intel.clm-bgcexp` on latest `maint-1.1` branch:
* pure-MPI run on 20 nodes with 18 tasks/node, all components stacked
* multi-threaded run on 20 nodes with 18x2 tasks x threads

Coupler history files `cpl.hi.0001-01-02-00000.nc` at the end of 1-day runs are BFB.

[BFB]

Fixes E3SM-Project/E3SM#1931