### PR TITLE
MPASA - Discard soundings that are not within a Limited-Area domain

### DIFF
--- a/src/core_atmosphere/diagnostics/Makefile
+++ b/src/core_atmosphere/diagnostics/Makefile
@@ -9,6 +9,7 @@ DIAGNOSTIC_MODULES = \
 	convective_diagnostics.o \
 	pv_diagnostics.o \
 	soundings.o \
+	mpas_kd_tree.o
 
 isobaric_diagnostics.o: mpas_atm_diagnostics_utils.o
 
@@ -16,7 +17,9 @@ convective_diagnostics.o: mpas_atm_diagnostics_utils.o
 
 pv_diagnostics.o: mpas_atm_diagnostics_utils.o
 
-soundings.o:
+soundings.o: mpas_kd_tree.o
+
+mpas_kd_tree.o:
 
 
 ################### Generally no need to modify below here ###################

--- a/src/core_atmosphere/diagnostics/mpas_kd_tree.F
+++ b/src/core_atmosphere/diagnostics/mpas_kd_tree.F
@@ -1,0 +1,378 @@
+module mpas_kd_tree
+    
+   !***********************************************************************
+   !
+   !  module mpas_kd_tree
+   !
+   !> \brief   MPAS KD-Tree module
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !>
+   !>
+   !
+   !-----------------------------------------------------------------------
+   implicit none
+
+   private
+
+   public :: kdnode
+
+   ! Public Subroutines
+   public :: mpas_kd_construct
+   public :: mpas_kd_search
+   public :: mpas_kd_free
+
+   type kdnode
+      type (kdnode), pointer :: left => null()
+      type (kdnode), pointer :: right => null()
+
+      integer :: split_dim
+      real, dimension(:), pointer :: point
+      
+      integer :: cell
+   end type kdnode
+
+   contains
+
+
+   !***********************************************************************
+   !
+   !  recusrive routine mpas_kd_construct_internal
+   !
+   !> \brief   Create a KD-Tree from a set of k-Dimensional points
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Recursive function for mpas_kd_construct. See mpas_kd_construct for
+   !> more information.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   recursive function mpas_kd_construct_internal(points, ndims, npoints, dim) result(tree)
+
+      implicit none
+
+      ! Input Varaibles
+      !real, dimension(:,:) :: points
+      type (kdnode), dimension(:), target :: points
+      integer, intent(in) :: ndims
+      integer, value :: npoints
+      integer, value :: dim
+
+      ! Return Value
+      type (kdnode), pointer :: tree
+
+      ! Local Variables
+      integer :: median
+
+      if (npoints < 1) then
+         tree => null()
+         return
+      endif
+
+      ! Sort the points at the split dimension
+      dim = mod(dim, ndims) + 1
+      call quickSort(points, dim, 1, npoints, ndims)
+
+      median = (1 + npoints) / 2 
+
+      points(median) % split_dim = dim
+      tree => points(median)
+
+      ! Build the right and left sub-trees but do not include the 
+      ! node that was just allocated (i.e. points(:, median))
+      points(median)%left => mpas_kd_construct_internal(points(1:median-1), ndims, median - 1, points(median) % split_dim)
+      points(median)%right => mpas_kd_construct_internal(points(median+1:npoints), ndims, npoints - median, points(median) % split_dim)
+
+   end function mpas_kd_construct_internal
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_construct
+   !
+   !> \brief   Create a KD-Tree from a set of k-Dimensional points
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> This routine creates a balanced KD-Tree from a set of K-dimensional 
+   !> points via quicksort and it returns a pointer to the root node of that
+   !> tree. The points dummy argument, should be an array with the dimensions
+   !> defined as: `points(k, n)` with k being the number of dimensions, and n
+   !> being the number of points.    
+   !>
+   !> tree => mpas_kd_construct(points)
+   !>
+   !
+   !-----------------------------------------------------------------------
+   function mpas_kd_construct(points, ndims) result(tree)
+
+      implicit none
+
+      ! Input Varaibles
+      !real, dimension(:,:) :: points
+      type (kdnode), dimension(:) :: points
+      integer, intent(in) :: ndims
+
+      ! Return Value
+      type (kdnode), pointer :: tree
+
+      ! Local Varaibles
+      integer :: npoints
+
+      npoints = size(points)
+      
+      if(npoints < 1) then
+         ! No points were passed in, return null
+         write(0,*) "ERROR: mpas_kd_tree - No points were passed in to construct!"
+         tree => null()
+         return
+      endif
+
+      tree => mpas_kd_construct_internal(points(:), ndims, npoints, 0)
+
+   end function mpas_kd_construct
+
+   !***********************************************************************
+   !
+   !  recursive routine mpas_kd_search_internal
+   !
+   !> \brief   Find the nearest neighbor within a KD-Tree
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Recursive subroutine for mpas_kd_search. See mpas_kd_search for more
+   !> information.
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine mpas_kd_search_internal(kdtree, query, res, distance)
+
+      implicit none
+
+      ! Input Variables
+      type(kdnode), pointer, intent(in) :: kdtree
+      real, dimension(:), intent(in) :: query
+      type(kdnode), pointer, intent(inout) :: res
+      !real, dimension(:), intent(inout) :: res
+      real, intent(inout) :: distance
+
+      ! Local Values
+      real :: current_distance
+
+      current_distance = sum((kdtree % point(:) - query(:))**2)
+      if (current_distance < distance) then
+         distance = current_distance
+         res => kdtree
+      endif
+
+      !
+      ! To find the nearest point, we first attempt to find the point in the same manner
+      ! as a single deminsion BST.
+      !
+      ! However, because we are looking for the nearest neighbor, then there might be
+      ! a possibility that the nearest neighbor is on the otherside of the tree.
+      !
+      ! Thus, to determine if we need to search the opposite child we just searched, we
+      ! will compare the distance of the current minimum distance, and the root node
+      ! that we branched off of.
+      !
+      ! If the distance to the root node, is less then the current minimum distance,
+      ! then the nearist neighbor might be in opposite child.
+      !
+
+      ! TODO: Double precision calculations
+
+      if (query(kdtree % split_dim) > kdtree % point(kdtree % split_dim)) then
+         if (associated(kdtree % right)) then ! Search right
+            call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         endif
+         if ((kdtree % point(kdtree % split_dim) - query(kdtree % split_dim))**2 <= distance .AND. associated(kdtree % left)) then 
+            call mpas_kd_search_internal(kdtree % left, query, res, distance)
+         endif
+      else if (query(kdtree % split_dim) < kdtree % point(kdtree % split_dim)) then 
+         if (associated(kdtree % left)) then ! Search left
+            call mpas_kd_search_internal(kdtree % left, query, res, distance)
+         endif
+         if ((kdtree % point(kdtree % split_dim) - query(kdtree % split_dim))**2 <= distance .AND. associated(kdtree % right)) then
+            call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         endif
+      else ! Nearest point could be in either left or right subtree, so search both
+         if(associated(kdtree % right)) call mpas_kd_search_internal(kdtree % right, query, res, distance)
+         if(associated(kdtree % left)) call mpas_kd_search_internal(kdtree % left, query, res, distance)
+      endif
+
+   end subroutine mpas_kd_search_internal
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_search
+   !
+   !> \brief   Find the nearest neighbor within a KD-Tree
+   !> \author  Miles A. Curry 
+   !> \date    03/04/19
+   !> \details
+   !> Find `point` within `kdtree` and return the nearest neighbor (or the point)
+   !> within `result` return the distance in `min_d`.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_kd_search(kdtree, query, res, distance)
+
+      implicit none
+      type(kdnode), pointer, intent(in) :: kdtree
+      real, dimension(:), intent(in) :: query
+      type(kdnode), pointer, intent(inout) :: res
+      real, intent(out), optional :: distance
+
+      real :: dis
+
+      if (size(kdtree % point) /= size(query)) then
+         write(0,*) "ERROR: Searching a ", size(kdtree % point), "dimensional kdtree for a point that only"
+         write(0,*) "ERROR: ", size(query), " dimensions. Please supply a point of equal"
+         write(0,*) "ERROR: dimensions!"
+         return
+      endif
+
+      dis = huge(dis)
+      call mpas_kd_search_internal(kdtree, query, res, dis)
+
+      if(present(distance)) then
+         distance = dis
+      endif
+
+   end subroutine mpas_kd_search
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_free
+   !
+   !> \brief   Free all nodes within a tree. 
+   !> \author  Miles A. Curry
+   !> \date    03/04/19
+   !> \details
+   !> Recursivly deallocate all nodes within `kdtree` including `kdtree` itself.
+   !>
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine mpas_kd_free(kdtree)
+
+      implicit none
+      type(kdnode), pointer :: kdtree
+
+      if (.not. associated(kdtree)) then
+         return
+      endif
+
+      if (associated(kdtree % left)) then
+         call mpas_kd_free(kdtree % left)
+      endif
+
+      if (associated(kdtree % right)) then
+         call mpas_kd_free(kdtree % right)
+      endif
+
+      deallocate(kdtree % point)
+
+   end subroutine mpas_kd_free
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Sorts
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   !***********************************************************************
+   !
+   !  routine mpas_kd_quicksort
+   !
+   !> \brief   Sort an array along a dimension
+   !> \author  Miles A. Curry
+   !> \date    03/04/19
+   !> \details
+   !> Sort points starting from arrayStart, to arrayEnd along the given dimension 
+   !> `dim`. If two points are swapped, the entire K-Coordinate point are swapped.
+   !>
+   !> TODO: Change the name of this function to mpas_kd_quicksort
+   !
+   !-----------------------------------------------------------------------
+   recursive subroutine quickSort(array, dim, arrayStart, arrayEnd, ndims)
+
+      implicit none
+
+      ! Input Variables
+      !real, dimension(:,:) :: array
+      type (kdnode), dimension(:) :: array
+      integer, intent(in), value :: dim
+      integer, intent(in), value :: arrayStart, arrayEnd
+      integer, intent(in) :: ndims
+
+      ! Local Variables
+      type (kdnode) :: temp
+      real, dimension(ndims) :: pivot_value
+
+      integer :: l, r, pivot, s
+
+      if ((arrayEnd - arrayStart) < 1) then
+         return
+      endif
+
+      ! Create the left, right, and start pointers
+      l = arrayStart
+      r = arrayEnd - 1
+      s = l
+
+      pivot = (l+r)/2
+      pivot_value = array(pivot) % point
+
+      ! Move the pivot to the far right
+      temp = array(pivot)
+      array(pivot) = array(arrayEnd)
+      array(arrayEnd) = temp
+
+      do while ( .TRUE. )
+         ! Advance the left pointer until it is a value less then our pivot_value(dim)
+         do while ( .TRUE. )
+            if (array(l) % point(dim) < pivot_value(dim)) then
+               l = l + 1
+            else
+               exit
+            endif
+         enddo
+
+         ! Advance the right pointer until it is a value more then our pivot_value(dim)
+         do while ( .TRUE. )
+            if ( r <= 0 ) then
+               exit
+            endif
+
+            if(array(r) % point(dim) >= pivot_value(dim)) then
+               r = r - 1
+            else
+               exit
+            endif
+         enddo
+
+         if ( l >= r ) then 
+            exit
+         else ! Swap elements about the pivot
+            temp = array(l)
+            array(l) = array(r)
+            array(r) = temp
+         endif
+      enddo
+
+      ! Move the pivot to l ended up
+      temp = array(l)
+      array(l) = array(arrayEnd)
+      array(arrayEnd) = temp
+
+      !Quick Sort on the lower partition
+      call quickSort(array(:), dim, s, l-1, ndims)
+
+      !Quick sort on the upper partition
+      call quickSort(array(:), dim, l+1, arrayEnd, ndims)
+
+   end subroutine quicksort
+
+end module mpas_kd_tree

