### PR TITLE
Fix thermal solver bugs for restarts and different decompositions

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -92,6 +92,10 @@
 		            description="If true, then multiply beta by effective pressure before passing to Albany.  This allows, e.g., a Weertman basal friction law with an effective pressure term.  Note that basal friction still needs to be selected in Albany xml file."
 		            possible_values=".true. or .false."
 		/>
+		<nml_option name="config_beta_thawed_only" type="logical" default_value=".false." units="unitless"
+		            description="If true, then beta is zeroed wherever the basal temperature is below the pressure-melting temperature"
+		            possible_values=".true. or .false."
+		/>
         <nml_option name="config_unrealistic_velocity" type="real" default_value="0.01592356685" units="m s^{-1}"
 		            description="Ice is removed at any locations with surface speed faster than this value and sent to the calving flux. The presence of icebergs can lead to unrealistically large velocities.  A simple method to remove icebergs is to remove ice where the velocity is faster than an arbitrarily large value."
 		            possible_values="Any positive, real number."

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -623,6 +623,8 @@
 			<var name="waterFrac" packages="thermal"/>
                         <var name="surfaceAirTemperature" packages="thermal"/>
                         <var name="basalHeatFlux" packages="thermal;hydro"/>
+                        <var name="basalFrictionFlux" packages="thermal"/>
+                        <var name="heatDissipation" packages="thermal"/>
 			<var name="cellMask"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -480,6 +480,8 @@
 
                 <package name="ismip6Melt" description="This package includes variables required for the ISMIP6 melt parameterization."/>
 
+                <package name="thermal" description="This package includes variables required for the thermal solver."/>
+
 	</packages>
 
 
@@ -532,7 +534,7 @@
 			<var name="meshDensity"/>
 		</stream>
 
-<!-- WHL: When using the enthalpy heat-balance solver, will need to add waterfrac to the streams with temperature. -->
+<!-- WHL: When using the enthalpy heat-balance solver, will need to add waterFrac to the streams with temperature. -->
 		<stream name="input"
 				type="input"
 				immutable="true"
@@ -544,6 +546,7 @@
 			<var name="basalWaterThickness"/>
 			<var name="bedTopography"/>
 			<var name="temperature"/>
+			<var name="waterFrac"/>
 			<var name="sfcMassBal"/>
                         <var name="floatingBasalMassBal"/>
                         <var name="surfaceAirTemperature"/>
@@ -615,10 +618,11 @@
                         <var name="xtime"/>
                         <var name="simulationStartTime"/>
 			<var name="thickness"/>
-			<var name="basalWaterThickness"/>
+			<var name="basalWaterThickness" packages="thermal"/>
 			<var name="temperature"/>
-                        <var name="surfaceAirTemperature"/>
-                        <var name="basalHeatFlux"/>
+			<var name="waterFrac" packages="thermal"/>
+                        <var name="surfaceAirTemperature" packages="thermal"/>
+                        <var name="basalHeatFlux" packages="thermal;hydro"/>
 			<var name="cellMask"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>
@@ -1177,7 +1181,7 @@ is the value of that variable from the *previous* time level!
                 <var name="temperature" type="real" dimensions="nVertLevels nCells Time" units="K" default_value="273.15"
                      description="interior ice temperature"
                 />
-                <var name="waterfrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
+                <var name="waterFrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="interior ice water fraction"
                 />
                 <var name="enthalpy" type="real" dimensions="nVertLevels nCells Time" units="J m^{-3}"

--- a/src/core_landice/mode_forward/Makefile
+++ b/src/core_landice/mode_forward/Makefile
@@ -56,7 +56,8 @@ mpas_li_diagnostic_vars.o: mpas_li_thermal.o
 mpas_li_velocity.o: mpas_li_sia.o \
                     mpas_li_velocity_simple.o \
                     mpas_li_velocity_external.o \
-		    mpas_li_advection.o
+		    mpas_li_advection.o \
+		    mpas_li_thermal.o
 
 mpas_li_sia.o: mpas_li_diagnostic_vars.o
 

--- a/src/core_landice/mode_forward/mpas_li_advection.F
+++ b/src/core_landice/mode_forward/mpas_li_advection.F
@@ -938,7 +938,7 @@ module li_advection
            config_thermal_solver
 
       integer, pointer :: &
-           nCellsSolve                ! number of locally owned cells
+           nCells                     ! number of cells
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
@@ -961,7 +961,7 @@ module li_advection
       integer :: iCell, iTracer
 
       ! get dimensions
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       ! get arrays from mesh pool
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
@@ -1001,7 +1001,7 @@ module li_advection
 
          ! Rather than assume that enthalpy is up to date, recompute it from temperature and waterfrac
 
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCells
 
             call li_temperature_to_enthalpy_kelvin(&
                  layerCenterSigma,      &

--- a/src/core_landice/mode_forward/mpas_li_advection.F
+++ b/src/core_landice/mode_forward/mpas_li_advection.F
@@ -150,7 +150,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,           & ! interior ice temperature
-           waterfrac,             & ! interior water fraction
+           waterFrac,             & ! interior water fraction
            enthalpy                 ! interior ice enthalpy
 
       real (kind=RKIND), dimension(:,:), pointer :: &
@@ -268,7 +268,7 @@ module li_advection
 
       ! get arrays from the thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+      call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
 
       ! get config variables
@@ -368,7 +368,7 @@ module li_advection
          endif
 
          ! Transport thickness and tracers using a first-order upwind scheme
-         ! Note:  For the enthalpy scheme, temperature and waterfrac are the primary prognostic
+         ! Note:  For the enthalpy scheme, temperature and waterFrac are the primary prognostic
          !        variables to be updated, but enthalpy is the advected tracer (for reasons of
          !        energy conservation).
 
@@ -544,7 +544,7 @@ module li_advection
          if (advectTracers) then
 
             ! Copy the advectedTracersNew values into the thermal tracer arrays
-            ! (temperature, waterfrac, enthalpy)
+            ! (temperature, waterFrac, enthalpy)
 
             call tracer_finish(&
                  meshPool,              &
@@ -942,7 +942,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
-           waterfrac,               & ! interior water fraction
+           waterFrac,               & ! interior water fraction
            enthalpy                   ! interior ice enthalpy
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -971,7 +971,7 @@ module li_advection
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+      call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
       call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
       call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
@@ -985,8 +985,8 @@ module li_advection
 
       ! Notes:
       ! (1) For the enthalpy solver, it is necessary to transport enthalpy (rather than
-      !     temperature and waterfrac separately) in order to conserve energy.
-      ! (2) Temperature and waterfrac must be up to date (including halo cells)
+      !     temperature and waterFrac separately) in order to conserve energy.
+      ! (2) Temperature and waterFrac must be up to date (including halo cells)
       !     before calling this subroutine.
       ! (3) Surface and basal temperature (or enthalpy) are not transported, but their
       !     values are applied to new accumulation at either surface.
@@ -999,7 +999,7 @@ module li_advection
 
       if (trim(config_thermal_solver) == 'enthalpy') then  ! advect enthalpy
 
-         ! Rather than assume that enthalpy is up to date, recompute it from temperature and waterfrac
+         ! Rather than assume that enthalpy is up to date, recompute it from temperature and waterFrac
 
          do iCell = 1, nCells
 
@@ -1007,7 +1007,7 @@ module li_advection
                  layerCenterSigma,      &
                  thickness(iCell),      &
                  temperature(:,iCell),  &
-                 waterfrac(:,iCell),    &
+                 waterFrac(:,iCell),    &
                  enthalpy(:,iCell))
 
          enddo
