### PR TITLE
Fixes to mpas_io

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1384,6 +1384,7 @@ module mpas_io
       integer, dimension(6) :: start6
       integer, dimension(6) :: count6
       character (len=StrKIND), dimension(1) :: tempchar
+      integer :: charLen
       type (fieldlist_type), pointer :: field_cursor
 
       integer i, j
@@ -1480,14 +1481,22 @@ module mpas_io
 !         call mpas_log_write('  value is char')
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
+            charLen = count2(1)
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, tempchar)
-            charVal(1:count2(1)) = tempchar(1)(1:count2(1))
          else
             start1(1) = 1
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
+            charLen = count1(1)
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, tempchar)
-            charVal(1:count1(1)) = tempchar(1)(1:count1(1))
          end if
+         ! Only keep up to the first null character
+         charVal(:) = ' '
+         do j = 1, charLen
+            if ((tempchar(1)(j:j) == CHAR(0)) ) then
+               exit
+            end if
+            charVal(j:j) = tempchar(1)(j:j)
+         end do
       else if (present(charArray1d)) then
 !         call mpas_log_write('  value is char1')
          if (field_cursor % fieldhandle % has_unlimited_dim) then
@@ -1505,11 +1514,10 @@ module mpas_io
                ! the string, whichever comes first
                charArray1d(i)(:) = ' '
                do j = 1, len(tempchar(1))
-                  if ( tempchar(1)(j:j) /= CHAR(0)) then
-                     charArray1d(i)(j:j) = tempchar(1)(j:j)
-                  else
+                  if (tempchar(1)(j:j) == CHAR(0)) then
                      exit
                   end if
+                  charArray1d(i)(j:j) = tempchar(1)(j:j)
                end do
             end do
          else

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -4612,8 +4612,8 @@ module mpas_io
       trimmedVal = trim(attValue)
 
       if ( valLen > StrKind ) then
-         call mpas_log_write('Attribute ''' // trim(attName) // ''' has a value longer than StrKIND. ' // &
-             'It will be cut to a length of $i', MPAS_LOG_WARN, intArgs=(/StrKIND/) )
+         call mpas_log_write("Attribute '" // trim(attName) // "' has a value longer than StrKIND. " // &
+             "It will be cut to a length of $i", MPAS_LOG_WARN, intArgs=(/StrKIND/) )
          attValueLocal = trimmedVal(1:StrKIND)
       else
          attValueLocal = trimmedVal


### PR DESCRIPTION
This merge includes some small fixes to the mpas_io module.  

The primary one modifies the reading of char data types to ignore null characters.  That behavior already exists for char_1 types, but it was not previously included for char types.  Without this fix, any null characters that exist at the end of a char data type get read into the MPAS variable.  In addition to looking ugly, that behavior can lead to unexpected results, notably errors in parsing xtime.  That particular situation happens when a restart file written using PIO2 (which uses C under the hood and terminates strings with null characters) is read back into a build of MPAS using PIO1 (which is based on Fortran and does not expect null-terminated strings).

The second fix is a formatting change that fixes #352 