### PR TITLE
Fix and Update Code Layout section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,17 @@ only described below the src directory.
 
 	MPAS-Model
 	├── src
-	│   ├── registry -- Code for building Registry.xml parser (Shared)
 	│   ├── driver -- Main driver for MPAS in stand-alone mode (Shared)
 	│   ├── external -- External software for MPAS (Shared)
 	│   ├── framework -- MPAS Framework (Includes DDT Descriptions, and shared routines. Shared)
 	│   ├── operators -- MPAS Opeartors (Includes Operators for MPAS meshes. Shared)
-	│   ├── inc -- Empty directory for include files that Registry generates (Shared)
+	│   ├── tools -- Empty directory for include files that Registry generates (Shared)
+	│   │   ├── registry -- Code for building Registry.xml parser (Shared)
+	│   │   └── input_gen -- Code for generating streams and namelist files (Shared)
 	│   └── core_* -- Individual model cores.
-        └────── testing_and_setup -- tools for setting up configurations and tests cases (Shared)
+	│       └── inc -- Empty directory for include files that Registry generates
+	├── testing_and_setup -- Tools for setting up configurations and test cases (Shared)
+	└── default_inputs -- Copies of default stream and namelists files (Shared)
 
 Model cores are typically developed independently. For information about
 building and running a particular core, please refer to that core's user's


### PR DESCRIPTION
`testing_and_setup` is at the same directory level as the `src` directory, so move `testing_and_setup` to be at the same level within the code layout section within the README.