### PR TITLE
Add two new upper absorbing layer options

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -256,22 +256,17 @@
                      description="Maximum w-damping coefficient at model top"
                      possible_values="0 $\leq$ config_xnutr $\leq$ 1"/>
 
-                <nml_option name="config_horiz_absorbing_layer" type="character" default_value="none" in_defaults="false"
-                     units="-"
-                     description="h_diffusion configuration for upper absorbing layer"
-                     possible_values="`none' or `mpas_cam'"/>
-
-                <nml_option name="config_mpas_cam_coef" type="real" default_value="0.2" in_defaults="false"
+                <nml_option name="config_mpas_cam_coef" type="real" default_value="0.0" in_defaults="false"
                      units="-"
                      description="coefficient for scaling the 2nd-order h-mixing in mpas_cam absorbing layer"
-                     possible_values="0 $\leq$ config_mpas_cam_coef $\leq$ 1"/>
+                     possible_values="0 $\leq$ config_mpas_cam_coef $\leq$ 1, standard value is 0.2"/>
 
                 <nml_option name="config_rayleigh_damp_u" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="use Rayleigh damping on horizontal velocity topmost model levels"
                      possible_values=".true. or .false."/>
 
-                <nml_option name="config_rayleigh_damp_u_timescale" type="real" default_value="5." in_defaults="false"
+                <nml_option name="config_rayleigh_damp_u_timescale_days" type="real" default_value="5." in_defaults="false"
                      units="days"
                      description="Rayleigh damping timescale in days"
                      possible_values="config_rayleigh_damp_u_timescale must be greater than 0"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -258,23 +258,23 @@
 
                 <nml_option name="config_mpas_cam_coef" type="real" default_value="0.0" in_defaults="false"
                      units="-"
-                     description="coefficient for scaling the 2nd-order h-mixing in mpas_cam absorbing layer"
+                     description="Coefficient for scaling the 2nd-order horizontal mixing in the mpas_cam absorbing layer"
                      possible_values="0 $\leq$ config_mpas_cam_coef $\leq$ 1, standard value is 0.2"/>
 
                 <nml_option name="config_rayleigh_damp_u" type="logical" default_value="false" in_defaults="false"
                      units="-"
-                     description="use Rayleigh damping on horizontal velocity topmost model levels"
+                     description="Whether to apply Rayleigh damping on horizontal velocity in the top-most model levels. The number of levels is specified by the config_number_rayleigh_damp_u_levels option, and the damping timescale is specified by the config_rayleigh_damp_u_timescale_days option."
                      possible_values=".true. or .false."/>
 
-                <nml_option name="config_rayleigh_damp_u_timescale_days" type="real" default_value="5." in_defaults="false"
+                <nml_option name="config_rayleigh_damp_u_timescale_days" type="real" default_value="5.0" in_defaults="false"
                      units="days"
-                     description="Rayleigh damping timescale in days"
-                     possible_values="config_rayleigh_damp_u_timescale must be greater than 0"/>
+                     description="Timescale, in days (86400 s), for the Rayleigh damping on horizontal velocity in the top-most model levels."
+                     possible_values="Positive real values"/>
 
                 <nml_option name="config_number_rayleigh_damp_u_levels" type="integer" default_value="6" in_defaults="false"
                      units="-"
-                     description="Number layers at top of domain to damp, linear ramp to zero by layer number from the top"
-                     possible_values="Integer values"/>
+                     description="Number layers in which to apply Rayleigh damping on horizontal velocity at top of model; damping linearly ramps to zero by layer number from the top"
+                     possible_values="Positive integer values"/>
         </nml_record>
 
         <nml_record name="io" in_defaults="true">

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -255,6 +255,31 @@
                      units="-"
                      description="Maximum w-damping coefficient at model top"
                      possible_values="0 $\leq$ config_xnutr $\leq$ 1"/>