@@ -1019,7 +1019,7 @@ module li_advection
          advectedTracers(iTracer,:,:) = enthalpy(:,:)
 
          ! set enthalpy of new ice at upper and lower surfaces
-         ! convert temperature to enthalpy assuming waterfrac = 0 for new ice
+         ! convert temperature to enthalpy assuming waterFrac = 0 for new ice
          surfaceTracers(iTracer,:) = min(surfaceAirTemperature(:), kelvin_to_celsius) * config_ice_density*cp_ice
          basalTracers(iTracer,:) = basalTemperature(:) * config_ice_density*cp_ice
 
@@ -1108,7 +1108,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
-           waterfrac,               & ! water fraction
+           waterFrac,               & ! water fraction
            enthalpy                   ! interior ice enthalpy
 
       integer :: iCell, iTracer
@@ -1124,7 +1124,7 @@ module li_advection
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+      call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
 
       ! get config variables
@@ -1146,7 +1146,7 @@ module li_advection
                  thickness(iCell),                           &
                  enthalpy(:,iCell),     &
                  temperature(:,iCell),  &
-                 waterfrac(:,iCell))
+                 waterFrac(:,iCell))
 
          enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -359,7 +359,7 @@ module li_calving
       ! These are needed to initialize the temperature profile in restored columns.
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,           &   ! interior ice temperature
-           waterfrac                  ! interior water fraction
+           waterFrac                  ! interior water fraction
 
       real (kind=RKIND), dimension(:), pointer :: &
            surfaceAirTemperature, &   ! surface air temperature
@@ -406,7 +406,7 @@ module li_calving
 
          ! get required fields from the thermal pool
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-         call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+         call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
@@ -485,7 +485,7 @@ module li_calving
                        thickness(iCell),              &
                        surfaceAirTemperature(iCell),  &
                        temperature(:,iCell),          &
-                       waterfrac(:,iCell),            &
+                       waterFrac(:,iCell),            &
                        surfaceTemperature(iCell),     &
                        basalTemperature(iCell))
 

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -101,6 +101,7 @@ module li_core_interface
       ! Local variables
       character (len=StrKIND), pointer :: config_velocity_solver
       character (len=StrKIND), pointer :: config_basal_mass_bal_float
+      character (len=StrKIND), pointer :: config_thermal_solver
       logical, pointer :: config_SGH
       logical, pointer :: config_adaptive_timestep_include_DCFL
       logical, pointer :: config_write_albany_ascii_mesh
@@ -110,6 +111,7 @@ module li_core_interface
       logical, pointer :: hydroActive
       logical, pointer :: observationsActive
       logical, pointer :: ismip6MeltActive
+      logical, pointer :: thermalActive
 
       ierr = 0
 
@@ -117,12 +119,14 @@ module li_core_interface
       call mpas_pool_get_config(configPool, 'config_SGH', config_SGH)
       call mpas_pool_get_config(configPool, 'config_write_albany_ascii_mesh', config_write_albany_ascii_mesh)
       call mpas_pool_get_config(configPool, 'config_basal_mass_bal_float', config_basal_mass_bal_float)
+      call mpas_pool_get_config(configPool, 'config_thermal_solver', config_thermal_solver)
 
       call mpas_pool_get_package(packagePool, 'SIAvelocityActive', SIAvelocityActive)
       call mpas_pool_get_package(packagePool, 'higherOrderVelocityActive', higherOrderVelocityActive)
       call mpas_pool_get_package(packagePool, 'hydroActive', hydroActive)
       call mpas_pool_get_package(packagePool, 'observationsActive', observationsActive)
       call mpas_pool_get_package(packagePool, 'ismip6MeltActive', ismip6MeltActive)
+      call mpas_pool_get_package(packagePool, 'thermalActive', thermalActive)
 
       if (trim(config_velocity_solver) == 'sia') then
          SIAvelocityActive = .true.
@@ -150,6 +154,13 @@ module li_core_interface
          call mpas_log_write("The 'ismip6Melt' package and assocated variables have been enabled because " // &
               "'config_basal_mass_bal_float' is set to 'ismip6'")
       endif
+
+      if ((trim(config_thermal_solver) == 'temperature') .or. (trim(config_thermal_solver) == 'enthalpy')) then
+         thermalActive = .true.
+         call mpas_log_write("The 'thermal' package and assocated variables have been enabled because " // &
+              "'config_thermal_solver' is set to either 'temperature' or 'enthalpy'.")
+      endif
+
 
 
       ! call setup packages in analysis driver

