### PR TITLE
Add four idealized RPE test cases to COMPASS

### DIFF
--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_analysis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_1/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_5/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_10/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_20/output.nc" dest="output_4.nc"/>
+	<add_link source="../rpe_test_5_nu_200/output.nc" dest="output_5.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_driver.xml
@@ -1,0 +1,26 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 1, nu=1 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_5">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 2, nu=5 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_10">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 3, nu=10 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_20">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=20 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_5_nu_200">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=200 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_initial_state.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'baroclinic_channel'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">16</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">10000.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_1_nu_1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_1_nu_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_10km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">1.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<model_run procs="8" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_2_nu_5.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_2_nu_5.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_5">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_10km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">5.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<model_run procs="8" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_3_nu_10.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_3_nu_10.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_10">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_10km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">10.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<model_run procs="8" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_4_nu_20.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_4_nu_20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_20">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_10km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">20.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<model_run procs="8" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_5_nu_200.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_rpe_test_5_nu_200.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_5_nu_200">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_10km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">200.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">8</argument>
+		</step>
+		<model_run procs="8" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/plot.py
@@ -1,0 +1,32 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy as np
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=1 #2
+nCol=5
+nu=['1','5','10','100','200']
+iTime=[0,1]
+time=['0 days','20 days']
+for iCol in range(nCol):
+    ncfile = Dataset('output_'+str(iCol+1)+'.nc','r')
+    var = ncfile.variables['temperature']
+    xtime = ncfile.variables['xtime']
+    for iRow in range(nRow):
+        print(var)
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(np.reshape(var[iTime[iRow],:,0],[50,16]),extent=[0,160,0,500])
+        plt.clim([11.8,13])
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('y, km')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iRow]+', nu='+nu[iCol])
+    ncfile.close()
+plt.savefig('sections_baroclinic_channel_10km.png')

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/baroclinic_channel_1km_template.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/baroclinic_channel_1km_template.xml
@@ -1,0 +1,43 @@
+<template>
+	<namelist>
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:00:30'</option>
+		<option name="config_btr_dt">'00:00:02'</option>
+		<option name="config_run_duration">'0000_00:15:00'</option>
+		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_time_integrator">'split_explicit'</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">10.0</option>
+		<option name="config_convective_visc">1.0</option>
+		<option name="config_convective_diff">1.0</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_vert_visc">1.0e-4</option>
+	</namelist>
+
+	<streams>
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+</template>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_analysis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_1/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_5/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_10/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_20/output.nc" dest="output_4.nc"/>
+	<add_link source="../rpe_test_5_nu_200/output.nc" dest="output_5.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_driver.xml
@@ -1,0 +1,26 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 1, nu=1 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_5">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 2, nu=5 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_10">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 3, nu=10 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_20">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=20 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_5_nu_200">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=200 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_initial_state.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'baroclinic_channel'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">160</argument>
+			<argument flag="--ny">500</argument>
+			<argument flag="--dc">1000.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_1_nu_1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_1_nu_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_1km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">1.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">144</argument>
+		</step>
+		<model_run procs="144" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_2_nu_5.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_2_nu_5.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_5">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_1km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">5.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">144</argument>
+		</step>
+		<model_run procs="144" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_3_nu_10.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_3_nu_10.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_10">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_1km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">10.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">144</argument>
+		</step>
+		<model_run procs="144" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_4_nu_20.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_4_nu_20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_20">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_1km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">20.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">144</argument>
+		</step>
+		<model_run procs="144" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_5_nu_200.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_rpe_test_5_nu_200.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_5_nu_200">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_1km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">200.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">144</argument>
+		</step>
+		<model_run procs="144" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/plot.py
@@ -1,0 +1,34 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy as np
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=1 #2
+nCol=5
+nu=['1','5','10','100','200']
+iTime=[0,1]
+time=['0 days','20 days']
+for iCol in range(nCol):
+    ncfile = Dataset('initial_state.nc','r')
+    #ncfile = Dataset('output_'+str(iCol+1)+'.nc','r')
+    var = ncfile.variables['temperature']
+    #xtime = ncfile.variables['xtime']
+    for iRow in range(nRow):
+        print(var)
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(np.reshape(var[iTime[iRow],:,0],[500,160]),extent=[0,160,0,500])
+        plt.gca().invert_yaxis()
+        plt.clim([11.8,13])
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('y, km')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iRow]+', nu='+nu[iCol])
+    ncfile.close()
+plt.savefig('sections_baroclinic_channel_1km.png')

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/baroclinic_channel_4km_template.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/baroclinic_channel_4km_template.xml
@@ -1,0 +1,43 @@
+<template>
+	<namelist>
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'00:02:00'</option>
+		<option name="config_btr_dt">'00:00:06'</option>
+		<option name="config_run_duration">'0000_00:15:00'</option>
+		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
+		<option name="config_write_output_on_startup">.false.</option>
+		<option name="config_time_integrator">'split_explicit'</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">10.0</option>
+		<option name="config_convective_visc">1.0</option>
+		<option name="config_convective_diff">1.0</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_vert_visc">1.0e-4</option>
+	</namelist>
+
+	<streams>
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="tracers" type="var_struct"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+</template>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_analysis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_1/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_5/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_10/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_20/output.nc" dest="output_4.nc"/>
+	<add_link source="../rpe_test_5_nu_200/output.nc" dest="output_5.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_driver.xml
@@ -1,0 +1,26 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 1, nu=1 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_5">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 2, nu=5 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_10">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 3, nu=10 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_20">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=20 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_5_nu_200">
+		<step executable="./run.py" quiet="true" pre_message=" * Running baroclinic channel RPE test 4, nu=200 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_initial_state.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'baroclinic_channel'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">40</argument>
+			<argument flag="--ny">126</argument>
+			<argument flag="--dc">4000.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_1_nu_1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_1_nu_1.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_4km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">1.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">36</argument>
+		</step>
+		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_2_nu_5.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_2_nu_5.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_5">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_4km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">5.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">36</argument>
+		</step>
+		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_3_nu_10.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_3_nu_10.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_10">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_4km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">10.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">36</argument>
+		</step>
+		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_4_nu_20.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_4_nu_20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_20">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_4km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">20.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">36</argument>
+		</step>
+		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_5_nu_200.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_rpe_test_5_nu_200.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<config case="rpe_test_5_nu_200">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="baroclinic_channel_4km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'20_00:00:00'</option>
+		<option name="config_mom_del2">200.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-20_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="relativeVorticity"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">36</argument>
+		</step>
+		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/plot.py
@@ -1,0 +1,34 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy as np
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=1 #2
+nCol=5
+nu=['1','5','10','100','200']
+iTime=[0,1]
+time=['0 days','20 days']
+for iCol in range(nCol):
+    ncfile = Dataset('output_'+str(iCol+1)+'.nc','r')
+    #ncfile = Dataset('initial_state.nc','r')
+    var = ncfile.variables['temperature']
+    #xtime = ncfile.variables['xtime']
+    for iRow in range(nRow):
+        print(var)
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(np.reshape(var[iTime[iRow],:,0],[126,40]),extent=[0,160,0,500])
+        plt.gca().invert_yaxis()
+        plt.clim([11.8,13])
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('y, km')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iRow]+', nu='+nu[iCol])
+    ncfile.close()
+plt.savefig('sections_baroclinic_channel_4km.png')

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_analysis.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_p01/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_1/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_15/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_150/output.nc" dest="output_4.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_driver.xml
@@ -1,0 +1,23 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_p01">
+		<step executable="./run.py" quiet="true" pre_message=" * Running internal wave RPE test 1, nu=0.01 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running internal wave RPE test 2, nu=1.0 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_15">
+		<step executable="./run.py" quiet="true" pre_message=" * Running internal wave RPE test 3, nu=15 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_150">
+		<step executable="./run.py" quiet="true" pre_message=" * Running internal wave RPE test 4, nu=150 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_initial_state.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'internal_waves'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">50</argument>
+			<argument flag="--dc">5000.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_1_nu_p01.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_1_nu_p01.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_p01">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="internal_waves_5km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'100_00:00:00'</option>
+		<option name="config_mom_del2">0.01</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-10_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_2_nu_1.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_2_nu_1.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="internal_waves_5km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'100_00:00:00'</option>
+		<option name="config_mom_del2">1.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-10_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_3_nu_15.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_3_nu_15.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_15">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="internal_waves_5km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'100_00:00:00'</option>
+		<option name="config_mom_del2">15</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-10_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_4_nu_150.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_rpe_test_4_nu_150.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_150">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="internal_waves_5km_template.xml" path_base="script_resolution_dir"/>
+		<option name="config_run_duration">'100_00:00:00'</option>
+		<option name="config_mom_del2">150</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-10_00:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/plot.py
@@ -1,0 +1,31 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=4
+nCol=2
+nu=['0.01','1','15','150']
+iTime=[1,2]
+time=['10 days','20 days']
+for iRow in range(nRow):
+    ncfile = Dataset('output_'+str(iRow+1)+'.nc','r')
+    var = ncfile.variables['temperature']
+    xtime = ncfile.variables['xtime']
+    for iCol in range(nCol):
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(var[iTime[iCol],0::4,:].T,extent=[0,250,500,0],aspect='auto')
+        plt.clim([10,20])
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('depth, m')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iCol]+', nu='+nu[iRow])
+    ncfile.close()
+plt.savefig('sections_internal_waves.png')

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_analysis.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_p01/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_p1/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_1/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_10/output.nc" dest="output_4.nc"/>
+	<add_link source="../rpe_test_5_nu_100/output.nc" dest="output_5.nc"/>
+	<add_link source="../rpe_test_6_nu_200/output.nc" dest="output_6.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_driver.xml
@@ -1,0 +1,29 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_p01">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 1, nu=0.01 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_p1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 2, nu=0.1 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 3, nu=1.0 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_10">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 4, nu=10 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_5_nu_100">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 5, nu=100 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_6_nu_200">
+		<step executable="./run.py" quiet="true" pre_message=" * Running lock exchange RPE test 6, nu=200 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_initial_state.xml
@@ -1,30 +1,25 @@
 <?xml version="1.0"?>