+
+                <nml_option name="config_horiz_absorbing_layer" type="character" default_value="none" in_defaults="false"
+                     units="-"
+                     description="h_diffusion configuration for upper absorbing layer"
+                     possible_values="`none' or `mpas_cam'"/>
+
+                <nml_option name="config_mpas_cam_coef" type="real" default_value="0.2" in_defaults="false"
+                     units="-"
+                     description="coefficient for scaling the 2nd-order h-mixing in mpas_cam absorbing layer"
+                     possible_values="0 $\leq$ config_mpas_cam_coef $\leq$ 1"/>
+
+                <nml_option name="config_rayleigh_damp_u" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="use Rayleigh damping on horizontal velocity topmost model levels"
+                     possible_values=".true. or .false."/>
+
+                <nml_option name="config_rayleigh_damp_u_timescale" type="real" default_value="5." in_defaults="false"
+                     units="days"
+                     description="Rayleigh damping timescale in days"
+                     possible_values="config_rayleigh_damp_u_timescale must be greater than 0"/>
+
+                <nml_option name="config_number_rayleigh_damp_u_levels" type="integer" default_value="6" in_defaults="false"
+                     units="-"
+                     description="Number layers at top of domain to damp, linear ramp to zero by layer number from the top"
+                     possible_values="Integer values"/>
         </nml_record>
 
         <nml_record name="io" in_defaults="true">

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3982,6 +3982,12 @@ module atm_time_integration
       real (kind=RKIND), pointer :: config_h_mom_eddy_visc2, config_v_mom_eddy_visc2
       real (kind=RKIND), pointer :: config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
+      character (len=StrKIND), pointer :: config_horiz_absorbing_layer
+      real (kind=RKIND), pointer :: config_mpas_cam_coef
+      logical, pointer :: config_rayleigh_damp_u
+      real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale
+      integer, pointer :: config_number_rayleigh_damp_u_levels
+
       logical :: inactive_rthdynten
 
 
@@ -3999,6 +4005,11 @@ module atm_time_integration
       call mpas_pool_get_config(configs, 'config_visc4_2dsmag', config_visc4_2dsmag)
       call mpas_pool_get_config(configs, 'config_len_disp', config_len_disp)
       call mpas_pool_get_config(configs, 'config_smagorinsky_coef', c_s)
+      call mpas_pool_get_config(configs, 'config_horiz_absorbing_layer', config_horiz_absorbing_layer)
+      call mpas_pool_get_config(configs, 'config_mpas_cam_coef', config_mpas_cam_coef)
+      call mpas_pool_get_config(configs, 'config_rayleigh_damp_u', config_rayleigh_damp_u)
+      call mpas_pool_get_config(configs, 'config_rayleigh_damp_u_timescale', config_rayleigh_damp_u_timescale)
+      call mpas_pool_get_config(configs, 'config_number_rayleigh_damp_u_levels', config_number_rayleigh_damp_u_levels)
 
       call mpas_pool_get_array(state, 'rho_zz', rho_zz, 2)
       call mpas_pool_get_array(state, 'u', u, 2)
@@ -4130,8 +4141,10 @@ module atm_time_integration
          rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
          tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
          config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
-         config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, dt, &
-         tend_rtheta_adv, rthdynten, &
+         config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
+         config_horiz_absorbing_layer, config_mpas_cam_coef, &
+         config_rayleigh_damp_u, config_rayleigh_damp_u_timescale, config_number_rayleigh_damp_u_levels, &
+         dt, tend_rtheta_adv, rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
          cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -4155,8 +4168,10 @@ module atm_time_integration
       rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
       tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
       config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
-      config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, dt, &
-      tend_rtheta_adv, rthdynten, &
+      config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
+      config_horiz_absorbing_layer, config_mpas_cam_coef, &
+      config_rayleigh_damp_u, config_rayleigh_damp_u_timescale, config_number_rayleigh_damp_u_levels, &
+      dt, tend_rtheta_adv, rthdynten, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
       cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -4272,6 +4287,13 @@ module atm_time_integration
       real (kind=RKIND) :: config_len_disp
       real (kind=RKIND) :: config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
+      character (len=StrKIND) :: config_horiz_absorbing_layer
+      real (kind=RKIND) :: config_mpas_cam_coef
+
+      logical, intent(in) :: config_rayleigh_damp_u
+      real (kind=RKIND), intent(in) :: config_rayleigh_damp_u_timescale
+      integer, intent(in) :: config_number_rayleigh_damp_u_levels
+
       integer, intent(in) :: rk_step
       real (kind=RKIND), intent(in) :: dt
 
@@ -4303,7 +4325,7 @@ module atm_time_integration
 
       real (kind=RKIND) :: kdiffu, z1, z2, z3, z4, zm, z0, zp
 
