### PR TITLE
removed need for -DROTATED_GRID in the build for the mtn_wave test case

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -422,6 +422,7 @@
 			<var name="zb3"/>
 			<var name="dss"/>
 			<var name="u_init"/>
+			<var name="v_init"/>
 			<var name="t_init"/>
 			<var name="qv_init"/>
 			<var name="deriv_two"/>
@@ -546,6 +547,7 @@
 			<var name="zb3"/>
 			<var name="dss"/>
 			<var name="u_init"/>
+			<var name="v_init"/>
 			<var name="t_init"/>
 			<var name="qv_init"/>
 			<var name="deriv_two"/>
@@ -1262,6 +1264,9 @@
                 <!-- Reference profiles -->
                 <var name="u_init" type="real" dimensions="nVertLevels" units="m s^{-1}"
                      description="u reference profile"/>
+
+                <var name="v_init" type="real" dimensions="nVertLevels" units="m s^{-1}"
+                     description="v reference profile"/>
 
                 <var name="t_init" type="real" dimensions="nVertLevels nCells" units="K"
                      description="theta reference profile"/>

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3953,7 +3953,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: deriv_two
       integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex
       integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge
-      real (kind=RKIND), dimension(:), pointer :: latCell, latEdge, angleEdge, u_init
+      real (kind=RKIND), dimension(:), pointer :: latCell, latEdge, angleEdge, u_init, v_init
 
       integer, dimension(:,:), pointer :: advCellsForEdge
       integer, dimension(:), pointer :: nAdvCellsForEdge
@@ -4059,6 +4059,7 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'meshScalingDel2', meshScalingDel2)
       call mpas_pool_get_array(mesh, 'meshScalingDel4', meshScalingDel4)
       call mpas_pool_get_array(mesh, 'u_init', u_init)
+      call mpas_pool_get_array(mesh, 'v_init', v_init)
       call mpas_pool_get_array(mesh, 't_init', t_init)
       call mpas_pool_get_array(mesh, 'qv_init', qv_init)
 
@@ -4126,7 +4127,7 @@ module atm_time_integration
          h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
          theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
          cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
-         latCell, latEdge, angleEdge, u_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
+         latCell, latEdge, angleEdge, u_init, v_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
          rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
          tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
          config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
@@ -4151,7 +4152,7 @@ module atm_time_integration
       h_divergence, kdiff, edgesOnCell_sign, edgesOnVertex_sign, rw_save, ru_save, &
       theta_m_save, exner, rr_save, scalars, tend_u_euler, tend_w_euler, tend_theta_euler, deriv_two, &
       cellsOnEdge, verticesOnEdge, edgesOnCell, edgesOnEdge, cellsOnCell, edgesOnVertex, nEdgesOnCell, nEdgesOnEdge, &
-      latCell, latEdge, angleEdge, u_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
+      latCell, latEdge, angleEdge, u_init, v_init, advCellsForEdge, nAdvCellsForEdge, adv_coefs, adv_coefs_3rd, &
       rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
       tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
       config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
@@ -4235,7 +4236,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nCells+1) :: latCell
       real (kind=RKIND), dimension(nEdges+1) :: latEdge
       real (kind=RKIND), dimension(nEdges+1) :: angleEdge
-      real (kind=RKIND), dimension(nVertLevels) :: u_init
+      real (kind=RKIND), dimension(nVertLevels) :: u_init, v_init
 
       integer, dimension(15,nEdges+1) :: advCellsForEdge
       integer, dimension(nEdges+1) :: nAdvCellsForEdge
@@ -4619,11 +4620,8 @@ module atm_time_integration
                   cell2 = cellsOnEdge(2,iEdge)
 
                   do k=1,nVertLevels
-#ifdef ROTATED_GRID
-                     u_mix(k) = u(k,iEdge) - u_init(k) * sin( angleEdge(iEdge) )
-#else
-                     u_mix(k) = u(k,iEdge) - u_init(k) * cos( angleEdge(iEdge) )
-#endif
+                     u_mix(k) = u(k,iEdge) - u_init(k) * cos( angleEdge(iEdge) ) &
+                                           - v_init(k) * sin( angleEdge(iEdge) )
                   end do
 
                   do k=2,nVertLevels-1

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -469,6 +469,7 @@
                         <var name="zb3" packages="vertical_stage_out;met_stage_out"/>
                         <var name="dss" packages="vertical_stage_out;met_stage_out"/>
                         <var name="u_init" packages="met_stage_out"/>
+                        <var name="v_init" packages="met_stage_out"/>
                         <var name="t_init" packages="met_stage_out"/>
                         <var name="qv_init" packages="met_stage_out"/>
                         <var_array name="scalars" packages="met_stage_out"/>
@@ -617,6 +618,7 @@
                 <var name="dss"                        type="real"     dimensions="nVertLevels nCells"/>
 
                 <var name="u_init"                     type="real"     dimensions="nVertLevels"/>
+                <var name="v_init"                     type="real"     dimensions="nVertLevels"/>
                 <var name="t_init"                     type="real"     dimensions="nVertLevels nCells"/>
                 <var name="qv_init"                    type="real"     dimensions="nVertLevels"/>
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -1834,7 +1834,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(nVertLevels ) :: zu, dzw, rdzwp, rdzwm
 
       real (kind=RKIND) :: d1, d2, d3, cof1, cof2
-      real (kind=RKIND) :: um, vm, us, vs, rcp, rcv
+      real (kind=RKIND) :: um, vm,rcp, rcv
       real (kind=RKIND) :: xmid, temp, pres, a_scale
 
       real (kind=RKIND) :: xi, xa, xc, xla, zinv, xn2, xn2m, xn2l, sm, dzh, dzht, dzmin, z_edge, z_edge3 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -75,29 +75,6 @@ module init_atm_cases
 
       call mpas_pool_get_config(domain % blocklist % configs, 'config_init_case', config_init_case)
 
