### PR TITLE
bugfix for mpas_init_atm_gwd.F to handle config_geog_data_path with and without trailing slashes

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_gwd.F
+++ b/src/core_init_atmosphere/mpas_init_atm_gwd.F
@@ -116,6 +116,7 @@ module mpas_init_atm_gwd
       character(len=StrKIND), pointer :: config_geog_data_path
       character(len=StrKIND), pointer :: config_topo_data
       character(len=StrKIND) :: geog_sub_path
+      character(len=StrKIND+1) :: geog_data_path      ! same as config_geog_data_path, but guaranteed to have a trailing slash
 
       ! Variables for smoothing variance
       integer, dimension(:,:), pointer:: cellsOnCell
@@ -133,6 +134,12 @@ module mpas_init_atm_gwd
       call mpas_pool_get_config(domain % configs, 'config_geog_data_path', config_geog_data_path)
       call mpas_pool_get_config(domain % configs, 'config_topo_data', config_topo_data)
       call mpas_pool_get_config(domain % configs, 'config_gwd_cell_scaling', config_gwd_cell_scaling)
+
+      write(geog_data_path, '(a)') config_geog_data_path
+      i = len_trim(geog_data_path)
+      if (geog_data_path(i:i) /= '/') then
+         geog_data_path(i+1:i+1) = '/'
+      end if
 
       select case(trim(config_topo_data))
          case('GTOPO30')
@@ -188,13 +195,13 @@ module mpas_init_atm_gwd
 
       allocate(hlanduse(nCells+1))    ! +1, since we access hlanduse(cellsOnCell(i,iCell)) later on for iCell=1,nCells
 
-      iErr = read_global_30s_topo(config_geog_data_path, geog_sub_path)
+      iErr = read_global_30s_topo(geog_data_path, geog_sub_path)
       if (iErr /= 0) then
          call mpas_log_write('Error reading global 30-arc-sec topography for GWD statistics', messageType=MPAS_LOG_ERR)
          return
       end if
 
-      iErr = read_global_30s_landuse(config_geog_data_path)
+      iErr = read_global_30s_landuse(geog_data_path)
       if (iErr /= 0) then
          call mpas_log_write('Error reading global 30-arc-sec landuse for GWD statistics', messageType=MPAS_LOG_ERR)
          return


### PR DESCRIPTION
This PR replicates logic from `mpas_init_atm_static.F` to handle `config_geog_data_path` with and without trailing slashes. Without this bugfix, specifying a `config_geog_data_path` without a trailing slash leads to an error.

Tested on macOS/clang+gfortran and hera/intel.

Please update the base for this PR as needed.