### PR TITLE
ocean tracer advection CPU optimizations

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -5,22 +5,23 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection
 !
 !> \brief MPAS ocean tracer advection driver
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This module contains driver routine for tracer advection tendencys
-!>  as well as the routines for setting up advection coefficients and
-!>  initialization of the advection routines.
+!>  This module contains initialization and driver routines for computing tracer
+!>  advection tendencies. It primarily calls submodule routines based on user
+!>  choices for advection options.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_tracer_advection
 
+   ! module includes
    use mpas_kind_types
    use mpas_derived_types
    use mpas_pool_routines
@@ -37,63 +38,115 @@ module ocn_tracer_advection
    private
    save
 
+   ! public module method interfaces
    public :: ocn_tracer_advection_init,         &
              ocn_tracer_advection_tend
 
-   logical :: tracerAdvOn
-   logical :: monotonicOn
+   ! privat module variables
+   logical :: tracerAdvOn !< flag to turn on tracer advection
+   logical :: monotonicOn !< flag to choose a monotone advection scheme
+   logical :: budgetDiagsOn !< flag to compute active tracer budgets
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 
    contains
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  routine ocn_tracer_advection_tend
 !
 !> \brief MPAS ocean tracer advection tendency
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This routine is the driver routine for computing the tendency for
-!>  advection of tracers.
+!>  This routine is the driver routine for computing tracer advection
+!>  tendencies. It simply calls submodule tendency routines based on choice of
+!>  algorithm.
 !
