### PR TITLE
Reduce time btr and full time step in QU60

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/QU60/template_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU60/template_forward.xml
@@ -1,7 +1,7 @@
 <template>
 	<namelist>
-		<option name="config_dt">'01:00:00'</option>
-		<option name="config_btr_dt">'00:03:00'</option>
+		<option name="config_dt">'00:40:00'</option>
+		<option name="config_btr_dt">'00:02:00'</option>
 		<option name="config_run_duration">'0000_03:00:00'</option>
 		<option name="config_mom_del4">3.2e12</option>
 		<option name="config_hmix_scaleWithMesh">.true.</option>


### PR DESCRIPTION
In my testing, this was necessary to get through the simulation phase.

I tried time steps of 50 minutes/ btr of 2.5 minutes and still got immediate crashes.