### PR TITLE
Parallelized Interpolation of Static Fields for MPAS-A

### DIFF
--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -19,7 +19,12 @@ OBJS =  \
 	mpas_atmphys_date_time.o \
 	mpas_atmphys_functions.o \
 	mpas_atmphys_initialize_real.o \
-	mpas_atmphys_utilities.o
+	mpas_atmphys_utilities.o \
+	mpas_geotile_manager.o \
+	read_tile.o \
+	mpas_kd_tree.o \
+	mpas_stack.o \
+	mpas_parse_geoindex.o
 
 all: core_hyd
 
@@ -66,17 +71,31 @@ mpas_init_atm_read_met.o:
 
 read_geogrid.o:
 
+read_tile.o:
+
+mpas_stack.o:
+
+mpas_kd_tree.o:
+
+mpas_parse_geoindex.o:
+
 mpas_init_atm_llxy.o:
+
 
 mpas_init_atm_core_interface.o: mpas_init_atm_core.o
 
 mpas_init_atm_core.o: mpas_advection.o mpas_init_atm_cases.o
 
 mpas_init_atm_static.o: \
+	read_tile.o \
 	mpas_atm_advection.o \
 	mpas_init_atm_hinterp.o \
 	mpas_init_atm_llxy.o \
-	mpas_atmphys_utilities.o
+	mpas_atmphys_utilities.o \
+	mpas_kd_tree.o \
+	mpas_stack.o \
+	mpas_geotile_manager.o \
+	mpas_parse_geoindex.o
 
 mpas_init_atm_surface.o: \
 	mpas_init_atm_hinterp.o  \
@@ -87,6 +106,11 @@ mpas_atmphys_initialize_real.o:  \
 	mpas_init_atm_surface.o  \
 	mpas_atmphys_date_time.o \
 	mpas_atmphys_utilities.o
+
+mpas_geotile_manager.o: \
+	mpas_kd_tree.o \
+	mpas_stack.o \
+	read_tile.o
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a

--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -81,9 +81,7 @@ module mpas_geotile_manager
       ! via add tile, which will also give us the tile_t type that contains
       ! that tile.
 
-      if (mpas_search_tile(lat, lon, tile, tile_hash, geo_pool)) then
-         ! pass
-      else
+      if (.not. mpas_search_tile(lat, lon, tile, tile_hash, geo_pool)) then
          call mpas_add_tile(lat, lon, tile, tile_hash, geo_pool)
       endif
 
@@ -133,8 +131,8 @@ module mpas_geotile_manager
 
       mpas_search_tile = .FALSE.
 
-      if (associated(tile_hash( (x-1)/tile_nx , (y-1)/tile_ny ) % ptr)) then
-         tile => tile_hash( (x-1)/tile_nx , (y-1)/tile_ny ) % ptr
+      tile => tile_hash( (x-1)/tile_nx , (y-1)/tile_ny ) % ptr
+      if (associated(tile)) then
          mpas_search_tile = .TRUE.
          return
       endif
@@ -163,7 +161,6 @@ module mpas_geotile_manager
 
       implicit none
 
-<<<<<<< HEAD
       interface
          subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
                                  scalefactor, wordsize, status) bind(C)
@@ -180,21 +177,6 @@ module mpas_geotile_manager
             integer (c_int), intent(inout) :: status
          end subroutine read_geogrid
       end interface
-=======
-   interface
-      integer (c_int) function c_get_tile(file, nx, ny, x_halo, y_halo, word_size, is_signed, tile) bind(C)
-         use iso_c_binding, only : c_int, c_char, c_float, c_ptr
-         character (c_char), intent(in) :: file
-         integer (c_int), intent(in), value :: nx
-         integer (c_int), intent(in), value :: ny
-         integer (c_int), intent(in), value :: x_halo
-         integer (c_int), intent(in), value :: y_halo
-         integer (c_int), intent(in), value :: word_size
-         integer (c_int), intent(in), value :: is_signed
-         type (c_ptr), value :: tile
-      end function c_get_tile
-   end interface
->>>>>>> 8f61fe8... Parallelized Interpolation of Land Use
 
       ! Input values
       real (kind=RKIND), intent(in), value :: lat, lon
@@ -213,11 +195,14 @@ module mpas_geotile_manager
       integer (c_int) :: nx, ny, nz
 
       integer, pointer :: wordsize
-      integer :: x_bdr, y_bdr
-      logical, pointer :: is_signed
-      integer (c_int) :: is_signed_int
+      integer (c_int) :: c_wordsize
 
-      real :: lat_deg, lon_deg
+      integer, pointer :: signed
+      integer (c_int) :: c_isigned
+      integer (c_int) :: status
+      
+      real, pointer :: scalefactor
+      real (c_float) :: c_scalefactor
 
       integer, pointer :: endian
       integer (c_int) :: c_endian
@@ -228,19 +213,18 @@ module mpas_geotile_manager
       call mpas_pool_get_config(geo_pool, 'tile_z', tile_nz)
       call mpas_pool_get_config(geo_pool, 'tile_bdr', tile_bdr)
       call mpas_pool_get_config(geo_pool, 'wordsize', wordsize)
-      call mpas_pool_get_config(geo_pool, 'signed', is_signed)
+      call mpas_pool_get_config(geo_pool, 'signed', signed)
       call mpas_pool_get_config(geo_pool, 'topo_dir_path', topo_dir_path)
       call mpas_pool_get_config(geo_pool, 'endian', endian)
       call mpas_pool_get_config(geo_pool, 'scalefactor', scalefactor)
 
-      if (is_signed) then
-         is_signed_int = 1
-      else
-         is_signed_int = 0
-      endif
-
-      x_bdr = tile_bdr * 2
-      y_bdr = tile_bdr * 2
+      nx = tile_nx
+      ny = tile_ny
+      nz = tile_nz
+      c_wordsize = wordsize
+      c_endian = endian
+      c_scalefactor = scalefactor
+      c_isigned = signed
 
       allocate(tile) ! Allocate the new node 
       allocate(tile%tile(tile_nx + (tile_bdr * 2), tile_ny + (tile_bdr * 2), tile_nz)) ! And its array to hold the tile
@@ -255,7 +239,6 @@ module mpas_geotile_manager
       call read_geogrid(c_fname, tile_ptr, nx, ny, nz, c_isigned, c_endian, c_scalefactor, c_wordsize, status)
       if (status /= 0) then
           call mpas_log_write("Error reading the geogrid "//fname, messageType=MPAS_LOG_CRIT)
-          stop
       endif
 
       tile % fname = fname
@@ -311,11 +294,11 @@ module mpas_geotile_manager
       call mpas_pool_get_config(geo_pool, 'dx', dx)
       call mpas_pool_get_config(geo_pool, 'dy', dy)
 
-      lat = lat * (180.0/pii)
-      lon = lon * (180.0/pii)
+      lat = lat * (180.0_RKIND/pii)
+      lon = lon * (180.0_RKIND/pii)
 
-      if (lon > 180) then
-         lon = lon - 360
+      if (lon > 180.0_RKIND) then
+         lon = lon - 360.0_RKIND
       end if
 
       x(1) = int( ( lon - known_lon) / dx)
@@ -441,12 +424,12 @@ module mpas_geotile_manager
       lat = (real((Y)) * dy ) + known_lat
       lon = (real((X)) * dx ) + known_lon
 
-      if ( lon < 0) then
-         lon = lon + 360
+      if ( lon < 0.0_RKIND) then
+         lon = lon + 360.0_RKIND
       endif
 
-      lat = lat * (pii/180.0)
-      lon = lon * (pii/180.0)
+      lat = lat * (pii/180.0_RKIND)
+      lon = lon * (pii/180.0_RKIND)
 
    end subroutine mpas_hash_to_latlon
 
@@ -492,8 +475,7 @@ module mpas_geotile_manager
             tile => top
             return
          class default
-            write(0,*) "BEERP!"
-            stop
+            call mpas_log_write("Error popping tile from mpas_stack - We got a type we didn't excpet", messageType=MPAS_LOG_CRIT)
       end select
 
    end function mpas_stack_pop_tile

--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -1,0 +1,479 @@
+module mpas_geotile_manager
+
+   use iso_c_binding, only : c_float, c_int, c_long, c_loc, c_ptr
+
+   use mpas_constants, only : pii
+
+   use mpas_pool_routines
+   use mpas_stack, only : payload_t
+
+
+   implicit none
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   private
+
+   public :: tile_t
+   public :: hash_table
+
+   public :: mpas_gen_file
+   public :: mpas_get_tile 
+   public :: mpas_get_tile_neighbors
+   public :: mpas_hash_to_latlon
+   public :: mpas_stack_pop_tile
+
+   type, extends(payload_t) :: tile_t
+      real (c_float), dimension(:,:,:), pointer, contiguous :: tile
+
+      character (len=StrKIND) :: fname
+      integer :: hash_x
+      integer :: hash_y
+
+      integer, dimension(2) :: x, y ! The tile's range
+      logical :: is_processed = .FALSE.
+   end type tile_t
+
+    type hash_table
+       type(tile_t), pointer :: ptr => null()
+    end type hash_table
+
+   contains
+
+   !***********************************************************************
+   !
+   !  function mpas_get_tile
+   !
+   !> \brief   Retrieve the tile associated with coordinates lat and long
+   !> \author  Miles Curry
+   !> \date    
+   !> \details 
+   !>    This function is an abstraction for reading values from a tile file.
+   !>  It enables the tiles to be read in from disk once and only once.
+   !>
+   !>  It does this by using a data structure of the `tile_t` type. Because
+   !> the we know all about the geographical datafiles from the index file
+   !> we know how many datafiles we know to read to read in, and how large they
+   !> are.
+   !>
+   !> So this function calls mpas_search_tile for a tile which contains `lat` 
+   !> and `lon` and if it is not found to be allocated it calls mpas_add_tile
+   !> to add that tile. If the tile is found, a pointer is returned in tile.
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_get_tile(lat, lon, tile, tile_hash, geo_pool)
+
+      implicit none
+
+      ! Input variables 
+      real (kind=RKIND), value :: lat, lon
+      type (tile_t), intent(out), pointer :: tile
+      type (hash_table), pointer, dimension(:,:), intent(inout) :: tile_hash
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      tile => null()
+      
+      ! Search for the tile in the data structure (ds) we have implemented, if
+      ! we find the tile in the ds, then the tile_t type will be returned in 
+      ! tile.
+      !
+      ! If we haven't found the tile in the ds, then we need to add the tile
+      ! via add tile, which will also give us the tile_t type that contains
+      ! that tile.
+
+      if (mpas_search_tile(lat, lon, tile, tile_hash, geo_pool)) then
+         ! pass
+      else
+         call mpas_add_tile(lat, lon, tile, tile_hash, geo_pool)
+      endif
+
+   end subroutine mpas_get_tile
+
+   !***********************************************************************
+   !
+   !  function mpas_search_tile
+   !
+   !> \brief   Searches for an allocated datafile tile
+   !> \author  Miles A. Curry
+   !> \date    
+   !> \details 
+   !>  Given a latitude and longitude, this function searches the implemented
+   !> data structure to determine if the tile containing that latitude and
+   !> longitude have been allocated or not. A pointer to the tile_t type 
+   !> containing that tile is returned in the tile argument.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   function mpas_search_tile(lat, lon, tile, tile_hash, geo_pool)
+      implicit none
+
+      ! Input variables
+      real (kind=RKIND), value :: lat, lon
+      type (tile_t), intent(out), pointer :: tile
+      type (hash_table), pointer, dimension(:,:), intent(inout) :: tile_hash
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+      
+      ! Return value
+      logical :: mpas_search_tile
+
+      ! Local variables
+      character (len=StrKIND) :: fname
+      integer :: x, y
+      integer, pointer :: tile_nx
+      integer, pointer :: tile_ny
+
+      tile => null()
+
+      call mpas_pool_get_config(geo_pool, 'tile_x', tile_nx)
+      call mpas_pool_get_config(geo_pool, 'tile_y', tile_ny)
+
+      ! Calculate the tiles filename, and its start x and y values. We will
+      ! use these values to calculate its location in our hash table
+      call mpas_gen_file(lat, lon, fname, x, y, geo_pool)
+
+      mpas_search_tile = .FALSE.
+
+      if (associated(tile_hash( (x-1)/tile_nx , (y-1)/tile_ny ) % ptr)) then
+         tile => tile_hash( (x-1)/tile_nx , (y-1)/tile_ny ) % ptr
+         mpas_search_tile = .TRUE.
+         return
+      endif
+
+   end function mpas_search_tile
+
+   
+   !***********************************************************************
+   !
+   !  function mpas_add_tile
+   !
+   !> \brief   Reads in a tile from disk and allocates it to main memory
+   !> \author  Miles A. Curry
+   !> \date    
+   !> \details 
+   !>    This function reads a datafile from disk and allocates it on the heap
+   !> /main memory. Given the latitude and longitude of a point, it calculates
+   !> which tilefile contains that points and reads in the datafile that contains
+   !> that point.
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_add_tile(lat, lon, tile, tile_hash, geo_pool)
+
+      use mpas_c_interfacing, only : mpas_f_to_c_string
+      use iso_c_binding, only : c_char 
+
+      implicit none
+
+      interface
+         subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
+                                 scalefactor, wordsize, status) bind(C)
+            use iso_c_binding, only : c_char, c_int, c_float, c_ptr
+            character (c_char), dimension(*), intent(in) :: fname
+            type (c_ptr), value :: rarray
+            integer (c_int), intent(in), value :: nx
+            integer (c_int), intent(in), value :: ny
+            integer (c_int), intent(in), value :: nz
+            integer (c_int), intent(in), value :: isigned
+            integer (c_int), intent(in), value :: endian
+            real (c_float), intent(in), value :: scalefactor
+            integer (c_int), intent(in), value :: wordsize
+            integer (c_int), intent(inout) :: status
+         end subroutine read_geogrid
+      end interface
+
+      ! Input values
+      real (kind=RKIND), intent(in), value :: lat, lon
+      type (tile_t), intent(out), pointer :: tile
+      type (hash_table), pointer, dimension(:,:), intent(inout) :: tile_hash
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      ! Local variables
+      integer :: x, y
+      character (len=StrKIND) :: fname
+      character (len=StrKIND, kind=c_char) :: c_fname
+      character (len=StrKIND), pointer :: topo_dir_path
+      type(c_ptr) :: tile_ptr
+
+      integer, pointer :: tile_nx, tile_ny, tile_nz, tile_bdr
+      integer (c_int) :: nx, ny, nz
+
+      integer, pointer :: wordsize
+      integer :: x_bdr, y_bdr
+
+      real :: lat_deg, lon_deg
+
+      integer, pointer :: endian
+      integer (c_int) :: c_endian
+   
+      tile => null()
+      call mpas_pool_get_config(geo_pool, 'tile_x', tile_nx)
+      call mpas_pool_get_config(geo_pool, 'tile_y', tile_ny)
+      call mpas_pool_get_config(geo_pool, 'tile_z', tile_nz)
+      call mpas_pool_get_config(geo_pool, 'tile_bdr', tile_bdr)
+      call mpas_pool_get_config(geo_pool, 'wordsize', wordsize)
+      call mpas_pool_get_config(geo_pool, 'signed', signed)
+      call mpas_pool_get_config(geo_pool, 'endian', endian)
+      call mpas_pool_get_config(geo_pool, 'scalefactor', scalefactor)
+      call mpas_pool_get_config(geo_pool, 'topo_dir_path', topo_dir_path)
+      call mpas_pool_get_config(geo_pool, 'endian', endian)
+      call mpas_pool_get_config(geo_pool, 'scalefactor', scalefactor)
+
+      x_bdr = tile_bdr * 2
+      y_bdr = tile_bdr * 2
+
+      allocate(tile) ! Allocate the new node 
+      allocate(tile%tile(tile_nx + (tile_bdr * 2), tile_ny + (tile_bdr * 2), tile_nz)) ! And its array to hold the tile
+
+      ! Build the filename for the call to the c_mpas_get_tile(...) 
+      call mpas_gen_file(lat, lon, fname, x, y, geo_pool)
+
+      write(c_fname, "(A, A)") trim(TOPO_DIR_PATH), trim(fname)
+      c_fname = trim(c_fname)//char(0)
+
+      tile_ptr = c_loc(tile%tile) ! Pass in the c_loc of our tile array 
+      call read_geogrid(c_fname, tile_ptr, nx, ny, nz, c_isigned, c_endian, c_scalefactor, c_wordsize, status)
+      if (status /= 0) then
+          call mpas_log_write("Error reading the geogrid "//fname, messageType=MPAS_LOG_CRIT)
+          stop
+      endif
+
+      tile % fname = fname
+      tile % x(1) = x
+      tile % x(2) = x + tile_nx - 1
+      tile % y(1) = y
+      tile % y(2) = y + tile_ny - 1
+      tile % is_processed = .FALSE.
+      tile % hash_x = (tile % x(1) - 1) / tile_nx
+      tile % hash_y = (tile % y(1) - 1) / tile_ny
+
+      tile_hash((tile % x(1) - 1 )/ tile_nx, (tile % y(1) - 1) / tile_ny) % ptr => tile
+
+   end subroutine mpas_add_tile
+
+
+   !***********************************************************************
+   !  function mpas_gen_file
+   !
+   !> \brief   Generate the filename of the datafile containing lat and lon
+   !> \input  
+   !>    lat -- a latitude value in radians
+   !>    lon -- a longitude value in radians
+   !>    fname --  intent(out) - String to contain the filename of the datafile
+   !>                            that contains the point latitude and longitude
+   !>    x -- intent(out) - The x start of the tile file in tile cords
+   !>    y -- intent(out) - The y start of the tile file in tile cords
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_gen_file(lat, lon, fname, x1, y1, geo_pool)
+      implicit none
+
+      real (kind=RKIND), value :: lat, lon
+      character (len=StrKIND), intent(out) :: fname
+      integer, intent(out) :: x1, y1   ! The start of the tile
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      character (len=StrKIND), parameter :: FMT1 = "(I5.5, '-', I5.5, '.', I5.5, '-', I5.5)"
+      integer, dimension(2) :: x, y    ! The x, y ranges for the constructing the filename
+      integer, pointer :: tile_nx, tile_ny
+      integer, pointer :: pixel_nx, pixel_ny
+      real, pointer :: known_lat, known_lon
+      real, pointer :: dx, dy
+
+      call mpas_pool_get_config(geo_pool, 'tile_x', tile_nx)
+      call mpas_pool_get_config(geo_pool, 'tile_y', tile_ny)
+
+      call mpas_pool_get_config(geo_pool, 'pixel_nx', pixel_nx)
+      call mpas_pool_get_config(geo_pool, 'pixel_ny', pixel_ny)
+
+      call mpas_pool_get_config(geo_pool, 'known_lat', known_lat)
+      call mpas_pool_get_config(geo_pool, 'known_lon', known_lon)
+      call mpas_pool_get_config(geo_pool, 'dx', dx)
+      call mpas_pool_get_config(geo_pool, 'dy', dy)
+
+      lat = lat * (180.0/pii)
+      lon = lon * (180.0/pii)
+
+      if (lon > 180) then
+         lon = lon - 360
+      end if
+
+      x(1) = int( ( lon - known_lon) / dx)
+      y(1) = int( ( lat - known_lat) / dy)
+
+      if ( x(1) < 0 ) then
+         x(1) = x(1) + pixel_nx
+      endif
+
+      x(1) = (x(1) - modulo(x(1), tile_nx))  + 1
+      x(2) = x(1) + tile_nx
+      x(2) = x(2) - modulo(x(2), tile_nx)
+
+      y(1) = (y(1) - modulo(y(1), tile_ny))  + 1
+      y(2) = y(1) + tile_ny
+      y(2) = y(2) - modulo(y(2), tile_ny)
+
+      write(fname, FMT1) x(1), x(2), y(1), y(2)
+
+      x1 = x(1)
+      y1 = y(1)
+
+   end subroutine mpas_gen_file
+
+
+   !***********************************************************************
+   !
+   !  subroutine mpas_get_tile_neighbors
+   !
+   !> \brief   Calculate the hash indexes of the current tiles neighbors
+   !> \author  Miles A. Curry
+   !> \date    03/29/2019
+   !> \details 
+   !>  Using the hash table, calculate the neighbors of the current tile
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_get_tile_neighbors(tile, up, down, left, right, geo_pool)
+      
+      implicit none
+      ! Input Variables
+      type (tile_t), pointer, intent(in) :: tile
+      type (tile_t), intent(inout) :: up, down, left, right
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      integer, pointer :: nTileX ! The number of tiles in the x direction
+      integer, pointer :: nTiley ! The number of tiles in the y direction
+
+      call mpas_pool_get_config(geo_pool, 'nTileX', nTileX)
+      call mpas_pool_get_config(geo_pool, 'nTileY', nTileY)
+
+      ! Up
+      up % hash_x = tile % hash_x
+      up % hash_y = tile % hash_y + 1
+      if (up % hash_y > nTileY - 1) then
+         up % hash_y = tile % hash_y
+         up % hash_x = modulo(tile % hash_x + (nTileX/2), nTileX)
+      endif
+
+      ! Right
+      right % hash_x = tile % hash_x + 1
+      right % hash_y = tile % hash_y
+      if ( right % hash_x > nTileX - 1 ) then
+         right % hash_x = 0
+      endif
+
+      ! Left
+      left % hash_x = tile % hash_x - 1
+      left % hash_y = tile % hash_y
+      if ( left % hash_x < 0 ) then
+         left % hash_x = nTileX - 1
+      endif
+
+      ! Down
+      down % hash_x = tile % hash_x
+      down % hash_y = tile % hash_y - 1
+      if (down % hash_y < 0) then
+         down % hash_y = tile % hash_y
+         down % hash_x = modulo(tile % hash_x + (nTileX/2), nTileX)
+      endif
+
+   end subroutine mpas_get_tile_neighbors
+
+
+   !***********************************************************************
+   !
+   !  function mpas_hash_to_latlon
+   !
+   !> \brief   Find the lat, lon from a given hash x, y pair
+   !> \author  Miles A. Curry
+   !> \date    03/29/2019
+   !> \details 
+   !>  Calculate a tile's center latitude and longitude values given is hash 
+   !>  x and y value.
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_hash_to_latlon(hash_x, hash_y, lat, lon, geo_pool)
+
+      implicit none
+
+      ! Input Variables
+      integer, intent(in) :: hash_x, hash_y
+      real (kind=RKIND), intent(inout) :: lat, lon
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      ! Local variables
+      integer :: X, Y
+
+      integer, pointer :: tile_nx  ! The number of pixels between tiles
+      integer, pointer :: tile_ny  ! The number of pixels between tiles
+      real, pointer :: known_lat, known_lon
+      real, pointer :: dx, dy
+
+      call mpas_pool_get_config(geo_pool, 'tile_x', tile_nx)
+      call mpas_pool_get_config(geo_pool, 'tile_y', tile_ny)
+      call mpas_pool_get_config(geo_pool, 'known_lat', known_lat)
+      call mpas_pool_get_config(geo_pool, 'known_lon', known_lon)
+      call mpas_pool_get_config(geo_pool, 'dx', dx)
+      call mpas_pool_get_config(geo_pool, 'dy', dy)
+
+      X = (hash_x * tile_nx) + (tile_nx / 2)
+      Y = (hash_y * tile_ny) + (tile_ny / 2)
+
+      lat = (real((Y)) * dy ) + known_lat
+      lon = (real((X)) * dx ) + known_lon
+
+      if ( lon < 0) then
+         lon = lon + 360
+      endif
+
+      lat = lat * (pii/180.0)
+      lon = lon * (pii/180.0)
+
+   end subroutine mpas_hash_to_latlon
+
+   !***********************************************************************
+   !
+   !  function mpas_stack_pop_tile
+   !
+   !> \brief   Pop a tile type from the mpas stack ds
+   !> \author  Miles A. Curry
+   !> \date    03/20/2019
+   !> \details 
+   !>  Functioning as a wrapper to mpas_stack_pop, this function pops the
+   !>  type(tile_t) from the stack that is an extension of the stack `node`
+   !>  data type.
+   !>
+   !>  This function allows us to extend the stack node type to contain
+   !>  relevant information for our specific use.
+   !>  
+   !
+   !-----------------------------------------------------------------------
+   function mpas_stack_pop_tile(stack) result(tile)
+
+      use mpas_stack, only : node
+      use mpas_stack, only : mpas_stack_pop
+      use mpas_stack, only : mpas_stack_is_empty
+
+      implicit none
+
+      type (node), intent(inout), pointer :: stack
+      class (payload_t), pointer :: top
+      type (tile_t), pointer :: tile
+
+      tile => null()
+
+      if (mpas_stack_is_empty(stack)) then
+         return
+      endif
+
+      top => mpas_stack_pop(stack)
+
+      select type(top)
+         type is(tile_t)
+            tile => top
+            return
+         class default
+            write(0,*) "BEERP!"
+            stop
+      end select
+
+   end function mpas_stack_pop_tile
+
+end module mpas_geotile_manager

--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -163,6 +163,7 @@ module mpas_geotile_manager
 
       implicit none
 
+<<<<<<< HEAD
       interface
          subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
                                  scalefactor, wordsize, status) bind(C)