--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -56,6 +56,8 @@ module soundings
         use mpas_timekeeping, only : MPAS_timeInterval_type, MPAS_time_type, MPAS_set_timeInterval, &
                                      MPAS_get_clock_time, MPAS_add_clock_alarm, MPAS_NOW
         use mpas_dmpar, only : IO_NODE, mpas_dmpar_bcast_int, mpas_dmpar_bcast_logical, mpas_dmpar_bcast_char
+        use mpas_kd_tree, only : kdnode
+        use mpas_kd_tree, only : mpas_kd_construct, mpas_kd_search, mpas_kd_free
 
         implicit none
 
@@ -69,6 +71,8 @@ module soundings
         integer :: i, ierr
         integer :: sndUnit
         real (kind=RKIND) :: station_lat, station_lon
+        real (kind=RKIND) :: stationX, stationY, stationZ
+        real, pointer :: sphere_radius
         character (len=StrKIND) :: tempstr
         character (len=StrKIND) :: station_name
         logical :: exists
@@ -77,9 +81,13 @@ module soundings
         integer, dimension(:), pointer :: nEdgesOnCell
         integer, dimension(:,:), pointer :: cellsOnCell
         real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
+        real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
         type (MPAS_timeInterval_type) :: intv
         type (MPAS_time_type) :: now
 
