### PR TITLE
Add mpas_in_cell, mpas_mirror_point, and mpas_rotate_about_vector to operators

### DIFF
--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -1728,4 +1728,142 @@ module mpas_geometry_utils
 
    end subroutine mpas_spherical_linear_interp !}}}
 
+
+!-----------------------------------------------------------------------
+!  routine mpas_rotate_about_vector
+!
+!> \brief Rotates a point about a vector in R3
+!> \author Michael Duda
+!> \date   7 March 2019
+!> \details
+!>  Rotates the point (x,y,z) through an angle theta about the vector
+!>  originating at (a, b, c) and having direction (u, v, w).
+!
+!>  Reference: https://sites.google.com/site/glennmurray/Home/rotation-matrices-and-formulas/rotation-about-an-arbitrary-axis-in-3-dimensions
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_rotate_about_vector(x, y, z, theta, a, b, c, u, v, w, xp, yp, zp)
+
+      implicit none
+
+      real (kind=RKIND), intent(in) :: x, y, z, theta, a, b, c, u, v, w
+      real (kind=RKIND), intent(out) :: xp, yp, zp
+
+      real (kind=RKIND) :: vw2, uw2, uv2
+      real (kind=RKIND) :: m
+
+      vw2 = v**2.0 + w**2.0
+      uw2 = u**2.0 + w**2.0
+      uv2 = u**2.0 + v**2.0
+      m = sqrt(u**2.0 + v**2.0 + w**2.0)
+
+      xp = (a*vw2 + u*(-b*v-c*w+u*x+v*y+w*z) + ((x-a)*vw2+u*(b*v+c*w-v*y-w*z))*cos(theta) + m*(-c*v+b*w-w*y+v*z)*sin(theta))/m**2.0
+      yp = (b*uw2 + v*(-a*u-c*w+u*x+v*y+w*z) + ((y-b)*uw2+v*(a*u+c*w-u*x-w*z))*cos(theta) + m*( c*u-a*w+w*x-u*z)*sin(theta))/m**2.0
+      zp = (c*uv2 + w*(-a*u-b*v+u*x+v*y+w*z) + ((z-c)*uv2+w*(a*u+b*v-u*x-v*y))*cos(theta) + m*(-b*u+a*v-v*x+u*y)*sin(theta))/m**2.0
+
+   end subroutine mpas_rotate_about_vector
+
+
+!-----------------------------------------------------------------------
+!  routine mpas_mirror_point
+!
+!> \brief Finds the "mirror" of a point about a great-circle arc
+!> \author Michael Duda
+!> \date   7 March 2019
+!> \details
+!>  Given the endpoints of a great-circle arc (A,B) and a point, computes
+!>  the location of the point on the opposite side of the arc along a great-
+!>  circle arc that intersects (A,B) at a right angle, and such that the arc
+!>  between the point and its mirror is bisected by (A,B).
+!>
+!>  Assumptions: A, B, and the point to be reflected all lie on the surface
+!>  of the unit sphere.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mirror_point(xPoint, yPoint, zPoint, xA, yA, zA, xB, yB, zB, xMirror, yMirror, zMirror)
+
+      implicit none
+
+      real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
+      real(kind=RKIND), intent(in) :: xA, yA, zA
+      real(kind=RKIND), intent(in) :: xB, yB, zB
+      real(kind=RKIND), intent(out) :: xMirror, yMirror, zMirror
+
+      real(kind=RKIND) :: alpha
+
+      !
+      ! Find the spherical angle between arcs AP and AB (where P is the point to be reflected)
+      !
+      alpha = mpas_sphere_angle(xA, yA, zA, xPoint, yPoint, zPoint, xB, yB, zB)
+
+      !
+      ! Rotate the point to be reflected by twice alpha about the vector from the origin to A
+      !
+      call mpas_rotate_about_vector(xPoint, yPoint, zPoint, 2.0_RKIND * alpha, 0.0_RKIND, 0.0_RKIND, 0.0_RKIND, &
+                                    xA, yA, zA, xMirror, yMirror, zMirror)
+
+   end subroutine mpas_mirror_point
+
+
+!-----------------------------------------------------------------------
+!  routine mpas_in_cell
+!
+!> \brief Determines whether a point is within a Voronoi cell
+!> \author Michael Duda
+!> \date   7 March 2019
+!> \details
+!>  Given a point on the surface of the sphere, the corner points of a Voronoi
+!>  cell, and the generating point for that Voronoi cell, determines whether
+!>  the given point is within the Voronoi cell.
+!
+!-----------------------------------------------------------------------
+   logical function mpas_in_cell(xPoint, yPoint, zPoint, xCell, yCell, zCell, &
+                                 nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex)
+
+      implicit none
+
+      real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
+      real(kind=RKIND), intent(in) :: xCell, yCell, zCell
+      integer, intent(in) :: nEdgesOnCell
+      integer, dimension(:), intent(in) :: verticesOnCell
+      real(kind=RKIND), dimension(:), intent(in) :: xVertex, yVertex, zVertex
+
+      integer :: i
+      integer :: vtx1, vtx2
+      real(kind=RKIND) :: xNeighbor, yNeighbor, zNeighbor
+      real(kind=RKIND) :: inDist, outDist
+      real(kind=RKIND) :: radius
+      real(kind=RKIND) :: radius_inv
+
+      radius = sqrt(xCell * xCell + yCell * yCell + zCell * zCell)
+      radius_inv = 1.0_RKIND / radius
+
+      inDist = mpas_arc_length(xPoint, yPoint, zPoint, xCell, yCell, zCell)
+
+      mpas_in_cell = .true.
+
+      do i=1,nEdgesOnCell
+         vtx1 = verticesOnCell(i)
+         vtx2 = verticesOnCell(mod(i,nEdgesOnCell)+1)
+
+         call mpas_mirror_point(xCell*radius_inv, yCell*radius_inv, zCell*radius_inv, &
+                                xVertex(vtx1)*radius_inv, yVertex(vtx1)*radius_inv, zVertex(vtx1)*radius_inv, &
+                                xVertex(vtx2)*radius_inv, yVertex(vtx2)*radius_inv, zVertex(vtx2)*radius_inv, &
+                                xNeighbor, yNeighbor, zNeighbor)
+
+         xNeighbor = xNeighbor * radius
+         yNeighbor = yNeighbor * radius
+         zNeighbor = zNeighbor * radius
+
+         outDist = mpas_arc_length(xPoint, yPoint, zPoint, xNeighbor, yNeighbor, zNeighbor)
+
+         if (outDist < inDist) then
+            mpas_in_cell = .false.
+            return
+         end if
+
+      end do
+
+   end function mpas_in_cell
+
 end module mpas_geometry_utils


### PR DESCRIPTION
This merge adds three new routines, mpas_in_cell, mpas_mirror_point, and 
mpas_rotate_about_vector, to the mpas_geometry_utils module.
Briefly, the routines provide the following:

 * mpas_in_cell: Given the Voronoi center and corner points of a cell, determine
       whether a point is inside the Voronoi cell

 * mpas_mirror_point: Given a point and a great-circle arc, find the mirror of
       the point on the other side of the arc

 * mpas_rotate_about_vector: Given a vector in R3 and a point, rotate the point
       by a specified angle about the vector