### PR TITLE
Add time-varying land-ice forcing to MPAS-Ocean

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -758,6 +758,30 @@
 			description="Number of days to ramp up time varying forcing"
 			possible_values="Any positive real number"
 		/>
+		<nml_option name="config_use_time_varying_land_ice_forcing" type="logical" default_value=".false." units="unitless"
+			description="If true calculate input forcing fields."
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_time_varying_land_ice_forcing_start_time" type="character" default_value="0001-01-01_00:00:00" units="unitless"
+			description="Forcing time to use at the simulation start time"
+			possible_values="'YYYY-MM-DD_HH:MM:SS"
+		/>
+		<nml_option name="config_time_varying_land_ice_forcing_reference_time" type="character" default_value="0001-01-01_00:00:00" units="unitless"
+			description="Reference time for the forcing"
+			possible_values="'YYYY-MM-DD_HH:MM:SS"
+		/>
+		<nml_option name="config_time_varying_land_ice_forcing_cycle_start" type="character" default_value="0001-01-01_00:00:00" units="unitless"
+			description="Start time for the forcing cycle."
+			possible_values="'YYYY-MM-DD_HH:MM:SS"
+		/>
+		<nml_option name="config_time_varying_land_ice_forcing_cycle_duration" type="character" default_value="2-00-00_00:00:00" units="unitless"
+			description="Duration of the forcing cycle."
+			possible_values="'YYYY-MM-DD_HH:MM:SS"
+		/>
+		<nml_option name="config_time_varying_land_ice_forcing_interval" type="character" default_value="01:00:00" units="unitless"
+			description="Time between forcing inputs"
+			possible_values="'YYYY-MM-DD_HH:MM:SS"
+		/>
 	</nml_record>
 	<nml_record name="coupling" mode="init;forward">
 		<nml_option name="config_ssh_grad_relax_timescale" type="real" default_value="0.0" units="seconds"
@@ -1306,6 +1330,7 @@
 	</nml_record>
 	<packages>
 		<package name="timeVaryingAtmosphericForcingPKG" description="This package includes variables required for time varying atmospheric forcing"/>
+		<package name="timeVaryingLandIceForcingPKG" description="This package includes variavles required for time varying land-ice forcing"/>
 		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
 
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
@@ -1712,6 +1737,17 @@
 			<var name="atmosPressure"/>
 			<var name="windSpeedU"/>
 			<var name="windSpeedV"/>
+		</stream>
+		<stream name="land_ice_forcing"
+				type="input"
+				filename_template="land_ice_forcing.nc"
+				filename_interval="none"
+				input_interval="none"
+				packages="timeVaryingLandIceForcingPKG"
+				immutable="true">
+			<var name="landIcePressureForcing"/>
+			<var name="landIceFractionForcing"/>
+			<var name="landIceDraftForcing"/>
 		</stream>
 
 		<!-- Diagnostics streams for forward mode -->
@@ -3124,6 +3160,18 @@
 		<var name="atmosPressure" type="real" dimensions="nCells Time" units="Pa"
 			description="Pressure at the sea surface due to the atmosphere."
 			packages="timeVaryingAtmosphericForcingPKG"
+		/>
+		<var name="landIceFractionForcing" type="real" dimensions="nCells Time" units="unitless"
+			description="The fraction of each cell covered by land ice"
+			packages="timeVaryingLandIceForcingPKG"
+		/>
+		<var name="landIcePressureForcing" type="real" dimensions="nCells Time" units="Pa"
+			description="Pressure defined at the sea surface due to land ice."
+			packages="timeVaryingLandIceForcingPKG"
+		/>
+		<var name="landIceDraftForcing" type="real" dimensions="nCells Time" units="m"
+			description="The elevation of the interface between land ice and the ocean."
+			packages="timeVaryingLandIceForcingPKG"
 		/>
 	</var_struct>
 	<var_struct name="scratch" time_levs="1">

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -1315,7 +1315,7 @@ contains
 
       ! landIceFreshwaterFlux
       variableIndex = variableIndex + 1
-      if (associated(landIceFreshwaterFlux)) then
+      if (associated(landIceFreshwaterFlux) .and. landIceFloatingAreaSum > 0.0_RKIND) then
          averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
          rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
       else
@@ -1328,7 +1328,7 @@ contains
 
       ! accumulatedLandIceMass
       variableIndex = variableIndex + 1
-      if (associated(accumulatedLandIceMass)) then
+      if (associated(accumulatedLandIceMass) .and. landIceFloatingAreaSum > 0.0_RKIND) then
          averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
          rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
       else
@@ -1338,7 +1338,7 @@ contains
 
       ! accumulatedLandIceHeat
       variableIndex = variableIndex + 1
-      if (associated(accumulatedLandIceHeat)) then
+      if (associated(accumulatedLandIceHeat) .and. landIceFloatingAreaSum > 0.0_RKIND) then
          averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
          rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
       else
@@ -1348,7 +1348,7 @@ contains
 
       ! accumulatedLandIceFrazilMass
       variableIndex = variableIndex + 1
-      if (landIceFluxesPkgActive .and. frazilIcePkgActive) then
+      if (landIceFluxesPkgActive .and. frazilIcePkgActive .and. landIceFloatingAreaSum > 0.0_RKIND) then
          averages(variableIndex) = sums(variableIndex)/(landIceFloatingAreaSum)
          rms(variableIndex) = sqrt(sumSquares(variableIndex)/(landIceFloatingAreaSum))
       else

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -124,6 +124,7 @@ module ocn_core_interface
       logical, pointer :: variableShortwaveActive
       logical, pointer :: gmActive
       logical, pointer :: timeVaryingAtmosphericForcingPKGActive
+      logical, pointer :: timeVaryingLandIceForcingPKGActive
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -149,6 +150,7 @@ module ocn_core_interface
       logical, pointer :: config_use_tidal_forcing
       logical, pointer :: config_use_standardGM
       logical, pointer :: config_use_time_varying_atmospheric_forcing
+      logical, pointer :: config_use_time_varying_land_ice_forcing
 
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
@@ -310,6 +312,12 @@ module ocn_core_interface
                                 config_use_time_varying_atmospheric_forcing)
       if (config_use_time_varying_atmospheric_forcing) then
          timeVaryingAtmosphericForcingPKGActive = .true.