-      !
-      ! Do some quick checks to make sure compile options are compatible with the chosen test case
-      !
-      if (config_init_case == 6) then
-#ifndef ROTATED_GRID
-         call mpas_log_write('*****************************************************************',  messageType=MPAS_LOG_ERR)
-         call mpas_log_write('To initialize and run the mountain wave test case (case 6),',        messageType=MPAS_LOG_ERR)
-         call mpas_log_write('   please clean and re-compile init_atmosphere with -DROTATED_GRID', messageType=MPAS_LOG_ERR)
-         call mpas_log_write('   added to the specification of MODEL_FORMULATION',                 messageType=MPAS_LOG_ERR)
-         call mpas_log_write('   at the top of the Makefile.',                                     messageType=MPAS_LOG_ERR)
-         call mpas_log_write('*****************************************************************',  messageType=MPAS_LOG_CRIT)
-#endif
-      else
-#ifdef ROTATED_GRID
-         call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
-         call mpas_log_write('Only test case 6 should use code compiled with -DROTATED_GRID',     messageType=MPAS_LOG_ERR)
-         call mpas_log_write('   specified in the Makefile.',                                     messageType=MPAS_LOG_ERR)
-         call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_CRIT)
-#endif
-      end if
-
-
-
       if ((config_init_case == 1) .or. (config_init_case == 2) .or. (config_init_case == 3)) then
 
          call mpas_log_write(' Jablonowski and Williamson baroclinic wave test case ')
@@ -1857,7 +1834,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(nVertLevels ) :: zu, dzw, rdzwp, rdzwm
 
       real (kind=RKIND) :: d1, d2, d3, cof1, cof2
-      real (kind=RKIND) :: um, us,  rcp, rcv
+      real (kind=RKIND) :: um, vm, us, vs, rcp, rcv
       real (kind=RKIND) :: xmid, temp, pres, a_scale
 
       real (kind=RKIND) :: xi, xa, xc, xla, zinv, xn2, xn2m, xn2l, sm, dzh, dzht, dzmin, z_edge, z_edge3 
@@ -1879,7 +1856,7 @@ module init_atm_cases
       real (kind=RKIND), pointer :: cf1, cf2, cf3
 
       real (kind=RKIND), dimension(:,:), pointer :: t_init, w, rw, v, rho, theta
-      real (kind=RKIND), dimension(:), pointer :: u_init, angleEdge, fEdge, fVertex
+      real (kind=RKIND), dimension(:), pointer :: u_init, v_init, angleEdge, fEdge, fVertex
 
 
       call mpas_pool_get_array(mesh, 'xCell', xCell)
@@ -1912,6 +1889,7 @@ module init_atm_cases
       call mpas_pool_get_array(mesh, 'deriv_two', deriv_two)
       call mpas_pool_get_array(mesh, 't_init', t_init)
       call mpas_pool_get_array(mesh, 'u_init', u_init)
+      call mpas_pool_get_array(mesh, 'v_init', v_init)
       call mpas_pool_get_array(mesh, 'angleEdge', angleEdge)
       call mpas_pool_get_array(mesh, 'fEdge', fEdge)
       call mpas_pool_get_array(mesh, 'fVertex', fVertex)
@@ -2160,8 +2138,8 @@ module init_atm_cases
          xn2m = 0.0000
          xn2l = 0.0001
 
-         um = 10.
-         us = 0.
+         vm = 10.
+         um = 0.
 
          do i=1,nCells
             do k=1,nz1
@@ -2185,13 +2163,15 @@ module init_atm_cases
             do k=1,nz1
                ztemp = .25*( zgrid(k,cell1 )+zgrid(k+1,cell1 )  &
                             +zgrid(k,cell2)+zgrid(k+1,cell2))
-               u(k,i) = um
-               if(i == 1 ) u_init(k) = u(k,i) - us
-#ifdef ROTATED_GRID
-               u(k,i) = sin(angleEdge(i)) * (u(k,i) - us)
-#else
-               u(k,i) = cos(angleEdge(i)) * (u(k,i) - us)
-#endif
+               u(k,i) = vm
+
+               if(i == 1 ) then 
+                 v_init(k) = vm
+                 u_init(k) = 0.
+               end if
+
+               u(k,i) =   vm*sin(angleEdge(i)) + um*cos(angleEdge(i))
+                        
             end do
             end if
          end do

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2141,6 +2141,11 @@ module init_atm_cases
          vm = 10.
          um = 0.
 
+         do k=1,nz1
+           v_init(k) = vm
+           u_init(k) = um
+         end do
+
          do i=1,nCells
             do k=1,nz1
                ztemp   = .5*(zgrid(k,i)+zgrid(k+1,i))
@@ -2163,15 +2168,7 @@ module init_atm_cases
             do k=1,nz1
                ztemp = .25*( zgrid(k,cell1 )+zgrid(k+1,cell1 )  &
                             +zgrid(k,cell2)+zgrid(k+1,cell2))
-               u(k,i) = vm
-
-               if(i == 1 ) then 
-                 v_init(k) = vm
-                 u_init(k) = 0.
-               end if
-
                u(k,i) =   vm*sin(angleEdge(i)) + um*cos(angleEdge(i))
-                        
             end do
             end if
          end do


### PR DESCRIPTION
This merge removed the need for -DROTATED_GRID in the build for the mtn_wave test case.
This was accomplished by adding a new 1D array (v_init) that compliments u_init, and adopting the standard vector definition V_init = u_init * cos(angleEdge) + v_init * sin(angleEdge) in the code.  Registry additions add the v_init(nVertLevels) array and other changes introduce the vector definition.