+        ! KD Tree
+        type (kdnode), pointer :: tree => null(), res => null()
+        type (kdnode), dimension(:), allocatable :: kdcords
 
         simulationClock => simulation_clock
 
@@ -161,6 +169,21 @@ module soundings
         call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
         call mpas_pool_get_array(mesh, 'latCell', latCell)
         call mpas_pool_get_array(mesh, 'lonCell', lonCell)
+        call mpas_pool_get_array(mesh, 'xCell', xCell)
+        call mpas_pool_get_array(mesh, 'yCell', yCell)
+        call mpas_pool_get_array(mesh, 'zCell', zCell)
+        call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
+
+
+        ! Setup KD-Tree
+        allocate(kdcords(nCells))
+        do i = 1, nCells
+           allocate(kdcords(i) % point(3))
+           kdcords(i) % point = (/xCell(i), yCell(i), zCell(i)/)
+           kdcords(i) % cell = i
+        enddo
+
+        tree => mpas_kd_construct(kdcords, 3)
 
         nearestCell = nCells
 
@@ -170,8 +193,14 @@ module soundings
             end if
             call mpas_dmpar_bcast_char(dminfo, tempstr)
             read(tempstr, fmt=*) stationLats(i), stationLons(i), stationNames(i)
-            nearestCell = nearest_cell((stationLats(i) * pi_const / 180.0_RKIND), (stationLons(i) * pi_const / 180.0_RKIND), &
-                                       nearestCell, nCells, maxEdges, nEdgesOnCell, cellsOnCell, latCell, lonCell)
+
+            stationZ = sphere_radius * sin(stationLats(i) * pi_const / 180.0_RKIND)
+            stationX = sphere_radius * cos(stationLons(i) * pi_const / 180.0_RKIND) * cos(stationLats(i) * pi_const / 180.0_RKIND)
+            stationY = sphere_radius * sin(stationLons(i) * pi_const / 180.0_RKIND) * cos(stationLats(i) * pi_const / 180.0_RKIND)
+
+            call mpas_kd_search(tree, (/stationX, stationY, stationZ/), res)
+            nearestCell = res % cell
+
             if (nearestCell <= nCellsSolve) then
                 stationOwned(i) = .true.
                 stationCells(i) = nearestCell

