### PR TITLE
Support multiple instances of domains in MPAS infrastructure

### DIFF
--- a/src/driver/mpas.F
+++ b/src/driver/mpas.F
@@ -8,14 +8,18 @@
 program mpas
 
    use mpas_subdriver
+   use mpas_derived_types, only : core_type, domain_type
 
    implicit none
 
-   call mpas_init()
+   type (core_type), pointer :: corelist => null()
+   type (domain_type), pointer :: domain => null()
 
-   call mpas_run() 
+   call mpas_init(corelist, domain)
 
-   call mpas_finalize()
+   call mpas_run(domain) 
+
+   call mpas_finalize(corelist, domain)
 
    stop
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -35,14 +35,11 @@ module mpas_subdriver
    use test_core_interface
 #endif
 
-   type (core_type), pointer :: corelist => null()
-   type (dm_info), pointer :: dminfo
-   type (domain_type), pointer :: domain_ptr
 
    contains
 
 
-   subroutine mpas_init()
+   subroutine mpas_init(corelist, domain_ptr, mpi_comm)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_init, MPAS_build_stream_filename, MPAS_stream_mgr_validate_streams
       use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
@@ -52,6 +49,10 @@ module mpas_subdriver
       use mpas_log
  
       implicit none
+
+      type (core_type), intent(inout), pointer :: corelist
+      type (domain_type), intent(inout), pointer :: domain_ptr
+      integer, intent(in), optional :: mpi_comm
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -154,7 +155,7 @@ module mpas_subdriver
       !
       ! Initialize infrastructure
       !
-      call mpas_framework_init_phase1(domain_ptr % dminfo)
+      call mpas_framework_init_phase1(domain_ptr % dminfo, mpi_comm=mpi_comm)
 
 
 #ifdef CORE_ATMOSPHERE
@@ -338,9 +339,11 @@ module mpas_subdriver
    end subroutine mpas_init
 
 
-   subroutine mpas_run()
+   subroutine mpas_run(domain_ptr)
 
       implicit none
+
+      type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
 
@@ -352,12 +355,15 @@ module mpas_subdriver
    end subroutine mpas_run
 
 
-   subroutine mpas_finalize()
+   subroutine mpas_finalize(corelist, domain_ptr)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
-      use mpas_log, only : mpas_log_finalize
+      use mpas_log, only : mpas_log_finalize, mpas_log_info
 
       implicit none
+
+      type (core_type), intent(inout), pointer :: corelist
+      type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -82,6 +82,7 @@ module mpas_subdriver
       character(len=StrKIND) :: iotype
       logical :: streamsExists
       integer :: mesh_iotype
+      integer, save :: domainID = 0
 
       interface
          subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
@@ -151,6 +152,9 @@ module mpas_subdriver
       domain_ptr % core => corelist
 
       call mpas_allocate_domain(domain_ptr)
+
+      domain_ptr % domainID = domainID
+      domainID = domainID + 1
 
       !
       ! Initialize infrastructure

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -341,11 +341,15 @@ module mpas_subdriver
 
    subroutine mpas_run(domain_ptr)
 
+      use mpas_log, only: mpas_log_info
+
       implicit none
 
       type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
+
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
 
       iErr = domain_ptr % core % core_run(domain_ptr)
       if ( iErr /= 0 ) then
