### PR TITLE
Multiple output intervals

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -470,7 +470,7 @@
  if(trim(config_radtlw_interval) /= "none") then
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_radtlw_interval,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,radtlwAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,radtlwAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_run_init: error creating radtlwAlarmID')
 
@@ -489,7 +489,7 @@
  if(trim(config_radtsw_interval) /= "none") then
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_radtsw_interval,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,radtswAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,radtswAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_run_init: error creating alarm radtsw')
 
@@ -508,7 +508,7 @@
  if(trim(config_conv_interval) /= "none") then
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_conv_interval,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,convAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,convAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating convAlarmID')
 
@@ -527,7 +527,7 @@
  if(trim(config_pbl_interval) /= "none") then
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_pbl_interval,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,pblAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,pblAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating pblAlarmID')
 
@@ -546,7 +546,7 @@
 !set alarm for updating the background surface albedo and the greeness fraction:
  call mpas_set_timeInterval(alarmTimeStep,timeString=config_greeness_update,ierr=ierr)
  alarmStartTime = startTime
- call mpas_add_clock_alarm(clock,greenAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+ call mpas_add_clock_alarm(clock,greenAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating alarm greeness')
 
@@ -556,7 +556,7 @@
                                       direction=MPAS_STREAM_INPUT, ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=stream_interval,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,sfcbdyAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,sfcbdyAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating alarm sfcbdy')
  endif
@@ -567,7 +567,7 @@
     trim(config_radt_sw_scheme) .eq. "cam_sw" ) then
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_camrad_abs_update,ierr=ierr)
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,camAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,camAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating alarm CAM')
  endif
@@ -581,7 +581,7 @@
     if(trim(stream_interval) /= 'none') then
        call mpas_set_timeInterval(alarmTimeStep,timeString=stream_interval,ierr=ierr)
        alarmStartTime = startTime + alarmTimeStep
-       call mpas_add_clock_alarm(clock,camlwAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+       call mpas_add_clock_alarm(clock,camlwAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
        if(ierr /= 0) &
           call physics_error_fatal('subroutine physics_init: error creating alarm CAMLW')
     endif
@@ -593,7 +593,7 @@
     call mpas_set_timeInterval(acrainTimeStep,dt=config_dt,ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
     alarmStartTime = startTime + alarmTimeStep
-    call mpas_add_clock_alarm(clock,acrainAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,acrainAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
        if(ierr /= 0) &
           call physics_error_fatal('subroutine physics_init: error creating alarm rain limit')
  endif
@@ -604,7 +604,7 @@
     call mpas_set_timeInterval(acradtTimeStep,dt=config_dt,ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
     alarmStartTime = startTime + alarmTimeStep
-    call mpas_add_clock_alarm(clock,acradtAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,acradtAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
        if(ierr /= 0) &
           call physics_error_fatal('subroutine physics_init: error creating alarm radiation limit')
  endif
@@ -625,7 +625,7 @@
        end if
     end if
     alarmStartTime = startTime
-    call mpas_add_clock_alarm(clock,diagAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+    call mpas_add_clock_alarm(clock,diagAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
     if(ierr /= 0) &
        call physics_error_fatal('subroutine physics_init: error creating alarm diag')
  else
@@ -634,7 +634,7 @@
     if(trim(stream_interval) /= 'none') then
        call mpas_set_timeInterval(alarmTimeStep,timeString=stream_interval,ierr=ierr)
        alarmStartTime = startTime
-       call mpas_add_clock_alarm(clock,diagAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+       call mpas_add_clock_alarm(clock,diagAlarmID,alarmStartTime,alarmTimeInterval=alarmTimeStep,ierr=ierr)
        if(ierr /= 0) &
           call physics_error_fatal('subroutine physics_init: error creating alarm diag')
     end if

--- a/src/core_landice/analysis_members/mpas_li_analysis_driver.F
+++ b/src/core_landice/analysis_members/mpas_li_analysis_driver.F
@@ -257,7 +257,7 @@ contains
                call MPAS_stream_mgr_get_property(domain % streamManager, config_AM_stream_name, &
                MPAS_STREAM_PROPERTY_REF_TIME, referenceTimeString, err_tmp)
                call mpas_set_time(referenceTime, dateTimeString=referenceTimeString, ierr=err_tmp)
-               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeStep, ierr=err_tmp)
+               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
                call mpas_reset_clock_alarm(domain % clock, alarmName, ierr=err_tmp)
             end if
             call mpas_timer_stop(timerName)

--- a/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_analysis_driver.F
@@ -503,7 +503,7 @@ contains
                   end if
 
                end if
-               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeStep, ierr=err_tmp)
+               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
                call mpas_reset_clock_alarm(domain % clock, alarmName, ierr=err_tmp)
             end if
 

--- a/src/core_ocean/analysis_members/mpas_ocn_time_series_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_time_series_stats.F
@@ -1566,21 +1566,21 @@ subroutine set_alarms(domain, instance, series, alarms, err)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % duration_alarm_ID, &
       duration_time, & ! duration sets the offset
-      alarms(b) % repeat_interval, ierr=err) ! but repeat is interval
+      alarmTimeInterval=alarms(b) % repeat_interval, ierr=err) ! but repeat is interval
 
     series % buffers(b) % repeat_alarm_ID = trim(alarm_prefix) // &
       trim(REPEAT_ALARM_PREFIX) // trim(buf_identifier)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % repeat_alarm_ID, &
       repeat_time, &
-      alarms(b) % repeat_interval, ierr=err)
+      alarmTimeInterval=alarms(b) % repeat_interval, ierr=err)
 
     series % buffers(b) % reset_alarm_ID = trim(alarm_prefix) // &
       trim(RESET_ALARM_PREFIX) // trim(buf_identifier)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % reset_alarm_ID, &
       reset_time, &
-      alarms(b) % reset_interval, ierr=err)
+      alarmTimeInterval=alarms(b) % reset_interval, ierr=err)
   end do
 end subroutine set_alarms
 

--- a/src/core_seaice/analysis_members/mpas_seaice_analysis_driver.F
+++ b/src/core_seaice/analysis_members/mpas_seaice_analysis_driver.F
@@ -484,7 +484,7 @@ contains
                   end if
 
                end if
-               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeStep, ierr=err_tmp)
+               call mpas_add_clock_alarm(domain % clock, alarmName, referenceTime, alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
                call mpas_reset_clock_alarm(domain % clock, alarmName, ierr=err_tmp)
             end if
 

--- a/src/core_seaice/analysis_members/mpas_seaice_time_series_stats.F
+++ b/src/core_seaice/analysis_members/mpas_seaice_time_series_stats.F
@@ -1567,21 +1567,21 @@ subroutine set_alarms(domain, instance, series, alarms, err)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % duration_alarm_ID, &
       duration_time, & ! duration sets the offset
-      alarms(b) % repeat_interval, ierr=err) ! but repeat is interval
+      alarmTimeInterval=alarms(b) % repeat_interval, ierr=err) ! but repeat is interval
 
     series % buffers(b) % repeat_alarm_ID = trim(alarm_prefix) // &
       trim(REPEAT_ALARM_PREFIX) // trim(buf_identifier)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % repeat_alarm_ID, &
       repeat_time, &
