### PR TITLE
Changes to COMPASS jigsaw tools to work for planar meshes too

### DIFF
--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/build_mesh.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/build_mesh.py
@@ -31,32 +31,49 @@ from define_base_mesh import define_base_mesh
 
 
 def build_mesh(preserve_floodplain=False, floodplain_elevation=20.0,
-               do_inject_bathymetry=False):
+               do_inject_bathymetry=False, geometry='sphere'):
 
-    print('Step 1. Build cellWidth array as function of latitude and '
-          'longitude')
-    cellWidth, lon, lat = define_base_mesh.cellWidthVsLatLon()
-    da = xarray.DataArray(cellWidth,
+    if geometry=='sphere':
+        on_sphere=True
+    else:
+        on_sphere=False
+
+    print('Step 1. Build cellWidth array as function of horizontal coordinates')
+    if on_sphere:
+       cellWidth, lon, lat = define_base_mesh.cellWidthVsLatLon()
+       da = xarray.DataArray(cellWidth,
                           dims=['lat','lon'],
                           coords={'lat':lat,'lon':lon},
                           name='cellWidth')
-    da.to_netcdf('cellWidthVsLatLon.nc')
-    
+       cw_filename='cellWidthVsLatLon.nc'
+       da.to_netcdf(cw_filename)
+    else:
+       cellWidth, x, y, geom_points, geom_edges = define_base_mesh.cellWidthVsXY()
+       da = xarray.DataArray(cellWidth,
+                          dims=['y','x'],
+                          coords={'y':y,'x':x},
+                          name='cellWidth')
+       cw_filename='cellWidthVsXY.nc'
+       da.to_netcdf(cw_filename)
+
 
     print('Step 2. Generate mesh with JIGSAW')
-    jigsaw_driver(cellWidth, lon, lat)
+    if on_sphere:
+       jigsaw_driver(cellWidth, lon, lat)
+    else:
+       jigsaw_driver(cellWidth, x, y, on_sphere=False, geom_points=geom_points, geom_edges=geom_edges)
 
     print('Step 3. Convert triangles from jigsaw format to netcdf')
     jigsaw_to_netcdf(msh_filename='mesh-MESH.msh',
-                     output_name='mesh_triangles.nc', on_sphere=True)
+                     output_name='mesh_triangles.nc', on_sphere=on_sphere)
 
     print('Step 4. Convert from triangles to MPAS mesh')
     write_netcdf(convert(xarray.open_dataset('mesh_triangles.nc')),
                  'base_mesh.nc')
 
     print('Step 5. Inject correct meshDensity variable into base mesh file')
-    inject_meshDensity(cw_filename='cellWidthVsLatLon.nc',
-                       mesh_filename='base_mesh.nc')
+    inject_meshDensity(cw_filename=cw_filename,
+                       mesh_filename='base_mesh.nc', on_sphere=on_sphere)
 
     if do_inject_bathymetry:
         print('Step 6. Injecting bathymetry')
@@ -89,6 +106,7 @@ if __name__ == '__main__':
     parser.add_argument('--floodplain_elevation', action='store',
                         type=float, default=20.0)
     parser.add_argument('--inject_bathymetry', action='store_true')
+    parser.add_argument('--geometry', default='sphere')
     cl_args = parser.parse_args()
     build_mesh(cl_args.preserve_floodplain, cl_args.floodplain_elevation,
-               cl_args.inject_bathymetry)
+               cl_args.inject_bathymetry, cl_args.geometry)

