### PR TITLE
Adds testing of aerosols with shortwave feedbacks

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -3753,7 +3753,6 @@
 		<var name="totalChlorophyll"			type="real"	dimensions="nCells Time"				name_in_code="totalChlorophyll"
 			units="mg/m^2"
 			description="Ice integrated chlorophyll concentration per cell"
-			packages="pkgTracerVerticalAlgae;pkgTracerSkeletalAlgae"
 		/>
 		<var name="totalNitrate"			type="real"	dimensions="nCells Time"				name_in_code="totalNitrate"
 			units="mmol/m^3"

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -12491,40 +12491,54 @@ contains
     logical, pointer :: &
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
-         config_use_column_package
+         config_use_column_package, &
+         config_use_vertical_biochemistry, &
+         config_use_vertical_zsalinity
 
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
 
-    if (config_use_column_package) then
+     if (config_use_column_package) then
 
        block => domain % blocklist
        do while (associated(block))
 
           ! biogeochemistry
           call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
+          call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
+          call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
 
           if (config_use_column_biogeochemistry) then
 
              call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistryPool)
 
-             call MPAS_pool_get_array(biogeochemistryPool, "primaryProduction", primaryProduction)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalChlorophyll", totalChlorophyll)
-             call MPAS_pool_get_array(biogeochemistryPool, "netSpecificAlgalGrowthRate", netSpecificAlgalGrowthRate)
+             if (config_use_vertical_biochemistry) then
+                call MPAS_pool_get_array(biogeochemistryPool, "primaryProduction", primaryProduction)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalChlorophyll", totalChlorophyll)
+                call MPAS_pool_get_array(biogeochemistryPool, "netSpecificAlgalGrowthRate", netSpecificAlgalGrowthRate)
+
+                primaryProduction          = 0.0_RKIND
+                totalChlorophyll           = 0.0_RKIND
+                netSpecificAlgalGrowthRate = 0.0_RKIND
+
+             end if
+
+             if (config_use_vertical_zsalinity) then
+                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityFlux", zSalinityFlux)
+                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityGDFlux", zSalinityGDFlux)
+
+                zSalinityFlux              = 0.0_RKIND
+                zSalinityGDFlux            = 0.0_RKIND
+
+             end if
+
              call MPAS_pool_get_array(biogeochemistryPool, "netBrineHeight", netBrineHeight)
-             call MPAS_pool_get_array(biogeochemistryPool, "zSalinityFlux", zSalinityFlux)
-             call MPAS_pool_get_array(biogeochemistryPool, "zSalinityGDFlux", zSalinityGDFlux)
              call MPAS_pool_get_array(biogeochemistryPool, "oceanBioFluxes", oceanBioFluxes)
              call MPAS_pool_get_array(biogeochemistryPool, "atmosIceBioFluxes", atmosIceBioFluxes)
              call MPAS_pool_get_array(biogeochemistryPool, "snowIceBioFluxes", snowIceBioFluxes)
              call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologyIce", totalVerticalBiologyIce)
              call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologySnow", totalVerticalBiologySnow)
 
-             primaryProduction          = 0.0_RKIND
-             totalChlorophyll           = 0.0_RKIND
-             netSpecificAlgalGrowthRate = 0.0_RKIND
              netBrineHeight             = 0.0_RKIND
-             zSalinityFlux              = 0.0_RKIND
-             zSalinityGDFlux            = 0.0_RKIND
              oceanBioFluxes             = 0.0_RKIND
              atmosIceBioFluxes          = 0.0_RKIND
              snowIceBioFluxes           = 0.0_RKIND

--- a/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -30,6 +30,8 @@
     config_do_restart_hbrine = false
     config_do_restart_zsalinity = false
     config_do_restart_bgc = false
+    config_do_restart_snow_density = false
+    config_do_restart_snow_grain_radius = false
 /
 &dimensions
     config_nCategories = 5
@@ -99,6 +101,7 @@
     config_use_column_biogeochemistry = true
     config_use_column_itd_thermodynamics = true
     config_use_column_ridging = true
+    config_use_column_snow_tracers = false
 /
 &column_tracers
     config_use_ice_age = true
@@ -108,6 +111,8 @@
     config_use_level_meltponds = true
     config_use_topo_meltponds = false
     config_use_aerosols = false
+    config_use_effective_snow_density = false
+    config_use_snow_grain_radius = false
 /
 &biogeochemistry
     config_use_brine = true
@@ -268,6 +273,16 @@
     config_temp_change_snow_grain_radius_change = 1.5
     config_max_melting_snow_grain_radius = 1500.0
     config_algae_absorption_coefficient = 0.6
+/
+&snow
+    config_snow_redistribution_scheme = 'none'
+    config_fallen_snow_radius = 54.526
+    config_use_snow_liquid_ponds = false
+    config_new_snow_density = 100.0
+    config_max_snow_density = 450.0
+    config_minimum_wind_compaction = 10.0
+    config_wind_compaction_factor = 27.3
+    config_max_dry_snow_radius = 1500.0
 /
 &meltponds
     config_snow_to_ice_transition_depth = 0.0