@@ -179,6 +180,21 @@ module mpas_geotile_manager
             integer (c_int), intent(inout) :: status
          end subroutine read_geogrid
       end interface
+=======
+   interface
+      integer (c_int) function c_get_tile(file, nx, ny, x_halo, y_halo, word_size, is_signed, tile) bind(C)
+         use iso_c_binding, only : c_int, c_char, c_float, c_ptr
+         character (c_char), intent(in) :: file
+         integer (c_int), intent(in), value :: nx
+         integer (c_int), intent(in), value :: ny
+         integer (c_int), intent(in), value :: x_halo
+         integer (c_int), intent(in), value :: y_halo
+         integer (c_int), intent(in), value :: word_size
+         integer (c_int), intent(in), value :: is_signed
+         type (c_ptr), value :: tile
+      end function c_get_tile
+   end interface
+>>>>>>> 8f61fe8... Parallelized Interpolation of Land Use
 
       ! Input values
       real (kind=RKIND), intent(in), value :: lat, lon
@@ -198,6 +214,8 @@ module mpas_geotile_manager
 
       integer, pointer :: wordsize
       integer :: x_bdr, y_bdr
+      logical, pointer :: is_signed
+      integer (c_int) :: is_signed_int
 
       real :: lat_deg, lon_deg
 
@@ -210,12 +228,16 @@ module mpas_geotile_manager
       call mpas_pool_get_config(geo_pool, 'tile_z', tile_nz)
       call mpas_pool_get_config(geo_pool, 'tile_bdr', tile_bdr)
       call mpas_pool_get_config(geo_pool, 'wordsize', wordsize)
-      call mpas_pool_get_config(geo_pool, 'signed', signed)
-      call mpas_pool_get_config(geo_pool, 'endian', endian)
-      call mpas_pool_get_config(geo_pool, 'scalefactor', scalefactor)
+      call mpas_pool_get_config(geo_pool, 'signed', is_signed)
       call mpas_pool_get_config(geo_pool, 'topo_dir_path', topo_dir_path)
       call mpas_pool_get_config(geo_pool, 'endian', endian)
       call mpas_pool_get_config(geo_pool, 'scalefactor', scalefactor)
+
+      if (is_signed) then
+         is_signed_int = 1
+      else
+         is_signed_int = 0
+      endif
 
       x_bdr = tile_bdr * 2
       y_bdr = tile_bdr * 2

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -179,12 +179,12 @@ module init_atm_cases
                !     will have convex partitions, it's safer to just stop if multiple MPI tasks are
                !     detected when performing the static_interp step.
                !  
-               if (domain % dminfo % nprocs > 1) then
-                 call mpas_log_write('****************************************************************', messageType=MPAS_LOG_ERR)
-                 call mpas_log_write('Error: Interpolation of static fields does not work in parallel.', messageType=MPAS_LOG_ERR)
-                 call mpas_log_write('Please run the static_interp step using only a single MPI task.',  messageType=MPAS_LOG_ERR)
-                 call mpas_log_write('****************************************************************', messageType=MPAS_LOG_CRIT)
-               end if
+!               if (domain % dminfo % nprocs > 1) then
+!                 call mpas_log_write('****************************************************************', messageType=MPAS_LOG_ERR)
+!                 call mpas_log_write('Error: Interpolation of static fields does not work in parallel.', messageType=MPAS_LOG_ERR)
+!                 call mpas_log_write('Please run the static_interp step using only a single MPI task.',  messageType=MPAS_LOG_ERR)
+!                 call mpas_log_write('****************************************************************', messageType=MPAS_LOG_CRIT)
+!               end if
 
                call init_atm_static(mesh, block_ptr % dimensions, block_ptr % configs)
             end if

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -83,7 +83,7 @@
                                         ! in the remapping of terrain, land use, and soil category pixels
 
 !local variables:
- type (mpas_pool_type), pointer :: topo_pool
+ type (mpas_pool_type), pointer :: geog_pool 
  type(proj_info):: proj
 
  character(len=StrKIND) :: fname
@@ -367,18 +367,18 @@
  ! Read in the data that describes this geog dataset
  fname = trim(geog_data_path)//trim(geog_sub_path)
 
- call mpas_pool_create_pool(topo_pool)
- call mpas_parse_index(fname, topo_pool)
- call mpas_pool_get_config(topo_pool, 'dx', dx) ! The distance between two pixels
- call mpas_pool_get_config(topo_pool, 'dy', dy) ! The distance between two pixels
- call mpas_pool_get_config(topo_pool, 'tile_x', tile_nx) ! The number of pixels between two tiles
- call mpas_pool_get_config(topo_pool, 'tile_y', tile_ny) ! The number of pixels between two tiles
- call mpas_pool_get_config(topo_pool, 'tile_bdr', tile_bdr)
- call mpas_pool_get_config(topo_pool, 'known_lat', start_lat)
- call mpas_pool_get_config(topo_pool, 'known_lon', start_lon)
- call mpas_pool_get_config(topo_pool, 'known_x', start_x)
- call mpas_pool_get_config(topo_pool, 'known_y', start_y)
- call mpas_pool_add_config(topo_pool, 'topo_dir_path', fname)
+ call mpas_pool_create_pool(geog_pool)
+ call mpas_parse_index(fname, geog_pool)
+ call mpas_pool_get_config(geog_pool, 'dx', dx) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'dy', dy) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'tile_x', tile_nx) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'tile_y', tile_ny) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'tile_bdr', tile_bdr)
+ call mpas_pool_get_config(geog_pool, 'known_lat', start_lat)
+ call mpas_pool_get_config(geog_pool, 'known_lon', start_lon)
+ call mpas_pool_get_config(geog_pool, 'known_x', start_x)
+ call mpas_pool_get_config(geog_pool, 'known_y', start_y)
+ call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
 
  f_endian = 0
  f_scalefactor = 1.0
@@ -397,14 +397,14 @@
  allocate(hash(0:nTileX, 0:nTileY)) 
 
  ! Add these values to the geo_pool
- call mpas_pool_add_config(topo_pool, 'nTileX', nTileX)
- call mpas_pool_add_config(topo_pool, 'nTileY', nTileY)
+ call mpas_pool_add_config(geog_pool, 'nTileX', nTileX)
+ call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
 
  ! Determine the amount of global pixels for this dataset
  pixel_nx = 360 / dx
  pixel_ny = 180 / dy
- call mpas_pool_add_config(topo_pool, 'pixel_nx', pixel_nx)
- call mpas_pool_add_config(topo_pool, 'pixel_ny', pixel_ny)
+ call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
+ call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
 
  ! 
  ! To ensure that we map all pixels of a topography dataset/geo-grid in parallel we have developed
@@ -473,7 +473,7 @@
     ! For instance if we have a discontinuous decomposition partition.
 
     if(nhs(cell) == 0) then
