### PR TITLE
Use CAM climatological O3 by default

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1742,7 +1742,7 @@
                      description="logical for configuration of deep soil temperatures"
                      possible_values=".true. for slowly time-varying deep soil temperatures; .false. otherwise"/>
 
-                <nml_option name="config_o3climatology" type="logical" default_value="false" in_defaults="false"
+                <nml_option name="config_o3climatology" type="logical" default_value="true" in_defaults="false"
                      units="-"
                      description="logical for configuration of input ozone data in RRMTG long- and short-wave radiation"
                      possible_values=".true. for using monthly-varying ozone data; .false. for using fixed vertical profile"/>


### PR DESCRIPTION
This merge sets the use of CAM climatological O3 by default, rather than using a single profile.

This change forces the RRTMG long- and short-wave radiation codes to use 
the monthly-mean global climatological ozone data also used in the CAM radiation
code, instead of a single vertical profile of ozone, one for winter and one for summer.

When config_o3climatology is true, the three-dimensional ozone data is updated
every day using temporal interpolation of the input global climatological data on fixed
presssure levels. The three-dimensional data is interpolated to the time-varying
pressure levels before calls to the RRTMG radiation codes.