### PR TITLE
Remove WRF if-defs around 2D dx declarations for New Tiedtke and MM5 sfclay

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -219,12 +219,8 @@ contains
 
       real,    intent(in) ::                                            &
                                         dt
-#if defined(mpas)
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         dx
-#elif defined(wrfmodel)
-      real,    intent(in) ::            dx
-#endif
 
       real,    dimension(ims:ime, jms:jme), intent(in) ::               &
                                         xland
@@ -378,15 +374,9 @@ contains
         slimsk(i)=int(abs(xland(i,j)-2.))
       enddo
 
-#if defined(mpas)
       do i=its,ite
          dx2d(i) = dx(i,j)
       enddo
-#else
-      do i=its,ite
-         dx2d(i) = dx
-      enddo
-#endif
 
       do k=kts,kte
         kp=k+1

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
@@ -173,14 +173,10 @@ CONTAINS
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)   ::                                 &
                                                               QGH
-#if defined(mpas)
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV
 
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(IN   )               ::                 DX
-#else
-      REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
-#endif
  
       REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
                 INTENT(OUT)     ::                  ck,cka,cd,cda
@@ -217,15 +213,9 @@ CONTAINS
 
       DO J=jts,jte
 
-#if defined(mpas)
         DO i=its,ite
            DX2D(i)=DX(i,j)
         ENDDO
-#else
-        DO i=its,ite
-           DX2D(i)=DX
-        ENDDo
-#endif
 
         DO i=its,ite
           dz8w1d(I) = dz8w(i,1,j)


### PR DESCRIPTION
For the purpose of WRF/MPAS physics unification,
'if defined(mpas/wrfmodel)' statements were originally added to
module_cu_ntiedtke and module_sf_sfclay because MPAS used a
2-dimensional dx, while WRF used a 1D dx. WRF code has now been modified
to use a 2d grid distance, and therefore these
'if defined(mpas/wrfmodel)' statements are no longer needed.

Confirmed that MPAS compiles with these modifications.

