### PR TITLE
Fixes implicit Rayleigh bug in implicit solver

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -303,7 +303,7 @@ contains
          enddo
 
          ! B is diagonal term
-         B(1) = 1 - C(1)
+         B(1) = 1 - C(1) + dt*rayleighDampingCoef
          do k = 2, N-1
             B(k) = 1.0_RKIND - A(k) - C(k) + dt*rayleighDampingCoef
          enddo


### PR DESCRIPTION
Fixes bug introduced in #289, corresponding to missing implicit Rayleigh drag for the top ocean layer.


 * Fixes typo in implicit Rayleigh drag

Top layer did not have implicit Rayleigh drag applied
and this commit fixes that omission.