### PR TITLE
Fix incorrect 'xtime' variable in MPAS-A when dt is non-integral

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -62,7 +62,7 @@ module atm_time_integration
    contains
 
 
-   subroutine atm_timestep(domain, dt, timeStamp, itimestep)
+   subroutine atm_timestep(domain, dt, nowTime, itimestep)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
@@ -76,7 +76,7 @@ module atm_time_integration
 
       type (domain_type), intent(inout) :: domain
       real (kind=RKIND), intent(in) :: dt
-      character(len=*), intent(in) :: timeStamp
+      type (MPAS_Time_type), intent(in) :: nowTime
       integer, intent(in) :: itimestep
 
 
@@ -98,9 +98,8 @@ module atm_time_integration
          call mpas_dmpar_global_abort('Currently, only ''SRK3'' is supported.')
       end if
 
-      call mpas_set_time(currTime, dateTimeString=timeStamp)
       call mpas_set_timeInterval(dtInterval, dt=dt)
-      currTime = currTime + dtInterval
+      currTime = nowTime + dtInterval
       call mpas_get_time(currTime, dateTimeString=xtime_new)
 
       block => domain % blocklist

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -36,7 +36,6 @@ module atm_core
       real (kind=RKIND), pointer :: dt
       type (block_type), pointer :: block
 
-      character(len=StrKIND) :: timeStamp
       integer :: i
       logical, pointer :: config_do_restart
 
@@ -846,7 +845,6 @@ module atm_core
       
       type (MPAS_Time_Type) :: startTime, currTime
       type (MPAS_TimeInterval_Type) :: xtimeTime
-      character(len=StrKIND) :: timeStamp
       integer :: s, s_n, s_d
       real (kind=RKIND) :: xtime_s
       integer :: ierr
@@ -858,8 +856,6 @@ module atm_core
       call mpas_get_timeInterval(interval=xtimeTime, S=s, S_n=s_n, S_d=s_d, ierr=ierr)         
       xtime_s = (s + s_n / s_d)
 
-      call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)         
-
 
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
@@ -869,7 +865,7 @@ module atm_core
       endif
 #endif
 
-      call atm_timestep(domain, dt, timeStamp, itimestep)
+      call atm_timestep(domain, dt, currTime, itimestep)
 
    end subroutine atm_do_timestep
    


### PR DESCRIPTION
This merge addresses a issue that caused incorrect 'xtime' strings when the model
timestep was non-integral.
    
When the model timestep is not an integer number of seconds, the xtime variable
computed in the atm_timestep(...) routine could be short by 1.9999... seconds.
    
The timestamp string valid at the beginning of the time step is computed from
the exact simulation clock time, and the conversion to a string truncates
the fractional part (i.e., up to 0.99999... seconds). Then, in the atm_timestep
routine, the model timestep, dt, is added to this truncated timestamp.
In the conversion of the resulting time back to a timestamp string, fractional
seconds (i.e., up to 0.99999... seconds) are again lost.
    
One practical impact of this is that model output and restart files would have
an incorrect 'xtime' field, preventing the model from restarting from the correct
time, e.g.,
```   
     xtime =
      "2010-10-23_23:59:59                                             " ;
```  
To address this problem, we now pass an MPAS_Time_type in place of the timeStamp
character string to the atm_timestep(...) routine. This preserves any fractional
seconds in the beginning time, allowing the computed time at the end of
the dynamics step (i.e., xtime) to be correct when the result has no fractional
part.
    
*Note: There are still other potential problems with fractional seconds.
      For example, if the output interval is not evenly divided by the fractional
      timestep, the 'xtime' field in the output file will contain only
      the integer part of the seconds, and will therefore be up to 0.99999...
      seconds short.*