### PR TITLE
Add radiation stress forcing and sloped beach test case

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -740,6 +740,10 @@
 					description="The length scale of exponential decay of river runoff. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 					possible_values="Any positive real number."
 		/>
+		<nml_option name="config_use_wave_radiation_stress_forcing" type="logical" default_value=".false." units="unitless"
+					description="Controls if wave radiation stress forcing is used."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">
 		<nml_option name="config_use_time_varying_atmospheric_forcing" type="logical" default_value=".false." units="unitless"
@@ -957,7 +961,6 @@
 					possible_values="Any positive real number"
 		/>
 	</nml_record>
-
 	<nml_record name="advection" mode="forward">
 		<nml_option name="config_vert_tracer_adv" type="character" default_value="stencil" units="unitless"
 					description="Method for interpolating tracer values from layer centers to layer edges"
@@ -1356,7 +1359,7 @@
 		<package name="timeVaryingAtmosphericForcingPKG" description="This package includes variables required for time varying atmospheric forcing"/>
 		<package name="timeVaryingLandIceForcingPKG" description="This package includes variavles required for time varying land-ice forcing"/>
 		<package name="variableShortwave" description="This package includes variables required to compute spatially variable shortwave extinction coefficients"/>
-
+		<package name="waveRadiationStressPKG" description="This package includes variables required for wave radiation stress forcing"/>
 		<package name="splitTimeIntegrator" description="This package includes variables required for either the split or unsplit explicit time integrators."/>
 		<package name="thicknessFilter" description="This package includes variables required for frequency filtered thickness."/>
 		<package name="windStressBulkPKG" description="This package includes varibles required for bulk wind stress forcing."/>
@@ -2854,6 +2857,10 @@
 		<var name="pressureAdjustedSSH" type="real" dimensions="nCells Time" units="m"
 			 description="sea surface height adjusted by sea surface pressure"
 		/>
+		<var name="waveRadiationStressXXdx" type="real" dimensions="nEdges Time" units="kg s^{-2}"
+			 description="x derivative of wave radiation stress xx component"
+			 packages="waveRadiationStressPKG"
+		/>
 	</var_struct>
 	<var_struct name="shortwave" time_levs="1">
 		<!-- **********************************************************************
@@ -3171,6 +3178,21 @@
 			 description="surface pressure forcing due to weight of frazil ice"
 			 packages="frazilIce"
 		/>
+    
+		<!-- Input fields for wave radiation stress forcing -->
+		<var name="waveRadiationStressXX" type="real" dimensions="nCells Time" units="kg s^{-2}"
+			 description="Depth averaged wave radiation stress xx component"
+			 packages="waveRadiationStressPKG"
+		/>
+		<var name="waveRadiationStressXY" type="real" dimensions="nCells Time" units="kg s^{-2}"
+			 description="Depth averaged wave radiation stress xy component"
+			 packages="waveRadiationStressPKG"
+		/>
+		<var name="waveRadiationStressYY" type="real" dimensions="nCells Time" units="kg s^{-2}"
+			 description="Depth averaged wave radiation stress yy component"
+			 packages="waveRadiationStressPKG"
+		/>
+
 	</var_struct>
 	<var_struct name="timeVaryingForcing" time_levs="1">
 		<var name="windSpeedU" type="real" dimensions="nCells Time" units="m/s"

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -125,6 +125,7 @@ module ocn_core_interface
       logical, pointer :: gmActive
       logical, pointer :: timeVaryingAtmosphericForcingPKGActive
       logical, pointer :: timeVaryingLandIceForcingPKGActive
+      logical, pointer :: waveRadiationStressPKGActive 
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -151,6 +152,7 @@ module ocn_core_interface
       logical, pointer :: config_use_standardGM
       logical, pointer :: config_use_time_varying_atmospheric_forcing
       logical, pointer :: config_use_time_varying_land_ice_forcing
+      logical, pointer :: config_use_wave_radiation_stress_forcing
 
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
@@ -318,6 +320,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_use_time_varying_land_ice_forcing', config_use_time_varying_land_ice_forcing)
       if (config_use_time_varying_land_ice_forcing) then
          timeVaryingLandIceForcingPKGActive = .true.
+      endif
+
+      !
+      ! test for wave radiation stress forcing
+      !
+      call mpas_pool_get_package(packagePool, 'waveRadiationStressPKGActive', waveRadiationStressPKGActive)
+      call mpas_pool_get_config(configPool, 'config_use_wave_radiation_stress_forcing', config_use_wave_radiation_stress_forcing)
+      if (config_use_wave_radiation_stress_forcing) then
+         waveRadiationStressPKGActive = .true.
       endif
 
       !

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -55,6 +55,7 @@ module ocn_forward_mode
    use ocn_surface_land_ice_fluxes
    use ocn_frazil_forcing
    use ocn_tidal_forcing
+   use ocn_vel_forcing_radiation_stress
 
    use ocn_tracer_hmix
    use ocn_tracer_hmix_redi
@@ -220,6 +221,8 @@ module ocn_forward_mode
       call ocn_frazil_forcing_init(err_tmp)
       ierr = ior(ierr, err_tmp)
       call ocn_tidal_forcing_init(err_tmp)
+      ierr = ior(ierr, err_tmp)
+      call ocn_vel_forcing_radiation_stress_init(err_tmp)
       ierr = ior(ierr, err_tmp)
 
       call ocn_tracer_hmix_init(err_tmp)

--- a/src/core_ocean/mode_init/Makefile
+++ b/src/core_ocean/mode_init/Makefile
@@ -25,7 +25,8 @@ TEST_CASES = mpas_ocn_init_baroclinic_channel.o \
              mpas_ocn_init_isomip.o \
              mpas_ocn_init_isomip_plus.o \
              mpas_ocn_init_hurricane.o \
-             mpas_ocn_init_tidal_boundary.o
+             mpas_ocn_init_tidal_boundary.o \
+             mpas_ocn_init_sloped_beach.o
              #mpas_ocn_init_TEMPLATE.o
 
 all: init_mode
@@ -79,6 +80,8 @@ mpas_ocn_init_ziso.o: $(UTILS)
 mpas_ocn_init_hurricane.o: $(UTILS)
 
 mpas_ocn_init_tidal_boundary.o: $(UTILS)
+
+mpas_ocn_init_sloped_beach.o: $(UTILS)
 
 #mpas_ocn_init_TEMPLATE.o: $(UTILS)
 

--- a/src/core_ocean/mode_init/Registry.xml
+++ b/src/core_ocean/mode_init/Registry.xml
@@ -16,4 +16,5 @@
 #include "Registry_isomip_plus.xml"
 #include "Registry_hurricane.xml"
 #include "Registry_tidal_boundary.xml"
+#include "Registry_sloped_beach.xml"
 // #include "Registry_TEMPLATE.xml"

--- a/src/core_ocean/mode_init/Registry_sloped_beach.xml
+++ b/src/core_ocean/mode_init/Registry_sloped_beach.xml
@@ -1,0 +1,20 @@
+       <dims>
+               <dim name="nSolPts" definition="1000" units="unitless"
+                        description="The number of solution points."
+               />
+	</dims>
+	<nml_record name="sloped_beach" mode="init" configuration="sloped_beach">
+		<nml_option name="config_sloped_beach_vert_levels" type="integer" default_value="20" units="unitless"
+			description="Number of vertical levels in sloped_beach test case. Typical values are 10 and 20."
+			possible_values="Any positive integer number greater than 0."
+		/>
+	</nml_record>
+        <var_struct name="exact_solution" time_levs="1">
+                <var name="xTransect" type="real" dimensions="nSolPts" units="meters"
+                         description="Solution points along the x-axis"
+                />
+                <var name="sshExact" type="real" dimensions="nSolPts" units="meters"
+                         description="Exact solution values"
+                />
+        </var_struct>
+

