### PR TITLE
Import netcdf constants for netcdf-only builds

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -17,6 +17,10 @@ module mpas_io
    use pionfatt_mod
    use pio_types
 
+#ifndef USE_PIO2
+include 'netcdf.inc'
+#endif
+
 #ifdef SINGLE_PRECISION
    integer, parameter :: PIO_REALKIND = PIO_REAL
 #else


### PR DESCRIPTION
When PIO is built without pnetcdf, fill value constants NF_FILL_INT, NF_FILL_CHAR etc. are not included. This update fixes build errors in such cases.

[BFB]