### PR TITLE
atmosphere: Remove microphysics call from with dynamics atm_srk3

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1657,12 +1657,6 @@ module atm_time_integration
       !
 #endif
 
-      if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
-
-         call dynamics_final_lbc_adjustment(domain, dt)
-
-      end if  ! regional_MPAS addition
-
    end subroutine atm_srk3
 
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -84,7 +84,7 @@ module atm_time_integration
    contains
 
 
-   subroutine atm_timestep(domain, dt, nowTime, itimestep)
+   subroutine dynamics_timestep(domain, dt, nowTime, itimestep)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
@@ -124,7 +124,7 @@ module atm_time_integration
          call mpas_log_write('Currently, only ''SRK3'' is supported.', messageType=MPAS_LOG_CRIT)
       end if
 
-   end subroutine atm_timestep
+   end subroutine dynamics_timestep
 
 
    subroutine atm_srk3(domain, dt, itimestep)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -20,7 +20,6 @@ module atm_time_integration
    use mpas_timer
 
 #ifdef DO_PHYSICS
-   use mpas_atmphys_driver_microphysics
    use mpas_atmphys_todynamics
    use mpas_atmphys_utilities
 #endif
@@ -178,8 +177,6 @@ module atm_time_integration
       logical, pointer :: config_positive_definite
       logical, pointer :: config_monotonic
       real (kind=RKIND), pointer :: config_dt
-      character (len=StrKIND), pointer :: config_microp_scheme
-      character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
       integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
@@ -213,8 +210,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: u, uReconstructZonal, uReconstructMeridional, uReconstructX, uReconstructY, uReconstructZ
       real (kind=RKIND), dimension(:,:,:), pointer :: scalars, scalars_1, scalars_2
 
-      real (kind=RKIND), dimension(:,:), pointer :: rqvdynten
-
       real (kind=RKIND)  :: time_dyn_step
       logical, parameter :: debug = .false.
 
@@ -228,8 +223,6 @@ module atm_time_integration
       call mpas_pool_get_config(domain % blocklist % configs, 'config_positive_definite', config_positive_definite)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_monotonic', config_monotonic)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', config_dt)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_microp_scheme', config_microp_scheme)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_convection_scheme', config_convection_scheme)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_IAU_option', config_IAU_option)
 
       !  config variables for dynamics-transport splitting, WCS 18 November 2014
@@ -1589,73 +1582,6 @@ module atm_time_integration
 
          block => block % next
       end do
-
-      !
-      ! call to parameterizations of cloud microphysics. calculation of the tendency of water vapor to horizontal and
-      ! vertical advection needed for the Tiedtke parameterization of convection.
-      !
-
-#ifdef DO_PHYSICS
-      block => domain % blocklist
-      do while(associated(block))
-
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
-         call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
-         call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-         if(config_convection_scheme == 'cu_grell_freitas'          .or. &
-            config_convection_scheme == 'cu_tiedtke'                .or. &
-            config_convection_scheme == 'cu_ntiedtke') then
-
-            call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
-
-            !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
-            !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
-            !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
-            if (config_monotonic) then
-               rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
-            else
-               rqvdynten(:,:) = 0._RKIND
-            end if
-         end if
-
-         !simply set to zero negative mixing ratios of different water species (for now):
-         where ( scalars_2(:,:,:) < 0.0)  &
-            scalars_2(:,:,:) = 0.0
-
-         !call microphysics schemes:
-         if (trim(config_microp_scheme) /= 'off')  then
-            call mpas_timer_start('microphysics')
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
-                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
-            end do
-!$OMP END PARALLEL DO
-            call mpas_timer_stop('microphysics')
-         end if
-         block => block % next
-      end do
-
-      !
-      ! Note: A halo exchange for 'exner' here as well as at the end of
-      ! the first (n-1) dynamics subcycles can substitute for the exchange at
-      ! the beginning of each dynamics subcycle. Placing halo exchanges here
-      ! and at the end of dynamics subcycles may in future allow for aggregation
-      ! of the 'exner' exchange with other exchanges.
-      !
-#endif
 
    end subroutine atm_srk3
 
@@ -7047,6 +6973,7 @@ module atm_time_integration
       end if  ! regional_MPAS addition
 
    end subroutine dynamics_final_lbc_adjustment
+
 
    subroutine dynamics_update_xtime(domain, dt, nowTime)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1791,8 +1791,6 @@ module atm_time_integration
 
       end if  ! regional_MPAS addition
 