+      endif
+
+      call mpas_pool_get_package(packagePool, 'timeVaryingLandIceForcingPKGActive', timeVaryingLandIceForcingPKGActive)
+      call mpas_pool_get_config(configPool, 'config_use_time_varying_land_ice_forcing', config_use_time_varying_land_ice_forcing)
+      if (config_use_time_varying_land_ice_forcing) then
+         timeVaryingLandIceForcingPKGActive = .true.
       endif
 
       !

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -489,6 +489,7 @@ module ocn_forward_mode
       logical, pointer :: config_use_activeTracers_surface_restoring
       logical, pointer :: config_use_surface_salinity_monthly_restoring
       logical, pointer :: config_use_time_varying_atmospheric_forcing
+      logical, pointer :: config_use_time_varying_land_ice_forcing
 
       ierr = 0
 
@@ -502,6 +503,8 @@ module ocn_forward_mode
                                                    config_use_surface_salinity_monthly_restoring)
       call MPAS_pool_get_config(domain % configs, 'config_use_time_varying_atmospheric_forcing', &
                                                    config_use_time_varying_atmospheric_forcing)
+      call MPAS_pool_get_config(domain % configs, 'config_use_time_varying_land_ice_forcing', &
+                                                   config_use_time_varying_land_ice_forcing)
 
       ! Eventually, dt should be domain specific
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=ierr)
@@ -644,7 +647,8 @@ module ocn_forward_mode
             if (trim(config_sw_absorption_type)=='ohlmann00' .or. &
                 config_use_ecosysTracers .or. &
                 (config_use_activeTracers_surface_restoring .and. config_use_surface_salinity_monthly_restoring) .or. &
-                config_use_time_varying_atmospheric_forcing) then
+                config_use_time_varying_atmospheric_forcing .or. &
+                config_use_time_varying_land_ice_forcing) then
 
                 call ocn_time_varying_forcing_write_restart_times(domain)
             end if

--- a/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
@@ -3,8 +3,8 @@
 !  ocn_time_varying_forcing
 !
 !> \brief Module to handle time-varying forcing for the ocean core
-!> \author Steven Brus, LANL
-!> \date 1/8/2019
+!> \author Steven Brus, Xylar Asay-Davis, LANL
+!> \date 2/3/2019 
 !> \details
 !>  Manages the wind and pressure forcing for the ocean.
 !>  Based very closely on the seaice forcing module and
@@ -42,8 +42,8 @@ contains
 !  ocn_time_varying_forcing_init
 !
 !> \brief Driver for ocean core forcing initialization
-!> \author Steven Brus, LANL
-!> \date 1/8/2019
+!> \author Steven Brus, Xylar Asay-Davis, LANL
+!> \date 2/3/2019
 !> \details
 !>
 !
@@ -54,13 +54,21 @@ contains
     type (domain_type) :: domain
 
     logical, pointer :: &
-         config_use_time_varying_atmospheric_forcing
+         config_use_time_varying_atmospheric_forcing, &
+         config_use_time_varying_land_ice_forcing
 
     call MPAS_pool_get_config(domain % configs, "config_use_time_varying_atmospheric_forcing", config_use_time_varying_atmospheric_forcing)
 
     ! init the atmospheric forcing
     if (config_use_time_varying_atmospheric_forcing) then
        call init_atmospheric_forcing(domain)
+    endif
+
+    call MPAS_pool_get_config(domain % configs, "config_use_time_varying_land_ice_forcing", config_use_time_varying_land_ice_forcing)
+
+    ! init other forcings, to be added later as needed
+    if (config_use_time_varying_land_ice_forcing) then
+      call init_land_ice_forcing(domain)
     endif
 
     ! init other forcings, to be added later as needed
@@ -229,8 +237,8 @@ contains
 !  ocn_time_varying_forcing_get
 !
 !> \brief Retrieve forcing data during time stepping
-!> \author Steven Brus, LANL
-!> \date 1/8/2019
+!> \author Steven Brus, Xylar Asay-Davis, LANL
+!> \date 2/3/2019
 !> \details
 !>  This routine calls the MPAS_forcing routine that will perform the
 !>  forcing data aquisition and interpolation during timestepping
@@ -246,13 +254,26 @@ contains
     type (MPAS_clock_type) :: simulationClock
 
     logical, pointer :: &
-         config_use_time_varying_atmospheric_forcing
+         config_use_time_varying_atmospheric_forcing, &
+         config_use_time_varying_land_ice_forcing
 
     call MPAS_pool_get_config(domain % configs, "config_use_time_varying_atmospheric_forcing", config_use_time_varying_atmospheric_forcing)
 
     if (config_use_time_varying_atmospheric_forcing) then
 
         call atmospheric_forcing(&
+             streamManager, &
+             domain, &
+             simulationClock)
+
+    endif
+
+    call MPAS_pool_get_config(domain % configs, "config_use_time_varying_land_ice_forcing", &
+                              config_use_time_varying_land_ice_forcing)
+
+    if (config_use_time_varying_land_ice_forcing) then
+
+        call land_ice_forcing(&
              streamManager, &
              domain, &
              simulationClock)
