### PR TITLE
Relocate microphysics driver call from atm_srk3

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6836,10 +6836,25 @@ module atm_time_integration
 
       type (domain_type), intent(inout) :: domain
       real (kind=RKIND), intent(in) :: dt
-
-
+      
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: state
+      type (mpas_pool_type), pointer :: diag
+      type (mpas_pool_type), pointer :: mesh
+
+      integer, pointer :: num_scalars, nCells, nVertLevels, nThreads
+      integer, dimension(:), pointer :: cellThreadStart, cellThreadEnd
+      integer, dimension(:), pointer :: cellSolveThreadStart, cellSolveThreadEnd
+      integer, dimension(:), pointer :: edgeThreadStart, edgeThreadEnd
+      integer, dimension(:), pointer :: edgeSolveThreadStart, edgeSolveThreadEnd
+      integer, dimension(:), pointer :: vertexThreadStart, vertexThreadEnd
+      integer, dimension(:), pointer :: vertexSolveThreadStart, vertexSolveThreadEnd
+
+      type (field3DReal), pointer :: scalars_field
+      integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
+
+      real (kind=RKIND)  :: time_dyn_step
+      integer :: thread
 
 
       clock => domain % clock
@@ -6984,6 +6999,7 @@ module atm_time_integration
 
       type (domain_type), intent(inout) :: domain
       real (kind=RKIND), intent(in) :: dt
+      type (MPAS_Time_type), intent(in) :: nowTime
 
 
       type (block_type), pointer :: block

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -83,7 +83,7 @@ module atm_time_integration
    contains
 
 
-   subroutine atm_timestep(domain, dt, nowTime, itimestep)
+   subroutine dynamics_timestep(domain, dt, nowTime, itimestep)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
@@ -135,7 +135,7 @@ module atm_time_integration
          block => block % next
       end do
 
-   end subroutine atm_timestep
+   end subroutine dynamics_timestep
 
 
    subroutine atm_srk3(domain, dt, itimestep)
@@ -1594,131 +1594,6 @@ module atm_time_integration
 
          block => block % next
       end do
-
-DAVE LBC AFTER MP - NEEDS TO BE MOVED
-      if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
-
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            allocate(rt_driving_values(nVertLevels,nCells+1))
-            allocate(rho_driving_values(nVertLevels,nCells+1))
-            time_dyn_step = dt  ! end of full timestep values
-
-            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
-
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
-                                                   rt_driving_values, rho_driving_values,                        &
-                                                   cellThreadStart(thread), cellThreadEnd(thread),               &
-                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
-!$OMP END PARALLEL DO
-
-            deallocate(rt_driving_values)
-            deallocate(rho_driving_values)
-            block => block % next
-
-         end do
-
-      end if  ! regional_MPAS addition
-
-
-      if (config_apply_lbcs) then  ! adjust boundary values for regional_MPAS scalar transport
-
-         call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
-         call mpas_dmpar_exch_halo_field(scalars_field)
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-   
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-            allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
-
-            !  get the scalar values driving the regional boundary conditions
-            !
-            call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-            call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-            call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-            call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-            call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-            call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-            call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-            call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-            if (index_qv > 0) then
-               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', dt )
-            end if
-            if (index_qc > 0) then
-               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', dt )
-            end if
-            if (index_qr > 0) then
-               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', dt )
-            end if
-            if (index_qi > 0) then
-               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', dt )
-            end if
-            if (index_qs > 0) then
-               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', dt )
-            end if
-            if (index_qg > 0) then
-               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', dt )
-            end if
-            if (index_nr > 0) then
-               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', dt )
-            end if
-            if (index_ni > 0) then
-               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
-            end if
-      
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
-                                         cellThreadStart(thread), cellThreadEnd(thread), &
-                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
-!$OMP END PARALLEL DO
-
-            deallocate(scalars_driving)
-
-            block => block % next
-         end do
-
-      end if  ! regional_MPAS addition
-
-      call summarize_timestep(domain)
 
    end subroutine atm_srk3
 
@@ -6943,5 +6818,194 @@ DAVE LBC AFTER MP - NEEDS TO BE MOVED
       end if
 
    end subroutine summarize_timestep