--- a/src/core_landice/mode_forward/mpas_li_thermal.F
+++ b/src/core_landice/mode_forward/mpas_li_thermal.F
@@ -155,7 +155,7 @@ module li_thermal
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,              & ! interior ice temperature (K)
-           waterfrac,                & ! interior water fraction (unitless)
+           waterFrac,                & ! interior water fraction (unitless)
            enthalpy                    ! interior ice enthalpy (J m^{-3})
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -242,7 +242,7 @@ module li_thermal
 
          ! get arrays from the thermal pool
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-         call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+         call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
          call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
@@ -371,26 +371,14 @@ module li_thermal
          ! The default is (1).
          ! If restarting, we always do (3).
          ! If (2) or (3), then the temperature should already have been read in, and there is
-         !  nothing to do here (except possibly to set waterfrac).
+         !  nothing to do here (except possibly to set waterFrac).
 
-         if (config_do_restart) then
+         if (config_do_restart .or. (trim(config_temperature_init) == 'file')) then
 
             ! nothing to do; temperature was read from the restart file
-            !TODO - Make sure waterfrac is also read, if needed
             if (config_print_thermal_info) then
-               call mpas_log_write('Initialized ice temperature from the restart file')
+               call mpas_log_write('Initialized ice temperature (and waterFrac if required) from file.')
             endif
-
-         elseif (trim(config_temperature_init) == 'file') then
-
-            ! Temperature was read from the input file
-            if (config_print_thermal_info) then
-               call mpas_log_write('Initialized ice temperature from the input file')
-            endif
-
-            ! initialize waterfrac, in case we are using the enthalpy solver
-            !TODO - Allow waterfrac to be read from the input file?
-            waterfrac(:,:) = 0.0_RKIND
 
          elseif (trim(config_temperature_init) == 'sfc_air_temperature') then
 
@@ -411,7 +399,7 @@ module li_thermal
             enddo
             deallocate(pmpTemperatureCol)
 
-            waterfrac(:,:) = 0.0_RKIND
+            waterFrac(:,:) = 0.0_RKIND
 
             if (config_print_thermal_info) then
                call mpas_log_write('Initialized ice column temperature to the surface air temperature')
@@ -434,7 +422,7 @@ module li_thermal
                     thickness(iCell),              &
                     surfaceAirTemperature(iCell),  &
                     temperature(:,iCell),          &
-                    waterfrac(:,iCell),            &
+                    waterFrac(:,iCell),            &
                     surfaceTemperature(iCell),     &
                     basalTemperature(iCell))
 
@@ -508,8 +496,8 @@ module li_thermal
       call mpas_dmpar_field_halo_exch(domain, 'temperature')
 
       if (trim(config_thermal_solver) == 'enthalpy') then
-         ! prognostic variables are temperature and waterfrac, so need to update waterfrac too
-         call mpas_dmpar_field_halo_exch(domain, 'waterfrac')
+         ! prognostic variables are temperature and waterFrac, so need to update waterFrac too
+         call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
       endif
 
       call mpas_timer_stop("halo updates")
@@ -544,7 +532,7 @@ module li_thermal
          thickness,              &
          surfaceAirTemperature,  &
          temperature,            &
-         waterfrac,              &
+         waterFrac,              &
          surfaceTemperature,     &
          basalTemperature)
 
@@ -568,7 +556,7 @@ module li_thermal
 
       real(kind=RKIND), dimension(nVertLevels), intent(out) ::  &
            temperature,     &           !< Output: interior ice temperature at midpoint of each layer
-           waterfrac                    !< Output: interior water fraction at midpoint of each layer
+           waterFrac                    !< Output: interior water fraction at midpoint of each layer
 
       real(kind=RKIND), intent(out) ::  &
            surfaceTemperature,     &    !< Output: surface ice temperature
@@ -622,8 +610,8 @@ module li_thermal
 
       temperature(:) = min(temperature(:), pmptemp(:) - pmpt_offset)
 
-      ! set waterfrac = 0
-      waterfrac(:) = 0.0_RKIND
+      ! set waterFrac = 0
+      waterFrac(:) = 0.0_RKIND
 
     end subroutine li_init_linear_temperature_in_column
 
@@ -733,7 +721,7 @@ module li_thermal
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,              & ! interior ice temperature (K)
-           waterfrac,                & ! interior water fraction (unitless)
+           waterFrac,                & ! interior water fraction (unitless)
            enthalpy,                 & ! interior ice enthalpy (J m^{-3})
            heatDissipation             ! interior heat dissipation (deg/s)
 
@@ -838,7 +826,7 @@ module li_thermal
 
          ! get fields from the thermal pool
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-         call mpas_pool_get_array(thermalPool, 'waterfrac', waterfrac)
+         call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
          call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature',   basalTemperature)
@@ -971,13 +959,13 @@ module li_thermal
 
                   if (trim(config_thermal_solver) == 'enthalpy') then
 
-                     ! Given temperature and waterfrac in ice interior, compute enthalpy
+                     ! Given temperature and waterFrac in ice interior, compute enthalpy
 
                      call li_temperature_to_enthalpy(&
                           layerCenterSigma,      &
                           thickness(iCell),      &
                           temperature(:,iCell),  &
-                          waterfrac(:,iCell),    &
+                          waterFrac(:,iCell),    &
                           enthalpy(:,iCell))
 
                      surfaceEnthalpy = surfaceTemperature(iCell) * rhoi*cp_ice
@@ -987,11 +975,11 @@ module li_thermal
                         call mpas_log_write(' ')
                         call mpas_log_write('Before prognostic enthalpy, iCell = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
-                        call mpas_log_write('Temperature (C), waterfrac, enthalpy/(rhoi*cp_ice):')
+                        call mpas_log_write('Temperature (C), waterFrac, enthalpy/(rhoi*cp_ice):')
                         call mpas_log_write('0 $r', realArgs=(/surfaceEnthalpy/(rhoi*cp_ice)/))
                         do k = 1, nVertLevels
                            call mpas_log_write('$i $r $r $r', intArgs=(/k/), realArgs= &
-                              (/temperature(k,iCell), waterfrac(k,iCell), enthalpy(k,iCell)/(rhoi*cp_ice)/))
+                              (/temperature(k,iCell), waterFrac(k,iCell), enthalpy(k,iCell)/(rhoi*cp_ice)/))
                         enddo
                         call mpas_log_write('$i $r', intArgs=(/nVertLevels+1/), realArgs=(/basalEnthalpy/(rhoi*cp_ice)/))
                      endif