@@ -459,6 +480,169 @@ contains
   end subroutine ocn_time_varying_forcing_write_restart_times!}}}
 
 !-----------------------------------------------------------------------
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_land_ice_forcing
+!
+!> \brief
+!> \author Xylar Asay-Davis, LANL
+!> \date 2/3/2019
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_land_ice_forcing(domain)!{{{
+
+    type (domain_type) :: domain
+
+    character(len=strKIND), pointer :: &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration, &
+         forcingInterval, &
+         forcingReferenceTime
+
+    logical, pointer :: &
+         config_do_restart
+
+
+    ! get land-ice forcing configuration options
+    call mpas_pool_get_config(domain % configs, "config_time_varying_land_ice_forcing_start_time", &
+         config_forcing_start_time)
+
+    call mpas_pool_get_config(domain % configs, "config_time_varying_land_ice_forcing_cycle_start", &
+         config_forcing_cycle_start)
+
+    call mpas_pool_get_config(domain % configs, "config_time_varying_land_ice_forcing_cycle_duration", &
+         config_forcing_cycle_duration)
+
+    call mpas_pool_get_config(domain % configs, "config_time_varying_land_ice_forcing_interval", &
+         forcingInterval)
+
+    call mpas_pool_get_config(domain % configs, "config_time_varying_land_ice_forcing_reference_time", &
+         forcingReferenceTime)
+
+    call mpas_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+
+    ! create the land-ice forcing group
+    call mpas_forcing_init_group(forcingGroupHead, "ocn_land_ice_forcing", domain, config_forcing_start_time, &
+         config_forcing_cycle_start, config_forcing_cycle_duration, config_do_restart)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIcePressure", "land_ice_forcing", "timeVaryingForcing", "landIcePressureForcing", "linear", &
+         forcingReferenceTime, forcingInterval)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIceFraction", "land_ice_forcing", "timeVaryingForcing", "landIceFractionForcing", "linear", &
+         forcingReferenceTime, forcingInterval)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIceDraft", "land_ice_forcing", "timeVaryingForcing", "landIceDraftForcing", "linear", &
+         forcingReferenceTime, forcingInterval)
+
+    call mpas_forcing_init_field_data(&
+         forcingGroupHead, &                     ! forcingGroupHead
+         "ocn_land_ice_forcing", &               ! forcingGroupName
+         domain % streamManager, &               ! streamManager
+         config_do_restart, &                    ! restart
+         .true.)                                 ! interpolateAtInit
+
+  end subroutine init_land_ice_forcing!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  land_ice_forcing
+!
+!> \brief Compute land-ice pressure
+!> \author Xylar Asay-Davis, LANL
+!> \date 2/3/2019
+!> \details Interpolate the pressure from overlying land ice
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine land_ice_forcing(streamManager, domain, simulationClock)!{{{
+
+    type (MPAS_streamManager_type), intent(inout) :: streamManager
+
+    type (domain_type) :: domain
+
+    type (MPAS_clock_type) :: simulationClock
+
+    type (MPAS_time_type) :: currentForcingTime
+
+    type (block_type), pointer :: block
+
+    character(len=StrKIND), pointer :: config_dt
+
+    type (MPAS_timeInterval_type) :: timeStepESMF
+
+    character(len=StrKIND) :: timeStamp
+
+    real (kind=RKIND) :: dtSim
+
+    integer :: err
+
+    type (mpas_pool_type), pointer :: &
+         mesh, &
+         forcingPool, &
+         timeVaryingForcingPool
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         landIceFractionForcing, &
+         landIceFraction, &
+         landIcePressureForcing, &
+         landIcePressure, &
+         landIceDraftForcing, &
+         landIceDraft
+
+    integer, pointer :: &
+         nCells
+
+    integer :: &
+         iCell
+
+    ! configurations
+    call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
+
+    ! convert config_dt to real
+    call mpas_set_timeInterval(timeStepESMF, timeString=config_dt,ierr=err)
+    call mpas_get_timeInterval(timeStepESMF, dt=dtSim)
+
+    ! use the forcing layer to get data
+    call mpas_forcing_get_forcing(forcingGroupHead, "ocn_land_ice_forcing", streamManager, dtSim)
+
+    call mpas_forcing_get_forcing_time(forcingGroupHead, "ocn_land_ice_forcing", currentForcingTime)
+
+    block => domain % blocklist
+    do while (associated(block))
+
+       call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+       call MPAS_pool_get_subpool(block % structs, "forcing", forcingPool)
+       call MPAS_pool_get_subpool(block % structs, "timeVaryingForcing", timeVaryingForcingPool)
+   
+       call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+   
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFractionForcing", landIceFractionForcing)
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIcePressureForcing", landIcePressureForcing)
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIceDraftForcing", landIceDraftForcing)
+       call MPAS_pool_get_array(forcingPool, "landIceFraction", landIceFraction)
+       call MPAS_pool_get_array(forcingPool, "landIcePressure", landIcePressure)
+       call MPAS_pool_get_array(forcingPool, "landIceDraft", landIceDraft)
+   
+       do iCell = 1, nCells
+   
+          landIceFraction(iCell) = landIceFractionForcing(iCell)
+          landIcePressure(iCell) = landIcePressureForcing(iCell)
+          landIceDraft(iCell) = landIceDraftForcing(iCell)
+   
+       enddo
+       block => block % next
+    end do
+
+  end subroutine land_ice_forcing!}}}
 
 end module ocn_time_varying_forcing
 ! vim: foldmethod=marker

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
@@ -30,10 +30,10 @@
 
 	<run_script name="run.py">
 		<step executable="./processInputGeometry.py">
-			<argument flag="">input_geometry.nc</argument>
-			<argument flag="">input_geometry_processed.nc</argument>
-			<argument flag="">2.0</argument>
-			<argument flag="">100.0</argument>
+			<argument flag="-i">input_geometry.nc</argument>
+			<argument flag="-o">input_geometry_processed.nc</argument>
+			<argument flag="-s">2.0</argument>
+			<argument flag="-m">100.0</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
@@ -32,10 +32,10 @@
 
 	<run_script name="run.py">
 		<step executable="./processInputGeometry.py">
-			<argument flag="">input_geometry.nc</argument>
-			<argument flag="">input_geometry_processed.nc</argument>
-			<argument flag="">2.0</argument>
-			<argument flag="">100.0</argument>
+			<argument flag="-i">input_geometry.nc</argument>
+			<argument flag="-o">input_geometry_processed.nc</argument>
+			<argument flag="-s">2.0</argument>
+			<argument flag="-m">100.0</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
@@ -16,6 +16,8 @@
 		<option name="config_pio_num_iotasks">1</option>
 		<option name="config_pio_stride">4</option>
 		<option name="config_iterative_init_variable">'ssh'</option>