--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_meshDensity.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_meshDensity.py
@@ -60,13 +60,13 @@ def inject_meshDensity(cw_filename, mesh_filename, on_sphere=True):
     if on_sphere:
        meshDensity[:] = meshDensityInterp(
            np.vstack(
-            (ds.variables['lonCell'][:],
-             np.mod(
-                ds.variables['latCell'][:] +
+            (np.mod(
+                ds.variables['lonCell'][:] +
                 np.pi,
                 2 *
                 np.pi) -
-                np.pi)).T)
+                np.pi,
+             ds.variables['latCell'][:])).T)
     else:
        meshDensity[:] = meshDensityInterp(
            np.vstack(

--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_meshDensity.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_meshDensity.py
@@ -16,48 +16,63 @@ import netCDF4 as nc4
 import sys
 
 
-def inject_meshDensity(cw_filename, mesh_filename):
+def inject_meshDensity(cw_filename, mesh_filename, on_sphere=True):
     print('Read cell width field from nc file regular grid...')
     ds = nc4.Dataset(cw_filename,'r')
     cellWidth = ds.variables['cellWidth'][:]
-    lon = ds.variables['lon'][:]
-    lat = ds.variables['lat'][:]
+    if on_sphere:
+       lon = ds.variables['lon'][:]
+       lat = ds.variables['lat'][:]
+    else:
+       x = ds.variables['x'][:]
+       y = ds.variables['y'][:]
     ds.close()
 
-    # Add extra column in longitude to interpolate over the Date Line
-    cellWidth = np.concatenate(
-        (cellWidth, cellWidth[:, 0:1]), axis=1)
-    LonPos = np.deg2rad(np.concatenate(
-        (lon.T, lon.T[0:1] + 360)))
-    LatPos = np.deg2rad(lat.T)
-    # set max lat position to be exactly at North Pole to avoid interpolation
-    # errors
-    LatPos[np.argmax(LatPos)] = np.pi / 2.0
+    if on_sphere:
+       # Add extra column in longitude to interpolate over the Date Line
+       cellWidth = np.concatenate(
+           (cellWidth, cellWidth[:, 0:1]), axis=1)
+       LonPos = np.deg2rad(np.concatenate(
+           (lon.T, lon.T[0:1] + 360)))
+       LatPos = np.deg2rad(lat.T)
+       # set max lat position to be exactly at North Pole to avoid interpolation
+       # errors
+       LatPos[np.argmax(LatPos)] = np.pi / 2.0
     minCellWidth = cellWidth.min()
-    meshDensityVsLatLon = (minCellWidth / cellWidth)**4
+    meshDensityVsXY = (minCellWidth / cellWidth)**4
     print('  minimum cell width in grid definition:', minCellWidth)
     print('  maximum cell width in grid definition:', cellWidth.max())
 
-    LON, LAT = np.meshgrid(LonPos, LatPos)
+    if on_sphere:
+       X, Y = np.meshgrid(LonPos, LatPos)
+    else:
+       X, Y = np.meshgrid(x, y)
 
     print('Open unstructured MPAS mesh file...')
     ds = nc4.Dataset(mesh_filename, 'r+')
     meshDensity = ds.variables['meshDensity']
 
-    print('Preparing interpolation of meshDensity from lat/lon to mesh...')
+    print('Preparing interpolation of meshDensity from native coordinates to mesh...')
     meshDensityInterp = interpolate.LinearNDInterpolator(
-        np.vstack((LAT.ravel(), LON.ravel())).T, meshDensityVsLatLon.ravel())
+        np.vstack((X.ravel(), Y.ravel())).T, meshDensityVsXY.ravel())
 
     print('Interpolating and writing meshDensity...')
-    meshDensity[:] = meshDensityInterp(
-        np.vstack(
-            (ds.variables['latCell'][:],
+    if on_sphere:
+       meshDensity[:] = meshDensityInterp(
+           np.vstack(
+            (ds.variables['lonCell'][:],
              np.mod(
-                ds.variables['lonCell'][:] +
+                ds.variables['latCell'][:] +
                 np.pi,
                 2 *
                 np.pi) -
                 np.pi)).T)
+    else:
+       meshDensity[:] = meshDensityInterp(
+           np.vstack(
+            (ds.variables['xCell'][:],
+             ds.variables['yCell'][:])
+            ).T)
 
     ds.close()
 

--- a/testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.py
+++ b/testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.py
@@ -5,7 +5,7 @@ import numpy
 import jigsawpy
 
 
-def jigsaw_driver(cellWidth, lon, lat):
+def jigsaw_driver(cellWidth, x, y, on_sphere=True, geom_points=None, geom_edges=None):
     '''
     A function for building a jigsaw mesh
 
@@ -14,8 +14,16 @@ def jigsaw_driver(cellWidth, lon, lat):
     cellWidth : ndarray
         The size of each cell in the resulting mesh as a function of space
 
-    lon, lat : ndarray
-        The lon. and lat. of each point in the cellWidth array
+    x, y : ndarray
+        The x and y coordinates of each point in the cellWidth array (lon and lat for spherical mesh)
+
+    on_sphere : logical
+        Whether this mesh is spherical or planar
+
+    geom_points : list of point coordinates for bounding polygon for planar mesh
+
+    geom_edges : list of edges between points in geom_points that define the bounding polygon
+
     '''
     # Authors
     # -------
@@ -27,28 +35,40 @@ def jigsaw_driver(cellWidth, lon, lat):
     opts.jcfg_file = 'mesh.jig'
     opts.mesh_file = 'mesh-MESH.msh'
     opts.hfun_file = 'mesh-HFUN.msh'
-           
+
     # save HFUN data to file
     hmat = jigsawpy.jigsaw_msh_t()
-    hmat.mshID = 'ELLIPSOID-GRID'
-    hmat.xgrid = numpy.radians(lon)
-    hmat.ygrid = numpy.radians(lat)
+    if on_sphere:
+       hmat.mshID = 'ELLIPSOID-GRID'
+       hmat.xgrid = numpy.radians(x)
+       hmat.ygrid = numpy.radians(y)
+    else:
+       hmat.mshID = 'EUCLIDEAN-GRID'
+       hmat.xgrid = x
+       hmat.ygrid = y
     hmat.value = cellWidth
     jigsawpy.savemsh(opts.hfun_file, hmat)
-   
+
     # define JIGSAW geometry
     geom = jigsawpy.jigsaw_msh_t()
-    geom.mshID = 'ELLIPSOID-MESH'
-    geom.radii = 6371.*numpy.ones(3, float)
+    if on_sphere:
+       geom.mshID = 'ELLIPSOID-MESH'
+       geom.radii = 6371.*numpy.ones(3, float)
+    else:
+       geom.mshID = 'EUCLIDEAN-MESH'
+       geom.vert2 = geom_points
+       geom.edge2 = geom_edges
+       #geom.edge2.index = geom_edges
+       print (geom_points)
     jigsawpy.savemsh(opts.geom_file, geom)
-   
+
     # build mesh via JIGSAW!
     mesh = jigsawpy.jigsaw_msh_t()
     opts.hfun_scal = 'absolute'
-    opts.hfun_hmax = float("inf") 
+    opts.hfun_hmax = float("inf")
     opts.hfun_hmin = 0.0
     opts.mesh_dims = +2  # 2-dim. simplexes
     opts.optm_qlim = 0.9375
     opts.verbosity = +1
-   
+
     jigsawpy.cmd.jigsaw(opts)


### PR DESCRIPTION
This merge modified the jigsaw_to_MPAS scripts in COMPASS to support running the Jigsaw workflow for planar meshes in addition to the current support for spherical meshes.  This is done by adding new flags to necessary functions that enable logic for spherical or planar coordinates to be used.  The default is always spherical, so existing ocean test cases do not need to be modified.
