### PR TITLE
Fix null pointer warning for string argument to parse_struct in registry code

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -2553,7 +2553,7 @@ int parse_structs_from_registry(ezxml_t registry)/*{{{*/
 	fd = fopen("structs_and_variables.inc", "w+");
 
 	for (structs_xml = ezxml_child(registry, "var_struct"); structs_xml; structs_xml = structs_xml->next){
-		err = parse_struct(fd, registry, structs_xml, 0, '\0', corename);
+		err = parse_struct(fd, registry, structs_xml, 0, "\0", corename);
 	}
 
 	fortprintf(fd, "   subroutine %s_generate_structs(block, structPool, dimensionPool, packagePool)\n", core_string);


### PR DESCRIPTION
This merge fixes a null pointer warning for a string argument to parse_struct
in the registry code.

The fifth argument to the parse_struct function in the gen_inc code is
a const char*. The call to parse_struct previously passed a C null character,
'\0', which evaluates to zero and is therefore interpreted as a null pointer.
It was likely intended to pass an empty C string, i.e., a string consisting
of a single null character, in the call to parse_struct, using "\0" rather
than '\0'. This was picked up by the XL C compiler:
```
gen_inc.c:2531:52: warning: expression which evaluates to zero treated as a null pointer constant of type 'const char *'
[-Wnon-literal-null-conversion]
                err = parse_struct(fd, registry, structs_xml, 0, '\0', corename);
                                                                 ^~~~
```
This warning turns out to be harmless, as the fifth argument to parse_struct
is only used when the fourth argument is non-zero.