### PR TITLE
Fix out-of-bounds array access when GWDO scheme was run with multiple threads

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
@@ -365,7 +365,7 @@ contains
    dxy4p(its:ite,3) = dxy4(its:ite,4)
    dxy4p(its:ite,4) = dxy4(its:ite,3)
 !
-   cleff(its:ite) = dxmeter
+   cleff(its:ite) = dxmeter(its:ite)
 !
 ! initialize arrays                                                 
 !                                                                       


### PR DESCRIPTION
This merge fixes an out-of-bounds array access when the GWDO scheme was run
with multiple threads.

When MPAS-Atmosphere was compiled with OpenMP and run with multiple threads,
an out-of-bounds array access was generated in the GWDO scheme when an array
of size (ims:ime) was assigned to an array of size (its:ite):

   cleff(its:ite) = dxmeter

The simple fix is to copy only the elements (its:ite) of the dxmeter array:

   cleff(its:ite) = dxmeter(its:ite)

When the GWDO scheme is run with just one thread, ims = its and ime = ite,
so there was no out-of-bounds access.