@@ -1015,7 +1003,7 @@ module li_thermal
                           temperature(:,iCell),           &
                           surfaceTemperature(iCell),      &
                           basalTemperature(iCell),        &
-                          waterfrac(:,iCell),             &
+                          waterFrac(:,iCell),             &
                           enthalpy(:,iCell),              &
                           heatDissipation(:,iCell),       &
                           basalHeatFlux(iCell),           &
@@ -1068,14 +1056,14 @@ module li_thermal
                      basalConductiveFlux(iCell) = -diffusivity(nVertLevels+1)/thickness(iCell) * &
                         denth_bot/(1.0_RKIND - layerCenterSigma(nVertLevels))
 
-                     ! convert enthalpy in ice interior back to temperature and waterfrac
+                     ! convert enthalpy in ice interior back to temperature and waterFrac
 
                      call li_enthalpy_to_temperature(&
                           layerCenterSigma,          &
                           thickness(iCell),          &
                           enthalpy(:,iCell),         &
                           temperature(:,iCell),      &
-                          waterfrac(:,iCell),        &
+                          waterFrac(:,iCell),        &
                           surfaceEnthalpy,           &
                           surfaceTemperature(iCell), &
                           basalEnthalpy,             &
@@ -1094,11 +1082,11 @@ module li_thermal
                         call mpas_log_write(' ')
                         call mpas_log_write('After prognostic enthalpy, iCell = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
-                        call mpas_log_write('Temperature, waterfrac, enthalpy/(rhoi*cp_ice):')
+                        call mpas_log_write('Temperature, waterFrac, enthalpy/(rhoi*cp_ice):')
                         call mpas_log_write('0 $r', realArgs=(/surfaceEnthalpy/(rhoi*cp_ice)/))
                         do k = 1, nVertLevels
                            call mpas_log_write('$i $r $r $r', intArgs=(/k/), realArgs= &
-                              (/temperature(k,iCell), waterfrac(k,iCell), enthalpy(k,iCell)/(rhoi*cp_ice)/))
+                              (/temperature(k,iCell), waterFrac(k,iCell), enthalpy(k,iCell)/(rhoi*cp_ice)/))
                         enddo
                         call mpas_log_write('$i $r', intArgs=(/nVertLevels+1/), realArgs=(/basalEnthalpy/(rhoi*cp_ice)/))
                      endif
@@ -1271,7 +1259,7 @@ module li_thermal
                   surfaceTemperature(iCell) = 0.0_RKIND
                   basalTemperature(iCell) = 0.0_RKIND
                   temperature(:,iCell) = 0.0_RKIND
-                  waterfrac(:,iCell) = 0.0_RKIND
+                  waterFrac(:,iCell) = 0.0_RKIND
                   enthalpy(:,iCell) = 0.0_RKIND
 
                endif   ! thickness > config_thermal_thickness
@@ -1300,7 +1288,7 @@ module li_thermal
                  thickness,                    &
                  temperature,                  &
                  basalTemperature,             &
-                 waterfrac,                    &
+                 waterFrac,                    &
                  enthalpy,                     &
                  basalFrictionFlux,            &
                  basalHeatFlux,                &
@@ -1389,8 +1377,8 @@ module li_thermal
       call mpas_dmpar_field_halo_exch(domain, 'temperature')
 
       if (trim(config_thermal_solver) == 'enthalpy') then
-         ! prognostic variables are temperature and waterfrac, so need to update waterfrac too
-         call mpas_dmpar_field_halo_exch(domain, 'waterfrac')
+         ! prognostic variables are temperature and waterFrac, so need to update waterFrac too
+         call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
       endif
 
       call mpas_timer_stop("halo updates")
@@ -1802,7 +1790,7 @@ module li_thermal
          layerCenterSigma,  &
          thickness,         &
          temperature,       &
-         waterfrac,         &
+         waterFrac,         &
          enthalpy)
 
       !-----------------------------------------------------------------
@@ -1817,7 +1805,7 @@ module li_thermal
 
       real (kind=RKIND), dimension(:), intent(in) :: &
            temperature,        & !< Input: interior ice temperature
-           waterfrac             !< Input: interior water fraction
+           waterFrac             !< Input: interior water fraction
 
       !-----------------------------------------------------------------
       ! output variables
@@ -1847,8 +1835,8 @@ module li_thermal
       ! Solve for enthalpy
 
       do k = 1, nVertLevels
-         enthalpy(k) = (1.0_RKIND - waterfrac(k)) * rhoi * cp_ice * temperature(k)   &
-                      + waterfrac(k) * rhoi * (cp_ice * (pmpTemperature(k)+kelvin_to_celsius) + latent_heat_ice)
+         enthalpy(k) = (1.0_RKIND - waterFrac(k)) * rhoi * cp_ice * temperature(k)   &
+                      + waterFrac(k) * rhoi * (cp_ice * (pmpTemperature(k)+kelvin_to_celsius) + latent_heat_ice)
       end do
 
     end subroutine li_temperature_to_enthalpy_kelvin
@@ -1869,7 +1857,7 @@ module li_thermal
          layerCenterSigma,  &
          thickness,         &
          temperature,       &
-         waterfrac,         &
+         waterFrac,         &
          enthalpy)
 
       !-----------------------------------------------------------------
@@ -1884,7 +1872,7 @@ module li_thermal
 
       real (kind=RKIND), dimension(:), intent(in) :: &
            temperature,        & !< Input: interior ice temperature
-           waterfrac             !< Input: interior water fraction
+           waterFrac             !< Input: interior water fraction
 
       !-----------------------------------------------------------------
       ! output variables
@@ -1914,8 +1902,8 @@ module li_thermal
       ! Solve for enthalpy
 
       do k = 1, nVertLevels
-         enthalpy(k) = (1.0_RKIND - waterfrac(k)) * rhoi * cp_ice * temperature(k)   &
-                      + waterfrac(k) * rhoi * (cp_ice * pmpTemperature(k) + latent_heat_ice)
+         enthalpy(k) = (1.0_RKIND - waterFrac(k)) * rhoi * cp_ice * temperature(k)   &
+                      + waterFrac(k) * rhoi * (cp_ice * pmpTemperature(k) + latent_heat_ice)
       end do
 
       ! TZ: we should use rhoi instead of rho_water in the second term here.