-      alarms(b) % repeat_interval, ierr=err)
+      alarmTimeInterval=alarms(b) % repeat_interval, ierr=err)
 
     series % buffers(b) % reset_alarm_ID = trim(alarm_prefix) // &
       trim(RESET_ALARM_PREFIX) // trim(buf_identifier)
     call mpas_add_clock_alarm(domain % clock, &
       series % buffers(b) % reset_alarm_ID, &
       reset_time, &
-      alarms(b) % reset_interval, ierr=err)
+      alarmTimeInterval=alarms(b) % reset_interval, ierr=err)
   end do
 end subroutine set_alarms
 

--- a/src/core_sw/mpas_sw_core.F
+++ b/src/core_sw/mpas_sw_core.F
@@ -147,7 +147,7 @@ module sw_core
       !if (trim(config_stats_interval) /= "none") then      
       !   call mpas_set_timeInterval(alarmTimeStep, timeString=config_stats_interval, ierr=local_err)
       !   alarmStartTime = startTime + alarmTimeStep
-      !   call mpas_add_clock_alarm(core_clock, statsAlarmID, alarmStartTime, alarmTimeStep, ierr=local_err)
+      !   call mpas_add_clock_alarm(core_clock, statsAlarmID, alarmStartTime, alarmInterval=alarmTimeStep, ierr=local_err)
       !end if
 
    end subroutine simulation_clock_init

--- a/src/framework/mpas_forcing.F
+++ b/src/framework/mpas_forcing.F
@@ -514,7 +514,7 @@ contains
 
     FORCING_DEBUG_WRITE('-- Forcing: create_new_forcing_stream forcingGroup % forcingGroupName: '//trim(forcingGroup % forcingGroupName))
     call mpas_add_clock_alarm(&
-         forcingGroup % forcingClock, forcingStreamNew % forcingAlarmID, forcingAlarmTime, forcingAlarmInterval)
+         forcingGroup % forcingClock, forcingStreamNew % forcingAlarmID, forcingAlarmTime, alarmTimeInterval=forcingAlarmInterval)
 
     ! check no alarms defined on stream
     call mpas_stream_mgr_get_clock(streamManager, streamClock, ierr)

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6020,7 +6020,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
                                     MPAS_stream_mgr_get_property
     use mpas_kind_types, only : StrKIND
     use mpas_timekeeping, only : mpas_add_clock_alarm, mpas_set_time, mpas_get_time, mpas_set_timeInterval, mpas_get_clock_time, &