--- a/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -1,0 +1,486 @@
+&seaice_model
+    config_dt = 3600.0
+    config_calendar_type = 'gregorian_noleap'
+    config_start_time = '2000-01-01_00:00:00'
+    config_stop_time = 'none'
+    config_run_duration = '00-00-01_00:00:00'
+    config_num_halos = 2
+/
+&io
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+    config_write_output_on_startup = false
+    config_test_case_diag = false
+    config_test_case_diag_type = 'none'
+    config_full_abort_write = true
+/
+&decomposition
+    config_block_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_number_of_blocks = 0
+    config_explicit_proc_decomp = false
+    config_proc_decomp_file_prefix = 'graphs/graph.info.part.'
+    config_use_halo_exch = true
+    config_aggregate_halo_exch = false
+    config_reuse_halo_exch = false
+    config_load_balance_timers = false
+/
+&restart
+    config_do_restart = false
+    config_restart_timestamp_name = 'restart_timestamp'
+    config_do_restart_hbrine = false
+    config_do_restart_zsalinity = false
+    config_do_restart_bgc = false
+/
+&dimensions
+    config_nCategories = 5
+    config_nIceLayers = 7
+    config_nSnowLayers = 1
+/
+&initialize
+    config_initial_condition_type = 'cice_default'
+    config_initial_ice_area = 1.0
+    config_initial_ice_volume = 1.0
+    config_initial_snow_volume = 0.0
+    config_initial_latitude_north = 70.0
+    config_initial_latitude_south = -60.0
+    config_initial_velocity_type = 'uniform'
+    config_initial_uvelocity = 0.0
+    config_initial_vvelocity = 0.0
+    config_calculate_coriolis = true
+/
+&use_sections
+    config_use_velocity_solver = true
+    config_use_advection = true
+    config_use_forcing = true
+    config_use_column_package = true
+/
+&forcing
+    config_atmospheric_forcing_type = 'CORE'
+    config_forcing_start_time = '2000-01-01_00:00:00'
+    config_forcing_cycle_start = '2000-01-01_00:00:00'
+    config_forcing_cycle_duration = '2-00-00_00:00:00'
+    config_forcing_precipitation_units = 'mm_per_sec'
+    config_forcing_sst_type = 'ncar'
+    config_update_ocean_fluxes = false
+    config_include_pond_freshwater_feedback = false
+/
+&unit_test
+    config_perform_unit_test = false
+    config_unit_test_type = ''
+    config_unit_test_subtype = ''
+    config_use_test_ice_shelf = false
+    config_testing_system_test = false
+/
+&velocity_solver
+    config_dynamics_subcycle_number = 1
+    config_rotate_cartesian_grid = true
+    config_include_metric_terms = true
+    config_elastic_subcycle_number = 120
+    config_stress_divergence_scheme = 'variational'
+    config_variational_basis = 'wachspress'
+    config_wachspress_integration_type = 'dunavant'
+    config_wachspress_integration_order = 8
+    config_revised_evp = false
+    config_use_air_stress = true
+    config_use_ocean_stress = true
+    config_use_surface_tilt = true
+    config_geostrophic_surface_tilt = true
+/
+&advection
+    config_advection_type = 'incremental_remap'
+    config_monotonic = true
+    config_conservation_check = false
+    config_monotonicity_check = false
+    config_recover_tracer_means_check = false
+/
+&column_package
+    config_use_column_shortwave = true
+    config_use_column_vertical_thermodynamics = true
+    config_use_column_biogeochemistry = true
+    config_use_column_itd_thermodynamics = true
+    config_use_column_ridging = true
+/
+&column_tracers
+    config_use_ice_age = true
+    config_use_first_year_ice = true
+    config_use_level_ice = true
+    config_use_cesm_meltponds = false
+    config_use_level_meltponds = true
+    config_use_topo_meltponds = false
+    config_use_aerosols = false
+/
+&biogeochemistry
+    config_use_brine = true
+    config_use_vertical_zsalinity = false
+    config_use_vertical_biochemistry = false
+    config_use_shortwave_bioabsorption = true
+    config_use_vertical_tracers = true
+    config_use_skeletal_biochemistry = false
+    config_use_nitrate = false
+    config_use_carbon = false
+    config_use_chlorophyll = false
+    config_use_ammonium = false
+    config_use_silicate = false
+    config_use_DMS = false
+    config_use_nonreactive = false
+    config_use_humics = false
+    config_use_DON = false
+    config_use_iron = false
+    config_use_modal_aerosols = false
+    config_use_zaerosols = true
+    config_skeletal_bgc_flux_type = 'Jin2006'
+    config_scale_initial_vertical_bgc = false
+    config_biogrid_bottom_molecular_sublayer = 0.006
+    config_biogrid_top_molecular_sublayer = 0.006
+    config_bio_gravity_drainage_length_scale = 0.024
+    config_zsalinity_molecular_sublayer = 0.0
+    config_zsalinity_gravity_drainage_scale = 0.028
+    config_snow_porosity_at_ice_surface = -0.3
+    config_new_ice_fraction_biotracer = 0.80
+    config_fraction_biotracer_in_frazil = 0.80
+    config_ratio_Si_to_N_diatoms = 1.80
+    config_ratio_Si_to_N_small_plankton = 0.00
+    config_ratio_Si_to_N_phaeocystis = 0.00
+    config_ratio_S_to_N_diatoms = 0.03
+    config_ratio_S_to_N_small_plankton = 0.03
+    config_ratio_S_to_N_phaeocystis = 0.03
+    config_ratio_Fe_to_C_diatoms = 0.0033
+    config_ratio_Fe_to_C_small_plankton = 0.0033
+    config_ratio_Fe_to_C_phaeocystis = 0.1
+    config_ratio_Fe_to_N_diatoms = 0.023
+    config_ratio_Fe_to_N_small_plankton = 0.023
+    config_ratio_Fe_to_N_phaeocystis = 0.7
+    config_ratio_Fe_to_DON = 0.023
+    config_ratio_Fe_to_DOC_saccharids = 0.1
+    config_ratio_Fe_to_DOC_lipids = 0.033
+    config_respiration_fraction_of_growth = 0.05
+    config_rapid_mobile_to_stationary_time = 5200.0
+    config_long_mobile_to_stationary_time = 173000.0
+    config_algal_maximum_velocity = 0.0000005
+    config_ratio_Fe_to_dust = 0.035
+    config_solubility_of_Fe_in_dust = 0.005
+    config_chla_absorptivity_of_diatoms = 0.03
+    config_chla_absorptivity_of_small_plankton = 0.01
+    config_chla_absorptivity_of_phaeocystis = 0.05
+    config_light_attenuation_diatoms = 0.3
+    config_light_attenuation_small_plankton = 0.2
+    config_light_attenuation_phaeocystis = 0.17
+    config_light_inhibition_diatoms = 0.002
+    config_light_inhibition_small_plankton = 0.001
+    config_light_inhibition_phaeocystis = 0.17
+    config_maximum_growth_rate_diatoms = 0.81
+    config_maximum_growth_rate_small_plankton = 0.41
+    config_maximum_growth_rate_phaeocystis = 0.63
+    config_temperature_growth_diatoms = 0.06
+    config_temperature_growth_small_plankton = 0.06
+    config_temperature_growth_phaeocystis = 0.06
+    config_grazed_fraction_diatoms = 0.0
+    config_grazed_fraction_small_plankton = 0.7
+    config_grazed_fraction_phaeocystis = 0.7
+    config_mortality_diatoms = 0.007
+    config_mortality_small_plankton = 0.007
+    config_mortality_phaeocystis = 0.007
+    config_temperature_mortality_diatoms = 0.03
+    config_temperature_mortality_small_plankton = 0.03
+    config_temperature_mortality_phaeocystis = 0.03
+    config_exudation_diatoms = 0.0
+    config_exudation_small_plankton = 0.0
+    config_exudation_phaeocystis = 0.0
+    config_nitrate_saturation_diatoms = 1.0
+    config_nitrate_saturation_small_plankton = 1.0
+    config_nitrate_saturation_phaeocystis = 1.0
+    config_ammonium_saturation_diatoms = 0.3
+    config_ammonium_saturation_small_plankton = 0.3
+    config_ammonium_saturation_phaeocystis = 0.3
+    config_silicate_saturation_diatoms = 4.0
+    config_silicate_saturation_small_plankton = 0.0
+    config_silicate_saturation_phaeocystis = 0.0
+    config_iron_saturation_diatoms = 1.0
+    config_iron_saturation_small_plankton = 0.2
+    config_iron_saturation_phaeocystis = 0.1
+    config_fraction_spilled_to_DON = 0.6
+    config_degredation_of_DON = 0.03
+    config_fraction_DON_ammonium = 0.25
+    config_fraction_loss_to_saccharids = 0.4
+    config_fraction_loss_to_lipids = 0.4
+    config_fraction_exudation_to_saccharids = 1.0
+    config_fraction_exudation_to_lipids = 1.0
+    config_remineralization_saccharids = 0.03
+    config_remineralization_lipids = 0.03
+    config_maximum_brine_temperature = 0.0
+    config_salinity_dependence_of_growth = 1.0
+    config_minimum_optical_depth = 0.1
+    config_slopped_grazing_fraction = 0.5
+    config_excreted_fraction = 0.5
+    config_fraction_mortality_to_ammonium = 0.5
+    config_fraction_iron_remineralized = 0.3
+    config_nitrification_rate = 0.0
+    config_desorption_loss_particulate_iron = 3065.0
+    config_maximum_loss_fraction = 0.9
+    config_maximum_ratio_iron_to_saccharids = 0.2
+    config_respiration_loss_to_DMSPd = 0.75
+    config_DMSP_to_DMS_conversion_fraction = 0.5
+    config_DMSP_to_DMS_conversion_time = 3.0
+    config_DMS_oxidation_time = 10.0
+    config_mobility_type_diatoms = 0.0
+    config_mobility_type_small_plankton = 0.0
+    config_mobility_type_phaeocystis = 0.0
+    config_mobility_type_nitrate = -1.0
+    config_mobility_type_ammonium = 1.0
+    config_mobility_type_silicate = -1.0
+    config_mobility_type_DMSPp = 0.5
+    config_mobility_type_DMSPd = 0.5
+    config_mobility_type_humics = 1.0
+    config_mobility_type_saccharids = 0.5
+    config_mobility_type_lipids = 0.5
+    config_mobility_type_proteins = 0.5
+    config_mobility_type_dissolved_iron = 0.5
+    config_mobility_type_particulate_iron = 0.5
+    config_mobility_type_black_carbon1 = 1.0
+    config_mobility_type_black_carbon2 = 1.0
+    config_mobility_type_dust1 = 1.0
+    config_mobility_type_dust2 = 1.0
+    config_mobility_type_dust3 = 1.0
+    config_mobility_type_dust4 = 1.0
+    config_ratio_C_to_N_diatoms = 7.0
+    config_ratio_C_to_N_small_plankton = 7.0
+    config_ratio_C_to_N_phaeocystis = 7.0
+    config_ratio_chla_to_N_diatoms = 2.1
+    config_ratio_chla_to_N_small_plankton = 1.1
+    config_ratio_chla_to_N_phaeocystis = 0.84
+    config_scales_absorption_diatoms = 2.0
+    config_scales_absorption_small_plankton = 4.0
+    config_scales_absorption_phaeocystis = 5.0
+    config_ratio_C_to_N_proteins = 7.0
+/
+&shortwave
+    config_shortwave_type = 'dEdd'
+    config_albedo_type = 'ccsm3'
+    config_use_snicar = false
+    config_visible_ice_albedo = 0.78
+    config_infrared_ice_albedo = 0.36
+    config_visible_snow_albedo = 0.98
+    config_infrared_snow_albedo = 0.70
+    config_variable_albedo_thickness_limit = 0.3
+    config_ice_shortwave_tuning_parameter = 0.0
+    config_pond_shortwave_tuning_parameter = 0.0
+    config_snow_shortwave_tuning_parameter = 1.5
+    config_temp_change_snow_grain_radius_change = 1.5
+    config_max_melting_snow_grain_radius = 1500.0
+    config_algae_absorption_coefficient = 0.6
+/
+&meltponds
+    config_snow_to_ice_transition_depth = 0.0
+    config_pond_refreezing_type = 'hlid'
+    config_pond_flushing_timescale = 1.0e-3
+    config_min_meltwater_retained_fraction = 0.15
+    config_max_meltwater_retained_fraction = 1.0
+    config_pond_depth_to_fraction_ratio = 0.8
+    config_snow_on_pond_ice_tapering_parameter = 0.03
+    config_critical_pond_ice_thickness = 0.01
+/
+&thermodynamics
+    config_thermodynamics_type = 'mushy'
+    config_heat_conductivity_type = 'bubbly'
+    config_rapid_mode_channel_radius = 0.5e-3
+    config_rapid_model_critical_Ra = 10.0
+    config_rapid_mode_aspect_ratio = 1.0
+    config_slow_mode_drainage_strength = -5.0e-8
+    config_slow_mode_critical_porosity = 0.05
+    config_congelation_ice_porosity = 0.85
+/
+&itd
+    config_itd_conversion_type = 'linear remap'
+    config_category_bounds_type = 'original'
+/
+&ridging
+    config_ice_strength_formulation = 'Rothrock75'
+    config_ridging_participation_function = 'exponential'
+    config_ridging_redistribution_function = 'exponential'
+    config_ridiging_efolding_scale = 3.0
+    config_ratio_ridging_work_to_PE = 17.0
+/
+&atmosphere
+    config_atmos_boundary_method = 'ccsm3'
+    config_calc_surface_stresses = true
+    config_calc_surface_temperature = true
+    config_use_form_drag = false
+    config_use_high_frequency_coupling = false
+    config_boundary_layer_iteration_number = 5
+/
+&ocean
+    config_use_ocean_mixed_layer = true
+    config_min_friction_velocity = 0.0005
+    config_ocean_heat_transfer_type = 'constant'
+    config_sea_freezing_temperature_type = 'mushy'
+    config_ocean_surface_type = 'free'
+    config_couple_biogeochemistry_fields = false
+/
+&diagnostics
+    config_check_state = false
+/
+&AM_highFrequencyOutput
+    config_AM_highFrequencyOutput_enable = false
+    config_AM_highFrequencyOutput_compute_interval = 'output_interval'
+    config_AM_highFrequencyOutput_output_stream = 'highFrequencyOutput'
+    config_AM_highFrequencyOutput_compute_on_startup = true
+    config_AM_highFrequencyOutput_write_on_startup = true
+/
+&AM_temperatures
+    config_AM_temperatures_enable = false
+    config_AM_temperatures_compute_interval = 'dt'
+    config_AM_temperatures_output_stream = 'output'
+    config_AM_temperatures_compute_on_startup = false
+    config_AM_temperatures_write_on_startup = false
+/
+&AM_regionalStatistics
+    config_AM_regionalStatistics_enable = false
+    config_AM_regionalStatistics_compute_interval = 'output_interval'
+    config_AM_regionalStatistics_output_stream = 'regionalStatisticsOutput'
+    config_AM_regionalStatistics_compute_on_startup = false
+    config_AM_regionalStatistics_write_on_startup = false
+    config_AM_regionalStatistics_ice_extent_limit = 0.15
+/
+&AM_ridgingDiagnostics
+    config_AM_ridgingDiagnostics_enable = false
+    config_AM_ridgingDiagnostics_compute_interval = 'dt'
+    config_AM_ridgingDiagnostics_output_stream = 'output'
+    config_AM_ridgingDiagnostics_compute_on_startup = false
+    config_AM_ridgingDiagnostics_write_on_startup = false
+/
+&AM_conservationCheck
+    config_AM_conservationCheck_enable = false
+    config_AM_conservationCheck_compute_interval = 'dt'
+    config_AM_conservationCheck_output_stream = 'conservationCheckOutput'
+    config_AM_conservationCheck_compute_on_startup = false
+    config_AM_conservationCheck_write_on_startup = false
+    config_AM_conservationCheck_write_to_logfile = true
+/
+&AM_geographicalVectors
+    config_AM_geographicalVectors_enable = false
+    config_AM_geographicalVectors_compute_interval = 'dt'
+    config_AM_geographicalVectors_output_stream = 'output'
+    config_AM_geographicalVectors_compute_on_startup = false
+    config_AM_geographicalVectors_write_on_startup = false
+/
+&AM_loadBalance
+    config_AM_loadBalance_enable = false
+    config_AM_loadBalance_compute_interval = 'output_interval'
+    config_AM_loadBalance_output_stream = 'loadBalanceOutput'
+    config_AM_loadBalance_compute_on_startup = false
+    config_AM_loadBalance_write_on_startup = false
+    config_AM_loadBalance_nProcs = 32
+/
+&AM_maximumIcePresence
+    config_AM_maximumIcePresence_enable = false
+    config_AM_maximumIcePresence_compute_interval = 'dt'
+    config_AM_maximumIcePresence_output_stream = 'maximumIcePresenceOutput'
+    config_AM_maximumIcePresence_compute_on_startup = false
+    config_AM_maximumIcePresence_write_on_startup = false
+    config_AM_maximumIcePresence_start_time = '0000-00-00_00:00:00'
+/
+&AM_miscellaneous
+    config_AM_miscellaneous_enable = false
+    config_AM_miscellaneous_compute_interval = 'dt'
+    config_AM_miscellaneous_output_stream = 'none'
+    config_AM_miscellaneous_compute_on_startup = false
+    config_AM_miscellaneous_write_on_startup = false
+/
+&AM_areaVariables
+    config_AM_areaVariables_enable = false
+    config_AM_areaVariables_compute_interval = 'dt'
+    config_AM_areaVariables_output_stream = 'none'
+    config_AM_areaVariables_compute_on_startup = false
+    config_AM_areaVariables_write_on_startup = false
+/
+&AM_pondDiagnostics
+    config_AM_pondDiagnostics_enable = false
+    config_AM_pondDiagnostics_compute_interval = 'dt'
+    config_AM_pondDiagnostics_output_stream = 'none'
+    config_AM_pondDiagnostics_compute_on_startup = false
+    config_AM_pondDiagnostics_write_on_startup = false
+/
+&AM_unitConversion
+    config_AM_unitConversion_enable = true
+    config_AM_unitConversion_compute_interval = 'dt'
+    config_AM_unitConversion_output_stream = 'none'
+    config_AM_unitConversion_compute_on_startup = false
+    config_AM_unitConversion_write_on_startup = false
+/
+&AM_pointwiseStats
+    config_AM_pointwiseStats_enable = false
+    config_AM_pointwiseStats_compute_interval = 'dt'
+    config_AM_pointwiseStats_output_stream = 'pointwiseStatsOutput'
+    config_AM_pointwiseStats_compute_on_startup = false
+    config_AM_pointwiseStats_write_on_startup = false
+/
+&AM_iceShelves
+    config_AM_iceShelves_enable = false
+    config_AM_iceShelves_compute_interval = 'output_interval'
+    config_AM_iceShelves_output_stream = 'iceShelvesOutput'
+    config_AM_iceShelves_compute_on_startup = true
+    config_AM_iceShelves_write_on_startup = true
+/
+&AM_icePresent
+    config_AM_icePresent_enable = false
+    config_AM_icePresent_compute_interval = 'dt'
+    config_AM_icePresent_output_stream = 'none'
+    config_AM_icePresent_compute_on_startup = false
+    config_AM_icePresent_write_on_startup = false
+/
+&AM_timeSeriesStatsDaily
+    config_AM_timeSeriesStatsDaily_enable = false
+    config_AM_timeSeriesStatsDaily_compute_on_startup = false
+    config_AM_timeSeriesStatsDaily_write_on_startup = false
+    config_AM_timeSeriesStatsDaily_compute_interval = 'dt'
+    config_AM_timeSeriesStatsDaily_output_stream = 'timeSeriesStatsDailyOutput'
+    config_AM_timeSeriesStatsDaily_restart_stream = 'timeSeriesStatsDailyRestart'
+    config_AM_timeSeriesStatsDaily_operation = 'avg'
+    config_AM_timeSeriesStatsDaily_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsDaily_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsDaily_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-01_00:00:00'
+    config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-01_00:00:00'
+/
+&AM_timeSeriesStatsMonthly
+    config_AM_timeSeriesStatsMonthly_enable = false
+    config_AM_timeSeriesStatsMonthly_compute_on_startup = false
+    config_AM_timeSeriesStatsMonthly_write_on_startup = false
+    config_AM_timeSeriesStatsMonthly_compute_interval = 'dt'
+    config_AM_timeSeriesStatsMonthly_output_stream = 'timeSeriesStatsMonthlyOutput'
+    config_AM_timeSeriesStatsMonthly_restart_stream = 'timeSeriesStatsMonthlyRestart'
+    config_AM_timeSeriesStatsMonthly_operation = 'avg'
+    config_AM_timeSeriesStatsMonthly_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthly_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthly_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthly_reset_intervals = '00-01-00_00:00:00'
+    config_AM_timeSeriesStatsMonthly_backward_output_offset = '00-01-00_00:00:00'
+/
+&AM_timeSeriesStatsClimatology
+    config_AM_timeSeriesStatsClimatology_enable = false
+    config_AM_timeSeriesStatsClimatology_compute_on_startup = false
+    config_AM_timeSeriesStatsClimatology_write_on_startup = false
+    config_AM_timeSeriesStatsClimatology_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsClimatology_output_stream = 'timeSeriesStatsClimatologyOutput'
+    config_AM_timeSeriesStatsClimatology_restart_stream = 'timeSeriesStatsClimatologyRestart'
+    config_AM_timeSeriesStatsClimatology_operation = 'avg'
+    config_AM_timeSeriesStatsClimatology_reference_times = '00-03-01_00:00:00;00-06-01_00:00:00;00-09-01_00:00:00;00-12-01_00:00:00'
+    config_AM_timeSeriesStatsClimatology_duration_intervals = '00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_repeat_intervals = '01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_reset_intervals = '1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_backward_output_offset = '00-03-00_00:00:00'
+/
+&AM_timeSeriesStatsCustom
+    config_AM_timeSeriesStatsCustom_enable = false
+    config_AM_timeSeriesStatsCustom_compute_on_startup = false
+    config_AM_timeSeriesStatsCustom_write_on_startup = false
+    config_AM_timeSeriesStatsCustom_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsCustom_output_stream = 'timeSeriesStatsCustomOutput'
+    config_AM_timeSeriesStatsCustom_restart_stream = 'timeSeriesStatsCustomRestart'
+    config_AM_timeSeriesStatsCustom_operation = 'avg'
+    config_AM_timeSeriesStatsCustom_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsCustom_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsCustom_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsCustom_reset_intervals = '00-00-07_00:00:00'
+    config_AM_timeSeriesStatsCustom_backward_output_offset = '00-00-01_00:00:00'
+/

