### PR TITLE
Fix warnings for implicitly declared functions in xml_stream_parser.c

### DIFF
--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -26,9 +26,9 @@
  *  Interface routines for building streams at run-time; defined in mpas_stream_manager.F
  */
 void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, const char *, const char *, int *, int *, int *, int *, int *);
-void mpas_stream_mgr_add_field_c(void *, const char *, const char *, const char *, int *);
-void mpas_stream_mgr_add_immutable_stream_fields_c(void *, const char *, const char *, const char *, int *);
-void mpas_stream_mgr_add_pool_c(void *, const char *, const char *, const char *, int *);
+void stream_mgr_add_field_c(void *, const char *, const char *, const char *, int *);
+void stream_mgr_add_immutable_stream_fields_c(void *, const char *, const char *, const char *, int *);
+void stream_mgr_add_pool_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_alarm_c(void *, const char *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pkg_c(void *, const char *, const char *, int *);
 


### PR DESCRIPTION
This merge fixes warnings for three implicitly declared functions in xml_stream_parser.c.

There were three functions defined in mpas_stream_manager.F whose declarations
in xml_stream_parser.c inadvertently contained the prefix "mpas_", effectively
declaring non-existent functions and implicitly declaring the actual functions
being called.

This commit simply corrects the names of these three functions in their
declarations:
 * stream_mgr_add_field_c
 * stream_mgr_add_pool_c
 * stream_mgr_add_immutable_stream_fields_c