### PR TITLE
Clone pool memory leak

### DIFF
--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -710,7 +710,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r0)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r0a(dptr % contentsTimeLevs), newmem % data % r0)
                         newmem % data % r0a(j) = newmem % data % r0
                         deallocate(newmem % data % r0)
@@ -728,7 +728,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r1)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r1a(dptr % contentsTimeLevs), newmem % data % r1)
                         newmem % data % r1a(j) = newmem % data % r1
                         deallocate(newmem % data % r1)
@@ -746,7 +746,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r2)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r2a(dptr % contentsTimeLevs), newmem % data % r2)
                         newmem % data % r2a(j) = newmem % data % r2
                         deallocate(newmem % data % r2)
@@ -764,7 +764,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r3)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r3a(dptr % contentsTimeLevs), newmem % data % r3)
                         newmem % data % r3a(j) = newmem % data % r3
                         deallocate(newmem % data % r3)
@@ -782,7 +782,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r4)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r4a(dptr % contentsTimeLevs), newmem % data % r4)
                         newmem % data % r4a(j) = newmem % data % r4
                         deallocate(newmem % data % r4)
@@ -800,7 +800,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % r5)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % r5a(dptr % contentsTimeLevs), newmem % data % r5)
                         newmem % data % r5a(j) = newmem % data % r5
                         deallocate(newmem % data % r5)
@@ -818,7 +818,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % i0)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % i0a(dptr % contentsTimeLevs), newmem % data % i0)
                         newmem % data % i0a(j) = newmem % data % i0
                         deallocate(newmem % data % i0)
@@ -836,7 +836,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % i1)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % i1a(dptr % contentsTimeLevs), newmem % data % i1)
                         newmem % data % i1a(j) = newmem % data % i1
                         deallocate(newmem % data % i1)
@@ -854,7 +854,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % i2)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % i2a(dptr % contentsTimeLevs), newmem % data % i2)
                         newmem % data % i2a(j) = newmem % data % i2
                         deallocate(newmem % data % i2)
@@ -872,7 +872,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % i3)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % i3a(dptr % contentsTimeLevs), newmem % data % i3)
                         newmem % data % i3a(j) = newmem % data % i3
                         deallocate(newmem % data % i3)
@@ -890,7 +890,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % c0)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % c0a(dptr % contentsTimeLevs), newmem % data % c0)
                         newmem % data % c0a(j) = newmem % data % c0
                         deallocate(newmem % data % c0)
@@ -908,7 +908,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % c1)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % c1a(dptr % contentsTimeLevs), newmem % data % c1)
                         newmem % data % c1a(j) = newmem % data % c1
                         deallocate(newmem % data % c1)
@@ -926,7 +926,7 @@ module mpas_pool_routines
                         deallocate(newmem % data % l0)
                      end do
 
-                     do j = minTimeLevels, newmem % data % contentsTimeLevs
+                     do j = minTimeLevels+1, newmem % data % contentsTimeLevs
                         call mpas_duplicate_field(dptr % l0a(dptr % contentsTimeLevs), newmem % data % l0)
                         newmem % data % l0a(j) = newmem % data % l0
                         deallocate(newmem % data % l0)


### PR DESCRIPTION
Currently, the subroutine `mpas_pool_clone_pool` double-allocates arrays due to an index error, so that `mpas_duplicate_field` is called twice (by mistake) but deallocate is only called once. This PR fixes that index. This error previously caused ocean simulations using RK4 time stepping to die with out-of-memory errors.

fixes #137