+		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
+		<option name="config_eos_type">'jm'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_adjust_ssh.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<config case="adjust_ssh">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/ocean.nc" dest="init0.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
+	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/plot_cart_ssh_landIcePressure.py" dest="plot_cart_ssh_landIcePressure.py"/>
+	<add_link source_path="script_core_dir" source="scripts/plot_globalStats.py" dest="plot_globalStats.py"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
+		<option name="config_iterative_init_variable">'ssh'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_adjust_ssh.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<stream name="globalStatsOutput">
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<step executable="./iterate_init.py">
+ 			<argument flag="--iteration_count">10</argument>
+ 			<argument flag="--variable_to_modify">landIcePressure</argument>
+		</step>
+	</run_script>
+
+	<run_script name="run_model.py">
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_driver.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_driver.xml
@@ -1,0 +1,22 @@
+<driver_script name="run_test.py">
+	<case name="init_step1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message="     Complete"/>
+	</case>
+	<case name="init_step2">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init_step2" post_message="     Complete"/>
+	</case>
+	<case name="adjust_ssh">
+		<step executable="./run.py" quiet="true" pre_message=" * Running adjust_ssh" post_message="     Complete"/>
+	</case>
+	<case name="forward_short">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward_short" post_message="     Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward_short/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+		<compare_fields file1="forward_short/land_ice_fluxes.nc">
+			<template file="land_ice_flux_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data_init.nc"/>
+	<add_link source="../adjust_ssh/init.nc" dest="init.nc"/>
+	<add_link source="forcing_data_init.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<add_link source_path="script_configuration_dir" source="viz" dest="viz"/>
+	<add_link source_path="script_configuration_dir" source="update_evaporationFlux.py" dest="update_evaporationFlux.py"/>
+	<add_link source_path="script_test_dir" source="processLandIceForcing.py" dest="processLandIceForcing.py"/>
+	<add_link source_path="utility_scripts" source="setup_restart.py" dest="setup_restart.py"/>
+	<add_link source_path="utility_scripts" source="check_progress.py" dest="check_progress.py"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_use_time_varying_land_ice_forcing">.true.</option>
+		<option name="config_time_varying_land_ice_forcing_start_time">'0001-01-01_00:00:00'</option>
+		<option name="config_time_varying_land_ice_forcing_reference_time">'0001-01-01_00:00:00'</option>
+		<option name="config_time_varying_land_ice_forcing_cycle_start">'none'</option>
+		<option name="config_time_varying_land_ice_forcing_cycle_duration">'0002-00-00_00:00:00'</option>
+		<option name="config_time_varying_land_ice_forcing_interval">'0001-00-00_00:00:00'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./processLandIceForcing.py">
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">136</argument>
+		</step>
+		<model_run procs="136" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./update_evaporationFlux.py">
+			<argument flag="--in_forcing_file">forcing_data_init.nc</argument>
+			<argument flag="--out_forcing_file">forcing_data_updated.nc</argument>
+			<argument flag="--out_forcing_link">forcing_data.nc</argument>
+			<argument flag="--avg_months">3</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward.xml
@@ -22,6 +22,8 @@
 		<option name="config_time_varying_land_ice_forcing_cycle_start">'none'</option>
 		<option name="config_time_varying_land_ice_forcing_cycle_duration">'0002-00-00_00:00:00'</option>
 		<option name="config_time_varying_land_ice_forcing_interval">'0001-00-00_00:00:00'</option>
+		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
+		<option name="config_eos_type">'jm'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward_short.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<config case="forward_short">
+	<add_link source="../init_step2/graph.info" dest="graph.info"/>
+	<add_link source="../init_step2/init_mode_forcing_data.nc" dest="forcing_data_init.nc"/>
+	<add_link source="../adjust_ssh/init.nc" dest="init.nc"/>
+	<add_link source="forcing_data_init.nc" dest="forcing_data.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<option name="config_run_duration">'0000-00-00_01:00:00'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<stream name="output">
+			<attribute name="output_interval">0000_01:00:00</attribute>
+		</stream>
+		<template file="land_ice_fluxes.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="land_ice_fluxes">
+			<attribute name="clobber_mode">overwrite</attribute>
+			<attribute name="output_interval">0000_01:00:00</attribute>
+		</stream>
+		<stream name="globalStatsOutput">
+			<attribute name="output_interval">0000_00:00:01</attribute>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward_short.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_forward_short.xml
@@ -13,6 +13,8 @@
 		<option name="config_run_duration">'0000-00-00_01:00:00'</option>
 		<option name="config_pio_num_iotasks">1</option>
 		<option name="config_pio_stride">4</option>
+		<option name="config_pressure_gradient_type">'Jacobian_from_TS'</option>
+		<option name="config_eos_type">'jm'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="forward">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init1.xml
@@ -19,9 +19,9 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_init.xml" path_base="script_configuration_dir"/>
 		<option name="config_write_cull_cell_mask">.true.</option>
-		<option name="config_isomip_plus_init_bot_temp">-1.9</option>
-		<option name="config_isomip_plus_init_bot_sal">34.55</option>
-		<option name="config_isomip_plus_restore_evap_rate">2.0</option>
+		<option name="config_isomip_plus_init_bot_temp">1.0</option>
+		<option name="config_isomip_plus_init_bot_sal">34.7</option>
+		<option name="config_isomip_plus_restore_evap_rate">200.0</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
@@ -34,6 +34,7 @@
 			<argument flag="-o">input_geometry_processed.nc</argument>
 			<argument flag="-s">2.0</argument>
 			<argument flag="-m">100.0</argument>
+			<argument flag="--scale">0.1</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">
@@ -41,10 +42,10 @@
 			<argument flag="">mesh.nc</argument>
 		</step>
 		<step executable="gpmetis">
-			<argument flag="graph.info">16</argument>
+			<argument flag="graph.info">4</argument>
 		</step>
 
-		<model_run procs="16" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 
 		<step executable="MpasCellCuller.x">
 			<argument flag="">ocean.nc</argument>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init2.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<config case="init_step2">
