### PR TITLE
Always allocate rainFlux and evaporationFlux.

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -3055,7 +3055,6 @@
 		<!-- Coupling fields associated with mass or salinity fluxes -->
 		<var name="evaporationFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Evaporation flux at cell centers from coupler. Positive into the ocean."
-			 packages="thicknessBulkPKG"
 		/>
 		<var name="seaIceSalinityFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Sea ice salinity flux at cell centers from coupler. Positive into the ocean."
@@ -3095,7 +3094,6 @@
 		/>
 		<var name="rainFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from rain at cell centers from coupler. Positive into the ocean."
-			 packages="thicknessBulkPKG"
 		/>
 		<var name="snowFlux" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
 			 description="Fresh water flux from snow at cell centers from coupler. Positive into the ocean."


### PR DESCRIPTION
Currently, `rainFlux` and `evaporationFlux` are in the `thicknessBulkPKG` package.  If 
`config_use_bulk_thickness_flux = .false.`
then the package is off and these arrays are not allocated. But they are accessed within various loops, and this causes a seg fault.

In E3SM surface fluxes are always on.  The seg fault occurs in idealized cases where thickness flux is off. For those cases, it is preferable to simply compute with zeros, rather than split up loops and put in checks for the packages, which reduces the performance of global runs.