### PR TITLE
Adds depth-averaged Rayleigh drag

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -456,7 +456,7 @@
 					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_Rayleigh_damping_coeff_depth_variable" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_Rayleigh_damping_depth_variable" type="logical" default_value=".false." units="unitless"
 					description="If true applies r h^-1 instead of just r."
 					possible_values=".true. or .false."
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -456,6 +456,10 @@
 					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
 					possible_values="Any positive real value."
 		/>
+		<nml_option name="config_Rayleigh_damping_coeff_depth_variable" type="logical" default_value=".false." units="unitless"
+					description="If true applies r h^-1 instead of just r."
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_Rayleigh_bottom_friction" type="logical" default_value=".false." units="unitless"
 					description="If true, Rayleigh friction is only applied to the bottom"
 					possible_values=".true. or .false."

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -189,18 +189,18 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_vel_vmix_tend_implicit
+!  routine ocn_vel_vmix_tend_implicit_rayleigh
 !
 !> \brief   Computes tendencies for implicit momentum vertical mixing
-!> \author  Mark Petersen
-!> \date    September 2011
+!> \author  Mark Petersen, Phillip J. Wolfram
+!> \date    September 2011, July 2019
 !> \details
 !>  This routine computes the tendencies for implicit vertical mixing for momentum
-!>  using computed coefficients.
+!>  using computed coefficients and includes implicit rayleigh drag.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
+   subroutine ocn_vel_vmix_tend_implicit_rayleigh(meshPool, dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
                                          layerThicknessEdge, normalVelocity, err)
 
       !-----------------------------------------------------------------
@@ -307,18 +307,164 @@ contains
          enddo
 
          ! B is diagonal term
-         B(1) = 1 - C(1) + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
+         B(1) = 1.0_RKIND - C(1) &
+           ! added Rayleigh terms
+           + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
          do k = 2, N-1
-            B(k) = 1.0_RKIND - A(k) - C(k) + &
-              dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
+            B(k) = 1.0_RKIND - A(k) - C(k) &
+              ! added Rayleigh terms
+              + dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
          enddo
 
          ! Apply bottom drag boundary condition on the viscous term
          ! second line uses sqrt(2.0*kineticEnergyEdge(k,iEdge))
          B(N) = 1.0_RKIND - A(N) + dt*implicitBottomDragCoef &
               * sqrt(kineticEnergyCell(k,cell1) + kineticEnergyCell(k,cell2)) / layerThicknessEdge(k,iEdge) &
+              ! added Rayleigh terms
               + dt*(rayleighBottomDampingCoef + &
                     rayleighDampingCoef /((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
+
+         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+
+         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
+
+        end if
+      end do
+      !$omp end do
+
+      deallocate(A,B,C,velTemp)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_vmix_tend_implicit_rayleigh!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vel_vmix_tend_implicit
+!
+!> \brief   Computes tendencies for implicit momentum vertical mixing
+!> \author  Mark Petersen
+!> \date    September 2011
+!> \details
+!>  This routine computes the tendencies for implicit vertical mixing for momentum
+!>  using computed coefficients.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
+                                         layerThicknessEdge, normalVelocity, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         kineticEnergyCell        !< Input: kinetic energy at cell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertViscTopOfEdge !< Input: vertical mixing coefficients
+
+      real (kind=RKIND), intent(in) :: &
+         dt            !< Input: time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness !< Input: thickness at cell center
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         normalVelocity             !< Input: velocity
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         layerThicknessEdge        !< Input: thickness at edge
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nEdgesArray
+
+      integer, dimension(:), pointer :: maxLevelEdgeTop
+
+      integer, dimension(:,:), pointer :: cellsOnEdge
+
+      real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
+
+      err = 0
+
+      if(.not.velVmixOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+
+      nEdges = nEdgesArray( 1 )
+
+      allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
+      A(1)=0.0_RKIND
+
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+        N = maxLevelEdgeTop(iEdge)
+        if (N .gt. 0) then
+
+         ! Compute A(k), B(k), C(k)
+         ! layerThicknessEdge is computed in compute_solve_diag, and is not available yet,
+         ! so recompute layerThicknessEdge here.
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         do k = 1, N
+            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
+         end do
+
+         ! A is lower diagonal term
+         do k = 2, N
+            A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
+               / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
+               / layerThicknessEdge(k,iEdge)
+         enddo
+
+         ! C is upper diagonal term
+         do k = 1, N-1
+            C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
+               / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
+               / layerThicknessEdge(k,iEdge)
+         enddo
+
+         ! B is diagonal term
+         B(1) = 1.0_RKIND - C(1)
+         do k = 2, N-1
+            B(k) = 1.0_RKIND - A(k) - C(k)
+         enddo
+
+         ! Apply bottom drag boundary condition on the viscous term
+         ! second line uses sqrt(2.0*kineticEnergyEdge(k,iEdge))
+         B(N) = 1.0_RKIND - A(N) + dt*implicitBottomDragCoef &
+              * sqrt(kineticEnergyCell(k,cell1) + kineticEnergyCell(k,cell2)) / layerThicknessEdge(k,iEdge)
 
          call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
 
@@ -429,7 +575,7 @@ contains
          N = maxLevelCell(iCell)
 
          ! A is lower diagonal term
-         A(1)=0
+         A(1)=0.0_RKIND
          do k = 2, N
             A(k) = -2.0_RKIND*dt*vertDiffTopOfCell(k,iCell) &
                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) / layerThickness(k,iCell)
@@ -444,7 +590,7 @@ contains
 
          ! B is diagonal term
          do k = 1, N
-            B(k) = 1 - A(k) - C(k)
+            B(k) = 1.0_RKIND - A(k) - C(k)
          enddo
 
          if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
@@ -508,6 +654,8 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
       logical, pointer :: config_use_cvmix,config_compute_active_tracer_budgets
       logical, pointer :: config_cvmix_kpp_nonlocal_with_implicit_mix
+      logical, pointer :: config_Rayleigh_friction, config_Rayleigh_bottom_friction, &
+                          config_Rayleigh_damping_depth_variable
 
       type (mpas_pool_iterator_type) :: groupItr
 
@@ -531,6 +679,12 @@ contains
                                 config_cvmix_kpp_nonlocal_with_implicit_mix)
       call mpas_pool_get_config(ocnConfigs, 'config_compute_active_tracer_budgets',  &
                                 config_compute_active_tracer_budgets)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_friction', &
+                                             config_Rayleigh_friction)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_bottom_friction', &
+                                             config_Rayleigh_bottom_friction)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_damping_depth_variable', &
+                                             config_Rayleigh_damping_depth_variable)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
@@ -578,8 +732,15 @@ contains
       !  Implicit vertical solve for momentum
       !
       call mpas_timer_start('vmix solve momentum', .false.)
