### PR TITLE
Update EISMINT2 tests

### DIFF
--- a/src/core_landice/analysis_members/mpas_li_global_stats.F
+++ b/src/core_landice/analysis_members/mpas_li_global_stats.F
@@ -457,8 +457,13 @@ contains
          groundingLineFlux = reductions(15)
          groundingLineMigrationFlux = reductions(16)
 
-         iceThicknessMean = totalIceVolume / totalIceArea
-         avgNetAccumulation = totalSfcMassBal / totalIceArea / rhoi
+         if (totalIceArea > 0.0_RKIND) then
+            iceThicknessMean = totalIceVolume / totalIceArea
+            avgNetAccumulation = totalSfcMassBal / totalIceArea / rhoi
+         else
+            iceThicknessMean = 0.0_RKIND
+            avgNetAccumulation = 0.0_RKIND
+         endif
          if (groundedIceArea > 0.0_RKIND) then
             avgGroundedBasalMelt = -1.0_RKIND * totalGroundedBasalMassBal / groundedIceArea / rhoi
          else

--- a/testing_and_setup/compass/README_landice.md
+++ b/testing_and_setup/compass/README_landice.md
@@ -6,14 +6,12 @@ To set up and run landice test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_py2.7 -c conda-forge python=2.7 geometric_features mpas_tools jigsaw metis pyflann scikit-image basemap pyamg pyqt
+conda create -n compass_py3.7 -c conda-forge -c xylar python=3.7 geometric_features mpas_tools jigsaw jigsawpy metis pyflann scikit-image basemap pyamg ffmpeg pyqt
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_py2.7
+conda activate compass_py3.7
 ```
-
-Note: As of June 2019 Python 2.7 is still the supported version of python, but migration to Python 3.7 is underway.
 
 ## Setting config options
 

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/EISMINT2_25000m_template.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/EISMINT2_25000m_template.xml
@@ -12,6 +12,7 @@
                 <option name="config_flowParamA_calculation">"PB1982"</option>
                 <option name="config_tracer_advection">'fo'</option>
                 <option name="config_thermal_solver">'temperature'</option>
+                <option name="config_thermal_calculate_bmb">.false.</option>
                 <option name="config_surface_air_temperature_source">'file'</option>
                 <option name="config_basal_heat_flux_source">'constant'</option>
                 <option name="config_basal_heat_flux_value">4.2e-2</option>

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/EISMINT2_25000m_template.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/EISMINT2_25000m_template.xml
@@ -19,6 +19,11 @@
                 <option name="config_ice_density">910.0</option>
                 <option name="config_dynamic_thickness">10.0</option>
                 <option name="config_year_digits">6</option>
+
+                <option name="config_AM_globalStats_enable">.true.</option>
+                <option name="config_AM_globalStats_compute_interval">'output_interval'</option>
+                <option name="config_AM_globalStats_compute_on_startup">.true.</option>
+                <option name="config_AM_globalStats_write_on_startup">.true.</option>
         </namelist>
 
         <streams>
@@ -51,6 +56,23 @@
                                 <member name="allowableDtACFL" type="var"/>
                                 <member name="allowableDtDCFL" type="var"/>
                                 <member name="deltat" type="var"/>
+                        </add_contents>
+                </stream>
+
+                <stream name="globalStatsOutput">
+                        <attribute name="type">output</attribute>
+                        <attribute name="filename_template">globalStats.nc</attribute>
+                        <attribute name="output_interval">0000-00-01_00:00:00</attribute>
+                        <attribute name="reference_time">0000-01-01_00:00:00</attribute>
+                        <attribute name="clobber_mode">overwrite</attribute>
+                        <!-- <attribute name="io_type">netcdf</attribute> -->
+                        <add_contents>
+                                <member name="xtime" type="var"/>
+                                <member name="deltat" type="var"/>
+                                <member name="daysSinceStart" type="var"/>
+                                <member name="allowableDtACFL" type="var"/>
+                                <member name="allowableDtDCFL" type="var"/>
+                                <member name="globalStatsAM" type="var_struct"/>
                         </add_contents>
                 </stream>
 

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_driver.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py">
+        <case name="setup_mesh">
+                <step executable="./setup_mesh.py" quiet="false" pre_message=" * Running setup_mesh step" post_message="     Complete"/>
+        </case>
+        <case name="experiment_F_1p">
+                <step executable="./1proc_run.py" quiet="false" pre_message=" * Running 1proc_run step" post_message="     Complete"/>
+        </case>
+        <case name="experiment_F_4p">
+                <step executable="./4proc_run.py" quiet="false" pre_message=" * Running 4proc_run step" post_message="     Complete"/>
+        </case>
+        <validation>
+                <compare_fields file1="experiment_F_1p/output.nc" file2="experiment_F_4p/output.nc">
+                        <template file="output_comparison.xml" path_base="script_test_dir"/>
+                </compare_fields>
+        </validation>
+</driver_script>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_experiment_F_1p.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_experiment_F_1p.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="experiment_F_1p">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'3000-00-00_00:00:00'</option>
+                <option name="config_thermal_solver">'enthalpy'</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0000-00-01_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <run_script name="1proc_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the model -->
+                <model_run procs="1" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_experiment_F_4p.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_experiment_F_4p.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<config case="experiment_F_4p">
+        <!-- add needed files/executables -->
+        <add_link source="../setup_mesh/graph.info" dest="."/>
+        <add_link source="../setup_mesh/graph.info.part.4" dest="."/>
+        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
+        <add_executable source="model" dest="landice_model"/>
+        <!-- link in scripts that the user will need -->
+        <add_link source_path="script_configuration_dir" source="setup_initial_conditions_EISMINT2.py" dest="."/>
+        <add_link source_path="script_configuration_dir" source="visualize_output_EISMINT2.py" dest="."/>
+
+        <namelist name="namelist.landice" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <option name="config_run_duration">'3000-00-00_00:00:00'</option>
+                <option name="config_thermal_solver">'enthalpy'</option>
+        </namelist>
+
+        <streams name="streams.landice" keep="immutable" mode="forward">
+                <template file="EISMINT2_25000m_template.xml" path_base="script_resolution_dir"/>
+                <stream name="output">
+                        <attribute name="output_interval">0000-00-01_00:00:00</attribute>
+                </stream>
+        </streams>
+
+        <run_script name="4proc_run.py">
+
+                <!-- Set up IC -->
+                <step executable="./setup_initial_conditions_EISMINT2.py">
+                        <argument flag="-e">f</argument>
+                </step>
+
+                <!-- Run the model -->
+                <model_run procs="4" threads="1" namelist="namelist.landice" streams="streams.landice"/>
+
+        </run_script>
+
+</config>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_setup_mesh_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/config_setup_mesh_step.xml
@@ -1,0 +1,1 @@
+../standard_experiments/config_setup_mesh_step.xml

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/output_comparison.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/enthalpy_decomposition_test/output_comparison.xml
@@ -1,0 +1,11 @@
+<template>
+        <validation>
+                <compare_fields>
+                        <field name="thickness" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="temperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="basalTemperature" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                        <field name="heatDissipation" l1_norm="0.0" l2_norm="0.0" linf_norm="0.0"/>
+                </compare_fields>
+        </validation>
+</template>
+

--- a/testing_and_setup/compass/landice/EISMINT2/25000m/standard_experiments/config_setup_mesh_step.xml
+++ b/testing_and_setup/compass/landice/EISMINT2/25000m/standard_experiments/config_setup_mesh_step.xml
@@ -16,9 +16,28 @@
                         <argument flag="">mpas_grid.nc</argument>
                 </step>
 
+                <!-- run though mesh converter to make sure MPAS compliant -->
+                <step executable="define_cullMask.py" >
+                        <argument flag="-f">mpas_grid.nc</argument>
+                        <argument flag="-m">radius</argument>
+                        <argument flag="-d">750.0</argument>
+                </step>
+
+                <!-- cull cells -->
+                <step executable="MpasCellCuller.x" >
+                        <argument flag="">mpas_grid.nc</argument>
+                        <argument flag="">culled_grid.nc</argument>
+                </step>
+
+                <!-- run though mesh converter to make sure MPAS compliant -->
+                <step executable="MpasMeshConverter.x" pre_message="\n\n### Creating MPAS mesh\n\n" post_message="\n\n### MPAS mesh creation complete\n\n">
+                        <argument flag="">culled_grid.nc</argument>
+                        <argument flag="">mpas_grid2.nc</argument>
+                </step>
+
                 <!-- Convert from basic MPAS mesh to MPASLI mesh -->
                 <step executable="create_landice_grid_from_generic_MPAS_grid.py" pre_message="\n\n### Creating LI mesh\n\n" post_message="\n\n### LI mesh creation complete\n\n">
-                        <argument flag="-i">mpas_grid.nc</argument>
+                        <argument flag="-i">mpas_grid2.nc</argument>
                         <argument flag="-o">landice_grid.nc</argument>
                         <argument flag="-l">10</argument>
                         <argument flag="--thermal"></argument>

--- a/testing_and_setup/compass/landice/EISMINT2/README
+++ b/testing_and_setup/compass/landice/EISMINT2/README
@@ -1,0 +1,7 @@
+To run EISMINT2 experiments, first set up the test case like usual,
+including running the auto-generated python script in the work directory.
+
+Then in each experiment directory, first run the setup_initial_conditions_EISMINT2.py.
+Then manually run landice_model on the number of processors you wish.
+
+To view the results, run visualize_output_EISMINT2.py.

--- a/testing_and_setup/compass/landice/EISMINT2/visualize_output_EISMINT2.py
+++ b/testing_and_setup/compass/landice/EISMINT2/visualize_output_EISMINT2.py
@@ -224,7 +224,8 @@ plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, c=np.array([[0.8, 
 #contour_intervals = np.linspace(0.0, 20.0, 20.0/2.0+1)
 contour_intervals = np.linspace(0.0, 16.0, 16.0/0.5+1)
 #contourMPAS(flwa[timelev,:,:].mean(axis=1) *3600.0*24.0*365.0 / 1.0e-17, contour_levs=contour_intervals)  # NOT SURE WHICH LEVEL FLWA SHOULD COME FROM - so taking column average
-contourMPAS(flwa[timelev,:,:].mean(axis=1) * 3600.0*24.0*365.0 / 1.0e-17)  # NOT SURE WHICH LEVEL FLWA SHOULD COME FROM - so taking column average
+if flwa[timelev,:,:].max()>0.0:  # this is not used if FO velo solver is used
+   contourMPAS(flwa[timelev,:,:].mean(axis=1) * 3600.0*24.0*365.0 / 1.0e-17)  # NOT SURE WHICH LEVEL FLWA SHOULD COME FROM - so taking column average
 ax.set_aspect('equal')
 plt.title('Final flow factor (10$^{-17}$ Pa$^{-3}$ a$^{-1}$)' )  # Note: the paper's figure claims units of 10$^{-25}$ Pa$^{-3}$ a$^{-1}$ but the time unit appears to be 10^-17
 #plt.xlim( (0.0, 750.0) ); plt.ylim( (0.0, 750.0) )
@@ -295,6 +296,7 @@ else:
     plt.ylabel('Volume (10$^6$ km$^3$)')
 plt.plot( (0.0,), volume, 'ro')  # MPAS results
 plt.xticks(())
+print("MALI volume = {}".format(volume))
 
 fig.add_subplot(152)
 area = (areaCell[iceIndices]).sum() / 1000.0**2 / 10.0**6
@@ -308,6 +310,7 @@ else:
     plt.ylabel('Area (10$^6$ km$^2$)')
 plt.plot( (0.0,), area, 'ro')  # MPAS results
 plt.xticks(())
+print("MALI area = {}".format(area))
 
 fig.add_subplot(153)
 warmBedIndices = np.where(np.logical_and(thickness[timelev,:] > 0.0, basalTemperature[timelev,:] >= (basalPmpTemperature[timelev,:] - 0.01) ) )[0]  # using threshold here to identify melted locations
@@ -326,6 +329,7 @@ else:
     plt.ylabel('Melt fraction')
 plt.plot( (0.0,), meltfraction, 'ro')  # MPAS results
 plt.xticks(())
+print("MALI melt fraction = {}".format(meltfraction))
 
 fig.add_subplot(154)
 dividethickness = thickness[timelev, divideIndex]
@@ -337,6 +341,7 @@ else:
     plt.ylabel('Divide thickness (m)')
 plt.plot( (0.0,), dividethickness, 'ro')  # MPAS results
 plt.xticks(())
+print("MALI divide thickness = {}".format(dividethickness[0]))
 
 fig.add_subplot(155)
 dividebasaltemp = basalTemperature[timelev, divideIndex]
@@ -349,6 +354,7 @@ else:
     plt.ylabel('Divide basal temp. (K)')
 plt.plot( (0.0,), dividebasaltemp, 'ro')  # MPAS results
 plt.xticks(())
+print("MALI divide basal temperature = {}".format(dividebasaltemp[0]))
 
 plt.tight_layout()
 

--- a/testing_and_setup/compass/landice/EISMINT2/visualize_output_EISMINT2.py
+++ b/testing_and_setup/compass/landice/EISMINT2/visualize_output_EISMINT2.py
@@ -10,7 +10,8 @@ import netCDF4
 from optparse import OptionParser
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.mlab import griddata
+#from matplotlib.mlab import griddata
+from scipy.interpolate import griddata
 
 # Parse options
 from optparse import OptionParser
@@ -59,7 +60,7 @@ def xtimeGetYear(xtime):
 
 
 
-def contourMPAS(field, contour_levs=None):
+def contourMPAS(field, contour_levs=np.array([0])):
   """Contours irregular MPAS data on cells"""
   #-- Now let's grid your data.
   # First we'll make a regular grid to interpolate onto.
@@ -69,9 +70,9 @@ def contourMPAS(field, contour_levs=None):
   yc = np.linspace(yCell.min(), yCell.max(), numrows)
   xi, yi = np.meshgrid(xc, yc)
   #-- Interpolate at the points in xi, yi
-  zi = griddata(xCell, yCell, field, xi, yi)
+  zi = griddata((xCell, yCell), field, (xi, yi))
   #-- Display the results
-  if contour_levs == None:
+  if len(contour_levs)==1:
      im = plt.contour(xi, yi, zi)
   else:
      im = plt.contour(xi, yi, zi, contour_levs, cmap=plt.cm.jet)
@@ -109,7 +110,7 @@ layerThicknessFractions = filein.variables['layerThicknessFractions'][:]
 secInYr = 365.0*24.0*3600.0
 
 timelev = -1  # Use final time
-print('Using final model time of ' + xtime[timelev,:].tostring().strip() + '\n')
+print('Using final model time of ' + xtime[timelev,:].tostring().strip().decode('utf-8') + '\n')
 
 
 ##### Print some stats about the error
@@ -148,14 +149,14 @@ fig.suptitle('Payne et al. Fig. 1, 3, 6, 9, or 11', fontsize=12, fontweight='bol
 
 # print ice locations with gray hexagons
 iceIndices = np.where(thickness[timelev,:]>10.0)[0]
-plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, (0.8, 0.8, 0.8), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
+plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, c=np.array([[0.8, 0.8, 0.8],]), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
 
 # add contours of ice temperature over the top
 basalTemp = basalTemperature[timelev,:]
 # fill places below dynamic limit with non-ice value of 273.15
 basalTemp[np.where(thickness[timelev,:]<10.0)] = 273.15
 #plt.scatter(xCell, yCell, markersize, basalTemp[:], marker=markershape, edgecolors='none') # print ice locations with gray hexagons; plt.plot()
-contourMPAS(basalTemp, np.linspace(240.0, 275.0, 8))
+contourMPAS(basalTemp, contour_levs=np.linspace(240.0, 275.0, 8))
 
 plt.axis('equal')
 plt.title('Modeled basal temperature (K) \n at time ' + netCDF4.chartostring(xtime)[timelev].strip() )
@@ -177,7 +178,7 @@ fig.suptitle('Payne et al. Fig. 2 or 4', fontsize=12, fontweight='bold')
 ax1 = fig.add_subplot(131)
 
 # print ice locations with gray hexagons
-plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, (0.8, 0.8, 0.8), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
+plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, c=np.array([[0.8, 0.8, 0.8],]), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
 
 # add contours of ice thickness over the top
 contour_intervals = np.linspace(0.0, 5000.0,  5000.0/250.0+1)
@@ -185,7 +186,7 @@ contourMPAS(thickness[timelev,:], contour_levs=contour_intervals)
 #contourMPAS(thickness[timelev,:])
 
 plt.title('Final thickness (m)' )
-plt.axis('equal')
+ax1.set_aspect('equal')
 #plt.xlim( (0.0, 750.0) ); plt.ylim( (0.0, 750.0) )
 plt.xlabel('X position (km)'); plt.ylabel('Y position (km)')
 
@@ -200,14 +201,14 @@ for k in range(nVertLevels):
     flux += speedLevel * thickness[timelev,:] * layerThicknessFractions[k]
 
 # print ice locations with gray hexagons
-plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, (0.8, 0.8, 0.8), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
+plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, c=np.array([[0.8, 0.8, 0.8],]), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
 
 # add contours over the top
 #contour_intervals = np.linspace(0.0, 10.0,  10.0/0.5+1)
 contour_intervals = np.linspace(0.0, 20.0,  11)
 contourMPAS(flux * 3600.0*24.0*365.0 / 10000.0, contour_levs=contour_intervals)
 #contourMPAS(flux * 3600.0*24.0*365.0 / 10000.0)
-plt.axis('equal')
+ax.set_aspect('equal')
 plt.title('Final flux (m$^2$ a$^{-1}$ / 10000)' )
 #plt.xlim( (0.0, 750.0) ); plt.ylim( (0.0, 750.0) )
 plt.xlabel('X position (km)'); plt.ylabel('Y position (km)')
@@ -217,14 +218,14 @@ plt.xlabel('X position (km)'); plt.ylabel('Y position (km)')
 ax = fig.add_subplot(132, sharex=ax1, sharey=ax1)
 
 # print ice locations with gray hexagons
-plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, (0.8, 0.8, 0.8), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
+plt.scatter(xCell[iceIndices], yCell[iceIndices], markersize, c=np.array([[0.8, 0.8, 0.8],]), marker=markershape, edgecolors='none') # print ice locations with gray hexagons
 
 # add contours over the top
 #contour_intervals = np.linspace(0.0, 20.0, 20.0/2.0+1)
 contour_intervals = np.linspace(0.0, 16.0, 16.0/0.5+1)
 #contourMPAS(flwa[timelev,:,:].mean(axis=1) *3600.0*24.0*365.0 / 1.0e-17, contour_levs=contour_intervals)  # NOT SURE WHICH LEVEL FLWA SHOULD COME FROM - so taking column average
 contourMPAS(flwa[timelev,:,:].mean(axis=1) * 3600.0*24.0*365.0 / 1.0e-17)  # NOT SURE WHICH LEVEL FLWA SHOULD COME FROM - so taking column average
-plt.axis('equal')
+ax.set_aspect('equal')
 plt.title('Final flow factor (10$^{-17}$ Pa$^{-3}$ a$^{-1}$)' )  # Note: the paper's figure claims units of 10$^{-25}$ Pa$^{-3}$ a$^{-1}$ but the time unit appears to be 10^-17
 #plt.xlim( (0.0, 750.0) ); plt.ylim( (0.0, 750.0) )
 plt.xlabel('X position (km)'); plt.ylabel('Y position (km)')

--- a/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
@@ -22,7 +22,7 @@
                 <script name="setup_and_run_EISMINT2_decomp_testcase.py"/>
         </test>
 
-        <test name="EISMINT2-F enthalpy decomposition test" core="landice" configuration="EISMINT2" resolution="25000m" test="decomposition_test">
+        <test name="EISMINT2-F enthalpy decomposition test" core="landice" configuration="EISMINT2" resolution="25000m" test="enthalpy_decomposition_test">
                 <script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py"/>
         </test>
 

--- a/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/combined_integration_test_suite.xml
@@ -22,6 +22,10 @@
                 <script name="setup_and_run_EISMINT2_decomp_testcase.py"/>
         </test>
 
+        <test name="EISMINT2-F enthalpy decomposition test" core="landice" configuration="EISMINT2" resolution="25000m" test="decomposition_test">
+                <script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py"/>
+        </test>
+
         <test name="GIS restart test" core="landice" configuration="greenland" resolution="20km" test="restart_test">
                 <script name="setup_and_run_testcase.py"/>
         </test>

--- a/testing_and_setup/compass/landice/regression_suites/sia_integration_test_suite.xml
+++ b/testing_and_setup/compass/landice/regression_suites/sia_integration_test_suite.xml
@@ -21,6 +21,10 @@
                 <script name="setup_and_run_EISMINT2_decomp_testcase.py"/>
         </test>
 
+        <test name="EISMINT2-F enthalpy decomposition test" core="landice" configuration="EISMINT2" resolution="25000m" test="decomposition_test">
+                <script name="setup_and_run_EISMINT2_enthalpy_decomp_testcase.py"/>
+        </test>
+
         <test name="GIS restart test" core="landice" configuration="greenland" resolution="20km" test="restart_test">
                 <script name="setup_and_run_testcase.py"/>
         </test>


### PR DESCRIPTION
This merge makes a number of small updates to the EISMINT2 tests in COMPASS:
* Updates the viz script to work properly with python3
* Changes the mesh from a square to a circle (note: requires an update to MPAS-Tools)
* Adds an decomp. test using the enthalpy solver
* Adds globalStats to output
There is an additional commit updating the COMPASS landice README file.
There also is a minor bugfix to globalStats to avoid divide by zero when no ice is in domain.

