### PR TITLE
Fixes debug error with unassigned variable

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vel_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing.F
@@ -176,7 +176,7 @@ contains
       integer :: err1, err2
 
       call ocn_vel_forcing_surface_stress_init(err1)
-      call ocn_vel_forcing_explicit_bottom_drag_init(err1)
+      call ocn_vel_forcing_explicit_bottom_drag_init(err2)
 
       err = ior(err1, err2)
 


### PR DESCRIPTION
Fixes this bug for DEBUG=true mode by correcting error-checking integer.

```
     *****************************
          ** Starting model run step **
               *****************************

               App launch reported: 1 (out of 1) daemons - 36 (out of
               36) procs
               forrtl: severe (194): Run-Time Check Failure. The
               variable 'ocn_vel_forcing_mp_ocn_vel_forcing_init_$ERR2'
               is being used in 'mpas_ocn_vel_forcing.F(181,7)' without
               being defined
               Image              PC                Routine
               Line        Source
               ocean_model        0000000001CE022B  ocn_vel_forcing_m
               181  mpas_ocn_vel_forcing.F
               ocean_model        0000000001C31723  ocn_forward_mode_
               212  mpas_ocn_forward_mode.F
               ocean_model        0000000001AD921B  ocn_core_mp_ocn_c
               76  mpas_ocn_core.F
               ocean_model        0000000000414289  mpas_subdriver_mp
               331  mpas_subdriver.F
               ocean_model        000000000040F725  MAIN__
               14  mpas.F
               ocean_model        000000000040F6AE  Unknown
               Unknown  Unknown
               libc-2.17.so       00002B93DFB093D5  __libc_start_main
               Unknown  Unknown
```
