### PR TITLE
Fixes Rayleigh bottom drag that wasn't applied unless Rayleigh drag applied

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_rayleigh.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_rayleigh.F
@@ -122,7 +122,7 @@ contains
 
       err = 0
 
-      if ( .not. rayleighFrictionOn ) return
+      if ( .not. (rayleighFrictionOn .or. rayleighBottomFrictionOn)) return
 
       call mpas_timer_start('vel rayleigh forcing')
 


### PR DESCRIPTION
This one line fix ensures that Rayleigh bottom drag is applied even if entire-water column Rayleigh drag isn't applied, e.g.,
```
-      if ( .not. rayleighFrictionOn ) return
+      if ( .not. (rayleighFrictionOn .or. rayleighBottomFrictionOn)) return
```

cc @sbrus89- thanks for the fruitful discussion yesterday!