### PR TITLE
Fix vertical coordinate weights

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2206,7 +2206,7 @@
 			 description="Reference depth of ocean for each vertical interface. Used in 'z-level' type runs."
 		/>
 		<var name="vertCoordMovementWeights" type="real" dimensions="nVertLevels" units="unitless"
-			 description="Weights used for distribution of sea surface heigh purturbations through multiple vertical levels."
+			 description="Weights used for distribution of sea surface height perturbations through multiple vertical levels."
 		/>
 		<var name="boundaryEdge" type="integer" dimensions="nVertLevels nEdges" units="unitless"
 			 description="Mask for determining boundary edges. A boundary edge has only one active ocean cell neighboring it."
@@ -2218,13 +2218,13 @@
 			 description="Mask for determining boundary cells. A boundary cell has at least one inactive cell neighboring it."
 		/>
 		<var name="edgeMask" type="integer" dimensions="nVertLevels nEdges" units="unitless"
-			 description="Mask on edges that determines if computations should be done on edge."
+			 description="Mask on edges that determines if computations should be done on edges."
 		/>
 		<var name="vertexMask" type="integer" dimensions="nVertLevels nVertices" units="unitless"
-			 description="Mask on vertices that determines if computations should be done on vertice."
+			 description="Mask on vertices that determines if computations should be done on vertices."
 		/>
 		<var name="cellMask" type="integer" dimensions="nVertLevels nCells" units="unitless"
-			 description="Mask on cells that determines if computations should be done on cell."
+			 description="Mask on cells that determines if computations should be done on cells."
 		/>
 		<var name="edgeSignOnCell" type="integer" dimensions="maxEdges nCells" units="unitless"
 			 description="Sign of edge contributions to a cell for each edge on cell. Used for bit-reproducible loops. Represents directionality of vector connecting cells."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -239,7 +239,15 @@
 	<nml_record name="ALE_vertical_grid" mode="forward">
 		<nml_option name="config_vert_coord_movement" type="character" default_value="uniform_stretching" units="unitless"
 					description="Determines the vertical coordinate movement type. 'uniform_stretching' distributes SSH perturbations through all vertical levels (z-star vertical coordinate); 'fixed' places them all in the top level (z-level vertical coordinate); 'user_specified' allows the input file to determine the distribution using the variable vertCoordMovementWeights (weighted z-star vertical coordinate); and 'impermeable_interfaces' makes the vertical transport between layers zero, i.e. $w^t=0$ (idealized isopycnal)."
-					possible_values="'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces', 'tapered_250m', 'tapered_500m', tapered_1000m'"
+					possible_values="'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces', 'tapered'"
+		/>
+		<nml_option name="config_vert_taper_weight_depth_1" type="real" default_value="250.0" units="m"
+					description="Vertical coordinate taper weight is one above this depth, linearly decreases to zero below."
+					possible_values="any positive real value, but typically 100 to 1000 m."
+		/>
+		<nml_option name="config_vert_taper_weight_depth_2" type="real" default_value="500.0" units="m"
+					description="Vertical coordinate taper weight is zero below this depth, linearly increases to one above."
+					possible_values="any positive real value, but typically 100 to 1000 m and greater than config_vert_taper_weight_depth_1."
 		/>
 		<nml_option name="config_use_min_max_thickness" type="logical" default_value=".false." units="unitless"
 					description="If true, a minimum and maximum thicknesses are enforced to prevent massless and very thick layers."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -239,7 +239,7 @@
 	<nml_record name="ALE_vertical_grid" mode="forward">
 		<nml_option name="config_vert_coord_movement" type="character" default_value="uniform_stretching" units="unitless"
 					description="Determines the vertical coordinate movement type. 'uniform_stretching' distributes SSH perturbations through all vertical levels (z-star vertical coordinate); 'fixed' places them all in the top level (z-level vertical coordinate); 'user_specified' allows the input file to determine the distribution using the variable vertCoordMovementWeights (weighted z-star vertical coordinate); and 'impermeable_interfaces' makes the vertical transport between layers zero, i.e. $w^t=0$ (idealized isopycnal)."
-					possible_values="'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces'"
+					possible_values="'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces', 'tapered_250m', 'tapered_500m', tapered_1000m'"
 		/>
 		<nml_option name="config_use_min_max_thickness" type="logical" default_value=".false." units="unitless"
 					description="If true, a minimum and maximum thicknesses are enforced to prevent massless and very thick layers."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -241,6 +241,10 @@
 					description="Determines the vertical coordinate movement type. 'uniform_stretching' distributes SSH perturbations through all vertical levels (z-star vertical coordinate); 'fixed' places them all in the top level (z-level vertical coordinate); 'user_specified' allows the input file to determine the distribution using the variable vertCoordMovementWeights (weighted z-star vertical coordinate); and 'impermeable_interfaces' makes the vertical transport between layers zero, i.e. $w^t=0$ (idealized isopycnal)."
 					possible_values="'uniform_stretching', 'fixed', 'user_specified', 'impermeable_interfaces', 'tapered'"
 		/>
