### PR TITLE
Add Wright (1997) equation of state

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -983,7 +983,7 @@
 	<nml_record name="eos">
 		<nml_option name="config_eos_type" type="character" default_value="linear" units="unitless"
 					description="Character string to choose EOS formulation"
-					possible_values="Jackett McDougall EOS = 'jm' and Linear EOS = 'linear'"
+					possible_values="Jackett McDougall EOS = 'jm', Wright = 'wright', and Linear EOS = 'linear'"
 		/>
 		<nml_option name="config_open_ocean_freezing_temperature_coeff_0" type="real" default_value="0.0" units="C"
 					description="The freezing temperature at zero pressure and salinity in open ocean."
@@ -1041,6 +1041,12 @@
 		/>
 		<nml_option name="config_eos_linear_densityref" type="real" default_value="1000.0" units="kg m^{-3}"
 					description="Reference density, i.e. density when T=Tref and S=Sref"
+					possible_values="any positive real"
+		/>
+	</nml_record>
+	<nml_record name="eos_wright">
+		<nml_option name="config_eos_wright_ref_pressure" type="real" default_value="0.0" units="N m^{-2}"
+					description="Reference pressure for potential density"
 					possible_values="any positive real"
 		/>
 	</nml_record>

--- a/src/core_ocean/ocean.cmake
+++ b/src/core_ocean/ocean.cmake
@@ -38,6 +38,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_equation_of_state.F
   core_ocean/shared/mpas_ocn_equation_of_state_jm.F
   core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+  core_ocean/shared/mpas_ocn_equation_of_state_wright.F
   core_ocean/shared/mpas_ocn_thick_hadv.F
   core_ocean/shared/mpas_ocn_thick_vadv.F
   core_ocean/shared/mpas_ocn_thick_surface_flux.F

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -12,6 +12,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_equation_of_state.o \
 	   mpas_ocn_equation_of_state_jm.o \
 	   mpas_ocn_equation_of_state_linear.o \
+	   mpas_ocn_equation_of_state_wright.o \
 	   mpas_ocn_mesh.o \
 	   mpas_ocn_thick_hadv.o \
 	   mpas_ocn_thick_vadv.o \
@@ -70,7 +71,7 @@ OBJS = mpas_ocn_init_routines.o \
 
 all: $(OBJS)
 
-mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o 
+mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
 mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o
 
@@ -78,7 +79,7 @@ mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_o
 
 mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
-mpas_ocn_mesh.o: 
+mpas_ocn_mesh.o:
 
 mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -144,11 +145,13 @@ mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnost
 
 mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
+mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_equation_of_state_wright.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_equation_of_state_jm.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_equation_of_state_linear.o: mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_equation_of_state_wright.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_test.o:  mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -26,6 +26,7 @@ module ocn_equation_of_state
    use mpas_pool_routines
    use ocn_equation_of_state_linear
    use ocn_equation_of_state_jm
+   use ocn_equation_of_state_wright
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
@@ -63,7 +64,8 @@ module ocn_equation_of_state
 
    integer, parameter ::        &! supported equation of state methods
       ocnEqStateTypeLinear = 1, &! linear equation of state
-      ocnEqStateTypeJM     = 2   ! Jackett-McDougall  eqn of state
+      ocnEqStateTypeJM     = 2, &! Jackett-McDougall eqn of state
+      ocnEqStateTypeWright = 3   ! Wright eqn of state
 
 !***********************************************************************
 
@@ -138,6 +140,7 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+      integer, dimension(:), pointer :: maxLevelCell
       integer :: iCell, k, nVertLevels, indexT, indexS
       integer, pointer :: indexTptr, indexSptr, nVertLevelsPtr
       integer :: timeLevel
@@ -167,6 +170,9 @@ contains
                                                  indexSptr)
       call mpas_pool_get_dimension(meshPool,    'nVertLevels', &
                                                  nVertLevelsPtr)
+      call mpas_pool_get_array    (meshPool,    'maxLevelCell', &
+                                                 maxLevelCell)
+
       indexT      = indexTptr
       indexS      = indexSptr
       nVertLevels = nVertLevelsPtr
@@ -206,6 +212,24 @@ contains
                      nCells, kDisplaced, displacement_type,           &
                      indexT, indexS, activeTracers, density, err,     &
                      tracersSurfaceValue)