-                                 mpas_adjust_alarm_to_reference_time
+                                 mpas_adjust_alarm_to_reference_time, operator(+), operator(-)
 
     implicit none
 
@@ -6036,8 +6036,8 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
     type (MPAS_streamManager_type), pointer :: manager
     type (MPAS_Clock_type), pointer :: clock
     character(len=StrKIND) :: streamID, direction, alarmID, alarmStartTime, alarmInterval, alarmString, alarmEndTime
-    type (MPAS_Time_type) :: alarmStartTime_local, alarmEndTime_local
-    type (MPAS_TimeInterval_type) :: alarmInterval_local
+    type (MPAS_Time_type) :: alarmStartTime_local, alarmEndTime_local, model_start, model_stop
+    type (MPAS_TimeInterval_type) :: alarmInterval_local, delay
     character(len=StrKIND) :: streamReferenceTimeString
     type (MPAS_Time_type) :: streamReferenceTime
     integer :: idirection
@@ -6046,8 +6046,6 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
 
     ierr = 0
     ierr_tmp = 0
-
-    alarmEndTime = ''
 
     call c_f_pointer(manager_c, manager)
     call mpas_c_to_f_string(streamID_c, streamID)
@@ -6069,24 +6067,40 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
     end if
 
     call MPAS_stream_mgr_get_clock(manager, clock)
+    model_start = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr_tmp)
+    ierr = ior(ierr, ierr_tmp)
+    model_stop = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
+    ierr = ior(ierr, ierr_tmp)
 
     if (trim(alarmStartTime) == 'start' .and. trim(alarmInterval) == 'final_only') then
-        alarmStartTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
-        ierr = ior(ierr, ierr_tmp)
+        alarmStartTime_local = model_stop
         call mpas_get_time(alarmStartTime_local, dateTimeString=alarmString)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, alarmString, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else if (trim(alarmStartTime) == 'start') then
-        alarmStartTime_local = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr_tmp)
-        ierr = ior(ierr, ierr_tmp)
+        alarmStartTime_local = model_start
+    else if (alarmStartTime(1:1) == '+') then
+        alarmStartTime = alarmStartTime(2:len_trim(alarmStartTime))
+        call mpas_set_timeInterval(delay, timestring=alarmStartTime)
+        alarmStartTime_local = model_start + delay
+    else if (alarmStartTime(1:1) == '-') then
+        alarmStartTime = alarmStartTime(2:len_trim(alarmStartTime))
+        call mpas_set_timeInterval(delay, timestring=alarmStartTime)
+        alarmStartTime_local = model_start - delay
     else
         call mpas_set_time(alarmStartTime_local, dateTimeString=alarmStartTime)
     end if
 
-    if (len_trim(alarmEndTime) > 0) then
-        call mpas_set_time(alarmEndTime_local, dateTimeString=alarmEndTime)
+    if (alarmEndTime(1:1) == '+') then
+        alarmEndTime = alarmEndTime(2:len_trim(alarmEndTime))
+        call mpas_set_timeInterval(delay, timeString=alarmEndTime)
+        alarmEndTime_local = alarmStartTime_local + delay
+    else if (alarmEndTime(1:1) == '-') then
+        alarmEndTime = alarmEndTime(2:len_trim(alarmEndTime))
+        call mpas_set_timeInterval(delay, timeString=alarmEndTime)
+        alarmEndTime_local = alarmStartTime_local - delay
     else
-        alarmEndTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
+        alarmEndTime_local = model_stop
     end if
 
 

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6046,6 +6046,8 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
     ierr = 0
     ierr_tmp = 0
 
+    alarmEndTime = ''
+
     call c_f_pointer(manager_c, manager)
     call mpas_c_to_f_string(streamID_c, streamID)
     call mpas_c_to_f_string(direction_c, direction)
@@ -6080,12 +6082,20 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
         call mpas_set_time(alarmStartTime_local, dateTimeString=alarmStartTime)
     end if
 
+    if (len_trim(alarmEndTime) > 0) then
+        call mpas_set_time(alarmEndTime_local, dateTimeString=alarmEndTime)
+    else
+        alarmEndTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
+    end if
+
+
     if (trim(alarmInterval) == 'initial_only' .or. trim(alarmInterval) == 'final_only') then
         call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else
         call mpas_set_timeInterval(alarmInterval_local, timeString=alarmInterval)
         call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, alarmTimeInterval=alarmInterval_local, ierr=ierr_tmp)
