### PR TITLE
Fix bug in landice.cmake

### DIFF
--- a/src/core_landice/landice.cmake
+++ b/src/core_landice/landice.cmake
@@ -71,7 +71,7 @@ list(APPEND RAW_SOURCES
   core_landice/mode_forward/mpas_li_subglacial_hydro.F
 )
 
-if (CPPFLAGS MATCHES ".*MPAS_LI_BUILD_INTERFACE.*")
+if (CPPDEFS MATCHES ".*MPAS_LI_BUILD_INTERFACE.*")
   list(APPEND RAW_SOURCES core_landice/mode_forward/Interface_velocity_solver.cpp)
 endif()
 


### PR DESCRIPTION
Fix mistake in landice.cmake that was causing Albany-enabled compsets to fail to build in E3SM.

I am unsure how this obvious mistake made it through my initial rounds of testing.