-      
+      real (kind=RKIND), dimension( nVertLevels ) :: rayleigh_damp_coef      
 
       real (kind=RKIND) :: flux3, flux4
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
@@ -4358,6 +4380,24 @@ module atm_time_integration
             kdiff(1:nVertLevels,cellStart:cellEnd) = config_h_theta_eddy_visc2
             h_mom_eddy_visc4 = config_h_mom_eddy_visc4
             h_theta_eddy_visc4 = config_h_theta_eddy_visc4
+
+         end if
+
+         if(config_horiz_absorbing_layer == "mpas_cam") then
+
+            do iCell = cellStart,cellEnd
+
+            !
+            ! 2nd-order filter for top absorbing layer as in CAM-SE :  WCS 10 May 2017
+            ! From MPAS-CAM V4.0 code, with addition to config-specified coefficient (V4.0_coef = 0.2; SE_coef = 1.0)
+            !
+            kdiff(nVertLevels-2,iCell) = max(kdiff(nVertLevels-2,iCell),   2.0833*config_len_disp*config_mpas_cam_coef)
+            kdiff(nVertLevels-1,iCell) = max(kdiff(nVertLevels-1,iCell),2.*2.0833*config_len_disp*config_mpas_cam_coef)
+            kdiff(nVertLevels  ,iCell) = max(kdiff(nVertLevels  ,iCell),4.*2.0833*config_len_disp*config_mpas_cam_coef)
+            !
+            !  end of absorbing layer addition
+
+            end do
 
          end if
             
@@ -4651,7 +4691,7 @@ module atm_time_integration
 
 !$OMP BARRIER
 
-!  add in mixing for u
+!  add in mixing and physics tendency for u
 
       do iEdge=edgeSolveStart,edgeSolveEnd
 !DIR$ IVDEP
@@ -4660,6 +4700,24 @@ module atm_time_integration
             tend_u(k,iEdge) = tend_u(k,iEdge) + tend_u_euler(k,iEdge) + tend_ru_physics(k,iEdge)
          end do
       end do
+
+!  Rayleigh damping on u 
+
+      if(config_rayleigh_damp_u) then
+         do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
+            rayleigh_damp_coef(k) = (real(k - (nVertLevels-config_number_rayleigh_damp_u_levels))/ &
+                                     real(config_number_rayleigh_damp_u_levels))/                  &
+                                        (config_rayleigh_damp_u_timescale*86400.)
+           rayleigh_damp_coef(k) = max(0.,rayleigh_damp_coef(k))
+         end do
+
+         do iEdge=edgeSolveStart,edgeSolveEnd
+!DIR$ IVDEP
+            do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
+               tend_u(k,iEdge) = tend_u(k,iEdge) - rho_edge(k,iEdge)*u(k,iEdge)*rayleigh_damp_coef(k)
+            end do
+         end do
+      end if
 
 
 !----------- rhs for w

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -58,6 +58,12 @@ module atm_time_integration
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_vertex
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_edge
 
+   ! Used for Rayleigh damping on u
+   ! NB: We do not necessarily want this to vary with calendar, as it is used to set
+   ! a timescale in seconds given a timescale in days, and it could be rather confusing
+   ! if damping in the model changed with the simulation calendar
+   real (kind=RKIND), parameter, private :: seconds_per_day = 86400.0_RKIND
+
       
    contains
 
@@ -4139,10 +4145,10 @@ module atm_time_integration
          rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
          tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
          config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
-         config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
+         config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, dt, &
          config_mpas_cam_coef, &
          config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, config_number_rayleigh_damp_u_levels, &
-         dt, tend_rtheta_adv, rthdynten, &
+         tend_rtheta_adv, rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
          cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -4166,10 +4172,10 @@ module atm_time_integration
       rdzu, rdzw, fzm, fzp, qv_init, t_init, cf1, cf2, cf3, r_earth, ur_cell, vr_cell, defc_a, defc_b, &
       tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
       config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
-      config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
+      config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, dt, &
       config_mpas_cam_coef, &
       config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, config_number_rayleigh_damp_u_levels, &
-      dt, tend_rtheta_adv, rthdynten, &
+      tend_rtheta_adv, rthdynten, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
       cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -4285,14 +4291,14 @@ module atm_time_integration
       real (kind=RKIND) :: config_len_disp
       real (kind=RKIND) :: config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
