### PR TITLE
Capture and output tracer fluxes on cell edges into maint 1.0

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2131,38 +2131,38 @@
 		      <var name="salinityNonLocalTendency" array_group="activeTracerNLTendGroup" units="PSU per second" name_in_code="salinityNonLocalTendency"
 			     description="salinity tendency due to kpp non-local flux"
 		      />
-      </var_array>
-      <var_array name="activeTracerVerticalAdvectionTopFlux" type="real" dimensions="nVertLevelsP1 nCells Time" packages="tracerBudget">
-          <var name="temperatureVerticalAdvectionTopFlux" array_group="activeTracerVertTopTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTopFlux"
-            description="potential temperature advective flux on cell top"
-            />
-          <var name="salinityVerticalAdvectionTopFlux" array_group="activeTracerVertTopTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTopFlux"
-            description="salinity advective flux on cell top"
-            />
-        </var_array>
-     <var_array name="activeTracerHorizontalAdvectionEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
-		      <var name="temperatureHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeTendGroup" units="C m^3 s^{-1}" name_in_code="temperatureHorizontaldvectionEdgeTend"
-			     description="potential temperature advective flux due to horizontal advection on edges"
-		      />
-		      <var name="salinityHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeTendGroup" units="PSU m^3 s^{-1}" name_in_code="salinityHorizontalAdvectionEdgeFlux"
-			     description="salinity tendency due to horizontal advection on edges"
-		      />
+	    </var_array>
+		<var_array name="activeTracerVerticalAdvectionTopFlux" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
+			<var name="temperatureVerticalAdvectionTopFlux" array_group="activeTracerVertTopFluxGroup" units="C m s^{-1}" name_in_code="temperatureVerticalAdvectionTopFlux"
+				description="potential temperature vertical advective flux through top of cell"
+			/>
+			<var name="salinityVerticalAdvectionTopFlux" array_group="activeTracerVertTopFluxGroup" units="PSU m s^{-1}" name_in_code="salinityVerticalAdvectionTopFlux"
+				description="salinity advective vertical advective flux through top of cell"
+			/>
+		</var_array>
+		<var_array name="activeTracerHorizontalAdvectionEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
+			<var name="temperatureHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeFluxGroup" units="C m s^{-1}" name_in_code="temperatureHorizontalAdvectionEdgeFlux"
+				description="potential temperature advective flux due to horizontal advection through edges"
+			/>
+			<var name="salinityHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeFluxGroup" units="PSU m s^{-1}" name_in_code="salinityHorizontalAdvectionEdgeFlux"
+				description="salinity advective flux due to horizontal advection through edges"
+			/>
 		</var_array>
 		<var_array name="activeTracerHorizontalAdvectionTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
-		      <var name="temperatureHorizontalAdvectionTendency" array_group="activeTracerHorAdvTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionTendency"
-			     description="potential temperature tendency due to horizontal advection"
-		      />
-		      <var name="salinityHorizontalAdvectionTendency" array_group="activeTracerHorAdvTendGroup" units="PSU per second" name_in_code="salinityHorizontalAdvectionTendency"
-			     description="salinity tendency due to horizontal advection"
-		      />
+			<var name="temperatureHorizontalAdvectionTendency" array_group="activeTracerHorAdvTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionTendency"
+				description="potential temperature tendency due to horizontal advection"
+			/>
+			<var name="salinityHorizontalAdvectionTendency" array_group="activeTracerHorAdvTendGroup" units="PSU per second" name_in_code="salinityHorizontalAdvectionTendency"
+				description="salinity tendency due to horizontal advection"
+			/>
 		</var_array>
 		<var_array name="activeTracerVerticalAdvectionTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
-		      <var name="temperatureVerticalAdvectionTendency" array_group="activeTracerVertAdvTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTendency"
-			     description="potential temperature tendency due to vertical advection"
-		      />
-		      <var name="salinityVerticalAdvectionTendency" array_group="activeTracerVertAdvTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTendency"
-			     description="salinity tendency due to vertical advection"
-		      />
+			<var name="temperatureVerticalAdvectionTendency" array_group="activeTracerVertAdvTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTendency"
+				description="potential temperature tendency due to vertical advection"
+			/>
+			<var name="salinityVerticalAdvectionTendency" array_group="activeTracerVertAdvTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTendency"
+				description="salinity tendency due to vertical advection"
+			/>
 		</var_array>
 		<var_array name="activeTracerVertMixTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
 		      <var name="temperatureVertMixTendency" array_group="activeTracerVertMixTendGroup" units="degrees Celsius per second" name_in_code="temperatureVertMixTendency"