+	<add_link source="../init_step1/culled_mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init_step1/culled_graph.info" dest="graph.info"/>
+	<add_link source="../init_step1/input_geometry_processed.nc" dest="input_geometry_processed.nc"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_init.xml" path_base="script_configuration_dir"/>
+		<option name="config_write_cull_cell_mask">.false.</option>
+		<option name="config_isomip_plus_init_bot_temp">1.0</option>
+		<option name="config_isomip_plus_init_bot_sal">34.7</option>
+		<option name="config_isomip_plus_restore_evap_rate">200.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_init.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/old_processLandIceForcing.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/old_processLandIceForcing.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+import numpy
+import netCDF4
+import os
+import scipy.ndimage.filters as filters
+from mpl_toolkits.basemap import interp
+
+
+def smoothGeometry(field, filterSigma):
+
+    smoothedField = filters.gaussian_filter(field, filterSigma,
+                                            mode='constant', cval=0.)
+
+    return smoothedField
+
+def readVar(varName, defaultValue=0.0):
+    field = defaultValue*numpy.ones((ny,nx),float)
+    field[buffer:-buffer,buffer:-buffer] = numpy.array(inFile.variables[varName])[:,minIndex:]
+    return field
+
+def writeVar(outVarName, field, attrs):
+    outVar = outFile.createVariable(outVarName, 'f8', ('Time', 'nCells'))
+    outVar[:, :] = field
+    outVar.setncatts(attrs)
+
+
+inIceGeomFileName = '../init_step1/input_geometry.nc'
+inMpasMeshFileName = 'init.nc'
+outFileName = 'land_ice_forcing.nc'
+filterSigma = 2.0
+initialScale = 0.1
+
+buffer = 1
+
+xMax = 800e3 #km
+x0 = 320e3 #km
+
+iceDensity = 918.
+oceanDensity = 1028.
+g = 9.80665
+  
+inFile = netCDF4.Dataset(inIceGeomFileName, 'r')
+x = numpy.array(inFile.variables['x'])[:]
+y = numpy.array(inFile.variables['y'])[:]
+
+deltaX = x[1]-x[0]
+deltaY = y[1]-y[0]
+
+minIndex = numpy.nonzero(x >= x0)[0][0]
+#print minIndex, x[minIndex]
+
+nx = len(x)-minIndex+2*buffer
+ny = len(y)+2*buffer
+
+outX = numpy.array(nx)
+outY = numpy.array(ny)
+
+outX = x[minIndex] + deltaX*(-buffer + numpy.arange(nx))
+#print outX
+outY = y[0] + deltaY*(-buffer + numpy.arange(ny))
+
+surf = readVar('upperSurface')
+draft = readVar('lowerSurface')
+groundedMask = readVar('groundedMask', defaultValue=1.0)
+inFile.close()
+
+iceThickness = surf-draft
+
+icePressure = iceDensity*g*iceThickness
+
+smoothedIcePressure = smoothGeometry(icePressure, filterSigma)
+
+oceanFraction = 1. - groundedMask
+smoothedMask = smoothGeometry(oceanFraction, filterSigma)
+smoothedDraft = smoothGeometry(oceanFraction*draft, filterSigma)
+threshold = 0.01
+mask = smoothedMask > threshold
+smoothedDraft[mask] /= smoothedMask[mask]
+
+# interpolate
+mpasFile = netCDF4.Dataset(inMpasMeshFileName, 'r')
+xCell = mpasFile.variables['xCell'][:]
+yCell = mpasFile.variables['yCell'][:]
+mpasFile.close()
+
+nCells = len(xCell)
+StrLen = 64
+xtime = numpy.zeros((2), 'S64')
+
+xtime[0] = "0001-01-01_00:00:00                                             "
+xtime[1] = "0002-01-01_00:00:00                                             "
+
+landIcePressure = numpy.zeros((2, nCells), float)
+landIcePressure[1, :] = interp(smoothedIcePressure, outX, outY, xCell, yCell)
+landIceFraction = numpy.zeros(landIcePressure.shape)
+landIceDraft = numpy.zeros(landIcePressure.shape)
+landIceDraft[1, :] = interp(smoothedDraft, outX, outY, xCell, yCell)
+
+outFile = netCDF4.Dataset(outFileName, 'w', format='NETCDF3_64BIT_OFFSET')
+outFile.createDimension('Time', size=None)
+outFile.createDimension('nCells', size=nCells)
+outFile.createDimension('StrLen', size=StrLen)
+
+outVar = outFile.createVariable('xtime', 'S1', ('Time', 'StrLen'))
+for tIndex in range(2):
+    outVar[tIndex, :] = netCDF4.stringtochar(xtime[tIndex])
+
+outVar.setncatts({'units': 'unitless'})
+writeVar('landIcePressureForcing', landIcePressure, 
+         {'units': 'Pa', 
+          'long_name': 'Pressure defined at the sea surface due to land ice'})
+writeVar('landIceFractionForcing', landIceFraction, 
+         {'units': 'unitless', 
+          'long_name': 'The fraction of each cell covered by land ice'})
+writeVar('landIceDraftForcing', landIceDraft, 
+         {'units': 'unitless', 
+          'long_name': 'The elevation of the interface between land ice and '
+                       'the ocean'})
+
+outFile.close()
+

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/processLandIceForcing.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/processLandIceForcing.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+import numpy
+import netCDF4
+import os
+import sys
+
+
+def writeVar(outVarName, field, attrs):
+    outVar = outFile.createVariable(outVarName, 'f8', ('Time', 'nCells'))
+    outVar[:, :] = field
+    outVar.setncatts(attrs)
+
+
+inMpasMeshFileName = 'init.nc'
+outFileName = 'land_ice_forcing.nc'
+initialScale = 0.1
+
+
+if os.path.exists(outFileName):
+    # nothing to do
+    sys.exit(0)
+
+# interpolate
+mpasFile = netCDF4.Dataset(inMpasMeshFileName, 'r')
+xCell = mpasFile.variables['xCell'][:]
+yCell = mpasFile.variables['yCell'][:]
+inLandIceDraft = mpasFile.variables['landIceDraft'][:]
+inLandIcePressure = mpasFile.variables['landIcePressure'][:]
+inLandIceFraction = mpasFile.variables['landIceFraction'][:]
+mpasFile.close()
+
+nCells = len(xCell)
+StrLen = 64
+nTime = 3
+xtime = numpy.zeros((nTime), 'S64')
+
+xtime[0] = "0001-01-01_00:00:00                                             "
+xtime[1] = "0002-01-01_00:00:00                                             "
+xtime[2] = "0003-01-01_00:00:00                                             "
+
+landIcePressure = numpy.zeros((nTime, nCells), float)
+landIcePressure[0, :] = inLandIcePressure
+landIcePressure[1, :] = inLandIcePressure/initialScale
+landIcePressure[2, :] = inLandIcePressure/initialScale
+landIceFraction = numpy.zeros(landIcePressure.shape)
+landIceFraction[0, :] = inLandIceFraction
+landIceFraction[1, :] = inLandIceFraction
+landIceFraction[2, :] = inLandIceFraction
+landIceDraft = numpy.zeros(landIcePressure.shape)
+landIceDraft[0, :] = inLandIceDraft
+landIceDraft[1, :] = inLandIceDraft/initialScale
+landIceDraft[2, :] = inLandIceDraft/initialScale
+
+outFile = netCDF4.Dataset(outFileName, 'w', format='NETCDF3_64BIT_OFFSET')
+outFile.createDimension('Time', size=None)
+outFile.createDimension('nCells', size=nCells)
+outFile.createDimension('StrLen', size=StrLen)
+
+outVar = outFile.createVariable('xtime', 'S1', ('Time', 'StrLen'))
+for tIndex in range(nTime):
+    outVar[tIndex, :] = netCDF4.stringtochar(xtime[tIndex])
+
+outVar.setncatts({'units': 'unitless'})
+writeVar('landIcePressureForcing', landIcePressure, 
+         {'units': 'Pa', 
+          'long_name': 'Pressure defined at the sea surface due to land ice'})
+writeVar('landIceFractionForcing', landIceFraction, 
+         {'units': 'unitless', 
+          'long_name': 'The fraction of each cell covered by land ice'})
+writeVar('landIceDraftForcing', landIceDraft, 
+         {'units': 'unitless', 
+          'long_name': 'The elevation of the interface between land ice and '
+                       'the ocean'})
+
+outFile.close()
+

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
@@ -30,10 +30,10 @@
 
 	<run_script name="run.py">
 		<step executable="./processInputGeometry.py">
