### PR TITLE
Create new script to set cullCell

### DIFF
--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_bathymetry.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_bathymetry.py
@@ -113,10 +113,7 @@ if __name__ == "__main__":
     nc_vars = nc_mesh.variables.keys()
     if 'bathymetry' not in nc_vars:
         nc_mesh.createVariable('bathymetry', 'f8', ('nCells'))
-    if 'cullCell' not in nc_vars:
-        nc_mesh.createVariable('cullCell', 'i', ('nCells'))
 
     # Write to mesh file
     nc_mesh.variables['bathymetry'][:] = bathymetry
-    nc_mesh.variables['cullCell'][:] = nc_mesh.variables['bathymetry'][:] > 20.0
     nc_mesh.close()

--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_cullCell.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_cullCell.py
@@ -1,0 +1,12 @@
+import netCDF4 as nc4
+
+if __name__ == "__main__":
+
+    mesh_file = sys.argv[1]
+    nc_mesh = nc4.Dataset(mesh_file, 'r+')
+
+    if 'cullCell' not in nc_vars:
+        nc_mesh.createVariable('cullCell', 'i', ('nCells'))
+    
+    mesh.variables['cullCell'][:] = nc_mesh.variables['bathymetry'][:] > 20.0
+    nc_mesh.close()


### PR DESCRIPTION
Currently, the cullCell variable is being set in the base_mesh step inside inject_bathymetry.py (#176). This PR puts this functionality in a new script, so it doesn't affect the global_ocean mesh creation.

closes #176 