-<config case="init_step1">
-
-	<get_file hash="ccb8wxfwaz" dest_path="mesh_database" file_name="doubly_periodic_0.5km_2x64km_planar.160120.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
-	</get_file>
-
-	<add_link source_path="mesh_database" source="doubly_periodic_0.5km_2x64km_planar.160120.nc" dest="base_mesh.nc"/>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
 
 	<add_executable source="model" dest="ocean_model"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<option name="config_init_configuration">'lock_exchange'</option>
-v		<option name="config_vert_levels">1</option>
+		<option name="config_vert_levels">-1</option>
 		<option name="config_ocean_run_mode">'init'</option>
-		<option name="config_write_cull_cell_mask">.true.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<stream name="input_init">
-			<attribute name="filename_template">mesh.nc</attribute>
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
 		</stream>
 		<stream name="output_init">
 			<attribute name="type">output</attribute>
 			<attribute name="output_interval">0000_00:00:01</attribute>
 			<attribute name="clobber_mode">truncate</attribute>
-			<attribute name="filename_template">ocean.nc</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
 			<add_contents>
 				<member name="input_init" type="stream"/>
 				<member name="tracers" type="var_struct"/>
@@ -47,34 +42,7 @@ v		<option name="config_vert_levels">1</option>
 	</streams>
 
 	<run_script name="run.py">