-      call summarize_timestep(domain)
-
    end subroutine atm_srk3
 
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -124,18 +124,6 @@ module atm_time_integration
          call mpas_log_write('Currently, only ''SRK3'' is supported.', messageType=MPAS_LOG_CRIT)
       end if
 
-      call mpas_set_timeInterval(dtInterval, dt=dt)
-      currTime = nowTime + dtInterval
-      call mpas_get_time(currTime, dateTimeString=xtime_new)
-
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_array(state, 'xtime', xtime, 2)
-         xtime = xtime_new
-         block => block % next
-      end do
-
    end subroutine atm_timestep
 
 
@@ -7065,6 +7053,43 @@ module atm_time_integration
       end if  ! regional_MPAS addition
 
    end subroutine dynamics_final_lbc_adjustment
+
+   subroutine dynamics_update_xtime(domain, dt, nowTime)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! After the end of the time step, advance the model time.
+   !
+   ! Input: domain - current time and timestep
+   ! Output: domain - upon exit, xtime is advanced
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      real (kind=RKIND), intent(in) :: dt
+      type (MPAS_Time_type), intent(in) :: nowTime
+
+
+      type (block_type), pointer :: block
+      type (MPAS_Time_type) :: currTime
+      type (MPAS_TimeInterval_type) :: dtInterval
+      character (len=StrKIND), pointer :: xtime
+      character (len=StrKIND) :: xtime_new
+      type (mpas_pool_type), pointer :: state
+
+
+      call mpas_set_timeInterval(dtInterval, dt=dt)
+      currTime = nowTime + dtInterval
+      call mpas_get_time(currTime, dateTimeString=xtime_new)
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_array(state, 'xtime', xtime, 2)
+         xtime = xtime_new
+         block => block % next
+      end do
+
+   end subroutine dynamics_update_xtime
 
 
 end module atm_time_integration

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1671,123 +1671,7 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            allocate(rt_driving_values(nVertLevels,nCells+1))
-            allocate(rho_driving_values(nVertLevels,nCells+1))
-            time_dyn_step = dt  ! end of full timestep values
-
-            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
-
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
-                                                   rt_driving_values, rho_driving_values,                        &
-                                                   cellThreadStart(thread), cellThreadEnd(thread),               &
-                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
-!$OMP END PARALLEL DO
-
-            deallocate(rt_driving_values)
-            deallocate(rho_driving_values)
-            block => block % next
-
-         end do
-
-      end if  ! regional_MPAS addition
-
-
-      if (config_apply_lbcs) then  ! adjust boundary values for regional_MPAS scalar transport
-
-         call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
-         call mpas_dmpar_exch_halo_field(scalars_field)
-
-         block => domain % blocklist
-         do while (associated(block))
-
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-   
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-            allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
-
-            !  get the scalar values driving the regional boundary conditions
-            !
-            call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-            call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-            call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-            call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-            call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-            call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-            call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-            call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-            if (index_qv > 0) then
-               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', dt )
-            end if
-            if (index_qc > 0) then
-               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', dt )
-            end if
-            if (index_qr > 0) then
-               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', dt )
-            end if
-            if (index_qi > 0) then
-               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', dt )
-            end if
-            if (index_qs > 0) then
-               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', dt )
-            end if
-            if (index_qg > 0) then
-               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', dt )
-            end if
-            if (index_nr > 0) then
-               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', dt )
-            end if
-            if (index_ni > 0) then
-               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
-            end if
-      
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
-                                         cellThreadStart(thread), cellThreadEnd(thread), &
-                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
-!$OMP END PARALLEL DO
-
-            deallocate(scalars_driving)
-
-            block => block % next
-         end do
+         call dynamics_final_lbc_adjustment(domain, dt)
 
       end if  ! regional_MPAS addition
 
@@ -7014,5 +6898,173 @@ module atm_time_integration
       end if
 
    end subroutine summarize_timestep
