### PR TITLE
Avoid calling mpas_atm_update_bdy_tend whenever config_apply_lbcs = false

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -491,6 +491,7 @@ module atm_core
    
       real (kind=RKIND), pointer :: dt
       logical, pointer :: config_do_restart
+      logical, pointer :: config_apply_lbcs
       type (block_type), pointer :: block_ptr
 
       type (MPAS_Time_Type) :: currTime
@@ -576,10 +577,13 @@ module atm_core
       call mpas_pool_get_subpool(block_ptr % structs, 'diag', diag)
       call mpas_pool_get_subpool(block_ptr % structs, 'diag_physics', diag_physics)
 
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_apply_lbcs', config_apply_lbcs)
+
       !
       ! Read initial boundary state
       !
-      if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='lbc_in', direction=MPAS_STREAM_INPUT, ierr=ierr)) then
+      if (config_apply_lbcs .and. &
+          MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='lbc_in', direction=MPAS_STREAM_INPUT, ierr=ierr)) then
          block_ptr => domain % blocklist
          do while (associated(block_ptr))
             call mpas_atm_update_bdy_tend(clock, domain % streamManager, block_ptr, .true., ierr)
@@ -608,7 +612,8 @@ module atm_core
          !
          ! Read future boundary state and compute boundary tendencies
          !
-         if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='lbc_in', direction=MPAS_STREAM_INPUT, ierr=ierr)) then
+         if (config_apply_lbcs .and. &
+             MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='lbc_in', direction=MPAS_STREAM_INPUT, ierr=ierr)) then
             block_ptr => domain % blocklist
             do while (associated(block_ptr))
                call mpas_atm_update_bdy_tend(clock, domain % streamManager, block_ptr, .false., ierr)
@@ -620,6 +625,9 @@ module atm_core
                block_ptr => block_ptr % next
             end do
          end if
+
+         ! Regardless of whether boundary tendencies were updated, above, we do not want to read the 'lbc_in' stream
+         ! as a general input stream, below.
          call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='lbc_in', direction=MPAS_STREAM_INPUT, ierr=ierr)
 
 


### PR DESCRIPTION
This merge ensures that the mpas_atm_update_bdy_tend routine is not
called when config_apply_lbcs = false, which implies that the 'limited_area'
package is inactive.

For global simulations in which config_apply_lbcs is necessarily set to
.false., if a valid input interval is provided for the 'lbc_in' stream,
the input alarm for this stream would ring even though the stream has no
active packages. This caused the mpas_atm_update_bdy_tend routine to be
called, leading to a one of several failures, e.g., a segfault due to
the use of unallocated (due to packages) lbc_* fields in the routine.

In order to avoid this, we now call the mpas_atm_update_bdy_tend routine
only if the 'lbc_in' input alarm is ringing and config_apply_lbcs == true.