### PR TITLE
Add missing dependency for module_sf_noah_seaice.o in physics_wrf/Makefile

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -87,11 +87,14 @@ module_sf_noahdrv.o: \
         module_sf_noahlsm_glacial_only.o \
 	module_sf_urban.o
 
-module_sf_noahlsm_glacial_only.o:  \
+module_sf_noahlsm_glacial_only.o: \
         module_sf_noahlsm.o
 
-module_sf_noah_seaice_drv.o:  \
+module_sf_noah_seaice_drv.o: \
         module_sf_noah_seaice.o
+
+module_sf_noah_seaice.o: \
+        module_sf_noahlsm.o
 
 clean:
 	$(RM) *.f90 *.o *.mod


### PR DESCRIPTION
This merge adds a missing dependency for module_sf_noah_seaice.o in physics_wrf/Makefile.

The module_sf_noah_seaice.o file depends on module_sf_noahlsm.mod. Occasionally,
parallel builds of MPAS-Atmosphere would fail due to this missing dependency
in src/core_atmoshere/physics/physics_wrf/Makefile. This commit adds a dependency
on module_sf_noahlsm.o for module_sf_noah_seaice.o.