### PR TITLE
Cleaned up names in rk4 time stepping for clarity

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -764,11 +764,11 @@ module ocn_time_integration_rk4
    end subroutine ocn_time_integrator_rk4!}}}
 
    subroutine ocn_time_integrator_rk4_compute_vel_tends(block, dt, &
-     rk_substep_weight, err)!{{{
+     rkSubstepWeight, err)!{{{
 
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rk_substep_weight
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -814,12 +814,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -829,10 +829,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rk_substep_weight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rkSubstepWeight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rk_substep_weight
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -878,12 +878,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -894,10 +894,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_thick_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_tracer_tends(block, dt, rk_substep_weight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_tracer_tends(block, dt, rkSubstepWeight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rk_substep_weight
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -944,12 +944,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rk_substep_weight, &
+            sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -1054,10 +1054,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_diagnostic_update(block, dt, rk_substep_weight, err)!{{{
+   subroutine ocn_time_integrator_rk4_diagnostic_update(block, dt, rkSubstepWeight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rk_substep_weight
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
       integer, intent(out) :: err
 
       logical, pointer :: config_prescribe_velocity, config_prescribe_thickness, config_use_standardGM
@@ -1130,7 +1130,7 @@ module ocn_time_integration_rk4
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, maxLevelEdgeTop(iEdge)
-            normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rk_substep_weight &
+            normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkSubstepWeight &
                                            * normalVelocityTend(k, iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
          end do
@@ -1141,7 +1141,7 @@ module ocn_time_integration_rk4
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
-            layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rk_substep_weight &
+            layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkSubstepWeight &
                                            * layerThicknessTend(k, iCell)
          end do
       end do
@@ -1164,7 +1164,7 @@ module ocn_time_integration_rk4
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
-                                                 + rk_substep_weight * tracersGroupTend(:, k, iCell) &
+                                                 + rkSubstepWeight * tracersGroupTend(:, k, iCell) &
                                                    ) / layerThicknessProvis(k, iCell)
                      end do
 
@@ -1178,7 +1178,7 @@ module ocn_time_integration_rk4
       if (associated(lowFreqDivergenceCur)) then
          !$omp do schedule(runtime)
          do iCell = 1, nCells
-            lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rk_substep_weight &
+            lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rkSubstepWeight &
                                               * lowFreqDivergenceTend(:, iCell)
          end do
          !$omp end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -763,10 +763,12 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_vel_tends(block, dt, rkWeight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_vel_tends(block, dt, &
+     rk_substep_weight, err)!{{{
+
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rkWeight
+      real (kind=RKIND), intent(in) :: rk_substep_weight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -812,12 +814,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -827,10 +829,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rkWeight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rk_substep_weight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rkWeight
+      real (kind=RKIND), intent(in) :: rk_substep_weight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -876,12 +878,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -892,10 +894,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_thick_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_tracer_tends(block, dt, rkWeight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_tracer_tends(block, dt, rk_substep_weight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rkWeight
+      real (kind=RKIND), intent(in) :: rk_substep_weight
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
@@ -942,12 +944,12 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
+            sshCur, rk_substep_weight, &
             vertAleTransportTop, err)
       endif
       call mpas_threading_barrier()
@@ -1052,10 +1054,10 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_diagnostic_update(block, dt, rkWeight, err)!{{{
+   subroutine ocn_time_integrator_rk4_diagnostic_update(block, dt, rk_substep_weight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
-      real (kind=RKIND), intent(in) :: rkWeight
+      real (kind=RKIND), intent(in) :: rk_substep_weight
       integer, intent(out) :: err
 
       logical, pointer :: config_prescribe_velocity, config_prescribe_thickness, config_use_standardGM
@@ -1128,7 +1130,7 @@ module ocn_time_integration_rk4
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, maxLevelEdgeTop(iEdge)
-            normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkWeight &
+            normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rk_substep_weight &
                                            * normalVelocityTend(k, iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
          end do
@@ -1139,7 +1141,7 @@ module ocn_time_integration_rk4
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
-            layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkWeight &
+            layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rk_substep_weight &
                                            * layerThicknessTend(k, iCell)
          end do
       end do
@@ -1162,7 +1164,7 @@ module ocn_time_integration_rk4
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
-                                                 + rkWeight * tracersGroupTend(:, k, iCell) &
+                                                 + rk_substep_weight * tracersGroupTend(:, k, iCell) &
                                                    ) / layerThicknessProvis(k, iCell)
                      end do
 
@@ -1176,7 +1178,7 @@ module ocn_time_integration_rk4
       if (associated(lowFreqDivergenceCur)) then
          !$omp do schedule(runtime)
          do iCell = 1, nCells
-            lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rkWeight &
+            lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rk_substep_weight &
                                               * lowFreqDivergenceTend(:, iCell)
          end do
          !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -196,7 +196,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_prevent_drying_rk4(block, dt, rk_substep_weight, config_zero_drying_velocity, err) !{{{
+   subroutine ocn_prevent_drying_rk4(block, dt, rkSubstepWeight, config_zero_drying_velocity, err) !{{{
 
      !-----------------------------------------------------------------
      !
@@ -206,7 +206,7 @@ contains
 
      type (block_type), intent(in) :: block
      real (kind=RKIND), intent(in) :: dt
-     real (kind=RKIND), intent(in) :: rk_substep_weight
+     real (kind=RKIND), intent(in) :: rkSubstepWeight
      logical, pointer :: config_zero_drying_velocity
 
      !-----------------------------------------------------------------
@@ -279,7 +279,7 @@ contains
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
      call ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdge, layerThicknessCur, layerThicknessProvis, &
-                                             normalTransportVelocity, rk_substep_weight, wettingVelocity, err)
+                                             normalTransportVelocity, rkSubstepWeight, wettingVelocity, err)
 
      ! prevent drying from happening with selective wettingVelocity
      !$omp do schedule(runtime)

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -196,7 +196,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_prevent_drying_rk4(block, dt, rkWeight, config_zero_drying_velocity, err) !{{{
+   subroutine ocn_prevent_drying_rk4(block, dt, rk_substep_weight, config_zero_drying_velocity, err) !{{{
 
      !-----------------------------------------------------------------
      !
@@ -206,7 +206,7 @@ contains
 
      type (block_type), intent(in) :: block
      real (kind=RKIND), intent(in) :: dt
-     real (kind=RKIND), intent(in) :: rkWeight
+     real (kind=RKIND), intent(in) :: rk_substep_weight
      logical, pointer :: config_zero_drying_velocity
 
      !-----------------------------------------------------------------
@@ -279,7 +279,7 @@ contains
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
      call ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdge, layerThicknessCur, layerThicknessProvis, &
-                                             normalTransportVelocity, rkWeight, wettingVelocity, err)
+                                             normalTransportVelocity, rk_substep_weight, wettingVelocity, err)
 
      ! prevent drying from happening with selective wettingVelocity
      !$omp do schedule(runtime)


### PR DESCRIPTION
Changed appropriate locations in subroutines with variables named rkWeight to rkSubstepWeight to clarify the process of the rk4 time stepping

