### PR TITLE
Update use of isice_lu and iswater_lu in core_atmosphere

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -442,6 +442,8 @@
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
 			<var name="mminlu"/>
+			<var name="isice_lu"/>
+			<var name="iswater_lu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -758,6 +760,8 @@
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
 			<var name="mminlu"/>
+			<var name="isice_lu"/>
+			<var name="iswater_lu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -907,6 +911,8 @@
 			<var name="pin"/>
 			<var name="ozmixm"/>
 			<var name="mminlu"/>
+			<var name="isice_lu"/>
+			<var name="iswater_lu"/>
 			<var name="xland"/>
 			<var name="skintemp"/>
 			<var name="snow"/>
@@ -2814,6 +2820,12 @@
 
                 <var name="mminlu" type="text" dimensions="" units="unitless"
                      description="land use classification"/>
+
+                <var name="isice_lu" name_in_code="isice" type="integer" dimensions="" units="unitless" default_value="24"
+                     description="Index category for snow/ice"/>
+
+                <var name="iswater_lu" name_in_code="iswater" type="integer" dimensions="" units="unitless" default_value="16"
+                     description="Index category for water"/>
 
                 <var name="landmask" type="integer"  dimensions="nCells" units="unitless"
                      description="land-ocean mask (1=land ; 0=ocean)"/>

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -185,7 +185,6 @@ mpas_atmphys_todynamics.o: \
 mpas_atmphys_update_surface.o: \
 	mpas_atmphys_date_time.o \
 	mpas_atmphys_constants.o \
-	mpas_atmphys_landuse.o \
 	mpas_atmphys_vars.o
 
 mpas_atmphys_update.o: \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -12,7 +12,7 @@
  use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 
  use mpas_atmphys_constants
- use mpas_atmphys_landuse
+ use mpas_atmphys_landuse, only: isurban
  use mpas_atmphys_lsm_noahinit
  use mpas_atmphys_vars
 
@@ -82,10 +82,11 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2016-05-11.
 ! * added the calculation of surface variables over seaice cells when config_frac_seaice is set to true.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-03.
+! * now use isice and iswater initialized in the init file instead of initialized in mpas_atmphys_landuse.F.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-01-13.
 ! * since we removed the local variable lsm_scheme from mpas_atmphys_vars.F, now defines lsm_scheme as a
 !   pointer to config_lsm_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
-
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
 
 !
 ! DOCUMENTATION:
@@ -726,6 +727,7 @@
  logical,pointer:: config_sfc_albedo
  character(len=StrKIND),pointer:: lsm_scheme
  character(len=StrKIND),pointer:: mminlu
+ integer,pointer:: isice
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
@@ -734,9 +736,11 @@
  call mpas_pool_get_config(configs,'config_sfc_albedo',config_sfc_albedo)
  call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
  call mpas_pool_get_array(sfc_input,'mminlu',mminlu)
+ call mpas_pool_get_array(sfc_input,'isice' ,isice )
 
 !copy MPAS arrays to local arrays:
  call lsm_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
+!write(0,*) '--- end lsm_from_MPAS'
 
 !call to land-surface scheme:
  lsm_select: select case (trim(lsm_scheme))

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -23,7 +23,7 @@
  public:: landuse_init_forMPAS
 
 !global variables:
- integer,public:: isice,iswater,isurban
+ integer,public:: isurban
 
  integer,parameter:: frac_seaice      = 0       ! = 1: treats seaice as fractional field.
                                                 ! = 0: ice/no-ice flag. 
@@ -72,6 +72,10 @@
 ! * in subroutine landuse_int_forMPAS, added the initialization of variable ust to a very small value. this was
 !   needed when the surface layer scheme was updated to that used in WRF version 3.8.1
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-27.
+! * removed the parameter frac_seaice which is not used anymore and has been replaced with config_frac_seaice. 
+!   Laura D. Fowler (laura@ucar.edu) / 2017-01-11.
+! * now use isice and iswater initialized in the init file instead of initialized in mpas_atmphys_landuse.F.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-01-13.
 
 
  contains