+      integer, intent(in) :: rk_step
+      real (kind=RKIND), intent(in) :: dt
+
       real (kind=RKIND) :: config_mpas_cam_coef
 
       logical, intent(in) :: config_rayleigh_damp_u
       real (kind=RKIND), intent(in) :: config_rayleigh_damp_u_timescale_days
       integer, intent(in) :: config_number_rayleigh_damp_u_levels
-
-      integer, intent(in) :: rk_step
-      real (kind=RKIND), intent(in) :: dt
 
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: tend_rtheta_adv
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: rthdynten
@@ -4380,16 +4386,16 @@ module atm_time_integration
 
          end if
 
-         if (config_mpas_cam_coef .gt. 0.) then
+         if (config_mpas_cam_coef > 0.0) then
 
             do iCell = cellStart,cellEnd
-              !
-              ! 2nd-order filter for top absorbing layer as in CAM-SE :  WCS 10 May 2017
-              ! From MPAS-CAM V4.0 code, with addition to config-specified coefficient (V4.0_coef = 0.2; SE_coef = 1.0)
-              !
-              kdiff(nVertLevels-2,iCell) = max(kdiff(nVertLevels-2,iCell),   2.0833*config_len_disp*config_mpas_cam_coef)
-              kdiff(nVertLevels-1,iCell) = max(kdiff(nVertLevels-1,iCell),2.*2.0833*config_len_disp*config_mpas_cam_coef)
-              kdiff(nVertLevels  ,iCell) = max(kdiff(nVertLevels  ,iCell),4.*2.0833*config_len_disp*config_mpas_cam_coef)
+               !
+               ! 2nd-order filter for top absorbing layer as in CAM-SE :  WCS 10 May 2017
+               ! From MPAS-CAM V4.0 code, with addition to config-specified coefficient (V4.0_coef = 0.2; SE_coef = 1.0)
+               !
+               kdiff(nVertLevels-2,iCell) = max(kdiff(nVertLevels-2,iCell),    2.0833*config_len_disp*config_mpas_cam_coef)
+               kdiff(nVertLevels-1,iCell) = max(kdiff(nVertLevels-1,iCell),2.0*2.0833*config_len_disp*config_mpas_cam_coef)
+               kdiff(nVertLevels  ,iCell) = max(kdiff(nVertLevels  ,iCell),4.0*2.0833*config_len_disp*config_mpas_cam_coef)
             end do
 
          end if
@@ -4686,13 +4692,19 @@ module atm_time_integration
 
 !  add in mixing and physics tendency for u
 
-!  Rayleigh damping on u coefficient
-
-      if(config_rayleigh_damp_u) then
-         rayleigh_coef_inverse = 1./( real(config_number_rayleigh_damp_u_levels)*(config_rayleigh_damp_u_timescale_days*86400.) )
-         do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
+!  Rayleigh damping on u
+      if (config_rayleigh_damp_u) then
+         rayleigh_coef_inverse = 1.0 / ( real(config_number_rayleigh_damp_u_levels) &
+                                         * (config_rayleigh_damp_u_timescale_days*seconds_per_day) )
+         do k=nVertLevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
             rayleigh_damp_coef(k) = real(k - (nVertLevels-config_number_rayleigh_damp_u_levels))*rayleigh_coef_inverse
-            rayleigh_damp_coef(k) = max(0.,rayleigh_damp_coef(k))
+         end do
+
+         do iEdge=edgeSolveStart,edgeSolveEnd
+!DIR$ IVDEP
+            do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
+               tend_u(k,iEdge) = tend_u(k,iEdge) - rho_edge(k,iEdge)*u(k,iEdge)*rayleigh_damp_coef(k)
+            end do
          end do
       end if
 
@@ -4703,17 +4715,6 @@ module atm_time_integration
             tend_u(k,iEdge) = tend_u(k,iEdge) + tend_u_euler(k,iEdge) + tend_ru_physics(k,iEdge)
          end do
       end do
