### PR TITLE
fix ZISO python quotes

### DIFF
--- a/testing_and_setup/compass/ocean/ziso/20km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/ziso/20km/default/config_forward.xml
@@ -60,7 +60,7 @@
 			<argument flag="">-p</argument>
 			<argument flag="">4</argument>
 			<argument flag="">--types</argument>
-			<argument flag="">["buoyancy"]</argument>
+			<argument flag="">buoyancy</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>


### PR DESCRIPTION
Nightly test suite on grizzly currently fails on `ziso/20km/default` case. Needs this correction, otherwise text parsing is incorrect within python.