### PR TITLE
Bugfix for snow grain aging, snow tracer updates and snow surface layer

### DIFF
--- a/src/core_seaice/column/ice_algae.F90
+++ b/src/core_seaice/column/ice_algae.F90
@@ -314,7 +314,8 @@
                                fbio_snoice,  fbio_atmice,&
                                PP_net,       ice_bio_net,&
                                snow_bio_net, grow_alg,   &
-                               grow_net,     totalChla)
+                               grow_net,     totalChla,  &
+                               nslyr)
  
       if (write_flux_diag) then
          if (aicen > c0) then

--- a/src/core_seaice/column/ice_snow.F90
+++ b/src/core_seaice/column/ice_snow.F90
@@ -21,7 +21,7 @@
 
       real (kind=dbl_kind), parameter, public :: &
          S_r  = 0.033_dbl_kind, & ! irreducible saturation (Anderson 1976)
-         S_wet= 4.22e-5_dbl_kind  ! (um^3/s) wet metamorphism parameters
+         S_wet= 0.422_dbl_kind  ! (um^3/s) wet metamorphism parameters
 
 !=======================================================================
 
@@ -843,7 +843,7 @@
 
       subroutine snow_wet_metamorph (dt, dr_wet, rsnw, smice, smliq)
 
-    use ice_constants_colpkg, only: c0, c1, c4, pi
+    use ice_constants_colpkg, only: c0, c1, c4, pi, p1, c100
     !
     ! Liquid water redistribution: Apply the grain growth function from:
     !   Brun, E. (1989), Investigation of wet-snow metamorphism in respect of
@@ -872,7 +872,7 @@
        dr_wet = c0
        fliq = c1
        if (smice + smliq > c0 .and. rsnw > c0) then
-         fliq = smliq/(smice + smliq)
+         fliq = min(smliq/(smice + smliq),p1)*c100
          dr_wet = S_wet * fliq**3*dt/(c4*pi*rsnw**2)
        endif
 

--- a/src/core_seaice/column/ice_zbgc.F90
+++ b/src/core_seaice/column/ice_zbgc.F90
@@ -538,7 +538,8 @@
                                zbgc_snow,    zbgc_atm,   &
                                PP_net,       ice_bio_net,&
                                snow_bio_net, grow_alg,   &
-                               grow_net,     totalChla)
+                               grow_net,     totalChla,  &
+                               nslyr)
  
       use ice_constants_colpkg, only: c1, c0, p5, secday, puny
       use ice_colpkg_shared, only: solve_zbgc, max_nbtrcr, hs_ssl, R_C2N, &
@@ -550,6 +551,7 @@
 
       integer (kind=int_kind), intent(in) :: &
          nblyr, &
+         nslyr, &       ! number of snow layers
          n_algae, &     !
          ntrcr, &       ! number of tracers
          nbtrcr         ! number of biology tracer tracers
@@ -625,7 +627,7 @@
       !-----------------------------------------------------------------
       ! Merge fluxes
       !-----------------------------------------------------------------
-         dvssl  = min(p5*vsnon, hs_ssl*aicen) ! snow surface layer
+         dvssl  = min(p5*vsnon/real(nslyr,kind=dbl_kind), hs_ssl*aicen) ! snow surface layer
          dvint  = vsnon - dvssl               ! snow interior
          snow_bio_net(mm) = snow_bio_net(mm) &
                           + trcrn(bio_index(mm)+nblyr+1)*dvssl &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -614,18 +614,7 @@ contains
 
              call MPAS_pool_get_array(tracers, "snowGrainRadius", snowGrainRadius, 1)
 
-             snowGrainRadius(:,:,:) = 0.0_RKIND
-
-             do iCell = 1, nCellsSolve
-
-                do iCategory = 1, nCategories
-                   if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
-                      do iSnowLayer = 1, nSnowLayers
-                         snowGrainRadius(iSnowLayer,iCategory,iCell) = config_fallen_snow_radius
-                      enddo
-                   endif
-                enddo
-             enddo
+             snowGrainRadius(:,:,:) = config_fallen_snow_radius
 
           endif ! config_do_restart_snow_grain_radius
        endif ! config_use_snow_grain_radius
@@ -2534,10 +2523,6 @@ contains
           abortFlag = .false.
           abortMessage = ""
 
-          ! set the category tracer array
-          call set_cice_tracer_array_category(block, ciceTracerObject, &
-                 tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
-
           call colpkg_clear_warnings()
           call colpkg_step_snow (&
                config_dt, &
@@ -2580,10 +2565,6 @@ contains
                abortMessage)
 
           call column_write_warnings(abortFlag)
-
-          ! get category tracer array
-          call get_cice_tracer_array_category(block, ciceTracerObject, &
-                 tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
        enddo !iCell
 


### PR DESCRIPTION
1. corrections to snow grain wet matamorphism
(set bound on liquid fraction and unit conversion error),
corrects snow grain radius initialization, and removes incorrect calls to
cice tracer arrays (nonBFB in regression test for snow_tracer_physics.
BFB in all other regression tests).

2. corrects snow surface layer contribution  to accumulated bgc snow tracer diagnostic.

Except for snow_tracer_physics regression test,  all other tests and testsuites pass.