-
-!  Rayleigh damping on u
-
-      if(config_rayleigh_damp_u) then
-         do iEdge=edgeSolveStart,edgeSolveEnd
-!DIR$ IVDEP
-            do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
-               tend_u(k,iEdge) = tend_u(k,iEdge) - rho_edge(k,iEdge)*u(k,iEdge)*rayleigh_damp_coef(k)
-            end do
-         end do
-      end if
 
 
 !----------- rhs for w

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3982,10 +3982,9 @@ module atm_time_integration
       real (kind=RKIND), pointer :: config_h_mom_eddy_visc2, config_v_mom_eddy_visc2
       real (kind=RKIND), pointer :: config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
-      character (len=StrKIND), pointer :: config_horiz_absorbing_layer
       real (kind=RKIND), pointer :: config_mpas_cam_coef
       logical, pointer :: config_rayleigh_damp_u
-      real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale
+      real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale_days
       integer, pointer :: config_number_rayleigh_damp_u_levels
 
       logical :: inactive_rthdynten
@@ -4005,10 +4004,9 @@ module atm_time_integration
       call mpas_pool_get_config(configs, 'config_visc4_2dsmag', config_visc4_2dsmag)
       call mpas_pool_get_config(configs, 'config_len_disp', config_len_disp)
       call mpas_pool_get_config(configs, 'config_smagorinsky_coef', c_s)
-      call mpas_pool_get_config(configs, 'config_horiz_absorbing_layer', config_horiz_absorbing_layer)
       call mpas_pool_get_config(configs, 'config_mpas_cam_coef', config_mpas_cam_coef)
       call mpas_pool_get_config(configs, 'config_rayleigh_damp_u', config_rayleigh_damp_u)
-      call mpas_pool_get_config(configs, 'config_rayleigh_damp_u_timescale', config_rayleigh_damp_u_timescale)
+      call mpas_pool_get_config(configs, 'config_rayleigh_damp_u_timescale_days', config_rayleigh_damp_u_timescale_days)
       call mpas_pool_get_config(configs, 'config_number_rayleigh_damp_u_levels', config_number_rayleigh_damp_u_levels)
 
       call mpas_pool_get_array(state, 'rho_zz', rho_zz, 2)
@@ -4142,8 +4140,8 @@ module atm_time_integration
          tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
          config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
          config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
-         config_horiz_absorbing_layer, config_mpas_cam_coef, &
-         config_rayleigh_damp_u, config_rayleigh_damp_u_timescale, config_number_rayleigh_damp_u_levels, &
+         config_mpas_cam_coef, &
+         config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, config_number_rayleigh_damp_u_levels, &
          dt, tend_rtheta_adv, rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
          cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
@@ -4169,8 +4167,8 @@ module atm_time_integration
       tend_w_pgf, tend_w_buoy, coef_3rd_order, c_s, config_mix_full, config_horiz_mixing, config_del4u_div_factor, &
       config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2, &
       config_h_theta_eddy_visc4, config_h_mom_eddy_visc4, config_visc4_2dsmag, config_len_disp, rk_step, &
-      config_horiz_absorbing_layer, config_mpas_cam_coef, &
-      config_rayleigh_damp_u, config_rayleigh_damp_u_timescale, config_number_rayleigh_damp_u_levels, &
+      config_mpas_cam_coef, &
+      config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, config_number_rayleigh_damp_u_levels, &
       dt, tend_rtheta_adv, rthdynten, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
       cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
@@ -4287,11 +4285,10 @@ module atm_time_integration
       real (kind=RKIND) :: config_len_disp
       real (kind=RKIND) :: config_h_mom_eddy_visc2, config_v_mom_eddy_visc2, config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
-      character (len=StrKIND) :: config_horiz_absorbing_layer
       real (kind=RKIND) :: config_mpas_cam_coef
 
       logical, intent(in) :: config_rayleigh_damp_u
-      real (kind=RKIND), intent(in) :: config_rayleigh_damp_u_timescale
+      real (kind=RKIND), intent(in) :: config_rayleigh_damp_u_timescale_days
       integer, intent(in) :: config_number_rayleigh_damp_u_levels
 
       integer, intent(in) :: rk_step
@@ -4323,9 +4320,9 @@ module atm_time_integration
       real (kind=RKIND) :: h_theta_eddy_visc4, v_theta_eddy_visc2
       real (kind=RKIND) :: u_diffusion
 
-      real (kind=RKIND) :: kdiffu, z1, z2, z3, z4, zm, z0, zp
+      real (kind=RKIND) :: kdiffu, z1, z2, z3, z4, zm, z0, zp, rayleigh_coef_inverse
 
