### PR TITLE
SST input and output interval check

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -74,7 +74,7 @@ module init_atm_cases
       character(len=StrKIND), pointer :: xtime
 
       type (MPAS_Time_type)  :: curr_time, stop_time
-      type (MPAS_TimeInterval_type)  :: clock_interval, lbc_stream_interval
+      type (MPAS_TimeInterval_type)  :: clock_interval, lbc_stream_interval, surface_stream_interval
       character(len=StrKIND) :: timeString
 
       integer, pointer :: nCells
@@ -264,6 +264,21 @@ module init_atm_cases
       else if (config_init_case == 8 ) then
 
          call mpas_log_write('real-data surface (SST) update test case ')
+
+         !
+         ! Check that config_fg_interval matches the output_interval of the surface stream
+         !
+         clock_interval = mpas_get_clock_timestep(domain % clock, ierr=ierr)
+         surface_stream_interval = MPAS_stream_mgr_get_stream_interval(stream_manager, 'surface', MPAS_STREAM_OUTPUT, ierr)
+         if (clock_interval /= surface_stream_interval) then
+            call mpas_log_write('****************************************************************',       messageType=MPAS_LOG_ERR)
+            call mpas_log_write('The intermediate SST file interval specified by ''config_fg_interval''', messageType=MPAS_LOG_ERR)
+            call mpas_log_write('does not match the output_interval for the ''surface'' stream.',         messageType=MPAS_LOG_ERR)
+            call mpas_log_write('Please correct the namelist.init_atmosphere and/or',                     messageType=MPAS_LOG_ERR)
+            call mpas_log_write('streams.init_atmosphere files.',                                         messageType=MPAS_LOG_ERR)
+            call mpas_log_write('****************************************************************',       messageType=MPAS_LOG_CRIT)
+         end if
+
          block_ptr => domain % blocklist
          do while (associated(block_ptr))
             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', mesh)


### PR DESCRIPTION
This commit checks to see that `config_fg_interval` in the
namelist.init_atmosphere and the output interval for the `surface` stream are
the same for init_case 8.