--- a/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/streams.seaice
+++ b/testing_and_setup/seaice/configurations/aerosol_shortwave_physics/streams.seaice
@@ -1,0 +1,367 @@
+<streams>
+<immutable_stream name="mesh"
+                  type="none"
+                  filename_template="mesh_variables.nc" />
+
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="grid.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<immutable_stream name="restart"
+                  type="input;output"
+                  filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
+                  filename_interval="00_00:00:01"
+                  input_interval="initial_only"
+                  output_interval="00-03-00_00:00:00" />
+
+<stream name="output"
+        type="output"
+        filename_template="output/output.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        clobber_mode="replace_files"
+        output_interval="00-01-00_00:00:00" >
+
+	<stream name="mesh"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="iceAgeCell"/>
+	<var name="uVelocity"/>
+	<var name="vVelocity"/>
+	<var name="surfaceTemperature"/>
+	<var name="shortwaveDown"/>
+	<var name="bioShortwaveFlux"/>
+	<var name="bioShortwaveFluxCell"/>
+	<var name="absorbedShortwaveFlux"/>
+	<var name="oceanShortwaveFlux"/>
+	<var name="oceanShortwaveFluxArea"/>
+	<var name="totalVerticalBiologyIce"/>
+	<var name="brineFractionCell"/>
+	<var name="netBrineHeight"/>
+	<var name="newlyFormedIce"/>
+	<var name="firstYearIceAreaCell"/>
+	<var name="levelIceAreaCell"/>
+	<var name="pondAreaCell"/>
+	<var name="surfaceIceMelt"/>
+	<var name="basalIceMelt"/>
+	<var name="lateralIceMelt"/>
+	<var name="congelation"/>
+	<var name="snowiceFormation"/>
+	<var name="frazilFormation"/>
+	<var name="snowThicknessChange"/>
+	<var name="snowAlbedoCell"/>
+	<var name="bareIceAlbedoCell"/>
+	<var name="pondAlbedoCell"/>
+	<var name="verticalAerosolsIceCell"/>
+	<var name="verticalAerosolsSnowCell"/>
+	<var name="iceEnthalpyCell"/>
+	<var name="iceSalinityCell"/>
+	<var name="oceanBioFluxes"/>
+	<var name="oceanBioConcentrations"/>
+</stream>
+
+<immutable_stream name="LYqSixHourlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_six_hourly.$Y.nc"
+                  filename_interval="0001-00-00_00:00:00"
+		  reference_time="2000-01-01_03:00:00"
+                  input_interval="none" />
+
+<immutable_stream name="LYqMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/atmosphere_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlySSTForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="NCARMonthlyForcing"
+                  type="input"
+                  filename_template="forcing/ocean_forcing_monthly.nc"
+                  filename_interval="none"
+                  input_interval="none" />
+
+<immutable_stream name="StandardAerosolsInput"
+                  type="input"
+                  filename_template="forcing/standard_optics_mpas_seaice.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<immutable_stream name="ModalAerosolsInput"
+                  type="input"
+                  filename_template="forcing/snicar_optics_5bnd_mam_c140303_mpas_seaice.nc"
+                  filename_interval="none"
+                  input_interval="initial_only" />
+
+<stream name="abort_block"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s_block_$B.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="abort"
+        type="output"
+        filename_template="abort_seaice_$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="none"
+        clobber_mode="truncate"
+        output_interval="none" >
+
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
+</stream>
+
+<stream name="regionalStatisticsOutput"
+        type="output"
+        filename_template="analysis_members/regionalStatistics.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="regionalStatisticsAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="totalIceArea"/>
+	<var name="totalIceExtent"/>
+	<var name="totalIceVolume"/>
+	<var name="totalSnowVolume"/>
+	<var name="totalKineticEnergy"/>
+	<var name="rmsIceSpeed"/>
+	<var name="averageAlbedo"/>
+	<var name="maximumIceVolume"/>
+	<var name="maximumIceVolumeLocked"/>
+	<var name="maximumIceVolumeNotLocked"/>
+	<var name="maximumIcePressure"/>
+	<var name="maximumIceSpeed"/>
+</stream>
+
+<stream name="conservationCheckOutput"
+        type="output"
+        filename_template="analysis_members/conservationCheck.nc"
+        filename_interval="none"
+        clobber_mode="replace_files"
+        packages="conservationCheckAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="initialEnergy"/>
+	<var name="finalEnergy"/>
+	<var name="energyChange"/>
+	<var name="netEnergyFlux"/>
+	<var name="absoluteEnergyError"/>
+	<var name="relativeEnergyError"/>
+	<var name="initialMass"/>
+	<var name="finalMass"/>
+	<var name="massChange"/>
+	<var name="netMassFlux"/>
+	<var name="absoluteMassError"/>
+	<var name="relativeMassError"/>
+	<var name="initialSalt"/>
+	<var name="finalSalt"/>
+	<var name="saltChange"/>
+	<var name="netSaltFlux"/>
+	<var name="absoluteSaltError"/>
+	<var name="relativeSaltError"/>
+</stream>
+
+
+<stream name="loadBalanceOutput"
+        type="output"
+        filename_template="analysis_members/cice_loadBalance.nc"
+        filename_interval="none"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="loadBalanceAMPKG"
+        output_interval="00-00-00_01:00:00" >
+
+	<var name="xtime"/>
+	<var name="nCellsProcWithSeaIce"/>
+	<var name="nCellsProc"/>
+</stream>
+
+<stream name="maximumIcePresenceOutput"
+        type="output"
+        filename_template="analysis_members/cice_maximumIcePresence.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="maximumIcePresenceAMPKG"
+        output_interval="01-00-00_00:00:00" >
+
+	<stream name="mesh"/>
+	<var name="xtime"/>
+	<var name="maximumIcePresence"/>
+</stream>
+
+<stream name="timeSeriesStatsDailyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsDaily.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsDailyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsDaily.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsDailyAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        input_interval="none"
+        output_interval="none" >
+
+</stream>
+
+<stream name="timeSeriesStatsMonthlyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsMonthly.$Y-$M.nc"
+        filename_interval="00-01-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        output_interval="00-01-00_00:00:00" >
+
+	<var name="daysSinceStartOfSim"/>
+	<var name="icePresent"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="iceAreaCategory"/>
+	<var name="iceVolumeCategory"/>
+	<var name="snowVolumeCategory"/>
+	<var name="surfaceTemperatureCell"/>
+	<var name="uVelocityGeo"/>
+	<var name="vVelocityGeo"/>
+	<var name="shortwaveDown"/>
+	<var name="longwaveDown"/>
+	<var name="seaSurfaceTemperature"/>
+	<var name="seaSurfaceSalinity"/>
+	<var name="uOceanVelocityVertexGeo"/>
+	<var name="vOceanVelocityVertexGeo"/>
+	<var name="freezingMeltingPotential"/>
+	<var name="shortwaveScalingFactor"/>
+	<var name="airTemperature"/>
+	<var name="congelation"/>
+	<var name="frazilFormation"/>
+	<var name="snowiceFormation"/>
+	<var name="snowMelt"/>
+	<var name="surfaceIceMelt"/>
+	<var name="basalIceMelt"/>
+	<var name="lateralIceMelt"/>
+	<var name="airStressVertexUGeo"/>
+	<var name="airStressVertexVGeo"/>
+	<var name="icePressure"/>
+	<var name="divergence"/>
+	<var name="shear"/>
+	<var name="principalStress1Var"/>
+	<var name="principalStress2Var"/>
+	<var name="iceVolumeTendencyThermodynamics"/>
+	<var name="iceVolumeTendencyTransport"/>
+	<var name="iceAreaTendencyThermodynamics"/>
+	<var name="iceAreaTendencyTransport"/>
+	<var name="iceAgeTendencyThermodynamics"/>
+	<var name="iceAgeTendencyTransport"/>
+	<var name="iceAgeCell"/>
+	<var name="firstYearIceAreaCell"/>
+	<var name="levelIceAreaCell"/>
+	<var name="levelIceVolumeCell"/>
+	<var name="ridgedIceAreaAverage"/>
+	<var name="ridgedIceVolumeAverage"/>
+	<var name="bulkSalinity"/>
+	<var name="broadbandAlbedo"/>
+	<var name="absorbedShortwaveFluxInitialArea"/>
+	<var name="latentHeatFluxInitialArea"/>
+	<var name="sensibleHeatFluxInitialArea"/>
+	<var name="longwaveUpInitialArea"/>
+	<var name="evaporativeWaterFluxInitialArea"/>
+	<var name="meltPondAreaFinalArea"/>
+	<var name="meltPondDepthFinalArea"/>
+	<var name="meltPondLidThicknessFinalArea"/>
+	<var name="verticalAerosolsIceCell"/>
+	<var name="verticalAerosolsSnowCell"/>
+	<var name="iceEnthalpyCell"/>
+	<var name="iceSalinityCell"/>
+	<var name="oceanBioFluxes"/>
+	<var name="oceanBioConcentrations"/>
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsClimatology.$Y.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-03-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        output_interval="00-03-00_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsClimatologyRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsClimatology.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsClimatologyAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomOutput"
+        type="output"
+        filename_template="analysis_members/timeSeriesStatsCustom.$Y$M-$D.nc"
+        filename_interval="00-00-07_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        output_interval="00-00-01_00:00:00" >
+
+</stream>
+
+<stream name="timeSeriesStatsCustomRestart"
+        type="input;output"
+        filename_template="restarts/restart.AM.timeSeriesStatsCustom.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="output_interval"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsCustomAMPKG"
+        input_interval="initial_only"
+        output_interval="stream:restart:output_interval" >
+
+</stream>
+
+</streams>
+