-      real (kind=RKIND), dimension( nVertLevels ) :: rayleigh_damp_coef      
+      real (kind=RKIND), dimension( nVertLevels ) :: rayleigh_damp_coef
 
       real (kind=RKIND) :: flux3, flux4
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
@@ -4383,20 +4380,16 @@ module atm_time_integration
 
          end if
 
-         if(config_horiz_absorbing_layer == "mpas_cam") then
+         if (config_mpas_cam_coef .gt. 0.) then
 
             do iCell = cellStart,cellEnd
-
-            !
-            ! 2nd-order filter for top absorbing layer as in CAM-SE :  WCS 10 May 2017
-            ! From MPAS-CAM V4.0 code, with addition to config-specified coefficient (V4.0_coef = 0.2; SE_coef = 1.0)
-            !
-            kdiff(nVertLevels-2,iCell) = max(kdiff(nVertLevels-2,iCell),   2.0833*config_len_disp*config_mpas_cam_coef)
-            kdiff(nVertLevels-1,iCell) = max(kdiff(nVertLevels-1,iCell),2.*2.0833*config_len_disp*config_mpas_cam_coef)
-            kdiff(nVertLevels  ,iCell) = max(kdiff(nVertLevels  ,iCell),4.*2.0833*config_len_disp*config_mpas_cam_coef)
-            !
-            !  end of absorbing layer addition
-
+              !
+              ! 2nd-order filter for top absorbing layer as in CAM-SE :  WCS 10 May 2017
+              ! From MPAS-CAM V4.0 code, with addition to config-specified coefficient (V4.0_coef = 0.2; SE_coef = 1.0)
+              !
+              kdiff(nVertLevels-2,iCell) = max(kdiff(nVertLevels-2,iCell),   2.0833*config_len_disp*config_mpas_cam_coef)
+              kdiff(nVertLevels-1,iCell) = max(kdiff(nVertLevels-1,iCell),2.*2.0833*config_len_disp*config_mpas_cam_coef)
+              kdiff(nVertLevels  ,iCell) = max(kdiff(nVertLevels  ,iCell),4.*2.0833*config_len_disp*config_mpas_cam_coef)
             end do
 
          end if
@@ -4693,6 +4686,16 @@ module atm_time_integration
 
 !  add in mixing and physics tendency for u
 
+!  Rayleigh damping on u coefficient
+
+      if(config_rayleigh_damp_u) then
+         rayleigh_coef_inverse = 1./( real(config_number_rayleigh_damp_u_levels)*(config_rayleigh_damp_u_timescale_days*86400.) )
+         do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
+            rayleigh_damp_coef(k) = real(k - (nVertLevels-config_number_rayleigh_damp_u_levels))*rayleigh_coef_inverse
+            rayleigh_damp_coef(k) = max(0.,rayleigh_damp_coef(k))
+         end do
+      end if
+
       do iEdge=edgeSolveStart,edgeSolveEnd
 !DIR$ IVDEP
          do k=1,nVertLevels
@@ -4701,16 +4704,9 @@ module atm_time_integration
          end do
       end do
 
-!  Rayleigh damping on u 
+!  Rayleigh damping on u
 
       if(config_rayleigh_damp_u) then
-         do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels
-            rayleigh_damp_coef(k) = (real(k - (nVertLevels-config_number_rayleigh_damp_u_levels))/ &
-                                     real(config_number_rayleigh_damp_u_levels))/                  &
-                                        (config_rayleigh_damp_u_timescale*86400.)
-           rayleigh_damp_coef(k) = max(0.,rayleigh_damp_coef(k))
-         end do
-
          do iEdge=edgeSolveStart,edgeSolveEnd
 !DIR$ IVDEP
             do k=nVertlevels-config_number_rayleigh_damp_u_levels+1,nVertLevels


### PR DESCRIPTION
2 additional upper absorbing layer options are added:

(1) The absorbing layer often used in the MPAS/CAM configuration.  This option
activates a fixed second-order horizontal diffusion in the topmost
three layers on the dynamics variables (u, w and theta).
(2) Rayleigh damping on the horizontal mumentum (u) with a user-specified
damping timescale and a linear ramp over a number of levels from the top
(also user specified).
