### PR TITLE
Add critical land blockages to global_ocean tests

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/config_files/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files/config_culled_mesh.xml
@@ -9,6 +9,7 @@
 	<add_link source_path="script_configuration_dir" source="cull_mesh.py" dest="cull_mesh.py"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/add_land_locked_cells_to_mask.py" dest="add_land_locked_cells_to_mask.py"/>
 	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/widen_transect_edge_masks.py" dest="widen_transect_edge_masks.py"/>
+	<add_link source_path="mpas_tools" source="ocean/coastline_alteration/add_critical_land_blockages_to_mask.py" dest="add_critical_land_blockages_to_mask.py"/>
 
 	<run_script name="run.py">
 		<step executable="./cull_mesh.py">


### PR DESCRIPTION
Adds support for transects that *must* be land to the new global ocean setup in COMPASS