### PR TITLE
When using specified zeta levels, set 'zt' for correct coordinate surface smoothing

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2956,6 +2956,7 @@ module init_atm_cases
          end if
 
          zw(:) = specified_zw(:)
+         zt = zw(nz)
 
          deallocate(specified_zw)
 


### PR DESCRIPTION
This merge ensures that the smoothing of coordinate surfaces is correct when
using specified zeta levels.

When config_specified_zeta_levels is set to the name of a text file containing
zeta levels to use in MPAS-A, the 'zt' variable needs to be set to the top level
in the list of specified zeta levels to ensure that the smoothing of coordinate
surfaces uses the intended smoothing coefficients.