@@ -1964,7 +1952,7 @@ module li_thermal
          thickness,          &
          enthalpy,           &
          temperature,        &
-         waterfrac,          &
+         waterFrac,          &
          surfaceEnthalpy,    &
          surfaceTemperature, &
          basalEnthalpy,      &
@@ -1999,7 +1987,7 @@ module li_thermal
            temperature           !< Output: interior ice temperature
 
       real (kind=RKIND), dimension(:), intent(out) :: &
-           waterfrac             !< Output: interior water fraction
+           waterFrac             !< Output: interior water fraction
 
       real (kind=RKIND), intent(out), optional :: &
            surfaceTemperature, & !< Output: surface ice temperature
@@ -2034,18 +2022,18 @@ module li_thermal
       pmpEnthalpy(:) = pmpTemperature(:) * rhoi*cp_ice
       pmpEnthalpyBed = pmpTemperatureBed * rhoi*cp_ice
 
-      ! Solve for temperature and waterfrac in ice interior
+      ! Solve for temperature and waterFrac in ice interior
 
       ! ice interior
 
       do k = 1, nVertLevels
          if (enthalpy(k) >= pmpEnthalpy(k)) then   ! temperate ice
             temperature(k) = pmpTemperature(k)
-            waterfrac(k) = (enthalpy(k) - pmpenthalpy(k)) /        &
+            waterFrac(k) = (enthalpy(k) - pmpenthalpy(k)) /        &
                           ((rho_water-rhoi)*cp_ice*pmpTemperature(k) + rhoi *latent_heat_ice)
          else   ! cold ice
             temperature(k) = enthalpy(k) / (rhoi*cp_ice)
-            waterfrac(k) = 0.0_RKIND
+            waterFrac(k) = 0.0_RKIND
          endif
       enddo   ! k
 
@@ -2101,7 +2089,7 @@ module li_thermal
          thickness,          &
          enthalpy,           &
          temperature,        &
-         waterfrac,          &
+         waterFrac,          &
          surfaceEnthalpy,    &
          surfaceTemperature, &
          basalEnthalpy,      &
@@ -2136,7 +2124,7 @@ module li_thermal
            temperature           !< Output: interior ice temperature
 
       real (kind=RKIND), dimension(:), intent(out) :: &
-           waterfrac             !< Output: interior water fraction
+           waterFrac             !< Output: interior water fraction
 
       real (kind=RKIND), intent(out), optional :: &
            surfaceTemperature, & !< Output: surface ice temperature
@@ -2171,18 +2159,18 @@ module li_thermal
       pmpEnthalpy(:) = (pmpTemperature(:)+kelvin_to_celsius) * rhoi*cp_ice
       pmpEnthalpyBed = (pmpTemperatureBed+kelvin_to_celsius) * rhoi*cp_ice
 
-      ! Solve for temperature and waterfrac in ice interior
+      ! Solve for temperature and waterFrac in ice interior
 
       ! ice interior
 
       do k = 1, nVertLevels
          if (enthalpy(k) >= pmpEnthalpy(k)) then   ! temperate ice
             temperature(k) = (pmpTemperature(k)+kelvin_to_celsius)
-            waterfrac(k) = (enthalpy(k) - pmpEnthalpy(k)) /        &
+            waterFrac(k) = (enthalpy(k) - pmpEnthalpy(k)) /        &
                           ((rho_water-rhoi)*cp_ice*(pmpTemperature(k)+kelvin_to_celsius) + rhoi *latent_heat_ice)
          else   ! cold ice
             temperature(k) = enthalpy(k) / (rhoi*cp_ice)
-            waterfrac(k) = 0.0_RKIND
+            waterFrac(k) = 0.0_RKIND
          endif
       enddo   ! k
 
@@ -2404,7 +2392,7 @@ module li_thermal
          temperature,           &
          surfaceTemperature,    &
          basalTemperature,      &
-         waterfrac,             &
+         waterFrac,             &
          enthalpy,              &
          heatDissipation,       &
          basalHeatFlux,         &
@@ -2444,7 +2432,7 @@ module li_thermal
 
       real(kind=RKIND), dimension(nVertLevels), intent(in) :: &
            temperature,           & !< Input: ice temperature (deg C)
-           waterfrac,             & !< Input: water fraction (unitless)
+           waterFrac,             & !< Input: water fraction (unitless)
            enthalpy                 !< Input: specific enthalpy (J/m^3)
 
       real(kind=RKIND), intent(in) :: &
@@ -2566,7 +2554,7 @@ module li_thermal
 
       enthalpyTemp(0) = surfaceEnthalpy
       do k = 1, nVertLevels
-         enthalpyTemp(k) = (1.0_RKIND - waterfrac(k)) * rhoi*cp_ice*temperature(k)
+         enthalpyTemp(k) = (1.0_RKIND - waterFrac(k)) * rhoi*cp_ice*temperature(k)
       enddo
       enthalpyTemp(nVertLevels+1) = basalEnthalpy
 
@@ -2588,7 +2576,7 @@ module li_thermal
          if (abs(dEnthalpy) > 1.e-20_RKIND * rho_water * latent_heat_ice) then
             avgFactor = max(0.0_RKIND, dEnthalpyTemp/dEnthalpy)
             avgFactor = min(1.0_RKIND, avgFactor)
-            ! TZ: Here temperature is in Celsius. dEnthalpyTemp <= 0 in temperate ice as waterfrac increases
+            ! TZ: Here temperature is in Celsius. dEnthalpyTemp <= 0 in temperate ice as waterFrac increases
             ! (or temperature decreases) with depth
          else
             avgFactor = 0.0_RKIND
@@ -2711,7 +2699,7 @@ module li_thermal
          thickness,                   &
          temperature,                 &
          basalTemperature,            &
-         waterfrac,                   &
+         waterFrac,                   &
          enthalpy,                    &
          basalFrictionFlux,           &
          basalHeatFlux,               &