--- a/src/core_ocean/mode_init/mpas_ocn_init_mode.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_mode.F
@@ -58,6 +58,7 @@ module ocn_init_mode
    use ocn_init_isomip_plus
    use ocn_init_hurricane
    use ocn_init_tidal_boundary
+   use ocn_init_sloped_beach
 
    implicit none
    private
@@ -286,6 +287,7 @@ module ocn_init_mode
       call ocn_init_setup_isomip_plus(domain, ierr)
       call ocn_init_setup_hurricane(domain, ierr)
       call ocn_init_setup_tidal_boundary(domain, ierr)
+      call ocn_init_setup_sloped_beach(domain, ierr)
       !call ocn_init_setup_TEMPLATE(domain, ierr)
 
       call mpas_log_write( ' Completed setup of: ' // trim(config_init_configuration))
@@ -394,6 +396,8 @@ module ocn_init_mode
       call ocn_init_validate_hurricane(configPool, packagePool, iocontext, iErr=err_tmp)
       iErr = ior(iErr, err_tmp)
       call ocn_init_validate_tidal_boundary(configPool, packagePool, iocontext, iErr=err_tmp)
+      iErr = ior(iErr, err_tmp)
+      call ocn_init_validate_sloped_beach(configPool, packagePool, iocontext, iErr=err_tmp)
       iErr = ior(iErr, err_tmp)
       ! call ocn_init_validate_TEMPLATE(configPool, packagePool, iocontext, iErr=err_tmp)
       ! iErr = ior(iErr, err_tmp)

--- a/src/core_ocean/mode_init/mpas_ocn_init_sloped_beach.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_sloped_beach.F
@@ -1,0 +1,516 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_init_sloped_beach
+!
+!> \brief MPAS ocean initialize case -- Tests radiation stress implementation 
+!> \author Steven Brus 
+!> \date   August 2019
+!> \details
+!>  This module contains the routines for initializing the
+!>  the sloped_beach test case
+!
+!-----------------------------------------------------------------------
+
+module ocn_init_sloped_beach
+
+   use mpas_constants
+   use mpas_kind_types
+   use mpas_io_units
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+
+   use ocn_constants
+   use ocn_init_vertical_grids
+   use ocn_init_cell_markers
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_init_setup_sloped_beach, &
+             ocn_init_validate_sloped_beach
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_init_setup_sloped_beach
+!
+!> \brief   Setup for sloped beach test case 
+!> \author  Steven Brus
+!> \date    August 2019
+!> \details
+!>  This routine sets up the initial conditions for the sloped_beach test case.
+!
+!-----------------------------------------------------------------------
+  subroutine ocn_init_setup_sloped_beach(domain, iErr)!{{{
+
+    !--------------------------------------------------------------------
+
+    implicit none
+
+    type (domain_type), intent(inout) :: domain
+    integer, intent(out) :: iErr
+
+    type (block_type), pointer :: block_ptr
+
+    type (mpas_pool_type), pointer :: meshPool
+    type (mpas_pool_type), pointer :: forcingPool
+    type (mpas_pool_type), pointer :: statePool
+    type (mpas_pool_type), pointer :: diagnosticsPool
+    type (mpas_pool_type), pointer :: verticalMeshPool
+    type (mpas_pool_type), pointer :: tracersPool
+    type (mpas_pool_type), pointer :: solPool
+
+    integer :: iCell, i
+    real(kind=RKIND) :: H0,T,theta,d0
+    real(kind=RKIND) :: d,x
+    real(kind=RKIND) :: Sxx,Sxy,Syy
+    real(kind=RKIND) :: dSxxdx
+
+    ! Define dimensions
+    integer, pointer :: nCellsSolve, nEdgesSolve, nVertLevels, nVertLevelsP1
+    integer, pointer :: index_temperature, index_salinity
+
+    ! Define arrays
+    integer, dimension(:), pointer :: maxLevelCell
+    integer, pointer :: npts 
+    real (kind=RKIND), dimension(:), pointer :: xCell, refBottomDepth, bottomDepth, vertCoordMovementWeights
+    real (kind=RKIND), dimension(:), pointer :: ssh
+    real (kind=RKIND), dimension(:), pointer :: sshExact,xTransect
+    real (kind=RKIND), dimension(:), pointer :: waveRadiationStressXX, waveRadiationStressYY, waveRadiationStressXY 
+    real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness, zMid
+    real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+
+    ! Define configs
+    character (len=StrKIND), pointer :: config_init_configuration, &
+                                        config_vertical_grid
+    integer, pointer :: config_sloped_beach_vert_levels
+
+    real (kind=RKIND), dimension(:), pointer :: interfaceLocations
+
+
+    iErr = 0
+
+    H0 = 0.6_RKIND
+    T = 5.0_RKIND
+    theta = 0.0_RKIND
+    d0 = 2.1_RKIND
+
+    call mpas_pool_get_config(ocnConfigs, 'config_init_configuration', config_init_configuration)
+
+    call mpas_log_write('here')
+    if(config_init_configuration .ne. trim('sloped_beach')) return
+
+    call mpas_pool_get_config(ocnConfigs, 'config_vertical_grid', config_vertical_grid)
+
+    call mpas_pool_get_config(ocnConfigs, 'config_sloped_beach_vert_levels', config_sloped_beach_vert_levels)
+
+    call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+    call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+    call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', nVertLevelsP1)
+    call mpas_pool_get_subpool(domain % blocklist % structs, 'exact_solution', solPool)
+
+    nVertLevels = config_sloped_beach_vert_levels
+    nVertLevelsP1 = nVertLevels + 1
+
+    allocate(interfaceLocations(nVertLevelsP1))
+    call ocn_generate_vertical_grid(config_vertical_grid, interfaceLocations)
+
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+      call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+      call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+      call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
+      call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+
+      call mpas_pool_get_array(meshPool, 'xCell', xCell)
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
+
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
+
+      call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressXX', waveRadiationStressXX, 1)
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressYY', waveRadiationStressYY, 1)
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressXY', waveRadiationStressXY, 1)
+
+      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+
+
+      ! Set refBottomDepth, bottomDepth, and maxLevelCell
+      do i = 1, nVertLevels
+        refBottomDepth(i) = d0 * interfaceLocations(i+1)
+      end do
+
+      do iCell = 1, nCellsSolve
+        if (xCell(iCell) >= 80.0_RKIND) then
+          bottomDepth(iCell) = d0
+        else
+          bottomDepth(iCell) = (1.0_RKIND/40.0_RKIND)*xCell(iCell) + 0.1_RKIND
+        end if
+      end do
+
+
+      do iCell = 1, nCellsSolve
+        maxLevelCell(iCell) = nVertLevels
+      end do 
+      do iCell = 1, nCellsSolve
+        ssh(iCell) = 0d0 
+      end do
+
+      do iCell = 1, nCellsSolve
+        do i = 1, maxLevelCell(iCell)
+          layerThickness(i,iCell) = bottomDepth(iCell)/real(nVertLevels,RKIND)
+          restingThickness(i, iCell) = layerThickness(i, iCell)
+        end do
+      end do
+
+      ! Set vertCoordMovementWeights
+      vertCoordMovementWeights(:) = 1.0_RKIND
+
+      ! Set salinity
+      do iCell = 1, nCellsSolve
+        activeTracers(index_salinity, :, iCell) = 33.0_RKIND 
+      end do
+
+      ! Set temperature
+      do iCell = 1, nCellsSolve
+        activeTracers(index_temperature, :, iCell) = 20.0_RKIND 
+      end do
+
+      ! Set wave radiation stress from linear wave theory
+      do iCell = 1, nCellsSolve
+        
+        d = bottomDepth(iCell)
+        x = xCell(iCell)
+
+        call compute_radiation_stress(x,d,H0,T,theta,d0,Sxx,Sxy,Syy,dSxxdx)
+
+        waveRadiationStressXX(iCell) = Sxx 
+        waveRadiationStressYY(iCell) = Syy
+        waveRadiationStressXY(iCell) = Sxy
+
+      enddo
+
+      block_ptr => block_ptr % next
+    end do
+
+    deallocate(interfaceLocations)
+
+    call mpas_pool_get_subpool(domain % blocklist % structs, 'exact_solution', solPool)
+    call mpas_pool_get_dimension(solPool, 'nSolPts', npts)
+    call mpas_pool_get_array(solPool, 'xTransect', xTransect)
+    call mpas_pool_get_array(solPool, 'sshExact',sshExact)
+    call compute_exact_solution(npts,d0,H0,T,xTransect,sshExact)
+
+    !--------------------------------------------------------------------
+
+  end subroutine ocn_init_setup_sloped_beach!}}}
+
+!***********************************************************************
+!
+!  routine compute_radiation_stress 
+!
+!> \brief   Computes wave radiation stress for sloped beach test case
+!> \author  Steven Brus 
+!> \date    August 2019
+!> \details
+!>  Computes the wave radiation stresses based on linear wave theory
+!
+!-----------------------------------------------------------------------
+  subroutine compute_radiation_stress(x,d,H0,T,theta,d0,Sxx,Sxy,Syy,dSxxdx) !{{{
+
+    !--------------------------------------------------------------------
+
+    implicit none
+
+    real(kind=RKIND), intent(in) :: x
+    real(kind=RKIND), intent(in) :: d
+    real(kind=RKIND), intent(in) :: H0
+    real(kind=RKIND), intent(in) :: T
+    real(kind=RKIND), intent(in) :: theta
+    real(kind=RKIND), intent(in) :: d0
+    real(kind=RKIND), intent(out) :: Sxx,Sxy,Syy
+    real(kind=RKIND), intent(out) :: dSxxdx
+
+    real(kind=RKIND) :: H,Hb,dHdx
+    real(kind=RKIND) :: kappa
+    real(kind=RKIND) :: sigma
+    real(kind=RKIND) :: dddx
+    real(kind=RKIND) :: k0,k,kd,dkdx
+    real(kind=RKIND) :: C,Cg,Cg0
+    real(kind=RKIND) :: n,n0,dndx
+    real(kind=RKIND) :: E,dEdx
+
+    sigma = 2.0_RKIND*pii/T
+    kappa = 0.78_RKIND
+
+    k0 = wavenumber(T,d0)
+    n0 =  0.5_RKIND*(1.0_RKIND + (2.0_RKIND*k0*d0)/sinh(2.0_RKIND*k0*d0))
+    Cg0 = n0*sigma/k0
+
+    k = wavenumber(T,d)
+    kd = k*d
+
+    n = 0.5_RKIND*(1.0_RKIND + (2.0_RKIND*kd)/sinh(2.0_RKIND*kd))
+    C = sigma/k
+    Cg = n*C
+    H = H0*sqrt(Cg0/Cg)
+    Hb = min(kappa*d,H)
+    E = (1.0_RKIND/8.0_RKIND)*rho_fw*gravity*Hb**2
+    
+    Sxx = E*(n*(cos(theta)**2+1.0_RKIND)-0.5_RKIND)
+    Syy = E*(n*(sin(theta)**2+1.0_RKIND)-0.5_RKIND)
+    Sxy = 0.5_RKIND*E*n*sin(2.0_RKIND*theta)
+
+    if (x <= 80.0_RKIND) then
+      dddx = 1.0_RKIND/40.0_RKIND
+    else  
+      dddx = 0.0_RKIND
+    end if
+
+    dkdx = -(k**2*dddx)/(cosh(kd)**2*tanh(kd) + kd)
+    dndx = (dkdx*d+k*dddx)*(sinh(2.0_RKIND*kd)-2.0_RKIND*kd*cosh(2.0_RKIND*kd))/sinh(2.0_RKIND*kd)**2
+    if (d <= H/kappa) then
+      dHdx = kappa*(1.0_RKIND/40.0_RKIND)
+    else
+      dHdx = 0.5_RKIND*H0/sqrt((n0/k0)*(k/n))*((dkdx*n-dndx*k)/n**2)*(n0/k0)
+    end if
+    dEdx = 0.25_RKIND*rho_fw*gravity*Hb*dHdx
+
+    dSxxdx = dEdx*(n*(cos(theta)**2+1.0_RKIND)-0.5_RKIND) + E*dndx*(cos(theta)**2+1.0_RKIND)
+
+    !--------------------------------------------------------------------
+
+  end subroutine compute_radiation_stress!}}}
+
+!***********************************************************************
+!
+!  routine compute_exact_solution 
+!
+!> \brief   Computes exact ssh solution for sloped beach case 
+!> \author  Steven Brus 
+!> \date    September 2019
+!> \details
+!>  Uses linear wave theory for setup/setdown  
+!
+!-----------------------------------------------------------------------
+  subroutine compute_exact_solution(npts,d0,H0,T,xTransect,sshExact)!{{{
+
+    !--------------------------------------------------------------------
+
+    implicit none
+
+    integer, intent(in) :: npts
+    real (kind=RKIND), intent(in) :: d0
+    real (kind=RKIND), intent(in) :: H0
+    real (kind=RKIND), intent(in) :: T 
+    real (kind=RKIND), dimension(:), intent(out) :: xTransect    
+    real (kind=RKIND), dimension(:), intent(out) :: sshExact    
+
+    integer :: i
+    integer :: breaking
+    real (kind=RKIND) :: a,d,k,H,n,C,Cg,Cg0,n0,k0
+    real (kind=RKIND) :: kappa,sigma
+    real (kind=RKIND) :: xb,db,dx
+    real (kind=RKIND) :: sshb
+
+    dx = 150.0/real(npts,RKIND)
+
+    ! Compute inital wave parameters
+    kappa = 0.78_RKIND
+    sigma = 2.0_RKIND*pii/T
+    k0 = wavenumber(T,d0)
+    n0 =  0.5_RKIND*(1.0_RKIND + (2.0_RKIND*k0*d0)/sinh(2.0_RKIND*k0*d0))
+    Cg0 = n0*sigma/k0
+
+    breaking = 0
+    do i = 1,npts
+      
+      ! Compute x location and depth moving toward coast
+      xTransect(i) = 150.0_RKIND - real(i-1,RKIND)*dx
+      d = xTransect(i)/40.0_RKIND + 0.1_RKIND
+
+      ! Compute wave height
+      k = wavenumber(T,d)
+      n = 0.5_RKIND*(1.0_RKIND + (2.0_RKIND*k*d)/sinh(2.0_RKIND*k*d))
+      C = sigma/k
+      Cg = n*C
+      H = H0*sqrt(Cg0/Cg)
+
+      ! Check breaking criteria
+      if (H >= kappa*d) then
+        breaking = 1
+      end if
+
+      if (breaking == 1) then
+        ! Setup solution
+        sshExact(i) = sshb + 3.0_RKIND*kappa**2/8.0_RKIND/(1.0_RKIND + 3.0_RKIND*kappa**2/8.0_RKIND)*(db - d)
+      else
+        ! Setdown solution
+        a = 0.5_RKIND*H
+        sshExact(i) = -0.5_RKIND*a**2*k/sinh(2.0_RKIND*d*k) 
+        
+        ! Keep track of ssh and d at breaking point
+        sshb = sshExact(i)
+        db = d
+      end if 
+
+    end do
+
+    !--------------------------------------------------------------------
+
+  end subroutine compute_exact_solution!}}}
+
+!***********************************************************************
+!
+!  function wavenumber 
+!
+!> \brief   Computes wavenumber given period and depth 
+!> \author  Steven Brus 
+!> \date    August 2019
+!> \details
+!>  Uses Newton's method iteration to solve linear dispersion relationship 
+!
+!-----------------------------------------------------------------------
+  function wavenumber(T,h) result(k)!{{{
+    
+    !--------------------------------------------------------------------
+
+    implicit none
+
+    real(kind=RKIND) :: k
+    real(kind=RKIND), intent(in) :: T
+    real(kind=RKIND), intent(in) :: h
+
+    real(kind=RKIND) :: sigma
+    real(kind=RKIND) :: tol
+    real(kind=RKIND) :: kh 
+    real(kind=RKIND) :: knew
+    real(kind=RKIND) :: f,fp 
+    integer :: i
+    integer :: maxit
+    
+    ! period to frequency
+    sigma = 2.0_RKIND*pii/T
+
+    ! initial guess (Eckart 1951)
+    k = sigma**2/(gravity*sqrt(tanh(sigma**2*h/gravity)))
+    
+    maxit = 100
+    tol = 1e-8_RKIND
+
+    do i = 1,maxit
+
+      kh = k*h
+      f = gravity*k*tanh(kh)-sigma**2      
+      fp = gravity*tanh(kh)+gravity*kh*(1.0_RKIND-tanh(kh)**2)
+      knew = k - f/fp
+ 
+      if (abs(knew-k) < tol) then
+        exit
+      end if
+
+      k = knew
+
+    end do
+    
+    !--------------------------------------------------------------------
+
+  end function wavenumber!}}}
+
+!***********************************************************************
+!
+!  routine ocn_init_validate_sloped_beach
+!
+!> \brief   Validation for radiation stress sloped beach test case
+!> \author  Steven Brus 
+!> \date    August 2019
+!> \details
+!>  This routine validates the configuration options for the sloped_beach test case.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_init_validate_sloped_beach(configPool, packagePool, iocontext, iErr)!{{{
+
+   !--------------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: configPool, packagePool
+      type (mpas_io_context_type), intent(inout) :: iocontext
+
+      integer, intent(out) :: iErr
+
+      character (len=StrKIND), pointer :: config_init_configuration
+      integer, pointer :: config_sloped_beach_vert_levels, config_vert_levels
+
+      iErr = 0
+
+      call mpas_pool_get_config(configPool, 'config_init_configuration', config_init_configuration)
+
+      if(config_init_configuration .ne. trim('sloped_beach')) return
+
+      call mpas_pool_get_config(configPool, 'config_vert_levels', config_vert_levels)
+      call mpas_pool_get_config(configPool, 'config_sloped_beach_vert_levels', config_sloped_beach_vert_levels)
+
+      if(config_vert_levels <= 0 .and. config_sloped_beach_vert_levels > 0) then
+         config_vert_levels = config_sloped_beach_vert_levels
+         !call mpas_log_write( 'Using value of $i', intArgs=(/config_vert_levels /))
+      else if(config_vert_levels <= 0) then
+         call mpas_log_write( 'Validation failed for sloped_beach testcase. ' &
+           // 'Not given a usable value for vertical levels.',MPAS_LOG_CRIT)
+         iErr = 1
+      end if
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_init_validate_sloped_beach!}}}
+
+
+!***********************************************************************
+
+end module ocn_init_sloped_beach
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker
+

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -23,6 +23,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_vel_hmix_del4.o \
 	   mpas_ocn_vel_forcing.o \
 	   mpas_ocn_vel_forcing_surface_stress.o \
+	   mpas_ocn_vel_forcing_radiation_stress.o \
 	   mpas_ocn_vel_forcing_explicit_bottom_drag.o \
 	   mpas_ocn_vel_pressure_grad.o \
 	   mpas_ocn_vmix.o \
@@ -72,7 +73,7 @@ all: $(OBJS)
 
 mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
-mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o
+mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_forcing_radiation_stress.o
 
 mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o
 
@@ -105,6 +106,8 @@ mpas_ocn_vel_hmix_del4.o: mpas_ocn_constants.o
 mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forcing_explicit_bottom_drag.o mpas_ocn_forcing.o mpas_ocn_constants.o
 
 mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o
+
+mpas_ocn_vel_forcing_radiation_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o
 
 mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -59,6 +59,7 @@ module ocn_tendency
    use ocn_vel_forcing
    use ocn_vmix
    use ocn_wetting_drying
+   use ocn_vel_forcing_radiation_stress
 
    implicit none
    private
@@ -222,7 +223,8 @@ contains
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh
+      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh, &
+        waveRadiationStressXX, waveRadiationStressXY, waveRadiationStressYY
       real (kind=RKIND), dimension(:,:), pointer :: &
         layerThicknessEdge, normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
         layerThickness, &
@@ -289,6 +291,12 @@ contains
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
 
       call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
+
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressXX', waveRadiationStressXX)
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressXY', waveRadiationStressXY)
+      call mpas_pool_get_array(forcingPool, 'waveRadiationStressYY', waveRadiationStressYY)
+
+
       !
       ! velocity tendency: start accumulating tendency terms
       !
@@ -365,6 +373,11 @@ contains
          tend_normalVelocity(:, iEdge) = tend_normalVelocity(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
       end do
       !$omp end do
+      ! velocity tendency: wave radiation stress 
+      !
+      call ocn_vel_forcing_radiation_stress_tend(meshPool, diagnosticsPool, &
+                                                 waveRadiationStressXX, waveRadiationStressXY, waveRadiationStressYY, & 
+                                                 layerThicknessEdge,tend_normalVelocity, err)
 
       !
       ! velocity tendency: vertical mixing d/dz( nu_v du/dz))

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_radiation_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_radiation_stress.F
@@ -1,0 +1,489 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vel_forcing_radiation_stress
+!
+!> \brief  MPAS ocean wave radiation stress
+!> \author Steven Brus 
+!> \date   April 2019
+!> \details
+!>  This module contains the routine for computing
+!>  tendencies from wave radiation stress.
+!
+!-----------------------------------------------------------------------
+
+module ocn_vel_forcing_radiation_stress
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_timer
+
+   use ocn_constants
+   use ocn_forcing
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_vel_forcing_radiation_stress_tend, &
+             ocn_vel_forcing_radiation_stress_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   logical :: radiationStressOn
+   real (kind=RKIND), dimension(:), allocatable :: normalRadiationStress
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_vel_forcing_radiation_stress_tend
+!
+!> \brief   Computes tendency term from wave radiation stress
+!> \author  Steven Brus 
+!> \date    April 2019
+!> \details
+!>  This routine computes the wave radiation stress tendency for momentum
+!>  based on current state.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vel_forcing_radiation_stress_tend(meshPool, & 
+                                                    diagnosticsPool, &
+                                                    waveRadiationStressXX, &
+                                                    waveRadiationStressXY, &
+                                                    waveRadiationStressYY, & 
+                                                    layerThicknessEdge, &
+                                                    tend, err) !{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         waveRadiationStressXX, &
+         waveRadiationStressXY, &
+         waveRadiationStressYY
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge     !< Input: thickness at edge
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool, &          !< Input: mesh information
+         diagnosticsPool      !< Input: Diagnostic information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, dimension(:), pointer :: nEdgesArray
+      integer, dimension(:), pointer :: maxLevelEdgeTop
+      integer, dimension(:,:), pointer :: edgeMask
+      real (kind=RKIND), pointer :: daysSinceStartOfSim 
+
+      integer :: i,j,k,l
+      integer :: iEdge, iVertex, iCell 
+      integer :: nEdges, vertex, cell
+      real (kind=RKIND) :: waterColumnHeight 
+      real (kind=RKIND) :: ramp,forcing_ramp
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      err = 0
+      if ( .not. radiationStressOn ) return
+
+      call mpas_timer_start('vel surface stress')
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      call MPAS_pool_get_array(diagnosticsPool, "daysSinceStartOfSim",daysSinceStartOfSim)
+
+      ! Compute radiation stress forcing
+      ! (right now, this is only called first timestep, 
+      ! when module variable normalRadiationStress hasn't been allocated yet.)
+      call compute_radiation_stress_gradient(meshPool, &
+                                             diagnosticsPool, &
+                                             waveRadiationStressXX, &
+                                             waveRadiationStressXY, &
+                                             waveRadiationStressYY, &
+                                             normalRadiationStress)
+
+      nEdges = nEdgesArray ( 1 )
+
+      ! Compute ramp factor for radiation stress forcing
+      forcing_ramp = 1.0_RKIND
+      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/forcing_ramp)
+
+edgeLoop: do iEdge = 1, nEdges
+
+        ! Compute water column height at edge
+        waterColumnHeight = 0.0_RKIND 
+        do k = 1, maxLevelEdgeTop(iEdge)
+          waterColumnHeight = waterColumnHeight + layerThicknessEdge(k,iEdge)
+        enddo
+
+        ! Sum into tendency 
+        do k = 1, maxLevelEdgeTop(iEdge)
+           tend(k,iEdge) =  tend(k,iEdge) - ramp * edgeMask(k, iEdge) * normalRadiationStress(iEdge) &
+                         / rho_sw / waterColumnHeight
+        enddo
+
+      enddo edgeLoop ! iEdge
+
+      call mpas_timer_stop('vel surface stress')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_radiation_stress_tend!}}}
+
+!***********************************************************************
+!
+!  routine  compute_radiation_stress_gradient 
+!
+!> \brief   Computes wave radiation stress gradients
+!> \author  Steven Brus
+!> \date    April 2019 
+!> \details
+!>  This routine computes radiation stress gradients on edges from 
+!>  cell-centered radiation stresses
+!
+!-----------------------------------------------------------------------
+
+   subroutine compute_radiation_stress_gradient(meshPool, &
+                                                diagnosticsPool, &
+                                                waveRadiationStressXX, &
+                                                waveRadiationStressXY, &
+                                                waveRadiationStressYY, &
+                                                normalRadiationStress) !{{{
+
+   implicit none
+
+   
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         waveRadiationStressXX, &
+         waveRadiationStressXY, &
+         waveRadiationStressYY
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool, &          !< Input: mesh information
+         diagnosticsPool      !< Input: Diagnostic information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), allocatable, intent(inout) :: normalRadiationStress
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, pointer :: nCells
+      integer, dimension(:), pointer :: nEdgesArray
+      integer, dimension(:,:), pointer :: verticesOnEdge, cellsOnVertex, cellsOnEdge
+      real (kind=RKIND), dimension(:), pointer :: lonCell, latCell
+      real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
+      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+      real (kind=RKIND), dimension(:), pointer :: waveRadiationStressXXdx
+      real (kind=RKIND), dimension(:,:), pointer :: edgeNormalVectors
+      logical, pointer :: on_a_sphere
+
+      integer :: i,j,k,l
+      integer :: iEdge, iVertex, iCell 
+      integer :: nEdges, vertex, cell
+      integer :: boundaryVertex
+      real (kind=RKIND), parameter :: sphereRadius = 6371229.0_RKIND
+      real (kind=RKIND) :: radiationStressTensor(3,3,3)
+      real (kind=RKIND) :: dxdlon(3), dxdlat(3)
+      real (kind=RKIND) :: dpdr(3,3), dxdr(3,3), drdx(3,3), detJ
+      real (kind=RKIND) :: dpdx(3,3)
+      real (kind=RKIND) :: x1, x2, x3
+      real (kind=RKIND) :: y1, y2, y3
+      real (kind=RKIND) :: z1, z2, z3
+      real (kind=RKIND) :: lat, lon
+      real (kind=RKIND) :: tauAvgDual(3,2), tauAvgEdge(3)
+      real (kind=RKIND) :: areaWeights(2)
+
+      !-----------------------------------------------------------------
+      !
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+
+      nEdges = nEdgesArray ( 1 )
+      if ( allocated(normalRadiationStress)) then
+        return
+      else
+        allocate(normalRadiationStress(nEdges))
+      end if
+ 
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
+      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
+      call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
+      call mpas_pool_get_array(meshPool, 'lonCell', lonCell )
+      call mpas_pool_get_array(meshPool, 'latCell', latCell )
+      call mpas_pool_get_array(meshPool, 'xCell', xCell )
+      call mpas_pool_get_array(meshPool, 'yCell', yCell )
+      call mpas_pool_get_array(meshPool, 'zCell', zCell )
+      call mpas_pool_get_array(meshPool, 'xVertex', xVertex )
+      call mpas_pool_get_array(meshPool, 'yVertex', yVertex )
+      call mpas_pool_get_array(meshPool, 'zVertex', zVertex )
+      call mpas_pool_get_array(meshPool, 'edgeNormalVectors', edgeNormalVectors)
+      call mpas_pool_get_array(diagnosticsPool, 'waveRadiationStressXXdx',waveRadiationStressXXdx, 1 )
+
+
+      ! Basis function derivatives with respect to local coordinates
+      dpdr(1,1) = -0.5_RKIND ; dpdr(1,2) = 0.5_RKIND ; dpdr(1,3) = 0.0_RKIND 
+      dpdr(2,1) = -0.5_RKIND ; dpdr(2,2) = 0.0_RKIND ; dpdr(2,3) = 0.5_RKIND
+
+edgeLoop: do iEdge = 1, nEdges
+        tauAvgDual = 0.0_RKIND
+
+        if (cellsOnEdge(2,iEdge) == nCells+1) then
+           cycle edgeLoop
+         end if
+ 
+         boundaryVertex = 0
+vertexLoop: do iVertex = 1,2
+          vertex = verticesOnEdge(iVertex,iEdge)
+          do iCell = 1,3
+            cell = cellsOnVertex(iCell,vertex)
+           
+            if (cell == nCells+1) then
+              boundaryVertex = iVertex
+              cycle vertexLoop
+            end if
+
+            if (on_a_sphere) then
+              lon = lonCell(cell)
+              lat = latCell(cell)
+      
+              ! Form rows of Jacobian matrix bewteen Cartesian and sperical coordinates (dxdrad not needed)
+              dxdlon(1) = -sphereRadius*cos(lat)*sin(lon)
+              dxdlon(2) =  sphereRadius*cos(lat)*cos(lat)
+              dxdlon(3) =  0.0_RKIND
+
+              dxdlat(1) = -sphereRadius*sin(lat)*cos(lon)
+              dxdlat(2) = -sphereRadius*sin(lat)*sin(lon)
+              dxdlat(3) =  sphereRadius*cos(lat)
+
+              ! Transform radiation stress tensor to Cartesian coordinates
+              do j = 1,3
+                do i = 1,3
+                  radiationStressTensor(i,j,iCell) = dxdlon(j)*(dxdlon(i)*waveRadiationStressXX(cell)  + &
+                                                                dxdlat(i)*waveRadiationStressXY(cell)) + &
+                                                     dxdlat(j)*(dxdlon(i)*waveRadiationStressXY(cell)  + &
+                                                                dxdlat(i)*waveRadiationStressYY(cell))
+                enddo
+              enddo
+            else              
+              radiationStressTensor(1,1,iCell) = waveRadiationStressXX(cell)
+              radiationStressTensor(1,2,iCell) = waveRadiationStressXY(cell)
+              radiationStressTensor(1,3,iCell) = 0.0_RKIND 
+              radiationStressTensor(2,1,iCell) = waveRadiationStressXY(cell)
+              radiationStressTensor(2,2,iCell) = waveRadiationStressYY(cell)
+              radiationStressTensor(2,3,iCell) = 0.0_RKIND
+              radiationStressTensor(3,1,iCell) = 0.0_RKIND
+              radiationStressTensor(3,2,iCell) = 0.0_RKIND
+              radiationStressTensor(3,3,iCell) = 0.0_RKIND
+            endif
+
+          enddo ! iCell
+
+          ! Get coordinates of dual-grid triangle
+          x1 = xCell(cellsOnVertex(1,vertex))
+          y1 = yCell(cellsOnVertex(1,vertex))
+          z1 = zCell(cellsOnVertex(1,vertex))
+
+          x2 = xCell(cellsOnVertex(2,vertex))
+          y2 = yCell(cellsOnVertex(2,vertex))
+          z2 = zCell(cellsOnVertex(2,vertex))
+
+          x3 = xCell(cellsOnVertex(3,vertex))
+          y3 = yCell(cellsOnVertex(3,vertex)) 
+          z3 = zCell(cellsOnVertex(3,vertex))
+
+          ! Avoid Jacobian singularity for planar meshes
+          if (abs(z1) < 1e-10_RKIND .and. abs(z2) < 1e-10_RKIND .and. abs(z3) < 1e-10_RKIND) then
+            z1 = 1.0_RKIND
+            z2 = 1.0_RKIND
+            z3 = 1.0_RKIND
+          endif
+
+          ! Compute derivatives of interpolating functions on dual-grid triangle
+          detJ = x1*(y2*z3-y3*z2)-y1*(x2*z3-x3*z2)+z1*(x2*y3-x3*y2)
+          dpdx(1,1) = (y2*z3-y3*z2)/detJ; dpdx(1,2) = (z1*y3-z3*y1)/detJ; dpdx(1,3) = (y1*z2-z1*y2)/detJ
+          dpdx(2,1) = (x3*z2-x2*z3)/detJ; dpdx(2,2) = (x1*z3-x3*z1)/detJ; dpdx(2,3) = (z1*x2-x1*z2)/detJ
+          dpdx(3,1) = (x2*y3-x3*y2)/detJ; dpdx(3,2) = (y1*x3-y3*x1)/detJ; dpdx(3,3) = (x1*y2-y1*x2)/detJ
+
+          ! Compute average wave radiation stress divergence on dual mesh triangle 
+          do i = 1,3
+            do l = 1,3
+              do j = 1,3 
+                tauAvgDual(i,iVertex) = tauAvgDual(i,iVertex) + radiationStressTensor(i,j,l)*dpdx(j,l)
+              enddo
+            enddo
+          enddo
+
+          ! Compute area weights for calculating area average edge values
+          ! (Probably not needed, areas should be the same)
+          x1 = xVertex(vertex)
+          y1 = yVertex(vertex)
+          z1 = zVertex(vertex)
+
+          x2 = xCell(cellsOnEdge(1,iEdge))
+          y2 = yCell(cellsOnEdge(1,iEdge))
+          z2 = zCell(cellsOnEdge(1,iEdge))
+
+          x3 = xCell(cellsOnEdge(2,iEdge))
+          y3 = yCell(cellsOnEdge(2,iEdge))
+          z3 = zCell(cellsOnEdge(2,iEdge))
+
+          areaWeights(iVertex) = 0.5_RKIND*(sqrt(((y2-y1)*(z3-z1)-(y3-y1)*(z2-z1))**2+ &
+                                                ((x3-x1)*(z2-z1)-(x2-x1)*(z3-z1))**2+ &
+                                                ((x2-x1)*(y3-y1)-(x3-x1)*(y2-y1))**2))
+
+        enddo vertexLoop
+
+        ! Set boundary vertex = to interior vertex on edge
+        ! (could probably do something better)
+        if (boundaryVertex > 0) then
+          do i = 1,3
+            tauAvgDual(i,boundaryVertex) = tauAvgDual(i,mod(boundaryVertex,2)+1)
+          enddo
+        endif
+
+        ! Compute area agerage edge value        
+        do i = 1,3
+          tauAvgEdge(i) = (tauAvgDual(i,1)*areaWeights(1) + tauAvgDual(i,2)*areaWeights(2))/(areaWeights(1) + areaWeights(2))
+        enddo
+
+        waveRadiationStressXXdx(iEdge) = tauAvgEdge(1)
+ 
+        ! Compute dot product of average edge value with edge normal
+        normalRadiationStress(iEdge) = 0.0_RKIND
+        do i = 1,3
+          normalRadiationStress(iEdge) = normalRadiationStress(iEdge) + tauAvgEdge(i)*edgeNormalVectors(i,iEdge)
+        enddo
+
+      enddo edgeLoop ! iEdge
+
+
+   !--------------------------------------------------------------------
+
+
+   end subroutine compute_radiation_stress_gradient!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vel_forcing_radiation_stress_init
+!
+!> \brief   Initializes ocean wave radiation stress forcing
+!> \author  Steven Brus
+!> \date    April 2019 
+!> \details
+!>  This routine initializes quantities related to wave radiation stress
+!>  in the ocean.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vel_forcing_radiation_stress_init(err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! call individual init routines for each parameterization
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      logical, pointer :: config_use_wave_radiation_stress_forcing
+
+      call mpas_pool_get_config(ocnConfigs, 'config_use_wave_radiation_stress_forcing', config_use_wave_radiation_stress_forcing)
+
+      radiationStressOn = .false.
+      if(config_use_wave_radiation_stress_forcing) radiationStressOn = .true.
+
+      err = 0
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_radiation_stress_init!}}}
+
+!***********************************************************************
+
+end module ocn_vel_forcing_radiation_stress
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_base_mesh.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config case="base_mesh">
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">150</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">1.</argument>
+			<argument flag="--npx"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_culled_mesh.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config case="culled_mesh">
+
+	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
+
+	<run_script name="run.py">
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_driver.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/build_mesh/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run.py">
+	<case name="base_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D global base mesh with jigsaw..." post_message="     complete!  Created file:  build_mesh/base_mesh.nc"/>
+	</case>
+	<case name="culled_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Culling land cells from 2D global mesh..." post_message="     complete!  Created file:  culled_mesh/culled_mesh.nc"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_analysis.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config case="analysis">
+	<add_link source_path="script_configuration_dir" source="plot_sloped_beach.py" dest="plot_sloped_beach.py"/>
+	<add_link source="../forward/output.nc" dest="output.nc"/>
+	<add_link source="../init/exact_solution.nc" dest="exact_solution.nc"/>
+
+	<run_script name="run.py">
+		<step executable="./plot_sloped_beach.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_forward.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_forward.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="input.nc"/>
+	<add_link source="../init/forcing.nc" dest="forcing.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_time_integrator">'RK4'</option>
+		<option name="config_dt">'00:00:00.1'</option>
+		<option name="config_use_wave_radiation_stress_forcing">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">input.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">input.nc</attribute>
+		</stream>
+                <stream name="forcing_data">
+                        <attribute name="filename_template">forcing.nc</attribute>
+                        <attribute name="type">input</attribute>
+                        <attribute name="input_interval">initial_only</attribute>
+                        <add_contents>
+                                <member name="waveRadiationStressXX" type="var"/>
+                                <member name="waveRadiationStressXY" type="var"/>
+                                <member name="waveRadiationStressYY" type="var"/>
+                        </add_contents>
+                </stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-00_01:00:00</attribute>
+                        <add_contents>
+                                <member name="ssh" type="var"/>
+                                <member name="kineticEnergyCell" type="var"/>
+                                <member name="waveRadiationStressXXdx" type="var"/>
+                        </add_contents>
+                        <remove_contents>
+                                <member name="tracers"/>
+                        </remove_contents>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">18</argument>
+		</step>
+
+		<model_run procs="18" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_init.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/1m/radiation_stress/config_init.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<config case="init">
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<add_link source="../../build_mesh/culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
+	<add_link source="../../build_mesh/culled_mesh/culled_graph.info" dest="graph.info"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'sloped_beach'</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_sloped_beach_vert_levels">20</option>
+		<option name="config_vertical_grid">'uniform'</option>
+		<option name="config_use_wave_radiation_stress_forcing">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="forcing_data_init">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">forcing.nc</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<add_contents>
+				<member name="waveRadiationStressXX" type="var"/>
+				<member name="waveRadiationStressXXdx" type="var"/>
+				<member name="waveRadiationStressYY" type="var"/>
+				<member name="waveRadiationStressXY" type="var"/>
+			</add_contents>
+		</stream>
+                <stream name="output_init">
+                        <attribute name="type">output</attribute>
+                        <attribute name="output_interval">0000_00:00:01</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                        <attribute name="filename_template">ocean.nc</attribute>
+                        <add_contents>
+                                <member name="input_init" type="stream"/>
+                                <member name="tracers" type="var_struct"/>
+                                <member name="refZMid" type="var"/>
+                                <member name="normalVelocity" type="var"/>
+                                <member name="layerThickness" type="var"/>
+                                <member name="restingThickness" type="var"/>
+                                <member name="refBottomDepth" type="var"/>
+                                <member name="bottomDepth" type="var"/>
+                                <member name="bottomDepthObserved" type="var"/>
+                                <member name="maxLevelCell" type="var"/>
+                                <member name="vertCoordMovementWeights" type="var"/>
+                                <member name="ssh" type="var"/>
+                        </add_contents>
+                </stream>
+	</streams>
+
+	<run_script name="run.py">
+<!--
+		<step executable="./metis">
+			<argument flag="graph.info">1</argument>
+		</step>
+-->
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_base_mesh.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<config case="base_mesh">
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">60</argument>
+			<argument flag="--ny">20</argument>
+			<argument flag="--dc">2.5</argument>
+			<argument flag="--npx"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_culled_mesh.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config case="culled_mesh">
+
+	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
+
+	<run_script name="run.py">
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_driver.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/build_mesh/config_driver.xml
@@ -1,0 +1,8 @@
+<driver_script name="run.py">
+	<case name="base_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D global base mesh with jigsaw..." post_message="     complete!  Created file:  build_mesh/base_mesh.nc"/>
+	</case>
+	<case name="culled_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Culling land cells from 2D global mesh..." post_message="     complete!  Created file:  culled_mesh/culled_mesh.nc"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_analysis.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config case="analysis">
+	<add_link source_path="script_configuration_dir" source="plot_sloped_beach.py" dest="plot_sloped_beach.py"/>
+	<add_link source="../forward/output.nc" dest="output.nc"/>
+	<add_link source="../init/exact_solution.nc" dest="exact_solution.nc"/>
+
+	<run_script name="run.py">
+		<step executable="./plot_sloped_beach.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_forward.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_forward.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="input.nc"/>
+	<add_link source="../init/forcing.nc" dest="forcing.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_time_integrator">'RK4'</option>
+		<option name="config_dt">'00:00:00.5'</option>
+		<option name="config_use_wave_radiation_stress_forcing">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">input.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">input.nc</attribute>
+		</stream>
+                <stream name="forcing_data">
+                        <attribute name="filename_template">forcing.nc</attribute>
+                        <attribute name="type">input</attribute>
+                        <attribute name="input_interval">initial_only</attribute>
+                        <add_contents>
+                                <member name="waveRadiationStressXX" type="var"/>
+                                <member name="waveRadiationStressXY" type="var"/>
+                                <member name="waveRadiationStressYY" type="var"/>
+                        </add_contents>
+                </stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<stream name="output">
+			<attribute name="output_interval">00-00-00_01:00:00</attribute>
+                        <add_contents>
+                                <member name="ssh" type="var"/>
+                                <member name="kineticEnergyCell" type="var"/>
+                                <member name="waveRadiationStressXXdx" type="var"/>
+                        </add_contents>
+                        <remove_contents>
+                                <member name="tracers"/>
+                        </remove_contents>
+		</stream>
+		<stream name="restart">
+			<attribute name="output_interval">00-00-10_00:00:00</attribute>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_init.xml
+++ b/testing_and_setup/compass/ocean/sloped_beach/2.5m/radiation_stress/config_init.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<config case="init">
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<add_link source="../../build_mesh/culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
+	<add_link source="../../build_mesh/culled_mesh/culled_graph.info" dest="graph.info"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'sloped_beach'</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_sloped_beach_vert_levels">10</option>
+		<option name="config_vertical_grid">'uniform'</option>
+		<option name="config_use_wave_radiation_stress_forcing">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="forcing_data_init">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">forcing.nc</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="output_interval">0000_00:00:00.5</attribute>
+			<add_contents>
+				<member name="waveRadiationStressXX" type="var"/>
+				<member name="waveRadiationStressXXdx" type="var"/>
+				<member name="waveRadiationStressYY" type="var"/>
+				<member name="waveRadiationStressXY" type="var"/>
+			</add_contents>
+		</stream>
+                <stream name="output_init">
+                        <attribute name="type">output</attribute>
+                        <attribute name="output_interval">0000_00:00:01</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                        <attribute name="filename_template">ocean.nc</attribute>
+                        <add_contents>
+                                <member name="input_init" type="stream"/>
+                                <member name="tracers" type="var_struct"/>
+                                <member name="refZMid" type="var"/>
+                                <member name="normalVelocity" type="var"/>
+                                <member name="layerThickness" type="var"/>
+                                <member name="restingThickness" type="var"/>
+                                <member name="refBottomDepth" type="var"/>
+                                <member name="bottomDepth" type="var"/>
+                                <member name="bottomDepthObserved" type="var"/>
+                                <member name="maxLevelCell" type="var"/>
+                                <member name="vertCoordMovementWeights" type="var"/>
+                                <member name="ssh" type="var"/>
+                        </add_contents>
+                </stream>
+                <stream name="exact_solution">
+                        <attribute name="type">output</attribute>
+                        <attribute name="output_interval">0000_00:00:01</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                        <attribute name="filename_template">exact_solution.nc</attribute>
+                        <add_contents>
+                                <member name="xTransect" type="var"/>
+                                <member name="sshExact" type="var"/>
+                        </add_contents>
+                </stream>
+	</streams>
+
+	<run_script name="run.py">
+<!--
+		<step executable="./metis">
+			<argument flag="graph.info">1</argument>
+		</step>
+-->
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/sloped_beach/plot_sloped_beach.py
+++ b/testing_and_setup/compass/ocean/sloped_beach/plot_sloped_beach.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import numpy as np
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+from scipy import spatial
+from scipy import interpolate
+plt.switch_backend('agg')
+
+# Read exact solution from init mode
+nc_fid = Dataset("exact_solution.nc", "r")
+x = nc_fid.variables["xTransect"][:]
+y = np.copy(x)*0.0 + 25.0
+ssh_exact = nc_fid.variables["sshExact"][:]
+nc_fid.close()
+
+# Read MPAS-O solution from forward mode
+nc_fid = Dataset("output.nc", "r")
+xCell = nc_fid.variables["xCell"][:]
+yCell = nc_fid.variables["yCell"][:]
+ssh = nc_fid.variables["ssh"][:]
+nc_fid.close()
+
+# Interpolate MPAS-O solution onto exact solution transect
+xyCell = np.vstack((xCell,yCell)).T
+interp = interpolate.LinearNDInterpolator(xyCell,ssh[-1,:])
+xy = np.vstack((x,y)).T
+ssh_mpas = interp(xy)
+
+# Plot comparison
+fig = plt.figure(figsize=(15,5))
+l1, = plt.plot(x,ssh_exact)
+l2, = plt.plot(x,ssh_mpas)
+plt.xlabel('x')
+plt.ylabel('sea surface height')
+plt.legend((l1,l2),('exact solution','MPAS-Ocean'))
+plt.tight_layout()
+plt.savefig('ssh_comparison.png',bbox_inches='tight')
+plt.close()
+
+