-			<argument flag="">input_geometry.nc</argument>
-			<argument flag="">input_geometry_processed.nc</argument>
-			<argument flag="">5.0</argument>
-			<argument flag="">100.0</argument>
+			<argument flag="-i">input_geometry.nc</argument>
+			<argument flag="-o">input_geometry_processed.nc</argument>
+			<argument flag="-s">2.0</argument>
+			<argument flag="-m">100.0</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
@@ -30,10 +30,10 @@
 
 	<run_script name="run.py">
 		<step executable="./processInputGeometry.py">
-			<argument flag="">input_geometry.nc</argument>
-			<argument flag="">input_geometry_processed.nc</argument>
-			<argument flag="">5.0</argument>
-			<argument flag="">100.0</argument>
+			<argument flag="-i">input_geometry.nc</argument>
+			<argument flag="-o">input_geometry_processed.nc</argument>
+			<argument flag="-s">2.0</argument>
+			<argument flag="-m">100.0</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
@@ -32,10 +32,10 @@
 
 	<run_script name="run.py">
 		<step executable="./processInputGeometry.py">
-			<argument flag="">input_geometry.nc</argument>
-			<argument flag="">input_geometry_processed.nc</argument>
-			<argument flag="">5.0</argument>
-			<argument flag="">100.0</argument>
+			<argument flag="-i">input_geometry.nc</argument>
+			<argument flag="-o">input_geometry_processed.nc</argument>
+			<argument flag="-s">2.0</argument>
+			<argument flag="-m">100.0</argument>
 		</step>
 
 		<step executable="MpasMeshConverter.x">

--- a/testing_and_setup/compass/ocean/isomip_plus/processInputGeometry.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/processInputGeometry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import numpy
 from netCDF4 import Dataset
-from optparse import OptionParser
+import argparse
 import os
 
 def smoothGeometry(landFraction, floatingFraction, bed, draft, filterSigma):
@@ -42,13 +42,22 @@ def writeVar(outVarName, inVarName, field):
   outVar[:,:] = field
   outVar.setncatts({k: inVar.getncattr(k) for k in inVar.ncattrs()})
 
-parser = OptionParser()
 
-options, args = parser.parse_args()
-inFileName=args[0]
-outFileName=args[1]
-filterSigma=float(args[2])
-minIceThickness=float(args[3])
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+
+parser.add_argument('-i', dest='inFileName', required=True,
+                    help='ISOMIP+ input geometry file')
+parser.add_argument('-o', dest='outFileName', required=True,
+                    help='output geometry file after smoothing, etc.')
+parser.add_argument('-s', dest='filterSigma', type=float, required=True,
+                    help='no. of grid cells over which to smooth the geometry')
+parser.add_argument('-m', dest='minIceThickness', type=float, required=True,
+                    help='minimum ice thickness, below which ice is "calved"')
+parser.add_argument('--scale', dest='scale', type=float, default=1.0,
+                    help='a scale factor by which to multiple the ice draft')
+
+args = parser.parse_args()
 
 buffer = 1
 
@@ -57,7 +66,7 @@ x0 = 320e3 #km
 
 densityRatio = 918./1028.
   
-inFile = Dataset(inFileName,'r')
+inFile = Dataset(args.inFileName,'r')
 x = numpy.array(inFile.variables['x'])[:]
 y = numpy.array(inFile.variables['y'])[:]
 
@@ -65,7 +74,6 @@ deltaX = x[1]-x[0]
 deltaY = y[1]-y[0]
 
 minIndex = numpy.nonzero(x >= x0)[0][0]
-#print minIndex, x[minIndex]
 
 nx = len(x)-minIndex+2*buffer
 ny = len(y)+2*buffer
@@ -74,7 +82,6 @@ outX = numpy.array(nx)
 outY = numpy.array(ny)
 
 outX = x[minIndex] + deltaX*(-buffer + numpy.arange(nx))
-#print outX
 outY = y[0] + deltaY*(-buffer + numpy.arange(ny))
 
 surf = readVar('upperSurface')
@@ -86,16 +93,19 @@ openOceanMask = readVar('openOceanMask')
 
 iceThickness = surf-draft
 
+draft *= args.scale
+
 # take care of calving criterion
-mask = numpy.logical_and(floatingMask > 0.1, iceThickness < minIceThickness)
+mask = numpy.logical_and(floatingMask > 0.1, 
+                         iceThickness < args.minIceThickness)
 surf[mask] = 0.
 draft[mask] = 0.
 floatingMask[mask] = 0.
 openOceanMask[mask] = 1. - groundedMask[mask]
 
-(bed,draft,smoothedDraftMask) = smoothGeometry(groundedMask, floatingMask, bed, draft, filterSigma)
+(bed,draft,smoothedDraftMask) = smoothGeometry(groundedMask, floatingMask, bed, draft, args.filterSigma)
 
-outFile = Dataset(outFileName,'w', format='NETCDF4')
+outFile = Dataset(args.outFileName,'w', format='NETCDF4')
 outFile.createDimension('x', nx)
 outFile.createDimension('y', ny)
 

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/__main__.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/__main__.py
@@ -9,6 +9,7 @@ from viz.streamfunction import compute_barotropic_streamfunction, \
 from viz.plot import MoviePlotter, TimeSeriesPlotter
 
 from viz.misomip import compute_misomip_interp_coeffs, interp_misomip
+from viz.haney import compute_haney_number
 
 
 def main():
