### PR TITLE
Remove compile-time switch between PIO1 and PIO2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,13 +426,6 @@ FCINCLUDES =
 LIBS = 
 
 #
-# If user has indicated a PIO2 library, define USE_PIO2 pre-processor macro
-#
-ifeq "$(USE_PIO2)" "true"
-	override CPPFLAGS += -DUSE_PIO2
-endif
-
-#
 # Regardless of PIO library version, look for a lib subdirectory of PIO path
 # NB: PIO_LIB is used later, so we don't just set LIBS directly
 #
@@ -577,12 +570,6 @@ ifeq "$(USE_PAPI)" "true"
 else # USE_PAPI IF
 	PAPI_MESSAGE="Papi libraries are off."
 endif # USE_PAPI IF
-
-ifeq "$(USE_PIO2)" "true"
-	PIO_MESSAGE="Using the PIO 2 library."
-else # USE_PIO2 IF
-	PIO_MESSAGE="Using the PIO 1.x library."
-endif # USE_PIO2 IF
 
 ifdef TIMER_LIB
 ifeq "$(TIMER_LIB)" "tau"
@@ -735,42 +722,22 @@ endif
 
 pio_test:
 	@#
-	@# Create two test programs: one that should work with PIO1 and a second that should work with PIO2
+	@# Create pio test program
 	@#
-	@echo "program pio1; use pio; use pionfatt_mod; integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET; integer, parameter :: MPAS_INT_FILLVAL = NF_FILL_INT; end program" > pio1.f90
-	@echo "program pio2; use pio; integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET_KIND; integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT; end program" > pio2.f90
+	@echo "program pio_test; use pio; integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET_KIND; integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT; end program" > pio_test.f90
 
 	@#
 	@# See whether either of the test programs can be compiled
 	@#
 	@echo "Checking for a usable PIO library..."
-	@($(FC) pio1.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out &> /dev/null && echo "=> PIO 1 detected") || \
-	 ($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out &> /dev/null && echo "=> PIO 2 detected") || \
+	@($(FC) pio_test.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio_test.out &> /dev/null && echo "=> PIO detected") || \
 	 (echo "************ ERROR ************"; \
 	  echo "Failed to compile a PIO test program"; \
 	  echo "Please ensure the PIO environment variable is set to the PIO installation directory"; \
 	  echo "************ ERROR ************"; \
-	  rm -rf pio[12].f90 pio[12].out; exit 1)
+	  rm -rf pio_test.f90 pio_test.out; exit 1)
 
-	@rm -rf pio[12].out
-
-	@#
-	@# Check that what the user has specified agrees with the PIO library version that was detected
-	@#
-ifeq "$(USE_PIO2)" "true"
-	@($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out &> /dev/null) || \
-	(echo "************ ERROR ************"; \
-	 echo "PIO 1 was detected, but USE_PIO2=true was specified in the make command"; \
-	 echo "************ ERROR ************"; \
-	 rm -rf pio[12].f90 pio[12].out; exit 1)
-else
-	@($(FC) pio1.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out &> /dev/null) || \
-	(echo "************ ERROR ************"; \
-	 echo "PIO 2 was detected. Please specify USE_PIO2=true in the make command"; \
-	 echo "************ ERROR ************"; \
-	 rm -rf pio[12].f90 pio[12].out; exit 1)
-endif
-	@rm -rf pio[12].f90 pio[12].out
+	@rm -rf pio_test.out
 
 
 mpas_main: openmp_test pio_test
@@ -890,7 +857,6 @@ errmsg:
 	@echo "                    TIMER_LIB=gptl - Uses gptl for the timer interface instead of the native interface"
 	@echo "                    TIMER_LIB=tau - Uses TAU for the timer interface instead of the native interface"
 	@echo "    OPENMP=true   - builds and links with OpenMP flags. Default is to not use OpenMP."
-	@echo "    USE_PIO2=true - links with the PIO 2 library. Default is to use the PIO 1.x library."
 	@echo "    PRECISION=single - builds with default single-precision real kind. Default is to use double-precision."
 	@echo ""
 	@echo "Ensure that NETCDF, PNETCDF, PIO, and PAPI (if USE_PAPI=true) are environment variables"

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -23,26 +23,13 @@ module mpas_io
    integer, parameter :: PIO_REALKIND = PIO_DOUBLE
 #endif
 
