### PR TITLE
Fix python 3 in BGC and CVMix makedep.py

### DIFF
--- a/src/core_ocean/get_BGC.sh
+++ b/src/core_ocean/get_BGC.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 ## BGC Tag for build
-#BGC_TAG=fa3d49a
-BGC_TAG=9c31e70
+BGC_TAG=maint-1.0
 
 ## Subdirectory in BGC repo to use
 BGC_SUBDIR=.
 
 ## Available protocols for acquiring BGC source code
-BGC_GIT_HTTP_ADDRESS=https://github.com/ACME-Climate/Ocean-BGC.git
-BGC_GIT_SSH_ADDRESS=git@github.com:ACME-Climate/Ocean-BGC.git
-BGC_SVN_ADDRESS=https://github.com/ACME-Climate/Ocean-BGC-src/tags
-BGC_WEB_ADDRESS=https://github.com/ACME-Climate/Ocean-BGC-src/archive
+BGC_GIT_HTTP_ADDRESS=https://github.com/E3SM-Project/Ocean-BGC.git
+BGC_GIT_SSH_ADDRESS=git@github.com:E3SM-Project/Ocean-BGC.git
+BGC_SVN_ADDRESS=https://github.com/E3SM-Project/Ocean-BGC-src/tags
+BGC_WEB_ADDRESS=https://github.com/E3SM-Project/Ocean-BGC-src/archive
 
 GIT=`which git`
 SVN=`which svn`

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=v0.84-beta
+CVMIX_TAG=maint-1.0
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 
 ## Available protocols for acquiring CVMix source code
-CVMIX_GIT_HTTP_ADDRESS=https://github.com/CVMix/CVMix-src.git
-CVMIX_GIT_SSH_ADDRESS=git@github.com:CVMix/CVMix-src.git
-CVMIX_SVN_ADDRESS=https://github.com/CVMix/CVMix-src/tags
-CVMIX_WEB_ADDRESS=https://github.com/CVMix/CVMix-src/archive
+CVMIX_GIT_HTTP_ADDRESS=https://github.com/E3SM-Project/CVMix-src.git
+CVMIX_GIT_SSH_ADDRESS=git@github.com:E3SM-Project/CVMix-src.git
+CVMIX_SVN_ADDRESS=https://github.com/E3SM-Project/CVMix-src/tags
+CVMIX_WEB_ADDRESS=https://github.com/E3SM-Project/CVMix-src/archive
 
 GIT=`which git`
 SVN=`which svn`


### PR DESCRIPTION
This is needed for E3SM builds of `maint-1.0` with python 3.