+		<nml_option name="config_ALE_thickness_proportionality" type="character" default_value="restingThickness_times_weights" units="unitless"
+					description="When config_vert_coord_movement='uniform_stretching' (z-star type coordinate), determines whether ALE layer thickness is proportional to the resting thickness times weights, or just the weights. The first is standard for global runs and is what is specified in Petersen et al 2015 eqns 4 and 6. The second is useful for wetting/drying test cases where resting thickness may be zero at the coastlines."
+					possible_values="'restingThickness_times_weights' or 'weights_only'"
+		/>
 		<nml_option name="config_vert_taper_weight_depth_1" type="real" default_value="250.0" units="m"
 					description="Vertical coordinate taper weight is one above this depth, linearly decreases to zero below."
 					possible_values="any positive real value, but typically 100 to 1000 m."

--- a/src/core_ocean/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -441,12 +441,13 @@ contains
       !!!! END TRANSECT INITIALIZATION
 
       if (transectsInAddGroup .ne. regionsInAddGroup) then
-         call mpas_log_write ('ocn_moc_streamfunction AM: transectsInGroup count does not ' &
-            // 'match regionsInGroup count: $i, $i', intArgs = (/ transectsInAddGroup, regionsInAddGroup /) )
+         ! This writes output every step, and is too verbose.
+         !call mpas_log_write ('ocn_moc_streamfunction AM: transectsInGroup count does not ' &
+         !   // 'match regionsInGroup count: $i, $i', intArgs = (/ transectsInAddGroup, regionsInAddGroup /) )
          i = min(transectsInAddGroup, regionsInAddGroup)
          transectsInAddGroup = i
          regionsInAddGroup = i
-         call mpas_log_write ('Setting both to min: $i, $i', intArgs = (/ transectsInAddGroup, regionsInAddGroup /) )
+         !call mpas_log_write ('Setting both to min: $i, $i', intArgs = (/ transectsInAddGroup, regionsInAddGroup /) )
       end if
 
       err = 0

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -281,6 +281,9 @@ module ocn_forward_mode
       if (config_vert_coord_movement.ne.'fixed'.and. &
           config_vert_coord_movement.ne.'uniform_stretching'.and. &
           config_vert_coord_movement.ne.'impermeable_interfaces'.and. &
+          config_vert_coord_movement.ne.'tapered_250m'.and. &
+          config_vert_coord_movement.ne.'tapered_500m'.and. &
+          config_vert_coord_movement.ne.'tapered_1000m'.and. &
           config_vert_coord_movement.ne.'user_specified') then
          call mpas_log_write(' Incorrect choice of config_vert_coord_movement.')
          call mpas_log_write('Incorrect choice of config_vert_coord_movement.', MPAS_LOG_CRIT)

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -281,9 +281,7 @@ module ocn_forward_mode
       if (config_vert_coord_movement.ne.'fixed'.and. &
           config_vert_coord_movement.ne.'uniform_stretching'.and. &
           config_vert_coord_movement.ne.'impermeable_interfaces'.and. &
-          config_vert_coord_movement.ne.'tapered_250m'.and. &
-          config_vert_coord_movement.ne.'tapered_500m'.and. &
-          config_vert_coord_movement.ne.'tapered_1000m'.and. &
+          config_vert_coord_movement.ne.'tapered'.and. &
           config_vert_coord_movement.ne.'user_specified') then
          call mpas_log_write(' Incorrect choice of config_vert_coord_movement.')
          call mpas_log_write('Incorrect choice of config_vert_coord_movement.', MPAS_LOG_CRIT)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -392,7 +392,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       type (block_type), pointer :: block
 
       integer :: iTracer, cell, cell1, cell2
-      real (kind=RKIND) :: normalThicknessFluxSum, thicknessSum, hEdge1, zMidPBC
+      real (kind=RKIND) :: normalThicknessFluxSum, thicknessSum, hEdge1, zMidPBC, &
+         depth1, depth2
 
       integer, dimension(:), pointer :: maxLevelCell, landIceMask
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth, &
@@ -458,6 +459,37 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          elseif (config_vert_coord_movement.eq.'uniform_stretching') then
 
             vertCoordMovementWeights = 1.0_RKIND
+
+         ! Set weight tapering:
+         !  1.0 shallower than depth1
+         !  linear in between
+         !  0.0 deeper than depth2
+         elseif (config_vert_coord_movement.eq.'tapered_250m') then
+
+            depth1 = 250.0
+            depth2 = 500.0
+            do k = 1, nVertLevels
+               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
+               vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
+            end do
+
+         elseif (config_vert_coord_movement.eq.'tapered_500m') then
+
+            depth1 = 500.0
+            depth2 = 1000.0
+            do k = 1, nVertLevels
+               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
+               vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
+            end do
+
+         elseif (config_vert_coord_movement.eq.'tapered_1000m') then
+
+            depth1 = 1000.0
+            depth2 = 1500.0
+            do k = 1, nVertLevels
+               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
+               vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
+            end do
 
          endif
 

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -408,6 +408,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       logical, pointer :: config_do_restart, config_check_ssh_consistency
       logical, pointer :: config_check_zlevel_consistency
       character (len=StrKIND), pointer :: config_vert_coord_movement
+      real (kind=RKIND), pointer :: config_vert_taper_weight_depth_1, config_vert_taper_weight_depth_2
 
       type (mpas_pool_iterator_type) :: groupItr
 
@@ -415,6 +416,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(domain % configs, 'config_check_ssh_consistency', config_check_ssh_consistency)
       call mpas_pool_get_config(domain % configs, 'config_check_zlevel_consistency', config_check_zlevel_consistency)
+      call mpas_pool_get_config(domain % configs, 'config_vert_taper_weight_depth_1', config_vert_taper_weight_depth_1)
+      call mpas_pool_get_config(domain % configs, 'config_vert_taper_weight_depth_2', config_vert_taper_weight_depth_2)
 
       ! Initialize z-level mesh variables from h, read in from input file.
       block => domain % blocklist
@@ -460,34 +463,16 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
             vertCoordMovementWeights = 1.0_RKIND
 
-         ! Set weight tapering:
-         !  1.0 shallower than depth1
-         !  linear in between
-         !  0.0 deeper than depth2
-         elseif (config_vert_coord_movement.eq.'tapered_250m') then
+         elseif (config_vert_coord_movement.eq.'tapered') then
 
-            depth1 = 250.0
-            depth2 = 500.0
+            ! Set weight tapering:
+            !  1.0 shallower than config_vert_taper_weight_depth_1
+            !  linear in between
+            !  0.0 deeper than config_vert_taper_weight_depth_2
             do k = 1, nVertLevels
-               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
-               vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
-            end do
-
-         elseif (config_vert_coord_movement.eq.'tapered_500m') then
-
-            depth1 = 500.0
-            depth2 = 1000.0
-            do k = 1, nVertLevels
-               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
-               vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
-            end do
-
-         elseif (config_vert_coord_movement.eq.'tapered_1000m') then
-
-            depth1 = 1000.0
-            depth2 = 1500.0
-            do k = 1, nVertLevels
-               vertCoordMovementWeights(k) = 1.0_RKIND + (refZMid(k) + depth1)/(depth2 - depth1)
+               vertCoordMovementWeights(k) = 1.0_RKIND + &
+                 (refZMid(k) + config_vert_taper_weight_depth_1) / &
+                 (config_vert_taper_weight_depth_2 - config_vert_taper_weight_depth_1)
                vertCoordMovementWeights(k) = max( 0.0_RKIND, min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
             end do
 

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -51,6 +51,8 @@ module ocn_thick_ale
    !
    !--------------------------------------------------------------------
 
+   integer :: configALEthicknessProportionality
+
 !***********************************************************************
 
 contains
@@ -110,7 +112,7 @@ contains
       integer, pointer :: nCells, nVertLevels
       integer, dimension(:), pointer :: maxLevelCell
 
-      real (kind=RKIND) :: weightSum, remainder, newThickness, thicknessWithRemainder
+      real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness, thicknessWithRemainder
       real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
       real (kind=RKIND), dimension(:), allocatable :: &
          SSH_ALE_thickness,      & !> ALE thickness alteration due to SSH (z-star)
@@ -147,26 +149,49 @@ contains
       !
       ! ALE thickness alteration due to SSH (z-star)
       !
-      !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         kMax = maxLevelCell(iCell)
+      if (configALEthicknessProportionality==1) then ! restingThickness_times_weights
 
-         weightSum = 1e-14_RKIND
-         do k = 1, kMax
-            weightSum = weightSum + vertCoordMovementWeights(k) 
-         end do
-
-         do k = 1, kMax
-            ! Using this, we must require that sum(restingThickness(k, iCell))
-            ! summed over k is equal to bottomDepth.
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+   
+            thicknessSum = 1e-14_RKIND
+            do k = 1, kMax
+               SSH_ALE_Thickness(k) = SSH(iCell) * vertCoordMovementWeights(k) * restingThickness(k, iCell)
+               thicknessSum = thicknessSum + vertCoordMovementWeights(k) * restingThickness(k, iCell)
+            end do
+   
+            ! Note that restingThickness is nonzero, and remaining terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
-            ! altered so only the W_k weights are used. The resting
-            ! thickness shown in eqn 6 is not included here.
-            ALE_Thickness(k, iCell) = restingThickness(k, iCell) + ssh(iCell) * vertCoordMovementWeights(k) / weightSum
-
-         end do
-      enddo
-      !$omp end do
+            do k = 1, kMax
+               SSH_ALE_Thickness(k) = SSH_ALE_Thickness(k) / thicknessSum
+               ALE_Thickness(k, iCell) = restingThickness(k, iCell) + SSH_ALE_Thickness(k)
+            end do
+         enddo
+         !$omp end do
+   
+         elseif (configALEthicknessProportionality==2) then ! weights_only
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            kMax = maxLevelCell(iCell)
+   
+            weightSum = 1e-14_RKIND
+            do k = 1, kMax
+               weightSum = weightSum + vertCoordMovementWeights(k) 
+            end do
+   
+            do k = 1, kMax
+               ! Using this, we must require that sum(restingThickness(k, iCell))
+               ! summed over k is equal to bottomDepth.
+               ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
+               ! altered so only the W_k weights are used. The resting
+               ! thickness shown in eqn 6 is not included here.
+               ALE_Thickness(k, iCell) = restingThickness(k, iCell) + ssh(iCell) * vertCoordMovementWeights(k) / weightSum
+   
+            end do
+         enddo
+         !$omp end do
+      endif
 
       if (thicknessFilterActive) then
          !$omp do schedule(runtime) private(kMax)
@@ -238,6 +263,19 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_thick_ale_init(err)!{{{
       integer, intent(out) :: err !< Output: Error flag
+      character (len=StrKIND), pointer :: config_ALE_thickness_proportionality
+
+      call mpas_pool_get_config(ocnConfigs,'config_ALE_thickness_proportionality',config_ALE_thickness_proportionality)
+
+      if (config_ALE_thickness_proportionality=='restingThickness_times_weights') then
+          configALEthicknessProportionality = 1
+      elseif (config_ALE_thickness_proportionality=='weights_only') then
+          configALEthicknessProportionality = 2
+      else
+          call mpas_log_write( &
+             ' Warning: config_ALE_thickness_proportionality is not valid', &
+             MPAS_LOG_CRIT)
+      endif
 
       err = 0
 

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -110,7 +110,7 @@ contains
       integer, pointer :: nCells, nVertLevels
       integer, dimension(:), pointer :: maxLevelCell
 
-      real (kind=RKIND) :: thicknessSum, remainder, newThickness, thicknessWithRemainder
+      real (kind=RKIND) :: weightSum, remainder, newThickness, thicknessWithRemainder
       real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
       real (kind=RKIND), dimension(:), allocatable :: &
          SSH_ALE_thickness,      & !> ALE thickness alteration due to SSH (z-star)
@@ -151,16 +151,19 @@ contains
       do iCell = 1, nCells
          kMax = maxLevelCell(iCell)
 
-         thicknessSum = 1e-14_RKIND
+         weightSum = 1e-14_RKIND
          do k = 1, kMax
-            SSH_ALE_Thickness(k) = SSH(iCell) * vertCoordMovementWeights(k) * restingThickness(k, iCell)
-            thicknessSum = thicknessSum + vertCoordMovementWeights(k) * restingThickness(k, iCell)
+            weightSum = weightSum + vertCoordMovementWeights(k) 
          end do
 
-         ! Note that restingThickness is nonzero, and remaining terms are perturbations about zero.
          do k = 1, kMax
-            SSH_ALE_Thickness(k) = SSH_ALE_Thickness(k) / thicknessSum
-            ALE_Thickness(k, iCell) = restingThickness(k, iCell) + SSH_ALE_Thickness(k)
+            ! Using this, we must require that sum(restingThickness(k, iCell))
+            ! summed over k is equal to bottomDepth.
+            ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
+            ! altered so only the W_k weights are used. The resting
+            ! thickness shown in eqn 6 is not included here.
+            ALE_Thickness(k, iCell) = restingThickness(k, iCell) + ssh(iCell) * vertCoordMovementWeights(k) / weightSum
+
          end do
       enddo
       !$omp end do


### PR DESCRIPTION
This PR does two things:
- Add optional new weighting in ALE SSH thickness distribution
- Add tapered weights options for z-star

The first is used for wetting/drying, to allow bottomDepth to be zero, which can easily occur on a beach. It changes the weighting for the z-star distribution from 
`vertCoordMovementWeights(k) * restingThickness(k, iCell)`
to 
`vertCoordMovementWeights(k)`.
The first formulation can be seen in eqn 6 of Petersen et al 2015.

The new formulation stretches in proportion to the defined weights. The standard formulation stretched in proportion to the weights*restingThickness. That stretches deep layers _more than shallow layers_ with surface gravity waves.

These changes are protected by flags, so are bfb in MPAS-Ocean and E3SM.

Fixes #316