@@ -3220,6 +3220,9 @@
 		/>
 		<var name="fluxOutgoing" persistence="scratch" type="real" dimensions="nVertLevels nCells" units=""
 			 description="Outgoing flux of a tracer for advection"
+		/>
+		<var name="lowOrderFlux" persistence="scratch" type="real" dimensions="nVertLevelsP1 nEdges" units=""
+			 description="Low order flux scratch variable for both horizontal and vertical advection."
 		/>
 		<var name="highOrderFlux" persistence="scratch" type="real" dimensions="nVertLevelsP1 nEdges" units=""
 			 description="High order flux scratch variable for both horizontal and vertical advection."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2131,6 +2131,14 @@
 		      <var name="salinityNonLocalTendency" array_group="activeTracerNLTendGroup" units="PSU per second" name_in_code="salinityNonLocalTendency"
 			     description="salinity tendency due to kpp non-local flux"
 		      />
+      </var_array>
+     <var_array name="activeTracerHorizontalAdvectionEdgeTend" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
+		      <var name="temperatureHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionEdgeTend"
+			     description="potential temperature tendency due to horizontal advection on edges"
+		      />
+		      <var name="salinityHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="PSU per second" name_in_code="salinityHorizontalAdvectionEdgeTend"
+			     description="salinity tendency due to horizontal advection on edges"
+		      />
 		</var_array>
 		<var_array name="activeTracerHorizontalAdvectionTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
 		      <var name="temperatureHorizontalAdvectionTendency" array_group="activeTracerHorAdvTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionTendency"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2132,9 +2132,17 @@
 			     description="salinity tendency due to kpp non-local flux"
 		      />
       </var_array>
+      <var_array name="activeTracerVerticalAdvectionTopTend" type="real" dimensions="nVertLevelsP1 nCells Time" packages="tracerBudget">
+          <var name="temperatureVerticalAdvectionTopTend" array_group="activeTracerVertTopTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTopTend"
+            description="potential temperature advective flux on cell top"
+            />
+          <var name="salinityVerticalAdvectionTopTend" array_group="activeTracerVertTopTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTopTend"
+            description="salinity advective flux on cell top"
+            />
+        </var_array>
      <var_array name="activeTracerHorizontalAdvectionEdgeTend" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
 		      <var name="temperatureHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionEdgeTend"
-			     description="potential temperature tendency due to horizontal advection on edges"
+			     description="potential temperature advective flux due to horizontal advection on edges"
 		      />
 		      <var name="salinityHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="PSU per second" name_in_code="salinityHorizontalAdvectionEdgeTend"
 			     description="salinity tendency due to horizontal advection on edges"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2132,19 +2132,19 @@
 			     description="salinity tendency due to kpp non-local flux"
 		      />
       </var_array>
-      <var_array name="activeTracerVerticalAdvectionTopTend" type="real" dimensions="nVertLevelsP1 nCells Time" packages="tracerBudget">
-          <var name="temperatureVerticalAdvectionTopTend" array_group="activeTracerVertTopTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTopTend"
+      <var_array name="activeTracerVerticalAdvectionTopFlux" type="real" dimensions="nVertLevelsP1 nCells Time" packages="tracerBudget">
+          <var name="temperatureVerticalAdvectionTopFlux" array_group="activeTracerVertTopTendGroup" units="degrees Celsius per second" name_in_code="temperatureVerticalAdvectionTopFlux"
             description="potential temperature advective flux on cell top"
             />
-          <var name="salinityVerticalAdvectionTopTend" array_group="activeTracerVertTopTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTopTend"
+          <var name="salinityVerticalAdvectionTopFlux" array_group="activeTracerVertTopTendGroup" units="PSU per second" name_in_code="salinityVerticalAdvectionTopFlux"
             description="salinity advective flux on cell top"
             />
         </var_array>
