### PR TITLE
Update CVMix to 0.95-beta

### DIFF
--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=v0.84-beta
+CVMIX_TAG=v0.95-beta
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 


### PR DESCRIPTION
This version introduces a bunch of fixes to python 3

Releases since 0.84-beta are described as:
* v0.90-beta - Add Schmittner tidal mixing
* v0.91-beta - Add low-level interface for Bryan-Lewis mixing
* v0.92-beta - Fix bug in computing derivative
* v0.93-beta - Performance enhancement
* v0.94-beta - Update interface to Langmuir parameterization
* v0.95-beta - Add python 3 support

closes #250 