--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -50,12 +50,13 @@ module soundings
     !-----------------------------------------------------------------------
     subroutine soundings_setup(configs, all_pools, simulation_clock, dminfo)
 
-        use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type, dm_info
+        use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type, dm_info, MPAS_LOG_WARN
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_get_dimension, mpas_pool_get_array, mpas_pool_get_config
         use mpas_io_units, only :  mpas_new_unit, mpas_release_unit
         use mpas_timekeeping, only : MPAS_timeInterval_type, MPAS_time_type, MPAS_set_timeInterval, &
                                      MPAS_get_clock_time, MPAS_add_clock_alarm, MPAS_NOW
         use mpas_dmpar, only : IO_NODE, mpas_dmpar_bcast_int, mpas_dmpar_bcast_logical, mpas_dmpar_bcast_char
+        use mpas_dmpar, only : mpas_dmpar_max_int
         use mpas_kd_tree, only : kdnode
         use mpas_kd_tree, only : mpas_kd_construct, mpas_kd_search, mpas_kd_free
 
@@ -76,6 +77,7 @@ module soundings
         character (len=StrKIND) :: station_name
         logical :: exists
         integer :: nearestCell
+        integer :: stationFlag, stationFlagMax
         integer, pointer :: nCells, nCellsSolve, maxEdges
         integer, dimension(:), pointer :: nEdgesOnCell
         integer, dimension(:,:), pointer :: cellsOnCell
