### PR TITLE
Prevent divide-by-zero in Langmuir number

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -469,10 +469,10 @@ contains
               ! compute Langmuir number and Langmuir enhancement factor
               ! TODO: theory-wave is the only option to get Langmuir number and enhancement factor for now <06-09-18, Qing Li> !
               if (config_cvmix_kpp_use_theory_wave .and. iceFraction(iCell) .lt. 0.05_RKIND) then
-                 langmuirNumber =  sqrt(surfaceFrictionVelocity(iCell) / &
+                 langmuirNumber =  sqrt(surfaceFrictionVelocity(iCell) / ( &
                          cvmix_kpp_ustokes_SL_model(windSpeed10m(iCell), &
                                                     boundaryLayerDepth(iCell), &
-                                                    cvmix_global_params))
+                                                    cvmix_global_params)+1e-15_RKIND) )
                  langmuirEnhancementFactor =  &
                          cvmix_kpp_EFactor_model(windSpeed10m(iCell), &
                                                  surfaceFrictionVelocity(iCell), &


### PR DESCRIPTION
Without this fix, code will die with zero division if there is a zero in the 10m wind speed.

