### PR TITLE
Fix MPAS-A rthratenlw Registry description

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2824,7 +2824,7 @@
                      description="tendency of potential temperature due to short wave radiation"/>
 
                 <var name="rthratenlw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="tendency of potential temperature due to short wave radiation"/>
+                     description="tendency of potential temperature due to long wave radiation"/>
         </var_struct>
 
 


### PR DESCRIPTION
This commit fixes a typo in the core_atmosphere's Registry.xml file by changing
"short" to "long" in the var rthratenlw's description.

This PR resolves issue #346. 