-     <var_array name="activeTracerHorizontalAdvectionEdgeTend" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
-		      <var name="temperatureHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorizontaldvectionEdgeTend"
+     <var_array name="activeTracerHorizontalAdvectionEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" packages="tracerBudget">
+		      <var name="temperatureHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeTendGroup" units="C m^3 s^{-1}" name_in_code="temperatureHorizontaldvectionEdgeTend"
 			     description="potential temperature advective flux due to horizontal advection on edges"
 		      />
-		      <var name="salinityHorizontalAdvectionEdgeTend" array_group="activeTracerHorAdvEdgeTendGroup" units="PSU per second" name_in_code="salinityHorizontalAdvectionEdgeTend"
+		      <var name="salinityHorizontalAdvectionEdgeFlux" array_group="activeTracerHorAdvEdgeTendGroup" units="PSU m^3 s^{-1}" name_in_code="salinityHorizontalAdvectionEdgeFlux"
 			     description="salinity tendency due to horizontal advection on edges"
 		      />
 		</var_array>

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -199,7 +199,8 @@ module ocn_time_integration_split
         activeTracerHorizontalAdvectionTendency,      &
         activeTracerVerticalAdvectionTendency,        &
         activeTracerSurfaceFluxTendency,              &
-        activeTracerNonLocalTendency
+        activeTracerNonLocalTendency,                 &
+        activeTracerHorizontalAdvectionEdgeTend
 
       real (kind=RKIND), dimension(:,:), pointer :: &
         temperatureShortWaveTendency
@@ -1639,13 +1640,27 @@ module ocn_time_integration_split
                   call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
                   call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
                   call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-               !$omp do schedule(runtime) private(k)
+                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionEdgeTend', &
+                          activeTracerHorizontalAdvectionEdgeTend)
+                  call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
+
+                  !$omp do schedule(runtime) private(k)
+                  do iEdge = 1, nEdges
+                     do k= 1, maxLevelEdgeTop(iEdge)
+                        activeTracerHorizontalAdvectionEdgeTend(:,k,iEdge) = &
+                          activeTracerHorizontalAdvectionEdgeTend(:,k,iEdge) / &
+                          layerThicknessEdge(k,iEdge)
+                     enddo
+                  enddo
+                  !$omp end do
+
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k= 1, maxLevelCell(iCell)
                         activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
                            activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
                            layerThicknessNew(k,iCell)
-        
+
                         activeTracerVerticalAdvectionTendency(:,k,iCell) = &
                            activeTracerVerticalAdvectionTendency(:,k,iCell) / &
                            layerThicknessNew(k,iCell)
@@ -1662,7 +1677,7 @@ module ocn_time_integration_split
                            activeTracerNonLocalTendency(:,k,iCell) / &
                            layerThicknessNew(k,iCell)
                      end do
-                  end do 
+                  end do
                   !$omp end do
                endif
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -200,7 +200,7 @@ module ocn_time_integration_split
         activeTracerVerticalAdvectionTendency,        &
         activeTracerSurfaceFluxTendency,              &
         activeTracerNonLocalTendency,                 &
-        activeTracerHorizontalAdvectionEdgeTend
+        activeTracerHorizontalAdvectionEdgeFlux
 
       real (kind=RKIND), dimension(:,:), pointer :: &
         temperatureShortWaveTendency
@@ -1640,15 +1640,15 @@ module ocn_time_integration_split
                   call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
                   call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
                   call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionEdgeTend', &
-                          activeTracerHorizontalAdvectionEdgeTend)
+                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionEdgeFlux', &
+                          activeTracerHorizontalAdvectionEdgeFlux)
                   call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
                   !$omp do schedule(runtime) private(k)
                   do iEdge = 1, nEdges
                      do k= 1, maxLevelEdgeTop(iEdge)
-                        activeTracerHorizontalAdvectionEdgeTend(:,k,iEdge) = &
-                          activeTracerHorizontalAdvectionEdgeTend(:,k,iEdge) / &
+                        activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
+                          activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
                           layerThicknessEdge(k,iEdge)
                      enddo
                   enddo

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -107,7 +107,8 @@ module ocn_tracer_advection_mono
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
               activeTracerHorizontalAdvectionTendency, &
-              activeTracerVerticalAdvectionTendency
+              activeTracerVerticalAdvectionTendency,   &
+              activeTracerHorizontalAdvectionEdgeTend
 
       real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
 
