### PR TITLE
corrected typo in ./src/core_atmosphere/diagnostics/Makefile

### DIFF
--- a/src/core_atmosphere/diagnostics/Makefile
+++ b/src/core_atmosphere/diagnostics/Makefile
@@ -24,7 +24,7 @@ soundings.o:
 
 OBJS = mpas_atm_diagnostics_manager.o mpas_atm_diagnostics_utils.o
 
-all: $(DIAGNOSTIC_MODULS) $(OBJS)
+all: $(DIAGNOSTIC_MODULES) $(OBJS)
 
 mpas_atm_diagnostics_manager.o: mpas_atm_diagnostics_utils.o $(DIAGNOSTIC_MODULES)
 


### PR DESCRIPTION
In ./src/core_atmosphere/diagnostics/Makefile, line 27 was
all: $(DIAGNOSTIC_MODULS) $(OBJS)

instead of
all: $(DIAGNOSTIC_MODULES) $(OBJS)

This PR simply corrects that typo.
