### PR TITLE
Update time on `animated_particles` to be compatible with `annotate_date` and convert to python3

### DIFF
--- a/testing_and_setup/compass/utility_scripts/LIGHTparticles/animated_particles.py
+++ b/testing_and_setup/compass/utility_scripts/LIGHTparticles/animated_particles.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """
-    Take an input netcdf database and extract particle information, converting to
-    vtu format for input into ParaView.
+    Take an input netcdf database and extract particle information,
+    converting to vtu format for input into ParaView.
 
     Usage exampe:
     ./animated_particles.py -f free_floating.nc
@@ -19,16 +19,16 @@
 from pyevtk.vtk import VtkGroup
 from pyevtk.hl import pointsToVTK
 import numpy as np
-
 import netCDF4
 import os
-import pdb
+
 
 def cleanup(data):
     if type(data) == np.ma.core.MaskedArray:
         data.data[data.mask] = data.fill_value
         data = data.data
     return data
+
 
 def build_particle_file(fname_in, fname_outbase):
     """
@@ -39,40 +39,27 @@ def build_particle_file(fname_in, fname_outbase):
     LANL
     07/15/2014
     """
-    ## initialize the starting points
+    # initialize the starting points
     fullpath = fname_in.split(os.sep)
 
     # don't want to place this in starting directory
-    #g = VtkGroup(os.sep.join(fullpath[:-1]) + '/' + fname_outbase + '_' + os.path.splitext(fullpath[-1])[0] )
-    g = VtkGroup(fname_outbase + '_' + os.path.splitext(fullpath[-1])[0] )
-
-    # load the netCDF database
-
-    ## get time
-    #time = 0.0
-
+    g = VtkGroup(fname_outbase + '_' + os.path.splitext(fullpath[-1])[0])
 
     # open the database
     f_in = netCDF4.Dataset(fname_in, 'r')
 
     # num particles and data frames
-    Npoints = len(f_in.dimensions['nParticles'])
     Ntime = len(f_in.dimensions['Time'])
 
     # initialize empty dictionary
     particleData = dict()
 
     for t in np.arange(Ntime):
-
         # get the points locations
-        #x = f_in.variables['xParticle'][t] #+ f_in.variables['zLevelParticle'][t]
-        #y = f_in.variables['yParticle'][t] #+ f_in.variables['zLevelParticle'][t]
-        #z = f_in.variables['zParticle'][t] #+ f_in.variables['zLevelParticle'][t]
         x = f_in.variables['xParticle'][t]
         y = f_in.variables['yParticle'][t]
         z = f_in.variables['zParticle'][t]
-        print t
-        print np.vstack((x,y,z)).T
+        print(f'{t}/{Ntime}...')
 
         particleType = f_in.variables['xParticle'].dimensions
         particleTypeStatic = f_in.variables['indexToParticleID'].dimensions
@@ -86,20 +73,16 @@ def build_particle_file(fname_in, fname_outbase):
             if dim == particleTypeStatic:
                 particleData[str(v)] = cleanup(f_in.variables[v][:])
 
-        #print particleData
-
         # set the new time (just use index for simplicity for now)
         time = 2*t
-        #time = ''.join(f_in.variables['xtime'][t,0,:]).replace(' ','')
 
         # file name
-        #f_out = fname_outbase + '_' + os.path.splitext(fname_in)[0] + '_' + str(t)
-        f_out = fname_outbase + '_' + os.path.splitext(fullpath[-1])[0] + '_' + str(t)
-        # output file
-        pointsToVTK(f_out, x, y, z, data = particleData)
-        # make sure the file is added to the time vector
-        g.addFile(filepath = f_out + '.vtu', sim_time = time)
+        f_out = f'{fname_outbase}_{os.path.splitext(fullpath[-1])[0]}_{str(t)}'
 
+        # output file
+        pointsToVTK(f_out, x, y, z, data=particleData)
+        # make sure the file is added to the time vector
+        g.addFile(filepath=f_out + '.vtu', sim_time=time)
 
     # save the animation file
     g.save()
@@ -111,14 +94,14 @@ if __name__ == "__main__":
     # Get command line parameters
     parser = OptionParser()
     parser.add_option("-f", "--file", dest="inputfilename",
-            help="file to open for appending \
-                    particle data 'particle_' extension",
-                    metavar="FILE")
+                      help="file to open for appending \
+                      particle data 'particle_' extension",
+                      metavar="FILE")
 
     parser.add_option("-o", "--output", dest="outputfilename",
-            help="output file name base for export to *.vtu \
-                    file which stores particle data",
-                    metavar="FILE")
+                      help="output file name base for export to *.vtu \
+                      file which stores particle data",
+                      metavar="FILE")
 
     options, args = parser.parse_args()
 


### PR DESCRIPTION
@pwolfram, per our conversations today.

This PR updates the time output for the LIGHT particle VTK conversion script (`animated_particles`) to be decimal time per in `paraview_vtk_field_extractor` in MPAS-Tools. In turn, one can run `annotate_date` on LIGHT particles in ParaView and get the proper datestring output.

This also cleans up commented out code (+ PEP8), makes it compatible with python3, and converts `optparse` to `argparse`, since the former is soon to be depricated.

Example LIGHT particles in ParaView after running through the updated script and running `annotate_date`:

![particles_with_xtime](https://user-images.githubusercontent.com/8881170/57880517-2e9c0c80-77dc-11e9-98cd-e0be60dd322f.png)


