### PR TITLE
PIO Version Compatibility Check - PGI Compiler Bug Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,8 +744,8 @@ pio_test:
 	@# See whether either of the test programs can be compiled
 	@#
 	@echo "Checking for a usable PIO library..."
-	@($(FC) $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out pio1.f90 &> /dev/null && echo "=> PIO 1 detected") || \
-	 ($(FC) $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out pio2.f90 &> /dev/null && echo "=> PIO 2 detected") || \
+	@($(FC) pio1.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out &> /dev/null && echo "=> PIO 1 detected") || \
+	 ($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out &> /dev/null && echo "=> PIO 2 detected") || \
 	 (echo "************ ERROR ************"; \
 	  echo "Failed to compile a PIO test program"; \
 	  echo "Please ensure the PIO environment variable is set to the PIO installation directory"; \
@@ -758,13 +758,13 @@ pio_test:
 	@# Check that what the user has specified agrees with the PIO library version that was detected
 	@#
 ifeq "$(USE_PIO2)" "true"
-	@($(FC) $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out pio2.f90 &> /dev/null) || \
+	@($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out &> /dev/null) || \
 	(echo "************ ERROR ************"; \
 	 echo "PIO 1 was detected, but USE_PIO2=true was specified in the make command"; \
 	 echo "************ ERROR ************"; \
 	 rm -rf pio[12].f90 pio[12].out; exit 1)
 else
-	@($(FC) $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out pio1.f90 &> /dev/null) || \
+	@($(FC) pio1.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out &> /dev/null) || \
 	(echo "************ ERROR ************"; \
 	 echo "PIO 2 was detected. Please specify USE_PIO2=true in the make command"; \
 	 echo "************ ERROR ************"; \


### PR DESCRIPTION
This commit fixes the bug addressed in issue #207, that caused the PGI compiler 18.10 to fail upon reaching the PIO version compatibility check. This single commit moves the target file to the front of the compiler arguments, which fixes the problems.