+         endif
+
+      case (ocnEqStateTypeWright)
+
+         if (present(thermalExpansionCoeff) .or. &
+             present(salineContractionCoeff)) then
+            call ocn_equation_of_state_wright_density(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err,                      &
+                     thermalExpansionCoeff, salineContractionCoeff,   &
+                     tracersSurfaceValue)
+
+         else
+            call ocn_equation_of_state_wright_density(nVertLevels,    &
+                     nCells, kDisplaced, displacement_type,           &
+                     indexT, indexS, activeTracers, zMid,             &
+                     maxLevelCell, density, err, tracersSurfaceValue)
          endif
 
       case default
@@ -275,10 +299,15 @@ contains
          ocnEqStateChoice  = ocnEqStateTypeJM
          call ocn_equation_of_state_jm_init(domain, err)
 
+      case ('wright', 'Wright', 'WRIGHT')
+
+         ocnEqStateChoice  = ocnEqStateTypeWright
+         call ocn_equation_of_state_wright_init(domain, err)
+
       case default
 
          call mpas_log_write(&
-         'Invalid choice for config_eos_type. Choices are: linear, jm')
+         'Invalid choice for config_eos_type. Choices are: linear, jm, wright')
          err = 1
 
       end select

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
@@ -392,7 +392,7 @@ contains
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lamda0, dlambda0dT, dlambda0dS, &
+      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lambda0, dlambda0dT, dlambda0dS, &
       !$omp         alpha0, dalpha0dT, dalpha0dS, denom, denom2, drhodT, drhodS)
 #endif
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
@@ -30,6 +30,7 @@ module ocn_equation_of_state_wright
    use mpas_log
    use mpas_constants
    use ocn_constants
+   use ocn_config
 
    implicit none
    private
@@ -692,14 +693,11 @@ contains
 
       else ! displacementType == 'absolute'
 
-         ! The reference gauge pressure is hard coded to the surface (zero)
-         ! for now but this could be replaced by a namelist option with a
-         ! different reference pressure in the future
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell=1,nCells
             do k = 1, nVertLevels
-               boussinesqPres(k, iCell) = 0.0_RKIND
+               boussinesqPres(k, iCell) = config_eos_wright_ref_pressure
             end do
          end do
          !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_wright.F
