### PR TITLE
Switch to getting Ocean-BGC and CVMix form hashes instead of branches

### DIFF
--- a/src/core_ocean/get_BGC.sh
+++ b/src/core_ocean/get_BGC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## BGC Tag for build
-BGC_TAG=maint-1.0
+BGC_TAG=1a99684
 
 ## Subdirectory in BGC repo to use
 BGC_SUBDIR=.

--- a/src/core_ocean/get_cvmix.sh
+++ b/src/core_ocean/get_cvmix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## CVMix Tag for build
-CVMIX_TAG=maint-1.0
+CVMIX_TAG=57dddb8
 ## Subdirectory in CVMix repo to use
 CVMIX_SUBDIR=src/shared
 


### PR DESCRIPTION
In my last PR (#392), I was downloading Ocean-BGC and CVMix from their respective `maint-1.0` branches.  In the discussion of https://github.com/E3SM-Project/E3SM/pull/3308, it became clear there was concern about this approach, so I have switched to commit hashes instead.