@@ -21,6 +22,13 @@ def main():
     parser.add_argument("--misomip", dest="misomip", action="store_true",
                         help="Indicates that standard MISOMIP output files "
                              "should be created")
+    parser.add_argument("--streamfunctions", dest="streamfunctions", 
+                        action="store_true",
+                        help="Indicates that the barotropic and overturning "
+                             "streamfunctions should be computed and plotted")
+    parser.add_argument("--haney", dest="haney", action="store_true",
+                        help="Indicates that the Haney number rx1 should be "
+                             "computed and plotted")
     args = parser.parse_args()
 
     folder = args.folder
@@ -31,9 +39,13 @@ def main():
     ds = xarray.open_mfdataset('{}/timeSeriesStatsMonthly*.nc'.format(folder),
                                concat_dim='Time')
 
-    compute_barotropic_streamfunction(dsMesh, ds, folder)
+    if args.streamfunctions:
+        compute_barotropic_streamfunction(dsMesh, ds, folder)
 
-    compute_overturning_streamfunction(dsMesh, ds, folder, dx=2e3, dz=5.)
+        compute_overturning_streamfunction(dsMesh, ds, folder, dx=2e3, dz=5.)
+
+    if args.haney:
+        compute_haney_number(dsMesh, ds, folder)
 
     tsPlotter = TimeSeriesPlotter(inFolder=folder,
                                   outFolder='{}/plots'.format(folder),
@@ -48,8 +60,13 @@ def main():
                            outFolder='{}/plots'.format(folder),
                            expt=expt)
 
-    mPlotter.plot_barotropic_streamfunction()
-    mPlotter.plot_overturning_streamfunction()
+    if args.streamfunctions:
+        mPlotter.plot_barotropic_streamfunction()
+        mPlotter.plot_overturning_streamfunction()
+
+    if args.haney:
+        mPlotter.plot_haney_number()
+
     mPlotter.plot_melt_rates()
     mPlotter.plot_ice_shelf_boundary_variables()
     mPlotter.plot_temperature()

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/haney.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/haney.py
@@ -1,0 +1,104 @@
+import xarray
+import numpy
+import progressbar
+import os
+
+from viz.io import write_netcdf, file_complete
+
+
+def compute_haney_number(dsMesh, ds, folder):
+    '''
+    compute the Haney number rx1 for each edge, and interpolate it to cells.
+    '''
+
+    haneyFileName = '{}/haney.nc'.format(folder)
+    if file_complete(ds, haneyFileName):
+        return
+
+    haneyEdge, haneyCell = _compute_haney_number(dsMesh, ds)
+    dsHaney = xarray.Dataset()
+    dsHaney['xtime_startMonthly'] = ds.xtime_startMonthly
+    dsHaney['xtime_endMonthly'] = ds.xtime_endMonthly
+    dsHaney['haneyEdge'] = haneyEdge
+    dsHaney.haneyEdge.attrs['units'] = 'unitless'
+    dsHaney.haneyEdge.attrs['description'] = 'Haney number on edges'
+    dsHaney['haneyCell'] = haneyCell
+    dsHaney.haneyCell.attrs['units'] = 'unitless'
+    dsHaney.haneyCell.attrs['description'] = 'Haney number on cells'
+    dsHaney = dsHaney.transpose('Time', 'nCells', 'nEdges', 'nVertLevels')
+    write_netcdf(dsHaney, haneyFileName)
+
+
+def _compute_haney_number(dsMesh, ds):
+
+    nEdges = dsMesh.sizes['nEdges']
+    nCells = dsMesh.sizes['nCells']
+    nVertLevels = dsMesh.sizes['nVertLevels']
+    nTime = ds.sizes['Time']
+
+    cellsOnEdge = dsMesh.cellsOnEdge - 1
+    maxLevelCell = dsMesh.maxLevelCell - 1
+    edgesOnCell = dsMesh.edgesOnCell - 1
+
+    internalMask = numpy.logical_and(cellsOnEdge[:, 0] >= 0,
+                                     cellsOnEdge[:, 1] >= 1)
+
+    cell0 = cellsOnEdge[:, 0]
+    cell1 = cellsOnEdge[:, 1]
+
+    maxLevelEdge = numpy.minimum(maxLevelCell[cell0], maxLevelCell[cell1])
+    vertIndex = \
+        xarray.DataArray.from_dict({'dims': ('nVertLevels',),
+                                    'data': numpy.arange(nVertLevels)})
+
+    edgeMask = vertIndex <= maxLevelEdge
+
+    cell0 = cell0[internalMask]
+    cell1 = cell1[internalMask]
+
+    haneyEdge = xarray.DataArray(numpy.zeros((nTime, nEdges, nVertLevels)),
+                                 dims=('Time', 'nEdges', 'nVertLevels'))
+
+    haneyCell = xarray.DataArray(numpy.zeros((nTime, nCells, nVertLevels)),
+                                 dims=('Time', 'nCells', 'nVertLevels'))
+
+    widgets = ['Haney number: ', progressbar.Percentage(), ' ',
+               progressbar.Bar(), ' ', progressbar.ETA()]
+    bar = progressbar.ProgressBar(widgets=widgets,
+                                  maxval=nTime).start()
+
+    for tIndex in range(nTime):
+
+        zMid = numpy.zeros((nCells, nVertLevels+1))
+        layerThickness = ds.timeMonthly_avg_layerThickness.isel(
+            Time=tIndex).values
+        ssh = ds.timeMonthly_avg_ssh.isel(Time=tIndex).values
+        bottomDepth = dsMesh.bottomDepth.values
+        zBot = -bottomDepth
+        for zIndex in range(nVertLevels-1, -1, -1):
+            zMid[:, zIndex+1] = zBot + 0.5*layerThickness[:, zIndex]
+            zBot += layerThickness[:, zIndex]
+        zMid[:, 0] = ssh
+
+        dzVert1 = zMid[cell0, 0:-1] - zMid[cell0, 1:]
+        dzVert2 = zMid[cell1, 0:-1] - zMid[cell1, 1:]
+        dzEdge = zMid[cell1, :] - zMid[cell0, :]
+
+        dzVert1[:, 0] *= 2
+        dzVert2[:, 0] *= 2
+
+        rx1 = numpy.zeros((nEdges, nVertLevels))
+
+        rx1[internalMask, :] = (numpy.abs(dzEdge[:, 0:-1] + dzEdge[:, 1:]) / 
+	                     (dzVert1 + dzVert2))
+
+        haneyEdge[tIndex, :, :] = rx1
+        haneyEdge[tIndex, :, :] = haneyEdge[tIndex, :, :].where(edgeMask)
+        haneyCell[tIndex, :, :] = haneyEdge[tIndex, edgesOnCell, :].max(
+            dim='maxEdges')
+        bar.update(tIndex+1)
+    bar.finish()
+
+    return haneyEdge, haneyCell
+
+

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/plot.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/plot.py
@@ -397,6 +397,19 @@ class MoviePlotter(object):
                                            prefix='PotRho', units='kg/m^3',
                                            vmin=1027., vmax=1028.)
 
