### PR TITLE
Use mminlu rather than config_landuse_data when initializing sea ice

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -599,7 +599,7 @@
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o,smcrel
 
  logical, pointer :: config_frac_seaice
- character(len=StrKIND),pointer:: config_landuse_data
+ character(len=StrKIND),pointer:: mminlu
  integer:: isice_lu
 
 !note that this threshold is also defined in module_physics_vars.F.It is defined here to avoid
@@ -613,10 +613,11 @@
 !call mpas_log_write('--- enter physics_init_seaice:')
 
  call mpas_pool_get_config(configs, 'config_frac_seaice', config_frac_seaice)
- call mpas_pool_get_config(configs, 'config_landuse_data', config_landuse_data)
 
  call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
  call mpas_pool_get_dimension(dims, 'nSoilLevels', nSoilLevels)
+
+ call mpas_pool_get_array(mesh, 'mminlu', mminlu)
 
  call mpas_pool_get_array(mesh, 'landmask', landmask)
  call mpas_pool_get_array(mesh, 'lu_index', ivgtyp)
@@ -636,7 +637,7 @@
  call mpas_pool_get_array(input, 'smcrel', smcrel)
 
 !define the land use category for sea-ice as a function of the land use category input file:
- sfc_input_select1: select case(trim(config_landuse_data))
+ sfc_input_select1: select case(trim(mminlu))
     case('OLD')
        isice_lu = 11
     case('USGS')
@@ -644,7 +645,7 @@
     case('MODIFIED_IGBP_MODIS_NOAH')
        isice_lu = 15
     case default
-       CALL physics_error_fatal ('Invalid Land Use Dataset '//trim(config_landuse_data))
+       CALL physics_error_fatal ('Invalid Land Use Dataset '//trim(mminlu))
  end select sfc_input_select1
  call mpas_log_write('--- isice_lu   = $i', intArgs=(/isice_lu/))
 


### PR DESCRIPTION
This merge makes changes to use mminlu rather than config_landuse_data when
initializing sea ice in the init_atmosphere core.

In the physics_init_seaice routine, we were previously using config_landuse_data
to determine the category to be used for ice. However, in cases where
the static file is produced with config_landuse_data = MODIFIED_IGPB_MODIS_NOAH,
but the model initial conditions file is produced with
config_landuse_data = USGS, the resulting sea ice points will have the wrong
category.

The solution to this issue implemented in this commit is to use mminlu rather
than config_landuse_data to determine the ice category. The mminlu value comes
from the input static file (or, in the case where static fields and initial
conditions are being processed all at once, from the config_landuse_data option),
and will therefore be consistent with the land use classification scheme used in
the static file.