### PR TITLE
Pool memory leak

### DIFF
--- a/src/framework/mpas_field_routines.F
+++ b/src/framework/mpas_field_routines.F
@@ -1388,43 +1388,65 @@ module mpas_field_routines
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0d_logical
+!  routine mpas_deallocate_field0D_logical
 !
-!> \brief   MPAS 0D logical deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 0D int deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 0D logical field.
+!>  This routine deallocates a 0D int field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_logical(f)!{{{
-       type (field0dLogical), pointer :: f !< Input: Field to deallocate
-       type (field0dLogical), pointer :: f_cursor
+   subroutine mpas_deallocate_field0d_logical(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field0dLogical), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field0dLogical), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
-   
-       if ( threadNum == 0 ) then
-          f_cursor => f
-   
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
 
-            deallocate(f_cursor)
-            f_cursor => f
-          end do
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
+       if ( threadNum == 0 ) then
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
+
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field0d_logical!}}}
@@ -1432,43 +1454,65 @@ module mpas_field_routines
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0d_integer
+!  routine mpas_deallocate_field0D_integer
 !
-!> \brief   MPAS 0D integer deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 0D int deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 0D integer field.
+!>  This routine deallocates a 0D int field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_integer(f)!{{{
-       type (field0dInteger), pointer :: f !< Input: Field to deallocate
-       type (field0dInteger), pointer :: f_cursor
+   subroutine mpas_deallocate_field0d_integer(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field0dInteger), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field0dInteger), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
-   
-       if ( threadNum == 0 ) then
-          f_cursor => f
-   
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
 
-            deallocate(f_cursor)
-            f_cursor => f
-          end do
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
+       if ( threadNum == 0 ) then
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
+
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field0d_integer!}}}
@@ -1478,45 +1522,67 @@ module mpas_field_routines
 !
 !  routine mpas_deallocate_field1D_integer
 !
-!> \brief   MPAS 1D integer deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 1D int deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 1D integer field.
+!>  This routine deallocates a 1D int field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_integer(f)!{{{
-       type (field1dInteger), pointer :: f !< Input: Field to deallocate
-       type (field1dInteger), pointer :: f_cursor
+   subroutine mpas_deallocate_field1d_integer(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field1dInteger), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field1dInteger), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
-       if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
 
-            deallocate(f_cursor)
-   
-            f_cursor => f
-          end do
+       if ( threadNum == 0 ) then
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
+
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
+
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field1d_integer!}}}
@@ -1526,45 +1592,67 @@ module mpas_field_routines
 !
 !  routine mpas_deallocate_field2D_integer
 !
-!> \brief   MPAS 2D integer deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 2D int deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 2D integer field.
+!>  This routine deallocates a 2D int field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field2d_integer(f)!{{{
-       type (field2dInteger), pointer :: f !< Input: Field to deallocate
-       type (field2dInteger), pointer :: f_cursor
+   subroutine mpas_deallocate_field2d_integer(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field2dInteger), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field2dInteger), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
-       if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
 
-            deallocate(f_cursor)
-   
-            f_cursor => f
-          end do
+       if ( threadNum == 0 ) then
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
+
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
+
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field2d_integer!}}}
@@ -1574,45 +1662,67 @@ module mpas_field_routines
 !
 !  routine mpas_deallocate_field3D_integer
 !
-!> \brief   MPAS 3D integer deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 3D int deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 3D integer field.
+!>  This routine deallocates a 3D int field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field3d_integer(f)!{{{
-       type (field3dInteger), pointer :: f !< Input: Field to deallocate
-       type (field3dInteger), pointer :: f_cursor
+   subroutine mpas_deallocate_field3d_integer(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field3dInteger), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field3dInteger), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
-       if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
 
-            deallocate(f_cursor)
-   
-            f_cursor => f
-          end do
+       if ( threadNum == 0 ) then
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
+
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
+
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field3d_integer!}}}
@@ -1620,44 +1730,65 @@ module mpas_field_routines
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0d_real
+!  routine mpas_deallocate_field0D_real
 !
 !> \brief   MPAS 0D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 0D real field.