+
+
+   subroutine dynamics_final_lbc_adjustment(domain, dt)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! For a regional domain, reset the values of rtheta in the specified zone
+   ! (modified by the microphysics scheme), and adjust the boundary values 
+   ! for scalar transport.
+   !
+   ! Input: domain - current model state in time level 1 (e.g., time_levs(1)state%h(:,:))
+   !                 plus grid meta-data
+   ! Output: domain - updated driving rtheta and rho in scpecified zone, and updated
+   !                  scalars in lateral boundary
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+      real (kind=RKIND), intent(in) :: dt
+      
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: state
+      type (mpas_pool_type), pointer :: diag
+      type (mpas_pool_type), pointer :: mesh
+
+      integer, pointer :: num_scalars, nCells, nVertLevels, nThreads
+      integer, dimension(:), pointer :: cellThreadStart, cellThreadEnd
+      integer, dimension(:), pointer :: cellSolveThreadStart, cellSolveThreadEnd
+      integer, dimension(:), pointer :: edgeThreadStart, edgeThreadEnd
+      integer, dimension(:), pointer :: edgeSolveThreadStart, edgeSolveThreadEnd
+      integer, dimension(:), pointer :: vertexThreadStart, vertexThreadEnd
+      integer, dimension(:), pointer :: vertexSolveThreadStart, vertexSolveThreadEnd
+
+      type (field3DReal), pointer :: scalars_field
+      integer, pointer :: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
+
+      real (kind=RKIND)  :: time_dyn_step
+      integer :: thread
+
+
+      clock => domain % clock
+      blocklist => domain % blocklist !!! DAVE this seems unnecessary
+
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_apply_lbcs', config_apply_lbcs)
+
+      if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
+
+         block => domain % blocklist
+         do while (associated(block))
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            allocate(rt_driving_values(nVertLevels,nCells+1))
+            allocate(rho_driving_values(nVertLevels,nCells+1))
+            time_dyn_step = dt  ! end of full timestep values
+
+            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
+                                                   rt_driving_values, rho_driving_values,                        &
+                                                   cellThreadStart(thread), cellThreadEnd(thread),               &
+                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(rt_driving_values)
+            deallocate(rho_driving_values)
+            block => block % next
+
+         end do
+
+      end if  ! regional_MPAS addition
+
+
+      if (config_apply_lbcs) then  ! adjust boundary values for regional_MPAS scalar transport
+
+         call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
+         call mpas_dmpar_exch_halo_field(scalars_field)
+
+         block => domain % blocklist
+         do while (associated(block))
+
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+   
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+            allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
+
+
+            !  get the scalar values driving the regional boundary conditions
+            !
+            call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+            call mpas_pool_get_dimension(state, 'index_qc', index_qc)
+            call mpas_pool_get_dimension(state, 'index_qr', index_qr)
+            call mpas_pool_get_dimension(state, 'index_qi', index_qi)
+            call mpas_pool_get_dimension(state, 'index_qs', index_qs)
+            call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+            call mpas_pool_get_dimension(state, 'index_nr', index_nr)
+            call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+
+            if (index_qv > 0) then
+               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', dt )
+            end if
+            if (index_qc > 0) then
+               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', dt )
+            end if
+            if (index_qr > 0) then
+               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', dt )
+            end if
+            if (index_qi > 0) then
+               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', dt )
+            end if
+            if (index_qs > 0) then
+               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', dt )
+            end if
+            if (index_qg > 0) then
+               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', dt )
+            end if
+            if (index_nr > 0) then
+               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', dt )
+            end if
+            if (index_ni > 0) then
+               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
+            end if
+      
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
+                                         cellThreadStart(thread), cellThreadEnd(thread), &
+                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(scalars_driving)
+
+            block => block % next
+         end do
+
+      end if  ! regional_MPAS addition
+
+   end subroutine dynamics_final_lbc_adjustment
+
 
 end module atm_time_integration

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -834,7 +834,7 @@ module atm_core
       use atm_time_integration
 #ifdef DO_PHYSICS
       use mpas_atmphys_control
-      use mpas_atmphys_driver
+      use mpas_atmphys_driver, only: physics_part1
       use mpas_atmphys_manager
       use mpas_atmphys_update
 #endif
@@ -866,7 +866,7 @@ module atm_core
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
-         call physics_driver(domain,itimestep,xtime_s)
+         call physics_part1(domain,itimestep,xtime_s)
       endif
 #endif
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -872,6 +872,15 @@ module atm_core
 
       call atm_timestep(domain, dt, currTime, itimestep)
 
+      !    
+      ! This is the summary of this time step from the following:
+      !  1) the physics before the dynamics solver (physics_part1)
+      !  2) the accumulated processing of the dynamics (atm_srk3)
+      !  3) the explicit microphysics (physics_part2)
+      !  4) the LBC adjustment (dynamics_final_lbc_adjustment)
+      ! 
+      call summarize_timestep(domain)
+
    end subroutine atm_do_timestep
    
    

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -873,6 +873,11 @@ module atm_core
       call atm_timestep(domain, dt, currTime, itimestep)
 
       !    
