### PR TITLE
Return error from read_stream() when inexact stream time not found

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -3815,6 +3815,8 @@ module mpas_stream_manager
                   call mpas_createStream(testStream, manager % ioContext, test_filename, stream % io_type, MPAS_IO_READ, precision=stream % precision, ierr=local_ierr)
               else
                   STREAM_DEBUG_WRITE(' Filename: ' // trim(test_filename) // ' does not exist.')
+                  ierr = MPAS_STREAM_MGR_ERROR
+                  return
               end if
            end if
 


### PR DESCRIPTION
This merge ensures that read_stream() returns an error code when an inexact
stream time is not found.

The MPAS_stream_mgr_read() routine calls read_stream() to handle the actual
reading of an individual stream. Previously, the read_stream routine did not
return an error code if the requested stream time was not MPAS_STREAM_EXACT_TIME
and the requested time could not be found. For example, if the earliest time
strictly after the current time was requested from a stream, but no file with
data after the current time was found, the read_stream routine would not return
an error, but would incorrectly try to read from record 0 (which is not valid)
from whatever file was last opened by the stream.

The fix in this commit simply sets the error code to MPAS_STREAM_MGR_ERROR
and returns when the Fortran INQUIRE statement for the appropriate file returns
false (indicating that the needed file is not found).