-      call ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, layerThicknessEdge, &
-                                      normalVelocity, err)
+      if (.not. (config_Rayleigh_friction .or. &
+                 config_Rayleigh_bottom_friction .or. &
+                 config_Rayleigh_damping_depth_variable)) then
+        call ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+      else
+        call ocn_vel_vmix_tend_implicit_rayleigh(meshPool, dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+      end if
       call mpas_timer_stop('vmix solve momentum')
 
       !

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -67,7 +67,8 @@ module ocn_vmix
 
    logical :: velVmixOn, tracerVmixOn
    real (kind=RKIND) :: implicitBottomDragCoef
-   real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef
+   real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef, &
+                        rayleighDepthVariable
 
 !***********************************************************************
 
@@ -258,6 +259,7 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
+      real (kind=RKIND) :: edgeThicknessTotal
 
       err = 0
 
@@ -284,8 +286,10 @@ contains
          ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
+         edgeThicknessTotal = 0.0_RKIND
          do k = 1, N
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
+            edgeThicknessTotal = edgeThicknessTotal + layerThicknessEdge(k,iEdge)
          end do
 
          ! A is lower diagonal term
@@ -303,16 +307,18 @@ contains
          enddo
 
          ! B is diagonal term
-         B(1) = 1 - C(1)
+         B(1) = 1 - C(1) + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
          do k = 2, N-1
-            B(k) = 1.0_RKIND - A(k) - C(k) + dt*rayleighDampingCoef
+            B(k) = 1.0_RKIND - A(k) - C(k) + &
+              dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
          enddo
 
          ! Apply bottom drag boundary condition on the viscous term
          ! second line uses sqrt(2.0*kineticEnergyEdge(k,iEdge))
          B(N) = 1.0_RKIND - A(N) + dt*implicitBottomDragCoef &
               * sqrt(kineticEnergyCell(k,cell1) + kineticEnergyCell(k,cell2)) / layerThicknessEdge(k,iEdge) &
-              + dt*(rayleighDampingCoef + rayleighBottomDampingCoef)
+              + dt*(rayleighBottomDampingCoef + &
+                    rayleighDampingCoef /((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
 
          call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
 
@@ -663,7 +669,8 @@ contains
       logical, pointer :: config_disable_vel_vmix, config_disable_tr_vmix
       logical, pointer :: config_use_implicit_bottom_drag
       real (kind=RKIND), pointer :: config_implicit_bottom_drag_coeff
-      logical, pointer :: config_Rayleigh_friction, config_Rayleigh_bottom_friction
+      logical, pointer :: config_Rayleigh_friction, config_Rayleigh_bottom_friction, &
+                          config_Rayleigh_damping_coeff_depth_variable
       real (kind=RKIND), pointer :: config_Rayleigh_damping_coeff, config_Rayleigh_bottom_damping_coeff
 
       err = 0
@@ -678,6 +685,8 @@ contains
                                              config_Rayleigh_bottom_friction)
       call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_damping_coeff', &
                                              config_Rayleigh_damping_coeff)
+      call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_damping_coeff_depth_variable', &
+                                             config_Rayleigh_damping_coeff_depth_variable)
       call mpas_pool_get_config(ocnConfigs, 'config_Rayleigh_bottom_damping_coeff', &
                                              config_Rayleigh_bottom_damping_coeff)
 
@@ -692,6 +701,11 @@ contains
       if (config_Rayleigh_bottom_friction) then
           rayleighBottomDampingCoef = config_Rayleigh_bottom_damping_coeff
       endif
+
+      rayleighDepthVariable = 0.0_RKIND
+      if (config_Rayleigh_damping_coeff_depth_variable) then
+        rayleighDepthVariable = 1.0_RKIND
+      end if
 
       velVmixOn = .true.
       tracerVmixOn = .true.


### PR DESCRIPTION
Insteady of a term like

du
-- = -r U + ...
dt

this applies

du       
-- = - (r/H) U
dt      

where r is the Rayleigh drag parameter.  Note, this is done
on a total depth basis; H is not the layer thickness.

This option allows for a direct comparison against idealized, quasi-analytical test cases as found in Warner et al (2013).