+                                  !alarmEndTime=alarmEndTime_local, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
         ! Now calibrate alarm to use the stream's reference time as the time coordinate origin for the stream's output alarm.
         call MPAS_stream_mgr_get_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, streamReferenceTimeString, ierr=ierr_tmp)

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6009,7 +6009,7 @@ subroutine stream_mgr_add_immutable_stream_fields_c(manager_c, streamID_c, refSt
 end subroutine stream_mgr_add_immutable_stream_fields_c !}}}
 
 
-subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_c, alarmInterval_c, ierr_c) bind(c) !{{{
+subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStartTime_c, alarmInterval_c, alarmEndTime_c, ierr_c) bind(c) !{{{
 
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
@@ -6027,13 +6027,14 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
     type (c_ptr) :: manager_c
     character(kind=c_char) :: streamID_c(*)
     character(kind=c_char) :: direction_c(*)
-    character(kind=c_char) :: alarmTime_c(*)
+    character(kind=c_char) :: alarmStartTime_c(*)
     character(kind=c_char) :: alarmInterval_c(*)
+    character(kind=c_char) :: alarmEndTime_c(*)
     integer(kind=c_int) :: ierr_c
 
     type (MPAS_streamManager_type), pointer :: manager
     type (MPAS_Clock_type), pointer :: clock
-    character(len=StrKIND) :: streamID, direction, alarmID, alarmTime, alarmInterval, alarmString
+    character(len=StrKIND) :: streamID, direction, alarmID, alarmStartTime, alarmInterval, alarmString, alarmEndTime
     type (MPAS_Time_type) :: alarmTime_local
     type (MPAS_TimeInterval_type) :: alarmInterval_local
     character(len=StrKIND) :: streamReferenceTimeString
@@ -6048,8 +6049,9 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
     call c_f_pointer(manager_c, manager)
     call mpas_c_to_f_string(streamID_c, streamID)
     call mpas_c_to_f_string(direction_c, direction)
-    call mpas_c_to_f_string(alarmTime_c, alarmTime)
+    call mpas_c_to_f_string(alarmStartTime_c, alarmStartTime)
     call mpas_c_to_f_string(alarmInterval_c, alarmInterval)
+    call mpas_c_to_f_string(alarmEndTime_c, alarmEndTime)
     write(alarmID, '(a)') trim(streamID)//'_'//trim(direction)
 
     ! Nothing to do for this stream
@@ -6065,17 +6067,17 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
 
     call MPAS_stream_mgr_get_clock(manager, clock)
 
-    if (trim(alarmTime) == 'start' .and. trim(alarmInterval) == 'final_only') then
+    if (trim(alarmStartTime) == 'start' .and. trim(alarmInterval) == 'final_only') then
         alarmTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
         call mpas_get_time(alarmTime_local, dateTimeString=alarmString)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, alarmString, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
-    else if (trim(alarmTime) == 'start') then
+    else if (trim(alarmStartTime) == 'start') then
         alarmTime_local = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else
-        call mpas_set_time(alarmTime_local, dateTimeString=alarmTime)
+        call mpas_set_time(alarmTime_local, dateTimeString=alarmStartTime)
     end if
 
     if (trim(alarmInterval) == 'initial_only' .or. trim(alarmInterval) == 'final_only') then

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6091,7 +6091,9 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
         call mpas_set_time(alarmStartTime_local, dateTimeString=alarmStartTime)
     end if
 
-    if (alarmEndTime(1:1) == '+') then
+    if (trim(alarmEndTime) == 'end') then
+        alarmEndTime_local = model_stop
+    else if (alarmEndTime(1:1) == '+') then
         alarmEndTime = alarmEndTime(2:len_trim(alarmEndTime))
         call mpas_set_timeInterval(delay, timeString=alarmEndTime)
         alarmEndTime_local = alarmStartTime_local + delay
@@ -6100,7 +6102,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, ala
         call mpas_set_timeInterval(delay, timeString=alarmEndTime)
         alarmEndTime_local = alarmStartTime_local - delay
     else
-        alarmEndTime_local = model_stop
+        call mpas_set_time(alarmEndTime_local, dateTimeString=alarmEndTime)
     end if
 
 

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6035,7 +6035,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
     type (MPAS_streamManager_type), pointer :: manager
     type (MPAS_Clock_type), pointer :: clock
     character(len=StrKIND) :: streamID, direction, alarmID, alarmStartTime, alarmInterval, alarmString, alarmEndTime
-    type (MPAS_Time_type) :: alarmTime_local
+    type (MPAS_Time_type) :: alarmStartTime_local, alarmEndTime_local
     type (MPAS_TimeInterval_type) :: alarmInterval_local
     character(len=StrKIND) :: streamReferenceTimeString
     type (MPAS_Time_type) :: streamReferenceTime
@@ -6068,24 +6068,24 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
     call MPAS_stream_mgr_get_clock(manager, clock)
 
     if (trim(alarmStartTime) == 'start' .and. trim(alarmInterval) == 'final_only') then
-        alarmTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
+        alarmStartTime_local = mpas_get_clock_time(clock, MPAS_STOP_TIME, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
-        call mpas_get_time(alarmTime_local, dateTimeString=alarmString)
+        call mpas_get_time(alarmStartTime_local, dateTimeString=alarmString)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, alarmString, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else if (trim(alarmStartTime) == 'start') then
-        alarmTime_local = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr_tmp)
+        alarmStartTime_local = mpas_get_clock_time(clock, MPAS_START_TIME, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else
-        call mpas_set_time(alarmTime_local, dateTimeString=alarmStartTime)
+        call mpas_set_time(alarmStartTime_local, dateTimeString=alarmStartTime)
     end if
 
     if (trim(alarmInterval) == 'initial_only' .or. trim(alarmInterval) == 'final_only') then
-        call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, ierr=ierr_tmp)
+        call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
     else
         call mpas_set_timeInterval(alarmInterval_local, timeString=alarmInterval)
-        call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, alarmTimeInterval=alarmInterval_local, ierr=ierr_tmp)
+        call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, alarmTimeInterval=alarmInterval_local, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
         ! Now calibrate alarm to use the stream's reference time as the time coordinate origin for the stream's output alarm.
         call MPAS_stream_mgr_get_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, streamReferenceTimeString, ierr=ierr_tmp)

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -6009,7 +6009,7 @@ subroutine stream_mgr_add_immutable_stream_fields_c(manager_c, streamID_c, refSt
 end subroutine stream_mgr_add_immutable_stream_fields_c !}}}
 
 
-subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStartTime_c, alarmInterval_c, alarmEndTime_c, ierr_c) bind(c) !{{{
+subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, num_c, alarmStartTime_c, alarmInterval_c, alarmEndTime_c, ierr_c) bind(c) !{{{
 
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
@@ -6027,6 +6027,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
     type (c_ptr) :: manager_c
     character(kind=c_char) :: streamID_c(*)
     character(kind=c_char) :: direction_c(*)
+    integer(kind=c_int) :: num_c
     character(kind=c_char) :: alarmStartTime_c(*)
     character(kind=c_char) :: alarmInterval_c(*)
     character(kind=c_char) :: alarmEndTime_c(*)
@@ -6054,7 +6055,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
     call mpas_c_to_f_string(alarmStartTime_c, alarmStartTime)
     call mpas_c_to_f_string(alarmInterval_c, alarmInterval)
     call mpas_c_to_f_string(alarmEndTime_c, alarmEndTime)
-    write(alarmID, '(a)') trim(streamID)//'_'//trim(direction)
+    write (alarmID, '(4A,I0)') trim(streamID), '_', trim(direction), '_', num_c
 
     ! Nothing to do for this stream
     if (trim(alarmInterval) == 'none') then
@@ -6094,8 +6095,8 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmStart
         ierr = ior(ierr, ierr_tmp)
     else
         call mpas_set_timeInterval(alarmInterval_local, timeString=alarmInterval)
-        call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, alarmTimeInterval=alarmInterval_local, ierr=ierr_tmp)
-                                  !alarmEndTime=alarmEndTime_local, ierr=ierr_tmp)
+        call mpas_add_clock_alarm(clock, alarmID, alarmStartTime_local, alarmTimeInterval=alarmInterval_local, &
+                                  alarmEndTime=alarmEndTime_local, ierr=ierr_tmp)
         ierr = ior(ierr, ierr_tmp)
         ! Now calibrate alarm to use the stream's reference time as the time coordinate origin for the stream's output alarm.
         call MPAS_stream_mgr_get_property(manager, streamID, MPAS_STREAM_PROPERTY_REF_TIME, streamReferenceTimeString, ierr=ierr_tmp)

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -471,8 +471,7 @@ module mpas_timekeeping
    end function mpas_get_clock_time
 
 
-   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr, alarmEndTime)
-   !subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr)
+   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, alarmEndTime, ierr)
 ! TODO: possibly add a stop time for recurring alarms
 
       implicit none