+      ! The end of the time step. Advance model xtime.
+      !    
+      call dynamics_update_xtime (domain, dt, currTime)
+
+      !    
       ! This is the summary of this time step from the following:
       !  1) the physics before the dynamics solver (physics_part1)
       !  2) the accumulated processing of the dynamics (atm_srk3)

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -870,7 +870,7 @@ module atm_core
       endif
 #endif
 
-      call atm_timestep(domain, dt, currTime, itimestep)
+      call dynamics_timestep(domain, dt, currTime, itimestep)
 
       !    
       ! If this is a regional domain, adjustments are required for the

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -834,7 +834,7 @@ module atm_core
       use atm_time_integration
 #ifdef DO_PHYSICS
       use mpas_atmphys_control
-      use mpas_atmphys_driver, only: physics_part1
+      use mpas_atmphys_driver, only: physics_part1, physics_part2
       use mpas_atmphys_manager
       use mpas_atmphys_update
 #endif
@@ -862,6 +862,12 @@ module atm_core
       xtime_s = (s + s_n / s_d)
 
 
+      !
+      ! This is a call to all of the slow, column-oriented physics, except for resolved
+      ! cloud microphysical processes. The microphysics is handled after the dynamics so 
+      ! that any supersaturation caused by various dynamical processes (advection, etc) 
+      ! may be removed before the end of each time step.
+      !
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
@@ -872,7 +878,18 @@ module atm_core
 
       call dynamics_timestep(domain, dt, currTime, itimestep)
 
-      !    
+      !
+      ! This part is the microphysics, which needs to happen after the
+      ! dynamics time stepping.
+      !
+#ifdef DO_PHYSICS
+      !proceed with physics if moist_physics is set to true:
+      if(moist_physics) then
+         call physics_part2(domain,itimestep,xtime_s)
+      endif
+#endif
+
+      !
       ! If this is a regional domain, adjustments are required for the
       ! lateral boundary conditions due to the microphysics.
       !    

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -873,6 +873,16 @@ module atm_core
       call atm_timestep(domain, dt, currTime, itimestep)
 
       !    
+      ! If this is a regional domain, adjustments are required for the
+      ! lateral boundary conditions due to the microphysics.
+      !    
+#ifdef DO_PHYSICS
+      if((moist_physics) .and. (config_apply_lbcs)) then 
+         call dynamics_final_lbc_adjustment (domain, dt)
+      endif
+#endif
+
+      !    
       ! The end of the time step. Advance model xtime.
       !    
       call dynamics_update_xtime (domain, dt, currTime)

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -79,6 +79,7 @@ mpas_atmphys_driver.o: \
 	mpas_atmphys_driver_radiation_sw.o \
 	mpas_atmphys_driver_sfclayer.o \
 	mpas_atmphys_driver_oml.o \
+	mpas_atmphys_driver_microphysics.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_interface.o \
 	mpas_atmphys_update.o \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -27,14 +27,14 @@
 
  implicit none
  private
- public:: physics_driver
+ public:: physics_part1
 
 
 !MPAS top physics driver.
 !Laura D. Fowler (send comments to laura@ucar.edu).
 !2013-05-01.
 !
-! subroutine physics_driver is the top physics driver from which separate drivers for all physics
+! subroutine physics_part1 is the top physics driver from which separate drivers for all physics
 ! parameterizations, except cloud microphysics parameterizations are called.
 !
 ! subroutines called in mpas_atmphys_driver:
@@ -103,7 +103,7 @@
 
 
 !=================================================================================================================
- subroutine physics_driver(domain,itimestep,xtime_s)
+ subroutine physics_part1(domain,itimestep,xtime_s)
 !=================================================================================================================
 
 !input arguments:
@@ -148,9 +148,9 @@
 
 !=================================================================================================================
 !call mpas_log_write('')
-!call mpas_log_write('--- enter subroutine mpas_atmphys_driver:')
+!call mpas_log_write('--- enter subroutine physics_part1:')
 
- call mpas_timer_start('physics driver')
+ call mpas_timer_start('physics_part1')
 
  call mpas_pool_get_config(domain%configs,'config_convection_scheme',config_convection_scheme)
  call mpas_pool_get_config(domain%configs,'config_gwdo_scheme'      ,config_gwdo_scheme      )