+    def plot_haney_number(self):
+        '''
+        Plot a series of images of the Haney number rx1 at the sea surface or
+        ice-ocean interface, sea floor and in an x-z section
+        '''
+
+        ds = xarray.open_dataset('{}/haney.nc'.format(self.inFolder))
+
+        self.plot_3d_field_top_bot_section(ds.haneyCell,
+                                           nameInTitle='Haney Number (rx1)',
+                                           prefix='Haney', units=None,
+                                           vmin=0., vmax=8.)
+
     def plot_horiz_series(self, da, nameInTitle, prefix, oceanDomain,
                           units=None, vmin=None, vmax=None):
         '''

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/plot.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/plot.py
@@ -25,7 +25,7 @@ class TimeSeriesPlotter(object):
         The folder with simulation results
 
     outFolder : str
-        The folder where images (and optionally movies) will be written
+        The folder where images will be written
 
     expt : int
         The number of the experiment (0 for Ocean0, 1 for Ocean1, etc.)
@@ -41,7 +41,7 @@ class TimeSeriesPlotter(object):
             The folder with simulation results
 
         outFolder : str, optional
-            The folder where images (and optionally movies) will be written
+            The folder where images will be written
 
         expt : int, optional
             The number of the experiment (0 for Ocean0, 1 for Ocean1, etc.)
@@ -103,10 +103,10 @@ class TimeSeriesPlotter(object):
                               'meanFrictionVelocity', 'm/s')
 
     def plot_time_series(self, da, nameInTitle, prefix, units=None,
-                         figsize=[12, 6], color=None):
+                         figsize=[12, 6], color=None, overwrite=True):
 
         fileName = '{}/{}.png'.format(self.outFolder, prefix)
-        if(os.path.exists(fileName)):
+        if(not overwrite and os.path.exists(fileName)):
             return
 
         nTime = da.sizes['Time']
@@ -138,7 +138,7 @@ class MoviePlotter(object):
         The folder with simulation results
 
     outFolder : str
-        The folder where images (and optionally movies) will be written
+        The folder where images will be written
 
     expt : int
         The number of the experiment (0 for Ocean0, 1 for Ocean1, etc.)
@@ -187,7 +187,7 @@ class MoviePlotter(object):
             The folder with simulation results
 
         outFolder : str, optional
-            The folder where images (and optionally movies) will be written
+            The folder where images will be written
 
         expt : int, optional
             The number of the experiment (0 for Ocean0, 1 for Ocean1, etc.)
@@ -530,7 +530,8 @@ class MoviePlotter(object):
             bar.update(tIndex+1)
         bar.finish()
 
-    def images_to_movies(self, outFolder, framesPerSecond=30, extension='mp4'):
+    def images_to_movies(self, outFolder, framesPerSecond=30, extension='mp4',
+                         overwrite=True):
         '''
         Convert all the image sequences into movies with ffmpeg
         '''
@@ -545,7 +546,7 @@ class MoviePlotter(object):
                 '{}/*/*0001.png'.format(self.outFolder))):
             prefix = os.path.basename(fileName)[:-9]
             outFileName = '{}/{}.{}'.format(outFolder, prefix, extension)
-            if os.path.exists(outFileName):
+            if not overwrite and os.path.exists(outFileName):
                 continue
 
             imageFileTemplate = '{}/{}/{}_%04d.png'.format(self.outFolder,
@@ -564,7 +565,7 @@ class MoviePlotter(object):
         xtime = ''.join(str(xtime.astype('U'))).strip()
         year = xtime[0:4]
         month = xtime[5:7]
-        self.date = '{}-{}'.format(month, year)
+        self.date = '{}-{}'.format(year, month)
 
     def _plot_horiz_field(self, field, title, outFileName, oceanDomain=True,
                           vmin=None, vmax=None, figsize=[9, 3]):

--- a/testing_and_setup/compass/ocean/isomip_plus/viz/streamfunction.py
+++ b/testing_and_setup/compass/ocean/isomip_plus/viz/streamfunction.py
@@ -499,7 +499,7 @@ def _horizontally_bin_overturning_streamfunction(ds, dsMesh, x, osfFileName,
     for xIndex in range(nx):
         fileName = cacheFileName.replace('.nc', '_{}.nc'.format(xIndex))
         fileNames.append(fileName)
-        if os.path.exists(fileName):
+        if file_complete(ds, fileName):
             continue
 
         cellMask = dsMesh.xCell >= x[xIndex]


### PR DESCRIPTION
This merge adds time-varying land-ice forcing via the following fields:
* `landIceDraft`
* `landIcePressure`
* `landIceFraction`

A test case `isomip_plus/2km/time_varying_Ocean0` is added as a (relatively trivial) test of this forcing.  In this test case, `landIcePressure` and `landIceDraft` are initially 10% of their "correct" values and increase linearly over 1 year to their full values, then remain constant for an additional year.  However, the test case crashes sometime during the second year because layers become too thin and/or tilted, or velocities become too large.  This is an intentional feature of the test case, showing why further work is needed to handle coupled ice dynamics.

Modifications are made to the ISOMIP+ viz (#275) to correctly handle repeated running of the viz while the simulation is in progress.  A few other tweaks (e.g. the format of dates in the figure titles) are also included.

Modifications were made to how sea-level is maintained in ISOMIP+ test cases despite freshwater fluxes and changes in land-ice pressure.  A fictitious evaporation was already used at the northern boundary, but this has been modified to adjust to sea-level itself rather than melt fluxes to accommodate changing land-ice pressure.

Finally, a division-by-zero error in timeSeriesStatsGlobal was fixed.  If melt fluxes are turned on but there are no locations where the melt mask nonzero (which happened in my testing), global stats was trying to compute mean fluxes and other stats with zero area in the denominator.  This has been fixed.