### PR TITLE
Fix snowFlow misspelling

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2167,8 +2167,8 @@ contains
                call ocn_write_field_statistics(debugUnit, fieldName, minValue, maxValue)
             end if
 
-            ! Test snowFlow
-            fieldName = 'snowFlow'
+            ! Test snowFlux
+            fieldName = 'snowFlux'
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)


### PR DESCRIPTION
The variable snowFlux is misspelled as snowFlow.  I think snowFlow causes a warning when the code tries to access that field, could cause an error on some machines.