-		<step executable="planar_hex">
-			<argument flag="--nx">6</argument>
-			<argument flag="--ny">30</argument>
-			<argument flag="--dc">1000.0</argument>
-			<argument flag="--npy"></argument>
-			<argument flag="-o">grid.nc</argument>
-		</step>
-		<step executable="MpasCellCuller.x">
-			<argument flag="">grid.nc</argument>
-			<argument flag="">culled_mesh.nc</argument>
-		</step>
-		<step executable="MpasMeshConverter.x">
-			<argument flag="">culled_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
-		</step>
-
 		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 	</run_script>
-	<run_script name="run.py">
-		<step executable="MpasMeshConverter.x">
-			<argument flag="">base_mesh.nc</argument>
-			<argument flag="">mesh.nc</argument>
-		</step>
 
-		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
-
-		<step executable="MpasCellCuller.x">
-			<argument flag="">ocean.nc</argument>
-		</step>
-	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">128</argument>
+			<argument flag="--dc">500.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_1_nu_p01.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_1_nu_p01.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_p01">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:02:00'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">0.01</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_2_nu_p1.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_2_nu_p1.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_p1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:02:00'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">0.1</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_3_nu_1.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_3_nu_1.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:02:00'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1.0</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_4_nu_10.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_4_nu_10.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_10">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:02:00'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">10.0</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_5_nu_100.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_5_nu_100.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_5_nu_100">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:01:00'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">100</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_6_nu_200.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_rpe_test_6_nu_200.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<config case="rpe_test_6_nu_200">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_link source="make_graph_file.py" source_path="utility_scripts" dest="make_graph_file.py"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:00:30'</option>
+		<option name="config_btr_dt">'0000_00:00:06'</option>
+		<option name="config_run_duration">'0000_17:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">0.0</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">200.0</option>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="./make_graph_file.py">
+			<argument flag="-f">initial_state.nc</argument>
+		</step>
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/plot.py
@@ -1,0 +1,30 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=6
+nCol=2
+iTime=[8,16]
+nu=['0.01','0.1','1','10','100','200']
+time=['8 hrs','16 hrs']
+for iRow in range(nRow):
+    ncfile = Dataset('output_'+str(iRow+1)+'.nc','r')
+    var = ncfile.variables['temperature']
+    xtime = ncfile.variables['xtime']
+    for iCol in range(nCol):
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(var[iTime[iCol],0:520:4,:].T,extent=[0,120,20,0],aspect=2)
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('depth, m')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iCol]+', nu='+nu[iRow])
+    ncfile.close()
+plt.savefig('sections_lock_exchange.png')

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_analysis.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<config case="analysis">
+
+	<add_link source="plot.py" source_path="script_test_dir" dest="plot.py"/>
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../rpe_test_1_nu_p01/output.nc" dest="output_1.nc"/>
+	<add_link source="../rpe_test_2_nu_p1/output.nc" dest="output_2.nc"/>
+	<add_link source="../rpe_test_3_nu_1/output.nc" dest="output_3.nc"/>
+	<add_link source="../rpe_test_4_nu_10/output.nc" dest="output_4.nc"/>
+	<add_link source="../rpe_test_5_nu_100/output.nc" dest="output_5.nc"/>
+	<add_link source="../rpe_test_6_nu_200/output.nc" dest="output_6.nc"/>
+
+	<run_script name="run.py">
+		<step executable="python plot.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_driver.xml
@@ -1,0 +1,29 @@
+<driver_script name="run_test.py">
+	<case name="mpas_mesh">
+		<step executable="./run.py" quiet="true" pre_message=" * Creating 2D MPAS mesh with planar_hex, MpasCellCuller, and MpasMeshConverter ..." post_message="     complete!  Created file:  mpas_mesh/mpas_mesh.nc"/>
+	</case>
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="rpe_test_1_nu_p01">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 1, nu=0.01 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_2_nu_p1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 2, nu=0.1 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_3_nu_1">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 3, nu=1.0 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_4_nu_10">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 4, nu=10 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_5_nu_100">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 5, nu=100 ..." post_message="     complete!"/>
+	</case>
+	<case name="rpe_test_6_nu_1000">
+		<step executable="./run.py" quiet="true" pre_message=" * Running overflow RPE test 6, nu=1000 ..." post_message="     complete!"/>
+	</case>
+<!--	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Visualization and analysis of RPE tests ..." post_message="     complete!"/> 
+	</case> -->
+</driver_script>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_initial_state.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<add_link source="../mpas_mesh/mpas_mesh.nc" dest="mpas_mesh.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'overflow'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_overflow_use_distances">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mpas_mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">initial_state.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="tracers" type="var_struct"/>
+				<member name="refZMid" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="surfaceStress" type="var"/>
+				<member name="atmosphericPressure" type="var"/>
+				<member name="boundaryLayerDepth" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="bottomDepthObserved" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+				<member name="cullCell" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_mpas_mesh.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config case="mpas_mesh">
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">200</argument>
+			<argument flag="--dc">1000.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">base_mesh.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">base_mesh.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mpas_mesh.nc</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_1_nu_p01.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_1_nu_p01.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_1_nu_p01">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">0.01</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_2_nu_p1.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_2_nu_p1.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_2_nu_p1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">0.1</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_3_nu_1.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_3_nu_1.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_3_nu_1">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_4_nu_10.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_4_nu_10.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_4_nu_10">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">10.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_5_nu_100.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_5_nu_100.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_5_nu_100">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">100</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_6_nu_1000.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_rpe_test_6_nu_1000.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="rpe_test_6_nu_1000">
+	<add_link source="../initial_state/initial_state.nc" dest="initial_state.nc"/>
+	<add_link source="../mpas_mesh/culled_graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_dt">'0000_00:03:00'</option>
+		<option name="config_btr_dt">'0000_00:00:09'</option>
+		<option name="config_run_duration">'0000_40:00:00'</option>
+		<option name="config_use_const_visc">.true.</option>
+		<option name="config_implicit_bottom_drag_coeff">1.0e-2</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_mom_del2">1000.0</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">initial_state.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_01:00:00</attribute>
+			<add_contents>
+				<member type="var_struct" name="tracers"/>
+				<member type="var" name="density"/>
+				<member type="var" name="daysSinceStartOfSim"/>
+				<member type="var" name="xtime"/>
+			</add_contents>
+		</stream>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/plot.py
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/plot.py
@@ -1,0 +1,31 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+import numpy
+
+fig = plt.gcf()
+fig.set_size_inches(8.0,10.0)
+nRow=1 #6
+nCol=2
+nu=['0.01','0.1','1','10','100','1000']
+iTime=[3,6]
+time=['3 hrs','6 hrs']
+for iRow in range(nRow):
+    ncfile = Dataset('output_'+str(iRow+1)+'.nc','r')
+    var = ncfile.variables['temperature']
+    xtime = ncfile.variables['xtime']
+    for iCol in range(nCol):
+        plt.subplot(nRow, nCol, iRow*nCol+iCol+1) 
+        ax = plt.imshow(var[iTime[iCol],0::4,:].T,extent=[0,200,2000,0],aspect=2)
+        plt.clim([10,20])
+        plt.jet()
+        if iRow==nRow-1:
+            plt.xlabel('x, km')
+        if iCol==0:
+            plt.ylabel('depth, m')
+        plt.colorbar()
+        #print(xtime[iTime[iCol],11:13])
+        plt.title('time='+time[iCol]+', nu='+nu[iRow])
+    ncfile.close()
+plt.savefig('sections_overflow.png')