+
+
+   subroutine dynamics_final_lbc_adjustment(domain, dt)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! For a regional domain, reset the values of rtheta in the specified zone
+   ! (modified by the microphysics scheme), and adjust the boundary values 
+   ! for scalar transport.
+   !
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
+   !                 plus grid meta-data
+   ! Output: domain - updated driving rtheta and rho in scpecified zone, and updated
+   !                  scalars in lateral boundary
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      real (kind=RKIND), intent(in) :: dt
+
+
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: state
+
+
+      clock => domain % clock
+      blocklist => domain % blocklist !!! DAVE this seems unnecessary
+
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_apply_lbcs', config_apply_lbcs)
+
+      if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
+
+         block => domain % blocklist
+         do while (associated(block))
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            allocate(rt_driving_values(nVertLevels,nCells+1))
+            allocate(rho_driving_values(nVertLevels,nCells+1))
+            time_dyn_step = dt  ! end of full timestep values
+
+            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
+                                                   rt_driving_values, rho_driving_values,                        &
+                                                   cellThreadStart(thread), cellThreadEnd(thread),               &
+                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(rt_driving_values)
+            deallocate(rho_driving_values)
+            block => block % next
+
+         end do
+
+      end if  ! regional_MPAS addition
+
+
+      if (config_apply_lbcs) then  ! adjust boundary values for regional_MPAS scalar transport
+
+         call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
+         call mpas_dmpar_exch_halo_field(scalars_field)
+
+         block => domain % blocklist
+         do while (associated(block))
+
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+   
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+            allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
+
+
+            !  get the scalar values driving the regional boundary conditions
+            !
+            call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+            call mpas_pool_get_dimension(state, 'index_qc', index_qc)
+            call mpas_pool_get_dimension(state, 'index_qr', index_qr)
+            call mpas_pool_get_dimension(state, 'index_qi', index_qi)
+            call mpas_pool_get_dimension(state, 'index_qs', index_qs)
+            call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+            call mpas_pool_get_dimension(state, 'index_nr', index_nr)
+            call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+
+            if (index_qv > 0) then
+               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', dt )
+            end if
+            if (index_qc > 0) then
+               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', dt )
+            end if
+            if (index_qr > 0) then
+               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', dt )
+            end if
+            if (index_qi > 0) then
+               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', dt )
+            end if
+            if (index_qs > 0) then
+               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', dt )
+            end if
+            if (index_qg > 0) then
+               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', dt )
+            end if
+            if (index_nr > 0) then
+               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', dt )
+            end if
+            if (index_ni > 0) then
+               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
+            end if
+      
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
+                                         cellThreadStart(thread), cellThreadEnd(thread), &
+                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(scalars_driving)
+
+            block => block % next
+         end do
+
+      end if  ! regional_MPAS addition
+
+   end subroutine dynamics_final_lbc_adjustment
+
+
+   subroutine dynamics_update_xtime(domain, dt, nowTime)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! After the end of the time step, advance the model time.
+   !
+   ! Input: domain - current time and timestep
+   ! Output: domain - upon exit, xtime is advanced
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      real (kind=RKIND), intent(in) :: dt
+
+
+      type (block_type), pointer :: block
+      type (MPAS_Time_type) :: currTime
+      type (MPAS_TimeInterval_type) :: dtInterval
+      character (len=StrKIND), pointer :: xtime
+      character (len=StrKIND) :: xtime_new
+      type (mpas_pool_type), pointer :: state
+
+
+      call mpas_set_timeInterval(dtInterval, dt=dt)
+      currTime = nowTime + dtInterval
+      call mpas_get_time(currTime, dateTimeString=xtime_new)
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_array(state, 'xtime', xtime, 2)
+         xtime = xtime_new
+         block => block % next
+      end do
+
+   end subroutine dynamics_update_xtime
 
 end module atm_time_integration

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -20,7 +20,6 @@ module atm_time_integration
    use mpas_timer
 
 #ifdef DO_PHYSICS
-   use mpas_atmphys_driver_microphysics
    use mpas_atmphys_todynamics
    use mpas_atmphys_utilities
 #endif
@@ -190,8 +189,6 @@ module atm_time_integration
       logical, pointer :: config_positive_definite
       logical, pointer :: config_monotonic
       real (kind=RKIND), pointer :: config_dt
-      character (len=StrKIND), pointer :: config_microp_scheme
-      character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
       integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
@@ -225,8 +222,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: u, uReconstructZonal, uReconstructMeridional, uReconstructX, uReconstructY, uReconstructZ
       real (kind=RKIND), dimension(:,:,:), pointer :: scalars, scalars_1, scalars_2
 
-      real (kind=RKIND), dimension(:,:), pointer :: rqvdynten
-
       real (kind=RKIND)  :: time_dyn_step
       logical, parameter :: debug = .false.
 
