### PR TITLE
Fixes indexing issue in SurfaceAreaWeighted AM

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -350,9 +350,10 @@ contains
          ! copy data into work array
          ! Note: Order of indices must match the ordering of vars in var_arrays in Registry_surface_area_weighted_averages.xml
          !       (and all var_arrays in Registry_surface_area_weighted_averages.xml must have same ordering!)
+
+         !initialize workArray to zeros
+         workArray(:,:) = 0.0_RKIND
          n = 1
-         workArray(n,:) = 0.0_RKIND
-         n = n + 1
          workArray(n,:) = workMask(:)
          n = n + 1
          workArray(n,:) = areaCell(:)


### PR DESCRIPTION
Nothing is presently being stored in workArray(1,:) leading to all
values in the var_array being shifted by one index.  This is causing
MPAS-Analysis failures. This results in avgSurfaceTemperature values
being stored in avgSurfaceSalinity in output files.

This commit shifts indices back one value so the ordering is as
expected.