@@ -2774,7 +2762,7 @@ module li_thermal
            basalWaterThickness      !< Input: thickness of basal water layer (m)
 
       real(kind=RKIND), dimension(:,:), intent(inout) :: &
-           waterfrac                !< Input/output: water fraction
+           waterFrac                !< Input/output: water fraction
 
       !-----------------------------------------------------------------
       ! output variables
@@ -2800,7 +2788,7 @@ module li_thermal
       real(kind=RKIND) :: internalMeltRate      ! internal melt rate, transferred to bed (m/s)
       real(kind=RKIND) :: excessWater           ! thickness of excess meltwater (m)
 
-      real(kind=RKIND) :: maxWaterfrac          ! maximum allowed water fraction; excess drains to bed
+      real(kind=RKIND) :: maxwaterFrac          ! maximum allowed water fraction; excess drains to bed
       real(kind=RKIND), pointer :: &
            config_max_water_fraction ! maximum allowable water fraction before additional melt drains
       real(kind=RKIND), parameter :: &
@@ -2808,7 +2796,7 @@ module li_thermal
 
       call mpas_pool_get_config(liConfigs, 'config_max_water_fraction', config_max_water_fraction)
 
-      maxWaterfrac = config_max_water_fraction
+      maxwaterFrac = config_max_water_fraction
 
       ! Compute melt rate for grounded ice
 
@@ -2844,7 +2832,7 @@ module li_thermal
 
             if (trim(config_thermal_solver) == 'enthalpy') then
                !groundedBasalMassBal(iCell) = -netBasalFlux / (latent_heat_ice * rhoi - enthalpy(nVertLevels,iCell))
-               groundedBasalMassBal(iCell) = -netBasalFlux / (latent_heat_ice * rhoi) / (1-waterfrac(nVertLevels,iCell))
+               groundedBasalMassBal(iCell) = -netBasalFlux / (latent_heat_ice * rhoi) / (1-waterFrac(nVertLevels,iCell))
                ! TZ: Don't understand yet why WHL added enthalpy(nVertLevels,iCell) here
                ! TZ: After a long discussion with Matt Hoffman, we decide to revise it
                ! to the form as Eqn (66) in Aschwanden and others (2012) "An
@@ -2870,14 +2858,14 @@ module li_thermal
 
             if (trim(config_thermal_solver) == 'enthalpy') then
 
-               ! Add internal melting associated with waterfrac > maxWaterfrac (1%)
+               ! Add internal melting associated with waterFrac > maxwaterFrac (1%)
                !TODO - Add correction for rhoi/rhow here?  Or melting ice that is already partly melted?
 
                do k = 1, nVertLevels
-                  if (waterfrac(k,iCell) > maxWaterfrac) then
+                  if (waterFrac(k,iCell) > maxwaterFrac) then
 
                      ! compute melt rate associated with excess water
-                     excessWater = (waterfrac(k,iCell) - maxWaterfrac) * thickness(iCell) * (layerInterfaceSigma(k+1) &
+                     excessWater = (waterFrac(k,iCell) - maxwaterFrac) * thickness(iCell) * (layerInterfaceSigma(k+1) &
                         - layerInterfaceSigma(k))  ! m
                      internalMeltRate = excessWater / deltat
 
@@ -2886,10 +2874,10 @@ module li_thermal
                      !       If so, then this melting will later be switched from groundedBasalMassBall to floatingBasalMassBal.
                      groundedBasalMassBal(iCell) = groundedBasalMassBal(iCell) - internalMeltRate      ! m/s
 
-                     ! reset waterfrac to max value
-                     waterfrac(k,iCell) = maxWaterfrac
+                     ! reset waterFrac to max value
+                     waterFrac(k,iCell) = maxwaterFrac
 
-                  endif   ! waterfrac > maxWaterfrac
+                  endif   ! waterFrac > maxwaterFrac
                enddo   ! k
 
             elseif (config_thermal_solver == 'temperature') then

--- a/src/core_landice/mode_forward/mpas_li_thermal.F
+++ b/src/core_landice/mode_forward/mpas_li_thermal.F
@@ -52,7 +52,8 @@ module li_thermal
              li_init_linear_temperature_in_column,  &
              li_temperature_to_enthalpy, li_enthalpy_to_temperature, &
              li_temperature_to_enthalpy_kelvin, li_enthalpy_to_temperature_kelvin, &
-             li_compute_pressure_melting_point_fields
+             li_compute_pressure_melting_point_fields, &
+             li_basal_friction, li_heat_dissipation_sia
 
    !--------------------------------------------------------------------
    !
@@ -867,19 +868,9 @@ module li_thermal
          enddo
 
 
-         ! === Calculate mechanical heating terms ===
-
-         if (trim(config_velocity_solver) == 'sia') then
-            ! Compute interior heat dissipation
-            call heat_dissipation_sia(domain, err_tmp)
-            err = ior(err, err_tmp)
-         endif   ! sia
-         ! (FO dissipation is calculated within dycore)
-
-         ! Compute heat flux due to basal friction
-         !   appropriate for SIA or FO dycore, assuming Taub=beta*ub
-         call basal_friction(domain, err_tmp)
-         err = ior(err, err_tmp)
+         ! === mechanical heating terms now calculated in li_velocity_solve ===
+         ! (this makes restarts easier because just heatDissipation and basalFrictionFlux
+         !  need to be restart variables, rather than all of their inputs.)
 
 
          ! === Update surfaceTemperature if using a lapse rate ===
@@ -1393,7 +1384,7 @@ module li_thermal
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  !  routine heat_dissipation_sia
+!  !  routine li_heat_dissipation_sia
 !
 !> \brief MPAS land ice heat dissipation for SIA velocity solver
 !> \author William Lipscomb
@@ -1403,7 +1394,7 @@ module li_thermal
 !>  in the ice interior, based on the shallow-ice approximation.
 !-----------------------------------------------------------------------
 
-  subroutine heat_dissipation_sia(domain, err)
+  subroutine li_heat_dissipation_sia(domain, err)
 
      !-----------------------------------------------------------------
      ! input/output variables
@@ -1649,12 +1640,12 @@ module li_thermal
         block => block % next
      enddo  ! associated(block)
 
-   end subroutine heat_dissipation_sia
+   end subroutine li_heat_dissipation_sia
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  !  routine basal_friction
+!  !  routine li_basal_friction
 !
 !> \brief MPAS heat flux due to basal friction for SIA dynamics
 !> \author William Lipscomb
@@ -1664,7 +1655,7 @@ module li_thermal
 !>  base of the ice, based on the shallow-ice approximation.
 !-----------------------------------------------------------------------
 
-   subroutine basal_friction(domain, err)
+   subroutine li_basal_friction(domain, err)
 
      !-----------------------------------------------------------------
      ! input/output variables
@@ -1772,7 +1763,7 @@ module li_thermal
         block => block % next
      enddo  ! associated(block)
 
-  end subroutine basal_friction
+  end subroutine li_basal_friction
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -577,7 +577,7 @@ module li_time_integration_fe
       real (kind=RKIND), dimension(:), pointer :: thickness
 
       real (kind=RKIND), dimension(:,:), pointer :: temperature
-      real (kind=RKIND), dimension(:,:), pointer :: waterfrac
+      real (kind=RKIND), dimension(:,:), pointer :: waterFrac
       real (kind=RKIND), dimension(:,:), pointer :: enthalpy
 
       integer, pointer :: nCells
@@ -603,7 +603,7 @@ module li_time_integration_fe
 
       ! Halo updates
       ! Note: The layer thickness and tracers must be up to date in halos before calling the advection subroutines.
-      !   The thermal tracers (temperature, waterfrac, enthalpy) are updated at the end of li_thermal_solver.
+      !   The thermal tracers (temperature, waterFrac, enthalpy) are updated at the end of li_thermal_solver.
       !   But thickness (which is used by subroutine li_advection_thickness_tracers) needs an update here. TODO: confirm this
 
       call mpas_timer_start("halo updates")
@@ -739,7 +739,7 @@ module li_time_integration_fe
 
       call mpas_dmpar_field_halo_exch(domain, 'thickness')
       call mpas_dmpar_field_halo_exch(domain, 'temperature')
-      call mpas_dmpar_field_halo_exch(domain, 'waterfrac')
+      call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
       call mpas_dmpar_field_halo_exch(domain, 'enthalpy')
 
       call mpas_timer_stop("halo updates")

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -227,6 +227,7 @@ contains
       use mpas_vector_reconstruction
       use li_mask
       use li_advection
+      use li_thermal
 
       !-----------------------------------------------------------------
       ! input variables
@@ -312,7 +313,7 @@ contains
          config_do_velocity_reconstruction_for_external_dycore)
       call mpas_pool_get_config(liConfigs, 'config_print_velocity_cleanup_details', config_print_velocity_cleanup_details)
       call mpas_pool_get_config(liConfigs, 'config_dynamic_thickness', config_dynamic_thickness)
