### PR TITLE
Ignore the word vector during preprocessing for E3SM Makefile

### DIFF
--- a/src/Makefile.in.E3SM
+++ b/src/Makefile.in.E3SM
@@ -67,6 +67,10 @@ ifeq ($(compile_threaded), TRUE)
     override CPPFLAGS += -DMPAS_OPENMP
 endif
 
+ifeq ($(GEN_F90), TRUE)
+    override CPPFLAGS += -Uvector
+endif
+
 all:
 	@echo $(CPPINCLUDES)
 	@echo $(FCINCLUDES)


### PR DESCRIPTION
Gnu CPP will treat "vector" as a macro on the PowerPC64 architecture. Add -Uvector to ignore.

This was already done in the standard MPAS Makefile, but is now being added to the E3SM Makefile.

fixes https://github.com/E3SM-Project/E3SM/issues/2725