### PR TITLE
Change name coriolis to hadv_coriolis

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1198,7 +1198,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_coriolis" type="logical" default_value=".false." units="unitless"
-					description="Diables tendencies on the velocity field from the Coriolis force."
+					description="Diables tendencies on the velocity field from the Coriolis force and momentum advection."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_pgrad" type="logical" default_value=".false." units="unitless"

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -49,7 +49,7 @@ module ocn_forward_mode
    use ocn_vel_vadv
    use ocn_vel_hmix
    use ocn_vel_forcing
-   use ocn_vel_coriolis
+   use ocn_vel_hadv_coriolis
    use ocn_vel_forcing_surface_stress
    use ocn_surface_bulk_forcing
    use ocn_surface_land_ice_fluxes
@@ -201,7 +201,7 @@ module ocn_forward_mode
       call ocn_thick_ale_init(err_tmp)
       ierr = ior(ierr,err_tmp)
 
-      call ocn_vel_coriolis_init(err_tmp)
+      call ocn_vel_hadv_coriolis_init(err_tmp)
       ierr = ior(ierr, err_tmp)
       call ocn_vel_pressure_grad_init(err_tmp)
       ierr = ior(ierr, err_tmp)

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -15,7 +15,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_thick_hadv.o \
 	   mpas_ocn_thick_vadv.o \
 	   mpas_ocn_thick_surface_flux.o \
-	   mpas_ocn_vel_coriolis.o \
+	   mpas_ocn_vel_hadv_coriolis.o \
 	   mpas_ocn_vel_vadv.o \
 	   mpas_ocn_vel_hmix.o \
 	   mpas_ocn_vel_hmix_del2.o \
@@ -111,7 +111,7 @@ mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o
 
 mpas_ocn_vel_forcing_rayleigh.o: mpas_ocn_constants.o
 
-mpas_ocn_vel_coriolis.o: mpas_ocn_constants.o
+mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o
 
 mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -52,7 +52,7 @@ module ocn_tendency
    use ocn_thick_vadv
    use ocn_thick_surface_flux
 
-   use ocn_vel_coriolis
+   use ocn_vel_hadv_coriolis
    use ocn_vel_pressure_grad
    use ocn_vel_vadv
    use ocn_vel_hmix
@@ -317,7 +317,7 @@ contains
       !
       ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
       !
-      call ocn_vel_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, layerThicknessEdge, &
+      call ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, layerThicknessEdge, &
          normalVelocity, kineticEnergyCell, tend_normalVelocity, err)
 
       !

--- a/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -7,19 +7,19 @@
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  ocn_vel_coriolis
+!  ocn_vel_hadv_coriolis
 !
 !> \brief MPAS ocean horizontal momentum mixing driver
 !> \author Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date   September 2011
 !> \details
 !>  This module contains the routine for computing
-!>  tendencies from the coriolis force.
+!>  tendencies from the horizontal advection and coriolis force.
 !>
 !
 !-----------------------------------------------------------------------
 
-module ocn_vel_coriolis
+module ocn_vel_hadv_coriolis
 
    use mpas_timer
    use mpas_derived_types
@@ -42,8 +42,8 @@ module ocn_vel_coriolis
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_vel_coriolis_tend, &
-             ocn_vel_coriolis_init
+   public :: ocn_vel_hadv_coriolis_tend, &
+             ocn_vel_hadv_coriolis_init
 
    !--------------------------------------------------------------------
    !
@@ -51,7 +51,7 @@ module ocn_vel_coriolis
    !
    !--------------------------------------------------------------------
 
-   logical :: coriolisOn
+   logical :: hadvAndCoriolisOn
    integer :: RK4On
 
 !***********************************************************************
@@ -60,18 +60,20 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_vel_coriolis_tend
+!  routine ocn_vel_hadv_coriolis_tend
 !
-!> \brief   Computes tendency term for coriolis force
+!> \brief   Computes tendency term for horizontal advection and coriolis force
 !> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date    September 2011
 !> \details
-!>  This routine computes the coriolis tendency for momentum
-!>  based on current state.
+
+!>  This routine computes the horizontal advection and coriolis and
+!>  advection tendencies for momentum based on current state.
+
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+   subroutine ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
                                     layerThicknessEdge, normalVelocity, kineticEnergyCell, tend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -127,7 +129,7 @@ contains
 
       err = 0
 
-      if ( .not. coriolisOn ) return
+      if ( .not. hadvAndCoriolisOn ) return
 
       call mpas_timer_start("coriolis")
 
@@ -184,24 +186,20 @@ contains
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_coriolis_tend!}}}
+   end subroutine ocn_vel_hadv_coriolis_tend!}}}
 
 !***********************************************************************
 !
-!  routine ocn_vel_coriolis_init
+!  routine ocn_vel_hadv_coriolis_init
 !
-!> \brief   Initializes ocean momentum horizontal mixing quantities
+!> \brief   Initializes ocean momentum horizontal advection and
+!>  coriolis tendencies
 !> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date    September 2011
-!> \details
-!>  This routine initializes a variety of quantities related to
-!>  horizontal velocity mixing in the ocean. Since a variety of
-!>  parameterizations are available, this routine primarily calls the
-!>  individual init routines for each parameterization.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_coriolis_init(err)!{{{
+   subroutine ocn_vel_hadv_coriolis_init(err)!{{{
 
    !--------------------------------------------------------------------
 
@@ -221,9 +219,9 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_coriolis', config_disable_vel_coriolis)
       call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
 
-      coriolisOn = .true.
+      hadvAndCoriolisOn = .true.
 
-      if ( config_disable_vel_coriolis ) coriolisOn = .false.
+      if ( config_disable_vel_coriolis ) hadvAndCoriolisOn = .false.
 
       if ( trim( config_time_integrator ) == 'RK4') then
          ! For RK4, coriolis tendency term includes f: (eta+f)/h.
@@ -238,11 +236,11 @@ contains
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_coriolis_init!}}}
+   end subroutine ocn_vel_hadv_coriolis_init!}}}
 
 !***********************************************************************
 
-end module ocn_vel_coriolis
+end module ocn_vel_hadv_coriolis
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker


### PR DESCRIPTION
The coriolis module was improperly named, as it also includes horizontal
advection of momentum.

fixes #291