@@ -340,12 +340,12 @@
 
  endif
 
- call mpas_timer_stop('physics driver')
+ call mpas_timer_stop('physics_part1')
 
-!call mpas_log_write('--- enter subroutine mpas_atmphys_driver:')
+!call mpas_log_write('--- exit subroutine physics_part1:')
 !call mpas_log_write('')
 
- end subroutine physics_driver
+ end subroutine physics_part1
 
 !=================================================================================================================
  end module mpas_atmphys_driver

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -10,6 +10,7 @@
  use mpas_kind_types
  use mpas_pool_routines
 
+ ! For physics_part1
  use mpas_atmphys_driver_cloudiness
  use mpas_atmphys_driver_convection
  use mpas_atmphys_driver_gwdo
@@ -19,6 +20,10 @@
  use mpas_atmphys_driver_radiation_sw 
  use mpas_atmphys_driver_sfclayer
  use mpas_atmphys_driver_oml
+
+ ! For physics_part2
+ use mpas_atmphys_driver_microphysics
+ 
  use mpas_atmphys_constants
  use mpas_atmphys_interface
  use mpas_atmphys_update
@@ -27,7 +32,7 @@
 
  implicit none
  private
- public:: physics_part1
+ public:: physics_part1,physics_part2
 
 
 !MPAS top physics driver.
@@ -37,40 +42,8 @@
 ! subroutine physics_part1 is the top physics driver from which separate drivers for all physics
 ! parameterizations, except cloud microphysics parameterizations are called.
 !
-! subroutines called in mpas_atmphys_driver:
-! ------------------------------------------
-! allocate_forall_physics     : allocate local arrays defining atmospheric soundings (pressure,..)
-! allocate_cloudiness         : allocate all local arrays used in driver_cloudiness.
-! allocate_convection         : allocate all local arrays used in driver_convection.
-! allocate_gwdo               : allocate all local arrays used in driver_gwdo.
-! allocate_lsm                : allocate all local arrays used in driver_lsm.
-! allocate_pbl                : allocate all local arrays used in driver_pbl.
-! allocate_radiation_lw       : allocate all local arrays used in driver_radiation_lw.
-! allocate_radiation_sw       : allocate all local arrays used in driver_radiation_sw.
-! allocate_sfclayer           : allocate all local arrays used in driver_sfclayer.
-!
-! deallocate_forall_physics   : deallocate local arrays defining atmospheric soundings.
-! deallocate_cloudiness       : dedeallocate all local arrays used in driver_cloudiness.
-! deallocate_convection       : deallocate all local arrays used in driver_convection.
-! deallocate_gwdo             : deallocate all local arrays used in driver_gwdo.
-! deallocate_lsm              : deallocate all local arrays used in driver_lsm.
-! deallocate_pbl              : deallocate all local arrays used in driver_pbl.
-! deallocate_radiation_lw     : deallocate all local arrays used in driver_radiation_lw.
-! deallocate_radiation_sw     : deallocate all local arrays used in driver_radiation_sw.
-! deallocate_sfclayer         : deallocate all local arrays used in driver_sfclayer.
-!
-! MPAS_to_physics             :
-! driver_cloudiness           : driver for parameterization of fractional cloudiness.
-! driver_convection           : driver for parameterization of convection.
-! driver_gwdo                 : driver for parameterization of gravity wave drag over orography.
-! driver_lsm                  : driver for land-surface scheme.
-! driver_pbl                  : driver for planetary boundary layer scheme.
-! driver_radiation_sw         : driver for short wave radiation schemes.
-! driver_radiation_lw         : driver for long wave radiation schemes.
-! driver_sfclayer             : driver for surface layer scheme.
-! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
-! update_convection_step2     : updates accumulated precipitation output from convection schemes.
-! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
+! subroutine physics_part2 is the top physics driver from which a separate driver for
+! cloud microphysics is called.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
@@ -97,6 +70,10 @@
 ! * modified call to driver_cloudiness to accomodate the calculation of the cloud fraction with the Thompson
 !   cloud microphysics scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-06-04.
+! * added a second subroutine so now all of the physics is called from this driver module; the original
+!   routine is physics_part1, and the new routine is named similarly: physics_part2; the 
+!   cloud microphysics processing is handled in the physics_part2 routine.
+!   Dave Gill (gill@ucar.edu) / 2019-09-05.
 
 
  contains