--- a/testing_and_setup/compass/ocean/sloped_beach/radiation_stress_testcase.py
+++ b/testing_and_setup/compass/ocean/sloped_beach/radiation_stress_testcase.py
@@ -1,0 +1,152 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Physical constants
+g = 9.81
+rho = 997.0
+
+# Solve for the wavenumber, k, using the linear dispersion relationship:
+#    sigma**2 = gk*tanh(kh)
+# given the period, T, and depth, h.
+def wavenumber(T,h):
+  
+  # Period to frequency
+  sigma = 2.0*np.pi/T
+
+  # Initial guess
+  k = sigma**2.0/(g*np.sqrt(np.tanh(sigma**2*h/g)))
+  
+  # Newton's method to solve for k
+  maxit = 100  
+  tol = 1e-8
+  for it in range(maxit):
+    
+    kh = np.multiply(k,h)
+    f = g*np.multiply(k,np.tanh(kh))-sigma**2
+    fp = g*np.tanh(kh)+g*np.multiply(kh,1.0-np.square(np.tanh(kh)))
+    knew = k - np.divide(f,fp)
+
+    if np.amax(np.absolute(knew-k)) < tol:
+      print it
+      break
+    k = knew
+
+  return knew
+
+def plot_rad_stress(X,Y,var,name):
+
+  fig = plt.figure()
+  ax = fig.add_subplot(2,1,1)
+  if np.amin(var) != np.amax(var):
+    levels = np.linspace(np.amin(var),np.amax(var),100)
+    cf = ax.contourf(X,Y,var,levels=levels)
+  else:
+    cf = ax.contourf(X,Y,var)
+  plt.colorbar(cf,ax=ax,orientation='horizontal')
+  ax.axis('image')
+  ax.set_title(name)
+  ax.set_xlabel('x (m)')
+  ax.set_ylabel('y (m)')
+  ax = fig.add_subplot(2,1,2)
+  ax.plot(X[0,:],var[0,:])
+  ax.set_xlabel('x (m)')
+  ax.set_ylabel(name)
+  plt.tight_layout()
+  plt.savefig(name+'.png',bbox_inches='tight')
+  plt.close()
+
+if __name__ == '__main__':
+
+  # Domain parameters
+  Lx  =150
+  Ly = 50
+  nx = 150
+  ny = 50
+  h0 = 2.1
+  
+  # Initialize domain coordinates
+  x = np.linspace(0,Lx,nx)
+  y = np.linspace(0,Ly,ny)
+  X,Y = np.meshgrid(x,y)
+  
+  # Initialize bathymetry
+  Z = np.zeros(X.shape)
+  Z = (1.0/40.0)*X + .1
+  idx = np.where(X >= 80)
+  Z[idx] = h0
+  
+  # Plot bathymetry
+  plt.figure()
+  plt.contourf(X,Y,Z)
+  plt.colorbar(orientation='horizontal')
+  plt.axis('image')
+  plt.title('depth')
+  plt.xlabel('x (m)')
+  plt.ylabel('y (m)')
+  plt.savefig('h.png',bbox_inches='tight')
+  
+  # Wave parameters
+  H0 = 0.6
+  T = 5.0
+  gamma = .78
+  theta = 0.0
+  h = Z
+  sigma = 2.0*np.pi/T
+  
+  # Calculate radiation stress
+  k0 = wavenumber(T,h0)
+  n0 = 0.5*(1 + (2.0*k0*h0)/np.sinh(2.0*k0*h0))
+  Cg0 = n0*sigma/k0
+  k = wavenumber(T,h)
+  kh = np.multiply(k,h)
+  n = 0.5*(1.0 + np.divide((2.0*kh),np.sinh(2.0*kh)))
+  C = sigma/k
+  Cg = np.multiply(n,C)
+  H = H0*np.sqrt(Cg0/Cg) # Assumes Kr=1
+  hb = np.minimum(gamma*h,H)
+  E = (1.0/8.0)*rho*g*hb**2
+  Sxx = np.multiply(E,(n*(np.cos(theta)**2 + 1.0) - 0.5))
+  Syy = np.multiply(E,(n*(np.sin(theta)**2 + 1.0) - 0.5))
+  Sxy = 0.5*np.multiply(E,n*(np.sin(2.0*theta)))
+  
+  # x-dervative of bathymetry
+  dhdx = np.zeros(X.shape)
+  idx = np.where(X <= 80.0)
+  dhdx[idx] = 1.0/40.0
+  
+  # x-derivative of wavenumber
+  dkdx = -np.multiply(np.square(k),dhdx)
+  denom = np.multiply(np.square(np.cosh(kh)),np.tanh(kh)) + kh
+  dkdx = np.divide(dkdx,denom)
+  
+  # x-derivative of n
+  fac = np.multiply(dkdx,h) + np.multiply(k,dhdx)
+  dndx = np.multiply(fac,np.sinh(kh)-np.multiply(kh,np.cosh(kh)))
+  dndx = np.divide(dndx,np.square(np.sinh(kh)))
+  
+  # x-derivative of energy
+  f = np.divide(n0/k0*k,n)
+  dfdx = n0/k0*np.divide(np.multiply(dkdx,n) - np.multiply(dndx,k),np.square(n))
+  dHdx = np.multiply(0.5*H0/np.sqrt(f),dfdx)
+  idx = np.where(h <= H/gamma)
+  dHdx[idx] = gamma*(1.0/40.0)
+  dEdx = .25*rho*g*np.multiply(hb,dHdx)
+  
+  # Derivative of radation stress
+  dSxxdx = np.multiply(dEdx,n*(np.cos(theta)**2 + 1.0) - 0.5) + np.multiply(E,dndx*(np.cos(theta)**2 + 1.0))
+  
+  # Plot radiation stress
+  plot_rad_stress(X,Y,hb,'hb')
+  plot_rad_stress(X,Y,Sxx,'Sxx')
+  plot_rad_stress(X,Y,Syy,'Syy')
+  plot_rad_stress(X,Y,Sxy,'Sxy')
+  plot_rad_stress(X,Y,dSxxdx,'dSxxdx')
+  
+  fig = plt.figure()
+  plt.plot(X[0,:],dSxxdx[0,:])
+  dx = x[1]-x[0]
+  dSxxdx_approx = (Sxx[:,1:]-Sxx[:,:-1])/dx
+  plt.plot(X[0,:-1],dSxxdx_approx[0,:])
+  plt.tight_layout()
+  plt.savefig('check_deriv.png',bbox_inches='tight')
+  plt.close()


### PR DESCRIPTION
 - Radiation stress gradients are calculated on edges from cell-centered
   values (test still needed for spherical mesh).

- Sloped beach test case configuration from Chou et al., Computers & Geosciences, 58 (2015) and Sheng and Liu, JGR-Oceans ,116 (2011).

 - Test case imposes an analytical radiation stress forcing  (time-ramped) based on wave theory and integrates to steady-state.

