### PR TITLE
Add optional argument 'unitNumbers' to core % setup_log(...) routine

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -195,15 +195,16 @@ module atm_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function atm_setup_log(logInfo, domain) result(iErr)!{{{
+   function atm_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -212,7 +213,7 @@ module atm_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -255,7 +255,7 @@ module init_atm_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function init_atm_setup_log(logInfo, domain) result(iErr)!{{{
+   function init_atm_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
@@ -264,6 +264,7 @@ module init_atm_core_interface
 
       type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
       type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -272,7 +273,7 @@ module init_atm_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -190,15 +190,16 @@ module li_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function li_setup_log(logInfo, domain) result(iErr)!{{{
+   function li_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types
       use mpas_log
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -207,7 +208,7 @@ module li_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -483,15 +483,16 @@ module ocn_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function ocn_setup_log(logInfo, domain) result(iErr)!{{{
+   function ocn_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types
       use mpas_log
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -500,7 +501,7 @@ module ocn_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -673,15 +673,16 @@ module seaice_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function seaice_setup_log(logInfo, domain) result(iErr)!{{{
+   function seaice_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types
       use mpas_log
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -690,7 +691,7 @@ module seaice_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -188,15 +188,16 @@ module sw_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function sw_setup_log(logInfo, domain) result(iErr)!{{{
+   function sw_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types
       use mpas_log
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -205,7 +206,7 @@ module sw_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -222,15 +222,16 @@ module test_core_interface
    !>  and allow the core to specify details of the configuration.
    !
    !-----------------------------------------------------------------------
-   function test_setup_log(logInfo, domain) result(iErr)!{{{
+   function test_setup_log(logInfo, domain, unitNumbers) result(iErr)!{{{
 
       use mpas_derived_types
       use mpas_log
 
       implicit none
 
-      type (mpas_log_type), intent(inout), pointer :: logInfo  !< logging information object to set up
-      type (domain_type), intent(in), pointer :: domain  !< domain object to provide info for setting up log manager
+      type (mpas_log_type), intent(inout), pointer :: logInfo    !< logging information object to set up
+      type (domain_type), intent(in), pointer :: domain          !< domain object to provide info for setting up log manager
+      integer, dimension(2), intent(in), optional :: unitNumbers !< Fortran unit numbers to use for output and error logs
       integer :: iErr
 
       ! Local variables
@@ -239,7 +240,7 @@ module test_core_interface
       iErr = 0
 
       ! Initialize log manager
-      call mpas_log_init(logInfo, domain, err=local_err)
+      call mpas_log_init(logInfo, domain, unitNumbers=unitNumbers, err=local_err)
       iErr = ior(iErr, local_err)
 
       ! Set core specific options here

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -64,12 +64,13 @@
    end interface
 
    abstract interface
-      function mpas_setup_log_function(logInfo, domain) result(iErr)
+      function mpas_setup_log_function(logInfo, domain, unitNumbers) result(iErr)
          import mpas_log_type
          import domain_type
 
          type (mpas_log_type), pointer, intent(inout) :: logInfo
          type (domain_type), pointer, intent(in) :: domain
+         integer, dimension(2), intent(in), optional :: unitNumbers
          integer :: iErr
       end function mpas_setup_log_function
    end interface


### PR DESCRIPTION
This merge adds a new optional argument, unitNumbers, to the core%setup_log routine.

The mpas_log_init routine takes an optional argument, unitNumbers, to specify
which Fortran unit numbers to use for the output and error log files written by
a core. The mpas_log_init routine is called by the core % setup_log routine,
which previously did not have an argument for passing in logging unit numbers.

This commit adds an optional argument, unitNumbers, to the core % setup_log
routine, and it modifies the implementation of each core's setup_log routine
to pass the optional unitNumbers argument to the mpas_log_init routine.

The core % setup_log routine is called by the MPAS subdriver's mpas_init
routine, and at present no changes are made to the mpas_init routine to pass
optional unitNumbers to the core % setup_log routine. However, the changes in
this commit do enable alternate implementations of mpas_init to supply unit
numbers to be used for logging, e.g., in coupled systems where the coupler
has already defined logging units for each component.