-      call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, topo_pool)
+      call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, geog_pool)
       stack => mpas_stack_push(stack, tile)
     endif
 
@@ -570,8 +570,8 @@
          ! Pass - All tiles mapped to its halo cells, so don't add any tiles to the stack
       else
          ! Calculate the tile neighbors of the current tile and push them onto the stack
-         call mpas_get_tile_neighbors(tile, up, down, left, right, topo_pool)
-         call push_tile_neighbors(stack, up, down, left, right, hash, topo_pool)
+         call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
+         call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
       endif
     enddo
  enddo
@@ -587,12 +587,6 @@
  deallocate(nhs)
  deallocate(ter_integer)
 
- ! Deallocate the kdcords
- do i = 1, nCells, 1 ! TODO: Update mpas_kd_tree so we can call that module to free this
-    deallocate(kdcords(i) % point)
- enddo
- deallocate(kdcords)
-
  ! Deallocate the stack
  call mpas_stack_free(stack, free_payload=.TRUE.)
 
@@ -606,6 +600,9 @@
     enddo
  enddo
  deallocate(hash)
+
+
+ call mpas_pool_destroy_pool(geog_pool)
 
  call mpas_log_write('--- end interpolate TER')
 
@@ -627,89 +624,175 @@
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select surface_input_select1
- nx = 1200
- ny = 1200
- nz = 1
- isigned  = 1
- endian   = 0
- wordsize = 1
- scalefactor = 1.0
- allocate(rarray(nx,ny,nz))
+
+ allocate(tile_bdr)
+ tile_bdr = 0
+ isigned = .False.
+
+ ! Read the index file for the choosen landuse dataset
+ fname = trim(geog_data_path)//trim(geog_sub_path)
+
+ call mpas_pool_create_pool(geog_pool)
+ call mpas_parse_index(fname, geog_pool)
+ call mpas_pool_get_config(geog_pool, 'dx', dx) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'dy', dy) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'tile_x', tile_nx) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'tile_y', tile_ny) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'known_lat', start_lat)
+ call mpas_pool_get_config(geog_pool, 'known_lon', start_lon)
+ call mpas_pool_get_config(geog_pool, 'known_x', start_x)
+ call mpas_pool_get_config(geog_pool, 'known_y', start_y)
+ call mpas_pool_add_config(geog_pool, 'tile_bdr', tile_bdr)
+ call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
+ call mpas_pool_add_config(geog_pool, 'signed', isigned_bool)
+
+ f_endian = 0
+ f_scalefactor = 1.0
+ call mpas_pool_add_config(geog_pool, 'endian', f_endian)
+ call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
+
+ ! Initalize the hash table
+ !
+ ! The tile_hash is used when searching, getting and adding tiles.
+ ! See get_tile(...), search_tile(...) and add_tile(...)
+ ! Create a hash table, mapping out each tile for quicker searching as
+ ! well as enabling us to grab a tile's neighbors.
+ !
+ nTileX = int((360. / dx)) / tile_nx
+ nTileY = int((180. / dy)) / tile_ny
+ allocate(hash(0:nTileX, 0:nTileY)) 
+
+ call mpas_log_write("nTileX: $i", intArgs=(/nTileX/))
+ call mpas_log_write("nTiley: $i", intArgs=(/nTileY/))
+
+ ! Add these values to the geo_pool
+ call mpas_pool_add_config(geog_pool, 'nTileX', nTileX)
+ call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
+
+ ! Determine the amount of global pixels for this dataset
+ pixel_nx = 360 / dx
+ pixel_ny = 180 / dy
+ call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
+ call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
+
+ call mpas_log_write("pixel_nx: $i", intArgs=(/pixel_nx/))
+ call mpas_log_write("pixel_ny: $i", intArgs=(/pixel_ny/))
+
+ num_processed_tiles = 0
  allocate(ncat(ismax_lu,nCells))
  ncat(:,:) = 0
  lu_index(:) = 0.0
 
- rarray_ptr = c_loc(rarray)
+ do cell = 1, nCells, 1
 
- do jTileStart = 1,20401,ny
-    jTileEnd = jTileStart + ny - 1
+   if (all(ncat(:,cell) == 0)) then
+      call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, geog_pool)
+      stack => mpas_stack_push(stack, tile)
+   endif
 
-    do iTileStart = 1,42001,nx
-       iTileEnd = iTileStart + nx - 1
-       write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
-             trim(geog_sub_path),iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
-       call mpas_log_write(trim(fname))
-       call mpas_f_to_c_string(fname, c_fname)
+   do while ( .NOT. mpas_stack_is_empty(stack))
+      tile => null()
+      tile => mpas_stack_pop_tile(stack)
 
-       call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                         scalefactor,wordsize,istatus)
-       call init_atm_check_read_error(istatus, fname)
+      if ( tile % is_processed ) then
+         cycle
+      else
+         tile % is_processed = .TRUE.
+      endif
 
-       iPoint = 1
-       do j=1,ny
-       do i=1,nx
-!
-! The MODIS dataset appears to have zeros at the South Pole, possibly other places, too
-!
-if (rarray(i,j,1) == 0) cycle
+      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .TRUE.
 
-          lat_pt = -89.99583  + (jTileStart + j - 2) * 0.0083333333
-          lon_pt = -179.99583 + (iTileStart + i - 2) * 0.0083333333
-          lat_pt = lat_pt * PI / 180.0
-          lon_pt = lon_pt * PI / 180.0
+      num_processed_tiles = num_processed_tiles + 1
+      call mpas_log_write("Proccessing a lu_tile ... $i - "//trim(tile%fname), intArgs=(/num_processed_tiles/)) 
+      do j = 1 + tile_bdr, tile_ny + tile_bdr
+         do i = 1 + tile_bdr, tile_nx + tile_bdr
 
-          iPoint = nearest_cell(lat_pt,lon_pt,iPoint,nCells,maxEdges, &
-                                nEdgesOnCell,cellsOnCell, &
-                                latCell,lonCell)
+            !call mpas_log_write("about to read the tile: ")
+            !write(0,*) tile % tile
 
-          !
-          ! For all but the outermost boundary cells, we can safely assume that the nearest
-          ! model grid cell contains the pixel (else, a different cell would be nearest)
-          !
-          if (bdyMaskCell(iPoint) < nBdyLayers) then
-             ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
+            !call mpas_log_write("This Cat: i: $i j: $i - cat: $i ", intArgs=(/i, j, int(tile % tile(i,j))/))
 
-          ! For outermost boundary cells, additional work is needed to verify that the pixel
-          ! actually lies within the nearest cell
-          else
-             zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
-             xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
-             yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
-                         nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
+            lat_pt = (j - (tile_bdr + 1) + real(tile % y(1)) - 1) * dy + start_lat
+            lon_pt = (i - (tile_bdr + 1) + real(tile % x(1)) - 1) * dx + start_lon
+         
+            if (lon_pt < 0) then
+               lon_pt = lon_pt + 360.0_RKIND
+            endif
 
-                ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
+            lat_pt = lat_pt * (pii/180.0_RKIND)
+            lon_pt = lon_pt * (pii/180.0_RKIND)
+
+            call convert_lx(x, y, z, sphere_radius, lat_pt, lon_pt)
+            call mpas_kd_search(tree, (/x, y, z/), res)
+
+             !
+             ! For all but the outermost boundary cells, we can safely assume that the nearest
+             ! model grid cell contains the pixel (else, a different cell would be nearest)
+             !
+             if (bdyMaskCell(res % cell) < nBdyLayers) then
+                ncat(int(tile % tile(i,j,1)), res % cell) = ncat(int(tile % tile(i,j,1)), res % cell) + 1
+
+                if (res % cell <= nCellsSolve) then
+                   ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+                endif
+
+             ! For outermost boundary cells, additional work is needed to verify that the pixel
+             ! actually lies within the nearest cell
+             else
+                zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
+                xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
+                yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+
+                if (in_cell(xPixel, yPixel, zPixel, xCell(res % cell), yCell(res % cell), zCell(res % cell), &
+                            nEdgesOnCell(res % cell), verticesOnCell(:, res % cell), xVertex, yVertex, zVertex)) then
+
+                   ncat(int(tile % tile(i,j,1)), res % cell) = ncat(int(tile % tile(i,j,1)), res % cell) + 1
+      
+                   if (res % cell <= nCellsSolve) then
+                      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+                   endif
+                end if
              end if
-          end if
-       end do
-       end do
+         enddo
+      enddo
+      if (ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
+         ! Pass - All pixels mapped to a halo cell, so don't add any neighboring tiles to the stack
+      else
+         call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
+         call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
+      endif
+   enddo
+ enddo
 
-    end do
- end do
 
- do iCell = 1,nCells
+ do iCell = 1, nCells
     lu_index(iCell) = 1
-    do i = 2,ismax_lu
-       if(ncat(i,iCell) > ncat(lu_index(iCell),iCell)) then
+    do i = 2, ismax_lu
+       if (ncat(i,iCell) > ncat(lu_index(iCell),iCell)) then
           lu_index(iCell) = i
        end if
     end do
  end do
- deallocate(rarray)
- deallocate(ncat)
- call mpas_log_write('--- end interpolate LU_INDEX')
 
+ ! Deallocate the stack
+ call mpas_stack_free(stack, free_payload=.TRUE.)
+ deallocate(ncat)
+
+ ! Use the hash table to deallocate each tile and then the hash itself.
+ do i = 0, nTileX
+    do j = 0, nTileY
+       if(associated(hash(i, j) % ptr)) then
+          deallocate(hash(i, j) % ptr % tile)
+          deallocate(hash(i, j) % ptr)
+       endif
+    enddo
+ enddo
+ deallocate(hash)
+
+ call mpas_pool_destroy_pool(geog_pool)
+
+ call mpas_log_write('--- end interpolate LU_INDEX')
 
 !
 ! Interpolate SOILCAT_TOP

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -797,72 +797,120 @@
 !
 ! Interpolate SOILCAT_TOP
 !
- nx = 1200
- ny = 1200
- nz = 1
- isigned     = 1
- endian      = 0
- wordsize    = 1
- scalefactor = 1.0
- allocate(rarray(nx,ny,nz))
+   
+ ! Read the index file for the choosen landuse dataset
+ fname = trim(geog_data_path)//'soiltype_top_30s/'
+
+ call mpas_pool_create_pool(geog_pool)
+ call mpas_parse_index(fname, geog_pool)
+ call mpas_pool_get_config(geog_pool, 'dx', dx) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'dy', dy) ! The distance between two pixels
+ call mpas_pool_get_config(geog_pool, 'tile_x', tile_nx) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'tile_y', tile_ny) ! The number of pixels between two tiles
+ call mpas_pool_get_config(geog_pool, 'known_lat', start_lat)
+ call mpas_pool_get_config(geog_pool, 'known_lon', start_lon)
+ call mpas_pool_get_config(geog_pool, 'known_x', start_x)
+ call mpas_pool_get_config(geog_pool, 'known_y', start_y)
+ call mpas_pool_add_config(geog_pool, 'tile_bdr', tile_bdr)
+ call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
+
+ f_endian = 0
+ f_scalefactor = 1.0
+ signed = 1
+ call mpas_pool_add_config(geog_pool, 'endian', f_endian)
+ call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
+ call mpas_pool_add_config(geog_pool, 'signed', signed)
+
+ nTileX = int((360.0_RKIND / dx)) / tile_nx
+ nTileY = int((180.0_RKIND / dy)) / tile_ny
+ allocate(hash(0:nTileX, 0:nTileY))
+
+ call mpas_pool_add_config(geog_pool, 'nTileX', nTileX)
+ call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
+
+ pixel_nx = 360.0_RKIND / dx
+ pixel_ny = 180.0_RKIND / dy
+ call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
+ call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
+
  allocate(ncat(16,nCells))
  ncat(:,:) = 0
  soilcat_top(:) = 0.0
 
- rarray_ptr = c_loc(rarray)
+ num_processed_tiles = 0
 
- do jTileStart = 1,20401,ny
-    jTileEnd = jTileStart + ny - 1
+ do cell = 1, nCells
 
-    do iTileStart = 1,42001,nx
-       iTileEnd = iTileStart + nx - 1
-       write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
-             'soiltype_top_30s/',iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
-       call mpas_log_write(trim(fname))
-       call mpas_f_to_c_string(fname, c_fname)
+   if (all(ncat(:,cell) == 0)) then
+      call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, geog_pool)
+      stack => mpas_stack_push(stack, tile)
+   endif
 
-       call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                         scalefactor,wordsize,istatus)
-       call init_atm_check_read_error(istatus, fname)
+   do while ( .NOT. mpas_stack_is_empty(stack))
+      tile => mpas_stack_pop_tile(stack)
 
-       iPoint = 1
-       do j=1,ny
-       do i=1,nx
-          lat_pt = -89.99583  + (jTileStart + j - 2) * 0.0083333333
-          lon_pt = -179.99583 + (iTileStart + i - 2) * 0.0083333333
-          lat_pt = lat_pt * PI / 180.0
-          lon_pt = lon_pt * PI / 180.0
+      if ( tile % is_processed ) then
+         cycle
+      else
+         tile % is_processed = .TRUE.
+      endif
 
