### PR TITLE
COMPASS ocean nightly regression: Add GM and cleanup

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -3720,9 +3720,8 @@
 			/>
 	</var_struct>
 
-<!-- Include init modes registry file -->
-#include "mode_init/Registry.xml"
-
+<!-- Include registry files from subdirectories -->
 #include "tracer_groups/Registry_tracers.xml"
 #include "analysis_members/Registry_analysis_members.xml"
+#include "mode_init/Registry.xml"
 </registry>

--- a/testing_and_setup/compass/general.config.ocean
+++ b/testing_and_setup/compass/general.config.ocean
@@ -9,8 +9,8 @@
 # init namelists in the default_inputs directory after a successful build of
 # the ocean model.
 [namelists]
-forward = FULL_PATH_TO_MPAS_MODEL_REPO/namelist.ocean.forward
-init    = FULL_PATH_TO_MPAS_MODEL_REPO/namelist.ocean.init
+forward = FULL_PATH_TO_MPAS_MODEL_REPO/namelist.ocean
+init    = FULL_PATH_TO_MPAS_MODEL_REPO/namelist.ocean
 
 # The streams section defines paths to template streams files that will be used
 # to generate specific streams files. Typically these will point to the forward and

--- a/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
@@ -16,5 +16,8 @@
 		<option name="config_use_bulk_wind_stress">.true.</option>
 		<option name="config_use_bulk_thickness_flux">.true.</option>
 		<option name="config_use_activeTracers_surface_restoring">.true.</option>
+		<option name="config_use_standardGM">.true.</option>
+		<option name="config_gm_lat_variable_c2">.true.</option>
+		<option name="config_gm_kappa_lat_depth_variable">.true.</option>
 	</namelist>
 </template>


### PR DESCRIPTION
Previously, GM was not tested in the nightly regression. This turns on GM for global cases, including the new depth varying piece. 

Also, I moved init flags to the end of the default namelist, and changed the suggested forward and init namelist to the full version (namelist.ocean). Now test cases no longer spew the warning
```
*** Encountered an issue while attempting to read namelist record ...
```
into the log file for every single missing namelist record.

