### PR TITLE
E3SM and CESM are now using TRUE|FALSE for compile_threaded

### DIFF
--- a/src/Makefile.in.ACME
+++ b/src/Makefile.in.ACME
@@ -1,11 +1,11 @@
 # Duplicate logic from Tools/Makefile to set compile_threaded
-compile_threaded = false
+compile_threaded = FALSE
 ifeq ($(strip $(SMP)),TRUE)
-   compile_threaded = true
+   compile_threaded = TRUE
    THREADDIR = threads
 else
    ifeq ($(strip $(BUILD_THREADED)),TRUE)
-      compile_threaded = true
+      compile_threaded = TRUE
       THREADDIR = threads
    else
       THREADDIR = nothreads
@@ -63,7 +63,7 @@ ifeq ($(DEBUG), TRUE)
     override CPPFLAGS += -DMPAS_DEBUG
 endif
 
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
     override CPPFLAGS += -DMPAS_OPENMP
 endif
 

--- a/src/Makefile.in.CESM
+++ b/src/Makefile.in.CESM
@@ -1,11 +1,11 @@
 # Duplicate logic from Tools/Makefile to set compile_threaded
-compile_threaded = false
+compile_threaded = FALSE
 ifeq ($(strip $(SMP)),TRUE)
-   compile_threaded = true
+   compile_threaded = TRUE
    THREADDIR = threads
 else
    ifeq ($(strip $(BUILD_THREADED)),TRUE)
-      compile_threaded = true
+      compile_threaded = TRUE
       THREADDIR = threads
    else
       THREADDIR = nothreads
@@ -63,7 +63,7 @@ ifeq ($(DEBUG), TRUE)
     override CPPFLAGS += -DMPAS_DEBUG
 endif
 
-ifeq ($(compile_threaded), true)
+ifeq ($(compile_threaded), TRUE)
     override CPPFLAGS += -DMPAS_OPENMP
 endif
 


### PR DESCRIPTION
This change will need to be reflected in the MPAS submodule of E3SM as soon as possible.