@@ -131,6 +132,8 @@ module ocn_tracer_advection_mono
 
       call mpas_pool_get_config(ocnConfigs, 'config_compute_active_tracer_budgets', config_compute_active_tracer_budgets)
       if (config_compute_active_tracer_budgets) then
+         call mpas_pool_get_array(diagnosticsPool, 'activeTracerHorizontalAdvectionEdgeTend', &
+                 activeTracerHorizontalAdvectionEdgeTend)
          call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
                  activeTracerHorizontalAdvectionTendency)
          call mpas_pool_get_array(diagnosticsPool,'activeTracerVerticalAdvectionTendency', &
@@ -399,6 +402,16 @@ module ocn_tracer_advection_mono
 
         if (config_compute_active_tracer_budgets) then
            if (tracerGroupName == 'activeTracers') then
+
+              !$omp do schedule(runtime) private(k)
+              do i = 1,nEdgesOnCell(iCell)
+                iEdge = edgesOnCell(i, iCell)
+                do k = 1,maxLevelEdgeTop(iEdge)
+                  activeTracerHorizontalAdvectionEdgeTend(iTracer,k,iEdge) = high_order_flux(k,iEdge)
+                enddo
+              enddo
+              !$omp end do
+
               !$omp do schedule(runtime) private(k)
               do iCell = 1, nCells
                 do k = 1, maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -407,16 +407,13 @@ module ocn_tracer_advection_mono
            if (tracerGroupName == 'activeTracers') then
 
               !$omp do schedule(runtime) private(k)
-              do i = 1,nEdgesOnCell(iCell)
-                iEdge = edgesOnCell(i, iCell)
-                do k = 1,maxLevelEdgeTop(iEdge)
-                  activeTracerHorizontalAdvectionEdgeTend(iTracer,k,iEdge) = high_order_flux(k,iEdge)
-                enddo
-              enddo
-              !$omp end do
-
-              !$omp do schedule(runtime) private(k)
               do iCell = 1, nCells
+                do i = 1,nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(i, iCell)
+                  do k = 1,maxLevelEdgeTop(iEdge)
+                    activeTracerHorizontalAdvectionEdgeTend(iTracer,k,iEdge) = high_order_flux(k,iEdge)
+                  enddo
+                enddo
                 do k = 1, maxLevelCell(iCell)
                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
                 end do
@@ -639,7 +636,7 @@ module ocn_tracer_advection_mono
                     activeTracerVerticalAdvectionTopTend(iTracer,k,iCell) = high_order_flux(k,iCell)
                 end do
                 k = maxLevelCell(iCell)+1
-                activeTracerVerticalAdvectionTopTend(iTracer,k,iEdge) = high_order_flux(k,iCell)
+                activeTracerVerticalAdvectionTopTend(iTracer,k,iCell) = high_order_flux(k,iCell)
               end do ! iCell loop
               !$omp end do
            end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -108,8 +108,8 @@ module ocn_tracer_advection_mono
       real (kind=RKIND), dimension(:,:,:), pointer :: &
               activeTracerHorizontalAdvectionTendency, &
               activeTracerVerticalAdvectionTendency,   &
-              activeTracerHorizontalAdvectionEdgeTend, &
-              activeTracerVerticalAdvectionTopTend
+              activeTracerHorizontalAdvectionEdgeFlux, &
+              activeTracerVerticalAdvectionTopFlux
 
       real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
 
@@ -133,10 +133,10 @@ module ocn_tracer_advection_mono
 
       call mpas_pool_get_config(ocnConfigs, 'config_compute_active_tracer_budgets', config_compute_active_tracer_budgets)
       if (config_compute_active_tracer_budgets) then
-         call mpas_pool_get_array(diagnosticsPool, 'activeTracerVerticalAdvectionTopTend', &
-                 activeTracerVerticalAdvectionTopTend)
-         call mpas_pool_get_array(diagnosticsPool, 'activeTracerHorizontalAdvectionEdgeTend', &
-                 activeTracerHorizontalAdvectionEdgeTend)
+         call mpas_pool_get_array(diagnosticsPool, 'activeTracerVerticalAdvectionTopFlux', &
+                 activeTracerVerticalAdvectionTopFlux)
+         call mpas_pool_get_array(diagnosticsPool, 'activeTracerHorizontalAdvectionEdgeFlux', &
+                 activeTracerHorizontalAdvectionEdgeFlux)
          call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
                  activeTracerHorizontalAdvectionTendency)
          call mpas_pool_get_array(diagnosticsPool,'activeTracerVerticalAdvectionTendency', &
@@ -411,7 +411,7 @@ module ocn_tracer_advection_mono
                 do i = 1,nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i, iCell)
                   do k = 1,maxLevelEdgeTop(iEdge)