@@ -1,0 +1,719 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_equation_of_state_wright
+!
+!> \brief MPAS ocean Wright (1997) equation of state
+!> \author Xylar Asay-Davis
+!> \date   June 30, 2019
+!> \details
+!>  This module contains the routines for computing density from
+!>  temperature, salinity and depth using an equation of state by Wright (1997)
+!>  that approximates the nonlinear equation of state using a set of
+!>  rational polynomials.
+!>  See Wright (1997), doi: 10.1175/1520-0426(1997)014<0735:AEOSFU>2.0.CO;2
+!
+!-----------------------------------------------------------------------
+
+module ocn_equation_of_state_wright
+
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_log
+   use mpas_constants
+   use ocn_constants
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_equation_of_state_wright_density, &
+             ocn_equation_of_state_wright_init
+
+   !*** generic interface for case of density only or density and
+   !*** expansion coeffs
+   interface ocn_equation_of_state_wright_density
+      module procedure ocn_equation_of_state_wright_density_only
+      module procedure ocn_equation_of_state_wright_density_exp
+   end interface
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   !*** temporary array to hold modified T, S, p for EOS calculation
+   !*** declared here to make it thread-shared - could be replaced
+   !***   by a local subroutine temporary in a different thread model
+
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      tracerTemp, tracerSalt, boussinesqPres
+
+   !*** valid range of T,S for Wright (1997) EOS
+   !***   allowing T to become more negative because of sub-ice-shelf cavities
+
+   real (kind=RKIND), parameter :: &
+      ocnEqStateTmin = -3.0_RKIND, &! valid pot. temp. range
+      ocnEqStateTmax = 30.0_RKIND, &
+      ocnEqStateSmin = 28.0_RKIND, &! valid salinity, in psu
+      ocnEqStateSmax = 38.0_RKIND
+
+   !***  Wright (1997) constants from Table 1, last column
+
+   real (kind=RKIND), parameter ::      &
+      a0 = 7.057924e-4_RKIND,           &
+      a1 = 3.480336e-7_RKIND,           &
+      a2 = -1.112733e-7_RKIND
+
+   real (kind=RKIND), parameter ::      &
+      b0 = 5.790749e8_RKIND,            &
+      b1 = 3.516535e6_RKIND,            &
+      b2 = -4.002714e4_RKIND,           &
+      b3 = 2.084372e2_RKIND,            &
+      b4 = 5.944068e5_RKIND,            &
+      b5 = -9.643486e3_RKIND
+
+   real (kind=RKIND), parameter ::      &
+      c0 = 1.704853e5_RKIND,            &
+      c1 = 7.904722e2_RKIND,            &
+      c2 = -7.984422_RKIND,             &
+      c3 = 5.140652e-2_RKIND,           &
+      c4 = -2.302158e2_RKIND,           &
+      c5 = -3.079464_RKIND
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_equation_of_state_wright_density_only
+!
+!> \brief   Computes equation of state
+!> \author  Xylar Asay-Davis
+!> \date    June 30, 2019
+!> \details
+!>  This routine computes the density from model temperature,
+!>  salinity, and depth using potential-temperature formulation from
+!>  Wright (1997), doi: 10.1175/1520-0426(1997)014<0735:AEOSFU>2.0.CO;2
+!>  and a simple linearization of pressure p = -rho0*g*z with the Boussinesq
+!>  reference density
+!>
+!>  Density can be computed in-situ using kDisplaced=0 and
+!>      displacementType = 'relative'.
+!>
+!>  Potential density (referenced to zero pressure) can be computed
+!>      using displacementType = 'absolute'. kDisplaced is ignored.
+!>
+!>  The density of SST/SSS after adiabatic displacement to each layer
+!>      can be computed using displacementType = 'surfaceDisplaced'.
+!>      kDisplaced is ignored and tracersSurfaceLayerValue must be present.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_equation_of_state_wright_density_only(nVertLevels,  &
+                               nCells, kDisplaced, displacementType,  &
+                               indexT, indexS, tracers, zMid,         &
+                               maxLevelCell, density, err, &
+                               tracersSurfaceLayerValue)
+
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         zMid
+
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+
+      integer :: &
+         iCell, k ! cell and vertical level loop indices
+
+      real (kind=RKIND) :: &
+         T, S, T2, T3,     &! adjusted T, S, T squared, T cubed,
+         p,                &! Boussinesq pressure at reference level,
+         alpha0, lambda0,  &! functions of theta and S defined by Wright (1997)
+         p0
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+      allocate(tracerTemp(nVertLevels, nCells))
+      allocate(tracerSalt(nVertLevels, nCells))
+      allocate(boussinesqPres(nVertLevels, nCells))
+
+      if (displacementType == 'surfaceDisplaced') then
+         call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
+                                            indexS, tracersSurfaceLayerValue, &
+                                            tracerTemp, tracerSalt)
+      else
+         call compute_bounded_T_S(nVertLevels, nCells, indexT, indexS, tracers, &
+                                  tracerTemp, tracerSalt)
+      end if
+
+      call compute_boussinesq_p(nVertLevels, nCells, kDisplaced,      &
+                                displacementType, zMid, maxLevelCell, &
+                                boussinesqPres)
+
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(density, boussinesqPres, tracerTemp, tracerSalt)
+      !$acc parallel loop gang vector collapse(2) &
+      !$acc&   present(density, boussinesqPres, tracerTemp, tracerSalt)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, S, T, p, T2, T3, p0, lambda0, alpha0)
+#endif
+
+      do iCell=1,nCells
+         do k=1,nVertLevels
+
+            S = tracerSalt(k, iCell)
+            T = tracerTemp(k, iCell)
+            p = boussinesqPres(k, iCell)
+
+            T2 = T*T
+            T3 = T*T2
+
+            p0 = b0 + b1*T + b2*T2 + b3*T3 + b4*S + b5*T*S
+            lambda0 = c0 + c1*T + c2*T2 + c3*T3 + c4*S + c5*T*S
+            alpha0 = a0 + a1*T + a2*S
+
+            density(k, iCell) = (p + p0)/(lambda0 + alpha0*(p + p0))
+
+         end do
+      end do
+
+#ifdef MPAS_OPENACC
+      !$acc update host(density)
+      !$acc exit data delete(density, boussinesqPres, tracerTemp, tracerSalt)
+#else
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      deallocate(tracerTemp)
+      deallocate(tracerSalt)
+      deallocate(boussinesqPres)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_wright_density_only!}}}
+
+!***********************************************************************
+!
+!  routine ocn_equation_of_state_wright_density_exp
+!
+!> \brief   Computes equation of state with expansion/contraction coeffs
+!> \author  Xylar Asay-Davis
+!> \date    July 1, 2019
+!> \details
+!>  This routine computes the density from model temperature,
+!>  salinity, and depth using potential-temperature formulation from
+!>  Wright (1997), doi: 10.1175/1520-0426(1997)014<0735:AEOSFU>2.0.CO;2
+!>  and a simple linearization of pressure p = -rho0*g*z with the Boussinesq
+!>  reference density
+!>
+!>  Density can be computed in-situ using kDisplaced=0 and
+!>      displacementType = 'relative'.
+!>
+!>  Potential density (referenced to zero pressure) can be computed
+!>      using displacementType = 'absolute'. kDisplaced is ignored.
+!>
+!>  The density of SST/SSS after adiabatic displacement to each layer
+!>      can be computed using displacementType = 'surfaceDisplaced'.
+!>      kDisplaced is ignored and tracersSurfaceLayerValue must be present.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_equation_of_state_wright_density_exp(nVertLevels,         &
+                               nCells, kDisplaced, displacementType,        &
+                               indexT, indexS, tracers, zMid, maxLevelCell, &
+                               density, err, thermalExpansionCoeff,         &
+                               salineContractionCoeff,                      &
+                               tracersSurfaceLayerValue)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced,         &! target layer for displacement
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         zMid
+
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         density         ! computed density
+
+      ! Thermal expansion coeff, $-1/\rho d\rho/dT$ (note negative sign)
+      ! Saline contraction coeff, $1/\rho d\rho/dS$
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         thermalExpansionCoeff,  &! Thermal expansion  coeff (alpha)
+         salineContractionCoeff   ! Saline contraction coeff (beta)
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, k ! cell and vertical level loop indices
+
+      real (kind=RKIND) :: &
+         T, S, T2, T3,     &! adjusted T, S, T squared, T cubed,
+         p,                &! Boussinesq pressure at reference level,
+         alpha0, lambda0,  &! functions of theta and S defined by Wright (1997)
+         p0,               &
+         denom, denom2,    &! denominator of rational polynomial for rho
+         dalpha0dT,        &! d(alpha0)/d(temperature)
+         dalpha0dS,        &! d(alpha0)/d(salinity)
+         dlambda0dT,       &! d(lambda0)/d(temperature)
+         dlambda0dS,       &! d(lambda0)/d(salinity)
+         dp0dT,            &! d(p0)/d(temperature)
+         dp0dS,            &! d(p0)/d(salinity)
+         drhodT,           &! derivative of density with respect to temperature
+         drhodS             ! derivative of density with respect to salinity
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+
+      allocate(tracerTemp(nVertLevels, nCells))
+      allocate(tracerSalt(nVertLevels, nCells))
+      allocate(boussinesqPres(nVertLevels, nCells))
+
+      if (displacementType == 'surfaceDisplaced') then
+         call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
+                                            indexS, tracersSurfaceLayerValue, &
+                                            tracerTemp, tracerSalt)
+      else
+         call compute_bounded_T_S(nVertLevels, nCells, indexT, indexS, tracers, &
+                                  tracerTemp, tracerSalt)
+      end if
+      call compute_boussinesq_p(nVertLevels, nCells, kDisplaced,      &
+                                displacementType, zMid, maxLevelCell, &
+                                boussinesqPres)
+
+
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(density, boussinesqPres, tracerTemp, tracerSalt, &
+      !$acc&                  thermalExpansionCoeff,  &
+      !$acc&                  salineContractionCoeff)
+      !$acc parallel loop gang vector collapse(2)     &
+      !$acc&   present(density, boussinesqPres, tracerTemp, tracerSalt, &
+      !$acc&           thermalExpansionCoeff,         &
+      !$acc&           salineContractionCoeff)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lamda0, dlambda0dT, dlambda0dS, &
+      !$omp         alpha0, dalpha0dT, dalpha0dS, denom, denom2, drhodT, drhodS)
+#endif
+
+
+      do iCell=1,nCells
+         do k=1,nVertLevels
+
+            S = tracerSalt(k, iCell)
+            T = tracerTemp(k, iCell)
+            p = boussinesqPres(k, iCell)
+
+            T2 = T*T
+            T3 = T*T2
+
+            p0 = b0 + b1*T + b2*T2 + b3*T3 + b4*S + b5*T*S
+            dp0dT = b1 + 2.0_RKIND*b2*T + 3.0_RKIND*b3*T2 + b5*S
+            dp0dS = b4 + b5*T
+
+            lambda0 = c0 + c1*T + c2*T2 + c3*T3 + c4*S + c5*T*S
+            dlambda0dT = c1 + 2.0_RKIND*c2*T + 3.0_RKIND*c3*T2 + c5*S
+            dlambda0dS = c4 + c5*T
+
+            alpha0 = a0 + a1*T + a2*S
+            dalpha0dT = a1
+            dalpha0dS = a2
+
+            denom = 1.0_RKIND/(lambda0 + alpha0*(p + p0))
+            denom2 = denom*denom
+
+            drhodT = (lambda0*dp0dT - (p + p0)*(dlambda0dT + (p + p0)*dalpha0dT))*denom2
+            drhodS = (lambda0*dp0dS - (p + p0)*(dlambda0dS + (p + p0)*dalpha0dS))*denom2
+
+            density(k, iCell) = (p + p0)*denom
+            thermalExpansionCoeff(k, iCell) = -drhodT/density(k, iCell)
+            salineContractionCoeff(k, iCell) = drhodS/density(k, iCell)
+
+         end do
+      end do
+
+#ifdef MPAS_OPENACC
+      !$acc update host(density,                &
+      !$acc&            thermalExpansionCoeff,  &
+      !$acc&            salineContractionCoeff)
+      !$acc exit data delete(density, boussinesqPres, tracerTemp, tracerSalt, &
+      !$acc&                 thermalExpansionCoeff,  &
+      !$acc&                 salineContractionCoeff)
+#else
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      deallocate(tracerTemp)
+      deallocate(tracerSalt)
+      deallocate(boussinesqPres)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_wright_density_exp!}}}
+
+!***********************************************************************
+!
+!  routine ocn_equation_of_state_wright_init
+!
+!> \brief   Initializes Wright equation of state
+!> \author  Xylar Asay-Davis
+!> \date    June 30, 2019
+!> \details
+!>  This routine initializes a variety of quantities related to
+!>  the equation of state from Wright (1997).
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_equation_of_state_wright_init(domain, err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(in) :: &
+         domain        ! domain containing all state, mesh info
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err  ! error flag
+
+      !-----------------------------------------------------------------
+
+      !*** initialize error flag
+
+      err = 0
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_equation_of_state_wright_init!}}}
+
+!***********************************************************************
+!
+!  routine compute_bounded_T_S
+!
+!> \brief   Compute T, S within valid bounds of Wright EOS
+!> \author  Xylar Asay-Davis
+!> \date    July 8, 2019
+!
+!-----------------------------------------------------------------------
+
+   subroutine compute_bounded_T_S(nVertLevels, nCells, indexT, indexS, &
+                                  tracers, tracerTemp, tracerSalt)!{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nVertLevels,        &! max number of verical levels
+         nCells,             &! number of horizontal cells
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers              ! array of tracers including T,S
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         tracerTemp, tracerSalt
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+
+      integer :: &
+         iCell, k
+
+      real (kind=RKIND) :: &
+         T, S               ! adjusted T, S
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, T, S)
+      do iCell=1,nCells
+         do k = 1, nVertLevels
+            T = min(tracers(indexT, k, iCell), ocnEqStateTmax)
+            S = min(tracers(indexS, k, iCell), ocnEqStateSmax)
+            tracerTemp(k, iCell) = max(T, ocnEqStateTmin)
+            tracerSalt(k, iCell) = max(S, ocnEqStateSmin)
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   !--------------------------------------------------------------------
+
+   end subroutine compute_bounded_T_S!}}}
+
+
+!***********************************************************************
+!
+!  routine compute_surface_displaced_T_S
+!
+!> \brief   Compute surface-displaced T, S within valid bounds of Wright EOS
+!> \author  Xylar Asay-Davis
+!> \date    Feb 4, 2021
+!
+!-----------------------------------------------------------------------
+
+   subroutine compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
+                                            indexS, tracersSurfaceLayerValue, &
+                                            tracerTemp, tracerSalt)!{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nVertLevels,        &! max number of verical levels
+         nCells,             &! number of horizontal cells
+         indexT,             &! temperature index in tracer array
+         indexS               ! salinity    index in tracer array
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceLayerValue
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         tracerTemp, tracerSalt
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+
+      integer :: &
+         iCell, k
+
+      real (kind=RKIND) :: &
+         T, S               ! adjusted T, S
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, T, S)
+      do iCell=1,nCells
+         do k = 1, nVertLevels
+            T = min(tracersSurfaceLayerValue(indexT, iCell), ocnEqStateTmax)
+            S = min(tracersSurfaceLayerValue(indexS, iCell), ocnEqStateSmax)
+            tracerTemp(k, iCell) = max(T, ocnEqStateTmin)
+            tracerSalt(k, iCell) = max(S, ocnEqStateSmin)
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   !--------------------------------------------------------------------
+
+   end subroutine compute_surface_displaced_T_S!}}}
+
+!***********************************************************************
+!
+!  routine compute_boussinesq_p
+!
+!> \brief   Compute Boussinesq pressure, referenced to requested layer
+!> \author  Xylar Asay-Davis
+!> \date    July 8, 2019
+!
+!-----------------------------------------------------------------------
+
+   subroutine compute_boussinesq_p(nVertLevels, nCells, kDisplaced,      &
+                                   displacementType, zMid, maxLevelCell, &
+                                   boussinesqPres)
+   !{{{
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: &
+         nCells,             &! number of horizontal cells
+         nVertLevels,        &! max number of verical levels
+         kDisplaced           ! target layer for displacement
+
+      character(len=*), intent(in) :: &
+         displacementType     ! choice of displacement
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         zMid
+
+      integer, dimension(:), intent(in) :: &
+         maxLevelCell
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         boussinesqPres
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         iCell, k,        &! cell and vertical level loop indices
+         kPressure         ! index to determine ref level for pressure
+
+      !-----------------------------------------------------------------
+      !  if displacementType = 'relative', density is calculated
+      !     with pressure referenced to level k + kDisplaced
+      !     If kDisplaced=0, in-situ density is returned (no displacement)
+      !     If kDisplaced/=0, a displaced density is returned
+      !
+      !  if displacementType = 'absolute', potential density is calculated
+      !     referenced to zero pressure
+
+      if ((displacementType == 'relative') .or. &
+          (displacementType == 'surfaceDisplaced')) then
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kPressure)
+         do iCell=1,nCells
+            do k = 1, nVertLevels
+               kPressure = min(k + kDisplaced, maxLevelCell(iCell))
+               kPressure = max(kPressure, 1)
+               boussinesqPres(k, iCell) = -rho_sw*gravity*zMid(kPressure, iCell)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      else ! displacementType == 'absolute'
+
+         ! The reference gauge pressure is hard coded to the surface (zero)
+         ! for now but this could be replaced by a namelist option with a
+         ! different reference pressure in the future
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell=1,nCells
+            do k = 1, nVertLevels
+               boussinesqPres(k, iCell) = 0.0_RKIND
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+      endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine compute_boussinesq_p!}}}
+
+!***********************************************************************
+
+end module ocn_equation_of_state_wright
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker


### PR DESCRIPTION
This merge adds a new equation of state (EOS) from [Wright (1997)](https://doi.org/10.1175/1520-0426(1997)014%3C0735:AEOSFU%3E2.0.CO;2):
  * This formulation of the new EOS is linear with depth (using the Boussinesq approximation of pressure as `p = p_s - rho0*g*(z - ssh)`), which will allow computation of the full pressure in the horizontal pressure gradient force (HPGF) to be computed analytically.  This is in contrast to the more complex formulation of the reference pressure used in the current Jacket and McDougall (JM) EOS.
  * The EOS accounts for surface pressure (for in situ density, but not potential density) from atmosphere, sea ice, frazil and ice shelves, unlike the JM EOS.
  * Potential density is referenced to `p = config_eos_wright_ref_pressure` (which is zero by default), not in the middle of the top reference grid cell as in JM.

COMPASS changes that were previously in this PR will instead be added to the `compass` package when the time comes.