### PR TITLE
Add temperature and spechum fields in JEDI DA package

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -336,7 +336,7 @@
                      possible_values="Non-negative real values"/>
 	</nml_record>
 
-        <nml_record name="assimilation" in_defaults="true">
+        <nml_record name="assimilation" in_defaults="false">
                 <nml_option name="config_jedi_da" type="logical" default_value="false"
                      units="-"
                      description="Whether this run is within the JEDI data assimilation framework; used to add temperature and specific humidity as diagnostics"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -336,6 +336,12 @@
                      possible_values="Non-negative real values"/>
 	</nml_record>
 
+        <nml_record name="assimilation" in_defaults="true">
+                <nml_option name="config_jedi_da" type="logical" default_value="false"
+                     units="-"
+                     description="Whether this run is within the JEDI data assimilation framework; used to add temperature and specific humidity as diagnostics"
+                     possible_values=".true. or .false."/>
+        </nml_record>
 
 <!-- **************************************************************************************** -->
 <!-- **************************************  Packages  ************************************** -->
@@ -352,6 +358,7 @@
                 <package name="bl_mynn_in" description="parameterization of MYNN Planetary Boundary Layer."/>
 
                 <package name="iau" description="Incremental Analysis Update"/>
+                <package name="jedi_da" description="Data Assimilation in JEDI framework"/>
         </packages>
 
 
@@ -1439,8 +1446,16 @@
                 <var name="theta" type="real" dimensions="nVertLevels nCells Time" units="K"
                      description="Potential temperature"/>
 
+                <var name="temperature" type="real" dimensions="nVertLevels nCells Time" units="K"
+                     description="temperature"
+                     packages="jedi_da"/>
+
                 <var name="relhum" type="real" dimensions="nVertLevels nCells Time" units="percent"
                      description="Relative humidity"/>
+
+                <var name="spechum" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+                     description="Specific humidity"
+                     packages="jedi_da"/>
 
                 <var name="v" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
                      description="Horizontal tangential velocity at edges"/>

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -119,6 +119,7 @@ module atm_core_interface
 
       logical, pointer :: iauActive
       character(len=StrKIND), pointer :: config_iau_option
+      logical, pointer :: config_jedi_da, jedi_daActive
 
       ierr = 0
 
@@ -133,6 +134,14 @@ module atm_core_interface
       else
          iauActive = .false.
       end if
+
+      nullify(config_jedi_da)
+      call mpas_pool_get_config(configs, 'config_jedi_da', config_jedi_da)
+
+      nullify(jedi_daActive)
+      call mpas_pool_get_package(packages, 'jedi_daActive', jedi_daActive)
+
+      jedi_daActive = config_jedi_da
 
 #ifdef DO_PHYSICS
       !check that all the physics options are correctly defined and that at

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -120,6 +120,7 @@ module atm_core_interface
       logical, pointer :: iauActive
       character(len=StrKIND), pointer :: config_iau_option
       logical, pointer :: config_jedi_da, jedi_daActive
+      integer :: local_ierr
 
       ierr = 0
 
@@ -155,10 +156,11 @@ module atm_core_interface
       !least one physics parameterization is called (using the logical moist_physics):
       call physics_namelist_check(configs)
 
-      ierr = atmphys_setup_packages(configs,packages,iocontext)
-      if(ierr /= 0) then
+      local_ierr = atmphys_setup_packages(configs, packages, iocontext)
+      if (local_ierr /= 0) then
+         ierr = ierr + 1
          call mpas_log_write('Package setup failed for atmphys in core_atmosphere', messageType=MPAS_LOG_ERR)
-      endif
+      end if
 #endif
 
    end function atm_setup_packages

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -141,7 +141,14 @@ module atm_core_interface
       nullify(jedi_daActive)
       call mpas_pool_get_package(packages, 'jedi_daActive', jedi_daActive)
 
-      jedi_daActive = config_jedi_da
+      if (associated(config_jedi_da) .and. associated(jedi_daActive)) then
+         jedi_daActive = config_jedi_da
+      else
+         ierr = ierr + 1
+         call mpas_log_write('Package setup failed for ''jedi_da''. '// &
+              'Either ''jedi_da'' is not a package, or ''config_jedi_da'' is not a namelist option.', &
+              messageType=MPAS_LOG_ERR)
+      end if
 
 #ifdef DO_PHYSICS
       !check that all the physics options are correctly defined and that at


### PR DESCRIPTION
These fields are used to produce analysis fields in the JEDI
data assimilation framework.  They are only used in that
external framework and thus need to be in a package.

All related DA tests pass.

This PR is related to https://github.com/MPAS-Dev/MPAS-Model/pull/106, https://github.com/MPAS-Dev/MPAS-Model/pull/107, and https://github.com/MPAS-Dev/MPAS-Model/pull/108.