### PR TITLE
Don't process trigraphs with the XL compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ xlf:
 	"CC_SERIAL = xlc_r" \
 	"CXX_SERIAL = xlc++_r" \
 	"FFLAGS_PROMOTION = -qrealsize=8" \
-	"FFLAGS_OPT = -O3 -qufmt=be" \
+	"FFLAGS_OPT = -O3 -qufmt=be -WF,-qnotrigraph" \
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -O0 -g -C -qufmt=be" \
+	"FFLAGS_DEBUG = -O0 -g -C -qufmt=be -WF,-qnotrigraph" \
 	"CFLAGS_DEBUG = -O0 -g" \
 	"CXXFLAGS_DEBUG = -O0 -g" \
 	"LDFLAGS_DEBUG = -O0 -g" \


### PR DESCRIPTION
This merge disables processing of trigraphs with the XL compilers.

The XL Fortran compiler invokes the XL C preprocessor, which by default processes
trigraphs (https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C). This can
cause problems in MPAS code, e.g., if a string '??' appears in a non-comment
context in the source, where the ??' characters are turned into a ^ character,
leading to an un-terminated character string.

To avoid processing of trigraphs, the `-qnotrigraph` option is passed to the C
preprocessor via `-WF` in the FFLAGS for the XL compiler only. There is apparently
no need to add `-qnotrigraph` to the CPPFLAGS, since the 'cpp' that is invoked
when explicitly preprocessing files with `GEN_F90=true` is the system's
C preprocessor, which doesn't process trigraphs.