### PR TITLE
Update BGC version

### DIFF
--- a/src/core_ocean/get_BGC.sh
+++ b/src/core_ocean/get_BGC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## BGC Tag for build
-BGC_TAG=2b8aadd
+BGC_TAG=5588636f0e71a97c532391a5d9c252b1c6f3611a
 
 ## Subdirectory in BGC repo to use
 BGC_SUBDIR=.


### PR DESCRIPTION
The only change is the addition of python 3 support during the build.

Brings in https://github.com/E3SM-Project/Ocean-BGC/pull/1 and https://github.com/E3SM-Project/Ocean-BGC/pull/2.