### PR TITLE
Remove C null characters from strings read by PIO

### DIFF
--- a/src/framework/mpas_c_interfacing.F
+++ b/src/framework/mpas_c_interfacing.F
@@ -5,6 +5,37 @@ module mpas_c_interfacing
 
 
     !-----------------------------------------------------------------------
+    !  routine mpas_sanitize_string
+    !
+    !> \brief Converts C null characters in a Fortran string to spaces
+    !> \author Michael Duda
+    !> \date   19 February 2019
+    !> \details
+    !>  Converts all C null characters in a Fortran string to spaces.
+    !>  This may be useful for strings that were provided by C code through other
+    !>  Fortran code external to MPAS.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_sanitize_string(str)
+    
+        use iso_c_binding, only : c_null_char
+    
+        implicit none
+    
+        character(len=*), intent(inout) :: str
+    
+        integer :: i
+    
+        do i=1,len(str)
+            if (str(i:i) == c_null_char) then
+                str(i:i) = ' '
+            end if
+        end do
+    
+    end subroutine mpas_sanitize_string
+
+
+    !-----------------------------------------------------------------------
     !  routine mpas_c_to_f_string
     !
     !> \brief Converts a C null-terminated string to a Fortran string

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -2187,6 +2187,8 @@ module mpas_io
 
    subroutine MPAS_io_get_var_char0d(handle, fieldname, val, ierr)
 
+      use mpas_c_interfacing, only : MPAS_sanitize_string
+
       implicit none
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
@@ -2198,11 +2200,14 @@ module mpas_io
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
       call MPAS_io_get_var_generic(handle, fieldname, charVal=val, ierr=ierr)
+      call MPAS_sanitize_string(val)
 
    end subroutine MPAS_io_get_var_char0d
 
 
    subroutine MPAS_io_get_var_char1d(handle, fieldname, val, ierr)
+
+      use mpas_c_interfacing, only : MPAS_sanitize_string
 
       implicit none
 
@@ -2211,10 +2216,15 @@ module mpas_io
       character (len=*), dimension(:), intent(out) :: val
       integer, intent(out), optional :: ierr
 
+      integer :: i
+
 !     call mpas_log_write('Called MPAS_io_get_var_char1d()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
       call MPAS_io_get_var_generic(handle, fieldname, charArray1d=val, ierr=ierr)
+      do i=1,size(val)
+         call MPAS_sanitize_string(val(i))
+      end do
 
    end subroutine MPAS_io_get_var_char1d
 


### PR DESCRIPTION
This merge adds a new routine, `MPAS_sanitize_string`, to convert C null characters to spaces
in Fortran strings, and it applies this routine to all strings read via PIO. The PIO2 library converts
unused characters of strings to C null characters when writing, and converts C null characters
back to spaces when reading. This can create problems if a file written with PIO2 is read by PIO1,
in which case the C null characters will remain in the string, potentially creating problems for
MPAS infrastructure.