-!-----------------------------------------------------------------------
-   subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, w, layerThickness, dt, meshPool, & !{{{
-                                        scratchPool, diagnosticsPool, tend, tracerGroupName)
+!-------------------------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tend !< Input/Output: tracer tendency
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input/Output: tracer values
-      real (kind=RKIND), dimension(:,:), intent(in) :: normalThicknessFlux !< Input: Thickness weighted horizontal velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: w  !< Input: Vertical velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness  !< Input: Thickness field
-      real (kind=RKIND), intent(in) :: dt !< Input: Time step
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch fields
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: pool for traceradvection budget term
+   subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, w,       &
+                                        layerThickness, dt, meshPool,          &
+                                        scratchPool, diagnosticsPool, tend,    &
+                                        tracerGroupName)!{{{
 
-      real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd
+      !*** Input/Output parameters
 
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, nAdvCellsForEdge
-      integer, dimension(:,:), pointer :: highOrderAdvectionMask, edgeSignOnCell, advCellsForEdge
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend            !< [in,out] Tracer tendency to which advection added
 
-      character (len=*), intent(in) :: tracerGroupName ! variable to check for tracer budget
+      !*** Input parameters
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers             !< [in] Current tracer values
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux !< [in] Thickness weighted horizontal velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w                   !< [in] Vertical velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness      !< [in] Thickness field
+      real (kind=RKIND), intent(in) :: &
+         dt                  !< [in] Time step
+      type (mpas_pool_type), intent(in) :: &
+         meshPool            !< [in] Mesh information
+      type (mpas_pool_type), intent(in) :: &
+         scratchPool         !< [in] Scratch fields
+      type (mpas_pool_type), intent(in) :: &
+         diagnosticsPool     !< [in] Diagnostic fields
+      character (len=*), intent(in) :: &
+         tracerGroupName     !< [in] Tracer name to check if active tracers
+
+      !*** Local variables
+
+      logical :: &
+         computeBudgets      ! flag to compute active tracer budget
+
+      real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
+         advCoefs, advCoefs3rd ! advection coefficients
+
+      integer, dimension(:), pointer, contiguous :: &
+         maxLevelCell,    &! index of max level at each cell
+         maxLevelEdgeTop, &! max level at edge with both cells active
+         nAdvCellsForEdge  ! number of advective cells for each edge
+      integer, dimension(:,:), pointer, contiguous :: &!
+         highOrderAdvectionMask, &! mask for higher order contributions
+         edgeSignOnCell,  &! sign at cell edge for fluxes
+         advCellsForEdge   ! index of advective cells for each edge
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      ! immediate return if tracer advection not selected
       if(.not. tracerAdvOn) return
 
       call mpas_timer_start("tracer adv")
 
+      ! extract pool variables
       call mpas_pool_get_array(meshPool, 'advCoefs', advCoefs)
       call mpas_pool_get_array(meshPool, 'advCoefs3rd', advCoefs3rd)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMask)
+      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', &
+                                          highOrderAdvectionMask)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge', nAdvCellsForEdge)
       call mpas_pool_get_array(meshPool, 'advCellsForEdge', advCellsForEdge)
 
-      if(monotonicOn) then
-         call ocn_tracer_advection_mono_tend(tracers, advCoefs, advCoefs3rd, &
-            nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
-            dt, meshPool, scratchPool, diagnosticsPool, tend, maxLevelCell, maxLevelEdgeTop, &
-            highOrderAdvectionMask, edgeSignOnCell, tracerGroupName)
+      ! determine whether active tracer budgets should be computed
+      computeBudgets = (budgetDiagsOn .and. tracerGroupName == 'activeTracers')
+
+      ! call specific advection routine based on choice of monotonicity
+      if (monotonicOn) then
+         call ocn_tracer_advection_mono_tend(tend, tracers, layerThickness,    &
+                                             normalThicknessFlux, w, dt,       &
+                                             advCoefs, advCoefs3rd,            &
+                                             nAdvCellsForEdge, advCellsForEdge,&
+                                             maxLevelCell, maxLevelEdgeTop,    &
+                                             highOrderAdvectionMask,           &
+                                             edgeSignOnCell, meshPool,         &
+                                             diagnosticsPool, computeBudgets)
+
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
             nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
@@ -102,58 +155,97 @@ module ocn_tracer_advection
       endif
 
       call mpas_timer_stop("tracer adv")
+
    end subroutine ocn_tracer_advection_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  routine ocn_tracer_advection_init
 !
 !> \brief MPAS ocean tracer advection tendency
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This routine is the driver routine for initialization of
-!>  the tracer advection routines.
+!>  This routine is the driver routine for initializing various tracer
+!>  advection choices and variables.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+
    subroutine ocn_tracer_advection_init(err)!{{{
 
-      integer, intent(inout) :: err !< Input/Output: Error flag
+      !*** output parameters
 
-      integer :: err_tmp
+      integer, intent(out) :: err !< [out] Error flag
 
-      logical, pointer :: config_disable_tr_adv, config_dzdk_positive, config_check_tracer_monotonicity, config_monotonic
-      integer, pointer :: config_horiz_tracer_adv_order, config_vert_tracer_adv_order, config_num_halos
-      real (kind=RKIND), pointer :: config_coef_3rd_order
+      !*** local variables
 
-      err = 0
+      integer :: errTmp ! temporary error flag
 
-      call mpas_pool_get_config(ocnConfigs, 'config_num_halos', config_num_halos)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_adv', config_disable_tr_adv)
-      call mpas_pool_get_config(ocnConfigs, 'config_dzdk_positive', config_dzdk_positive)
-      call mpas_pool_get_config(ocnConfigs, 'config_check_tracer_monotonicity', config_check_tracer_monotonicity)
-      call mpas_pool_get_config(ocnConfigs, 'config_horiz_tracer_adv_order', config_horiz_tracer_adv_order)
-      call mpas_pool_get_config(ocnConfigs, 'config_vert_tracer_adv_order', config_vert_tracer_adv_order)
-      call mpas_pool_get_config(ocnConfigs, 'config_coef_3rd_order', config_coef_3rd_order)
-      call mpas_pool_get_config(ocnConfigs, 'config_monotonic', config_monotonic)
+      ! pointer variables needed to extract options from config
+      logical, pointer ::        &
+         disableTracerAdvection, &! flag to disable advection
+         checkMonotonicity,      &! flag to check monotonicity
+         useMonotone,            &! flag to choose monotone scheme
+         computeBudgetDiags       ! flag to compute active tracer budgets
 
-      tracerAdvOn = .true.
+      integer, pointer :: &
+         horzAdvOrder,    &! choice of horizontal advection order
+         vertAdvOrder,    &! choice of vertical advection order
+         numHalos          ! width of halo region
 
-      if(config_disable_tr_adv) tracerAdvOn = .false.
+      real (kind=RKIND), pointer :: &
+         coef3rdOrder  ! coefficient for blending high-order horz adv terms
 
-      call ocn_tracer_advection_std_init(config_horiz_tracer_adv_order, config_vert_tracer_adv_order, config_coef_3rd_order, &
-                                         config_dzdk_positive, config_check_tracer_monotonicity, err_tmp)
-      call ocn_tracer_advection_mono_init(config_num_halos, config_horiz_tracer_adv_order, config_vert_tracer_adv_order, &
-                                          config_coef_3rd_order, config_dzdk_positive, config_check_tracer_monotonicity, err_tmp)
+      ! end preamble
+      !-------------
+      ! begin code
 
-      err = ior(err, err_tmp)
+      err = 0 ! initialize error code to success
 
-      monotonicOn = .false.
+      ! extract options from config
+      call mpas_pool_get_config(ocnConfigs,'config_num_halos', numHalos)
+      call mpas_pool_get_config(ocnConfigs,'config_disable_tr_adv', &
+                                            disableTracerAdvection)
+      call mpas_pool_get_config(ocnConfigs,'config_check_tracer_monotonicity', &
+                                            checkMonotonicity)
+      call mpas_pool_get_config(ocnConfigs,'config_horiz_tracer_adv_order', &
+                                            horzAdvOrder)
+      call mpas_pool_get_config(ocnConfigs,'config_vert_tracer_adv_order', &
+                                            vertAdvOrder)
+      call mpas_pool_get_config(ocnConfigs,'config_coef_3rd_order', &
+                                            coef3rdOrder)
+      call mpas_pool_get_config(ocnConfigs,'config_monotonic', &
+                                            useMonotone)
+      call mpas_pool_get_config(ocnConfigs, &
+                                'config_compute_active_tracer_budgets', &
+                                 computeBudgetDiags)
 
-      if(config_monotonic) then
-         monotonicOn = .true.
+      ! set some basic flags for options
+      tracerAdvOn = .not. disableTracerAdvection
+      monotonicOn = useMonotone
+      budgetDiagsOn = computeBudgetDiags
+
+      ! set all other options from submodule initialization routines
+      call ocn_tracer_advection_std_init(horzAdvOrder, vertAdvOrder,      &
+                                         coef3rdOrder, checkMonotonicity, &
+                                         errTmp)
+      call ocn_tracer_advection_mono_init(numHalos, horzAdvOrder,    &
+                                          vertAdvOrder, coef3rdOrder, &
+                                          checkMonotonicity, err)
+
+      ! if an error is returned from init routines, write an error
+      ! message and return a non-zero error code
+      if (err /= 0 .or. errTmp /= 0) then
+         err = 1
+         call mpas_log_write(                                 &
+            'Error encountered during tracer advection init', &
+            MPAS_LOG_ERR, masterOnly=.true.)
       endif
 
    end subroutine ocn_tracer_advection_init!}}}
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
 end module ocn_tracer_advection
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -5,24 +5,28 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection_mono
 !
 !> \brief MPAS monotonic tracer advection with FCT
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This module contains routines for monotonic advection of tracers using a FCT
+!>  This module contains routines for monotonic advection of tracers
+!>  using a Flux Corrected Transport (FCT) algorithm
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+
 module ocn_tracer_advection_mono
 
+   ! module includes
 #ifdef _ADV_TIMERS
    use mpas_timer
 #endif
    use mpas_kind_types
    use mpas_derived_types
+   use mpas_dmpar
    use mpas_pool_routines
    use mpas_io_units
    use mpas_threading
@@ -34,97 +38,169 @@ module ocn_tracer_advection_mono
    private
    save
 
-   real (kind=RKIND) :: coef_3rd_order
-   integer :: horizOrder
-   logical :: vert2ndOrder, vert3rdOrder, vert4thOrder
-   logical :: positiveDzDk, monotonicityCheck
+   ! module private variables
+   real (kind=RKIND) ::  &
+      coef3rdOrder        !< high-order horizontal coefficient
+   logical ::            &
+      monotonicityCheck   !< flag to check monotonicity
+   integer ::            &
+      vertOrder           !< choice of order for vertical advection
+   integer, parameter :: &! enum for supported vertical algorithm order
+      vertOrder2 = 2,    &!< 2nd order scheme
+      vertOrder3 = 3,    &!< 3rd order scheme
+      vertOrder4 = 4      !< 4th order scheme
 
+   ! These temporary allocatable arrays will eventually be moved back into
+   ! the tendency routine, but must be declared here for now so that they
+   ! retain the shared attribute. Once the threading model has been changed,
+   ! these should become thread private again with reduced size
+
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      tracerCur,     &! reordered current tracer
+      tracerMax,     &! max tracer in neighbors for limiting
+      tracerMin,     &! min tracer in neighbors for limiting
+      hNewInv,       &! inverse of new layer thickness
+      hProv,         &! provisional layer thickness
+      hProvInv,      &! inverse of provisional layer thickness
+      flxIn,         &! flux coming into each cell
+      flxOut,        &! flux going out of each cell
+      workTend,      &! temp for holding some tendency values
+      lowOrderFlx,   &! low order flux for FCT
+      highOrderFlx    ! high order flux for FCT
+
+   ! public method interfaces
    public :: ocn_tracer_advection_mono_tend, &
              ocn_tracer_advection_mono_init
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
    contains
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  routine ocn_tracer_advection_mono_tend
 !
 !> \brief MPAS monotonic tracer horizontal advection tendency with FCT
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This routine computes the monotonic tracer horizontal advection tendencity using a FCT.
+!>  This routine computes the monotonic tracer horizontal advection tendency
+!>  using a flux-corrected transport (FCT) algorithm.
 !
-!-----------------------------------------------------------------------
-   subroutine ocn_tracer_advection_mono_tend(tracers, adv_coefs, adv_coefs_3rd, nAdvCellsForEdge, advCellsForEdge, &!{{{
-                                              normalThicknessFlux, w, layerThickness, dt, meshPool, &
-                                              scratchPool, diagnosticsPool, tend, maxLevelCell, maxLevelEdgeTop, &
-                                              highOrderAdvectionMask, edgeSignOnCell, tracerGroupName)
+!-------------------------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input: current tracer values
-      real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs !< Input: Advection coefficients for 2nd order advection
-      real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs_3rd !< Input: Advection coeffs for mising 3rd/4th order advection
-      integer, dimension(:), intent(in) :: nAdvCellsForEdge !< Input: Number of advection cells for each edge
-      integer, dimension(:,:), intent(in) :: advCellsForEdge !< Input: List of advection cells for each edge
-      real (kind=RKIND), dimension(:,:), intent(in) :: normalThicknessFlux !< Input: Thichness weighted velocitiy
-      real (kind=RKIND), dimension(:,:), intent(in) :: w !< Input: Vertical velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Thickness
-      real (kind=RKIND), intent(in) :: dt !< Input: Timestep
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch fields
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: pool for traceradvection budget term
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tend !< Input/Output: Tracer tendency
+   subroutine ocn_tracer_advection_mono_tend(tend, tracers, layerThickness,    &
+                                             normalThicknessFlux, w, dt,       &
+                                             advCoefs, advCoefs3rd,            &
+                                             nAdvCellsForEdge, advCellsForEdge,&
+                                             maxLevelCell, maxLevelEdgeTop,    &
+                                             highOrderAdvectionMask,           &
+                                             edgeSignOnCell, meshPool,         &
+                                             diagnosticsPool, computeBudgets)!{{{
 
-      ! These variables are passed in to match the version of the interface in operators.
-      integer, dimension(:), pointer :: maxLevelCell !< Input: Index to max level at cell center
-      integer, dimension(:), pointer :: maxLevelEdgeTop !< Input: Index to max level at edge with non-land cells on both sides
-      integer, dimension(:,:), pointer :: highOrderAdvectionMask !< Input: Mask for high order advection
-      integer, dimension(:, :), pointer :: edgeSignOnCell !< Input: Sign for flux from edge on each cell.
+      !*** Input/Output parameters
 
-      character (len=*), intent(in) :: tracerGroupName ! variable to check for tracer budget
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend            !< [in,out] Tracer tendency to which advection added
 
-      logical, pointer :: config_compute_active_tracer_budgets
+      !*** Input parameters
 
-      integer :: i, iCell, iEdge, k, iTracer, cell1, cell2, nVertLevels, num_tracers, nCells, nEdges
-      integer, pointer :: maxEdges
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers             !< [in] Current tracer values
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness      !< [in] Thickness
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux !< [in] Thichness weighted velocitiy
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w                   !< [in] Vertical velocity
+      real (kind=RKIND), intent(in) :: &
+         dt                  !< [in] Timestep
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs            !< [in] Coefficients for 2nd order advection
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs3rd         !< [in] Coeffs for missing 3rd/4th order advection
+      integer, dimension(:), intent(in) :: &
+         nAdvCellsForEdge    !< [in] Number of advection cells for each edge
+      integer, dimension(:,:), intent(in) :: &
+         advCellsForEdge     !< [in] List of advection cells for each edge
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell        !< [in] Index to max level at cell center
+      integer, dimension(:), intent(in) :: &
+         maxLevelEdgeTop     !< [in] Indx max edge lvl with both non-land cells
+      integer, dimension(:,:), intent(in) :: &
+         highOrderAdvectionMask !< [in] Mask for high order advection
+      integer, dimension(:,:), intent(in) :: &
+         edgeSignOnCell         !< [in] Sign for flux from edge on each cell
+      type (mpas_pool_type), intent(in) :: &
+         meshPool               !< [in] Mesh information
+      type (mpas_pool_type), intent(in) :: &
+         diagnosticsPool        !< [in] pool for traceradvection budget term
+      logical, intent(in) :: &
+         computeBudgets         !< [in] Flag to compute active tracer budgets
 
-      real (kind=RKIND) :: signedFactor, tracer_new 
-      real (kind=RKIND) :: tracer_min_new, tracer_max_new, tracer_upwind_new, scale_factor
-      real (kind=RKIND) :: flux, tracer_weight, invAreaCell1, invAreaCell2
-      real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
-      real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: tracer_cur, work_tend, h_new_inv
-      real (kind=RKIND), dimension(:,:), pointer :: tracer_max, tracer_min
-      real (kind=RKIND), dimension(:,:), pointer :: flux_incoming, flux_outgoing
-      real (kind=RKIND), dimension(:,:), pointer :: low_order_flux
-      real (kind=RKIND), dimension(:,:), pointer :: high_order_flux
-      real (kind=RKIND), dimension(:,:), pointer :: h_prov, h_prov_inv
+      !*** Local variables
 
-      type (field2DReal), pointer :: tracerCurField, workTendencyField, hNewInvField, tracerMinField, &
-                                     tracerMaxField, fluxIncomingField, fluxOutgoingField, &
-                                     hProvInvField, hProvField, lowOrderFluxField, highOrderFluxField
+      integer ::          &
+         i, iCell, iEdge, &! horz indices
+         cell1, cell2,    &! neighbor cell indices
+         nCells, nEdges,  &! numbers of cells or edges
+         k,k2,kmax,       &! vert index variants
+         nVertLevels,     &! total num vertical levels
+         iTracer,         &! tracer index
+         numTracers        ! total number of tracers
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-              activeTracerHorizontalAdvectionTendency, &
-              activeTracerVerticalAdvectionTendency,   &
-              activeTracerHorizontalAdvectionEdgeFlux, &
-              activeTracerVerticalAdvectionTopFlux
+      ! pointers for mesh variables retrieved from mesh pool
+      integer, dimension(:), pointer, contiguous :: &
+         nCellsArray,   &! number of cells for each halo depth
+         nEdgesArray,   &! number of edges for each halo depth
+         nEdgesOnCell    ! number of edges on each cell
+      integer, dimension(:,:), pointer, contiguous :: &
+         cellsOnEdge,   &! indices of cells on edges
+         cellsOnCell,   &! indices of cells on cells
+         edgesOnCell     ! indices of edges on cells
+      real (kind=RKIND), dimension(:),   pointer, contiguous :: &
+         dvEdge,            &! edge metric
+         areaCell            ! cell area
 
-      real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
+      real (kind=RKIND) ::  &
+         signedFactor,      &! temp factor including flux sign
+         tracerNew,         &! updated tracer
+         tracerMinNew,      &! updated tracer minimum
+         tracerMaxNew,      &! updated tracer maximum
+         tracerUpwindNew,   &! tracer updated with upwind flx
+         scaleFactor,       &! factor for normalizing fluxes
+         flux,              &! flux temporary
+         tracerWeight,      &! tracer weighting temporary
+         invAreaCell1,      &! inverse cell area
+         invAreaCell2,      &! inverse cell area
+         verticalWeightK,   &! vertical weighting
+         verticalWeightKm1, &! vertical weighting
+         coef1, coef3        ! temporary coefficients
+
+      real (kind=RKIND), dimension(size(tracers, dim=2)) :: &
+         wgtTmp,            &! vertical temporaries for
+         flxTmp, sgnTmp      !   high-order flux computation
+
+      ! pointers for tendencies used in diagnostic budget computation
+      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+         activeTracerHorizontalAdvectionTendency, &
+         activeTracerVerticalAdvectionTendency,   &
+         activeTracerHorizontalAdvectionEdgeFlux, &
+         activeTracerVerticalAdvectionTopFlux
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
+
+      ! end of preamble
+      !----------------
+      ! begin code
 
 #ifdef _ADV_TIMERS
       call mpas_timer_start('startup')
 #endif
-      ! Get dimensions
+      ! Get mesh data
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
-      nVertLevels = size(tracers,dim=2)
-      num_tracers = size(tracers,dim=1)
-
-      ! Initialize pointers
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -132,75 +208,70 @@ module ocn_tracer_advection_mono
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
 
-      call mpas_pool_get_config(ocnConfigs, 'config_compute_active_tracer_budgets', config_compute_active_tracer_budgets)
-      if (config_compute_active_tracer_budgets) then
-         call mpas_pool_get_array(diagnosticsPool, 'activeTracerVerticalAdvectionTopFlux', &
+      if (computeBudgets) then
+         call mpas_pool_get_array(diagnosticsPool,         &
+                'activeTracerVerticalAdvectionTopFlux',    &
                  activeTracerVerticalAdvectionTopFlux)
-         call mpas_pool_get_array(diagnosticsPool, 'activeTracerHorizontalAdvectionEdgeFlux', &
+         call mpas_pool_get_array(diagnosticsPool,         &
+                'activeTracerHorizontalAdvectionEdgeFlux', &
                  activeTracerHorizontalAdvectionEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
+         call mpas_pool_get_array(diagnosticsPool,         &
+                'activeTracerHorizontalAdvectionTendency', &
                  activeTracerHorizontalAdvectionTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerVerticalAdvectionTendency', &
+         call mpas_pool_get_array(diagnosticsPool,         &
+                'activeTracerVerticalAdvectionTendency',   &
                  activeTracerVerticalAdvectionTendency)
       end if
 
-      call mpas_pool_get_field(scratchPool, 'tracerCur', tracerCurField)
-      call mpas_pool_get_field(scratchPool, 'workTendency', workTendencyField)
-      call mpas_pool_get_field(scratchPool, 'hNewInv', hNewInvField)
-      call mpas_pool_get_field(scratchPool, 'tracerMin', tracerMinField)
-      call mpas_pool_get_field(scratchPool, 'tracerMax', tracerMaxField)
-      call mpas_pool_get_field(scratchPool, 'fluxIncoming', fluxIncomingField)
-      call mpas_pool_get_field(scratchPool, 'fluxOutgoing', fluxOutgoingField)
-      call mpas_pool_get_field(scratchPool, 'hProvInv', hProvInvField)
-      call mpas_pool_get_field(scratchPool, 'hProv', hProvField)
-      call mpas_pool_get_field(scratchPool, 'lowOrderFlux', lowOrderFluxField)
-      call mpas_pool_get_field(scratchPool, 'highOrderFlux', highOrderFluxField)
+      ! Get dimensions
+      nVertLevels = size(tracers,dim=2)
+      numTracers  = size(tracers,dim=1)
+      nCells = nCellsArray(size(nCellsArray))
+      nEdges = nEdgesArray(size(nEdgesArray))
 
-      call mpas_allocate_scratch_field(tracerCurField, .true., .false.)
-      call mpas_allocate_scratch_field(workTendencyField, .true., .false.)
-      call mpas_allocate_scratch_field(hNewInvField, .true., .false.)
-      call mpas_allocate_scratch_field(tracerMinField, .true., .false.)
-      call mpas_allocate_scratch_field(tracerMaxField, .true., .false.)
-      call mpas_allocate_scratch_field(fluxIncomingField, .true., .false.)
-      call mpas_allocate_scratch_field(fluxOutgoingField, .true., .false.)
-      call mpas_allocate_scratch_field(hProvInvField, .true., .false.)
-      call mpas_allocate_scratch_field(hProvField, .true., .false.)
-      call mpas_allocate_scratch_field(lowOrderFluxField, .true., .false.)
-      call mpas_allocate_scratch_field(highOrderFluxField, .true., .false.)
+      ! allocate temporary arrays
+      !$omp master
+      allocate(tracerCur   (nVertLevels  ,nCells), &
+               tracerMin   (nVertLevels  ,nCells), &
+               tracerMax   (nVertLevels  ,nCells), &
+               hNewInv     (nVertLevels  ,nCells), &
+               hProv       (nVertLevels  ,nCells), &
+               hProvInv    (nVertLevels  ,nCells), &
+               flxIn       (nVertLevels  ,nCells), &
+               flxOut      (nVertLevels  ,nCells), &
+               workTend    (nVertLevels  ,nCells), &
+               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)), &
+               highOrderFlx(nVertLevels+1,max(nCells,nEdges)))
+      !$omp end master
+      !$omp barrier
 
-      ! allocate nCells arrays
-      h_prov_inv => hProvInvField % array
-      h_prov => hProvField % array
-      h_new_inv => hNewInvField % array
-      tracer_cur => tracerCurField % array
-      tracer_max => tracerMaxField % array
-      tracer_min => tracerMinField % array
-      work_tend => workTendencyField % array
-      flux_incoming => fluxIncomingField % array
-      flux_outgoing => fluxOutgoingField % array
-      low_order_flux => lowOrderFluxField % array
-      high_order_flux => highOrderFluxField % array
-
-      nCells = nCellsArray( size(nCellsArray) )
-
+      ! Compute some provisional layer thicknesses
       ! Note: This assumes we are in the first part of the horizontal/
       ! vertical operator splitting, which is true because currently
       ! we dont flip order and horizontal is always first.
       ! See notes in commit 2cd4a89d.
-      !$omp do schedule(runtime) private(k, i, iEdge, invAreaCell1)
+
+      !$omp do schedule(runtime)
       do iCell = 1, nCells
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-        do k = 1, maxLevelCell(iCell)
-          h_prov(k, iCell) = layerThickness(k, iCell)
-          do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-            ! Provisional layer thickness is after horizontal thickness flux only
-            h_prov(k, iCell) = h_prov(k, iCell) + dt * invAreaCell1 * dvEdge(iEdge) * &
-                                            edgeSignOnCell(i, iCell) * normalThicknessFlux(k, iEdge)
+        invAreaCell1 = dt/areaCell(iCell)
+        kmax = maxLevelCell(iCell)
+        do k = 1, kmax
+          hProv(k, iCell) = layerThickness(k, iCell)
+        end do
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i,iCell)
+          signedFactor = invAreaCell1*dvEdge(iEdge)*edgeSignOnCell(i,iCell)
+          ! Provisional layer thickness is after horizontal thickness flux only
+          do k = 1, kmax
+            hProv(k, iCell) = hProv(k, iCell) &
+                            + signedFactor*normalThicknessFlux(k,iEdge)
           end do
-          h_prov_inv(k, iCell) = 1.0_RKIND / h_prov(k, iCell)
-          ! New layer thickness is after horizontal and vertical thickness flux
-          h_new_inv(k, iCell) = 1.0_RKIND / (h_prov(k, iCell) - dt * w(k, iCell) + dt * w(k+1, iCell))
+        end do
+        ! New layer thickness is after horizontal and vertical thickness flux
+        do k = 1, kmax
+          hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+          hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                         dt*w(k,iCell) + dt*w(k+1, iCell))
         end do
       end do
       !$omp end do
@@ -209,43 +280,51 @@ module ocn_tracer_advection_mono
       call mpas_timer_stop('startup')
 #endif
 
-      ! Loop over tracers. One tracer is advected at a time. It is copied into a temporary array in order to improve locality
-      do iTracer = 1, num_tracers
+      ! Loop over tracers. One tracer is advected at a time.
+      do iTracer = 1, numTracers
+
 #ifdef _ADV_TIMERS
         call mpas_timer_start('cell init')
 #endif
+        ! reset nCells to include all cells
         nCells = nCellsArray( size(nCellsArray) )
-        ! Initialize variables for use in this iTracer iteration
-        !$omp do schedule(runtime) private(k)
+
+        ! Extract current tracer and change index order to improve locality
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
-          do k=1, nVertLevels
-            tracer_cur(k,iCell) = tracers(iTracer,k,iCell)
-            work_tend(k, iCell) = 0.0_RKIND
-            flux_incoming(k, iCell) = 0.0_RKIND
-            flux_outgoing(k, iCell) = 0.0_RKIND
-          end do ! k loop
+        do k=1, nVertLevels
+           tracerCur(k,iCell) = tracers(iTracer,k,iCell)
+        end do ! k loop
         end do ! iCell loop
         !$omp end do
+
+        ! Compute the high and low order horizontal fluxes.
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('cell init')
-#endif
-
-#ifdef _ADV_TIMERS
         call mpas_timer_start('horiz flux')
 #endif
+
+        ! set nCells to first halo level
         nCells = nCellsArray( 2 )
-        !  Compute the high and low order vertical fluxes. Also determine bounds on tracer_cur.
-        !$omp do schedule(runtime) private(k, i)
+
+        ! Determine bounds on tracer (tracerMin and tracerMax) from
+        ! surrounding cells for later limiting.
+
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
           do k=1, maxLevelCell(iCell)
-            tracer_min(k,iCell) = tracer_cur(k,iCell)
-            tracer_max(k,iCell) = tracer_cur(k,iCell)
+            tracerMin(k,iCell) = tracerCur(k,iCell)
+            tracerMax(k,iCell) = tracerCur(k,iCell)
           end do
-          ! pull tracer_min and tracer_max from the (horizontal) surrounding cells
           do i = 1, nEdgesOnCell(iCell)
-            do k=1, min(maxLevelCell(iCell), maxLevelCell(cellsOnCell(i,iCell)))
-              tracer_max(k,iCell) = max(tracer_max(k,iCell),tracer_cur(k, cellsOnCell(i,iCell)))
-              tracer_min(k,iCell) = min(tracer_min(k,iCell),tracer_cur(k, cellsOnCell(i,iCell)))
+            cell2 = cellsOnCell(i,iCell)
+            kmax  = min(maxLevelCell(iCell), &
+                        maxLevelCell(cell2))
+            do k=1, kmax
+              tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+                                       tracerCur(k,cell2))
+              tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+                                       tracerCur(k,cell2))
             end do ! k loop
           end do ! i loop over nEdgesOnCell
         end do
@@ -253,62 +332,84 @@ module ocn_tracer_advection_mono
 
         ! Need all the edges around the 1 halo cells and owned cells
         nEdges = nEdgesArray( 3 )
-        !  Compute the high order horizontal flux
-        !$omp do schedule(runtime) private(cell1, cell2, k, tracer_weight, i, iCell)
+
+        ! Compute the high order horizontal flux
+
+        !$omp do schedule(runtime)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
 
+          ! compute some common intermediate factors
           do k = 1, nVertLevels
-            high_order_flux(k, iEdge) = 0.0_RKIND
+             wgtTmp(k) = normalThicknessFlux   (k,iEdge)* &
+                         highOrderAdvectionMask(k,iEdge)
+             sgnTmp(k) = sign(1.0_RKIND, &
+                              normalThicknessFlux(k,iEdge))
+             flxTmp(k) = 0.0_RKIND
           end do
 
           ! Compute 3rd or 4th fluxes where requested.
           do i = 1, nAdvCellsForEdge(iEdge)
             iCell = advCellsForEdge(i,iEdge)
+            coef1 = advCoefs       (i,iEdge)
+            coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
             do k = 1, maxLevelCell(iCell)
-              tracer_weight = highOrderAdvectionMask(k, iEdge) * (adv_coefs(i,iEdge) &
-                            + coef_3rd_order*sign(1.0_RKIND,normalThicknessFlux(k,iEdge))*adv_coefs_3rd(i,iEdge))
-
-              tracer_weight = normalThicknessFlux(k,iEdge)*tracer_weight
-              high_order_flux(k,iEdge) = high_order_flux(k,iEdge) + tracer_weight * tracer_cur(k,iCell)
+              flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
+                          wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
             end do ! k loop
           end do ! i loop over nAdvCellsForEdge
+
+          do k=1,nVertLevels
+             highOrderFlx(k,iEdge) = flxTmp(k)
+          end do
 
           ! Compute 2nd order fluxes where needed.
           ! Also compute low order upwind horizontal flux (monotonic and diffused)
           ! Remove low order flux from the high order flux
-          ! Store left over high order flux in high_order_flux array
+          ! Store left over high order flux in highOrderFlx array
           do k = 1, maxLevelEdgeTop(iEdge)
-            tracer_weight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) * (dvEdge(iEdge) * 0.5_RKIND) &
-                          * normalThicknessFlux(k, iEdge)
+            tracerWeight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) &
+                         * (dvEdge(iEdge) * 0.5_RKIND)                 &
+                         * normalThicknessFlux(k, iEdge)
 
-            low_order_flux(k,iEdge) = dvEdge(iEdge) &
-                                       * (  max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell1) &
-                                          + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell2) )
+            lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+               (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell1) &
+              + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell2))
 
