### PR TITLE
Updates to hurricane test case

### DIFF
--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_base_mesh.xml
@@ -3,7 +3,6 @@
 
         <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
         <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.m" dest="jigsaw_driver.m"/>
-        <add_link source_path="jigsaw-geo-matlab" source="." dest="jigsaw-geo-matlab"/>
         <add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
         <add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/sandy/config_forward.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/sandy/config_forward.xml
@@ -11,8 +11,8 @@
 		<option name="config_run_duration">'none'</option>
 
 		<option name="config_time_integrator">'split_explicit'</option>
-		<option name="config_dt">'00:00:30'</option>
-		<option name="config_btr_dt">'0000_00:00:03'</option>
+		<option name="config_dt">'00:00:40'</option>
+		<option name="config_btr_dt">'0000_00:00:04'</option>
 <!--
 		<option name="config_dt">'00:00:05'</option>
 		<option name="config_time_integrator">'RK4'</option>
@@ -20,8 +20,11 @@
 		<option name="config_hmix_scaleWithMesh">.true.</option>
 		<option name="config_mom_del4">4.0e8</option>
 		<option name="config_use_mom_del4">.true.</option>
+		<option name="config_ALE_thickness_proportionality">'weights_only'</option>
 		<option name="config_vert_coord_movement">'uniform_stretching'</option>
                 <option name="config_use_bulk_wind_stress">.true.</option>
+                <option name="config_use_const_visc">.true.</option>
+                <option name="config_vert_visc">1.0e4</option>
                 <option name="config_use_time_varying_atmospheric_forcing">.true.</option>
                 <option name="config_time_varying_atmospheric_forcing_start_time">'2012-10-01_00:00:00'</option>
                 <option name="config_time_varying_atmospheric_forcing_reference_time">'2012-10-01_00:00:00'</option>


### PR DESCRIPTION
Most important change is turning on constant vertical mixing and setting it equal to 1e4. This depth averages the water column, resulting in improved stability and a better validation results against water level gauge data from Hurricane Sandy.

The split-explicit time-step is also increased to 40/4 seconds from 30/3.
