### PR TITLE
Change default topo and landuse to GMTED2010 and MODIFIED_IGBP_MODIS_NOAH

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -101,7 +101,7 @@
 
                 <nml_option name="config_dynamics_split_steps" type="integer" default_value="3"
                      units="-"
-                     description="When config\_split\_dynamics\_transport = T, the number of RK steps per transport step"
+                     description="When config_split_dynamics_transport = T, the number of RK steps per transport step"
                      possible_values="Positive integer values"/>
 
                 <nml_option name="config_h_mom_eddy_visc2" type="real" default_value="0.0"

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -145,12 +145,12 @@
                      description="Interval between SST and sea-ice files (case 8 only)"
                      possible_values="[DDD_]hh:mm:ss"/>
 
-                <nml_option name="config_landuse_data"          type="character"     default_value="USGS"
+                <nml_option name="config_landuse_data"          type="character"     default_value="MODIFIED_IGBP_MODIS_NOAH"
                      units="-"
                      description="The land use classification to use (case 7 only)"
                      possible_values="`USGS' or `MODIFIED\_IGBP\_MODIS\_NOAH'"/>
 
-                <nml_option name="config_topo_data"             type="character"     default_value="GTOPO30"
+                <nml_option name="config_topo_data"             type="character"     default_value="GMTED2010"
                      units="-"
                      description="The topography dataset to use for the model terrain and for GWDO static fields (case 7 only)"
                      possible_values="`GTOPO30' or `GMTED2010'"/>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -148,7 +148,7 @@
                 <nml_option name="config_landuse_data"          type="character"     default_value="MODIFIED_IGBP_MODIS_NOAH"
                      units="-"
                      description="The land use classification to use (case 7 only)"
-                     possible_values="`USGS' or `MODIFIED\_IGBP\_MODIS\_NOAH'"/>
+                     possible_values="`USGS' or `MODIFIED_IGBP_MODIS_NOAH'"/>
 
                 <nml_option name="config_topo_data"             type="character"     default_value="GMTED2010"
                      units="-"


### PR DESCRIPTION
This merge changes the default values for config_topo_data
and config_landuse_data to GMTED2010 and MODIFIED_IGBP_MODIS_NOAH in
the Registry.xml file for the init_atmosphere core. These default should
give closer static fields to those used in the ARW model.