-            high_order_flux(k, iEdge) = high_order_flux(k, iedge) + tracer_weight * (tracer_cur(k, cell1) &
-                                            + tracer_cur(k, cell2))
+            highOrderFlx(k, iEdge) = highOrderFlx(k, iedge) &
+                                   + tracerWeight * (tracerCur(k, cell1) &
+                                                   + tracerCur(k, cell2))
 
-            high_order_flux(k,iEdge) = high_order_flux(k,iEdge) - low_order_flux(k,iEdge)
+            highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                  -  lowOrderFlx(k,iEdge)
           end do ! k loop
         end do ! iEdge loop
         !$omp end do
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('horiz flux')
-#endif
-
-#ifdef _ADV_TIMERS
         call mpas_timer_start('scale factor build')
 #endif
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
+
+        ! Initialize flux arrays
+        !$omp do schedule(runtime)
+        do iCell = 1, nCells
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+           flxIn   (k, iCell) = 0.0_RKIND
+           flxOut  (k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+
         !$omp do schedule(runtime)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
           ! Finish computing the low order horizontal fluxes
-          ! Upwind fluxes are accumulated in work_tend
+          ! Upwind fluxes are accumulated in workTend
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             cell1 = cellsOnEdge(1,iEdge)
@@ -316,42 +417,45 @@ module ocn_tracer_advection_mono
             signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
 
             do k = 1, maxLevelEdgeTop(iEdge)
-              ! Here work_tend is the advection tendency due to the upwind (low order) fluxes.
-              work_tend(k,iCell) = work_tend(k,iCell) + signedFactor * low_order_flux(k,iEdge)
+              ! Here workTend is the advection tendency due to the
+              ! upwind (low order) fluxes.
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor*lowOrderFlx(k,iEdge)
 
               ! Accumulate remaining high order fluxes
-              flux_outgoing(k,iCell) = flux_outgoing(k,iCell) + min(0.0_RKIND, signedFactor &
-                                     * high_order_flux(k, iEdge))
-              flux_incoming(k,iCell) = flux_incoming(k,iCell) + max(0.0_RKIND, signedFactor &
-                                     * high_order_flux(k, iEdge))
+              flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
+              flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
 
             end do
           end do
 
           ! Build the factors for the FCT
-          ! Computed using the bounds that were computed previously, and the bounds on the newly updated value
-          ! Factors are placed in the flux_incoming and flux_outgoing arrays
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
           do k = 1, maxLevelCell(iCell)
-            ! Here work_tend is the upwind tendency
-            tracer_min_new = (tracer_cur(k,iCell)*layerThickness(k,iCell) + dt*(work_tend(k,iCell)+flux_outgoing(k,iCell))) &
-                           * h_prov_inv(k,iCell)
-            tracer_max_new = (tracer_cur(k,iCell)*layerThickness(k,iCell) + dt*(work_tend(k,iCell)+flux_incoming(k,iCell))) &
-                           * h_prov_inv(k,iCell)
-            tracer_upwind_new = (tracer_cur(k,iCell)*layerThickness(k,iCell) + dt*work_tend(k,iCell)) * h_prov_inv(k,iCell)
+            ! Here workTend is the upwind tendency
+            tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
+                             + dt*workTend(k,iCell)) * hProvInv(k,iCell)
+            tracerMinNew = tracerUpwindNew &
+                         + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+            tracerMaxNew = tracerUpwindNew &
+                         + dt*flxIn (k,iCell)*hProvInv(k,iCell)
 