-                    activeTracerHorizontalAdvectionEdgeTend(iTracer,k,iEdge) = high_order_flux(k,iEdge)
+                    activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = high_order_flux(k,iEdge)
                   enddo
                 enddo
                 do k = 1, maxLevelCell(iCell)
@@ -633,10 +633,10 @@ module ocn_tracer_advection_mono
               do iCell = 1, nCells
                 do k = 1, maxLevelCell(iCell)
                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
-                    activeTracerVerticalAdvectionTopTend(iTracer,k,iCell) = high_order_flux(k,iCell)
+                    activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = high_order_flux(k,iCell)
                 end do
                 k = maxLevelCell(iCell)+1
-                activeTracerVerticalAdvectionTopTend(iTracer,k,iCell) = high_order_flux(k,iCell)
+                activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = high_order_flux(k,iCell)
               end do ! iCell loop
               !$omp end do
            end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -108,7 +108,8 @@ module ocn_tracer_advection_mono
       real (kind=RKIND), dimension(:,:,:), pointer :: &
               activeTracerHorizontalAdvectionTendency, &
               activeTracerVerticalAdvectionTendency,   &
-              activeTracerHorizontalAdvectionEdgeTend
+              activeTracerHorizontalAdvectionEdgeTend, &
+              activeTracerVerticalAdvectionTopTend
 
       real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
 
@@ -132,6 +133,8 @@ module ocn_tracer_advection_mono
 
       call mpas_pool_get_config(ocnConfigs, 'config_compute_active_tracer_budgets', config_compute_active_tracer_budgets)
       if (config_compute_active_tracer_budgets) then
+         call mpas_pool_get_array(diagnosticsPool, 'activeTracerVerticalAdvectionTopTend', &
+                 activeTracerVerticalAdvectionTopTend)
          call mpas_pool_get_array(diagnosticsPool, 'activeTracerHorizontalAdvectionEdgeTend', &
                  activeTracerHorizontalAdvectionEdgeTend)
          call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
@@ -633,7 +636,10 @@ module ocn_tracer_advection_mono
               do iCell = 1, nCells
                 do k = 1, maxLevelCell(iCell)
                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
+                    activeTracerVerticalAdvectionTopTend(iTracer,k,iCell) = high_order_flux(k,iCell)
                 end do
+                k = maxLevelCell(iCell)+1
+                activeTracerVerticalAdvectionTopTend(iTracer,k,iEdge) = high_order_flux(k,iCell)
               end do ! iCell loop
               !$omp end do
            end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -91,19 +91,20 @@ module ocn_tracer_advection_mono
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
 
       real (kind=RKIND) :: signedFactor, tracer_new 
-      real (kind=RKIND) :: flux_upwind, tracer_min_new, tracer_max_new, tracer_upwind_new, scale_factor
+      real (kind=RKIND) :: tracer_min_new, tracer_max_new, tracer_upwind_new, scale_factor
       real (kind=RKIND) :: flux, tracer_weight, invAreaCell1, invAreaCell2
       real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
       real (kind=RKIND), dimension(:,:), pointer :: tracer_cur, work_tend, h_new_inv
       real (kind=RKIND), dimension(:,:), pointer :: tracer_max, tracer_min
       real (kind=RKIND), dimension(:,:), pointer :: flux_incoming, flux_outgoing
+      real (kind=RKIND), dimension(:,:), pointer :: low_order_flux
       real (kind=RKIND), dimension(:,:), pointer :: high_order_flux
       real (kind=RKIND), dimension(:,:), pointer :: h_prov, h_prov_inv
 
       type (field2DReal), pointer :: tracerCurField, workTendencyField, hNewInvField, tracerMinField, &
                                      tracerMaxField, fluxIncomingField, fluxOutgoingField, &