@@ -240,8 +235,6 @@ module atm_time_integration
       call mpas_pool_get_config(domain % blocklist % configs, 'config_positive_definite', config_positive_definite)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_monotonic', config_monotonic)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', config_dt)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_microp_scheme', config_microp_scheme)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_convection_scheme', config_convection_scheme)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_IAU_option', config_IAU_option)
 
       !  config variables for dynamics-transport splitting, WCS 18 November 2014
@@ -1602,73 +1595,7 @@ module atm_time_integration
          block => block % next
       end do
 
-      !
-      ! call to parameterizations of cloud microphysics. calculation of the tendency of water vapor to horizontal and
-      ! vertical advection needed for the Tiedtke parameterization of convection.
-      !
-
-#ifdef DO_PHYSICS
-      block => domain % blocklist
-      do while(associated(block))
-
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
-         call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
-         call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-         if(config_convection_scheme == 'cu_grell_freitas'          .or. &
-            config_convection_scheme == 'cu_tiedtke'                .or. &
-            config_convection_scheme == 'cu_ntiedtke') then
-
-            call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
-
-            !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
-            !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
-            !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
-            if (config_monotonic) then
-               rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
-            else
-               rqvdynten(:,:) = 0._RKIND
-            end if
-         end if
-
-         !simply set to zero negative mixing ratios of different water species (for now):
-         where ( scalars_2(:,:,:) < 0.0)  &
-            scalars_2(:,:,:) = 0.0
-
-         !call microphysics schemes:
-         if (trim(config_microp_scheme) /= 'off')  then
-            call mpas_timer_start('microphysics')
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
-                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
-            end do
-!$OMP END PARALLEL DO
-            call mpas_timer_stop('microphysics')
-         end if
-         block => block % next
-      end do
-
-      !
-      ! Note: A halo exchange for 'exner' here as well as at the end of
-      ! the first (n-1) dynamics subcycles can substitute for the exchange at
-      ! the beginning of each dynamics subcycle. Placing halo exchanges here
-      ! and at the end of dynamics subcycles may in future allow for aggregation
-      ! of the 'exner' exchange with other exchanges.
-      !
-#endif
-
+DAVE LBC AFTER MP - NEEDS TO BE MOVED
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
          block => domain % blocklist

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -863,13 +863,12 @@ module atm_core
 
 
       !
-      ! This is a call to all of the slow, column-oriented physics, except for resolved
-      ! cloud microphysical processes. The microphysics is handled after the dynamics so 
-      ! that any supersaturation caused by various dynamical processes (advection, etc) 
-      ! may be removed before the end of each time step.
+      ! Except for the resolved cloud microphysical processes, this is a call to all of the 
+      ! column-oriented physics. 
       !
 #ifdef DO_PHYSICS
-      !proceed with physics if moist_physics is set to true:
+      ! Proceed with physics if moist_physics is set to true. If
+      ! moist_physics is false, then this is a dry dynamics case.
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
          call physics_part1(domain,itimestep,xtime_s)
@@ -879,11 +878,15 @@ module atm_core
       call dynamics_timestep(domain, dt, currTime, itimestep)
 
       !