-            scale_factor = (tracer_max(k,iCell)-tracer_upwind_new)/(tracer_max_new-tracer_upwind_new+eps)
-            flux_incoming(k,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
+            scaleFactor = (tracerMax(k,iCell) - tracerUpwindNew)/ &
+                          (tracerMaxNew - tracerUpwindNew + eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
 
-            scale_factor = (tracer_upwind_new-tracer_min(k,iCell))/(tracer_upwind_new-tracer_min_new+eps)
-            flux_outgoing(k,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
+            scaleFactor = (tracerUpwindNew - tracerMin(k,iCell))/ &
+                          (tracerUpwindNew - tracerMinNew + eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
           end do ! k loop
         end do ! iCell loop
         !$omp end do
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
-#endif
-
-#ifdef _ADV_TIMERS
         call mpas_timer_start('rescale horiz fluxes')
 #endif
         ! Need all of the edges around owned cells
@@ -362,24 +466,21 @@ module ocn_tracer_advection_mono
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
           do k = 1, maxLevelEdgeTop(iEdge)
-            flux = high_order_flux(k,iEdge)
-            flux = max(0.0_RKIND,flux) * min(flux_outgoing(k,cell1), flux_incoming(k,cell2)) &
-                 + min(0.0_RKIND,flux) * min(flux_incoming(k,cell1), flux_outgoing(k,cell2))
-            high_order_flux(k,iEdge) = flux
+            highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                  + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxIn (k,cell1), flxOut(k,cell2))
           end do ! k loop
         end do ! iEdge loop
         !$omp end do
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
-#endif
-
-#ifdef _ADV_TIMERS
         call mpas_timer_start('flux accumulate')
 #endif
 
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
-        !$omp do schedule(runtime)
+        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, flux, k)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -388,84 +489,87 @@ module ocn_tracer_advection_mono
             iEdge = edgesOnCell(i, iCell)
             signedFactor = invAreaCell1 * edgeSignOnCell(i, iCell)
             do k = 1, maxLevelEdgeTop(iEdge)
-              ! work_tend on the RHS is the upwind tendency
-              ! work_tend on the LHS is the total horizontal advection tendency
-              work_tend(k, iCell) = work_tend(k, iCell) + signedFactor * high_order_flux(k, iEdge)
+              ! workTend on the RHS is the upwind tendency
+              ! workTend on the LHS is the total horizontal advection tendency
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor * highOrderFlx(k, iEdge)
             end do
           end do
 
           do k = 1, maxLevelCell(iCell)
-            ! work_tend on the RHS is the total horizontal advection tendency
-            ! tracer_cur on LHS is the  provisional tracer after horizontal fluxes only.
-            tracer_cur(k,iCell) = (tracer_cur(k, iCell)*layerThickness(k, iCell) + dt*work_tend(k, iCell)) &
-                                  * h_prov_inv(k, iCell)
-            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + work_tend(k,iCell)
+            ! workTend on the RHS is the total horizontal advection tendency
+            ! tracerCur on LHS is the  provisional tracer after horizontal fluxes only.
+            tracerCur(k,iCell) = (tracerCur(k,iCell)*layerThickness(k,iCell) &
+                                  + dt*workTend(k,iCell))*hProvInv(k,iCell)
+            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
           end do
 
         end do ! iCell loop
         !$omp end do
 
-        if (config_compute_active_tracer_budgets) then
-           if (tracerGroupName == 'activeTracers') then
-
-              !$omp do schedule(runtime) private(k)
-              do iEdge = 1,nEdgesArray( 2 )
-                do k = 1,maxLevelEdgeTop(iEdge)
-                  ! Save u*h*T flux on edge for analysis. This variable will be
-                  ! divided by h at the end of the time step.
-                  activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
-                    ( low_order_flux(k,iEdge) + high_order_flux(k,iEdge) ) / dvEdge(iEdge)
-                enddo
-              enddo
-              !$omp end do
-
-              !$omp do schedule(runtime) private(k)
-              do iCell = 1, nCellsArray( 1 )
-                do k = 1, maxLevelCell(iCell)
-                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
-                end do
-              end do ! iCell loop
-              !$omp end do
-           end if
-        end if
-
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags')
 #endif
+        ! Compute budget and monotonicity diagnostics if needed
+        if (computeBudgets) then
 
-#ifdef _ADV_TIMERS
-        call mpas_timer_start('monotonic check')
-#endif
+           !$omp do schedule(runtime)
+           do iEdge = 1,nEdgesArray( 2 )
+           do k = 1,maxLevelEdgeTop(iEdge)
+              ! Save u*h*T flux on edge for analysis. This variable will be
+              ! divided by h at the end of the time step.
+              activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                 (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+           enddo
+           enddo
+           !$omp end do
+
+           !$omp do schedule(runtime)
+           do iCell = 1, nCellsArray( 1 )
+           do k = 1, maxLevelCell(iCell)
+              activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                                                     workTend(k,iCell)
+           end do
+           end do ! iCell loop
+           !$omp end do
+
+        end if ! computeBudgets
+
         if (monotonicityCheck) then
-          nCells = nCellsArray( 1 )
-          !build min and max bounds on old and new tracer for check on monotonicity.
-          !$omp do schedule(runtime) private(k)
-          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-              if(tracer_cur(k,iCell) < tracer_min(k, iCell)-eps) then
+           nCells = nCellsArray( 1 )
+           ! Check tracer values against local min,max to detect
+           ! non-monotone values and write warning if found
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+           do k = 1, maxLevelCell(iCell)
+              if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
                  call mpas_log_write( &
                     'Horizontal minimum out of bounds on tracer: $i $r $r ', &
-                    MPAS_LOG_WARN, intArgs=(/iTracer/), realArgs=(/ tracer_min(k, iCell), tracer_cur(k,iCell) /) )
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMin(k, iCell), tracerCur(k,iCell) /) )
               end if
 
-              if(tracer_cur(k,iCell) > tracer_max(k,iCell)+eps) then
+              if(tracerCur(k,iCell) > tracerMax(k,iCell)+eps) then
                  call mpas_log_write( &
                     'Horizontal maximum out of bounds on tracer: $i $r $r ', &
-                    MPAS_LOG_WARN, intArgs=(/iTracer/), realArgs=(/ tracer_max(k, iCell), tracer_cur(k,iCell) /) )
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMax(k, iCell), tracerCur(k,iCell) /) )
               end if