-                                     hProvInvField, hProvField, highOrderFluxField
+                                     hProvInvField, hProvField, lowOrderFluxField, highOrderFluxField
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
               activeTracerHorizontalAdvectionTendency, &
@@ -152,6 +153,7 @@ module ocn_tracer_advection_mono
       call mpas_pool_get_field(scratchPool, 'fluxOutgoing', fluxOutgoingField)
       call mpas_pool_get_field(scratchPool, 'hProvInv', hProvInvField)
       call mpas_pool_get_field(scratchPool, 'hProv', hProvField)
+      call mpas_pool_get_field(scratchPool, 'lowOrderFlux', lowOrderFluxField)
       call mpas_pool_get_field(scratchPool, 'highOrderFlux', highOrderFluxField)
 
       call mpas_allocate_scratch_field(tracerCurField, .true., .false.)
@@ -163,6 +165,7 @@ module ocn_tracer_advection_mono
       call mpas_allocate_scratch_field(fluxOutgoingField, .true., .false.)
       call mpas_allocate_scratch_field(hProvInvField, .true., .false.)
       call mpas_allocate_scratch_field(hProvField, .true., .false.)
+      call mpas_allocate_scratch_field(lowOrderFluxField, .true., .false.)
       call mpas_allocate_scratch_field(highOrderFluxField, .true., .false.)
       call mpas_threading_barrier()
 
@@ -176,6 +179,7 @@ module ocn_tracer_advection_mono
       work_tend => workTendencyField % array
       flux_incoming => fluxIncomingField % array
       flux_outgoing => fluxOutgoingField % array
+      low_order_flux => lowOrderFluxField % array
       high_order_flux => highOrderFluxField % array
 
       nCells = nCellsArray( size(nCellsArray) )
@@ -251,7 +255,7 @@ module ocn_tracer_advection_mono
         ! Need all the edges around the 1 halo cells and owned cells
         nEdges = nEdgesArray( 3 )
         !  Compute the high order horizontal flux
-        !$omp do schedule(runtime) private(cell1, cell2, k, tracer_weight, i, iCell, flux_upwind)
+        !$omp do schedule(runtime) private(cell1, cell2, k, tracer_weight, i, iCell)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
@@ -280,12 +284,14 @@ module ocn_tracer_advection_mono
             tracer_weight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) * (dvEdge(iEdge) * 0.5_RKIND) &
                           * normalThicknessFlux(k, iEdge)
 
+            low_order_flux(k,iEdge) = dvEdge(iEdge) &
+                                       * (  max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell1) &
+                                          + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell2) )
+
             high_order_flux(k, iEdge) = high_order_flux(k, iedge) + tracer_weight * (tracer_cur(k, cell1) &
                                             + tracer_cur(k, cell2))
 
-            flux_upwind = dvEdge(iEdge) * (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell1) &
-                        + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell2))
-            high_order_flux(k,iEdge) = high_order_flux(k,iEdge) - flux_upwind
+            high_order_flux(k,iEdge) = high_order_flux(k,iEdge) - low_order_flux(k,iEdge)
           end do ! k loop
         end do ! iEdge loop
         !$omp end do
@@ -299,7 +305,7 @@ module ocn_tracer_advection_mono
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
         !$omp do schedule(runtime) private(k, tracer_max_new, tracer_min_new, tracer_upwind_new, scale_factor, invAreaCell1, i, &
-        !$omp                              iEdge, cell1, cell2, flux_upwind, signedFactor)
+        !$omp                              iEdge, cell1, cell2, signedFactor)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -312,17 +318,15 @@ module ocn_tracer_advection_mono
             signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
 
             do k = 1, maxLevelEdgeTop(iEdge)
-              flux_upwind = dvEdge(iEdge) * (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell1) &
-                                          + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracer_cur(k,cell2))
-
-              ! Here work_tend is the upwind tendency
-              work_tend(k,iCell) = work_tend(k,iCell) + signedFactor * flux_upwind
+              ! Here work_tend is the advection tendency due to the upwind (low order) fluxes.
+              work_tend(k,iCell) = work_tend(k,iCell) + signedFactor * low_order_flux(k,iEdge)
 
               ! Accumulate remaining high order fluxes
               flux_outgoing(k,iCell) = flux_outgoing(k,iCell) + min(0.0_RKIND, signedFactor &
                                      * high_order_flux(k, iEdge))
               flux_incoming(k,iCell) = flux_incoming(k,iCell) + max(0.0_RKIND, signedFactor &
                                      * high_order_flux(k, iEdge))
