### PR TITLE
Fix formatting on E3SM Makefile

### DIFF
--- a/src/Makefile.in.E3SM
+++ b/src/Makefile.in.E3SM
@@ -67,7 +67,7 @@ ifeq ($(compile_threaded), TRUE)
     override CPPFLAGS += -DMPAS_OPENMP
 endif
 
-ifeq ($(GEN_F90), TRUE)
+ifeq "$(GEN_F90)" "true"
     override CPPFLAGS += -Uvector
 endif
 


### PR DESCRIPTION
I used the wrong case. GEN_F90 uses lowercase throughout.