-            end do
-          end do
-          !$omp end do
-        end if
+           end do
+           end do
+           !$omp end do
+        end if ! monotonicity check
 #ifdef _ADV_TIMERS
-        call mpas_timer_stop('monotonic check')
+        call mpas_timer_stop('advect diags')
 #endif
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  Vertical advection
-!
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+        !-----------------------------------------------------------------------
+        !
+        !  Horizontal advection complete
+        !  Begin vertical advection
+        !
+        !-----------------------------------------------------------------------
 
 #ifdef _ADV_TIMERS
         call mpas_timer_start('cell init')
@@ -475,10 +579,10 @@ module ocn_tracer_advection_mono
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
           do k=1, nVertLevels
-            high_order_flux(k, iCell) = 0.0_RKIND
-            work_tend(k, iCell) = 0.0_RKIND
+            highOrderFlx(k, iCell) = 0.0_RKIND
+            workTend(k, iCell) = 0.0_RKIND
           end do ! k loop
-          high_order_flux(nVertLevels+1, iCell) = 0.0_RKIND
+          highOrderFlx(nVertLevels+1, iCell) = 0.0_RKIND
 
         end do ! iCell loop
         !$omp end do
@@ -492,91 +596,148 @@ module ocn_tracer_advection_mono
 
         ! Need all owned and 1 halo cells
         nCells = nCellsArray( 2 )
-        !  Compute the high and low order vertical fluxes. Also determine bounds on tracer_cur.
+
+        ! Determine bounds on tracerCur from neighbor values for limiting
         !$omp do schedule(runtime)
         do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
 
-          ! Operate on top cell in column
-          k = 1
-          tracer_max(k,iCell) = max(tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-          tracer_min(k,iCell) = min(tracer_cur(k,iCell),tracer_cur(k+1,iCell))
+          ! take care of top cell
+          tracerMax(1,iCell) = max(tracerCur(1,iCell), &
+                                   tracerCur(2,iCell))
+          tracerMin(1,iCell) = min(tracerCur(1,iCell), &
+                                   tracerCur(2,iCell))
+          do k=2,kmax-1
+            tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
+                                     tracerCur(k  ,iCell), &
+                                     tracerCur(k+1,iCell))
+            tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
+                                     tracerCur(k  ,iCell), &
+                                     tracerCur(k+1,iCell))
+          end do
+          ! finish with bottom cell
+          tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
+                                      tracerCur(kmax-1,iCell))
+          tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
+                                      tracerCur(kmax-1,iCell))
+        end do ! cell loop
+        !$omp end do
 