@@ -98,6 +102,7 @@
  character(len=StrKIND),pointer:: mminlu
 
  integer,pointer:: nCells
+ integer,pointer:: isice,iswater
  integer,dimension(:),pointer:: ivgtyp
  integer,dimension(:),pointer:: landmask
 
@@ -130,19 +135,21 @@
  call mpas_pool_get_config(configs,'config_do_restart' ,config_do_restart )
  call mpas_pool_get_config(configs,'config_frac_seaice',config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfc_albedo' ,config_sfc_albedo )
- call mpas_pool_get_array(sfc_input,'mminlu',mminlu)
 
  call mpas_pool_get_dimension(mesh,'nCells',nCells)
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  
- call mpas_pool_get_array(sfc_input,'landmask'  , landmask  )
- call mpas_pool_get_array(sfc_input,'ivgtyp'    , ivgtyp    )
- call mpas_pool_get_array(sfc_input,'snoalb'    , snoalb    )
- call mpas_pool_get_array(sfc_input,'snowc'     , snowc     )
- call mpas_pool_get_array(sfc_input,'xice'      , xice      )
- call mpas_pool_get_array(sfc_input,'xland'     , xland     )
- call mpas_pool_get_array(sfc_input,'sfc_albbck', albbck    )
+ call mpas_pool_get_array(sfc_input,'mminlu'    ,mminlu  )
+ call mpas_pool_get_array(sfc_input,'isice'     ,isice   )
+ call mpas_pool_get_array(sfc_input,'iswater'   ,iswater )
+ call mpas_pool_get_array(sfc_input,'landmask'  ,landmask)
+ call mpas_pool_get_array(sfc_input,'ivgtyp'    ,ivgtyp  )
+ call mpas_pool_get_array(sfc_input,'snoalb'    ,snoalb  )
+ call mpas_pool_get_array(sfc_input,'snowc'     ,snowc   )
+ call mpas_pool_get_array(sfc_input,'xice'      ,xice    )
+ call mpas_pool_get_array(sfc_input,'xland'     ,xland   )
+ call mpas_pool_get_array(sfc_input,'sfc_albbck',albbck  )
 
  nullify(mavail)
  nullify(ust)
@@ -203,27 +210,17 @@
 !      if(is .lt. luseas) call mpas_log_write('')
     enddo
 
-!defines the index isurban, iswater and, isice as a function of sfc_input_data:
+!defines the index isurban as a function of sfc_input_data:
     sfc_input_select: select case(trim(lutype))
        case('OLD')
-          iswater = 7
-          isice   = 11
           isurban = 1
        case('USGS')
-          iswater = 16
-          isice   = 24
           isurban = 1
        case('MODIFIED_IGBP_MODIS_NOAH')
-          iswater = 17
-          isice   = 15
           isurban = 13
        case('SiB')
-          iswater = 15
-          isice   = 16
           isurban = 11
        case('LW12')
-          iswater = 2
-          isice   = 3
           isurban = 1
        case default
     end select sfc_input_select

--- a/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
@@ -13,7 +13,6 @@
 
  use mpas_atmphys_date_time
  use mpas_atmphys_constants,only: stbolt
- use mpas_atmphys_landuse, only : isice,iswater 
  use mpas_atmphys_vars
 
  implicit none
@@ -41,6 +40,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2013-08-24.
 ! * modified sourcecode to use pools.
 !   Laura D. Fowler (laura@ucar.edu) / 2014-05-15.
+! * now use isice and iswater initialized in the init file instead of initialized in mpas_atmphys_landuse.F.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-01-13.
 
 
  contains
@@ -121,6 +122,7 @@
 
 
  integer,pointer:: nCellsSolve,nSoilLevels
+ integer,pointer:: isice,iswater
 
  real(kind=RKIND),dimension(:),pointer  :: sfc_albbck,sst,snow,tmn,tsk,vegfra,xice,seaice
  real(kind=RKIND),dimension(:),pointer  :: snowc,snowh
@@ -144,6 +146,8 @@
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nSoilLevels',nSoilLevels)
 
+ call mpas_pool_get_array(sfc_input,'isice'     ,isice     )
+ call mpas_pool_get_array(sfc_input,'iswater'   ,iswater   )
  call mpas_pool_get_array(sfc_input,'isltyp'    ,isltyp    )    
  call mpas_pool_get_array(sfc_input,'ivgtyp'    ,ivgtyp    )
  call mpas_pool_get_array(sfc_input,'landmask'  ,landmask  )

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -334,8 +334,10 @@
                         <var name="fVertex" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="ter" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="landmask" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
-                        <var name="ivgtyp" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="mminlu" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
+                        <var name="isice_lu" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
+                        <var name="iswater_lu" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
+                        <var name="ivgtyp" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="isltyp" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="snoalb" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
                         <var name="soiltemp" packages="gwd_stage_in;vertical_stage_in;met_stage_in"/>
@@ -428,8 +430,10 @@
                         <var name="fVertex"/>
                         <var name="ter"/>
                         <var name="landmask"/>
-                        <var name="ivgtyp"/>
                         <var name="mminlu"/>
+                        <var name="isice_lu"/>
+                        <var name="iswater_lu"/>
+                        <var name="ivgtyp"/>
                         <var name="isltyp"/>
                         <var name="snoalb"/>
                         <var name="soiltemp"/>
@@ -586,6 +590,8 @@
                 <var name="shdmin"                               type="real"     dimensions="nCells"/>
                 <var name="shdmax"                               type="real"     dimensions="nCells"/>
                 <var name="albedo12m"                            type="real"     dimensions="nMonths nCells"/>
+                <var name="isice_lu"                             type="integer"  dimensions=""/>
+                <var name="iswater_lu"                           type="integer"  dimensions=""/>
 
                 <!-- GWDO fields -->
                 <var name="varsso"                               type="real"     dimensions="nCells"/>

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -47,8 +47,7 @@
  character(len=StrKIND+1) :: geog_data_path      ! same as config_geog_data_path, but guaranteed to have a trailing slash
  character(len=StrKIND+1) :: geog_sub_path       ! subdirectory names in config_geog_data_path, with trailing slash
 
- integer:: isice_lu,iswater_lu,ismax_lu
-
+ integer:: ismax_lu
  integer:: nx,ny,nz
  integer:: endian,isigned,istatus,wordsize
  integer:: i,j,k
@@ -69,6 +68,7 @@
  real(kind=RKIND),dimension(:,:),allocatable  :: maxsnowalb
  real(kind=RKIND),dimension(:,:,:),allocatable:: vegfra
 
+ integer, pointer :: isice_lu, iswater_lu
  integer, pointer :: nCells, nEdges, nVertices, maxEdges
  logical, pointer :: on_a_sphere
  real (kind=RKIND), pointer :: sphere_radius
@@ -147,6 +147,8 @@
  call mpas_pool_get_array(mesh, 'ter', ter)
  call mpas_pool_get_array(mesh, 'lu_index', lu_index)
  call mpas_pool_get_array(mesh, 'mminlu', mminlu)
+ call mpas_pool_get_array(mesh, 'isice_lu', isice_lu)
+ call mpas_pool_get_array(mesh, 'iswater_lu', iswater_lu)
  call mpas_pool_get_array(mesh, 'soilcat_top', soilcat_top)
  call mpas_pool_get_array(mesh, 'landmask', landmask)
  call mpas_pool_get_array(mesh, 'soiltemp', soiltemp)


### PR DESCRIPTION
isice_lu and iswater_lu are now defined in the initial conditions file instead of being defined in core_atmosphere. Changes to the different files in this PR reflect that the 2 variables are now in the init file.