@@ -145,6 +122,41 @@
 
  integer,pointer:: nThreads
  integer,dimension(:),pointer:: cellSolveThreadStart, cellSolveThreadEnd
+
+! subroutines called
+! ------------------------------------------
+! allocate_forall_physics     : allocate local arrays defining atmospheric soundings (pressure,..)
+! allocate_cloudiness         : allocate all local arrays used in driver_cloudiness.
+! allocate_convection         : allocate all local arrays used in driver_convection.
+! allocate_gwdo               : allocate all local arrays used in driver_gwdo.
+! allocate_lsm                : allocate all local arrays used in driver_lsm.
+! allocate_pbl                : allocate all local arrays used in driver_pbl.
+! allocate_radiation_lw       : allocate all local arrays used in driver_radiation_lw.
+! allocate_radiation_sw       : allocate all local arrays used in driver_radiation_sw.
+! allocate_sfclayer           : allocate all local arrays used in driver_sfclayer.
+!
+! deallocate_forall_physics   : deallocate local arrays defining atmospheric soundings.
+! deallocate_cloudiness       : dedeallocate all local arrays used in driver_cloudiness.
+! deallocate_convection       : deallocate all local arrays used in driver_convection.
+! deallocate_gwdo             : deallocate all local arrays used in driver_gwdo.
+! deallocate_lsm              : deallocate all local arrays used in driver_lsm.
+! deallocate_pbl              : deallocate all local arrays used in driver_pbl.
+! deallocate_radiation_lw     : deallocate all local arrays used in driver_radiation_lw.
+! deallocate_radiation_sw     : deallocate all local arrays used in driver_radiation_sw.
+! deallocate_sfclayer         : deallocate all local arrays used in driver_sfclayer.
+!
+! MPAS_to_physics             : conversion of input "MPAS" variables to "physics" variables.
+! driver_cloudiness           : driver for parameterization of fractional cloudiness.
+! driver_convection           : driver for parameterization of convection.
+! driver_gwdo                 : driver for parameterization of gravity wave drag over orography.
+! driver_lsm                  : driver for land-surface scheme.
+! driver_pbl                  : driver for planetary boundary layer scheme.
+! driver_radiation_sw         : driver for short wave radiation schemes.
+! driver_radiation_lw         : driver for long wave radiation schemes.
+! driver_sfclayer             : driver for surface layer scheme.
+! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
+! update_convection_step2     : updates accumulated precipitation output from convection schemes.
+! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
 
 !=================================================================================================================
 !call mpas_log_write('')
@@ -346,6 +358,126 @@
 !call mpas_log_write('')
 
  end subroutine physics_part1