@@ -481,8 +480,8 @@ module mpas_timekeeping
       character (len=*), intent(in) :: alarmID
       type (MPAS_Time_type), intent(in) :: alarmTime
       type (MPAS_TimeInterval_type), intent(in), optional :: alarmTimeInterval
-      integer, intent(out), optional :: ierr
       type (MPAS_Time_type), intent(in), optional :: alarmEndTime
+      integer, intent(out), optional :: ierr
 
       type (MPAS_Alarm_type), pointer :: alarmPtr
       integer :: threadNum

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -891,7 +891,15 @@ module mpas_timekeeping
          end if
 
          if (alarmThreshold <= alarmNow) then
-            mpas_in_ringing_envelope = .true.
+             if (associated(alarmPtr % ringEndTime % t % calendar)) then
+                 if (alarmNow <= alarmPtr % ringEndTime) then
+                    mpas_in_ringing_envelope = .true.
+                else
+                    mpas_in_ringing_envelope = .false.
+                end if
+             else
+                mpas_in_ringing_envelope = .true.
+             end if
          end if
       else
 
@@ -904,7 +912,15 @@ module mpas_timekeeping
          end if
             
          if (alarmThreshold >= alarmNow) then
-            mpas_in_ringing_envelope = .true.
+             if (associated(alarmPtr % ringEndTime % t % calendar)) then
+                 if (alarmNow >= alarmPtr % ringEndTime) then
+                    mpas_in_ringing_envelope = .true.
+                else
+                    mpas_in_ringing_envelope = .false.
+                end if
+             else
+                mpas_in_ringing_envelope = .true.
+             end if
          end if
       end if
 