@@ -113,6 +115,7 @@ module soundings
             return
         end if
       
+
         call MPAS_set_timeInterval(intv, timeString=trim(soundingInterval))
         now = MPAS_get_clock_time(simulationClock, MPAS_NOW)
         call MPAS_add_clock_alarm(simulationClock, 'soundingAlarm', now, alarmTimeInterval=intv) 
@@ -206,17 +209,29 @@ module soundings
             call mpas_kd_search(tree, (/stationX, stationY, stationZ/), res)
             nearestCell = res % cell
 
+            ! When running on a limited area mesh, check to see if the location we found is actually,
+            ! within its reported cell. If its not, then its outside of the region and should be discarded.
             if (in_cell(stationX, stationY, stationZ, xCell(nearestCell), yCell(nearestCell), zCell(nearestCell), &
                         nEdgesOnCell(nearestCell), verticesOnCell(:,nearestCell), xVertex, yVertex, zVertex)) then
                if (nearestCell <= nCellsSolve) then
                    stationOwned(i) = .true.
                    stationCells(i) = nearestCell
+                   stationFlag = 1
                else
                    stationOwned(i) = .false.
+                   stationFlag = 0
                end if
             else
                 stationOwned(i) = .false.
+                stationFlag = 0
             end if
+
+            ! Communicate and report if the station is being discarded or not
+            call mpas_dmpar_max_int(dminfo, stationFlag, stationFlagMax)
+            if (dminfo % my_proc_id == IO_NODE .AND. stationFlagMax == 0) then
+               call mpas_log_write("Sounding '"//trim(stationNames(i))//"' is being discarded as it lies outside the region", &
+                                                                         messageType=MPAS_LOG_WARN)
+            endif
         end do
 
         if (dminfo % my_proc_id == IO_NODE) then

--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -72,7 +72,6 @@ module soundings
         integer :: sndUnit
         real (kind=RKIND) :: station_lat, station_lon
         real (kind=RKIND) :: stationX, stationY, stationZ
-        real, pointer :: sphere_radius
         character (len=StrKIND) :: tempstr
         character (len=StrKIND) :: station_name
         logical :: exists
@@ -80,8 +79,11 @@ module soundings
         integer, pointer :: nCells, nCellsSolve, maxEdges
         integer, dimension(:), pointer :: nEdgesOnCell
         integer, dimension(:,:), pointer :: cellsOnCell
+        integer, dimension(:,:), pointer :: verticesOnCell
         real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
         real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
+        real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+        real (kind=RKIND), pointer :: sphere_radius
         type (MPAS_timeInterval_type) :: intv
         type (MPAS_time_type) :: now
 
@@ -167,13 +169,16 @@ module soundings
         call mpas_pool_get_dimension(mesh, 'maxEdges', maxEdges)
         call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
         call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
+        call mpas_pool_get_array(mesh, 'verticesOnCell', verticesOnCell)
         call mpas_pool_get_array(mesh, 'latCell', latCell)
         call mpas_pool_get_array(mesh, 'lonCell', lonCell)
         call mpas_pool_get_array(mesh, 'xCell', xCell)
         call mpas_pool_get_array(mesh, 'yCell', yCell)
         call mpas_pool_get_array(mesh, 'zCell', zCell)
+        call mpas_pool_get_array(mesh, 'xVertex', xVertex)
+        call mpas_pool_get_array(mesh, 'yVertex', yVertex)
+        call mpas_pool_get_array(mesh, 'zVertex', zVertex)
         call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
-
 
         ! Setup KD-Tree
         allocate(kdcords(nCells))
@@ -201,9 +206,14 @@ module soundings
             call mpas_kd_search(tree, (/stationX, stationY, stationZ/), res)
             nearestCell = res % cell
 