--- a/testing_and_setup/compass/ocean/regression_suites/rpe_tests.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/rpe_tests.xml
@@ -1,0 +1,33 @@
+<!--
+This regression suite follows the test cases from Petersen et al. (2015):
+
+1. lock exchange, 0.5km
+2. overflow, 1km
+3. internal gravity wave, 5km
+4. baroclinic channel: 1, 4, 10km
+
+The purpose of these tests is to measure the change in the Reference Potential
+Energy (RPE), which is a measure of mixing. These tests are set to have zero
+horizontal and vertical tracer diffusion and zero surface fluxes, so all mixing
+measured by RPE is due to spurious numerical diffusion.
+-->
+<regression_suite name="rpe_test_suite">
+	<test name="Lock Exchange 0.5km - RPE Test" core="ocean" configuration="lock_exchange" resolution="0.5km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Overflow 1km - RPE Test" core="ocean" configuration="overflow" resolution="1km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Internal Waves 5km - RPE Test" core="ocean" configuration="internal_waves" resolution="5km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 10km - RPE Test" core="ocean" configuration="baroclinic_channel" resolution="10km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 4km - RPE Test" core="ocean" configuration="baroclinic_channel" resolution="4km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+	<test name="Baroclinic Channel 1km - RPE Test" core="ocean" configuration="baroclinic_channel" resolution="1km" test="rpe_test">
+		<script name="run_test.py"/>
+	</test>
+</regression_suite>


### PR DESCRIPTION
This PR adds the following test cases from [Petersen et al. (2015)](https://www.sciencedirect.com/science/article/pii/S1463500314001796) to COMPASS:
1. lock exchange, 0.5km 
2. overflow, 1km
3. internal gravity wave, 5km
4. baroclinic channel: 1, 4, 10km

These were previously in init mode, but had not been added to COMPASS (except baroclinic channel 10km). In addition, a new regression suite called `rpe_tests.xml` runs the full suite. The purpose of these tests is to measure the change in the Reference Potential Energy (RPE), which is a measure of mixing. These tests are set to have zero horizontal and vertical tracer diffusion and zero surface fluxes, so all mixing measured by RPE is due to spurious numerical diffusion.