@@ -1407,7 +1423,6 @@ module mpas_timekeeping
 
 
       if (present(timeString) .or. present(dt)) then
-
 
          if(present(dt)) then
             write (timeString_,*) "00:00:", dt         

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -471,7 +471,8 @@ module mpas_timekeeping
    end function mpas_get_clock_time
 
 
-   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr)
+   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr, alarmEndTime)
+   !subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr)
 ! TODO: possibly add a stop time for recurring alarms
 
       implicit none
@@ -481,6 +482,7 @@ module mpas_timekeeping
       type (MPAS_Time_type), intent(in) :: alarmTime
       type (MPAS_TimeInterval_type), intent(in), optional :: alarmTimeInterval
       integer, intent(out), optional :: ierr
+      type (MPAS_Time_type), intent(in), optional :: alarmEndTime
 
       type (MPAS_Alarm_type), pointer :: alarmPtr
       integer :: threadNum
@@ -544,6 +546,10 @@ module mpas_timekeeping
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
       end if
+
+!      if (present(alarmEndTime)) then
+!          alarmPtr % ringEndTime = alarmEndTime
+!      end if
 
       !$omp barrier
 

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -472,7 +472,6 @@ module mpas_timekeeping
 
 
    subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, alarmEndTime, ierr)
-! TODO: possibly add a stop time for recurring alarms
 
       implicit none
 
@@ -541,14 +540,16 @@ module mpas_timekeeping
             alarmPtr % isRecurring = .false.
             alarmPtr % prevRingTime = alarmTime
          end if
+
+         if (present(alarmEndTime)) then
+            alarmPtr % ringEndTime = alarmEndTime
+         end if
+
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
       end if
 
-!      if (present(alarmEndTime)) then
-!          alarmPtr % ringEndTime = alarmEndTime
-!      end if
 
       !$omp barrier
 

--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -24,6 +24,7 @@
       logical :: isRecurring
       logical :: isSet
       type (MPAS_Time_type) :: ringTime
+      type (MPAS_Time_type) :: ringEndTime
       type (MPAS_Time_type) :: prevRingTime
       type (MPAS_TimeInterval_type) :: ringTimeInterval
       type (MPAS_Alarm_type), pointer :: next => null()

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1398,7 +1398,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				return;
 			}
 #endif