-            if (nearestCell <= nCellsSolve) then
-                stationOwned(i) = .true.
-                stationCells(i) = nearestCell
+            if (in_cell(stationX, stationY, stationZ, xCell(nearestCell), yCell(nearestCell), zCell(nearestCell), &
+                        nEdgesOnCell(nearestCell), verticesOnCell(:,nearestCell), xVertex, yVertex, zVertex)) then
+               if (nearestCell <= nCellsSolve) then
+                   stationOwned(i) = .true.
+                   stationCells(i) = nearestCell
+               else
+                   stationOwned(i) = .false.
+               end if
             else
                 stationOwned(i) = .false.
             end if
@@ -214,6 +224,9 @@ module soundings
 
             call mpas_release_unit(sndUnit)
         end if
+
+        call mpas_kd_free(tree)
+        deallocate(kdcords)
 
     end subroutine soundings_setup
 
@@ -420,6 +433,146 @@ module soundings
     
     end function sphere_distance
 
+    !-----------------------------------------------------------------------
+    !  routine mirror_point
+    !
+    !> \brief Finds the "mirror" of a point about a great-circle arc
+    !> \author Michael Duda
+    !> \date   7 March 2019
+    !> \details
+    !>  Given the endpoints of a great-circle arc (A,B) and a point, computes
+    !>  the location of the point on the opposite side of the arc along a great-
+    !>  circle arc that intersects (A,B) at a right angle, and such that the arc
+    !>  between the point and its mirror is bisected by (A,B).
+    !>
+    !>  Assumptions: A, B, and the point to be reflected all lie on the surface
+    !>  of the unit sphere.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mirror_point(xPoint, yPoint, zPoint, xA, yA, zA, xB, yB, zB, xMirror, yMirror, zMirror)
+
+       use mpas_geometry_utils, only : mpas_sphere_angle
+
+       implicit none
+
+       real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
+       real(kind=RKIND), intent(in) :: xA, yA, zA
+       real(kind=RKIND), intent(in) :: xB, yB, zB
+       real(kind=RKIND), intent(out) :: xMirror, yMirror, zMirror
+
+       real(kind=RKIND) :: alpha
+
+       !
+       ! Find the spherical angle between arcs AP and AB (where P is the point to be reflected)
+       !
+       alpha = mpas_sphere_angle(xA, yA, zA, xPoint, yPoint, zPoint, xB, yB, zB)
+
+       !
+       ! Rotate the point to be reflected by twice alpha about the vector from the origin to A
+       !
+       call rotate_about_vector(xPoint, yPoint, zPoint, 2.0_RKIND * alpha, 0.0_RKIND, 0.0_RKIND, 0.0_RKIND, &
+                                xA, yA, zA, xMirror, yMirror, zMirror)
+
+    end subroutine mirror_point
+
+
+    !-----------------------------------------------------------------------
+    !  routine rotate_about_vector
+    !
+    !> \brief Rotates a point about a vector in R3
+    !> \author Michael Duda
+    !> \date   7 March 2019
+    !> \details
+    !>  Rotates the point (x,y,z) through an angle theta about the vector
+    !>  originating at (a, b, c) and having direction (u, v, w).
+    !
+    !>  Reference: https://sites.google.com/site/glennmurray/Home/rotation-matrices-and-formulas/rotation-about-an-arbitrary-axis-in-3-dimensions
+    !
+    !-----------------------------------------------------------------------
+    subroutine rotate_about_vector(x, y, z, theta, a, b, c, u, v, w, xp, yp, zp)
+
+       implicit none
+
+       real (kind=RKIND), intent(in) :: x, y, z, theta, a, b, c, u, v, w
+       real (kind=RKIND), intent(out) :: xp, yp, zp
+
+       real (kind=RKIND) :: vw2, uw2, uv2
+       real (kind=RKIND) :: m
+
+       vw2 = v**2.0 + w**2.0
+       uw2 = u**2.0 + w**2.0
+       uv2 = u**2.0 + v**2.0
+       m = sqrt(u**2.0 + v**2.0 + w**2.0)
+
+       xp = (a*vw2 + u*(-b*v-c*w+u*x+v*y+w*z) + ((x-a)*vw2+u*(b*v+c*w-v*y-w*z))*cos(theta) + m*(-c*v+b*w-w*y+v*z)*sin(theta))/m**2.0
+       yp = (b*uw2 + v*(-a*u-c*w+u*x+v*y+w*z) + ((y-b)*uw2+v*(a*u+c*w-u*x-w*z))*cos(theta) + m*( c*u-a*w+w*x-u*z)*sin(theta))/m**2.0
+       zp = (c*uv2 + w*(-a*u-b*v+u*x+v*y+w*z) + ((z-c)*uv2+w*(a*u+b*v-u*x-v*y))*cos(theta) + m*(-b*u+a*v-v*x+u*y)*sin(theta))/m**2.0
+
+    end subroutine rotate_about_vector
+
+
+    !-----------------------------------------------------------------------
+    !  routine in_cell
+    !
+    !> \brief Determines whether a point is within a Voronoi cell
+    !> \author Michael Duda
+    !> \date   7 March 2019
+    !> \details
+    !>  Given a point on the surface of the sphere, the corner points of a Voronoi
+    !>  cell, and the generating point for that Voronoi cell, determines whether
+    !>  the given point is within the Voronoi cell.
+    !
+    !-----------------------------------------------------------------------
+    logical function in_cell(xPoint, yPoint, zPoint, xCell, yCell, zCell, &
+                             nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex)
+
+       use mpas_geometry_utils, only : mpas_arc_length
+
+       implicit none
+
+       real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
+       real(kind=RKIND), intent(in) :: xCell, yCell, zCell
+       integer, intent(in) :: nEdgesOnCell
+       integer, dimension(:), intent(in) :: verticesOnCell
+       real(kind=RKIND), dimension(:), intent(in) :: xVertex, yVertex, zVertex
+
+       integer :: i
+       integer :: vtx1, vtx2
+       real(kind=RKIND) :: xNeighbor, yNeighbor, zNeighbor
+       real(kind=RKIND) :: inDist, outDist
+       real(kind=RKIND) :: radius
+       real(kind=RKIND) :: radius_inv
+
+       radius = sqrt(xCell * xCell + yCell * yCell + zCell * zCell)
+       radius_inv = 1.0_RKIND / radius
+
+       inDist = mpas_arc_length(xPoint, yPoint, zPoint, xCell, yCell, zCell)
+
+       in_cell = .true.
+
+       do i=1,nEdgesOnCell
+          vtx1 = verticesOnCell(i)
+          vtx2 = verticesOnCell(mod(i,nEdgesOnCell)+1)
+
+          call mirror_point(xCell*radius_inv, yCell*radius_inv, zCell*radius_inv, &
+                            xVertex(vtx1)*radius_inv, yVertex(vtx1)*radius_inv, zVertex(vtx1)*radius_inv, &
+                            xVertex(vtx2)*radius_inv, yVertex(vtx2)*radius_inv, zVertex(vtx2)*radius_inv, &
+                            xNeighbor, yNeighbor, zNeighbor)
+
+          xNeighbor = xNeighbor * radius
+          yNeighbor = yNeighbor * radius
+          zNeighbor = zNeighbor * radius
+
+          outDist = mpas_arc_length(xPoint, yPoint, zPoint, xNeighbor, yNeighbor, zNeighbor)
+
+          if (outDist < inDist) then
+             in_cell = .false.
+             return
+          end if
+
+       end do
+
+    end function in_cell
 
 !=============================================================================================
 !NOTE: functions rslf and rsif are taken from module_mp_thompson temporarily for computing


### PR DESCRIPTION
This PR contains changes and a bug fix for src/diagnostics/soundings.F soundings_setup routine.

First, it implements a KD-Tree to fix a bug that would place soundings in the incorrect grid cell if within a concave decomposition. Using the KD-Tree the correct cell will be located even within concave decomposition.

Next, it adds logic to discard specified soundings that are outside of regional domains. Using the in_cell(...) function, to determine if the station is actually within the closet cell (found by the KD-Tree).



@mgduda, this PR is still missing its last commit (The MPI communication about owned and not owned stations). I noticed there are a few functions for calculating sphere_angle (As well as arc_length). There is a sphere_angle within [src/operators/mpas_geometry_utils.F](https://github.com/MPAS-Dev/MPAS-Model/blob/51d5624709f75182130a2fd94715e1bb13310172/src/operators/mpas_geometry_utils.F#L21-L71). Should I be using that one? Or copy it into the file, like I have done here.