### PR TITLE
Fix particle animation script's VTK generation to allow for particle pathlines in ParaView

### DIFF
--- a/testing_and_setup/compass/utility_scripts/LIGHTparticles/animated_particles.py
+++ b/testing_and_setup/compass/utility_scripts/LIGHTparticles/animated_particles.py
@@ -79,7 +79,9 @@ def build_particle_file(fname_in, fname_outbase):
 
         # get particle data
         particleData.clear()
-        for v in f_in.variables:
+        coordinateVars = ['xParticle', 'yParticle', 'zParticle']
+        nonCoords = [i for i in f_in.variables if i not in coordinateVars]
+        for v in nonCoords:
             dim = f_in.variables[v].dimensions
             if dim == particleType:
                 particleData[str(v)] = cleanup(f_in.variables[v][t])


### PR DESCRIPTION
@xylar, @pwolfram, this builds on https://github.com/MPAS-Dev/MPAS-Model/pull/252 and will thus be rebased and merged after it. I wanted to open the discussion here while we work on where to merge https://github.com/MPAS-Dev/MPAS-Model/pull/252. 

This PR fixes the VTK generation in `animated_particles.py`. In the previous version, the generated VTK file had `xParticle`, `yParticle`, `zParticle` as booth coordinate and point data in the VTK file. This is not only an inaccurate representation of the output, but it also breaks some of the nice particle filters in ParaView.

---

Upon running the new `animated_particles` and importing the `.pvd` file, one can run the filter `TemporalParticlesToPathlines` directly on the output to generate pathlines of particle trajectories. Note that this feature broke in the previous version of the script, since xyz information was duplicated as point data.

Here's a demo on some LIGHT output from our 30to10 run with BGC. Key properties to input after applying the filter to get this to work:

![Screen Shot 2019-05-20 at 10 53 05 AM](https://user-images.githubusercontent.com/8881170/58038622-9d83a900-7aed-11e9-9267-74e11efeb8b3.png)

Where `Mask Points` is the stride value (i.e., the Nth particle to compute the pathline for), `Max Track Length` is how many timesteps to retain on the pathline visualization. `Max Step Distance` is how long of a spatial step to allow for particles (this is crucial since we are working on true Earth coordinates).  A glyph filter can be applied to the `particles` partition of the filter, and a tube filter to the `pathlines` partition as well.

**Note**: You have to advance the time to see the pathlines appear.

Some images from every 5th surface float in our 30to10 run. Coloring is the time-history DIC for each float at 2-day recording intervals

![Screen Shot 2019-05-20 at 11 08 37 AM](https://user-images.githubusercontent.com/8881170/58039320-aa090100-7aef-11e9-9d86-7e4f87a17bde.png)

![Screen Shot 2019-05-20 at 11 11 36 AM](https://user-images.githubusercontent.com/8881170/58039451-0e2bc500-7af0-11e9-9851-065e1100a9bf.png)