### PR TITLE
Fix race condition in file tests when clobber_mode = 'append' or 'overwrite'

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -3047,6 +3047,8 @@ module mpas_stream_manager
     !-----------------------------------------------------------------------
     subroutine write_stream(manager, stream, blockID, timeLevel, mgLevel, forceWritenow, writeTime, ierr) !{{{
 
+        use mpas_dmpar, only : IO_NODE
+
         implicit none
 
         type (MPAS_streamManager_type), intent(inout) :: manager
@@ -3154,7 +3156,10 @@ module mpas_stream_manager
                    STREAM_DEBUG_WRITE(' -- Cobber mode is overwrite or append...')
     
                    ! Check if the file exists
-                   inquire(file=trim(stream % filename), exist=recordSeek)
+                   if (manager % ioContext % dminfo % my_proc_id == IO_NODE) then
+                       inquire(file=trim(stream % filename), exist=recordSeek)
+                   end if
+                   call mpas_dmpar_bcast_logical(manager % ioContext % dminfo, recordSeek)
                end if
 
                !
@@ -3237,7 +3242,10 @@ module mpas_stream_manager
                        STREAM_DEBUG_WRITE(' -- Cobber mode is overwrite or append...')
            
                        ! Check if the file exists
-                       inquire(file=trim(stream % filename), exist=recordSeek)
+                       if (manager % ioContext % dminfo % my_proc_id == IO_NODE) then
+                           inquire(file=trim(stream % filename), exist=recordSeek)
+                       end if
+                       call mpas_dmpar_bcast_logical(manager % ioContext % dminfo, recordSeek)
                    end if
 
                    stream % nRecords = 1
@@ -3548,6 +3556,8 @@ module mpas_stream_manager
     !-----------------------------------------------------------------------
     subroutine read_stream(manager, stream, timeLevel, mgLevel, forceReadNow, when, whence, actualWhen, ierr) !{{{
 
+        use mpas_dmpar, only : IO_NODE
+
         implicit none
 
         type (MPAS_streamManager_type), intent(inout) :: manager
@@ -3813,7 +3823,10 @@ module mpas_stream_manager
 
               STREAM_DEBUG_WRITE(' --- Retesting filename is ' // trim(test_filename))
 
-              inquire(file=trim(test_filename), exist=retestFile)
+              if (manager % ioContext % dminfo % my_proc_id == IO_NODE) then
+                 inquire(file=trim(test_filename), exist=retestFile)
+              end if
+              call mpas_dmpar_bcast_logical(manager % ioContext % dminfo, retestFile)
 
               ! If file exists, the testing stream needs to be built.
               if ( retestFile ) then


### PR DESCRIPTION
This merge fixes a race condition in file tests when clobber_mode = 'overwrite'
or 'append'.

The stream manager's write_stream(...) routine tests on the existence of files
to be written when clobber_mode = 'append' or 'overwrite' for a stream.
Each MPI task was independently testing whether the output file existed using
calls to Fortran's inquire intrinsic, and the results of these inquiries could
disagree among MPI tasks, apparently due to race conditions between the creation
of output files and the testing of files on different tasks.

The solution adopted in this commit is essentially the same approach as is used
in the low-level mpas_io_open(...) routine: we test for the existence of the file
only on the IO_NODE and broadcast the result to all other MPI tasks.

There are two places in write_stream(...) where file inquiries are modified.
There is also one file inquiry in read_stream(...) that has been modified, too,
not out of concerns for correctness, but simply because it seemed more efficient
to make filesystem inquiries only from one MPI task and to broadcast the result
than to have a potentially large number of MPI tasks all making filesystem
inquiries.