### PR TITLE
Avoid use of paths in include statements for registry-generated files in MPAS-A

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -70,8 +70,8 @@ clean:
 .F.o:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
-	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) $< > $*.f90
+	$(CPP) $(CPPFLAGS) $(PHYSICS) $(CPPINCLUDES) -I./inc $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators -I./physics -I./dynamics -I./diagnostics -I./physics/physics_wrf -I../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I./physics -I./dynamics -I./diagnostics -I./physics/physics_wrf -I../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(PHYSICS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./inc -I../framework -I../operators -I./physics -I./dynamics -I./diagnostics -I./physics/physics_wrf -I../external/esmf_time_f90
 endif

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -55,7 +55,7 @@ module atm_core_interface
       core % Conventions = 'MPAS'
       core % source = 'MPAS'
 
-#include "inc/core_variables.inc"
+#include "core_variables.inc"
 
    end subroutine atm_setup_core
 
@@ -80,7 +80,7 @@ module atm_core_interface
 
       type (domain_type), pointer :: domain
 
-#include "inc/domain_variables.inc"
+#include "domain_variables.inc"
 
    end subroutine atm_setup_domain
 
@@ -346,16 +346,16 @@ module atm_core_interface
    end function atm_setup_block
 
 
-#include "inc/setup_immutable_streams.inc"
+#include "setup_immutable_streams.inc"
 
-#include "inc/block_dimension_routines.inc"
+#include "block_dimension_routines.inc"
 
-#include "inc/define_packages.inc"
+#include "define_packages.inc"
 
-#include "inc/structs_and_variables.inc"
+#include "structs_and_variables.inc"
 
-#include "inc/namelist_call.inc"
+#include "namelist_call.inc"
 
-#include "inc/namelist_defines.inc"
+#include "namelist_defines.inc"
 
 end module atm_core_interface

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -99,10 +99,10 @@ clean:
 .F.o:
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
-	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) -I./inc $< > $*.f90
 	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I../framework -I../operators  -I../external/esmf_time_f90
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators  -I../external/esmf_time_f90
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I./inc -I../framework -I../operators  -I../external/esmf_time_f90
 endif
 
 .c.o:

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -56,7 +56,7 @@ module init_atm_core_interface
       core % Conventions = 'MPAS'
       core % source = 'MPAS'
 
-#include "inc/core_variables.inc"
+#include "core_variables.inc"
 
    end subroutine init_atm_setup_core
 
@@ -81,7 +81,7 @@ module init_atm_core_interface
 
       type (domain_type), pointer :: domain
 
-#include "inc/domain_variables.inc"
+#include "domain_variables.inc"
 
    end subroutine init_atm_setup_domain
 
@@ -396,16 +396,16 @@ module init_atm_core_interface
    end function init_atm_setup_block
 
 
-#include "inc/setup_immutable_streams.inc"
+#include "setup_immutable_streams.inc"
 
-#include "inc/block_dimension_routines.inc"
+#include "block_dimension_routines.inc"
 
-#include "inc/define_packages.inc"
+#include "define_packages.inc"
 
-#include "inc/structs_and_variables.inc"
+#include "structs_and_variables.inc"
 
-#include "inc/namelist_call.inc"
+#include "namelist_call.inc"
 
-#include "inc/namelist_defines.inc"
+#include "namelist_defines.inc"
 
 end module init_atm_core_interface


### PR DESCRIPTION
This merge eliminates the the use of paths in include statements for registry-generated
files in MPAS-Atmosphere.

In both the atmosphere and init_atmosphere core interface modules, files
generated by the registry were assumed to be found in a sub-directory named
"inc/". When building MPAS-A in alternate ways, the "*.inc" files generated
by the registry program may be located elsewhere.

This commit removes the "inc/" prefix for *.inc files included in the core
interface modules, which necessitates the addition of -I./inc in the Makefiles
for the atmosphere and init_atmosphere cores.