### PR TITLE
Point global_ocean_V1 test cases to correct templates

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC120to60/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC120to60/default/config_init2.xml
@@ -33,13 +33,13 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC120to60/spin_up/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC120to60/spin_up/config_init2.xml
@@ -33,13 +33,13 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/default/config_init2.xml
@@ -33,13 +33,13 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/five_cell/config_init1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/five_cell/config_init1.xml
@@ -9,7 +9,7 @@
 	<add_executable source="mask_creator" dest="MpasMaskCreator.x"/>
 
 	<add_link source_path="mesh_database" source="mesh.EC.60-30km.160115.nc" dest="base_mesh.nc"/>
-	<add_link source_path="compass" source="ocean/global_ocean/EC60to30/five_cell/land_coverage_5_cell.geojson" dest="land_coverage_5_cell.geojson"/>
+	<add_link source_path="case_dir" source="land_coverage_5_cell.geojson" dest="land_coverage_5_cell.geojson"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/add_land_locked_cells_to_mask.py" dest="add_land_locked_cells_to_mask.py"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/widen_transect_edge_masks.py" dest="widen_transect_edge_masks.py"/>
 

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/five_cell/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/five_cell/config_init2.xml
@@ -30,11 +30,11 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/single_cell/config_init1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/single_cell/config_init1.xml
@@ -9,7 +9,7 @@
 	<add_executable source="mask_creator" dest="MpasMaskCreator.x"/>
 
 	<add_link source_path="mesh_database" source="mesh.EC.60-30km.160115.nc" dest="base_mesh.nc"/>
-	<add_link source_path="compass" source="ocean/global_ocean/EC60to30/single_cell/land_coverage_1_cell.geojson" dest="land_coverage_1_cell.geojson"/>
+	<add_link source_path="case_dir" source="land_coverage_1_cell.geojson" dest="land_coverage_1_cell.geojson"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/add_land_locked_cells_to_mask.py" dest="add_land_locked_cells_to_mask.py"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/widen_transect_edge_masks.py" dest="widen_transect_edge_masks.py"/>
 

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/single_cell/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/single_cell/config_init2.xml
@@ -30,11 +30,11 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/spin_up/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/spin_up/config_init2.xml
@@ -33,13 +33,13 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/with_land_ice/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/EC60to30/with_land_ice/config_init2.xml
@@ -34,7 +34,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<option name="config_pio_num_iotasks">8</option>
 		<option name="config_pio_stride">16</option>
@@ -43,7 +43,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU120/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU120/default/config_init2.xml
@@ -34,12 +34,12 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU120/ecosys_60_layer/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU120/ecosys_60_layer/config_init2.xml
@@ -44,7 +44,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_use_ecosysTracers">.true.</option>
 		<option name="config_use_DMSTracers">.true.</option>
@@ -53,7 +53,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU120/with_land_ice/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU120/with_land_ice/config_init2.xml
@@ -34,14 +34,14 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<option name="config_iterative_init_variable">'landIcePressure_from_top_density'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/analysis_test/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/analysis_test/config_init2.xml
@@ -34,12 +34,12 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/default/config_init2.xml
@@ -34,7 +34,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_use_debugTracers">.true.</option>
@@ -42,7 +42,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/performance_test/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/performance_test/config_init2.xml
@@ -34,12 +34,12 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/restart_test/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/restart_test/config_init2.xml
@@ -32,7 +32,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_use_debugTracers">.true.</option>
@@ -40,7 +40,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/rk4_blocks_test/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/rk4_blocks_test/config_init2.xml
@@ -32,7 +32,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_use_debugTracers">.true.</option>
@@ -40,7 +40,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/se_blocks_test/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/se_blocks_test/config_init2.xml
@@ -32,7 +32,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_use_debugTracers">.true.</option>
@@ -40,7 +40,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/with_land_ice/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/with_land_ice/config_init2.xml
@@ -32,7 +32,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
@@ -43,7 +43,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/with_land_ice_no_iter/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/with_land_ice_no_iter/config_init2.xml
@@ -32,7 +32,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
@@ -43,7 +43,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU240/zstar_128_layers/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU240/zstar_128_layers/config_init2.xml
@@ -39,13 +39,13 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_file">'vertical_grid.nc'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/QU480/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/QU480/default/config_init2.xml
@@ -34,7 +34,7 @@
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
 		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
 		<option name="config_use_debugTracers">.true.</option>
@@ -42,7 +42,7 @@
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_init2.xml" path_base="script_configuration_dir"/>
-		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_critical_passages.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS15to5/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS15to5/default/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS15to5/spin_up/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS15to5/spin_up/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS18to6/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS18to6/default/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS18to6/spin_up/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS18to6/spin_up/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS30to10/default/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS30to10/default/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean_V1/RRS30to10/spin_up/config_init2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean_V1/RRS30to10/spin_up/config_init2.xml
@@ -32,12 +32,12 @@
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
 
 	<namelist name="namelist.ocean" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
-		<template file="template_init2.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init2.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">


### PR DESCRIPTION
Many test cases are trying to use templates from `global_ocean`, which works for critical passages (but is not necessary, since `global_ocean_V1` has a copy of the same template, and could lead to issues in the future) but not for `init2`, since `global_ocean` does not use this template.