### PR TITLE
Change length of xtime variables to ShortStrKIND to match netCDF files

### DIFF
--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -148,12 +148,12 @@ module mpas_io_streams
       integer :: io_err
       integer :: i
       integer :: timeDim
-      character (len=StrKIND), dimension(:), pointer :: xtimes
-      character (len=StrKIND) :: strTemp
+      character (len=ShortStrKIND), dimension(:), pointer :: xtimes
+      character (len=ShortStrKIND) :: strTemp
       type (MPAS_Time_type) :: sliceTime, startTime
       type (MPAS_TimeInterval_type) :: timeDiff, minTimeDiff
 
-      character (len=StrKIND) :: xtime0, xtime1, xtime2, xtimeGuess
+      character (len=ShortStrKIND) :: xtime0, xtime1, xtime2, xtimeGuess
       type (MPAS_Time_type) :: time0, time1, time2, timeGuess, timeGuessData
       type (MPAS_TimeInterval_type) :: timeInterval
 
@@ -1510,10 +1510,10 @@ module mpas_io_streams
       idim = ndims
       allocate(indices(0))
       allocate(dimSizes(1))
-      dimSizes(1) = 64
+      dimSizes(1) = ShortStrKIND
       dimNames(1) = 'StrLen'
-      globalDimSize = 64
-      totalDimSize = 64
+      globalDimSize = ShortStrKIND
+      totalDimSize = ShortStrKIND
 
       
       if (field % isVarArray) then
@@ -1602,7 +1602,7 @@ module mpas_io_streams
       idim = ndims
       allocate(indices(1))
       allocate(dimSizes(2))
-      dimSizes(1) = 64
+      dimSizes(1) = ShortStrKIND
       dimNames(1) = 'StrLen'
       dimSizes(2) = field % dimSizes(1)
       dimNames(2) = field % dimNames(1)


### PR DESCRIPTION
This merge changes the declared length of xtime and similar timestamp
variables in the mpas_io_streams module from StrKIND to ShortStrKIND to
match the length of xtime in netCDF files.

Prior to this change, because the in-memory xtime variable was larger
than the in-file version, reading xtime could result in a string with
garbage characters at the end (beginning at character ShortStrKIND+1).
These gargbage characters, in turn, could lead to errors in the timekeeping
module when trying to parse the string as a timestamp. By matching
the in-memory size of the xtime variable with its size in files,
we avoid this problem.