-      ! This part is the microphysics, which needs to happen after the
-      ! dynamics time stepping.
+      ! The call to the microphysics scheme must occur after the
+      ! dynamics time stepping. The microphysics is handled after
+      ! the dynamics so that any supersaturation (caused by various 
+      ! dynamical processes (advection, etc) may be removed before the 
+      ! end of each time step.  
       !
 #ifdef DO_PHYSICS
-      !proceed with physics if moist_physics is set to true:
+      ! Proceed with physics if moist_physics is set to true. If
+      ! moist_physics is false, then this is a dry dynamics case.
       if(moist_physics) then
          call physics_part2(domain,itimestep,xtime_s)
       endif
@@ -893,12 +896,9 @@ module atm_core
       ! If this is a regional domain, adjustments are required for the
       ! lateral boundary conditions due to the microphysics.
       !
-!DAVE if this really is due to MP, the moist physics switch is legit??
-#ifdef DO_PHYSICS
-      if((moist_physics) .and. (config_apply_lbcs)) then
+      if(config_apply_lbcs) then
          call dynamics_final_lbc_adjustment (domain, dt)
       endif
-#endif
 
       !
       ! The end of the time step. Advance model xtime.

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -834,7 +834,7 @@ module atm_core
       use atm_time_integration
 #ifdef DO_PHYSICS
       use mpas_atmphys_control
-      use mpas_atmphys_driver, only : physics_driver_before_dyn, physics_driver_after_dyn
+      use mpas_atmphys_driver, only : physics_part1, physics_part2
       use mpas_atmphys_manager
       use mpas_atmphys_update
 #endif
@@ -863,31 +863,53 @@ module atm_core
 
 
       !
-      ! All physics, except for explict moist physics.
+      ! This is a call to all of the slow, column-oriented physics, except for resolved
+      ! cloud microphysical processes. The microphysics is handled after the dynamics so 
+      ! that any supersaturation caused by various dynamical processes (advection, etc) 
+      ! may be removed before the end of each time step.
+      !
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
-         call physics_driver_before_dyn(domain,itimestep,xtime_s)
+         call physics_part1(domain,itimestep,xtime_s)
       endif
 #endif
 
-      call atm_timestep(domain, dt, currTime, itimestep)
+      call dynamics_timestep(domain, dt, currTime, itimestep)
 
       !
       ! This part is the microphysics, which needs to happen after the
       ! dynamics time stepping.
+      !
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
-         call physics_driver_after_dyn(domain,itimestep,xtime_s)
+         call physics_part2(domain,itimestep,xtime_s)
       endif
 #endif
 
       !
-      ! This is the summary from the physics before the dynamics solver, 
-      ! the accumulated processing of the dynamics, and the final physics
-      ! call after the dynamics completes.
+      ! If this is a regional domain, adjustments are required for the
+      ! lateral boundary conditions due to the microphysics.
+      !
+!DAVE if this really is due to MP, the moist physics switch is legit??
+#ifdef DO_PHYSICS
+      if((moist_physics) .and. (config_apply_lbcs)) then
+         call dynamics_final_lbc_adjustment (domain, dt)
+      endif
+#endif
+
+      !
+      ! The end of the time step. Advance model xtime.
+      !
+      call dynamics_update_xtime (domain, dt, currTime)
+
+      !
+      ! This is the summary from the physics before the dynamics solver,
+      ! (part1), the accumulated processing of the dynamics, the final 
+      ! physics (part2), and the LBC adjustment.
+      !
       call summarize_timestep(domain)
 
    end subroutine atm_do_timestep

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -834,7 +834,7 @@ module atm_core
       use atm_time_integration
 #ifdef DO_PHYSICS
       use mpas_atmphys_control
-      use mpas_atmphys_driver
+      use mpas_atmphys_driver, only : physics_driver_before_dyn, physics_driver_after_dyn
       use mpas_atmphys_manager
       use mpas_atmphys_update
 #endif
@@ -862,15 +862,33 @@ module atm_core
       xtime_s = (s + s_n / s_d)
 
 
+      !
+      ! All physics, except for explict moist physics.
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
-         call physics_driver(domain,itimestep,xtime_s)
+         call physics_driver_before_dyn(domain,itimestep,xtime_s)
       endif
 #endif
 
       call atm_timestep(domain, dt, currTime, itimestep)
+
+      !
+      ! This part is the microphysics, which needs to happen after the
+      ! dynamics time stepping.
+#ifdef DO_PHYSICS
+      !proceed with physics if moist_physics is set to true:
+      if(moist_physics) then
+         call physics_driver_after_dyn(domain,itimestep,xtime_s)
+      endif
+#endif
+
+      !
+      ! This is the summary from the physics before the dynamics solver, 
+      ! the accumulated processing of the dynamics, and the final physics
+      ! call after the dynamics completes.
+      call summarize_timestep(domain)
 
    end subroutine atm_do_timestep
    

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -79,6 +79,7 @@ mpas_atmphys_driver.o: \
 	mpas_atmphys_driver_radiation_sw.o \
 	mpas_atmphys_driver_sfclayer.o \
 	mpas_atmphys_driver_oml.o \
+	mpas_atmphys_driver_microphysics.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_interface.o \
 	mpas_atmphys_update.o \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -23,7 +23,6 @@
 
  ! For physics_part2
  use mpas_atmphys_driver_microphysics
- 
  use mpas_atmphys_constants
  use mpas_atmphys_interface
  use mpas_atmphys_update

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -70,8 +70,8 @@
 !   cloud microphysics scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-06-04.
 ! * added a second subroutine so now all of the physics is called from this driver module; the original
-!   routine has an added suffix _before_dyn, and the new routine is named similarly: _after_dyn processing; the 
-!   cloud microphysics processing is handled in the _after_dyn routine.
+!   routine is renamed physics_part1, and the new routine is named similarly: physics_part2; the 
+!   driver for the cloud microphysics processing is handled in the physics_part2 routine.
 !   Dave Gill (gill@ucar.edu) / 2017-09-14.
 
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -10,6 +10,7 @@
  use mpas_kind_types
  use mpas_pool_routines
 
+ ! For physics_driver_before_dyn
  use mpas_atmphys_driver_cloudiness
  use mpas_atmphys_driver_convection
  use mpas_atmphys_driver_gwdo
@@ -19,6 +20,10 @@
  use mpas_atmphys_driver_radiation_sw 
  use mpas_atmphys_driver_sfclayer
  use mpas_atmphys_driver_oml
+
+ ! For physics_driver_after_dyn
+ use mpas_atmphys_driver_microphysics
+ 
  use mpas_atmphys_constants
  use mpas_atmphys_interface
  use mpas_atmphys_update
@@ -27,50 +32,18 @@
 
  implicit none
  private
- public:: physics_driver
+ public:: physics_driver_before_dyn,physics_driver_after_dyn
 
 
 !MPAS top physics driver.
 !Laura D. Fowler (send comments to laura@ucar.edu).
 !2013-05-01.
 !
-! subroutine physics_driver is the top physics driver from which separate drivers for all physics
+! subroutine physics_driver_before_dyn is the top physics driver from which separate drivers for all physics
 ! parameterizations, except cloud microphysics parameterizations are called.
 !
-! subroutines called in mpas_atmphys_driver:
-! ------------------------------------------
-! allocate_forall_physics     : allocate local arrays defining atmospheric soundings (pressure,..)
-! allocate_cloudiness         : allocate all local arrays used in driver_cloudiness.
-! allocate_convection         : allocate all local arrays used in driver_convection.
-! allocate_gwdo               : allocate all local arrays used in driver_gwdo.
-! allocate_lsm                : allocate all local arrays used in driver_lsm.
-! allocate_pbl                : allocate all local arrays used in driver_pbl.
-! allocate_radiation_lw       : allocate all local arrays used in driver_radiation_lw.
-! allocate_radiation_sw       : allocate all local arrays used in driver_radiation_sw.
-! allocate_sfclayer           : allocate all local arrays used in driver_sfclayer.
-!
-! deallocate_forall_physics   : deallocate local arrays defining atmospheric soundings.
-! deallocate_cloudiness       : dedeallocate all local arrays used in driver_cloudiness.
-! deallocate_convection       : deallocate all local arrays used in driver_convection.
-! deallocate_gwdo             : deallocate all local arrays used in driver_gwdo.
-! deallocate_lsm              : deallocate all local arrays used in driver_lsm.
-! deallocate_pbl              : deallocate all local arrays used in driver_pbl.
-! deallocate_radiation_lw     : deallocate all local arrays used in driver_radiation_lw.
-! deallocate_radiation_sw     : deallocate all local arrays used in driver_radiation_sw.
-! deallocate_sfclayer         : deallocate all local arrays used in driver_sfclayer.
-!
-! MPAS_to_physics             :
-! driver_cloudiness           : driver for parameterization of fractional cloudiness.
-! driver_convection           : driver for parameterization of convection.
-! driver_gwdo                 : driver for parameterization of gravity wave drag over orography.
-! driver_lsm                  : driver for land-surface scheme.
-! driver_pbl                  : driver for planetary boundary layer scheme.
-! driver_radiation_sw         : driver for short wave radiation schemes.
-! driver_radiation_lw         : driver for long wave radiation schemes.
-! driver_sfclayer             : driver for surface layer scheme.
-! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
-! update_convection_step2     : updates accumulated precipitation output from convection schemes.
-! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
+! subroutine physics_driver_after_dyn is the top physics driver from which a separate driver for
+! cloud microphysics is called.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
@@ -97,13 +70,17 @@
 ! * modified call to driver_cloudiness to accomodate the calculation of the cloud fraction with the Thompson
 !   cloud microphysics scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-06-04.
+! * added a second subroutine so now all of the physics is called from this driver module; the original
+!   routine has an added suffix _before_dyn, and the new routine is named similarly: _after_dyn processing; the 
+!   cloud microphysics processing is handled in the _after_dyn routine.
+!   Dave Gill (gill@ucar.edu) / 2017-09-14.
 
 
  contains
 
 
 !=================================================================================================================
- subroutine physics_driver(domain,itimestep,xtime_s)
+ subroutine physics_driver_before_dyn(domain,itimestep,xtime_s)
 !=================================================================================================================
 
 !input arguments:
@@ -146,11 +123,46 @@
  integer,pointer:: nThreads
  integer,dimension(:),pointer:: cellSolveThreadStart, cellSolveThreadEnd
 
+! subroutines called
+! ------------------------------------------
+! allocate_forall_physics     : allocate local arrays defining atmospheric soundings (pressure,..)
+! allocate_cloudiness         : allocate all local arrays used in driver_cloudiness.
+! allocate_convection         : allocate all local arrays used in driver_convection.
+! allocate_gwdo               : allocate all local arrays used in driver_gwdo.
+! allocate_lsm                : allocate all local arrays used in driver_lsm.
+! allocate_pbl                : allocate all local arrays used in driver_pbl.
+! allocate_radiation_lw       : allocate all local arrays used in driver_radiation_lw.
+! allocate_radiation_sw       : allocate all local arrays used in driver_radiation_sw.
+! allocate_sfclayer           : allocate all local arrays used in driver_sfclayer.
+!
+! deallocate_forall_physics   : deallocate local arrays defining atmospheric soundings.
+! deallocate_cloudiness       : dedeallocate all local arrays used in driver_cloudiness.
+! deallocate_convection       : deallocate all local arrays used in driver_convection.
+! deallocate_gwdo             : deallocate all local arrays used in driver_gwdo.
+! deallocate_lsm              : deallocate all local arrays used in driver_lsm.
+! deallocate_pbl              : deallocate all local arrays used in driver_pbl.
+! deallocate_radiation_lw     : deallocate all local arrays used in driver_radiation_lw.
+! deallocate_radiation_sw     : deallocate all local arrays used in driver_radiation_sw.
+! deallocate_sfclayer         : deallocate all local arrays used in driver_sfclayer.
+!
+! MPAS_to_physics             : conversion of input "MPAS" variables to "physics" variables.
+! driver_cloudiness           : driver for parameterization of fractional cloudiness.
+! driver_convection           : driver for parameterization of convection.
+! driver_gwdo                 : driver for parameterization of gravity wave drag over orography.
+! driver_lsm                  : driver for land-surface scheme.
+! driver_pbl                  : driver for planetary boundary layer scheme.
+! driver_radiation_sw         : driver for short wave radiation schemes.
+! driver_radiation_lw         : driver for long wave radiation schemes.
+! driver_sfclayer             : driver for surface layer scheme.
+! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
+! update_convection_step2     : updates accumulated precipitation output from convection schemes.
+! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
+
 !=================================================================================================================
 !call mpas_log_write('')
-!call mpas_log_write('--- enter subroutine mpas_atmphys_driver:')
+!call mpas_log_write('--- enter subroutine physics_driver_before_dyn:')
 
- call mpas_timer_start('physics driver')
+ call mpas_timer_start('physics_driver_before_dyn')
 
  call mpas_pool_get_config(domain%configs,'config_convection_scheme',config_convection_scheme)
  call mpas_pool_get_config(domain%configs,'config_gwdo_scheme'      ,config_gwdo_scheme      )
@@ -340,12 +352,132 @@
 
  endif
 
- call mpas_timer_stop('physics driver')
+ call mpas_timer_stop('physics_driver_before_dyn')
 
-!call mpas_log_write('--- enter subroutine mpas_atmphys_driver:')
+!call mpas_log_write('--- exit subroutine physics_driver_before_dyn:')
 !call mpas_log_write('')
 
- end subroutine physics_driver
+ end subroutine physics_driver_before_dyn
+
+
+!=================================================================================================================
+ subroutine physics_driver_after_dyn(domain,itimestep,xtime_s)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: itimestep
+ real(kind=RKIND),intent(in):: xtime_s
+
+!inout arguments:
+ type(domain_type),intent(inout):: domain
+
+!local pointers:
+ type(mpas_pool_type)               ,pointer ::  configs                  ,&
+                                                 mesh                     ,&
+                                                 state                    ,&
+                                                 diag                     ,&
+                                                 diag_physics             ,&
+                                                 tend_physics             ,&
+                                                 tend
+
+ real (kind=RKIND), dimension(:,:,:), pointer :: scalars_1                ,& 
+                                                 scalars_2
+ real (kind=RKIND), dimension(:,:)  , pointer :: rqvdynten
+ real (kind=RKIND)                  , pointer :: config_dt
+
+ logical                            , pointer :: config_monotonic
+
+ character(len=StrKIND)             , pointer :: config_microp_scheme     ,&
+                                                 config_convection_scheme
+
+ integer                            , pointer :: nThreads                 ,& 
+                                                 index_qv
+ integer,dimension(:)               , pointer :: cellSolveThreadStart     ,& 
+                                                 cellSolveThreadEnd
+
+ type(block_type)                   , pointer :: block
+
+!local variables:
+ integer:: time_lev
+ integer:: thread
+
+!=================================================================================================================
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine physics_driver_after_dyn:')
+
+ call mpas_timer_start('physics_driver_after_dyn')
+
+ call mpas_pool_get_config(domain%configs,'config_microp_scheme'    ,config_microp_scheme    )
+
+ if(config_microp_scheme     .ne. 'off') then
+
+    call mpas_pool_get_config(domain%configs,'config_convection_scheme',config_convection_scheme)
+    call mpas_pool_get_config(domain%configs,'config_dt'               ,config_dt               )
+    call mpas_pool_get_config(domain%configs,'config_monotonic'        ,config_monotonic        )
+
+    block => domain % blocklist
+    do while(associated(block))
+
+       call mpas_pool_get_subpool(block%structs,'mesh'        ,mesh        )
+       call mpas_pool_get_subpool(block%structs,'state'       ,state       )
+       call mpas_pool_get_subpool(block%structs,'diag'        ,diag        )
+       call mpas_pool_get_subpool(block%structs,'diag_physics',diag_physics)
+       call mpas_pool_get_subpool(block%structs,'tend_physics',tend_physics)
+       call mpas_pool_get_subpool(block%structs,'tend'        ,tend        )
+
+       call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
+       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
+
+       call mpas_pool_get_dimension(state           ,'index_qv'            ,index_qv            )
+       call mpas_pool_get_dimension(block%dimensions,'nThreads'            ,nThreads            )
+       call mpas_pool_get_dimension(block%dimensions,'cellSolveThreadStart',cellSolveThreadStart)
+       call mpas_pool_get_dimension(block%dimensions,'cellSolveThreadEnd'  ,cellSolveThreadEnd  )
+
+       !physics prep step:
+       time_lev = 1
+
+       if(config_convection_scheme == 'cu_grell_freitas'          .or. &
+          config_convection_scheme == 'cu_tiedtke'                .or. &
+          config_convection_scheme == 'cu_ntiedtke') then
+
+          call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
+
+          !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
+          !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
+          !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above.
+          if (config_monotonic) then
+             rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
+          else
+             rqvdynten(:,:) = 0._RKIND
+          end if
+       end if
+
+       !simply set to zero negative mixing ratios of different water species (for now):
+       where ( scalars_2(:,:,:) < 0.0)  &
+          scalars_2(:,:,:) = 0.0
+
+       !call microphysics schemes:
+       if (trim(config_microp_scheme) /= 'off')  then
+          call mpas_timer_start('microphysics')
+!$OMP PARALLEL DO
+          do thread=1,nThreads
+             call driver_microphysics ( block%configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
+                                        cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+          end do
+!$OMP END PARALLEL DO
+          call mpas_timer_stop('microphysics')
+       end if
+    block => block % next
+ end do 
+
+ endif
+
+ call mpas_timer_stop('physics_driver_after_dyn')
+
+!call mpas_log_write('--- exit subroutine physics_driver_after_dyn:')
+!call mpas_log_write('')
+
+ end subroutine physics_driver_after_dyn
 
 !=================================================================================================================
  end module mpas_atmphys_driver

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -10,7 +10,7 @@
  use mpas_kind_types
  use mpas_pool_routines
 
- ! For physics_driver_before_dyn
+ ! For physics_part1
  use mpas_atmphys_driver_cloudiness
  use mpas_atmphys_driver_convection
  use mpas_atmphys_driver_gwdo
@@ -21,7 +21,7 @@
  use mpas_atmphys_driver_sfclayer
  use mpas_atmphys_driver_oml
 
- ! For physics_driver_after_dyn
+ ! For physics_part2
  use mpas_atmphys_driver_microphysics
  
  use mpas_atmphys_constants
@@ -32,17 +32,17 @@
 
  implicit none
  private
- public:: physics_driver_before_dyn,physics_driver_after_dyn
+ public:: physics_part1,physics_part2
 
 
 !MPAS top physics driver.
 !Laura D. Fowler (send comments to laura@ucar.edu).
 !2013-05-01.
 !
-! subroutine physics_driver_before_dyn is the top physics driver from which separate drivers for all physics
+! subroutine physics_part1 is the top physics driver from which separate drivers for all physics
 ! parameterizations, except cloud microphysics parameterizations are called.
 !
-! subroutine physics_driver_after_dyn is the top physics driver from which a separate driver for
+! subroutine physics_part2 is the top physics driver from which a separate driver for
 ! cloud microphysics is called.
 !
 ! add-ons and modifications to sourcecode:
@@ -80,7 +80,7 @@
 
 
 !=================================================================================================================
- subroutine physics_driver_before_dyn(domain,itimestep,xtime_s)
+ subroutine physics_part1(domain,itimestep,xtime_s)
 !=================================================================================================================
 
 !input arguments:
@@ -160,9 +160,9 @@
 
 !=================================================================================================================
 !call mpas_log_write('')
-!call mpas_log_write('--- enter subroutine physics_driver_before_dyn:')
+!call mpas_log_write('--- enter subroutine physics_part1:')
 
- call mpas_timer_start('physics_driver_before_dyn')
+ call mpas_timer_start('physics_part1')
 
  call mpas_pool_get_config(domain%configs,'config_convection_scheme',config_convection_scheme)
  call mpas_pool_get_config(domain%configs,'config_gwdo_scheme'      ,config_gwdo_scheme      )
@@ -352,16 +352,16 @@
 
  endif
 
- call mpas_timer_stop('physics_driver_before_dyn')
+ call mpas_timer_stop('physics_part1')
 
-!call mpas_log_write('--- exit subroutine physics_driver_before_dyn:')
+!call mpas_log_write('--- exit subroutine physics_part1:')
 !call mpas_log_write('')
 
- end subroutine physics_driver_before_dyn
+ end subroutine physics_part1
 
 
 !=================================================================================================================
- subroutine physics_driver_after_dyn(domain,itimestep,xtime_s)
+ subroutine physics_part2(domain,itimestep,xtime_s)
 !=================================================================================================================
 
 !input arguments:
@@ -403,9 +403,9 @@
 
 !=================================================================================================================
 !call mpas_log_write('')
-!call mpas_log_write('--- enter subroutine physics_driver_after_dyn:')
+!call mpas_log_write('--- enter subroutine physics_part2:')
 
- call mpas_timer_start('physics_driver_after_dyn')
+ call mpas_timer_start('physics_part2')
 
  call mpas_pool_get_config(domain%configs,'config_microp_scheme'    ,config_microp_scheme    )
 
@@ -472,12 +472,12 @@
 
  endif
 
- call mpas_timer_stop('physics_driver_after_dyn')
+ call mpas_timer_stop('physics_part2')
 
-!call mpas_log_write('--- exit subroutine physics_driver_after_dyn:')
+!call mpas_log_write('--- exit subroutine physics_part2:')
 !call mpas_log_write('')
 
- end subroutine physics_driver_after_dyn
+ end subroutine physics_part2
 
 !=================================================================================================================
  end module mpas_atmphys_driver


### PR DESCRIPTION
This PR changes the high-level dynamics calling tree for the atmosphere model. 

To more accurately describe the organizational logic in the top-level of the atmosphere time 
step routine, the call to the microphysics driver is removed from the SRK3 routine. The 
microphysics driver is now called from a new, secondary physics driver. 
```
    Original calling structure
    --------------------------
    atm_do_timestep
       physics_driver <----------------
       atm_timestep                   |
          atm_srk3                    |
             driver_microphysics      | same routine,
                                      | mostly just renamed
    New calling structure             |
    ------------------------          |
    atm_do_timestep                   |
       physics_part1 <-----------------
       dynamics_timestep <----- | just renamed
          atm_srk3
       physics_part2
          driver_microphysics
```

To assist in the expected use of the MPAS dynamics from within other models, a couple of
subroutine names were modified:
1. `physics_driver` is changed to `physics_part1` (the new routine to call the driver for the
microphysics is called `physics_part2`)
2. `atm_timestep` is renamed `dynamics_timestep`

 - [x] Even though this is a restructuring of the calling tree, the order of the various subroutine 
calls is maintained. As such, we should expect to get and do indeed get bit-wise identical 
results (before vs after this modification). The outputs from both history and diag were tested 
for the standard 40962 grid cell case from 2010 Oct 23 0000 + 24 h with Intel 18.0.5.
  - [ ] Need to verify with a regional domain, since LBC code was modified