-          call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
+      call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
 
       uphillMarginEdgesFixed = 0
 
@@ -669,6 +670,21 @@ contains
 
          block => block % next
       end do
+
+      ! calculate velocity-related thermal source term fields
+      ! (do it here to make restarts easier - this way only the fields need to be restart
+      !  variables, rather than the fields that are input to the calculations.)
+      if (solveVelo) then
+         ! (on a restart value, do not try to calculate these - instead use the fields in the restart file)
+         call li_basal_friction(domain, err_tmp)
+         err = ior(err, err_tmp)
+
+         if (trim(config_velocity_solver) == 'sia') then
+            ! For FO solver, heatDissipation is passed back from Albany
+            call li_heat_dissipation_sia(domain, err_tmp)
+            err = ior(err, err_tmp)
+         endif
+      endif
 
       ! === error check
       if (err > 0) then

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -797,12 +797,15 @@ contains
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: thermalPool
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: betaSolve, beta
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: basalTemperature, basalPmpTemperature
       integer, dimension(:), pointer :: cellMask
       logical, pointer :: config_use_glp
       logical, pointer :: config_beta_use_effective_pressure
+      logical, pointer :: config_beta_thawed_only
       logical, pointer :: hydroActive
       real (kind=RKIND) :: betaAccum
       integer :: nBetaValues
@@ -816,9 +819,11 @@ contains
 
       call mpas_pool_get_config(liConfigs, 'config_use_glp', config_use_glp)
       call mpas_pool_get_config(liConfigs, 'config_beta_use_effective_pressure', config_beta_use_effective_pressure)
+      call mpas_pool_get_config(liConfigs, 'config_beta_thawed_only', config_beta_thawed_only)
 
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+      call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
       call mpas_pool_get_array(velocityPool, 'betaSolve', betaSolve)
@@ -868,6 +873,14 @@ contains
 
       end if ! if config_beta_use_effective_pressure
 