+
             end do
           end do
 
@@ -407,15 +411,20 @@ module ocn_tracer_advection_mono
            if (tracerGroupName == 'activeTracers') then
 
               !$omp do schedule(runtime) private(k)
-              do iCell = 1, nCells
-                do i = 1,nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-                  do k = 1,maxLevelEdgeTop(iEdge)
-                    activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = high_order_flux(k,iEdge)
-                  enddo
+              do iEdge = 1,nEdgesArray( 2 )
+                do k = 1,maxLevelEdgeTop(iEdge)
+                  ! Save u*h*T flux on edge for analysis. This variable will be
+                  ! divided by h at the end of the time step.
+                  activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                    ( low_order_flux(k,iEdge) + high_order_flux(k,iEdge) ) / dvEdge(iEdge)
                 enddo
+              enddo
+              !$omp end do
+
+              !$omp do schedule(runtime) private(k)
+              do iCell = 1, nCellsArray( 1 )
                 do k = 1, maxLevelCell(iCell)
-                    activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
+                  activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
                 end do
               end do ! iCell loop
               !$omp end do
@@ -486,7 +495,7 @@ module ocn_tracer_advection_mono
         ! Need all owned and 1 halo cells
         nCells = nCellsArray( 2 )
         !  Compute the high and low order vertical fluxes. Also determine bounds on tracer_cur.
-        !$omp do schedule(runtime) private(k, verticalWeightK, verticalWeightKm1, i, flux_upwind)
+        !$omp do schedule(runtime) private(k, verticalWeightK, verticalWeightKm1, i)
         do iCell = 1, nCells
 
           ! Operate on top cell in column
@@ -547,10 +556,10 @@ module ocn_tracer_advection_mono
           !  Store left over high order flux in high_order_flux array.
           !  Upwind fluxes are accumulated in work_tend
           do k = 2, maxLevelCell(iCell)
-            flux_upwind = min(0.0_RKIND,w(k,iCell))*tracer_cur(k-1,iCell) + max(0.0_RKIND,w(k,iCell))*tracer_cur(k,iCell)
-            work_tend(k-1,iCell) = work_tend(k-1,iCell) + flux_upwind
-            work_tend(k  ,iCell) = work_tend(k  ,iCell) - flux_upwind
-            high_order_flux(k,iCell) = high_order_flux(k,iCell) - flux_upwind
+            low_order_flux(k,iCell) = min(0.0_RKIND,w(k,iCell))*tracer_cur(k-1,iCell) + max(0.0_RKIND,w(k,iCell))*tracer_cur(k,iCell)
+            work_tend(k-1,iCell) = work_tend(k-1,iCell) + low_order_flux(k,iCell)
+            work_tend(k  ,iCell) = work_tend(k  ,iCell) - low_order_flux(k,iCell)
+            high_order_flux(k,iCell) = high_order_flux(k,iCell) - low_order_flux(k,iCell)
           end do ! k loop
 
           ! flux_incoming contains the total remaining high order flux into iCell
@@ -632,11 +641,9 @@ module ocn_tracer_advection_mono
               !$omp do schedule(runtime) private(k)
               do iCell = 1, nCells
                 do k = 1, maxLevelCell(iCell)
-                    activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
-                    activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = high_order_flux(k,iCell)
+                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = low_order_flux(k,iCell) + high_order_flux(k,iCell)
+                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = work_tend(k,iCell)
                 end do
-                k = maxLevelCell(iCell)+1
-                activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = high_order_flux(k,iCell)
               end do ! iCell loop
               !$omp end do
            end if
@@ -695,6 +702,7 @@ module ocn_tracer_advection_mono
       call mpas_deallocate_scratch_field(fluxOutgoingField, .true.)
       call mpas_deallocate_scratch_field(hProvInvField, .true.)
       call mpas_deallocate_scratch_field(hProvField, .true.)
