### PR TITLE
Fixes typo in particle file initialization script

### DIFF
--- a/testing_and_setup/compass/ocean/scripts/LIGHTparticles/make_particle_file.py
+++ b/testing_and_setup/compass/ocean/scripts/LIGHTparticles/make_particle_file.py
@@ -582,7 +582,7 @@ if __name__ == "__main__":
     if not args.remap:
         print('Building particle file...')
         build_particle_file(args.init, args.particles, args.graph, args.types, args.spatialfilter,
-                np.linspace(args.potdensmin, args.potdensmax, int(args.nbuoysurf)), int(args.nvertlevels),
+                np.linspace(float(args.potdensmin), float(args.potdensmax), int(args.nbuoysurf)), int(args.nvertlevels),
                 int(args.downsample), args.vertseedtype, args.loc)
         print('Done building particle file')
     else:


### PR DESCRIPTION
Inputs for the potential density option in the the LIGHT preprocessor did not properly modify the input type, which is now fixed.