### PR TITLE
Fix iceshelf restart tests

### DIFF
--- a/testing_and_setup/compass/landice/MISMIP+/albany_input.yaml
+++ b/testing_and_setup/compass/landice/MISMIP+/albany_input.yaml
@@ -105,7 +105,7 @@ ANONYMOUS:
                       Num Blocks: 200
                       Flexible Gmres: false
                       Verbosity: 33
-              Preconditioner Type: ML
+              Preconditioner Type: Ifpack
               Preconditioner Types: 
                 Ifpack: 
                   Overlap: 1

--- a/testing_and_setup/compass/landice/MISMIP+/cull_cells_for_MISMIP.py
+++ b/testing_and_setup/compass/landice/MISMIP+/cull_cells_for_MISMIP.py
@@ -63,7 +63,7 @@ cullCell_local[np.nonzero(yCell == unique_ys[-1])] = 1
 
 # For a periodidic hex the leftmost and rightmost *TWO* columns need to be marked
 unique_Xs=np.array(sorted(list(set(xCell[:]))))
-print("Found {} unique x values".format(unique_Xs))
+print("Found {} unique x values".format(len(unique_Xs)))
 cullCell_local[np.nonzero(xCell == unique_Xs[0])] = 1
 cullCell_local[np.nonzero(xCell == unique_Xs[1])] = 1
 cullCell_local[np.nonzero(xCell == unique_Xs[-1])] = 1

--- a/testing_and_setup/compass/landice/Thwaites_variability/albany_input.yaml
+++ b/testing_and_setup/compass/landice/Thwaites_variability/albany_input.yaml
@@ -102,7 +102,7 @@ ANONYMOUS:
                       Block Size: 1
                       Num Blocks: 200
                       Flexible Gmres: false
-              Preconditioner Type: ML
+              Preconditioner Type: Ifpack
               Preconditioner Types: 
                 Ifpack: 
                   Overlap: 2


### PR DESCRIPTION
The ML preconditioner in Albany currently is unable to be bit-restartable due to the usage of a random number generator to initialize the search for eigenvalues.  Until this is fixed, the merge switches from ML to Ifpack to allow for bit-restartability testing to work.