### PR TITLE
Only access config_pio_stride and config_pio_num_iotasks when necessary

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -85,22 +85,36 @@ module mpas_framework
       call mpas_pool_set_error_level(MPAS_POOL_WARN)
 #endif
 
-      call mpas_pool_get_config(domain % configs, 'config_calendar_type', config_calendar_type)
-      call mpas_pool_get_config(domain % configs, 'config_pio_num_iotasks', config_pio_num_iotasks)
-      call mpas_pool_get_config(domain % configs, 'config_pio_stride', config_pio_stride)
-
       if (present(calendar)) then
          call mpas_timekeeping_init(calendar)
       else
+         call mpas_pool_get_config(domain % configs, 'config_calendar_type', config_calendar_type)
          call mpas_timekeeping_init(config_calendar_type)
       end if
 
-      pio_num_iotasks = config_pio_num_iotasks
-      pio_stride = config_pio_stride
+      !
+      ! Note: pio_num_iotasks and pio_stride are only used in MPAS_io_init if io_system is
+      !       not present. In stand-alone configurations, we expect that io_system will not
+      !       be present and that pio_num_iotasks and pio_stride will be available from
+      !       the namelist; in other systems, a PIO io_system may be provided.
+      !
+      if (.not. present(io_system)) then
+         call mpas_pool_get_config(domain % configs, 'config_pio_num_iotasks', config_pio_num_iotasks)
+         call mpas_pool_get_config(domain % configs, 'config_pio_stride', config_pio_stride)
+         pio_num_iotasks = config_pio_num_iotasks
+         pio_stride = config_pio_stride
+      else
+         pio_num_iotasks = -1    ! Not used when external io_system is provided
+         pio_stride      = -1    ! Not used when external io_system is provided
+      end if
+
+      ! A value of 0 for pio_num_iotasks actually indicates that every task should be an I/O task
       if (pio_num_iotasks == 0) then
          pio_num_iotasks = domain % dminfo % nprocs
       end if
+
       domain % ioContext % dminfo => domain % dminfo
+
       call MPAS_io_init(domain % ioContext, pio_num_iotasks, pio_stride, io_system)
 
    end subroutine mpas_framework_init_phase2!}}}


### PR DESCRIPTION
This merge ensures that the namelist options config_pio_stride and config_pio_num_iotasks
are accessed only when necessary, enabling the namelists for coupled MPAS configurations
to be minimized by omitting these options.

In the mpas_framework_init_phase2 routine, the namelist options config_pio_stride
and config_pio_num_iotasks were accessed regardless of whether MPAS was being
run in a configuration that used an external PIO io_system or not.

For stand-alone configurations, an external PIO io_system will generally not be
available, in which case config_pio_stride and config_pio_num_iotasks must be
accessible so that their values can be passed to mpas_io_init, where PIO is
initialized.

In coupled configurations, an external PIO io_system will often be provided by
the driver, and a minimal MPAS Registry.xml file may omit config_pio_stride and
config_pio_num_iotasks. Accordingly, the values of these non-existent namelist
options must not be accessed in mpas_framework_init_phase2.

Besides accessing config_pio_stride and config_pio_num_iotasks only when
necessary, this commit also moves the access of config_calendar_type inside of
an if-test on the presence of an external calendar.