+      if (config_beta_thawed_only) then
+         call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
+         call mpas_pool_get_array(thermalPool, 'basalPmpTemperature', basalPmpTemperature)
+         where (basalPmpTemperature - basalTemperature > 0.01_RKIND)
+            ! Use a small difference to account for roundoff.  0.01 is value used in thermal module.
+            betaSolve = 1.0e6_RKIND  ! no-slip value for frozen bed locations
+         end where
+      endif
 
       if (.not. config_use_glp) then
          where (li_mask_is_floating_ice(cellMask))

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_driver.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="setup_and_run_EISMINT2_enthalpy_restart_testcase.py">
+        <case name="setup_mesh">
+                <step executable="./setup_mesh.py" quiet="false" pre_message=" * Running setup_mesh step" post_message="     Complete"/>
+        </case>
+        <case name="full_run">
+                <step executable="./full_run.py" quiet="false" pre_message=" * Running full_run step" post_message="     Complete"/>
+        </case>
+        <case name="restart_run">
+                <step executable="./restart_run.py" quiet="false" pre_message=" * Running restart_run step" post_message="     Complete"/>
+        </case>
+        <validation>
+                <compare_fields file1="full_run/output.nc" file2="restart_run/output.nc">
+                        <template file="output_comparison.xml" path_base="script_test_dir"/>
+                </compare_fields>
+        </validation>
+</driver_script>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_full_run_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_full_run_step.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<config case="full_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'3000-00-00_00:00:00'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+                <option name="config_thermal_solver">'enthalpy'</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <run_script name="full_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the model -->
+                <model_run procs="1" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_restart_run_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_restart_run_step.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<config case="restart_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'2000-00-00_00:00:00'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+                <option name="config_thermal_solver">'enthalpy'</option>
+        </namelist>
+
+        <namelist name="namelist.landice.rst" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'1000-00-00_00:00:00'</option>
+                <option name="config_start_time">'file'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.true.</option>
+                <option name="config_thermal_solver">'enthalpy'</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <streams name="streams.landice.rst" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">overwrite</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+
+        <run_script name="restart_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the first part of the run -->
+                <model_run procs="1" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+                <!-- Run the restart part of the run -->
+                <model_run procs="1" threads="1" namelist="namelist.landice.rst" streams="streams.landice.rst"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_setup_mesh_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/config_setup_mesh_step.xml
@@ -1,0 +1,1 @@
+../standard_experiments/config_setup_mesh_step.xml

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_restart_test/output_comparison.xml
@@ -1,0 +1,11 @@
+<template>
+        <validation>
+                <compare_fields>
+                        <field name="thickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="temperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="basalTemperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="heatDissipation" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                </compare_fields>
+        </validation>
+</template>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_driver.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="setup_and_run_EISMINT2_restart_testcase.py">
+        <case name="setup_mesh">
+                <step executable="./setup_mesh.py" quiet="false" pre_message=" * Running setup_mesh step" post_message="     Complete"/>
+        </case>
+        <case name="full_run">
+                <step executable="./full_run.py" quiet="false" pre_message=" * Running full_run step" post_message="     Complete"/>
+        </case>
+        <case name="restart_run">
+                <step executable="./restart_run.py" quiet="false" pre_message=" * Running restart_run step" post_message="     Complete"/>
+        </case>
+        <validation>
+                <compare_fields file1="full_run/output.nc" file2="restart_run/output.nc">
+                        <template file="output_comparison.xml" path_base="script_test_dir"/>
+                </compare_fields>
+        </validation>
+</driver_script>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_full_run_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_full_run_step.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<config case="full_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'3000-00-00_00:00:00'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <run_script name="full_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the model -->
+                <model_run procs="1" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_restart_run_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_restart_run_step.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<config case="restart_run">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'2000-00-00_00:00:00'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.false.</option>
+        </namelist>
+
+        <namelist name="namelist.landice.rst" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'1000-00-00_00:00:00'</option>
+                <option name="config_start_time">'file'</option>
+                <option name="config_dt">'0100-00-00_00:00:00'</option>
+                <option name="config_adaptive_timestep">.false.</option>
+                <option name="config_write_output_on_startup">.true.</option>
+                <option name="config_do_restart">.true.</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">truncate</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <streams name="streams.landice.rst" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0100-00-00_00:00:00</attribute>
+                        <attribute name="clobber_mode">overwrite</attribute>
+                </stream>
+                <stream name="restart">
+                        <attribute name="filename_template">rst.$Y.nc</attribute>
+                        <attribute name="filename_interval">output_interval</attribute>
+                        <attribute name="output_interval">1000-00-00_00:00:00</attribute>
+                </stream>
+        </streams>
+
+
+        <run_script name="restart_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the first part of the run -->
+                <model_run procs="1" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+                <!-- Run the restart part of the run -->
+                <model_run procs="1" threads="1" namelist="namelist.landice.rst" streams="streams.landice.rst"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_setup_mesh_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/config_setup_mesh_step.xml
@@ -1,0 +1,1 @@
+../standard_experiments/config_setup_mesh_step.xml

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/restart_test/output_comparison.xml
@@ -1,0 +1,11 @@
+<template>
+        <validation>
+                <compare_fields>
+                        <field name="thickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="temperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="basalTemperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="heatDissipation" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                </compare_fields>
+        </validation>
+</template>
+

--- a/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
@@ -26,6 +26,14 @@
                 <script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py"/>
         </test>
 
+        <test name="EISMINT2-F restart test" core="landice" configuration="EISMINT2" resolution="25000m" test="restart_test">
+                <script name="setup_and_run_EISMINT2_restart_testcase.py"/>
+        </test>
+
+        <test name="EISMINT2-F enthalpy restart test" core="landice" configuration="EISMINT2" resolution="25000m" test="enthalpy_restart_test">
+                <script name="setup_and_run_EISMINT2_enthalpy_restart_testcase.py"/>
+        </test>
+
         <test name="GIS restart test" core="landice" configuration="greenland" resolution="20km" test="restart_test">
                 <script name="setup_and_run_testcase.py"/>
         </test>

--- a/testing_and_setup/compass/landice/regression_suites/sia_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/sia_integration_test_suite.xml
@@ -25,6 +25,14 @@
                 <script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py"/>
         </test>
 
+        <test name="EISMINT2-F restart test" core="landice" configuration="EISMINT2" resolution="25000m" test="restart_test">
+                <script name="setup_and_run_EISMINT2_restart_testcase.py"/>
+        </test>
+
+        <test name="EISMINT2-F enthalpy restart test" core="landice" configuration="EISMINT2" resolution="25000m" test="enthalpy_restart_test">
+                <script name="setup_and_run_EISMINT2_enthalpy_restart_testcase.py"/>
+        </test>
+
         <test name="GIS restart test" core="landice" configuration="greenland" resolution="20km" test="restart_test">
                 <script name="setup_and_run_testcase.py"/>
         </test>


### PR DESCRIPTION
This merge addresses a number of issues with the thermal solver

* Fixes a bug that prevented the enthalpy solver from being BFB across different decompositions (Bug and its fix found by Tong Zhang)
* Fixes a bug that prevented both the temperature and enthalpy solvers from being BFB on restarts (mechanical heat source terms were incorrect on restart) (bug found by Trevor Hillebrand)
* waterfrac has been renamed to waterFrac everywhere
* some thermal fields are now only restart fields if the thermal solver is on (by adding a new 'thermal' package)
* new restart tests are added to COMPASS for both temperature and enthalpy solvers (using EISMINT2 test case)

This merge also includes a related (as in related to thermal conditions) but separate modification that provides an option to force the bed to be no-slip where the bed is frozen.