--- a/testing_and_setup/seaice/configurations/standard_bgc/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/standard_bgc/namelist.seaice
@@ -101,7 +101,7 @@
     config_use_column_biogeochemistry = true
     config_use_column_itd_thermodynamics = true
     config_use_column_ridging = true
-    config_use_column_snow_density = false
+    config_use_column_snow_tracers = false
 /
 &column_tracers
     config_use_ice_age = true

--- a/testing_and_setup/seaice/testing/tests/restartability.py
+++ b/testing_and_setup/seaice/testing/tests/restartability.py
@@ -68,22 +68,19 @@ def restartability(mpasDevelopmentDir, domainsDir, domain, configuration, option
         snowModsRestart = True
 
     if (not bgcRestart):
-        nmlChanges = {"seaice_model": {"config_start_time":"file"},
-                      "restart": {"config_do_restart":True}}
+        if (not snowModsRestart):
+             nmlChanges = {"seaice_model": {"config_start_time":"file"},
+                           "restart": {"config_do_restart":True}}
+        else:
+             nmlChanges = {"seaice_model": {"config_start_time":"file"},
+                      "restart": {"config_do_restart":True,
+                                  "config_do_restart_snow_density":True,
+                                  "config_do_restart_snow_grain_radius":True}}
     else:
         nmlChanges = {"seaice_model": {"config_start_time":"file"},
                       "restart": {"config_do_restart":True,
                                   "config_do_restart_bgc":True,
                                   "config_do_restart_hbrine":True}}
-
-    if (not snowModsRestart):
-        nmlChanges = {"seaice_model": {"config_start_time":"file"},
-                      "restart": {"config_do_restart":True}}
-    else:
-        nmlChanges = {"seaice_model": {"config_start_time":"file"},
-                      "restart": {"config_do_restart":True,
-                                  "config_do_restart_snow_density":True,
-                                  "config_do_restart_snow_grain_radius":True}}
 
     if (check):
         nmlChanges["unit_test"] = {"config_testing_system_test":True}

--- a/testing_and_setup/seaice/testing/testsuites/testsuite.aerosol_shortwave.xml
+++ b/testing_and_setup/seaice/testing/testsuites/testsuite.aerosol_shortwave.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="standard">
+	<configuration name="standard_bgc">
+		<domain name="domain_QU240km">
+			<test name="regression"/>
+			<test name="parallelism"/>
+			<test name="restartability">
+			      <option name="bgc" value="True"/>
+			    </test>
+		</domain>
+	</configuration>
+</testsuite>

--- a/testing_and_setup/seaice/testing/testsuites/testsuite.aerosol_shortwave.xml
+++ b/testing_and_setup/seaice/testing/testsuites/testsuite.aerosol_shortwave.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="standard">
-	<configuration name="standard_bgc">
+	<configuration name="aerosol_shortwave_physics">
 		<domain name="domain_QU240km">
 			<test name="regression"/>
 			<test name="parallelism"/>


### PR DESCRIPTION
Corrections in Registry and mpas_seaice_column to enable vertical
aerosol implementation without other bgc tracers.  BFB in standard tests.  Standard-bgc test broke during the last merge (namelist error)  and is corrected in this PR.  With the namelist correction to seaice/develop, BGC test is BFB. 


