### PR TITLE
Communicate effective radii for cloud, ice, and snow between MPAS and WSM6

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -572,6 +572,9 @@
           qi_p(i,k,j) = qi(k,i)
           qs_p(i,k,j) = qs(k,i)
           qg_p(i,k,j) = qg(k,i)
+          recloud_p(i,k,j) = re_cloud(k,i)
+          reice_p(i,k,j)   = re_ice(k,i)
+          resnow_p(i,k,j)  = re_snow(k,i)
        enddo
        enddo
        enddo
@@ -595,9 +598,6 @@
              nr_p(i,k,j) = nr(k,i)
              rainprod_p(i,k,j) = rainprod(k,i)
              evapprod_p(i,k,j) = evapprod(k,i)
-             recloud_p(i,k,j)  = re_cloud(k,i)
-             reice_p(i,k,j)    = re_ice(k,i)
-             resnow_p(i,k,j)   = re_snow(k,i)
           enddo
           enddo
           enddo
@@ -750,6 +750,9 @@
           qi(k,i) = qi_p(i,k,j)
           qs(k,i) = qs_p(i,k,j)
           qg(k,i) = qg_p(i,k,j)
+          re_cloud(k,i) = recloud_p(i,k,j)
+          re_ice(k,i)   = reice_p(i,k,j)
+          re_snow(k,i)  = resnow_p(i,k,j)
        enddo
        enddo
        enddo
@@ -767,9 +770,6 @@
              nr(k,i) = nr_p(i,k,j)
              rainprod(k,i) = rainprod_p(i,k,j)
              evapprod(k,i) = evapprod_p(i,k,j)
-             re_cloud(k,i) = recloud_p(i,k,j)
-             re_ice(k,i)   = reice_p(i,k,j)
-             re_snow(k,i)  = resnow_p(i,k,j)
           enddo
           enddo
           enddo


### PR DESCRIPTION
This merge corrects a bug, wherein the effective radii for cloud, ice, and
snow were not being communicated between the WSM6 microphysics
scheme and MPAS. Specifically, this fix affects simulations that use
the WSM6 microphysics scheme and the RRTMG radiation schemes,
and that have config_microp_re = true in the namelist. Without this fix,
the RRTMG schemes would not use the effective radii from the microphysics,
but would instead use zero values (which are then set according to a lower
bound in the RRTMG schemes) everywhere for these fields.