+      call mpas_deallocate_scratch_field(lowOrderFluxField, .true.)
       call mpas_deallocate_scratch_field(highOrderFluxField, .true.)
 
 #ifdef _ADV_TIMERS

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -325,7 +325,6 @@ module mpas_io
          pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
       endif
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -335,7 +334,6 @@ module mpas_io
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
-            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -347,7 +345,6 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
-               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                return
             end if
@@ -454,7 +451,6 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -572,7 +568,6 @@ module mpas_io
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -657,7 +652,6 @@ module mpas_io
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
-            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -669,7 +663,6 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
-            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -695,7 +688,6 @@ module mpas_io
          ! Get number of dimensions
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
-            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -709,7 +701,6 @@ module mpas_io
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
-               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -731,7 +722,6 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
-               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -742,7 +732,6 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
-               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -1016,7 +1005,6 @@ module mpas_io
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -1024,7 +1012,6 @@ module mpas_io
       ! Get the varid for use by put_att routines
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -2004,7 +1991,6 @@ module mpas_io
 
 !      call mpas_log_write('Checking for error')
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -2328,7 +2314,6 @@ module mpas_io
          ! an error under harmless circumstances; so, don't return only for
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. (.not. handle % preexisting_file)) then
-            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -2913,7 +2898,6 @@ module mpas_io
          end if
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3228,7 +3212,6 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3239,7 +3222,6 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3371,7 +3353,6 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3383,7 +3364,6 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3391,7 +3371,6 @@ module mpas_io
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3532,7 +3511,6 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3567,7 +3545,6 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3710,14 +3687,12 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3759,7 +3734,6 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3891,7 +3865,6 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3902,7 +3875,6 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4084,7 +4056,6 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4242,7 +4213,6 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4411,7 +4381,6 @@ module mpas_io
       end if
 
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4592,7 +4561,6 @@ module mpas_io
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       end if
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4752,7 +4720,6 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
-         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
 
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
 
@@ -4946,7 +4913,6 @@ module mpas_io
          if ( finalize_iosystem ) then
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
-              call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
               return
            end if

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -325,6 +325,7 @@ module mpas_io
          pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
       endif
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -334,6 +335,7 @@ module mpas_io
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
+            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -345,6 +347,7 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
+               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                return
             end if
@@ -451,6 +454,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -568,6 +572,7 @@ module mpas_io
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -652,6 +657,7 @@ module mpas_io
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
+            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -663,6 +669,7 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
+            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -688,6 +695,7 @@ module mpas_io
          ! Get number of dimensions
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
+            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -701,6 +709,7 @@ module mpas_io
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
+               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -722,6 +731,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
+               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -732,6 +742,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
+               call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -1005,6 +1016,7 @@ module mpas_io
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -1012,6 +1024,7 @@ module mpas_io
       ! Get the varid for use by put_att routines
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -1991,6 +2004,7 @@ module mpas_io
 
 !      call mpas_log_write('Checking for error')
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -2314,6 +2328,7 @@ module mpas_io
          ! an error under harmless circumstances; so, don't return only for
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. (.not. handle % preexisting_file)) then
+            call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -2898,6 +2913,7 @@ module mpas_io
          end if
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3212,6 +3228,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3222,6 +3239,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3353,6 +3371,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3364,6 +3383,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3371,6 +3391,7 @@ module mpas_io
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3511,6 +3532,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3545,6 +3567,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3687,12 +3710,14 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3734,6 +3759,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3865,6 +3891,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3875,6 +3902,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4056,6 +4084,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4213,6 +4242,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4381,6 +4411,7 @@ module mpas_io
       end if
 
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4561,6 +4592,7 @@ module mpas_io
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       end if
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4720,6 +4752,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
+         call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
 
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
 
@@ -4913,6 +4946,7 @@ module mpas_io
          if ( finalize_iosystem ) then
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
+              call mpas_log_write('MPAS I/O: PIO Returned Erorr, CODE = $i',intArgs=(/pio_ierr/), MPAS_LOG_WARN)
               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
               return
            end if


### PR DESCRIPTION
This PR adds variables within tracer_advection_mono to capture the edge based fluxes of temperature and salinity to fully close the heat and salinity budgets regionally.

See PR #136 for original code merge into ocean/develop. This merge is for E3SM maint1.0 branch.