@@ -389,6 +393,8 @@ module mpas_subdriver
       ! Print out log stats and close log file
       !   (Do this after timer stats are printed and stream mgr finalized,
       !    but before framework is finalized because domain is destroyed there.)
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
+
       call mpas_log_finalize(iErr)
       if ( iErr /= 0 ) then
          call mpas_dmpar_global_abort('ERROR: Log finalize failed for core ' // trim(domain_ptr % core % coreName))

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -349,7 +349,13 @@ include 'mpif.h'
 #ifdef _MPI
       integer :: mpi_ierr, mpi_errcode
 
-      call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      !
+      ! Only if MPI was initialized by MPAS should we call MPI_Abort
+      ! Otherwise, MPI was initialized outside of MPAS and we should not abort on MPI_COMM_WORLD
+      !
+      if ( dminfo % initialized_mpi ) then
+         call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      end if
 #endif
 
       stop

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -26,6 +26,9 @@
       character (len=StrKIND) :: mesh_spec = '' !< mesh_spec attribute, read in from input file.
       character (len=StrKIND) :: parent_id = '' !< parent_id attribute, read in from input file.
 
+      ! Unique global ID number for this domain
+      integer :: domainID
+
       ! Pointer to timer root
       type (mpas_timer_root), pointer :: timer_root => null()
 

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -120,6 +120,7 @@ module mpas_log
       ! local variables
       !-----------------------------------------------------------------
       character(len=16) :: taskString  !< variable to build the task number as a string with appropriate zero padding
+      character(len=4) :: domainString  !< variable to store the domain number as a string with appropriate zero padding
       integer :: unitNumber !< local variable used to get a unit number
       character(len=strKind) :: proposedLogFileName, proposedErrFileName
       logical :: isOpen
@@ -176,6 +177,10 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
+      ! Store the domain number
+      !   This will be used to number the log files
+      mpas_log_info % domainID = domain % domainID
+
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
       !   * Debug build: All tasks active
@@ -207,8 +212,17 @@ module mpas_log
       else
          write(taskString, '(i9.9)') mpas_log_info % taskID
       end if
-      write(proposedLogFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".out"
-      write(proposedErrFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".err"
+
+      if ( mpas_log_info % domainID > 0 ) then
+         write(domainString, '(i4.4)') mpas_log_info % domainID
+         write(proposedLogFileName, fmt='(a, a, a, a, a, a, a)') &
+                                    "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".d", trim(domainString), ".out"
+         write(proposedErrFileName, fmt='(a, a, a, a, a, a, a)') &
+                                    "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".d", trim(domainString), ".err"
+      else
+         write(proposedLogFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".out"
+         write(proposedErrFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".err"
+      end if
 
       ! Set the log and err file names and unit numbers
       if (present(unitNumbers)) then
@@ -420,6 +434,9 @@ module mpas_log
          write(unitNumber, '(a)') '----------------------------------------------------------------------'
          write(unitNumber, '(a,a,a,a,a,i7.1,a,i7.1)') 'Beginning MPAS-', trim(mpas_log_info % coreName), ' ', &
             trim(logTypeString), ' Log File for task ', mpas_log_info % taskID, ' of ', mpas_log_info % nTasks
+         if ( mpas_log_info % domainID > 0 ) then
+            write(unitNumber, '(a,i7.1)') '    for domain ID ',  mpas_log_info % domainID
+         end if
          call date_and_time(date,time)
          write(unitNumber, '(a)') '    Opened at ' // date(1:4)//'/'//date(5:6)//'/'//date(7:8) // &
             ' ' // time(1:2)//':'//time(3:4)//':'//time(5:6)

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -41,6 +41,7 @@ module mpas_log
 
    use mpas_derived_types
    use mpas_abort, only : mpas_dmpar_global_abort
+   use mpas_io_units, only : mpas_new_unit, mpas_release_unit
 
    implicit none
    private
@@ -96,8 +97,6 @@ module mpas_log
 !-----------------------------------------------------------------------
 
    subroutine mpas_log_init(coreLogInfo, domain, unitNumbers, err)
-
-      use mpas_io_units
 
       !-----------------------------------------------------------------
       ! input variables
@@ -711,6 +710,7 @@ module mpas_log
       !   2) the log mgr opened the file (otherwise the driver that opened it should close it)
       if (mpas_log_info % outputLog % isActive .and. mpas_log_info % outputLog % openedByLogModule) then
          close(mpas_log_info % outputLog % unitNum, iostat = err)
+         call mpas_release_unit(mpas_log_info % outputLog % unitNum)
       endif
 
       ! Note: should not need to close an err file.  If these are open, they are intended to quickly lead to abort
@@ -840,6 +840,7 @@ module mpas_log
 
       ! Close the err log to be clean
       close(mpas_log_info % errorLog % unitNum)
+      call mpas_release_unit(mpas_log_info % errorLog % unitNum)
 
       deallocate(mpas_log_info % errorLog)
       deallocate(mpas_log_info % outputLog)

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -176,9 +176,12 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
-      ! Store the domain number
+      ! Store the domain number and initialized_mpi
       !   This will be used to number the log files
       mpas_log_info % domainID = domain % domainID
+
+      !   This will be used to decide whether to abort MPI
+      mpas_log_info % initialized_mpi = domain % dminfo % initialized_mpi
 
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
@@ -847,7 +850,13 @@ module mpas_log
       deallocate(mpas_log_info)
 
 #ifdef _MPI
-      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+      !
+      ! Only if MPI was initialized by MPAS should we call MPI_Abort
+      ! Otherwise, MPI was initialized outside of MPAS and we should not abort on MPI_COMM_WORLD
+      !
+      if ( mpas_log_info % initialized_mpi ) then
+         call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+      end if
 #else
       stop
 #endif

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -27,6 +27,7 @@
       integer :: nTasks !<  number of total tasks associated with this instance
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
+      integer :: domainID !< domain number for this instance of the log manager
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -28,6 +28,7 @@
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
       integer :: domainID !< domain number for this instance of the log manager
+      logical :: initialized_mpi  !< Whether MPI was initialized internally by MPAS
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run


### PR DESCRIPTION
This merge introduces several changes in the MPAS infrastructure to better support
multiple concurrent instances of domains.
1) The `domain_ptr` and `corelist` module variables in `mpas_subdriver` are now
subroutine arguments to `mpas_init`, `mpas_run`, and `mpas_finalize`. See commit ea13ea2.
2) The pointer to `mpas_log_info` is now reset at the beginning of each call to
`mpas_run` and `mpas_finalize`. See commit db97841.
3) The domain type now includes a unique global ID, which is now used in log filenames
when multiple domains are active. See commit 9597b6f.
4) When MPAS is using an externally initialized MPI communicator, calls to `MPI_Abort`
are avoided whenever possible. See commit ffe6b7b.
5) In order to avoid eventually running out of unit numbers, logging units are explicity
freed with `mpas_release_unit` after the associated log unit has been closed.
See commit 4a78140.