### PR TITLE
Remove broken log write of cf1,cf2,cf3 from init_atm_case_gfs

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3094,8 +3094,6 @@ module init_atm_cases
 !      cf3 = d1*d2*(d2-d1)/(d2*d3*(d3-d2)+d1*d3*(d1-d3)+d1*d2*(d2-d1))
 
 
-      call mpas_log_write(' cf1, cf2, cf3 = ', realArgs=(/cf1,cf2,cf3/))
-
 !     Smoothing algorithm for coordinate surfaces 
 
       smooth = config_smooth_surfaces


### PR DESCRIPTION
This merge removes a broken write to log files of the cf1, cf2, and cf3
variables.

The init_atm_case_gfs routine previously had a call to mpas_log_write
that was intended to print out the values of cf1, cf2, and cf3. However,
this call was missing '$r' conversion specifications for the cf{1,2,3}
variables.

Rather than fixing this mpas_log_write call, it seems cleaner to simply
remove it, since the values of cf1, cf2, and cf3 do not appear to be used
directly in the init_atm_case_gfs routine, and the values of these variables
can be found in the model initial conditions file.