-#ifdef USE_PIO2
    integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT
-   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)  ! TODO: To be replaced with PIO_FILL_CHAR once PIO2 provides this variable
-#else
-   integer, parameter :: MPAS_INT_FILLVAL = NF_FILL_INT
-   character, parameter :: MPAS_CHAR_FILLVAL = achar(NF_FILL_CHAR)
-#endif
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(PIO_FILL_CHAR)
 
-#ifdef USE_PIO2
 #ifdef SINGLE_PRECISION
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = PIO_FILL_FLOAT
 #else
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = PIO_FILL_DOUBLE
-#endif
-#else
-#ifdef SINGLE_PRECISION
-   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_FLOAT
-#else
-   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_DOUBLE
-#endif
 #endif
 
    interface MPAS_io_get_var
@@ -281,11 +268,7 @@ module mpas_io
             pio_mode = PIO_64BIT_OFFSET
          else if (ioformat == MPAS_IO_NETCDF4) then
             pio_iotype = PIO_iotype_netcdf4p
-#ifdef USE_PIO2
-            pio_mode = 0
-#else
             pio_mode = PIO_64BIT_OFFSET
-#endif
          end if
       end if
 
@@ -1430,11 +1413,7 @@ module mpas_io
 
 !      call mpas_log_write('Checking for unlimited dim')
       if (field_cursor % fieldhandle % has_unlimited_dim) then
-#ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
-#else
-         call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
-#endif
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -2348,11 +2327,7 @@ module mpas_io
 
       if (field_cursor % fieldhandle % has_unlimited_dim) then
 
-#ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
-#else
-         call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
-#endif
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -3149,11 +3124,7 @@ module mpas_io
       integer :: pio_ierr
       integer :: varid
       integer :: xtype
-#ifdef USE_PIO2
       integer (kind=MPAS_IO_OFFSET_KIND) :: len
-#else
-      integer :: len
-#endif
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: att_cursor, new_att_node
 
@@ -3288,11 +3259,7 @@ module mpas_io
       integer :: pio_ierr
       integer :: varid
       integer :: xtype
-#ifdef USE_PIO2
       integer (kind=MPAS_IO_OFFSET_KIND) :: len, attlen
-#else
-      integer :: len, attlen
-#endif
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: att_cursor, new_att_node
 
@@ -3442,11 +3409,7 @@ module mpas_io
       real (kind=R4KIND) :: singleVal
       real (kind=R8KIND) :: doubleVal
       integer :: xtype
-#ifdef USE_PIO2
       integer (kind=MPAS_IO_OFFSET_KIND) :: len
-#else
-      integer :: len
-#endif
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: att_cursor, new_att_node
 
@@ -3616,11 +3579,7 @@ module mpas_io
       real (kind=R4KIND), dimension(:), allocatable :: singleVal
       real (kind=R8KIND), dimension(:), allocatable :: doubleVal
       integer :: xtype
-#ifdef USE_PIO2
       integer (kind=MPAS_IO_OFFSET_KIND) :: len, attlen
-#else
-      integer :: len, attlen
-#endif
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: att_cursor, new_att_node
 
@@ -3802,11 +3761,7 @@ module mpas_io
       integer :: pio_ierr
       integer :: varid
       integer :: xtype
-#ifdef USE_PIO2
       integer (kind=MPAS_IO_OFFSET_KIND) :: len
-#else
-      integer :: len
-#endif
       type (fieldlist_type), pointer :: field_cursor
       type (attlist_type), pointer :: att_cursor, new_att_node
 

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -1,8 +1,4 @@
-#ifdef USE_PIO2
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET_KIND
-#else
-   integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET
-#endif
 
    ! File access modes
    integer, parameter :: MPAS_IO_READ  = 1, &


### PR DESCRIPTION
Earlier versions of PIO1 and PIO2 had incompatibilities between
the interfaces and types provided to the user. These issues were
fixed and there is no longer a requirement to compile MPAS
differently for PIO1 and PIO2.

[BFB]