-          ! Operate on next-to-top cell in column
-          k = max(1, min(maxLevelCell(iCell), 2))
-          if ( k >= 2 ) then
-            verticalWeightK = h_prov(k-1, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-            verticalWeightKm1 = h_prov(k, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-            high_order_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1 &
-                *tracer_cur(k-1,iCell))
-            tracer_max(k,iCell) = max(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-            tracer_min(k,iCell) = min(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
+        ! Compute the high order vertical fluxes based on order selected.
+        ! Special cases for top and bottom layers handled in following loop.
+
+        select case (vertOrder)
+        case (vertOrder4)
+
+          !$omp do schedule(runtime)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = w(k,iCell)*( &
+                  7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
+                            (tracerCur(k+1,iCell) + tracerCur(k-2,iCell)))/ &
+                  12.0_RKIND
+
+            end do
+          end do ! cell loop
+          !$omp end do
+
+        case (vertOrder3)
+
+          !$omp do schedule(runtime)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = (w(k,iCell)* &
+                   (7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
+                              (tracerCur(k+1,iCell) + tracerCur(k-2,iCell))) - &
+                        coef3rdOrder*abs(w(k,iCell))* &
+                             ((tracerCur(k+1,iCell) - tracerCur(k-2,iCell)) - &
+                    3.0_RKIND*(tracerCur(k  ,iCell) - tracerCur(k-1,iCell))))/ &
+                   12.0_RKIND
+
+
+            end do
+          end do ! cell loop
+          !$omp end do
+
+       case (vertOrder2)
+
+          !$omp do schedule(runtime)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              verticalWeightK   = hProv(k-1,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              verticalWeightKm1 = hProv(k  ,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              highOrderFlx(k,iCell) = w(k,iCell)* &
+                                 (verticalWeightK  *tracerCur(k  ,iCell) + &
+                                  verticalWeightKm1*tracerCur(k-1,iCell))
+            end do
+          end do ! cell loop
+          !$omp end do
+
+        end select ! vertical order
+
+        ! Treat special cases for high order flux
+        ! Compute low order upwind vertical flux (monotonic and diffused)
+        ! Remove low order flux from the high order flux.
+        ! Store left over high order flux in highOrderFlx array.
+        !$omp do schedule(runtime)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+          ! Next-to-top cell in column is second-order
+          highOrderFlx(1,iCell) = 0.0_RKIND
+          if (kmax > 1) then
+            verticalWeightK   = hProv(1,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            verticalWeightKm1 = hProv(2,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            highOrderFlx(2,iCell) = w(2,iCell)* &
+                               (verticalWeightK  *tracerCur(2,iCell) + &
+                                verticalWeightKm1*tracerCur(1,iCell))
           end if
+          ! Deepest vertical cell in column is second order
+          k = max(2,kmax)
+          verticalWeightK   = hProv(k-1,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          verticalWeightKm1 = hProv(k  ,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          highOrderFlx(k,iCell) = w(k,iCell)* &
+                             (verticalWeightK  *tracerCur(k  ,iCell) + &
+                              verticalWeightKm1*tracerCur(k-1,iCell))
+          highOrderFlx(k+1,iCell) = 0.0_RKIND
 
-          ! Operate on internal cells in column
-          if ( vert4thOrder ) then
-             do k=3,maxLevelCell(iCell)-1
-                high_order_flux(k, iCell) = mpas_tracer_advection_vflux4( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
-                                       tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell))
-
-                tracer_max(k,iCell) = max(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-                tracer_min(k,iCell) = min(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-             end do
-          else if ( vert3rdOrder ) then
-             do k=3,maxLevelCell(iCell)-1
-                high_order_flux(k, iCell) = mpas_tracer_advection_vflux3( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
-                                       tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell), coef_3rd_order )
-
-                tracer_max(k,iCell) = max(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-                tracer_min(k,iCell) = min(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-             end do
-          else if ( vert2ndOrder ) then
-             do k=3,maxLevelCell(iCell)-1
-                verticalWeightK = h_prov(k-1, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-                verticalWeightKm1 = h_prov(k, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-                high_order_flux(k,iCell) = w(k,iCell) * (verticalWeightK * tracer_cur(k,iCell) + verticalWeightKm1 &
-                                              * tracer_cur(k-1,iCell))
-
-                tracer_max(k,iCell) = max(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-                tracer_min(k,iCell) = min(tracer_cur(k-1,iCell),tracer_cur(k,iCell),tracer_cur(k+1,iCell))
-             end do
-          end if
-
-          ! Operate on deepest vertical cell in column.
-          k = max(1, maxLevelCell(iCell))
-          verticalWeightK = h_prov(k-1, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-          verticalWeightKm1 = h_prov(k, iCell) / (h_prov(k, iCell) + h_prov(k-1, iCell))
-          high_order_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
-          tracer_max(k,iCell) = max(tracer_cur(k,iCell),tracer_cur(k-1,iCell))
-          tracer_min(k,iCell) = min(tracer_cur(k,iCell),tracer_cur(k-1,iCell))
-
-          !  low order upwind vertical flux (monotonic and diffused)
-          !  Remove low order flux from the high order flux.
-          !  Store left over high order flux in high_order_flux array.
-          !  Upwind fluxes are accumulated in work_tend
-          do k = 2, maxLevelCell(iCell)
-            low_order_flux(k,iCell) = min(0.0_RKIND,w(k,iCell))*tracer_cur(k-1,iCell) + max(0.0_RKIND,w(k,iCell))*tracer_cur(k,iCell)
-            work_tend(k-1,iCell) = work_tend(k-1,iCell) + low_order_flux(k,iCell)
-            work_tend(k  ,iCell) = work_tend(k  ,iCell) - low_order_flux(k,iCell)
-            high_order_flux(k,iCell) = high_order_flux(k,iCell) - low_order_flux(k,iCell)
+          ! Compute low order (upwind) flux and remove from high order
+          lowOrderFlx(1,iCell) = 0.0_RKIND
+          do k = 2, kmax
+            lowOrderFlx(k,iCell) = &
+                min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
+                max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
+            highOrderFlx(k,iCell) = highOrderFlx(k,iCell) - &
+                                     lowOrderFlx(k,iCell)
           end do ! k loop
+          lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
 
-          ! flux_incoming contains the total remaining high order flux into iCell
+          ! Upwind fluxes are accumulated in workTend
+          ! flxIn contains the total remaining high order flux into iCell
           !          it is positive.
-          ! flux_outgoing contains the total remaining high order flux out of iCell
+          ! flxOut contains the total remaining high order flux out of iCell
           !           it is negative
-          do k = 1, maxLevelCell(iCell)
-            flux_incoming(k, iCell) = max(0.0_RKIND, high_order_flux(k+1, iCell)) &
-                                    - min(0.0_RKIND, high_order_flux(k, iCell))
-            flux_outgoing(k, iCell) = min(0.0_RKIND, high_order_flux(k+1, iCell)) &
-                                    - max(0.0_RKIND, high_order_flux(k, iCell))
+          do k = 1, kmax
+            workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                              - lowOrderFlx(k  ,iCell)
+            flxIn (k, iCell) = max(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - min(0.0_RKIND, highOrderFlx(k  , iCell))
+            flxOut(k, iCell) = min(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - max(0.0_RKIND, highOrderFlx(k  , iCell))
           end do ! k Loop
         end do ! iCell Loop
         !$omp end do
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('vertical flux')
-#endif
 
 #ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux')
         call mpas_timer_start('scale factor build')
 #endif
         ! Need one halo of cells around owned cells
@@ -584,120 +745,135 @@ module ocn_tracer_advection_mono
         !$omp do schedule(runtime)
         do iCell = 1, nCells
 
-          ! Build the factors for the FCT
-          ! Computed using the bounds that were computed previously, and the bounds on the newly updated value
-          ! Factors are placed in the flux_incoming and flux_outgoing arrays
+          ! Build the scale factors to limit flux for FCT
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
+
           do k = 1, maxLevelCell(iCell)
-            ! work_tend on the RHS is the upwind tendency
-            tracer_min_new = (tracer_cur(k,iCell)*h_prov(k,iCell) + dt*(work_tend(k,iCell)+flux_outgoing(k,iCell))) &
-                           * h_new_inv(k,iCell)
-            tracer_max_new = (tracer_cur(k,iCell)*h_prov(k,iCell) + dt*(work_tend(k,iCell)+flux_incoming(k,iCell))) &
-                           * h_new_inv(k,iCell)
-            tracer_upwind_new = (tracer_cur(k,iCell)*h_prov(k,iCell) + dt*work_tend(k,iCell)) * h_new_inv(k,iCell)
+            ! workTend on the RHS is the upwind tendency
+            tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                         * hNewInv(k,iCell)
+            tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                         * hNewInv(k,iCell)
+            tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                            + dt*workTend(k,iCell)) * hNewInv(k,iCell)
 
-            scale_factor = (tracer_max(k,iCell)-tracer_upwind_new)/(tracer_max_new-tracer_upwind_new+eps)
-            flux_incoming(k,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
+            scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
+                          (tracerMaxNew-tracerUpwindNew+eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
 
-            scale_factor = (tracer_upwind_new-tracer_min(k,iCell))/(tracer_upwind_new-tracer_min_new+eps)
-            flux_outgoing(k,iCell) = min( 1.0_RKIND, max( 0.0_RKIND, scale_factor) )
+            scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
+                          (tracerUpwindNew-tracerMinNew+eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
           end do ! k loop
         end do ! iCell loop
         !$omp end do
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
-#endif
-
-#ifdef _ADV_TIMERS
         call mpas_timer_start('flux accumulate')
 #endif
 
         nCells = nCellsArray( 1 )
-        ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
-        !$omp do schedule(runtime) private(flux, k)
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+        !$omp do schedule(runtime)
         do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
           ! rescale the high order vertical flux
-          do k = 2, maxLevelCell(iCell)
-            flux =  high_order_flux(k,iCell)
-            flux = max(0.0_RKIND,flux) * min(flux_outgoing(k  ,iCell), flux_incoming(k-1,iCell)) &
-                 + min(0.0_RKIND,flux) * min(flux_outgoing(k-1,iCell), flux_incoming(k  ,iCell))
-            high_order_flux(k,iCell) = flux
+          do k = 2, kmax
+            flux =  highOrderFlx(k,iCell)
+            highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                    min(flxOut(k  ,iCell), &
+                                        flxIn (k-1,iCell)) &
+                                  + min(0.0_RKIND,flux)*   &
+                                    min(flxOut(k-1,iCell), &
+                                        flxIn (k  ,iCell))
           end do ! k loop
 
-          do k = 1,maxLevelCell(iCell)
-            ! work_tend on the RHS is the upwind tendency
-            ! work_tend on the LHS is the total vertical advection tendency
-            work_tend(k, iCell) = work_tend(k, iCell) + (high_order_flux(k+1, iCell) &
-                                  - high_order_flux(k, iCell))
-            tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + work_tend(k, iCell) 
+          do k = 1,kmax
+            ! workTend on the RHS is the upwind tendency
+            ! workTend on the LHS is the total vertical advection tendency
+            workTend(k, iCell) = workTend(k, iCell)       &
+                               + (highOrderFlx(k+1,iCell) &
+                                - highOrderFlx(k  ,iCell))
+            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
           end do ! k loop
 
         end do ! iCell loop
         !$omp end do
 
-        if (config_compute_active_tracer_budgets) then
-           if (tracerGroupName == 'activeTracers') then
-              !$omp do schedule(runtime) private(k)
-              do iCell = 1, nCells
-                do k = 2, maxLevelCell(iCell)
-                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = low_order_flux(k,iCell) + high_order_flux(k,iCell)
-                end do
-                do k = 1, maxLevelCell(iCell)
-                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
-                end do
-              end do ! iCell loop
-              !$omp end do
-           end if
-        end if
+        ! Compute advection diagnostics and monotonicity checks if requested
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags')
 #endif
+        if (computeBudgets) then
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              do k = 2, maxLevelCell(iCell)
+                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
+                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
+              end do
+              do k = 1, maxLevelCell(iCell)
+                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                    workTend(k,iCell)
+              end do
+           end do ! iCell loop
+           !$omp end do
+        end if ! computeBudgets
 
-#ifdef _ADV_TIMERS
-        call mpas_timer_start('monotonic check')
-#endif
         if (monotonicityCheck) then
           nCells = nCellsArray( 1 )
           ! Check for monotonicity of new tracer value
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
-              ! work_tend on the RHS is the total vertical advection tendency
-              tracer_new = (tracer_cur(k, iCell)*h_prov(k, iCell) + dt * work_tend(k, iCell)) * h_new_inv(k, iCell)
+          do k = 1, maxLevelCell(iCell)
+             ! workTend on the RHS is the total vertical advection tendency
+             tracerNew = (tracerCur(k, iCell)*hProv(k, iCell) &
+                          + dt*workTend(k, iCell))*hNewInv(k, iCell)
 
-              if(tracer_new < tracer_min(k, iCell)-eps) then
-                 call mpas_log_write( &
-                    'Vertical minimum out of bounds on tracer: $i $i $i $r $r ', &
-                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), realArgs=(/ tracer_min(k, iCell), tracer_new /) )
-              end if
+             if (tracerNew < tracerMin(k, iCell)-eps) then
+                call mpas_log_write( &
+                   'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
+                   MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                   realArgs=(/ tracerMin(k, iCell), tracerNew /) )
+             end if
 
-              if(tracer_new > tracer_max(k,iCell)+eps) then
-                 call mpas_log_write( &
-                    'Vertical maximum out of bounds on tracer: $i $i $i $r $r ', &
-                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), realArgs=(/ tracer_max(k, iCell), tracer_new /) )
-              end if
-            end do
+             if (tracerNew > tracerMax(k,iCell)+eps) then
+                call mpas_log_write( &
+                   'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
+                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                    realArgs=(/ tracerMax(k, iCell), tracerNew /) )
+             end if
+          end do
           end do
           !$omp end do
-        end if
+        end if ! monotonicity check
 #ifdef _ADV_TIMERS
-        call mpas_timer_stop('monotonic check')
+        call mpas_timer_stop('advect diags')
 #endif
       end do ! iTracer loop
 
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif
-      call mpas_deallocate_scratch_field(tracerCurField, .true.)
-      call mpas_deallocate_scratch_field(workTendencyField, .true.)
-      call mpas_deallocate_scratch_field(hNewInvField, .true.)
-      call mpas_deallocate_scratch_field(tracerMinField, .true.)
-      call mpas_deallocate_scratch_field(tracerMaxField, .true.)
-      call mpas_deallocate_scratch_field(fluxIncomingField, .true.)
-      call mpas_deallocate_scratch_field(fluxOutgoingField, .true.)
-      call mpas_deallocate_scratch_field(hProvInvField, .true.)
-      call mpas_deallocate_scratch_field(hProvField, .true.)
-      call mpas_deallocate_scratch_field(lowOrderFluxField, .true.)
-      call mpas_deallocate_scratch_field(highOrderFluxField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(tracerCur,    &
+                 tracerMin,    &
+                 tracerMax,    &
+                 hNewInv,      &
+                 hProv,        &
+                 hProvInv,     &
+                 flxIn,        &
+                 flxOut,       &
+                 workTend,     &
+                 lowOrderFlx,  &
+                 highOrderFlx)
+      !$omp end master
 
 #ifdef _ADV_TIMERS
       call mpas_timer_stop('deallocates')
@@ -705,66 +881,92 @@ module ocn_tracer_advection_mono
 
    end subroutine ocn_tracer_advection_mono_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  routine ocn_tracer_advection_mono_init
 !
 !> \brief MPAS initialize monotonic tracer advection tendency with FCT
-!> \author Mark Petersen, David Lee, Doug Jacobsen
-!> \date   October 2017
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
 !> \details
-!>  This routine initializes the monotonic tracer advection tendencity using a FCT.
+!>  This routine initializes monotonic tracer advection quantities for
+!>  the flux-corrected transport (FCT) algorithm.
 !
-!-----------------------------------------------------------------------
-   subroutine ocn_tracer_advection_mono_init(nHalos, horiz_adv_order, vert_adv_order, coef_3rd_order_in, dzdk_positive, & !{{{
-                                             check_monotonicity, err)
+!-------------------------------------------------------------------------------
 
-      use mpas_dmpar
-      integer, intent(in) :: nHalos !< Input: number of halos in current simulation
-      integer, intent(in) :: horiz_adv_order !< Input: Order for horizontal advection
-      integer, intent(in) :: vert_adv_order !< Input: Order for vertical advection
-      real (kind=RKIND), intent(in) :: coef_3rd_order_in !< Input: coefficient for blending advection orders.
-      logical, intent(in) :: dzdk_positive !< Input: Logical flag determining if dzdk is positive or negative.
-      logical, intent(in) :: check_monotonicity !< Input: Logical flag determining check on monotonicity of tracers
-      integer, intent(inout) :: err !< Input/Output: Error Flag
+   subroutine ocn_tracer_advection_mono_init(nHalos, horizAdvOrder,        &
+                                             vertAdvOrder, inCoef3rdOrder, &
+                                             checkMonotonicity, err)!{{{
 
-      err = 0
+      !*** input parameters
 
-      vert2ndOrder = .false.
-      vert3rdOrder = .false.
-      vert4thOrder = .false.
+      integer, intent(in) :: &
+         nHalos               !< [in] number of halos in current simulation
+      integer, intent(in) :: &
+         horizAdvOrder        !< [in] order for horizontal advection
+      integer, intent(in) :: &
+         vertAdvOrder         !< [in] order for vertical advection
+      real (kind=RKIND), intent(in) :: &
+         inCoef3rdOrder       !< [in] coefficient for blending advection orders
+      logical, intent(in) :: &
+         checkMonotonicity    !< [in] flag to check monotonicity of tracers
 
-      if ( horiz_adv_order == 3) then
-          coef_3rd_order = coef_3rd_order_in
-      else if(horiz_adv_order == 2 .or. horiz_adv_order == 4) then
-          coef_3rd_order = 0.0_RKIND
-      end if
+      !*** output parameters
 
-      horizOrder = horiz_adv_order
+      integer, intent(out) :: &
+         err                   !< [out] error flag
 
-      if (vert_adv_order == 3) then
-          vert3rdOrder = .true.
-      else if (vert_adv_order == 4) then
-          vert4thOrder = .true.
-      else
-          vert2ndOrder = .true.
-          if(vert_adv_order /= 2) then
-             call mpas_log_write( &
-                'Invalid value for vert_adv_order, defaulting to 2nd order', &
-                MPAS_LOG_WARN)
-          end if
-      end if
+      ! end of preamble
+      !----------------
+      ! begin code
 
+      err = 0 ! initialize error code to success
+
+      ! Check that the halo is wide enough for FCT
       if (nHalos < 3) then
          call mpas_log_write( &
             'Monotonic advection cannot be used with less than 3 halos.', &
             MPAS_LOG_CRIT)
+         err = -1
       end if
 
-      positiveDzDk = dzdk_positive
-      monotonicityCheck = check_monotonicity
+      ! Set blending coefficient if 3rd order horizontal advection chosen
+      select case (horizAdvOrder)
+      case (2)
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         coef3rdOrder = inCoef3rdOrder
+      case (4)
+         coef3rdOrder = 0.0_RKIND
+      case default
+         coef3rdOrder = 0.0_RKIND
+         call mpas_log_write( &
+            'Invalid value for horizontal advection order, defaulting to 2',&
+            MPAS_LOG_WARN)
+      end select ! horizontal advection order
+
+      ! Set vertical advection order
+      select case (vertAdvOrder)
+      case (2)
+         vertOrder = vertOrder2
+      case (3)
+         vertOrder = vertOrder3
+      case (4)
+         vertOrder = vertOrder4
+      case default
+         vertOrder = vertOrder2
+         call mpas_log_write( &
+            'Invalid value for vertical advection order, defaulting to 2', &
+            MPAS_LOG_WARN)
+      end select ! vertical advection order
+
+      ! Set flag for checking monotonicity
+      monotonicityCheck = checkMonotonicity
 
    end subroutine ocn_tracer_advection_mono_init!}}}
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
 end module ocn_tracer_advection_mono
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -5,19 +5,22 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tracer_advection_std
 !
 !> \brief MPAS standard tracer advection
-!> \author Doug Jacobsen
-!> \date   03/09/12
+!> \author Doug Jacobsen, Phil Jones
+!> \date   03/09/12, updated May 2019
 !> \details
-!>  This module contains routines for standard advection of tracers
+!>  This module contains routines for advection of tracers using a standard
+!>  FV algorithm in MPAS discretization.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+
 module ocn_tracer_advection_std
 
+   ! module includes
    use mpas_kind_types
    use mpas_derived_types
    use mpas_pool_routines
@@ -30,11 +33,19 @@ module ocn_tracer_advection_std
    private
    save
 
-   real (kind=RKIND) :: coef_3rd_order
-   integer :: horizOrder
-   logical :: vert2ndOrder, vert3rdOrder, vert4thOrder
-   logical :: positiveDzDk, monotonicityCheck
+   ! private module variables
+   real (kind=RKIND) :: &
+      coef3rdOrder       !< coefficient for blending high-order terms
 
+   integer :: vertOrder  !< choice of order for vertical advection
+   integer, parameter :: &! enumerator for supported vertical adv order
+      vertOrder2=2,      &!< 2nd order
+      vertOrder3=3,      &!< 3rd order
+      vertOrder4=4        !< 4th order
+
+   logical :: monotonicityCheck !< flag to check monotonicity
+
+   ! public method interfaces
    public :: ocn_tracer_advection_std_tend, &
              ocn_tracer_advection_std_init
 
@@ -116,6 +127,7 @@ module ocn_tracer_advection_std
       call mpas_allocate_scratch_field(highOrderHorizFluxField, .true.)
       call mpas_allocate_scratch_field(tracerCurField, .true.)
       call mpas_allocate_scratch_field(highOrderVertFluxField, .true.)
+      call mpas_threading_barrier()
 
       high_order_horiz_flux => highOrderHorizFluxField % array
       tracer_cur => tracerCurField % array
@@ -147,18 +159,19 @@ module ocn_tracer_advection_std
           high_order_vert_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
 
           do k=3,maxLevelCell(iCell)-1
-             if(vert4thOrder) then
+             select case (vertOrder)
+             case (vertOrder4)
                high_order_vert_flux(k, iCell) = mpas_tracer_advection_vflux4( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
                                       tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell))
-             else if(vert3rdOrder) then
+             case (vertOrder3)
                high_order_vert_flux(k, iCell) = mpas_tracer_advection_vflux3( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
-                                      tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell), coef_3rd_order )
-             else if (vert2ndOrder) then
+                                      tracer_cur(k  ,iCell),tracer_cur(k+1,iCell), w(k,iCell), coef3rdOrder )
+             case (vertOrder2)
                verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
                verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
                high_order_vert_flux(k,iCell) = w(k, iCell) * (verticalWeightK * tracer_cur(k, iCell) &
                                              + verticalWeightKm1 * tracer_cur(k-1, iCell))
-             end if
+             end select ! vertOrder
           end do
 
           k = max(1, maxLevelCell(iCell))
@@ -187,7 +200,7 @@ module ocn_tracer_advection_std
           do i = 1, nAdvCellsForEdge(iEdge)
             iCell = advCellsForEdge(i,iEdge)
             do k = 1, maxLevelCell(iCell)
-              tracer_weight = highOrderAdvectionMask(k, iEdge) * (adv_coefs(i,iEdge) + coef_3rd_order &
+              tracer_weight = highOrderAdvectionMask(k, iEdge) * (adv_coefs(i,iEdge) + coef3rdOrder &
                             * sign(1.0_RKIND,normalThicknessFlux(k,iEdge))*adv_coefs_3rd(i,iEdge))
 
               tracer_weight = normalThicknessFlux(k,iEdge)*tracer_weight
@@ -222,6 +235,7 @@ module ocn_tracer_advection_std
         !$omp end do
       end do ! iTracer loop
 
+      call mpas_threading_barrier()
       call mpas_deallocate_scratch_field(highOrderHorizFluxField, .true.)
       call mpas_deallocate_scratch_field(tracerCurField, .true.)
       call mpas_deallocate_scratch_field(highOrderVertFluxField, .true.)
@@ -230,57 +244,80 @@ module ocn_tracer_advection_std
 
    end subroutine ocn_tracer_advection_std_tend!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  routine ocn_tracer_advection_std_init
 !
 !> \brief MPAS initialize standard tracer advection tendency.
-!> \author Doug Jacobsen
-!> \date   03/09/12
+!> \author Doug Jacobsen, Phil Jones
+!> \date   03/09/12, updated May 2019
 !> \details
-!>  This routine initializes the standard tracer advection tendencity.
+!>  This routine initializes constants and choices for the standard tracer
+!>  advection tendency.
 !
-!-----------------------------------------------------------------------
-   subroutine ocn_tracer_advection_std_init(horiz_adv_order, vert_adv_order, coef_3rd_order_in, dzdk_positive, & !{{{
-                                            check_monotonicity, err)
-      integer, intent(in) :: horiz_adv_order !< Input: Order for horizontal advection
-      integer, intent(in) :: vert_adv_order !< Input: Order for vertical advection
-      real (kind=RKIND), intent(in) :: coef_3rd_order_in !< Input: coefficient for blending advection orders.
-      logical, intent(in) :: dzdk_positive !< Input: Logical flag determining if dzdk is positive or negative.
-      logical, intent(in) :: check_monotonicity !< Input: Logical flag determining check on monotonicity of tracers
-      integer, intent(inout) :: err !< Input/Output: Error Flag
+!-------------------------------------------------------------------------------
 
-      err = 0
+   subroutine ocn_tracer_advection_std_init(horzAdvOrder, vertAdvOrder, &
+                                            inCoef3rdOrder,             &
+                                            checkMonotonicity, err) !{{{
 
-      vert2ndOrder = .false.
-      vert3rdOrder = .false.
-      vert4thOrder = .false.
+      !*** input parameters
 
-      if ( horiz_adv_order == 3) then
-          coef_3rd_order = coef_3rd_order_in
-      else if(horiz_adv_order == 2 .or. horiz_adv_order == 4) then
-          coef_3rd_order = 0.0_RKIND
-      end if
+      integer, intent(in) :: &
+         horzAdvOrder         !< [in] Order for horizontal advection
+      integer, intent(in) :: &
+         vertAdvOrder         !< [in] Order for vertical advection
+      real (kind=RKIND), intent(in) :: &
+         inCoef3rdOrder       !< [in] Coefficient for blending advection orders
+      logical, intent(in) :: &
+         checkMonotonicity    !< [in] Flag to check on monotonicity of tracers
 
-      horizOrder = horiz_adv_order
+      !*** output parameters
 
-      if (vert_adv_order == 3) then
-          vert3rdOrder = .true.
-      else if (vert_adv_order == 4) then
-          vert4thOrder = .true.
-      else
-          vert2ndOrder = .true.
-          if(vert_adv_order /= 2) then
-             call mpas_log_write( &
-                'Invalid value for vert_adv_order, defaulting to 2nd order', &
-                MPAS_LOG_WARN)
-          end if
-      end if
+      integer, intent(out) :: err !< [out] Error Flag
 
-      positiveDzDk = dzdk_positive
-      monotonicityCheck = check_monotonicity
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      err = 0 ! set error code to success
+
+      ! set monotonicity flag
+      monotonicityCheck = checkMonotonicity
+
+      ! set 3rd order coefficient based on horizontal order choice
+      select case (horzAdvOrder)
+      case (2)
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         coef3rdOrder = inCoef3rdOrder
+      case (4)
+         coef3rdOrder = 0.0_RKIND
+      case default
+         call mpas_log_write( &
+            'Invalid value for horz advection order, defaulting to 2nd order', &
+            MPAS_LOG_WARN)
+      end select ! horzAdvOrder
+
+      ! set choice of vertical advection order
+      select case (vertAdvOrder)
+      case (2)
+         vertOrder = vertOrder2
+      case (3)
+         vertOrder = vertOrder3
+      case (4)
+         vertOrder = vertOrder4
+      case default
+         vertOrder = vertOrder2
+         call mpas_log_write( &
+         'Invalid value for vertical advection order, defaulting to 2nd order',&
+         MPAS_LOG_WARN)
+      end select ! vertAdvOrder
 
    end subroutine ocn_tracer_advection_std_init!}}}
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
 end module ocn_tracer_advection_std
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||


### PR DESCRIPTION
ocean tracer advection CPU optimizations, including:
  - moving options to module private variable to reduce config calls
  - added contiguous keyword to pointers
  - passed pointers to automatic arrays
  - replaced diagnostic string argument with logical flag
  - replaced scratch fields with local thread-shared allocatable arrays
  - changed loop order in provisional thickness calc to reduce flops
  - introduced temps in horz flux calculation to reduce flops
  - moved min, max calculations to separate loops (both vert, horz)
  - modified high-order vert flux to move conditionals outside loops
  - inlined high-order vert flux functions
  - reordered a few other calculations for efficiency
  - general cleanup to remove stale variables, reduce long lines, etc

Changes are not b4b, but are at round-off. I've been very careful, but due to the large number of changes, probably should be evaluated in a transport test case or longer sim.

Tested mostly with a QU240 test case both after a single step (to confirm roundoff) and in 2-day runs. Most tests on Cori. Changes resulted in 2-3x speedup for tracer adv timers, depending on configuration.