+!>  This routine deallocates a 0D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_real(f)!{{{
-       type (field0dReal), pointer :: f !< Input: Field to deallocate
-       type (field0dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field0d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field0dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field0dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
-       f_cursor => f
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
 
        if ( threadNum == 0 ) then
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
-   
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            deallocate(f_cursor)
-   
-            f_cursor => f
-          end do
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
+
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
+
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field0d_real!}}}
@@ -1668,44 +1799,66 @@ module mpas_field_routines
 !  routine mpas_deallocate_field1D_real
 !
 !> \brief   MPAS 1D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 1D real field.
+!>  This routine deallocates a 1D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_real(f)!{{{
-       type (field1dReal), pointer :: f !< Input: Field to deallocate
-       type (field1dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field1d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field1dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field1dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field1d_real!}}}
@@ -1716,44 +1869,66 @@ module mpas_field_routines
 !  routine mpas_deallocate_field2D_real
 !
 !> \brief   MPAS 2D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 2D real field.
+!>  This routine deallocates a 2D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field2d_real(f)!{{{
-       type (field2dReal), pointer :: f !< Input: Field to deallocate
-       type (field2dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field2d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field2dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field2dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field2d_real!}}}
@@ -1764,44 +1939,66 @@ module mpas_field_routines
 !  routine mpas_deallocate_field3D_real
 !
 !> \brief   MPAS 3D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 3D real field.
+!>  This routine deallocates a 3D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field3d_real(f)!{{{
-       type (field3dReal), pointer :: f !< Input: Field to deallocate
-       type (field3dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field3d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field3dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field3dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field3d_real!}}}
@@ -1812,44 +2009,66 @@ module mpas_field_routines
 !  routine mpas_deallocate_field4D_real
 !
 !> \brief   MPAS 4D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 4D real field.
+!>  This routine deallocates a 4D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field4d_real(f)!{{{
-       type (field4dReal), pointer :: f !< Input: Field to deallocate
-       type (field4dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field4d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field4dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field4dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field4d_real!}}}
@@ -1860,44 +2079,66 @@ module mpas_field_routines
 !  routine mpas_deallocate_field5D_real
 !
 !> \brief   MPAS 5D real deallocation routine.
-!> \author  Doug Jacobsen
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 5D real field.
+!>  This routine deallocates a 5D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field5d_real(f)!{{{
-       type (field5dReal), pointer :: f !< Input: Field to deallocate
-       type (field5dReal), pointer :: f_cursor
+   subroutine mpas_deallocate_field5d_real(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field5dReal), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field5dReal), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field5d_real!}}}
@@ -1907,41 +2148,63 @@ module mpas_field_routines
 !
 !  routine mpas_deallocate_field0D_char
 !
-!> \brief   MPAS 0D character deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 0D real deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 0D character field.
+!>  This routine deallocates a 0D real field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_char(f)!{{{
-       type (field0dChar), pointer :: f !< Input: Field to deallocate
-       type (field0dChar), pointer :: f_cursor
+   subroutine mpas_deallocate_field0d_char(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field0dChar), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field0dChar), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            deallocate(f_cursor)
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field0d_char!}}}
@@ -1951,45 +2214,67 @@ module mpas_field_routines
 !
 !  routine mpas_deallocate_field1D_char
 !
-!> \brief   MPAS 1D character deallocation routine.
-!> \author  Doug Jacobsen
+!> \brief   MPAS 1D char deallocation routine.
+!> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!> This routine deallocates a 1D character field.
+!>  This routine deallocates a 1D char field. If the optional argument
+!>  keep_head_ptr is .true., the field type pointed to by f will not be
+!>  deallocated -- only the contents (array, attLists, constituentNames)
+!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  for all blocks other than the first (including the field types themselves)
+!>  will be deallocated.
+!>
+!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_char(f)!{{{
-       type (field1dChar), pointer :: f !< Input: Field to deallocate
-       type (field1dChar), pointer :: f_cursor
+   subroutine mpas_deallocate_field1d_char(f, keep_head_ptr)!{{{
+
+       implicit none
+
+       type (field1dChar), target :: f !< Input: Field to deallocate
+       logical, intent(in), optional :: keep_head_ptr
+
+       type (field1dChar), pointer :: f_cursor, f_next
+       logical :: local_keep_head_ptr
        integer :: threadNum
        integer :: i, iErr
 
        threadNum = mpas_threading_get_thread_num()
 
+       if (present(keep_head_ptr)) then
+           local_keep_head_ptr = keep_head_ptr
+       else
+           local_keep_head_ptr = .false.
+       end if
+
        if ( threadNum == 0 ) then
-          f_cursor => f
-          do while(associated(f_cursor))
-            if(associated(f % next)) then
-              f => f % next
-            else
-              nullify(f)
-            end if
+           f_cursor => f
+           do while(associated(f_cursor))
+               f_next => f_cursor % next
 
-            if(associated(f_cursor % array)) then
-              deallocate(f_cursor % array)
-            end if
+               if (associated(f_cursor % array)) then
+                   deallocate(f_cursor % array)
+               end if
 
-            if ( associated(f_cursor % attLists) ) then
-               do i = 1, size(f_cursor % attLists, dim=1)
-                  call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
-               end do
-               deallocate(f_cursor % attLists)
-            end if
+               if (associated(f_cursor % attLists)) then
+                   do i = 1, size(f_cursor % attLists, dim=1)
+                       call mpas_deallocate_attlist(f_cursor % attLists(i) % attList, iErr)
+                   end do
+                   deallocate(f_cursor % attLists)
+               end if
 
-            deallocate(f_cursor)
+               if (associated(f_cursor % constituentNames)) then
+                   deallocate(f_cursor % constituentNames)
+               end if
 
-            f_cursor => f
-          end do
+               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+                   deallocate(f_cursor)
+               end if
+
+               f_cursor => f_next
+           end do
        end if
 
    end subroutine mpas_deallocate_field1d_char!}}}

--- a/src/framework/mpas_field_routines.F
+++ b/src/framework/mpas_field_routines.F
@@ -1394,14 +1394,12 @@ module mpas_field_routines
 !> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
-!>  This routine deallocates a 0D int field. If the optional argument
+!>  This routine deallocates a 0D logical field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1441,7 +1439,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1463,11 +1461,9 @@ module mpas_field_routines
 !>  This routine deallocates a 0D int field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1507,7 +1503,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1529,11 +1525,9 @@ module mpas_field_routines
 !>  This routine deallocates a 1D int field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1577,7 +1571,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1599,11 +1593,11 @@ module mpas_field_routines
 !>  This routine deallocates a 2D int field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  will be deallocated.
 !>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1647,7 +1641,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1669,11 +1663,9 @@ module mpas_field_routines
 !>  This routine deallocates a 3D int field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1717,7 +1709,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1739,11 +1731,9 @@ module mpas_field_routines
 !>  This routine deallocates a 0D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1783,7 +1773,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1805,11 +1795,9 @@ module mpas_field_routines
 !>  This routine deallocates a 1D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1853,7 +1841,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1875,11 +1863,9 @@ module mpas_field_routines
 !>  This routine deallocates a 2D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1923,7 +1909,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -1945,11 +1931,11 @@ module mpas_field_routines
 !>  This routine deallocates a 3D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
+!>  will be deallocated.
 !>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -1993,7 +1979,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -2015,11 +2001,9 @@ module mpas_field_routines
 !>  This routine deallocates a 4D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -2063,7 +2047,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -2085,11 +2069,9 @@ module mpas_field_routines
 !>  This routine deallocates a 5D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -2133,7 +2115,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -2155,11 +2137,9 @@ module mpas_field_routines
 !>  This routine deallocates a 0D real field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -2199,7 +2179,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 
@@ -2221,11 +2201,9 @@ module mpas_field_routines
 !>  This routine deallocates a 1D char field. If the optional argument
 !>  keep_head_ptr is .true., the field type pointed to by f will not be
 !>  deallocated -- only the contents (array, attLists, constituentNames)
-!>  will be deallocated. If the field contains multiple blocks, all memory
-!>  for all blocks other than the first (including the field types themselves)
 !>  will be deallocated.
 !>
-!>  The principal use fo rthe keep_head_ptr argument is for situations in
+!>  The principal use for the keep_head_ptr argument is for situations in
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
@@ -2269,7 +2247,7 @@ module mpas_field_routines
                    deallocate(f_cursor % constituentNames)
                end if
 
-               if ((.not. local_keep_head_ptr) .or. (.not. associated(f_cursor, f))) then
+               if (.not. local_keep_head_ptr) then
                    deallocate(f_cursor)
                end if
 

--- a/src/framework/mpas_field_routines.F
+++ b/src/framework/mpas_field_routines.F
@@ -108,6 +108,22 @@ module mpas_field_routines
       module procedure mpas_deallocate_field1d_char
    end interface
 
+   interface mpas_deallocate_field_target
+      module procedure mpas_deallocate_field0d_logical_target
+      module procedure mpas_deallocate_field0d_integer_target
+      module procedure mpas_deallocate_field1d_integer_target
+      module procedure mpas_deallocate_field2d_integer_target
+      module procedure mpas_deallocate_field3d_integer_target
+      module procedure mpas_deallocate_field0d_real_target
+      module procedure mpas_deallocate_field1d_real_target
+      module procedure mpas_deallocate_field2d_real_target
+      module procedure mpas_deallocate_field3d_real_target
+      module procedure mpas_deallocate_field4d_real_target
+      module procedure mpas_deallocate_field5d_real_target
+      module procedure mpas_deallocate_field0d_char_target
+      module procedure mpas_deallocate_field1d_char_target
+   end interface
+
    contains
 
 !***********************************************************************
@@ -1391,6 +1407,396 @@ module mpas_field_routines
 !  routine mpas_deallocate_field0D_logical
 !
 !> \brief   MPAS 0D int deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 0-d logical field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field0d_logical(f)!{{{
+
+       implicit none
+
+       type (field0dLogical), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field0d_logical!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field0D_integer
+!
+!> \brief   MPAS 0D int deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 0-d integer field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field0d_integer(f)!{{{
+
+       implicit none
+
+       type (field0dInteger), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field0d_integer!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field1D_integer
+!
+!> \brief   MPAS 1D int deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 1-d integer field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field1d_integer(f)!{{{
+
+       implicit none
+
+       type (field1dInteger), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field1d_integer!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field2D_integer
+!
+!> \brief   MPAS 2D int deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 2-d integer field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field2d_integer(f)!{{{
+
+       implicit none
+
+       type (field2dInteger), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field2d_integer!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field3D_integer
+!
+!> \brief   MPAS 3D int deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 3-d integer field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field3d_integer(f)!{{{
+
+       implicit none
+
+       type (field3dInteger), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field3d_integer!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field0D_real
+!
+!> \brief   MPAS 0D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 0-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field0d_real(f)!{{{
+
+       implicit none
+
+       type (field0dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field0d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field1D_real
+!
+!> \brief   MPAS 1D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 1-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field1d_real(f)!{{{
+
+       implicit none
+
+       type (field1dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field1d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field2D_real
+!
+!> \brief   MPAS 2D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 2-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field2d_real(f)!{{{
+
+       implicit none
+
+       type (field2dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field2d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field3D_real
+!
+!> \brief   MPAS 3D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 3-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field3d_real(f)!{{{
+
+       implicit none
+
+       type (field3dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field3d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field4D_real
+!
+!> \brief   MPAS 4D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 4-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field4d_real(f)!{{{
+
+       implicit none
+
+       type (field4dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field4d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field5D_real
+!
+!> \brief   MPAS 5D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 5-d real field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field5d_real(f)!{{{
+
+       implicit none
+
+       type (field5dReal), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field5d_real!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field0D_char
+!
+!> \brief   MPAS 0D real deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 0-d character field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field0d_char(f)!{{{
+
+       implicit none
+
+       type (field0dChar), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field0d_char!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field1D_char
+!
+!> \brief   MPAS 1D char deallocation routine.
+!> \author  Michael G. Duda
+!> \date    4 November 2019
+!> \details 
+!>  This routine deallocates a 1-d character field. Upon return, all memory
+!>  that is uniquely associated with the field pointed to by f
+!>  (i.e., array storage, attribute lists, constitutent names; *not* sendList,
+!>  recvList, block, etc. that are potentially referenced by other fields)
+!>  will have been freed, and the input pointer will be nullified.
+!>
+!>  For fields that are elements of an array of fields, do not use this
+!>  routine, and instead use mpas_deallocate_field_target.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_deallocate_field1d_char(f)!{{{
+
+       implicit none
+
+       type (field1dChar), pointer :: f !< Input: Field to deallocate
+
+       call mpas_deallocate_field_target(f, keep_head_ptr=.false.)
+       nullify(f)
+
+   end subroutine mpas_deallocate_field1d_char!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_deallocate_field0D_logical_target
+!
+!> \brief   MPAS 0D int deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
 !> \date    04/02/13
 !> \details 
@@ -1403,7 +1809,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_logical(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field0d_logical_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1447,12 +1853,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field0d_logical!}}}
+   end subroutine mpas_deallocate_field0d_logical_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0D_integer
+!  routine mpas_deallocate_field0D_integer_target
 !
 !> \brief   MPAS 0D int deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1467,7 +1873,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_integer(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field0d_integer_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1511,12 +1917,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field0d_integer!}}}
+   end subroutine mpas_deallocate_field0d_integer_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field1D_integer
+!  routine mpas_deallocate_field1D_integer_target
 !
 !> \brief   MPAS 1D int deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1531,7 +1937,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_integer(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field1d_integer_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1579,12 +1985,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field1d_integer!}}}
+   end subroutine mpas_deallocate_field1d_integer_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field2D_integer
+!  routine mpas_deallocate_field2D_integer_target
 !
 !> \brief   MPAS 2D int deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1601,7 +2007,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field2d_integer(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field2d_integer_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1649,12 +2055,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field2d_integer!}}}
+   end subroutine mpas_deallocate_field2d_integer_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field3D_integer
+!  routine mpas_deallocate_field3D_integer_target
 !
 !> \brief   MPAS 3D int deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1669,7 +2075,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field3d_integer(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field3d_integer_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1717,12 +2123,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field3d_integer!}}}
+   end subroutine mpas_deallocate_field3d_integer_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0D_real
+!  routine mpas_deallocate_field0D_real_target
 !
 !> \brief   MPAS 0D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1737,7 +2143,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field0d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1781,12 +2187,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field0d_real!}}}
+   end subroutine mpas_deallocate_field0d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field1D_real
+!  routine mpas_deallocate_field1D_real_target
 !
 !> \brief   MPAS 1D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1801,7 +2207,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field1d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1849,12 +2255,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field1d_real!}}}
+   end subroutine mpas_deallocate_field1d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field2D_real
+!  routine mpas_deallocate_field2D_real_target
 !
 !> \brief   MPAS 2D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1869,7 +2275,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field2d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field2d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1917,12 +2323,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field2d_real!}}}
+   end subroutine mpas_deallocate_field2d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field3D_real
+!  routine mpas_deallocate_field3D_real_target
 !
 !> \brief   MPAS 3D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -1939,7 +2345,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field3d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field3d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -1987,12 +2393,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field3d_real!}}}
+   end subroutine mpas_deallocate_field3d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field4D_real
+!  routine mpas_deallocate_field4D_real_target
 !
 !> \brief   MPAS 4D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -2007,7 +2413,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field4d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field4d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -2055,12 +2461,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field4d_real!}}}
+   end subroutine mpas_deallocate_field4d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field5D_real
+!  routine mpas_deallocate_field5D_real_target
 !
 !> \brief   MPAS 5D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -2075,7 +2481,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field5d_real(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field5d_real_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -2123,12 +2529,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field5d_real!}}}
+   end subroutine mpas_deallocate_field5d_real_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field0D_char
+!  routine mpas_deallocate_field0D_char_target
 !
 !> \brief   MPAS 0D real deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -2143,7 +2549,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field0d_char(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field0d_char_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -2187,12 +2593,12 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field0d_char!}}}
+   end subroutine mpas_deallocate_field0d_char_target!}}}
 
 
 !***********************************************************************
 !
-!  routine mpas_deallocate_field1D_char
+!  routine mpas_deallocate_field1D_char_target
 !
 !> \brief   MPAS 1D char deallocation routine.
 !> \author  Doug Jacobsen, Michael G. Duda
@@ -2207,7 +2613,7 @@ module mpas_field_routines
 !>  which elemements of an array of fields need to be deallocated.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_deallocate_field1d_char(f, keep_head_ptr)!{{{
+   subroutine mpas_deallocate_field1d_char_target(f, keep_head_ptr)!{{{
 
        implicit none
 
@@ -2255,7 +2661,7 @@ module mpas_field_routines
            end do
        end if
 
-   end subroutine mpas_deallocate_field1d_char!}}}
+   end subroutine mpas_deallocate_field1d_char_target!}}}
 
 
 !***********************************************************************

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -276,67 +276,67 @@ module mpas_pool_routines
                      call mpas_deallocate_field(dptr % l0)
                   else if (associated(dptr % r0a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r0a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r0a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r0a, stat=local_err)
                   else if (associated(dptr % r1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r1a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r1a, stat=local_err)
                   else if (associated(dptr % r2a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r2a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r2a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r2a, stat=local_err)
                   else if (associated(dptr % r3a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r3a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r3a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r3a, stat=local_err)
                   else if (associated(dptr % r4a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r4a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r4a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r4a, stat=local_err)
                   else if (associated(dptr % r5a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % r5a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % r5a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r5a, stat=local_err)
                   else if (associated(dptr % i0a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % i0a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % i0a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i0a, stat=local_err)
                   else if (associated(dptr % i1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % i1a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % i1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i1a, stat=local_err)
                   else if (associated(dptr % i2a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % i2a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % i2a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i2a, stat=local_err)
                   else if (associated(dptr % i3a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % i3a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % i3a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i3a, stat=local_err)
                   else if (associated(dptr % c0a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % c0a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % c0a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % c0a, stat=local_err)
                   else if (associated(dptr % c1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % c1a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % c1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % c1a, stat=local_err)
                   else if (associated(dptr % l0a)) then
                      do j=1,dptr % contentsTimeLevs
-                        call mpas_deallocate_field(dptr % l0a(j), keep_head_ptr=.true.)
+                        call mpas_deallocate_field_target(dptr % l0a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % l0a, stat=local_err)
                   else

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -1819,7 +1819,7 @@ module mpas_pool_routines
                      end if
                   else if (poolItr % nDims == 4) then
                      if (poolItr % nTimeLevels > 1) then
-                        decompType = pool_get_member_decomp_type(poolMem % r4 % dimNames(4))
+                        decompType = pool_get_member_decomp_type(poolMem % r4a(1) % dimNames(4))
 
                         if (decompType == MPAS_DECOMP_CELLS) then
                            do i = 1, poolItr % nTimeLevels

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -249,31 +249,44 @@ module mpas_pool_routines
    
                   ! Do this through brute force...
                   if (associated(dptr % r0)) then
-                     call mpas_deallocate_field(dptr % r0)
+                     call mpas_deallocate_field_target(dptr % r0, keep_head_ptr=.true.)
+                     deallocate(dptr % r0)
                   else if (associated(dptr % r1)) then
-                     call mpas_deallocate_field(dptr % r1)
+                     call mpas_deallocate_field_target(dptr % r1, keep_head_ptr=.true.)
+                     deallocate(dptr % r1)
                   else if (associated(dptr % r2)) then
-                     call mpas_deallocate_field(dptr % r2)
+                     call mpas_deallocate_field_target(dptr % r2, keep_head_ptr=.true.)
+                     deallocate(dptr % r2)
                   else if (associated(dptr % r3)) then
-                     call mpas_deallocate_field(dptr % r3)
+                     call mpas_deallocate_field_target(dptr % r3, keep_head_ptr=.true.)
+                     deallocate(dptr % r3)
                   else if (associated(dptr % r4)) then
-                     call mpas_deallocate_field(dptr % r4)
+                     call mpas_deallocate_field_target(dptr % r4, keep_head_ptr=.true.)
+                     deallocate(dptr % r4)
                   else if (associated(dptr % r5)) then
-                     call mpas_deallocate_field(dptr % r5)
+                     call mpas_deallocate_field_target(dptr % r5, keep_head_ptr=.true.)
+                     deallocate(dptr % r5)
                   else if (associated(dptr % i0)) then
-                     call mpas_deallocate_field(dptr % i0)
+                     call mpas_deallocate_field_target(dptr % i0, keep_head_ptr=.true.)
+                     deallocate(dptr % i0)
                   else if (associated(dptr % i1)) then
-                     call mpas_deallocate_field(dptr % i1)
+                     call mpas_deallocate_field_target(dptr % i1, keep_head_ptr=.true.)
+                     deallocate(dptr % i1)
                   else if (associated(dptr % i2)) then
-                     call mpas_deallocate_field(dptr % i2)
+                     call mpas_deallocate_field_target(dptr % i2, keep_head_ptr=.true.)
+                     deallocate(dptr % i2)
                   else if (associated(dptr % i3)) then
-                     call mpas_deallocate_field(dptr % i3)
+                     call mpas_deallocate_field_target(dptr % i3, keep_head_ptr=.true.)
+                     deallocate(dptr % i3)
                   else if (associated(dptr % c0)) then
-                     call mpas_deallocate_field(dptr % c0)
+                     call mpas_deallocate_field_target(dptr % c0, keep_head_ptr=.true.)
+                     deallocate(dptr % c0)
                   else if (associated(dptr % c1)) then
-                     call mpas_deallocate_field(dptr % c1)
+                     call mpas_deallocate_field_target(dptr % c1, keep_head_ptr=.true.)
+                     deallocate(dptr % c1)
                   else if (associated(dptr % l0)) then
-                     call mpas_deallocate_field(dptr % l0)
+                     call mpas_deallocate_field_target(dptr % l0, keep_head_ptr=.true.)
+                     deallocate(dptr % l0)
                   else if (associated(dptr % r0a)) then
                      do j=1,dptr % contentsTimeLevs
                         call mpas_deallocate_field_target(dptr % r0a(j), keep_head_ptr=.true.)

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -249,137 +249,95 @@ module mpas_pool_routines
    
                   ! Do this through brute force...
                   if (associated(dptr % r0)) then
-                     deallocate(dptr % r0, stat=local_err)
+                     call mpas_deallocate_field(dptr % r0)
                   else if (associated(dptr % r1)) then
-                     if (associated(dptr % r1 % array)) then
-                        deallocate(dptr % r1 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % r1, stat=local_err)
+                     call mpas_deallocate_field(dptr % r1)
                   else if (associated(dptr % r2)) then
-                     if (associated(dptr % r2 % array)) then
-                        deallocate(dptr % r2 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % r2, stat=local_err)
+                     call mpas_deallocate_field(dptr % r2)
                   else if (associated(dptr % r3)) then
-                     if (associated(dptr % r3 % array)) then
-                        deallocate(dptr % r3 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % r3, stat=local_err)
+                     call mpas_deallocate_field(dptr % r3)
                   else if (associated(dptr % r4)) then
-                     if (associated(dptr % r4 % array)) then
-                        deallocate(dptr % r4 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % r4, stat=local_err)
+                     call mpas_deallocate_field(dptr % r4)
                   else if (associated(dptr % r5)) then
-                     if (associated(dptr % r5 % array)) then
-                        deallocate(dptr % r5 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % r5, stat=local_err)
+                     call mpas_deallocate_field(dptr % r5)
                   else if (associated(dptr % i0)) then
-                     deallocate(dptr % i0, stat=local_err)
+                     call mpas_deallocate_field(dptr % i0)
                   else if (associated(dptr % i1)) then
-                     if (associated(dptr % i1 % array)) then
-                        deallocate(dptr % i1 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % i1, stat=local_err)
+                     call mpas_deallocate_field(dptr % i1)
                   else if (associated(dptr % i2)) then
-                     if (associated(dptr % i2 % array)) then
-                        deallocate(dptr % i2 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % i2, stat=local_err)
+                     call mpas_deallocate_field(dptr % i2)
                   else if (associated(dptr % i3)) then
-                     if (associated(dptr % i3 % array)) then
-                        deallocate(dptr % i3 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % i3, stat=local_err)
+                     call mpas_deallocate_field(dptr % i3)
                   else if (associated(dptr % c0)) then
-                     deallocate(dptr % c0, stat=local_err)
+                     call mpas_deallocate_field(dptr % c0)
                   else if (associated(dptr % c1)) then
-                     if (associated(dptr % c1 % array)) then
-                        deallocate(dptr % c1 % array, stat=local_err)
-                     end if
-   
-                     deallocate(dptr % c1, stat=local_err)
+                     call mpas_deallocate_field(dptr % c1)
                   else if (associated(dptr % l0)) then
-                     deallocate(dptr % l0, stat=local_err)
+                     call mpas_deallocate_field(dptr % l0)
                   else if (associated(dptr % r0a)) then
+                     do j=1,dptr % contentsTimeLevs
+                        call mpas_deallocate_field(dptr % r0a(j), keep_head_ptr=.true.)
+                     end do
                      deallocate(dptr % r0a, stat=local_err)
                   else if (associated(dptr % r1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % r1a(j) % array)) then
-                           deallocate(dptr % r1a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % r1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r1a, stat=local_err)
                   else if (associated(dptr % r2a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % r2a(j) % array)) then
-                           deallocate(dptr % r2a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % r2a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r2a, stat=local_err)
                   else if (associated(dptr % r3a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % r3a(j) % array)) then
-                           deallocate(dptr % r3a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % r3a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r3a, stat=local_err)
                   else if (associated(dptr % r4a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % r4a(j) % array)) then
-                           deallocate(dptr % r4a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % r4a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r4a, stat=local_err)
                   else if (associated(dptr % r5a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % r5a(j) % array)) then
-                           deallocate(dptr % r5a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % r5a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % r5a, stat=local_err)
                   else if (associated(dptr % i0a)) then
+                     do j=1,dptr % contentsTimeLevs
+                        call mpas_deallocate_field(dptr % i0a(j), keep_head_ptr=.true.)
+                     end do
                      deallocate(dptr % i0a, stat=local_err)
                   else if (associated(dptr % i1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % i1a(j) % array)) then
-                           deallocate(dptr % i1a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % i1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i1a, stat=local_err)
                   else if (associated(dptr % i2a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % i2a(j) % array)) then
-                           deallocate(dptr % i2a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % i2a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i2a, stat=local_err)
                   else if (associated(dptr % i3a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % i3a(j) % array)) then
-                           deallocate(dptr % i3a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % i3a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % i3a, stat=local_err)
                   else if (associated(dptr % c0a)) then
+                     do j=1,dptr % contentsTimeLevs
+                        call mpas_deallocate_field(dptr % c0a(j), keep_head_ptr=.true.)
+                     end do
                      deallocate(dptr % c0a, stat=local_err)
                   else if (associated(dptr % c1a)) then
                      do j=1,dptr % contentsTimeLevs
-                        if (associated(dptr % c1a(j) % array)) then
-                           deallocate(dptr % c1a(j) % array, stat=local_err)
-                        end if
+                        call mpas_deallocate_field(dptr % c1a(j), keep_head_ptr=.true.)
                      end do
                      deallocate(dptr % c1a, stat=local_err)
                   else if (associated(dptr % l0a)) then
+                     do j=1,dptr % contentsTimeLevs
+                        call mpas_deallocate_field(dptr % l0a(j), keep_head_ptr=.true.)
+                     end do
                      deallocate(dptr % l0a, stat=local_err)
                   else
                      call pool_mesg('While destroying pool, member '//trim(ptr % key)//' has no valid field pointers.')


### PR DESCRIPTION
The `destroy_pool` subroutine does not deallocate the memory associated with a field, because it uses a simple fortran `deallocate` rather than the more thorough `mpas_deallocate_field` routine. This has become a problem when using RK4 time-stepping in the ocean model, as we hit an out-of-memory error.

fixes #350