+
+
+!=================================================================================================================
+ subroutine physics_part2(domain,itimestep,xtime_s)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: itimestep
+ real(kind=RKIND),intent(in):: xtime_s
+
+!inout arguments:
+ type(domain_type),intent(inout):: domain
+
+!local pointers:
+ type(mpas_pool_type)               ,pointer ::  configs                  ,&
+                                                 mesh                     ,&
+                                                 state                    ,&
+                                                 diag                     ,&
+                                                 diag_physics             ,&
+                                                 tend_physics             ,&
+                                                 tend
+
+ real (kind=RKIND), dimension(:,:,:), pointer :: scalars_1                ,& 
+                                                 scalars_2
+ real (kind=RKIND), dimension(:,:)  , pointer :: rqvdynten
+ real (kind=RKIND)                  , pointer :: config_dt
+
+ logical                            , pointer :: config_monotonic
+
+ character(len=StrKIND)             , pointer :: config_microp_scheme     ,&
+                                                 config_convection_scheme
+
+ integer                            , pointer :: nThreads                 ,& 
+                                                 index_qv
+ integer,dimension(:)               , pointer :: cellSolveThreadStart     ,& 
+                                                 cellSolveThreadEnd
+
+ type(block_type)                   , pointer :: block
+
+!local variables:
+ integer:: time_lev
+ integer:: thread
+
+!=================================================================================================================
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine physics_part2:')
+
+ call mpas_timer_start('physics_part2')
+
+ call mpas_pool_get_config(domain%configs,'config_microp_scheme'    ,config_microp_scheme    )
+
+ if(config_microp_scheme     .ne. 'off') then
+
+    call mpas_pool_get_config(domain%configs,'config_convection_scheme',config_convection_scheme)
+    call mpas_pool_get_config(domain%configs,'config_dt'               ,config_dt               )
+    call mpas_pool_get_config(domain%configs,'config_monotonic'        ,config_monotonic        )
+
+    block => domain % blocklist
+    do while(associated(block))
+
+       call mpas_pool_get_subpool(block%structs,'mesh'        ,mesh        )
+       call mpas_pool_get_subpool(block%structs,'state'       ,state       )
+       call mpas_pool_get_subpool(block%structs,'diag'        ,diag        )
+       call mpas_pool_get_subpool(block%structs,'diag_physics',diag_physics)
+       call mpas_pool_get_subpool(block%structs,'tend_physics',tend_physics)
+       call mpas_pool_get_subpool(block%structs,'tend'        ,tend        )
+
+       call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
+       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
+
+       call mpas_pool_get_dimension(state           ,'index_qv'            ,index_qv            )
+       call mpas_pool_get_dimension(block%dimensions,'nThreads'            ,nThreads            )
+       call mpas_pool_get_dimension(block%dimensions,'cellSolveThreadStart',cellSolveThreadStart)
+       call mpas_pool_get_dimension(block%dimensions,'cellSolveThreadEnd'  ,cellSolveThreadEnd  )
+
+       !physics prep step:
+       time_lev = 1
+
+       if(config_convection_scheme == 'cu_grell_freitas'          .or. &
+          config_convection_scheme == 'cu_tiedtke'                .or. &
+          config_convection_scheme == 'cu_ntiedtke') then
+
+          call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
+
+          !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
+          !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
+          !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above.
+          if (config_monotonic) then
+             rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
+          else
+             rqvdynten(:,:) = 0._RKIND
+          end if
+       end if
+
+       !simply set to zero negative mixing ratios of different water species (for now):
+       where ( scalars_2(:,:,:) < 0.0)  &
+          scalars_2(:,:,:) = 0.0
+
+       !call microphysics schemes:
+       if (trim(config_microp_scheme) /= 'off')  then
+          call mpas_timer_start('microphysics')
+!$OMP PARALLEL DO
+          do thread=1,nThreads
+             call driver_microphysics ( block%configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
+                                        cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+          end do
+!$OMP END PARALLEL DO
+          call mpas_timer_stop('microphysics')
+       end if
+    block => block % next
+ end do 
+
+ endif
+
+ call mpas_timer_stop('physics_part2')
+
+!call mpas_log_write('--- exit subroutine physics_part2:')
+!call mpas_log_write('')
+
+ end subroutine physics_part2
 
 !=================================================================================================================
  end module mpas_atmphys_driver


### PR DESCRIPTION
The original calling structure for MPAS-A included a direct call to the microphysics driver from
within atm_srk3. This has caused a few troubles.
1. For an effort to organize physics calls for GPU, having multiple locations to deal with physics 
interfaces are problematic.
2. Given the location of the call to the MP driver, the regional development was required to place 
wrap-up code for the end of each time step inside of the atm_srk3 routine also.
3. The eventual usage of the CPF in MPAS-A requires a single calling location for all of the top-
level physics drivers.

The above problems are alleviated by restructuring the high-level timestep loop in 
atm_do_timestep.
```
Original calling structure
---------------------------
atm_do_timestep
   physics_driver
   atm_timestep
      atm_srk3
         driver_microphysics
         atm_bdy_reset_speczone_values
         atm_bdy_set_scalars
         summarize_timestep

New calling structure
---------------------------
atm_do_timestep
   physics_part1
   dynamics_timestep
      atm_srk3
   physics_part2
      driver_microphysics
   dynamics_final_lbc_adjustment
      atm_bdy_reset_speczone_values
      atm_bdy_set_scalars
   dynamics_update_xtime
   summarize_timestep
```

Testing:
1. This PR consists of 8 commits. Each of the commits is able to build, run, and give bit-wise 
identical results to the base develop branch. The tests are using the 40962 domain, for a 24-h
simulation, Intel 18 (using FFLAGS_OPT = -O0 -fp-model  precise).
2. Even with relocating some calls to routines between the src/core_atmosphere/dynamics and the
src/core_atmosphere directories, the dependencies for mpas_atm_core.F and
mpas_atm_time_integration.F were already handled.
3. The physics/Makefile was modified to handle the new dependency of mpas_atmphys_driver on mpas_atmphys_driver_microphysics.
dependency.