-          iPoint = nearest_cell(lat_pt,lon_pt,iPoint,nCells,maxEdges, &
-                                nEdgesOnCell,cellsOnCell, &
-                                latCell,lonCell)
+      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .TRUE.
+      
+      num_processed_tiles = num_processed_tiles + 1
+      call mpas_log_write("Processing a Soil category tile ... $i - "//trim(tile%fname), intArgs=(/num_processed_tiles/))
 
-          !
-          ! For all but the outermost boundary cells, we can safely assume that the nearest
-          ! model grid cell contains the pixel (else, a different cell would be nearest)
-          !
-          if (bdyMaskCell(iPoint) < nBdyLayers) then
-             ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
+      do j = 1 + tile_bdr, tile_ny + tile_bdr
+         do i = 1 + tile_bdr, tile_nx + tile_bdr
+   
+            lat_pt = real((j - (tile_bdr + 1) + tile % y(1)) - 1, kind=RKIND) * dy + start_lat
+            lon_pt = real((i - (tile_bdr + 1) + tile % x(1)) - 1, kind=RKIND) * dx + start_lon
 
-          ! For outermost boundary cells, additional work is needed to verify that the pixel
-          ! actually lies within the nearest cell
-          else
-             zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
-             xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
-             yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+            if (lon_pt < 0.0_RKIND) then
+               lon_pt = lon_pt + 360.0_RKIND
+            endif
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
-                         nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
+            lat_pt = lat_pt * (pii/180.0_RKIND)
+            lon_pt = lon_pt * (pii/180.0_RKIND)
 
-                ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
+            call convert_lx(x, y, z, sphere_radius, lat_pt, lon_pt)
+            call mpas_kd_search(tree, (/x, y, z/), res)
 
+             !
+             ! For all but the outermost boundary cells, we can safely assume that the nearest
+             ! model grid cell contains the pixel (else, a different cell would be nearest)
+             !
+             if (bdyMaskCell(res % cell) < nBdyLayers) then
+                ncat(int(tile % tile(i,j,1)), res % cell) = ncat(int(tile % tile(i,j,1)), res % cell) + 1
+
+                if (res % cell <= nCellsSolve) then
+                   ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+                endif
+             ! For outermost boundary cells, additional work is needed to verify that the pixel
+             ! actually lies within the nearest cell
+             else
+                zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
+                xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
+                yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+
+                if (in_cell(xPixel, yPixel, zPixel, xCell(res % cell), yCell(res % cell), zCell(res % cell), &
+                            nEdgesOnCell(res % cell), verticesOnCell(:,res % cell), xVertex, yVertex, zVertex)) then
+
+                   ncat(int(tile % tile(i,j,1)), res % cell) = ncat(int(tile % tile(i,j,1)), res % cell) + 1
+
+                   if (res % cell <= nCellsSolve) then
+                      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+                   endif
+                end if
              end if
-          end if
-       end do
-       end do
-
-    end do
- end do
+         enddo
+      enddo
+      if (.not. ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
+         call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
+         call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
+      endif
+   enddo
+ enddo
 
  do iCell = 1,nCells
     soilcat_top(iCell) = 1
@@ -872,8 +920,24 @@
        end if
     end do
  end do
- deallocate(rarray)
  deallocate(ncat)
+
+ ! Deallocate the stack
+ call mpas_stack_free(stack, free_payload=.TRUE.)
+
+ ! Use the hash table to deallocate each tile and then the hash itself.
+ do i = 0, nTileX
+    do j = 0, nTileY
+       if(associated(hash(i, j) % ptr)) then
+          deallocate(hash(i, j) % ptr % tile)
+          deallocate(hash(i, j) % ptr)
+       endif
+    enddo
+ enddo
+ deallocate(hash)
+
+ call mpas_pool_destroy_pool(geog_pool)
+
  call mpas_log_write('--- end interpolate SOILCAT_TOP')
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -51,6 +51,27 @@
  subroutine init_atm_static(mesh, dims, configs)
 !==================================================================================================
 
+ use iso_c_binding, only : c_float, c_int, c_long, c_loc, c_ptr
+
+ use mpas_kd_tree, only : kdnode
+ use mpas_kd_tree, only : mpas_kd_construct
+ use mpas_kd_tree, only : mpas_kd_free
+ use mpas_kd_tree, only : mpas_kd_search
+
+ use mpas_stack, only : node
+ use mpas_stack, only : payload_t
+ use mpas_stack, only : mpas_stack_push
+ use mpas_stack, only : mpas_stack_is_empty
+ use mpas_stack, only : mpas_stack_free
+
+ use mpas_geotile_manager, only : tile_t, hash_table
+ use mpas_geotile_manager, only : mpas_get_tile
+ use mpas_geotile_manager, only : mpas_get_tile_neighbors
+ use mpas_geotile_manager, only : mpas_hash_to_latlon
+ use mpas_geotile_manager, only : mpas_stack_pop_tile
+
+ use mpas_parse_geoindex, only : mpas_parse_index
+
 !inout arguments:
  type (mpas_pool_type), intent(inout) :: mesh
  type (mpas_pool_type), intent(in) :: dims
@@ -62,6 +83,7 @@
                                         ! in the remapping of terrain, land use, and soil category pixels
 
 !local variables:
+ type (mpas_pool_type), pointer :: topo_pool
  type(proj_info):: proj
 
  character(len=StrKIND) :: fname
@@ -87,11 +109,14 @@
  integer,dimension(:,:),allocatable:: ncat
       
  real(kind=c_float):: scalefactor
+ real(kind=RKIND):: f_scalefactor
  real(kind=c_float),dimension(:,:,:),pointer,contiguous :: rarray
  type(c_ptr) :: rarray_ptr
 
- real(kind=RKIND):: start_lat
- real(kind=RKIND):: start_lon
+ real(kind=RKIND), pointer :: start_lat
+ real(kind=RKIND), pointer :: start_lon
+ real(kind=RKIND), pointer :: start_x
+ real(kind=RKIND), pointer :: start_y
 
  integer, pointer :: supersample_fac
 
@@ -101,7 +126,7 @@
  real(kind=RKIND),dimension(:,:),allocatable  :: maxsnowalb
  real(kind=RKIND),dimension(:,:,:),allocatable:: vegfra
 
- integer, pointer :: nCells, nEdges, nVertices, maxEdges
+ integer, pointer :: nCells, nCellsSolve, nEdges, nVertices, maxEdges
  logical, pointer :: on_a_sphere
  real (kind=RKIND), pointer :: sphere_radius
  
@@ -133,6 +158,40 @@
  character(len=StrKIND), pointer :: mminlu
 
  real (kind=RKIND) :: xPixel, yPixel, zPixel
+
+ type (hash_table), pointer, dimension(:, :) :: hash
+ type (kdnode), dimension(:), allocatable :: kdCords
+ type (kdnode), pointer :: tree => null(), res => null()
+
+ type (node), pointer :: stack => null()
+
+ type (tile_t), pointer :: tile => null()
+ type (tile_t) :: up, down, left, right
+
+ logical :: ALL_PIXELS_MAPPED_TO_HALO_CELLS
+
+ real(kind=RKIND), pointer :: dx, dy
+ integer, pointer :: tile_nx, tile_ny
+ integer, pointer :: tile_bdr
+
+ integer :: nTileX, nTileY ! The number of tiles in each direction
+ integer :: pixel_nx, pixel_ny ! The number of pixel in each direction
+ integer :: num_processed_tiles
+ integer :: cell
+
+ ! To handle possible values that are considerably large then the RKIND
+ ! and to possible take care of differences in order of summation, we will
+ ! briefly hold terrain values in an I8KIND integer array and then convert
+ ! them to RKIND's when they are divided by nhs.
+ !
+ ! This will allow larger values to be held, but will disallow smaller
+ ! resolution terrain values.
+ !
+ ! TODO: Check this and add more detail .
+ !
+ integer (kind=I8KIND), dimension(:), pointer :: ter_integer
+ real (kind=RKIND) :: tval
+
 
 !--------------------------------------------------------------------------------------------------
 
@@ -206,6 +265,7 @@
  call mpas_pool_get_dimension(dims, 'nEdges', nEdges)
  call mpas_pool_get_dimension(dims, 'nVertices', nVertices)
  call mpas_pool_get_dimension(dims, 'maxEdges', maxEdges)
+ call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
 
  xCell = xCell * sphere_radius
  yCell = yCell * sphere_radius
@@ -221,6 +281,25 @@
  areaCell = areaCell * sphere_radius**2.0
  areaTriangle = areaTriangle * sphere_radius**2.0
  kiteAreasOnVertex = kiteAreasOnVertex * sphere_radius**2.0
+
+
+ ! Set up the KD-Tree of Grid Cell Cartisian Coordinates
+ allocate(kdcords(nCells))
+ do i = 1, nCells, 1
+    call convert_lx(x, y, z, sphere_radius, latCell(i), lonCell(i))
+
+    allocate(kdcords(i) % point(3))
+    kdcords(i) % point = (/x, y, z/)
+    kdcords(i) % cell = i
+
+    ! Mark if a cell is a halo cell or not
+    if(i > nCellsSolve) then
+       kdcords(i) % is_halo = .TRUE.
+    else
+       kdcords(i) % is_halo = .FALSE.
+    endif
+ enddo
+ tree => mpas_kd_construct(kdcords, 3)
 
 
 !
@@ -268,32 +347,14 @@
 !
 ! Interpolate HGT
 !
-!nx = 126
-!ny = 126
- nx = 1206
- ny = 1206
- nz = 1
- isigned  = 1
- endian   = 0
- wordsize = 2
- scalefactor = 1.0
- allocate(rarray(nx,ny,nz))
- allocate(nhs(nCells))
- nhs(:) = 0
- ter(:) = 0.0
 
- rarray_ptr = c_loc(rarray)
-
- start_lat = -89.99583
  select case(trim(config_topo_data))
     case('GTOPO30')
        call mpas_log_write('Using GTOPO30 terrain dataset')
        geog_sub_path = 'topo_30s/'
-       start_lon = -179.99583
     case('GMTED2010')
        call mpas_log_write('Using GMTED2010 terrain dataset')
        geog_sub_path = 'topo_gmted2010_30s/'
-       start_lon = 0.004166667
     case('default')
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Invalid topography dataset '''//trim(config_topo_data) &
@@ -303,68 +364,250 @@
        call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select
 
- do jTileStart = 1,20401,ny-6
-    jTileEnd = jTileStart + ny - 1 - 6
+ ! Read in the data that describes this geog dataset
+ fname = trim(geog_data_path)//trim(geog_sub_path)
 
-    do iTileStart=1,42001,nx-6
-       iTileEnd = iTileStart + nx - 1 - 6
-       write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)//trim(geog_sub_path), &
-                    iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
-       call mpas_log_write(trim(fname))
-       call mpas_f_to_c_string(fname, c_fname)
+ call mpas_pool_create_pool(topo_pool)
+ call mpas_parse_index(fname, topo_pool)
+ call mpas_pool_get_config(topo_pool, 'dx', dx) ! The distance between two pixels
+ call mpas_pool_get_config(topo_pool, 'dy', dy) ! The distance between two pixels
+ call mpas_pool_get_config(topo_pool, 'tile_x', tile_nx) ! The number of pixels between two tiles
+ call mpas_pool_get_config(topo_pool, 'tile_y', tile_ny) ! The number of pixels between two tiles
+ call mpas_pool_get_config(topo_pool, 'tile_bdr', tile_bdr)
+ call mpas_pool_get_config(topo_pool, 'known_lat', start_lat)
+ call mpas_pool_get_config(topo_pool, 'known_lon', start_lon)
+ call mpas_pool_get_config(topo_pool, 'known_x', start_x)
+ call mpas_pool_get_config(topo_pool, 'known_y', start_y)
+ call mpas_pool_add_config(topo_pool, 'topo_dir_path', fname)
 
-       call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                         scalefactor,wordsize,istatus)
-       call init_atm_check_read_error(istatus, fname)
+ f_endian = 0
+ f_scalefactor = 1.0
+ call mpas_pool_add_config(geog_pool, 'endian', f_endian)
+ call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
 
-       iPoint = 1
-       do j=4,ny-3
-       do i=4,nx-3
-          lat_pt = start_lat + (jTileStart + j - 5) * 0.0083333333
-          lon_pt = start_lon + (iTileStart + i - 5) * 0.0083333333
-          lat_pt = lat_pt * PI / 180.0
-          lon_pt = lon_pt * PI / 180.0
+ ! Initalize the hash table
+ !
+ ! The tile_hash is used when searching, getting and adding tiles.
+ ! See get_tile(...), search_tile(...) and add_tile(...)
+ ! Create a hash table, mapping out each tile for quicker searching as
+ ! well as enabling us to grab a tile's neighbors.
+ !
+ nTileX = int((360. / dx)) / tile_nx
+ nTileY = int((180. / dy)) / tile_ny
+ allocate(hash(0:nTileX, 0:nTileY)) 
 
-          iPoint = nearest_cell(lat_pt,lon_pt,iPoint,nCells,maxEdges, &
-                                nEdgesOnCell,cellsOnCell, &
-                                latCell,lonCell)
+ ! Add these values to the geo_pool
+ call mpas_pool_add_config(topo_pool, 'nTileX', nTileX)
+ call mpas_pool_add_config(topo_pool, 'nTileY', nTileY)
 
-          !
-          ! For all but the outermost boundary cells, we can safely assume that the nearest
-          ! model grid cell contains the pixel (else, a different cell would be nearest)
-          !
-          if (bdyMaskCell(iPoint) < nBdyLayers) then
-             ter(iPoint) = ter(iPoint) + rarray(i,j,1)
-             nhs(iPoint) = nhs(iPoint) + 1
+ ! Determine the amount of global pixels for this dataset
+ pixel_nx = 360 / dx
+ pixel_ny = 180 / dy
+ call mpas_pool_add_config(topo_pool, 'pixel_nx', pixel_nx)
+ call mpas_pool_add_config(topo_pool, 'pixel_ny', pixel_ny)
 
-          ! For outermost boundary cells, additional work is needed to verify that the pixel
-          ! actually lies within the nearest cell
-          else
-             zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
-             xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
-             yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+ ! 
+ ! To ensure that we map all pixels of a topography dataset/geo-grid in parallel we have developed
+ ! the following algorithm:
+ !
+ ! We have the following data structures:
+ !  1. A stack - That holds tiles that may or may not need to be processed
+ !  2. A kdtree - That holds the locations of every cell in our decomposition
+ !  3. A hash table - That enables us to see if a tile is loaded, or not
+ !
+ ! A rough description of the algorithm is:
+ !
+ ! Push a single tile on the stack. While the stack is not empty, pop a tile off the
+ ! stack and map its tiles to a mesh cell using the KD tree.
+ !
+ ! If all the pixels in the tile map to halo cells, then don't add that tiles neighbors to
+ ! the stack. If a single pixel does map to a non-halo cell, then add all of its neighbors
+ ! (up, down, left, right) to the stack. 
+ !
+ ! And continue until the stack is empty.
+ !
+ ! An outer loop loops through all nCells to insure that all cells have had terrain values
+ ! mapped to them.
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
-                         nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
+ ! Pseudocode:
+ !
+ ! for cell in Ncells: 
+ !  if(nhs == 0) 
+ !     load the tile for that cell
+ !     push tile
+ !  do while(stack is not empty)
+ !     pop tile
+ !     if tile == proccseed then 
+ !         cycle
+ !
+ !     mapped_all_to_halo = True
+ !     for pixels in tile:
+ !        tval = tile(pixel)
+ !        call kd_search(pixel, nCell_result)
+ !        ter(nCell_result) += tval 
+ !        nhs(nCell_result) += 1
+ !     
+ !        if (nCell_result < nCellSolve) then
+ !           mapped_all_to_halo = False
+ !
+ !     if(mapped_all_to_halo) then
+ !        pass
+ !     else
+ !        push tile_neighbors_onto_stack
+ !
 
-                ter(iPoint) = ter(iPoint) + rarray(i,j,1)
-                nhs(iPoint) = nhs(iPoint) + 1
+ num_processed_tiles = 0
+ allocate(nhs(nCells))
+ allocate(ter_integer(nCells))
 
-             end if
-          end if
-       end do
-       end do
+ nhs(:) = 0
+ ter(:) = 0
+ ter_integer(:) = 0
 
-    end do
- end do
+ do cell = 1, nCells, 1
 
- do iCell = 1,nCells
-    ter(iCell) = ter(iCell) / real(nhs(iCell))
- end do
- deallocate(rarray)
+    ! To insure that all the cells in our decompositions have values, check to see if 
+    ! the nhs for that cells is greater then 0. If it is 0, then we have not added
+    ! any terrain values to it, so push it onto the stack to insure it gets processed.
+    ! 
+    ! For instance if we have a discontinuous decomposition partition.
+
+    if(nhs(cell) == 0) then
+      call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, topo_pool)
+      stack => mpas_stack_push(stack, tile)
+    endif
+
+    do while( .NOT. mpas_stack_is_empty(stack))
+      tile => null()
+      tile => mpas_stack_pop_tile(stack)
+
+      if ( tile % is_processed ) then
+         cycle
+      else
+         tile % is_processed = .TRUE.
+      endif
+   
+      num_processed_tiles = num_processed_tiles + 1
+      call mpas_log_write("Processing a terrain tile ... $i - "//trim(tile%fname), intArgs=(/num_processed_tiles/))
+
+      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .TRUE.
+
+      ! For each pixel within a tile, calculate its Cartesian coordinate. Then, using its
+      ! Cartesian coordinates, search the KD tree for the mesh cell that is closest and 
+      ! assign that pixels terrain value to that mesh cell.
+      !
+      ! If we find that none of the pixels map a non-halo cell (ie < nCellsSolve) then 
+      ! we know that this tile is outside of our processor decomposition, so most likely
+      ! so is its neighbors, so don't add them to the stack.
+
+      do j = 1 + tile_bdr, tile_ny + tile_bdr, 1
+         do i = 1 + tile_bdr, tile_nx + tile_bdr, 1
+
+            tval = tile % tile(i, j, 1)
+
+            lat_pt = (j - (tile_bdr - 1) + real(tile % y(1)) - 1) * dy + start_lat
+            lon_pt = (i - (tile_bdr - 1) + real(tile % x(1)) - 1) * dx + start_lon
+
+            if (lon_pt < 0) then
+               lon_pt = lon_pt + 360
+            endif
+
+            lat_pt = lat_pt * (pii / 180.0)
+            lon_pt = lon_pt * (pii / 180.0)
+
+            ! Convert the pixel ll x, y to lat, lon and then to Cartesian coordinates
+            ! (tile_bdr - 1) represents the 1 + tile_bdr start, and the later - 1 represent the
+            ! subtraction to achieve zero based.
+            call convert_lx(x, y, z, sphere_radius, lat_pt, lon_pt)
+
+            res => null()
+            call mpas_kd_search(tree, (/x, y, z/), res)
+
+            !
+            ! For all but the outermost boundary cells, we can safely assume that the nearest
+            ! model grid cell contains the pixel (else, a different cell would be nearest)
+            !
+            if (bdyMaskCell(res % cell) < nBdyLayers) then
+               ter_integer(res % cell) = ter_integer(res % cell) + int(tval, kind=I8KIND)
+               nhs(res % cell) = nhs(res % cell) + 1
+
+               ! To insure that the algorithm is not processing tiles that are too far
+               ! outside of its decomposition (i.e. tiles that do not map to any of this MPI
+               ! process' cells, if all the pixels of a completely to halo cells, then we know
+               ! we don't need to add this tiles neighbors to the stack.
+               ! 
+               ! However, if a single pixel maps to one of our cells then to be safe we should
+               ! push on its surrounding tiles.
+               if (res % cell <= nCellsSolve) then
+                  ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+               endif
+
+            ! For outermost boundary cells, additional work is needed to verify that the pixel
+            ! actually lies within the nearest cell
+            else
+               zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
+               xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
+               yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+
+               if (in_cell(xPixel, yPixel, zPixel, xCell(res % cell), yCell(res % cell), zCell(res % cell), &
+                           nEdgesOnCell(res % cell), verticesOnCell(:,res % cell), xVertex, yVertex, zVertex)) then
+
+                  ter_integer(res % cell) = ter_integer(res % cell) + int(tval, kind=I8KIND)
+                  nhs(res % cell) = nhs(res % cell) + 1
+
+                  ! Similarly, if we have a border cell that is not a halo cell, then we should
+                  ! grab the current tiles surrounding tiles.
+                  if (res % cell <= nCellsSolve) then
+                     ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
+                  endif
+
+               endif
+            endif
+         enddo
+      enddo
+
+      if (ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
+         ! Pass - All tiles mapped to its halo cells, so don't add any tiles to the stack
+      else
+         ! Calculate the tile neighbors of the current tile and push them onto the stack
+         call mpas_get_tile_neighbors(tile, up, down, left, right, topo_pool)
+         call push_tile_neighbors(stack, up, down, left, right, hash, topo_pool)
+      endif
+    enddo
+ enddo
+
+ ! Since we are taking an average of all the pixels that map to  a cell, divide each cell's 
+ ! terrain value by the number of pixels that we alloted to it.
+ do i = 1, nCells, 1
+    ter(i) = real(ter_integer(i), kind=R8KIND) / real(nhs(i), kind=R8KIND)
+ enddo
+
+
+ !! Deallocations
  deallocate(nhs)
- call mpas_log_write('--- end interpolate TER')
+ deallocate(ter_integer)
 
+ ! Deallocate the kdcords
+ do i = 1, nCells, 1 ! TODO: Update mpas_kd_tree so we can call that module to free this
+    deallocate(kdcords(i) % point)
+ enddo
+ deallocate(kdcords)
+
+ ! Deallocate the stack
+ call mpas_stack_free(stack, free_payload=.TRUE.)
+
+ ! Use the hash table to deallocate each tile and then the hash itself.
+ do i = 0, nTileX, 1
+    do j = 0, nTileY, 1
+       if(associated(hash(i, j) % ptr)) then
+          deallocate(hash(i, j) % ptr % tile)
+          deallocate(hash(i, j) % ptr)
+       endif
+    enddo
+ enddo
+ deallocate(hash)
+
+ call mpas_log_write('--- end interpolate TER')
 
 !
 ! Interpolate LU_INDEX
@@ -447,7 +690,6 @@ if (rarray(i,j,1) == 0) cycle
                          nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
 
                 ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
-
              end if
           end if
        end do
@@ -1248,8 +1490,72 @@ if (rarray(i,j,1) == 0) cycle
 
  call mpas_log_write('--- end interpolate ALBEDO12M')
 
-
  end subroutine init_atm_static
+
+ !***********************************************************************
+ !
+ !  subroutine push_tile_neighbors
+ !
+ !> \brief   Push a tiles neighbors onto the stack
+ !> \author  Miles A. Curry
+ !> \date    03/29/2019
+ !> \details 
+ !>  Given that up, down, left, right contain their relevant hashes,
+ !>  (from mpas_get_tile_neighbors) get and push the relevant tiles onto
+ !>  the stack to be processed.
+ !
+ !-----------------------------------------------------------------------
+ subroutine push_tile_neighbors(stack, up, down, left, right, tile_hash, geo_pool)
+
+    use mpas_stack, only : node
+    use mpas_stack, only : payload_t
+    use mpas_stack, only : mpas_stack_is_empty
+    use mpas_stack, only : mpas_stack_push
+
+    use mpas_geotile_manager, only : tile_t, hash_table
+    use mpas_geotile_manager, only : mpas_get_tile
+    use mpas_geotile_manager, only : mpas_hash_to_latlon
+    use mpas_geotile_manager, only : mpas_stack_pop_tile
+
+    implicit none
+
+    type (node), intent(inout), pointer :: stack
+    type (tile_t), intent(inout) :: up
+    type (tile_t), intent(inout) :: down
+    type (tile_t), intent(inout) :: left
+    type (tile_t), intent(inout) :: right
+    type (hash_table), pointer, dimension(:, :), intent(inout) :: tile_hash
+    type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+    type (tile_t), pointer :: tile
+    real (kind=RKIND) :: lat
+    real (kind=RKIND) :: lon
+
+    ! Right
+    tile => null()
+    call mpas_hash_to_latlon(right % hash_x, right % hash_y, lat, lon, geo_pool)
+    call mpas_get_tile(lat, lon, tile, tile_hash, geo_pool)
+    stack => mpas_stack_push(stack, tile)
+
+    ! Left
+    tile => null()
+    call mpas_hash_to_latlon(left % hash_x, left % hash_y, lat, lon, geo_pool)
+    call mpas_get_tile(lat, lon, tile, tile_hash, geo_pool)
+    stack => mpas_stack_push(stack, tile)
+
+    ! Up
+    tile => null()
+    call mpas_hash_to_latlon(up % hash_x, up % hash_y, lat, lon, geo_pool)
+    call mpas_get_tile(lat, lon, tile, tile_hash, geo_pool)
+    stack => mpas_stack_push(stack, tile)
+    
+    ! Down
+    tile => null()
+    call mpas_hash_to_latlon(down % hash_x, down % hash_y, lat, lon, geo_pool)
+    call mpas_get_tile(lat, lon, tile, tile_hash, geo_pool)
+    stack => mpas_stack_push(stack, tile)
+
+ end subroutine push_tile_neighbors
 
 !==================================================================================================
  subroutine init_atm_check_read_error(istatus, fname)
@@ -1264,6 +1570,32 @@ if (rarray(i,j,1) == 0) cycle
  end if
 
  end subroutine init_atm_check_read_error
+
+ !***********************************************************************
+ !
+ !  function convert_lx
+ !
+ !> \brief   Convert a latitude and longitude to cartisian x, y, z
+ !> \author  Michael G. Duda
+ !> \details 
+ !>  Convert a lat, lon coordinate to an x, y, z using a given radius.
+ !
+ !-----------------------------------------------------------------------
+ subroutine convert_lx(x, y, z, radius, lat, lon)
+
+    implicit none
+
+    real (kind=RKIND), intent(in) :: radius
+    real (kind=RKIND), intent(in) :: lat
+    real (kind=RKIND), intent(in) :: lon
+    real (kind=RKIND), intent(out) :: x, y, z
+
+    z = radius * sin(lat)
+    x = radius * cos(lon) * cos(lat)
+    y = radius * sin(lon) * cos(lat)
+
+ end subroutine convert_lx
+
 
 !==================================================================================================
  integer function nearest_cell(target_lat, target_lon, start_cell, nCells, maxEdges, &

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -101,6 +101,8 @@
 
  integer(c_int):: nx,ny,nz
  integer(c_int):: endian,isigned,istatus,wordsize
+ integer :: f_endian
+ integer :: signed
  integer:: i,j,k
  integer :: ii, jj
  integer:: iCell,iEdge,iVtx,iPoint,iTileStart,iTileEnd,jTileStart,jTileEnd
@@ -378,7 +380,7 @@
  call mpas_pool_get_config(geog_pool, 'known_lon', start_lon)
  call mpas_pool_get_config(geog_pool, 'known_x', start_x)
  call mpas_pool_get_config(geog_pool, 'known_y', start_y)
- call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
+ call mpas_pool_add_config(geog_pool, 'geog_dir_path', fname)
 
  f_endian = 0
  f_scalefactor = 1.0
@@ -392,8 +394,8 @@
  ! Create a hash table, mapping out each tile for quicker searching as
  ! well as enabling us to grab a tile's neighbors.
  !
- nTileX = int((360. / dx)) / tile_nx
- nTileY = int((180. / dy)) / tile_ny
+ nTileX = int((360.0_RKIND / dx)) / tile_nx
+ nTileY = int((180.0_RKIND / dy)) / tile_ny
  allocate(hash(0:nTileX, 0:nTileY)) 
 
  ! Add these values to the geo_pool
@@ -401,8 +403,8 @@
  call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
 
  ! Determine the amount of global pixels for this dataset
- pixel_nx = 360 / dx
- pixel_ny = 180 / dy
+ pixel_nx = 360.0_RKIND / dx
+ pixel_ny = 180.0_RKIND / dy
  call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
  call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
 
@@ -464,7 +466,7 @@
  ter(:) = 0
  ter_integer(:) = 0
 
- do cell = 1, nCells, 1
+ do cell = 1, nCells
 
     ! To insure that all the cells in our decompositions have values, check to see if 
     ! the nhs for that cells is greater then 0. If it is 0, then we have not added
@@ -478,7 +480,6 @@
     endif
 
     do while( .NOT. mpas_stack_is_empty(stack))
-      tile => null()
       tile => mpas_stack_pop_tile(stack)
 
       if ( tile % is_processed ) then
@@ -500,27 +501,26 @@
       ! we know that this tile is outside of our processor decomposition, so most likely
       ! so is its neighbors, so don't add them to the stack.
 
-      do j = 1 + tile_bdr, tile_ny + tile_bdr, 1
-         do i = 1 + tile_bdr, tile_nx + tile_bdr, 1
+      do j = 1 + tile_bdr, tile_ny + tile_bdr
+         do i = 1 + tile_bdr, tile_nx + tile_bdr
 
             tval = tile % tile(i, j, 1)
 
-            lat_pt = (j - (tile_bdr - 1) + real(tile % y(1)) - 1) * dy + start_lat
-            lon_pt = (i - (tile_bdr - 1) + real(tile % x(1)) - 1) * dx + start_lon
+            lat_pt = real((j - (tile_bdr + 1) + tile % y(1) - 1), kind=RKIND) * dy + start_lat
+            lon_pt = real((i - (tile_bdr + 1) + tile % x(1) - 1), kind=RKIND) * dx + start_lon
 
-            if (lon_pt < 0) then
-               lon_pt = lon_pt + 360
+            if (lon_pt < 0.0_RKIND) then
+               lon_pt = lon_pt + 360.0_RKIND
             endif
 
-            lat_pt = lat_pt * (pii / 180.0)
-            lon_pt = lon_pt * (pii / 180.0)
+            lat_pt = lat_pt * (pii / 180.0_RKIND)
+            lon_pt = lon_pt * (pii / 180.0_RKIND)
 
             ! Convert the pixel ll x, y to lat, lon and then to Cartesian coordinates
             ! (tile_bdr - 1) represents the 1 + tile_bdr start, and the later - 1 represent the
             ! subtraction to achieve zero based.
             call convert_lx(x, y, z, sphere_radius, lat_pt, lon_pt)
 
-            res => null()
             call mpas_kd_search(tree, (/x, y, z/), res)
 
             !
@@ -560,15 +560,12 @@
                   if (res % cell <= nCellsSolve) then
                      ALL_PIXELS_MAPPED_TO_HALO_CELLS = .FALSE.
                   endif
-
                endif
             endif
          enddo
       enddo
 
-      if (ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
-         ! Pass - All tiles mapped to its halo cells, so don't add any tiles to the stack
-      else
+      if (.NOT. ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
          ! Calculate the tile neighbors of the current tile and push them onto the stack
          call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
          call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
@@ -578,7 +575,7 @@
 
  ! Since we are taking an average of all the pixels that map to  a cell, divide each cell's 
  ! terrain value by the number of pixels that we alloted to it.
- do i = 1, nCells, 1
+ do i = 1, nCells
     ter(i) = real(ter_integer(i), kind=R8KIND) / real(nhs(i), kind=R8KIND)
  enddo
 
@@ -591,8 +588,8 @@
  call mpas_stack_free(stack, free_payload=.TRUE.)
 
  ! Use the hash table to deallocate each tile and then the hash itself.
- do i = 0, nTileX, 1
-    do j = 0, nTileY, 1
+ do i = 0, nTileX
+    do j = 0, nTileY
        if(associated(hash(i, j) % ptr)) then
           deallocate(hash(i, j) % ptr % tile)
           deallocate(hash(i, j) % ptr)
@@ -627,7 +624,6 @@
 
  allocate(tile_bdr)
  tile_bdr = 0
- isigned = .False.
 
  ! Read the index file for the choosen landuse dataset
  fname = trim(geog_data_path)//trim(geog_sub_path)
@@ -643,23 +639,18 @@
  call mpas_pool_get_config(geog_pool, 'known_x', start_x)
  call mpas_pool_get_config(geog_pool, 'known_y', start_y)
  call mpas_pool_add_config(geog_pool, 'tile_bdr', tile_bdr)
- call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
- call mpas_pool_add_config(geog_pool, 'signed', isigned_bool)
+ call mpas_pool_add_config(geog_pool, 'geog_dir_path', fname)
 
  f_endian = 0
  f_scalefactor = 1.0
+ signed = 0
  call mpas_pool_add_config(geog_pool, 'endian', f_endian)
  call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
+ call mpas_pool_add_config(geog_pool, 'signed', signed)
 
  ! Initalize the hash table
- !
- ! The tile_hash is used when searching, getting and adding tiles.
- ! See get_tile(...), search_tile(...) and add_tile(...)
- ! Create a hash table, mapping out each tile for quicker searching as
- ! well as enabling us to grab a tile's neighbors.
- !
- nTileX = int((360. / dx)) / tile_nx
- nTileY = int((180. / dy)) / tile_ny
+ nTileX = int((360.0_RKIND / dx)) / tile_nx
+ nTileY = int((180.0_RKIND / dy)) / tile_ny
  allocate(hash(0:nTileX, 0:nTileY)) 
 
  call mpas_log_write("nTileX: $i", intArgs=(/nTileX/))
@@ -670,8 +661,8 @@
  call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
 
  ! Determine the amount of global pixels for this dataset
- pixel_nx = 360 / dx
- pixel_ny = 180 / dy
+ pixel_nx = 360.0_RKIND / dx
+ pixel_ny = 180.0_RKIND / dy
  call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
  call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
 
@@ -681,9 +672,9 @@
  num_processed_tiles = 0
  allocate(ncat(ismax_lu,nCells))
  ncat(:,:) = 0
- lu_index(:) = 0.0
+ lu_index(:) = 0
 
- do cell = 1, nCells, 1
+ do cell = 1, nCells
 
    if (all(ncat(:,cell) == 0)) then
       call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, geog_pool)
@@ -691,7 +682,6 @@
    endif
 
    do while ( .NOT. mpas_stack_is_empty(stack))
-      tile => null()
       tile => mpas_stack_pop_tile(stack)
 
       if ( tile % is_processed ) then
@@ -707,16 +697,10 @@
       do j = 1 + tile_bdr, tile_ny + tile_bdr
          do i = 1 + tile_bdr, tile_nx + tile_bdr
 
-            !call mpas_log_write("about to read the tile: ")
-            !write(0,*) tile % tile
-
-            !call mpas_log_write("This Cat: i: $i j: $i - cat: $i ", intArgs=(/i, j, int(tile % tile(i,j))/))
-
-
-            lat_pt = (j - (tile_bdr + 1) + real(tile % y(1)) - 1) * dy + start_lat
-            lon_pt = (i - (tile_bdr + 1) + real(tile % x(1)) - 1) * dx + start_lon
+            lat_pt = real((j - (tile_bdr + 1) + tile % y(1)) - 1, kind=RKIND) * dy + start_lat
+            lon_pt = real((i - (tile_bdr + 1) + tile % x(1)) - 1, kind=RKIND) * dx + start_lon
          
-            if (lon_pt < 0) then
+            if (lon_pt < 0.0_RKIND) then
                lon_pt = lon_pt + 360.0_RKIND
             endif
 
@@ -756,9 +740,7 @@
              end if
          enddo
       enddo
-      if (ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
-         ! Pass - All pixels mapped to a halo cell, so don't add any neighboring tiles to the stack
-      else
+      if (.NOT. ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
          call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
          call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
       endif
@@ -815,7 +797,7 @@
  call mpas_pool_get_config(geog_pool, 'known_x', start_x)
  call mpas_pool_get_config(geog_pool, 'known_y', start_y)
  call mpas_pool_add_config(geog_pool, 'tile_bdr', tile_bdr)
- call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
+ call mpas_pool_add_config(geog_pool, 'geog_dir_path', fname)
 
  f_endian = 0
  f_scalefactor = 1.0
@@ -1085,7 +1067,7 @@
     call mpas_pool_get_config(geog_pool, 'known_y', start_y)
     call mpas_pool_get_config(geog_pool, 'tile_bdr', tile_bdr)
     call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
-    call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
+    call mpas_pool_add_config(geog_pool, 'geog_dir_path', fname)
 
     endian = 0
     msgval = real(-999.0,kind=R4KIND)*real(0.01,kind=R4KIND)
@@ -1703,6 +1685,12 @@
  end if
 
  call mpas_log_write('--- end interpolate ALBEDO12M')
+
+ ! Deallocate the kdcords
+ do i = 1, nCells ! TODO: Update mpas_kd_tree so we can call that module to free this
+    deallocate(kdcords(i) % point)
+ enddo
+ deallocate(kdcords)
 
  end subroutine init_atm_static
 

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -801,6 +801,9 @@
  ! Read the index file for the choosen landuse dataset
  fname = trim(geog_data_path)//'soiltype_top_30s/'
 
+ allocate(tile_bdr)
+ tile_bdr = 0
+
  call mpas_pool_create_pool(geog_pool)
  call mpas_parse_index(fname, geog_pool)
  call mpas_pool_get_config(geog_pool, 'dx', dx) ! The distance between two pixels
@@ -908,6 +911,8 @@
       if (.not. ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
          call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
          call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
+      else
+         write(0,*) "Not pushing anymore tiles"
       endif
    enddo
  enddo
@@ -925,7 +930,7 @@
  ! Deallocate the stack
  call mpas_stack_free(stack, free_payload=.TRUE.)
 
- ! Use the hash table to deallocate each tile and then the hash itself.
+! Use the hash table to deallocate each tile and then the hash itself.
  do i = 0, nTileX
     do j = 0, nTileY
        if(associated(hash(i, j) % ptr)) then
@@ -1061,84 +1066,130 @@
        call mpas_log_write('   Dataset will be supersampled by a factor of $i', intArgs=(/supersample_fac/))
     end if
 
-    nx = 1206
-    ny = 1206
-    nz = 1
-    isigned  = 1
-    endian   = 0
-    wordsize = 2
-    scalefactor = 0.01
-    msgval = real(-999.0,kind=R4KIND)*real(0.01,kind=R4KIND)
-    fillval = 0.0
-    allocate(rarray(nx,ny,nz))
     allocate(nhs(nCells))
     nhs(:) = 0
-    snoalb(:) = 0.0
+    snoalb(:) = 0
 
-    rarray_ptr = c_loc(rarray)
+    f_scalefactor = 0.01_RKIND
 
-    start_lat = 90.0 - 0.05 * 0.5 / supersample_fac
-    start_lon = -180.0 + 0.05 * 0.5 / supersample_fac
-    geog_sub_path = 'maxsnowalb_modis/'
+    fname = trim(geog_data_path)//'maxsnowalb_modis/'
+    call mpas_pool_create_pool(geog_pool)
+    call mpas_parse_index(fname, geog_pool)
+    call mpas_pool_get_config(geog_pool, 'dx', dx)
+    call mpas_pool_get_config(geog_pool, 'dy', dy)
+    call mpas_pool_get_config(geog_pool, 'tile_x', tile_nx)
+    call mpas_pool_get_config(geog_pool, 'tile_y', tile_ny)
+    call mpas_pool_get_config(geog_pool, 'known_lat', start_lat)
+    call mpas_pool_get_config(geog_pool, 'known_lon', start_lon)
+    call mpas_pool_get_config(geog_pool, 'known_x', start_x)
+    call mpas_pool_get_config(geog_pool, 'known_y', start_y)
+    call mpas_pool_get_config(geog_pool, 'tile_bdr', tile_bdr)
+    call mpas_pool_add_config(geog_pool, 'scalefactor', f_scalefactor)
+    call mpas_pool_add_config(geog_pool, 'topo_dir_path', fname)
 
-    do jTileStart = 1,02401,ny-6
-       jTileEnd = jTileStart + ny - 1 - 6
+    endian = 0
+    msgval = real(-999.0,kind=R4KIND)*real(0.01,kind=R4KIND)
+    fillval = 0.0
+    call mpas_pool_add_config(geog_pool, 'endian', endian)
 
-       do iTileStart=1,06001,nx-6
-          iTileEnd = iTileStart + nx - 1 - 6
-          write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)//trim(geog_sub_path), &
-                       iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
-          call mpas_log_write(trim(fname))
-          call mpas_f_to_c_string(fname, c_fname)
+    ! Allocate the hash table
+    nTileX = int((360.0_RKIND / dx)) / tile_nx
+    nTileY = int((180.0_RKIND / abs(dy))) / tile_ny
+    allocate(hash(0:nTileX, 0:nTileY))
 
-          call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                            scalefactor,wordsize,istatus)
-          call init_atm_check_read_error(istatus, fname)
+    call mpas_pool_add_config(geog_pool, 'nTileX', nTileX)
+    call mpas_pool_add_config(geog_pool, 'nTileY', nTileY)
 
-          iPoint = 1
-          do j=supersample_fac * 3 + 1, supersample_fac * (ny-3)
-          do i=supersample_fac * 3 + 1, supersample_fac * (nx-3)
-             ii = (i - 1) / supersample_fac + 1
-             jj = (j - 1) / supersample_fac + 1
+    ! Determine the amount of global pixels for this dataset
+    pixel_nx = 360.0_RKIND / dx
+    pixel_ny = 180.0_RKIND / dy
+    call mpas_pool_add_config(geog_pool, 'pixel_nx', pixel_nx)
+    call mpas_pool_add_config(geog_pool, 'pixel_ny', pixel_ny)
 
-             lat_pt = start_lat - (supersample_fac*(jTileStart-1) + j - (supersample_fac*3+1)) * 0.05 / supersample_fac
-             lon_pt = start_lon + (supersample_fac*(iTileStart-1) + i - (supersample_fac*3+1)) * 0.05 / supersample_fac
-             lat_pt = lat_pt * PI / 180.0
-             lon_pt = lon_pt * PI / 180.0
+    num_processed_tiles = 0
+    do cell = 1, nCells
 
-             iPoint = nearest_cell(lat_pt,lon_pt,iPoint,nCells,maxEdges, &
-                                   nEdgesOnCell,cellsOnCell, &
-                                   latCell,lonCell)
-             if (rarray(ii,jj,1) /= msgval) then
+       if(nhs(cell) == 0) then
+         call mpas_get_tile(latCell(cell), lonCell(cell), tile, hash, geog_pool)
+         stack => mpas_stack_push(stack, tile)
+      endif
 
-                !
-                ! This field only matters for land cells, and for all but the outermost boundary cells,
-                ! we can safely assume that the nearest model grid cell contains the pixel (else, a different
-                ! cell would be nearest)
-                !
-                if (landmask(iPoint) == 1 .and. bdyMaskCell(iPoint) < nBdyLayers) then
-                   snoalb(iPoint) = snoalb(iPoint) + rarray(ii,jj,1)
-                   nhs(iPoint) = nhs(iPoint) + 1
+      do while ( .not. mpas_stack_is_empty(stack))
+         tile => mpas_stack_pop_tile(stack)
 
-                ! For outermost land cells, additional work is needed to verify that the pixel
-                ! actually lies within the nearest cell
-                else if (landmask(iPoint) == 1) then
-                   zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
-                   xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
-                   yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+         if ( tile % is_processed ) then
+            cycle
+         else
+            tile % is_processed = .true.
+         endif
 
-                   if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
-                               nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
-                      snoalb(iPoint) = snoalb(iPoint) + rarray(ii,jj,1)
-                      nhs(iPoint) = nhs(iPoint) + 1
-                   end if
-                end if
-             end if
-          end do
-          end do
 
-       end do
-    end do
+         ALL_PIXELS_MAPPED_TO_HALO_CELLS = .true.
+
+         num_processed_tiles = num_processed_tiles + 1
+         call mpas_log_write("Processing a SNOALB tile ... $i - "//trim(tile%fname), intArgs=(/num_processed_tiles/))
+
+         do j = supersample_fac * tile_bdr + 1, supersample_fac * (tile_ny - tile_bdr) 
+            do i = supersample_fac * tile_bdr + 1, supersample_fac * (tile_nx - tile_bdr)
+               ii = (i - 1) / supersample_fac + 1
+               jj = (j - 1) / supersample_fac + 1
+
+               lat_pt = real(j - (supersample_fac * tile_bdr + 1) &
+                             + (supersample_fac * tile % y(1)) - 1, kind=RKIND) * (dy / supersample_fac) + start_lat 
+               lon_pt = real(i - (supersample_fac * tile_bdr + 1) &
+                             + (supersample_fac * tile % x(1)) - 1, kind=RKIND) * (dx / supersample_fac) + start_lon
+
+               if (lon_pt < 0.0_RKIND) then
+                  lon_pt = lon_pt + 360.0_RKIND
+               endif
+
+               lat_pt = lat_pt * (pii/180.0_RKIND)
+               lon_pt = lon_pt * (pii/180.0_RKIND)
+
+
+               call convert_lx(x, y, z, sphere_radius, lat_pt, lon_pt)
+               call mpas_kd_search(tree, (/x, y, z/), res)
+
+               if (tile % tile (ii,jj,1) /= msgval) then
+
+                   !
+                   ! This field only matters for land cells, and for all but the outermost boundary cells,
+                   ! we can safely assume that the nearest model grid cell contains the pixel (else, a different
+                   ! cell would be nearest)
+                   !
+                   if (landmask(res % cell) == 1 .and. bdyMaskCell(res % cell) < nBdyLayers) then
+                      snoalb(res % cell) = snoalb(res % cell) + tile % tile(ii,jj,1)
+                      nhs(res % cell) = nhs(res % cell) + 1
+
+                      if ( res % cell <= nCellsSolve ) then
+                         ALL_PIXELS_MAPPED_TO_HALO_CELLS = .false.
+                      endif
+                   ! For outermost land cells, additional work is needed to verify that the pixel
+                   ! actually lies within the nearest cell
+                   else if (landmask(res % cell) == 1) then
+                      zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
+                      xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
+                      yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
+
+                      if (in_cell(xPixel, yPixel, zPixel, xCell(res % cell), yCell(res % cell), zCell(res % cell), &
+                                  nEdgesOnCell(res % cell), verticesOnCell(:,res % cell), xVertex, yVertex, zVertex)) then
+                         snoalb(res % cell) = snoalb(res % cell) + tile % tile(ii,jj,1)
+                         nhs(res % cell) = nhs(res % cell) + 1
+                      end if
+         
+                      if (res % cell <= nCellsSolve) then
+                         ALL_PIXELS_MAPPED_TO_HALO_CELLS = .false.
+                      endif
+                  end if
+               end if
+            enddo
+         enddo
+         if (.not. ALL_PIXELS_MAPPED_TO_HALO_CELLS) then
+            call mpas_get_tile_neighbors(tile, up, down, left, right, geog_pool)
+            call push_tile_neighbors(stack, up, down, left, right, hash, geog_pool)
+         endif
+      enddo
+    enddo
 
     do iCell = 1,nCells
        !
@@ -1154,8 +1205,24 @@
        end if
        snoalb(iCell) = 0.01_RKIND * snoalb(iCell)        ! Convert from percent to fraction
     end do
-    deallocate(rarray)
     deallocate(nhs)
+
+    ! Deallocate the stack
+    call mpas_stack_free(stack, free_payload=.true.)
+
+    ! Use the hash table to deallocate each tile and then the hash itself
+    do i = 0, nTileX
+       do j = 0, nTileY
+          if (associated(hash(i, j) % ptr)) then
+               deallocate(hash(i, j) % ptr % tile)
+               deallocate(hash(i, j) % ptr)
+          endif
+       enddo
+    enddo
+    deallocate(hash)
+
+    call mpas_pool_destroy_pool(geog_pool)
+
 
  else if (trim(config_maxsnowalbedo_data) == 'NCEP') then
 

--- a/src/core_init_atmosphere/mpas_kd_tree.F
+++ b/src/core_init_atmosphere/mpas_kd_tree.F
@@ -1,0 +1,447 @@
+module mpas_kd_tree
+    
+   !***********************************************************************
+   !
+   !  module mpas_kd_tree
+   !
+   !> \brief   MPAS KD-Tree module
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !>
+   !>
+   !> TODO: Fail immediatly edge cases  
+   !>       1. Different number of dimensions
+   !>       2. No points
+   !>       3. No dimensions
+   !>
+   !> TODO: Add nn-search - Search for n nearest neighbors instead of only 1
+   !>
+   !
+   !-----------------------------------------------------------------------
+   implicit none
+
+   private
+
+   public :: kdnode
+
+   ! Public Subroutines
+   public :: mpas_kd_insert
+   public :: mpas_kd_construct
+   public :: mpas_kd_search
+   public :: mpas_kd_free
+
+   type kdnode
+      type (kdnode), pointer :: left => null()
+      type (kdnode), pointer :: right => null()
+
+      integer :: split_dim
+      real, dimension(:), pointer :: point
+      
+      integer :: cell
+      logical :: is_halo
+   end type kdnode
+
+   contains
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_insert
+   !
+   !> \brief   MPAS KD-Tree insert routine
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> This routine adds a point, `val(:)` to an existing KD-Tree or it creates 
+   !> a new kdtree if kdtree is not associated.
+   !>
+   !> The `dim` variable is an optional dummy argument and should not be set 
+   !> to zero, but preferably not used when starting with the root of a kdtree
+   !> i.e.:
+   !> 
+   !> call mpas_kdtree(kdtree, val)
+   !>
+   !> TODO: Create a wrapper?
+   !> TODO: Does insert work?
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine mpas_kd_insert(kdtree, val, dim)
+
+      implicit none
+
+      ! Input Variables
+      type(kdnode), intent(inout), pointer :: kdtree
+      real, dimension(:), intent(in) :: val
+      integer, optional, value :: dim
+
+      integer :: d 
+
+      if (.NOT. present(dim)) then
+         d = 0
+      else
+         d = dim
+      endif
+
+      d = modulo(d, size(val)) + 1
+
+      if ( .NOT. associated(kdtree)) then
+         allocate(kdtree)
+         allocate(kdtree % point(size(val)))
+         kdtree % left => null()
+         kdtree % right => null()
+         kdtree % split_dim = d
+         kdtree % point(:) = val(:)
+         return
+      endif
+
+      if (val(kdtree % split_dim ) > kdtree % point(kdtree % split_dim)) then
+         call mpas_kd_insert(kdtree % right, val, kdtree % split_dim)
+      else
+         call mpas_kd_insert(kdtree % left, val, kdtree % split_dim)
+      endif
+
+   end subroutine mpas_kd_insert
+
+   !***********************************************************************
+   !
+   !  recusrive routine mpas_kd_construct_internal
+   !
+   !> \brief   Create a KD-Tree from a set of k-Dimensional points
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Recursive function for mpas_kd_construct. See mpas_kd_construct for
+   !> more information.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   recursive function mpas_kd_construct_internal(points, ndims, npoints, dim) result(tree)
+
+      implicit none
+
+      ! Input Varaibles
+      !real, dimension(:,:) :: points
+      type (kdnode), dimension(:), target :: points
+      integer, intent(in) :: ndims
+      integer, value :: npoints
+      integer, value :: dim
+
+      ! Return Value
+      type (kdnode), pointer :: tree
+
+      ! Local Variables
+      integer :: median
+
+      if (npoints < 1) then
+         tree => null()
+         return
+      endif
+
+      ! Sort the points at the split dimension
+      dim = mod(dim, ndims) + 1
+      call quickSort(points, dim, 1, npoints, ndims)
+
+      median = (1 + npoints) / 2 
+
+      points(median) % split_dim = dim
+      tree => points(median)
+
+      ! Build the right and left sub-trees but do not include the 
+      ! node that was just allocated (i.e. points(:, median))
+      points(median)%left => mpas_kd_construct_internal(points(1:median-1), ndims, median - 1, points(median) % split_dim)
+      points(median)%right => mpas_kd_construct_internal(points(median+1:npoints), ndims, npoints - median, points(median) % split_dim)
+
+   end function mpas_kd_construct_internal
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_construct
+   !
+   !> \brief   Create a KD-Tree from a set of k-Dimensional points
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> This routine creates a balanced KD-Tree from a set of K-dimensional 
+   !> points via quicksort and it returns a pointer to the root node of that
+   !> tree. The points dummy argument, should be an array with the dimensions
+   !> defined as: `points(k, n)` with k being the number of dimensions, and n
+   !> being the number of points.    
+   !>
+   !> tree => mpas_kd_construct(points)
+   !>
+   !
+   !-----------------------------------------------------------------------
+   function mpas_kd_construct(points, ndims) result(tree)
+
+      implicit none
+
+      ! Input Varaibles
+      !real, dimension(:,:) :: points
+      type (kdnode), dimension(:) :: points
+      integer, intent(in) :: ndims
+
+      ! Return Value
+      type (kdnode), pointer :: tree
+
+      ! Local Varaibles
+      integer :: npoints
+
+      npoints = size(points)
+      
+      if(npoints < 1) then
+         ! No points were passed in, return null
+         write(0,*) "ERROR: mpas_kd_tree - No points were passed in to construct!"
+         tree => null()
+         return
+      endif
+
+      tree => mpas_kd_construct_internal(points(:), ndims, npoints, 0)
+
+   end function mpas_kd_construct
+
+   !***********************************************************************
+   !
+   !  recursive routine mpas_kd_search_internal
+   !
+   !> \brief   Find the nearest neighbor within a KD-Tree
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Recursive subroutine for mpas_kd_search. See mpas_kd_search for more
+   !> information.
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine mpas_kd_search_internal(kdtree, query, res, distance)
+
+      implicit none
+
+      ! Input Variables
+      type(kdnode), pointer, intent(in) :: kdtree
+      real, dimension(:), intent(in) :: query
+      type(kdnode), pointer, intent(inout) :: res
+      !real, dimension(:), intent(inout) :: res
+      real, intent(inout) :: distance
+
+      ! Local Values
+      real :: current_distance
+
+      current_distance = sum((kdtree % point(:) - query(:))**2)
+      if (current_distance < distance) then
+         distance = current_distance
+         res => kdtree
+      endif
+
+      !
+      ! To find the nearest point, we first attempt to find the point in the same manner
+      ! as a single deminsion BST.
+      !
+      ! However, because we are looking for the nearest neighbor, then there might be
+      ! a possibility that the nearest neighbor is on the otherside of the tree.
+      !
+      ! Thus, to determine if we need to search the opposite child we just searched, we
+      ! will compare the distance of the current minimum distance, and the root node
+      ! that we branched off of.
+      !
+      ! If the distance to the root node, is less then the current minimum distance,
+      ! then the nearist neighbor might be in opposite child.
+      !
+
+      ! TODO: Double precision calculations
+
+      if (query(kdtree % split_dim) > kdtree % point(kdtree % split_dim)) then
+         if (associated(kdtree % right)) then ! Search right
+            call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         endif
+         if ((kdtree % point(kdtree % split_dim) - query(kdtree % split_dim))**2 <= distance .AND. associated(kdtree % left)) then 
+            call mpas_kd_search_internal(kdtree % left, query, res, distance)
+         endif
+      else if (query(kdtree % split_dim) < kdtree % point(kdtree % split_dim)) then 
+         if (associated(kdtree % left)) then ! Search left
+            call mpas_kd_search_internal(kdtree % left, query, res, distance)
+         endif
+         if ((kdtree % point(kdtree % split_dim) - query(kdtree % split_dim))**2 <= distance .AND. associated(kdtree % right)) then
+            call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         endif
+      else ! Nearest point could be in either left or right subtree, so search both
+         if(associated(kdtree % right)) call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         if(associated(kdtree % left)) call mpas_kd_search_internal(kdtree % left, query, res, distance)
+      endif
+
+   end subroutine mpas_kd_search_internal
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_search
+   !
+   !> \brief   Find the nearest neighbor within a KD-Tree
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Find `point` within `kdtree` and return the nearest neighbor (or the point)
+   !> within `result` return the distance in `min_d`.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_kd_search(kdtree, query, res, distance)
+
+      implicit none
+      type(kdnode), pointer, intent(in) :: kdtree
+      real, dimension(:), intent(in) :: query
+      type(kdnode), pointer, intent(inout) :: res
+      real, intent(out), optional :: distance
+
+      real :: dis
+
+      if (size(kdtree % point) /= size(query)) then
+         write(0,*) "ERROR: Searching a ", size(kdtree % point), "dimensional kdtree for a point that only"
+         write(0,*) "ERROR: ", size(query), " dimensions. Please supply a point of equal"
+         write(0,*) "ERROR: dimensions!"
+         return
+      endif
+
+      dis = huge(dis)
+      call mpas_kd_search_internal(kdtree, query, res, dis)
+
+      if(present(distance)) then
+         distance = dis
+      endif
+
+   end subroutine mpas_kd_search
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_free
+   !
+   !> \brief   Free all nodes within a tree. 
+   !> \author  Miles A. Curry
+   !> \date    03/04/19
+   !> \details
+   !> Recursivly deallocate all nodes within `kdtree` including `kdtree` itself.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine mpas_kd_free(kdtree)
+
+      implicit none
+      type(kdnode), pointer :: kdtree
+
+      write(0,*) "in tree"
+
+      if (.not. associated(kdtree)) then
+         return
+      endif
+
+      if (associated(kdtree % left)) then
+         call mpas_kd_free(kdtree % left)
+      endif
+
+      if (associated(kdtree % right)) then
+         call mpas_kd_free(kdtree % right)
+      endif
+
+      deallocate(kdtree % point)
+      deallocate(kdtree)
+
+   end subroutine mpas_kd_free
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Sorts
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_quicksort
+   !
+   !> \brief   Sort an array along a dimension
+   !> \author  Miles A. Curry
+   !> \date    03/04/19
+   !> \details
+   !> Sort points starting from arrayStart, to arrayEnd along the given dimension 
+   !> `dim`. If two points are swapped, the entire K-Coordinate point are swapped.
+   !>
+   !> TODO: Change the name of this function to mpas_kd_quicksort
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine quickSort(array, dim, arrayStart, arrayEnd, ndims)
+
+      implicit none
+
+      ! Input Variables
+      !real, dimension(:,:) :: array
+      type (kdnode), dimension(:) :: array
+      integer, intent(in), value :: dim
+      integer, intent(in), value :: arrayStart, arrayEnd
+      integer, intent(in) :: ndims
+
+      ! Local Variables
+      type (kdnode) :: temp
+      real, dimension(ndims) :: pivot_value
+
+      integer :: l, r, pivot, s
+
+      if ((arrayEnd - arrayStart) < 1) then
+         return
+      endif
+
+      ! Create the left, right, and start pointers
+      l = arrayStart
+      r = arrayEnd - 1
+      s = l
+
+      pivot = (l+r)/2
+      pivot_value = array(pivot) % point
+
+      ! Move the pivot to the far right
+      temp = array(pivot)
+      array(pivot) = array(arrayEnd)
+      array(arrayEnd) = temp
+
+      do while ( .TRUE. )
+         ! Advance the left pointer until it is a value less then our pivot_value(dim)
+         do while ( .TRUE. )
+            if (array(l) % point(dim) < pivot_value(dim)) then
+               l = l + 1
+            else
+               exit
+            endif
+         enddo
+
+         ! Advance the right pointer until it is a value more then our pivot_value(dim)
+         do while ( .TRUE. )
+            if ( r <= 0 ) then
+               exit
+            endif
+
+            if(array(r) % point(dim) >= pivot_value(dim)) then
+               r = r - 1
+            else
+               exit
+            endif
+         enddo
+
+         if ( l >= r ) then 
+            exit
+         else ! Swap elements about the pivot
+            temp = array(l)
+            array(l) = array(r)
+            array(r) = temp
+         endif
+      enddo
+
+      ! Move the pivot to l ended up
+      temp = array(l)
+      array(l) = array(arrayEnd)
+      array(arrayEnd) = temp
+
+      !Quick Sort on the lower partition
+      call quickSort(array(:), dim, s, l-1, ndims)
+
+      !Quick sort on the upper partition
+      call quickSort(array(:), dim, l+1, arrayEnd, ndims)
+
+   end subroutine quicksort
+
+end module mpas_kd_tree

--- a/src/core_init_atmosphere/mpas_parse_geoindex.F
+++ b/src/core_init_atmosphere/mpas_parse_geoindex.F
@@ -88,16 +88,16 @@ module mpas_parse_geoindex
             allocate(int_t)
             read(rhs, *, iostat=READ_STAT, iomsg=READ_ERR_MSG) int_t
             call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
-         ! Booleans
+         ! Booleans - Now assigned to 0 or 1
          else if (lhs == 'signed') then
             if (trim(rhs) == 'yes' .OR. trim(rhs) == 'true' .OR. trim(rhs) == 'True' .OR. trim(rhs) == 'TRUE') then 
-               allocate(bool_t)
-               bool_t = .TRUE.
-               call mpas_pool_add_config(geo_pool, trim(lhs), bool_t)
+               allocate(int_t)
+               int_t = 1
+               call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
             else if (trim(rhs) == 'no' .OR. trim(rhs) == 'false' .OR. trim(rhs) == 'False' .OR. trim(rhs) == 'FALSE') then 
-               allocate(bool_t)
-               bool_t = .FALSE.
-               call mpas_pool_add_config(geo_pool, trim(lhs), bool_t)
+               allocate(int_t)
+               int_t = 0
+               call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
             else
                READ_STAT = -1
                READ_ERR_MSG = "Logical was not correct type"

--- a/src/core_init_atmosphere/mpas_parse_geoindex.F
+++ b/src/core_init_atmosphere/mpas_parse_geoindex.F
@@ -1,0 +1,122 @@
+module mpas_parse_geoindex
+
+   use mpas_log, only : mpas_log_write
+   use mpas_derived_types, only : MPAS_LOG_ERR, MPAS_LOG_WARN
+   use mpas_pool_routines
+
+   implicit none
+
+   private
+
+   public :: mpas_parse_index
+
+   contains
+
+   !***********************************************************************
+   !
+   !  subroutine mpas_parse_geoindex
+   !
+   !> \brief   Parse a geogrid's index file and put the results into geo_pool
+   !> \author  Miles A. Curry 
+   !> \date    03/25/2019
+   !> \details 
+   !>  Parse an index file and report type errors when they occured. Invalid types
+   !>  will cause the model to abort. Unrecognized options will be skipped. Lines 
+   !>  that start with a '#' will be treated as comments and will be ignored!
+   !>
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_parse_index(path, geo_pool)
+
+      implicit none
+      ! Input Variables
+      character (len=StrKIND), intent(in) :: path
+      type (mpas_pool_type), intent(inout), pointer :: geo_pool
+
+      ! Local Variables
+      character (len=StrKIND) :: index_path, line, lhs, rhs
+      character (len=StrKIND) :: READ_ERR_MSG
+      integer :: READ_STAT, LINE_READ_STAT
+      integer :: k
+      integer :: i, j
+      logical :: res
+
+      character (len=StrKIND), pointer :: char_t
+      integer, pointer :: int_t
+      real, pointer :: real_t
+      logical, pointer :: bool_t
+
+      index_path = trim(path)//"index"
+      inquire(file=index_path, exist=res)
+
+      if ( .not. res) then
+         call mpas_log_write("Index file for this geogrid was not found", messageType=MPAS_LOG_ERR)
+         call mpas_log_write("Location: "//index_path, messageType=MPAS_LOG_ERR)
+      endif
+
+      open(10, FILE=index_path, action='READ')
+
+      LINE_READ_STAT = 0
+      READ_STAT = 0
+      k = 0
+      do while ( LINE_READ_STAT == 0 )
+         read(10,'(A)', iostat=LINE_READ_STAT) line
+         k = k + 1
+
+         if (line(1:1) == '#') cycle
+
+         j = len(trim(line))
+         do i = 1, len(trim(line)), 1
+            if (line(i:i) == '=') then
+               lhs = adjustl(trim(line(1:i-1)))
+               rhs = adjustl(trim(line(i+1:len(trim(line)))))
+            endif
+         enddo
+
+         ! Strings
+         if(trim(lhs) == 'type' .OR. trim(lhs) == 'projection' .OR. trim(lhs) == 'units' .OR. trim(lhs) == 'description') then
+            allocate(char_t)
+            char_t = rhs   
+            call mpas_pool_add_config(geo_pool, trim(lhs), char_t)
+         else if ( trim(lhs) == 'dx' .OR. trim(lhs) == 'dy' .OR. trim(lhs) == 'known_x' .OR. trim(lhs) == 'known_y' &
+              .OR. trim(lhs) == 'known_lat' .OR. trim(lhs) == 'known_lon') then ! Reals
+            allocate(real_t)
+            read(rhs, *, iostat=READ_STAT, iomsg=READ_ERR_MSG) real_t
+            call mpas_pool_add_config(geo_pool, trim(lhs), real_t)
+         else if (trim(lhs) == 'tile_x' .OR. trim(lhs) == 'tile_y' .OR. trim(lhs) == 'tile_z' .OR. trim(lhs) == 'tile_bdr' &
+             .OR. trim(lhs) == 'wordsize') then ! Integers
+            allocate(int_t)
+            read(rhs, *, iostat=READ_STAT, iomsg=READ_ERR_MSG) int_t
+            call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
+         ! Booleans
+         else if (lhs == 'signed') then
+            if (trim(rhs) == 'yes' .OR. trim(rhs) == 'true' .OR. trim(rhs) == 'True' .OR. trim(rhs) == 'TRUE') then 
+               allocate(bool_t)
+               bool_t = .TRUE.
+               call mpas_pool_add_config(geo_pool, trim(lhs), bool_t)
+            else if (trim(rhs) == 'no' .OR. trim(rhs) == 'false' .OR. trim(rhs) == 'False' .OR. trim(rhs) == 'FALSE') then 
+               allocate(bool_t)
+               bool_t = .FALSE.
+               call mpas_pool_add_config(geo_pool, trim(lhs), bool_t)
+            else
+               READ_STAT = -1
+               READ_ERR_MSG = "Logical was not correct type"
+            endif
+          else
+            call mpas_log_write("Unrecognized keyword while reading "//trim(index_path)//".", messageType=MPAS_LOG_WARN)
+            call mpas_log_write("Unrecognized keyword: '"//trim(lhs)//"' on line $i. Skipping. ", intArgs=(/k/), &
+                               messageType=MPAS_LOG_WARN)
+         endif
+         if ( READ_STAT /= 0) then ! Report Type Error Here
+            close(10)
+            call mpas_log_write("Type error while reading "//trim(index_path)//".", messageType=MPAS_LOG_ERR)
+            call mpas_log_write(trim(READ_ERR_MSG)//" at line $i: "//line, intArgs=(/k/), messageType=MPAS_LOG_ERR)
+            call mpas_log_write("", messageType=MPAS_LOG_CRIT)
+         endif
+      enddo
+
+      close(10)
+   end subroutine mpas_parse_index
+
+
+end module mpas_parse_geoindex

--- a/src/core_init_atmosphere/mpas_parse_geoindex.F
+++ b/src/core_init_atmosphere/mpas_parse_geoindex.F
@@ -78,13 +78,16 @@ module mpas_parse_geoindex
             allocate(char_t)
             char_t = rhs   
             call mpas_pool_add_config(geo_pool, trim(lhs), char_t)
+         ! Reals
          else if ( trim(lhs) == 'dx' .OR. trim(lhs) == 'dy' .OR. trim(lhs) == 'known_x' .OR. trim(lhs) == 'known_y' &
-              .OR. trim(lhs) == 'known_lat' .OR. trim(lhs) == 'known_lon') then ! Reals
+              .OR. trim(lhs) == 'known_lat' .OR. trim(lhs) == 'known_lon' .OR. trim(lhs) == 'scale_factor') then
             allocate(real_t)
             read(rhs, *, iostat=READ_STAT, iomsg=READ_ERR_MSG) real_t
             call mpas_pool_add_config(geo_pool, trim(lhs), real_t)
+         ! Integers
          else if (trim(lhs) == 'tile_x' .OR. trim(lhs) == 'tile_y' .OR. trim(lhs) == 'tile_z' .OR. trim(lhs) == 'tile_bdr' &
-             .OR. trim(lhs) == 'wordsize') then ! Integers
+             .OR. trim(lhs) == 'wordsize' .OR. trim(lhs) == 'category_max' .OR. trim(lhs) == 'category_min' &
+             .OR. trim(lhs) == 'missing_value') then
             allocate(int_t)
             read(rhs, *, iostat=READ_STAT, iomsg=READ_ERR_MSG) int_t
             call mpas_pool_add_config(geo_pool, trim(lhs), int_t)

--- a/src/core_init_atmosphere/mpas_stack.F
+++ b/src/core_init_atmosphere/mpas_stack.F
@@ -1,0 +1,279 @@
+module mpas_stack
+    
+   implicit none
+
+   private
+
+   ! Public Subroutines and Structures
+   public :: mpas_stack_is_empty
+   public :: mpas_stack_push
+   public :: mpas_stack_pop
+   public :: mpas_stack_free
+
+   public :: node, payload_t
+
+   type payload_t
+   end type payload_t
+
+   type node
+      type (node), pointer :: next => null()
+      class (payload_t), pointer :: payload => null()
+   end type node
+
+   !***********************************************************************
+   !
+   !  module mpas_stack
+   !
+   !> \brief   MPAS KD-Tree module
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !> \details
+   !>
+   !> Introduction
+   !> ==============
+   !> The MPAS stack is a simple, extensible data stack data structure for use
+   !> within the MPAS atmospheric model. It functions as a wrapper around a 
+   !> data structure to provide usage in different areas.
+   !>
+   !>
+   !> Creating a Stack
+   !> ==================
+   !> The stack data structure (`type (node)`) is defined by a single `next` pointer
+   !> and a pointer to a `type (payload_t)`, which is defined as a empty derived type.
+   !>
+   !> To use the stack, create a derived type to fit your usage, this may be a point 
+   !> (x, y, z) a string or a more complicated object with multiple variables of 
+   !> different types within it. Define the class as the following:
+   !>
+   !> ```
+   !> type, extends(payload_t) :: my_payload_name
+   !>    ! Define your type as you wish
+   !> end type my_payload_name
+   !>
+   !> type (my_payload_name) :: item1, item2
+   !> ```
+   !>
+   !> This will enable your type to ride along with the stack. It will also enable
+   !> you to push the same payload twice (if need-be).
+   !>
+   !> You will then need to create a stack (or multiple stacks if you desire) as
+   !> the following:
+   !>
+   !> ```
+   !> type (node) :: stack1, stack2
+   !> ```
+   !> 
+   !>  Pushing onto a Stack
+   !>  ====================
+   !>  You can push your items onto a stack as:
+   !> 
+   !> ```
+   !> stack1 => mpas_satck_push(stack1, item1)
+   !> ```
+   !> 
+   !> Popping an item off of the stack
+   !> ================================
+   !> Popping an item off of the stack will require a bit more work then pushing.
+   !> Because we've done some fancy Fortran class polymorphism, we will need to 
+   !> use the select case to get our type (or multiple types) back into a usable
+   !> object.
+   !> 
+   !> 
+   !> ```
+   !> ! The item to pop items into
+   !> class (payload_t), pointer :: top
+   !> type (my_payload_name), pointer :: my_item
+   !> 
+   !> top => mpas_stack_pop(stack1)
+   !> select type(top)
+   !>    type is(my_payload_name)
+   !>       my_item => top
+   !> end  select
+   !> ```
+   !> 
+   !> Note: It is recommended to create your own `pop` function so you can limit 
+   !> reduce the amount of coded needed. An example is provided at the bottom of
+   !> this module as the function `my_pop(..)`
+   !
+   !-----------------------------------------------------------------------
+
+   contains
+
+   !***********************************************************************
+   !
+   !  routine mpas_stack_is_empty
+   !
+   !> \brief   Returns .TRUE. if the stack is empty, otherwise .FALSE.
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !>
+   !
+   !-----------------------------------------------------------------------
+   function mpas_stack_is_empty(stack) result(is_empty)
+
+      implicit none
+      type (node), intent(in), pointer :: stack
+      logical :: is_empty
+
+      is_empty = .TRUE.
+      if (associated(stack)) then
+         is_empty = .FALSE.
+         return
+      endif
+
+      return
+   end function mpas_stack_is_empty
+
+   !***********************************************************************
+   !
+   !  routine mpas_stack_push
+   !
+   !> \brief   Push an item onto stack
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !> \details
+   !>
+   !> Push a defined type that extends the payload_t type onto the specified
+   !> stack.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   function mpas_stack_push(stack, payload) result(new_stack)
+      
+      implicit none
+
+      type(node), intent(inout), pointer :: stack
+      class(payload_t), intent(inout), target :: payload
+
+      type(node), pointer :: new_stack
+      ! Allocate a new type(node) for the stack: new_stack
+      !  Point new_stack % payload => payload
+
+      allocate(new_stack)
+      new_stack % payload => payload
+      new_stack % next => stack
+
+      return
+
+   end function mpas_stack_push
+
+   !***********************************************************************
+   !
+   !  function mpas_stack_pop
+   !
+   !> \brief   Pop off the last item added from a stack 
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !> \details
+   !> Pop off the top of the stack as a payload_t type. Note, that to return
+   !> top to a user defined type, a 'select type' statment will need to be
+   !> used. See the top of this module for an explanation, or the bottom of
+   !> this module for an example function.
+   !
+   !-----------------------------------------------------------------------
+   function mpas_stack_pop(stack) result(top)
+
+      implicit none
+
+      type (node), intent(inout), pointer :: stack
+      class(payload_t), pointer :: top
+
+      if ( .NOT. associated(stack)) then
+         write(0,*) "I returned here :("
+         top => null()
+         return
+      endif
+
+      top => stack % payload
+      stack => stack % next
+      return
+
+   end function mpas_stack_pop
+
+   !***********************************************************************
+   !
+   !  function mpas_stack_free
+   !
+   !> \brief   Deallocate the entire stack. Optionally deallocate payloads
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !> \details
+   !>  Deallocate the entire stack. If free_payload is set to `.TRUE.` or absent
+   !>  then the payload will be deallocated. If not, then the payload will not
+   !>  be deallocated.
+   !  
+   !-----------------------------------------------------------------------
+   subroutine mpas_stack_free(stack, free_payload)
+
+      implicit none
+
+      type(node), intent(inout), pointer :: stack
+      logical, intent(in), optional :: free_payload
+      logical :: fpl
+
+      type(node), pointer :: cur, prev
+
+      if (present(free_payload)) then
+         fpl = free_payload
+      else
+         fpl = .TRUE.
+      endif
+
+      cur => stack
+      do while(associated(stack)) 
+         stack => stack % next
+         if ( fpl ) then
+            deallocate(cur % payload)
+         endif
+         deallocate(cur)
+         cur => stack
+      enddo
+
+   end subroutine mpas_stack_free
+
+
+   !***********************************************************************
+   !
+   !  Example user-defined pop function
+   !
+   !> \brief   Pop off the last item added from a stack and return it as our 
+   !>          defined type
+   !> \author  Miles A. Curry 
+   !> \date    04/04/19
+   !> 
+   !
+   !-----------------------------------------------------------------------
+   ! function my_pop(stack) result(item)
+   !
+   !    use mpas_stack, only : node, payload_t, mpas_stack_pop
+   !
+   !    implicit none
+   !
+   !    type(node), intent(inout), pointer :: stack
+   !
+   !    type(my_item), pointer :: item    ! Our user defined node
+   !    class(payload_t), pointer :: top  ! We will need to use the payload_t type to use mpas_stack_pop(...)
+   !
+   !    !
+   !    ! Handle a pop on an empty stack if we want to here
+   !    ! Note the stack will return null if it is empty.
+   !    !
+   !    if (mpas_stack_is_empty(stack)) then
+   !       write(0,*) "The stack was empty!"
+   !       return
+   !    endif
+   ! 
+   !    top => mpas_stack_pop(stack)
+   !    
+   !    select type(top)
+   !       type is(my_item)
+   !          item => top
+   !       class default
+   !          write(0,*) "We got an Error and we should handle it if we need to!!"
+   !          stop
+   !    end select
+
+
+
+end module mpas_stack
+

--- a/src/core_init_atmosphere/read_tile.c
+++ b/src/core_init_atmosphere/read_tile.c
@@ -1,0 +1,136 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/* Opens and reads a binary tile file and returns its contents into an array.
+
+
+   The interface for the following function is described as:
+
+   use iso_c_binding, only : c_int, c_char, c_float, c_ptr, c_loc
+ 
+   interface
+      integer (c_int) function c_get_tile(file, nx, ny, x_halo, y_halo, word_size, tile) bind(C)
+         use iso_c_binding, only : c_int, c_char, c_float, c_ptr
+         character (c_char), intent(in) :: file
+         integer (c_int), intent(in), value :: nx
+         integer (c_int), intent(in), value :: ny
+         integer (c_int), intent(in), value :: x_halo
+         integer (c_int), intent(in), value :: y_halo
+         integer (c_int), intent(in), value :: word_size
+         type (c_ptr), value :: tile
+      end function c_get_tile
+   end interface
+
+
+   To pass in the tile argument do the following in fortran:
+
+
+   ! Define the tile with attributes POINTER, and CONTIGUOUS
+   ! and a define a c_ptr.
+
+   real (c_float), dimension(:,:), pointer, contiguous :: tile
+   type (c_ptr) :: tile_ptr
+
+   ! Then set the c_ptr point to our contiguous tile. After tile tile_ptr
+   ! will be 'pointing' to our tile.
+
+   tile_ptr = c_loc(tile)
+
+   ! Then pass it into C:
+
+   iErr = c_get_tile(file, nx, ny, x_halo, y_halo, word_size, tile_ptr)
+
+
+
+   Because we have defined our tile array to be CONTIGUOUS, we can safely pass
+   the c_loc (ie the address) to C and have C loop over its contents via
+   implicit pointer arithmatic!
+
+*/
+
+#define GEOG_BIG_ENDIAN 0
+#define GEOG_LITTLE_ENDIAN 1
+
+/* int c_get_tile(char *file, int nx, int ny, int *tile[nx][ny])
+ *
+ * char *file        - The path, realtive or absolute to the file
+ * int nx            - The size of the x direction of the tile
+ * int ny            - The size of the y direction of the tile
+ * int *tile[nx][ny] - The array to hold the tile values on return
+ *
+ * returns - 1 if success and -1 if file does not exist
+ */
+
+int c_get_tile(char *file, 
+               int nx, 
+               int ny, 
+               int x_halo, 
+               int y_halo, 
+               int word_size, 
+               float* tile)
+{
+    int fd;                /* File Descriptor */
+    int i, j;
+    unsigned char *buf;
+	 size_t numBytes = 0;
+    int value = 0;
+
+    int narray = (nx + x_halo) * (ny + y_halo); /* Extent of bytes we have to read */
+    float tile_1d[narray];             
+
+    /* Allocate enough space for the entire file */
+    buf = (unsigned char *) malloc(sizeof(unsigned char)*(word_size) * narray);
+
+    fd = open(file, O_RDONLY);
+    if (fd == -1){
+		perror("OPEN ERROR: ");
+        printf("C filename was: %s\n", file);
+        return -1;
+    }
+
+    numBytes = read(fd, buf, word_size * narray); // Read in all the values at once
+    if (numBytes == -1){
+        perror("READ ERROR: ");
+        return -1;
+    }
+    if(close(fd) == -1){
+        perror("CLOSE ERROR: ");
+        return -1;
+    }
+
+
+    for(i=0; i < narray ; i++){
+        switch(word_size) {
+            case 2: 
+                /* Shift the first byte read by 8 bytes to make room for the 
+                 * 2nd byte we have read.
+                 */
+
+                value = (int) (buf[ word_size * i ] << 8 | buf[ word_size * i + 1 ]);
+
+                /* Special case for a negative value. Our sign bit is currently
+                 * at the most significant bit (MSB) for an 8-bit value, but it 
+                 * needs to bet at the MSB for a 16-bit value.
+                 */
+                if(buf[word_size * i] >> 7 == 1)
+                    value -= 1 << ( 8 * word_size);
+                tile_1d[i] = (float) value;
+                break;
+        }
+    }
+
+    for(i=0; i < nx + x_halo; i++){
+        for(j=0; j < ny + y_halo; j++){
+            /* Place the values into the fortran interoperable array and return */
+            tile[j * (nx + x_halo) + i] = tile_1d[ j * (nx + x_halo) + i ];
+        }
+    }
+
+    free(buf);
+
+    return 1;
+}


### PR DESCRIPTION
This PR introduces changes to the `init_atmosphere_core` that parallelize the interpolation of static fields including terrain, land use, soil category, landmask, snow albedo, green fraction and albedo 12m.

This PR (currently) serves as a staging ground for the completion of the above to better manage, bugs, code cleanup, and static fields left to do.



Static Fields Still to Do:
- [x] Terrain (ter) - Completed
- [x] Landuse (ivgtyp) - Completed
- [x] Soil Cat (isltyp) - Currently Doing
- [x] Snow albedo (snoalb)
- [ ] Green Frac (greenfrac)
- [ ] 12m Albedo (albedo12m)

### Terrain
- [x] Implementation 
- [x] Testing
- [x] Correct?
### Landuse
- [x] Implementation 
- [x] Testing
- [x] Correct?
### Soil Cat
- [x] Implementation 
- [x] Testing
- [x] Correct?
### Snow Albedo
- [x] Implementation 
- [x] Testing
- [x] Correct?
### Green Fraction
- [ ] Implementation 
- [ ] Testing
- [ ] Correct?
### 12m Albedo
- [ ] Implementation 
- [ ] Testing
- [ ] Correct?
### General clean-up
- [x] Ensure that all real constants are of the form X.Y_RKIND (e.g., `360.0_RKIND`)
- [x] When using `int` to convert a real to an integer, consider whether we should instead use `nint`
- [x] When type converting to a real, include the optional kind (e.g., `real(nx, kind=RKIND)`)
- [x] Eliminate loop strides of 1 (e.g., change `do i=1,nx,1` to `do i=1,nx`)
### Other
- [ ] KD Tree testing
- [x] Stack Free
- [x] Update to use `read_geogrid.c`
- [ ] Change the branch name to 'init_atmosphere/parallel_static_interp
- [x] Update reals to X.X_RKIND