-			if (parse_interval(interval_in2, &pints, &npints) == 0) {
+			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
 					snprintf(msgbuf, MSGSIZE, "call imm add_alarm with %s[%d]\n", "output", i);
 					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
@@ -2101,8 +2101,6 @@ parse_interval(const char *str, struct interval **sint, int *n)
 
 	while(*str) *n += *(str++) == delim[0];
 	++*n;
-	snprintf(msgbuf, MSGSIZE, "*n = %d", *n);
-	mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 
 	*sint = malloc(*n * sizeof(**sint));
 	if (!*sint) {

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1369,8 +1369,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					snprintf(msgbuf, MSGSIZE, "call imm add_alarm with input %d: %s %s\n", i, pints[i].start, pints[i].frequency);
-					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 					stream_mgr_add_alarm_c(manager, streamID, "input",
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
@@ -1400,8 +1398,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					snprintf(msgbuf, MSGSIZE, "call imm add_alarm with %s[%d]\n", "output", i);
-					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 					stream_mgr_add_alarm_c(manager, streamID, "output",
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
@@ -1708,8 +1704,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					snprintf(msgbuf, MSGSIZE, "call non-imm add_alarm with %s[%d]\n", "input", i);
-					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 					stream_mgr_add_alarm_c(manager, streamID, "input",
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
@@ -1739,8 +1733,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					snprintf(msgbuf, MSGSIZE, "%d: HERE call non-imm add_alarm with %s [%d] %s\n", npints, "output", i, pints[i].frequency);
-					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 					stream_mgr_add_alarm_c(manager, streamID, "output",
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
@@ -2067,7 +2059,9 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
  *   the model start and ending a day later at 1100hrs.
  *
  * Note a that missing start or end fields are filled in
- * as "start" and "end".
+ * as "start" and "".
+ *
+ * A non-zero return value implies an error occured.
  *
  */
 static int
@@ -2088,13 +2082,13 @@ parse_interval(const char *str, struct interval **sint, int *n)
 	if (!str) {
 		snprintf(msgbuf, MSGSIZE, "%s: input string was NULL", __func__);
 		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
-		return -EINVAL;
+		return EINVAL;
 	}
 
 	if (*sint) {
 		snprintf(msgbuf, MSGSIZE, "%s: output pointer was not NULL", __func__);
 		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
-		return -EINVAL;
+		return EINVAL;
 	}
 
 	tmp = strdup(str);
@@ -2106,7 +2100,7 @@ parse_interval(const char *str, struct interval **sint, int *n)
 	if (!*sint) {
 		snprintf(msgbuf, MSGSIZE, "%s: unable to malloc", __func__);
 		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
-		return -ENOMEM;
+		return ENOMEM;
 	}
 	memset(*sint, '\0', *n * sizeof(**sint));
 

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -2106,7 +2106,7 @@ parse_interval(const char *str, struct interval **ptr, int *n)
 			(*ptr)[i].start = strdup("start");
 		}
 		if (!(*ptr)[i].end) {
-			(*ptr)[i].end = strdup("");
+			(*ptr)[i].end = strdup("end");
 		}
 	}
 

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -29,7 +29,7 @@ void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const
 void stream_mgr_add_field_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_immutable_stream_fields_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pool_c(void *, const char *, const char *, const char *, int *);
-void stream_mgr_add_alarm_c(void *, const char *, const char *, const char *, const char *, const char *, int *);
+void stream_mgr_add_alarm_c(void *, const char *, const char *, int *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pkg_c(void *, const char *, const char *, int *);
 
 
@@ -1369,7 +1369,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					stream_mgr_add_alarm_c(manager, streamID, "input",
+					stream_mgr_add_alarm_c(manager, streamID, "input", &i,
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
 						*status = 1;
@@ -1398,7 +1398,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					stream_mgr_add_alarm_c(manager, streamID, "output",
+					stream_mgr_add_alarm_c(manager, streamID, "output", &i,
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
 						*status = 1;
@@ -1704,7 +1704,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					stream_mgr_add_alarm_c(manager, streamID, "input",
+					stream_mgr_add_alarm_c(manager, streamID, "input", &i,
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
 						*status = 1;
@@ -1733,7 +1733,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 #endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
-					stream_mgr_add_alarm_c(manager, streamID, "output",
+					stream_mgr_add_alarm_c(manager, streamID, "output", &i,
 							       pints[i].start, pints[i].frequency, pints[i].end, &err);
 					if (err != 0) {
 						*status = 1;

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -1360,13 +1360,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* Possibly add an input alarm for this stream */
 		if (itype == 3 || itype == 1) {
-#if 0
-			stream_mgr_add_alarm_c(manager, streamID, "input", "start", interval_in2, &err);
-			if (err != 0) {
-				*status = 1;
-				return;
-			}
-#endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
 					stream_mgr_add_alarm_c(manager, streamID, "input", &i,
@@ -1389,13 +1382,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* Possibly add an output alarm for this stream */
 		if (itype == 3 || itype == 2) {
-#if 0
-			stream_mgr_add_alarm_c(manager, streamID, "output", "start", interval_out2, &err);
-			if (err != 0) {
-				*status = 1;
-				return;
-			}
-#endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
 					stream_mgr_add_alarm_c(manager, streamID, "output", &i,
@@ -1695,13 +1681,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* Possibly add an input alarm for this stream */
 		if (itype == 3 || itype == 1) {
-#if 0
-			stream_mgr_add_alarm_c(manager, streamID, "input", "start", interval_in2, &err);
-			if (err != 0) {
-				*status = 1;
-				return;
-			}
-#endif
 			if (parse_interval(interval_in2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
 					stream_mgr_add_alarm_c(manager, streamID, "input", &i,
@@ -1724,13 +1703,6 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* Possibly add an output alarm for this stream */
 		if (itype == 3 || itype == 2) {
-#if 0
-			stream_mgr_add_alarm_c(manager, streamID, "output", "start", interval_out2, &err);
-			if (err != 0) {
-				*status = 1;
-				return;
-			}
-#endif
 			if (parse_interval(interval_out2, &pints, &npints) == 0) {
 				for (i = 0; i < npints; ++i) {
 					stream_mgr_add_alarm_c(manager, streamID, "output", &i,

--- a/src/framework/xml_stream_parser.c
+++ b/src/framework/xml_stream_parser.c
@@ -2027,7 +2027,7 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
  * end time (in that order) separated by a commar.
  * For example:
  * - "1_00:00:00" once a day.
- * - "01:00:00,start,1_11:00:00" once an hour, starting at
+ * - "01:00:00,start,+1_11:00:00" once an hour, starting at
  *   the model start and ending a day later at 1100hrs.
  *
  * Note a that missing start or end fields are filled in
@@ -2037,7 +2037,7 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
  *
  */
 static int
-parse_interval(const char *str, struct interval **sint, int *n)
+parse_interval(const char *str, struct interval **ptr, int *n)
 {
 	static const char *delim = ";";
 	static const char *sdelim = ",";
@@ -2057,7 +2057,7 @@ parse_interval(const char *str, struct interval **sint, int *n)
 		return EINVAL;
 	}
 
-	if (*sint) {
+	if (*ptr) {
 		snprintf(msgbuf, MSGSIZE, "%s: output pointer was not NULL", __func__);
 		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
 		return EINVAL;
@@ -2068,13 +2068,13 @@ parse_interval(const char *str, struct interval **sint, int *n)
 	while(*str) *n += *(str++) == delim[0];
 	++*n;
 
-	*sint = malloc(*n * sizeof(**sint));
-	if (!*sint) {
+	*ptr = malloc(*n * sizeof(**ptr));
+	if (!*ptr) {
 		snprintf(msgbuf, MSGSIZE, "%s: unable to malloc", __func__);
 		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
 		return ENOMEM;
 	}
-	memset(*sint, '\0', *n * sizeof(**sint));
+	memset(*ptr, '\0', *n * sizeof(**ptr));
 
 	i = 0;
 	s1 = tmp;
@@ -2085,13 +2085,13 @@ parse_interval(const char *str, struct interval **sint, int *n)
 		while (stkn) {
 			switch(j) {
 				case 0:
-					(*sint)[i].frequency = strdup(stkn);
+					(*ptr)[i].frequency = strdup(stkn);
 					break;
 				case 1:
-					(*sint)[i].start = strdup(stkn);
+					(*ptr)[i].start = strdup(stkn);
 					break;
 				case 2:
-					(*sint)[i].end = strdup(stkn);
+					(*ptr)[i].end = strdup(stkn);
 					break;
 			}
 			stkn = strtok_r(NULL, sdelim, &p2);
@@ -2102,11 +2102,11 @@ parse_interval(const char *str, struct interval **sint, int *n)
 	}
 
 	for (i = 0; i < *n; ++i) {
-		if (!(*sint)[i].start) {
-			(*sint)[i].start = strdup("start");
+		if (!(*ptr)[i].start) {
+			(*ptr)[i].start = strdup("start");
 		}
-		if (!(*sint)[i].end) {
-			(*sint)[i].end = strdup("");
+		if (!(*ptr)[i].end) {
+			(*ptr)[i].end = strdup("");
 		}
 	}
 


### PR DESCRIPTION
This adds the ability to have multiple different output frequencies/intervals per stream.

The key points are

* Streams can have multiple alarms.
* The alarms now has an end timer.
* Parsing of the XML stream attributes `input_interval` and `output_interval`.

The XML stream attributes `input_interval` and `output_interval` are backwards compatible. However the new parser looks for `interval,start,end` 3-tuples. 
For example: 

```
output_interval="1:00:00,start,+1_11:00:00;6:00:00,+1_12:00:00,end"
```

Means there are two output intervals.

1. Hourly, starting at the model start time, and going for 35 hours.
2. Every six hours, starting at 36 hours, and going to the model end time.

Note, that the time interval argument is still a time interval (`MPAS_TimeInterval_type`), while the start and end arguments can be times (`MPAS_Time_type`) if specified as `YYYY-MM-DD_hh:mm:ss` or time intervals (`MPAS_TimeInterval_type`) if prefixed with either `+` or `-`.