### PR TITLE
Diagnostics: Move mpas_pool_get_config to init

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1955,8 +1955,6 @@
 			<var name="iceFraction"/>
 			<var name="windSpeed10m"/>
 			<var name="nAccumulatedCoupled"/>
-			<var name="thermalExpansionCoeff"/>
-			<var name="salineContractionCoeff"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
 			<var_array name="landIceInterfaceTracers"/>
@@ -3332,53 +3330,6 @@
 			 units="m"
 			 description="total thickness at edge, sum(h)"
 		/>
-		<var name="vorticityGradientTangentialComponent"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nEdges Time"
-			units="s^{-1} m^{-1}"
-			description="gradient of vorticity in the tangent direction (positive points from vertex1 to vertex2)"
-		/>
-		<var name="vorticityGradientNormalComponent"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nEdges Time"
-			units="s^{-1} m^{-1}"
-			description="gradient of vorticity in the normal direction (positive points from cell1 to cell2)"
-		/>
-		<var name="normalizedRelativeVorticityVertex"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nVertices Time" units="s^{-1}"
-			description="curl of horizontal velocity divided by layer thickness, defined at vertices"
-		/>
-		<var name="normalizedPlanetaryVorticityVertex"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nVertices Time" units="s^{-1}"
-			description="earth's rotational rate (Coriolis parameter, f) divided by layer thickness, defined at vertices"
-		/>
-		<var name="kineticEnergyVertex"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nVertices Time" units="m^2 s^{-2}"
-			description="kinetic energy of horizonal velocity defined at vertices"
-		/>
-		<var name="kineticEnergyVertexOnCells"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-2}"
-			description="kinetic energy of horizonal velocity defined at vertices"
-		/>
-		<var name="densitySurfaceDisplaced"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3}"
-			description="Density computed by displacing SST and SSS to every vertical layer within the column"
-		/>
-		<var name="thermalExpansionCoeff"
-			 persistence="persistent"
-			 type="real" dimensions="nVertLevels nCells Time" units="C^{-1}"
-			 description="Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign)."
-		/>
-		<var name="salineContractionCoeff"
-			 persistence="persistent"
-			 type="real" dimensions="nVertLevels nCells Time" units="PSU^{-1}"
-			 description="Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$. This is also called the haline contraction coefficient."
-		/>
 
 		<!-- FIELDS FOR TENSOR OPERATIONS -->
 		<var name="normalVelocityTest"
@@ -3560,15 +3511,6 @@
 				 description="tracer"
 			/>
 		</var_array>
-		<var name="div_hu" persistence="scratch" type="real" dimensions="nVertLevels nCells" units=""
-			 description="div_hu"
-		/>
-		<var name="projectedSSH" persistence="scratch" type="real" dimensions="nCells" units=""
-			 description="projectedSSH"
-		/>
-		<var name="ALE_Thickness" persistence="scratch" type="real" dimensions="nVertLevels nCells" units=""
-			 description="ALE_Thickness"
-		/>
 		<var name="delsq_u" persistence="scratch" type="real" dimensions="nVertLevels nEdgesP1" units=""
 			 description="delsq_u"
 		/>
@@ -3627,16 +3569,6 @@
 			 description="btrvel_temp"
 		/>
 		<!-- FIELDS FOR LAND-ICE FORCING -->
-		<var name="boundaryLayerTemperatureScratch"
-			persistence="scratch"
-			type="real" dimensions="nCells" units="^\circ C"
-			description="temperature averaged vertically over the sub-ice-shelf boundary layer"
-		/>
-		<var name="boundaryLayerSalinityScratch"
-			persistence="scratch"
-			type="real" dimensions="nCells" units="PSU"
-			description="salinity averaged vertically over the sub-ice-shelf boundary layer"
-		/>
 		<var name="freezeInterfaceSalinityScratch"
 			persistence="scratch"
 			type="real" dimensions="nCells" units="PSU"

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -101,6 +101,8 @@ module ocn_diagnostics
    real (kind=RKIND), pointer :: config_land_ice_flux_attenuation_coefficient
    logical :: jenkinsOn, hollandJenkinsOn
 
+   integer, pointer :: indexTemperature, indexSalinity
+
    !--------------------------------------------------------------------
    !
    ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
@@ -202,7 +204,6 @@ contains
       type (field2DReal), pointer :: vorticityGradientNormalComponentField, vorticityGradientTangentialComponentField
 
       integer :: timeLevel
-      integer, pointer :: indexTemperature, indexSalinity
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
@@ -218,9 +219,6 @@ contains
       else
          timeLevel = 1
       end if
-
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
@@ -1336,6 +1334,9 @@ contains
 
       err = 0
 
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
 
@@ -1860,8 +1861,8 @@ contains
 
       !$omp barrier
       !$omp master
-      allocate(blTempScratch(nCells), &
-               blSaltScratch(nCells))
+      deallocate(blTempScratch, &
+                 blSaltScratch)
       !$omp end master
 
       ! modify the spatially-varying attenuation coefficient where there is land ice

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -101,8 +101,6 @@ module ocn_diagnostics
    real (kind=RKIND), pointer :: config_land_ice_flux_attenuation_coefficient
    logical :: jenkinsOn, hollandJenkinsOn
 
-   integer, pointer :: indexTemperature, indexSalinity
-
    !--------------------------------------------------------------------
    !
    ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
@@ -204,6 +202,8 @@ contains
       type (field2DReal), pointer :: vorticityGradientNormalComponentField, vorticityGradientTangentialComponentField
 
       integer :: timeLevel
+      integer, pointer :: indexTemperature, indexSalinity
+
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
@@ -219,6 +219,9 @@ contains
       else
          timeLevel = 1
       end if
+
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
@@ -1333,9 +1336,6 @@ contains
       character (len=StrKIND), pointer :: config_time_integrator
 
       err = 0
-
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
       call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -101,6 +101,35 @@ module ocn_diagnostics
    real (kind=RKIND), pointer :: config_land_ice_flux_attenuation_coefficient
    logical :: jenkinsOn, hollandJenkinsOn
 
+   !--------------------------------------------------------------------
+   !
+   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
+   ! These variables were moved from the subroutines, but will be moved back once the 
+   ! threading implementation is changed to more localized threading
+   !
+   !--------------------------------------------------------------------
+
+   ! Subroutine ocn_diagnostic_solve
+   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex, kineticEnergyVertexOnCells
+   real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
+   real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
+   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
+   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
+
+   ! Subroutine ocn_vert_transport_velocity_top
+   real (kind=RKIND), dimension(:), allocatable :: &
+      projectedSSH       !> projected SSH at new time
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      ALE_Thickness, & !> ALE thickness at new time
+      div_hu           !> divergence of (thickness*velocity)
+
+   ! subroutine ocn_compute_KPP_input_fields
+   real (kind=RKIND), dimension(:,:), allocatable ::  &
+        densitySurfaceDisplaced, thermalExpansionCoeff, salineContractionCoeff
+
+   ! subroutine ocn_compute_land_ice_flux_input_fields
+   real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
+
 !***********************************************************************
 
 contains
@@ -154,10 +183,10 @@ contains
         weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
         vertAleTransportTop, zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
-        normalizedPlanetaryVorticityEdge, normalizedPlanetaryVorticityVertex, normalizedRelativeVorticityEdge, &
-        normalizedRelativeVorticityVertex, normalizedRelativeVorticityCell, density, displacedDensity, potentialDensity, &
-        temperature, salinity, kineticEnergyVertex, kineticEnergyVertexOnCells, vertVelocityTop, vertTransportVelocityTop, &
-        vertGMBolusVelocityTop, BruntVaisalaFreqTop, vorticityGradientNormalComponent, vorticityGradientTangentialComponent, &
+        normalizedPlanetaryVorticityEdge, normalizedRelativeVorticityEdge, &
+        normalizedRelativeVorticityCell, density, displacedDensity, potentialDensity, &
+        temperature, salinity, vertVelocityTop, vertTransportVelocityTop, &
+        vertGMBolusVelocityTop, BruntVaisalaFreqTop, &
         RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers, derivTwo
@@ -429,13 +458,12 @@ contains
       ! Compute kinetic energy
       !
       if ( ke_vertex_flag == 1 ) then
-         call mpas_pool_get_field(scratchPool, 'kineticEnergyVertex', kineticEnergyVertexField)
-         call mpas_pool_get_field(scratchPool, 'kineticEnergyVertexOnCells', kineticEnergyVertexOnCellsField)
-         call mpas_allocate_scratch_field(kineticEnergyVertexField, .true.)
-         call mpas_allocate_scratch_field(kineticEnergyVertexOnCellsField, .true.)
 
-         kineticEnergyVertex         => kineticEnergyVertexField % array
-         kineticEnergyVertexOnCells  => kineticEnergyVertexOnCellsField % array
+         !$omp master
+         allocate(kineticEnergyVertex(nVertLevels, nVertices), &
+                  kineticEnergyVertexOnCells(nVertLevels, nCells))
+         !$omp end master
+         !$omp barrier
 
          !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
          do iVertex = 1, nVertices
@@ -477,20 +505,21 @@ contains
          end do
          !$omp end do
 
-         call mpas_deallocate_scratch_field(kineticEnergyVertexField, .true.)
-         call mpas_deallocate_scratch_field(kineticEnergyVertexOnCellsField, .true.)
+         !$omp barrier
+         !$omp master
+         deallocate(kineticEnergyVertex, &
+                    kineticEnergyVertexOnCells)
+         !$omp end master
       end if
 
       !
       ! Compute normalized relative and planetary vorticity
       !
-      call mpas_pool_get_field(scratchPool, 'normalizedRelativeVorticityVertex', normalizedRelativeVorticityVertexField)
-      call mpas_pool_get_field(scratchPool, 'normalizedPlanetaryVorticityVertex', normalizedPlanetaryVorticityVertexField)
-      call mpas_allocate_scratch_field(normalizedRelativeVorticityVertexField, .true., .false.)
-      call mpas_allocate_scratch_field(normalizedPlanetaryVorticityVertexField, .true., .false.)
-
-      normalizedPlanetaryVorticityVertex  => normalizedPlanetaryVorticityVertexField % array
-      normalizedRelativeVorticityVertex  => normalizedRelativeVorticityVertexField % array
+      !$omp master
+      allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVertices), &
+               normalizedRelativeVorticityVertex(nVertLevels, nVertices))
+      !$omp end master
+      !$omp barrier
 
       nVertices = nVerticesArray( 3 )
 
@@ -553,13 +582,11 @@ contains
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
       if (config_apvm_scale_factor>1e-10) then
 
-         call mpas_pool_get_field(scratchPool, 'vorticityGradientNormalComponent', vorticityGradientNormalComponentField)
-         call mpas_pool_get_field(scratchPool, 'vorticityGradientTangentialComponent', vorticityGradientTangentialComponentField)
-         call mpas_allocate_scratch_field(vorticityGradientNormalComponentField, .true.)
-         call mpas_allocate_scratch_field(vorticityGradientTangentialComponentField, .true.)
-
-         vorticityGradientNormalComponent => vorticityGradientNormalComponentField % array
-         vorticityGradientTangentialComponent => vorticityGradientTangentialComponentField % array
+         !$omp master
+         allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
+                  vorticityGradientTangentialComponent(nVertLevels, nEdges))
+         !$omp end master
+         !$omp barrier
 
          nEdges = nEdgesArray( 2 )
 
@@ -603,13 +630,19 @@ contains
          enddo
          !$omp end do
 
-         call mpas_deallocate_scratch_field(vorticityGradientNormalComponentField, .true.)
-         call mpas_deallocate_scratch_field(vorticityGradientTangentialComponentField, .true.)
+         !$omp barrier
+         !$omp master
+         deallocate(vorticityGradientNormalComponent, &
+                    vorticityGradientTangentialComponent)
+         !$omp end master
 
       endif
 
-      call mpas_deallocate_scratch_field(normalizedRelativeVorticityVertexField, .true.)
-      call mpas_deallocate_scratch_field(normalizedPlanetaryVorticityVertexField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(normalizedPlanetaryVorticityVertex, &
+                 normalizedRelativeVorticityVertex)
+      !$omp end master
 
       !
       ! equation of state
@@ -976,12 +1009,7 @@ contains
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:), pointer :: &
-         projectedSSH       !> projected SSH at new time
       type (field1DReal), pointer :: projectedSSHField
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         ALE_Thickness, & !> ALE thickness at new time
-         div_hu           !> divergence of (thickness*velocity)
       type (field2DReal), pointer :: ALE_ThicknessField, div_huField
 
       err = 0
@@ -1002,19 +1030,17 @@ contains
         return
       end if
 
+      ncells = nCellsArray(size(nCellsArray))
+
+      !$omp master
+      allocate(div_hu(nVertLevels, nCells), &
+               projectedSSH(nCells), &
+               ALE_Thickness(nVertLevels, nCells))
+      !$omp end master
+      !$omp barrier
+
       ! Only need to compute over 0 and 1 halos
       nCells = nCellsArray( 2 )
-
-      call mpas_pool_get_field(scratchPool, 'div_hu', div_huField)
-      call mpas_pool_get_field(scratchPool, 'projectedSSH', projectedSSHField)
-      call mpas_pool_get_field(scratchPool, 'ALE_Thickness', ALE_ThicknessField)
-      call mpas_allocate_scratch_field(div_huField, .true.)
-      call mpas_allocate_scratch_field(projectedSSHField, .true.)
-      call mpas_allocate_scratch_field(ALE_ThicknessField, .true.)
-
-      div_hu => div_huField % array
-      projectedSSH => projectedSSHField % array
-      ALE_Thickness => ALE_ThicknessField % array
 
       !
       ! thickness-weighted divergence and barotropic divergence
@@ -1068,9 +1094,12 @@ contains
       end do
       !$omp end do
 
-      call mpas_deallocate_scratch_field(div_huField, .true.)
-      call mpas_deallocate_scratch_field(projectedSSHField, .true.)
-      call mpas_deallocate_scratch_field(ALE_ThicknessField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(div_hu, &
+                 projectedSSH, &
+                 ALE_Thickness)
+      !$omp end master
 
    end subroutine ocn_vert_transport_velocity_top!}}}
 
@@ -1418,8 +1447,8 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
-           layerThickness, zMid, zTop, densitySurfaceDisplaced, density, &
-           normalVelocity, activeTracersSurfaceFlux, thermalExpansionCoeff, salineContractionCoeff, &
+           layerThickness, zMid, zTop, density, &
+           normalVelocity, activeTracersSurfaceFlux, &
            activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -1490,17 +1519,15 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
-      ! allocate scratch space displaced density computation
-      call mpas_pool_get_field(scratchPool, 'densitySurfaceDisplaced', densitySurfaceDisplacedField)
-      call mpas_pool_get_field(scratchPool, 'thermalExpansionCoeff', thermalExpansionCoeffField)
-      call mpas_pool_get_field(scratchPool, 'salineContractionCoeff', salineContractionCoeffField)
-      call mpas_allocate_scratch_field(densitySurfaceDisplacedField, .true., .false.)
-      call mpas_allocate_scratch_field(thermalExpansionCoeffField, .true., .false.)
-      call mpas_allocate_scratch_field(salineContractionCoeffField, .true., .false.)
 
-      densitySurfaceDisplaced => densitySurfaceDisplacedField % array
-      thermalExpansionCoeff => thermalExpansionCoeffField % array
-      salineContractionCoeff => salineContractionCoeffField % array
+      ! allocate scratch space displaced density computation
+      ncells = nCellsArray(size(nCellsArray))
+      !$omp master
+      allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
+               thermalExpansionCoeff(nVertLevels, nCells), &
+               salineContractionCoeff(nVertLevels, nCells))
+      !$omp end master
+      !$omp barrier
 
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsArray( 3 )
@@ -1576,9 +1603,12 @@ contains
       !$omp end do
 
       ! deallocate scratch space
-      call mpas_deallocate_scratch_field(thermalExpansionCoeffField, .true.)
-      call mpas_deallocate_scratch_field(salineContractionCoeffField, .true.)
-      call mpas_deallocate_scratch_field(densitySurfaceDisplacedField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(thermalExpansionCoeff, &
+                 salineContractionCoeff, &
+                 densitySurfaceDisplaced)
+      !$omp end master
 
       call mpas_timer_stop('KPP input fields')
 
@@ -1632,7 +1662,6 @@ contains
                                                   topDrag, &
                                                   topDragMagnitude, &
                                                   fCell, &
-                                                  blTempScratch, blSaltScratch, &
                                                   surfaceFluxAttenuationCoefficient
 
       integer, dimension(:), pointer :: landIceMask
@@ -1716,13 +1745,11 @@ contains
       end if
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
-      call mpas_pool_get_field(scratchPool, 'boundaryLayerTemperatureScratch', boundaryLayerTemperatureField)
-      call mpas_pool_get_field(scratchPool, 'boundaryLayerSalinityScratch', boundaryLayerSalinityField)
-      call mpas_allocate_scratch_field(boundaryLayerTemperatureField, .true.)
-      call mpas_allocate_scratch_field(boundaryLayerSalinityField, .true.)
-
-      blTempScratch => boundaryLayerTemperatureField % array
-      blSaltScratch => boundaryLayerSalinityField % array
+      !$omp master
+      allocate(blTempScratch(nCells), &
+               blSaltScratch(nCells))
+      !$omp end master
+      !$omp barrier
 
       if(hollandJenkinsOn) then
          call mpas_pool_get_array(meshPool, 'fCell', fCell)
@@ -1831,8 +1858,11 @@ contains
          !$omp end do
       end if
 
-      call mpas_deallocate_scratch_field(boundaryLayerTemperatureField, .true.)
-      call mpas_deallocate_scratch_field(boundaryLayerSalinityField, .true.)
+      !$omp barrier
+      !$omp master
+      allocate(blTempScratch(nCells), &
+               blSaltScratch(nCells))
+      !$omp end master
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
       !$omp do schedule(runtime)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -72,6 +72,35 @@ module ocn_diagnostics
    real (kind=RKIND) ::  fCoef
    real (kind=RKIND), pointer ::  coef_3rd_order
 
+   !--------------------------------------------------------------------
+   !
+   ! Config variables moved from subroutines to module level so calls to 
+   ! mpas_pool_get_config only needs to be called during init
+   !
+   !--------------------------------------------------------------------
+
+   logical, pointer :: config_use_cvmix_kpp
+   logical, pointer :: config_use_wetting_drying
+   real (kind=RKIND), pointer :: config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
+   character (len=StrKIND), pointer :: config_pressure_gradient_type
+   character (len=StrKIND), pointer :: config_thickness_flux_type
+
+   real (kind=RKIND), pointer :: config_flux_attenuation_coefficient
+   real (kind=RKIND), pointer :: config_flux_attenuation_coefficient_runoff
+
+   character (len=StrKIND), pointer :: config_vert_coord_movement
+
+   character (len=StrKIND), pointer :: config_land_ice_flux_mode
+   character (len=StrKIND), pointer :: config_land_ice_flux_formulation
+   real (kind=RKIND), pointer :: config_land_ice_flux_boundaryLayerThickness
+   real (kind=RKIND), pointer :: config_land_ice_flux_boundaryLayerNeighborWeight
+   real (kind=RKIND), pointer :: config_land_ice_flux_topDragCoeff
+   real (kind=RKIND), pointer :: config_land_ice_flux_rms_tidal_velocity
+   real (kind=RKIND), pointer :: config_land_ice_flux_jenkins_heat_transfer_coefficient
+   real (kind=RKIND), pointer :: config_land_ice_flux_jenkins_salt_transfer_coefficient
+   real (kind=RKIND), pointer :: config_land_ice_flux_attenuation_coefficient
+   logical :: jenkinsOn, hollandJenkinsOn
+
 !***********************************************************************
 
 contains
@@ -145,14 +174,7 @@ contains
 
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
-      logical, pointer :: config_use_cvmix_kpp
-      logical, pointer :: config_use_wetting_drying
-      real (kind=RKIND), pointer :: config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
-      character (len=StrKIND), pointer :: config_pressure_gradient_type
-      character (len=StrKIND), pointer :: config_thickness_flux_type
 
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient_runoff
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
 
@@ -167,17 +189,6 @@ contains
       else
          timeLevel = 1
       end if
-
-      call mpas_pool_get_config(ocnConfigs, 'config_apvm_scale_factor', config_apvm_scale_factor)
-      call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
-      call mpas_pool_get_config(ocnConfigs, 'config_coef_3rd_order', config_coef_3rd_order)
-      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_surface_layer_averaging', config_cvmix_kpp_surface_layer_averaging)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient_runoff',  &
-                                             config_flux_attenuation_coefficient_runoff)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_wetting_drying', config_use_wetting_drying)
-      call mpas_pool_get_config(ocnConfigs, 'config_thickness_flux_type', config_thickness_flux_type)
 
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
@@ -973,11 +984,7 @@ contains
          div_hu           !> divergence of (thickness*velocity)
       type (field2DReal), pointer :: ALE_ThicknessField, div_huField
 
-      character (len=StrKIND), pointer :: config_vert_coord_movement
-
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_vert_coord_movement', config_vert_coord_movement)
 
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -1300,6 +1307,46 @@ contains
 
       err = 0
 
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
+
+      jenkinsOn = .false.
+      hollandJenkinsOn = .false.
+      if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
+         jenkinsOn = .true.
+      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
+         hollandJenkinsOn = .true.
+      end if
+
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_topDragCoeff', config_land_ice_flux_topDragCoeff)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerThickness', &
+                                config_land_ice_flux_boundaryLayerThickness)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerNeighborWeight', &
+                                config_land_ice_flux_boundaryLayerNeighborWeight)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_rms_tidal_velocity', config_land_ice_flux_rms_tidal_velocity)
+      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_attenuation_coefficient', &
+                                config_land_ice_flux_attenuation_coefficient)
+
+      if(jenkinsOn) then
+         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_heat_transfer_coefficient', &
+                                   config_land_ice_flux_jenkins_heat_transfer_coefficient)
+         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_salt_transfer_coefficient', &
+                                   config_land_ice_flux_jenkins_salt_transfer_coefficient)
+      end if
+
+      call mpas_pool_get_config(ocnConfigs, 'config_vert_coord_movement', config_vert_coord_movement)
+
+      call mpas_pool_get_config(ocnConfigs, 'config_apvm_scale_factor', config_apvm_scale_factor)
+      call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
+      call mpas_pool_get_config(ocnConfigs, 'config_coef_3rd_order', config_coef_3rd_order)
+      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_surface_layer_averaging', config_cvmix_kpp_surface_layer_averaging)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
+      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
+      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient_runoff',  &
+                                             config_flux_attenuation_coefficient_runoff)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_wetting_drying', config_use_wetting_drying)
+      call mpas_pool_get_config(ocnConfigs, 'config_thickness_flux_type', config_thickness_flux_type)
+
       call mpas_pool_get_config(ocnConfigs, 'config_include_KE_vertex', config_include_KE_vertex)
       call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
 
@@ -1368,7 +1415,6 @@ contains
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
            surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
            normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient, config_flux_attenuation_coefficient_runoff
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
@@ -1403,9 +1449,6 @@ contains
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient_runoff',   &
-              config_flux_attenuation_coefficient_runoff)
       ! set the parameter turbulentVelocitySquared
       turbulentVelocitySquared = 0.001_RKIND
 
@@ -1582,16 +1625,6 @@ contains
 
       integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
-      character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
-
-      real (kind=RKIND), pointer :: config_land_ice_flux_boundaryLayerThickness, &
-                                    config_land_ice_flux_boundaryLayerNeighborWeight, &
-                                    config_land_ice_flux_topDragCoeff, &
-                                    config_land_ice_flux_rms_tidal_velocity, &
-                                    config_land_ice_flux_jenkins_heat_transfer_coefficient, &
-                                    config_land_ice_flux_jenkins_salt_transfer_coefficient, &
-                                    config_land_ice_flux_attenuation_coefficient
-
       real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
       real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
@@ -1609,8 +1642,6 @@ contains
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       type (field1DReal), pointer :: boundaryLayerTemperatureField, boundaryLayerSalinityField
 
-      logical :: jenkinsOn, hollandJenkinsOn
-
       ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
       real (kind=RKIND), parameter :: &
          Pr = 13.8_RKIND, &             ! the Prandtl number
@@ -1620,7 +1651,6 @@ contains
          xiN = 0.052_RKIND              ! dimensionless planetary boundary layer constant
 
 
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
       if ( trim(config_land_ice_flux_mode) .ne. 'off' ) then
 
          ! we need to compute the landiceMask regardless of which mode we're in so it can be
@@ -1650,31 +1680,6 @@ contains
       end if
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
-
-      jenkinsOn = .false.
-      hollandJenkinsOn = .false.
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
-      if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
-         jenkinsOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
-         hollandJenkinsOn = .true.
-      end if
-
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_topDragCoeff', config_land_ice_flux_topDragCoeff)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerThickness', &
-                                config_land_ice_flux_boundaryLayerThickness)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerNeighborWeight', &
-                                config_land_ice_flux_boundaryLayerNeighborWeight)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_rms_tidal_velocity', config_land_ice_flux_rms_tidal_velocity)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_attenuation_coefficient', &
-                                config_land_ice_flux_attenuation_coefficient)
-
-      if(jenkinsOn) then
-         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_heat_transfer_coefficient', &
-                                   config_land_ice_flux_jenkins_heat_transfer_coefficient)
-         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_salt_transfer_coefficient', &
-                                   config_land_ice_flux_jenkins_salt_transfer_coefficient)
-      end if
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -74,7 +74,7 @@ module ocn_diagnostics
 
    !--------------------------------------------------------------------
    !
-   ! Config variables moved from subroutines to module level so calls to 
+   ! Config variables moved from subroutines to module level so calls to
    ! mpas_pool_get_config only needs to be called during init
    !
    !--------------------------------------------------------------------
@@ -104,31 +104,62 @@ module ocn_diagnostics
    !--------------------------------------------------------------------
    !
    ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the 
+   ! These variables were moved from the subroutines, but will be moved back once the
    ! threading implementation is changed to more localized threading
    !
    !--------------------------------------------------------------------
 
    ! Subroutine ocn_diagnostic_solve
-   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex, kineticEnergyVertexOnCells
+   !---
+   ! kineticEnergyVertex: kinetic energy of horizonal velocity defined at vertices
+   !               units: m^2 s^{-2}
+   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
+   ! kineticEnergyVertexOnCells: kinetic energy of horizonal velocity defined at vertices
+   !                      units: m^2 s^{-2}
+   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
+   ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f) divided by
+   !                                     layer thickness, defined at vertices
+   !                              units: s^{-1}
    real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
+   ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness, defined at vertices
+   !                             units: s^{-1}
    real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
+   ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction (positive
+   !                                   points from cell1 to cell2)
+   !                            units: s^{-1} m^{-1}
    real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
+   ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction (positive
+   !                                       points from vertex1 to vertex2)
+   !                                units: s^{-1} m^{-1}
    real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
 
    ! Subroutine ocn_vert_transport_velocity_top
-   real (kind=RKIND), dimension(:), allocatable :: &
-      projectedSSH       !> projected SSH at new time
-   real (kind=RKIND), dimension(:,:), allocatable :: &
-      ALE_Thickness, & !> ALE thickness at new time
-      div_hu           !> divergence of (thickness*velocity)
+   !---
+   real (kind=RKIND), dimension(:), allocatable :: projectedSSH     !> projected SSH at new time
+   real (kind=RKIND), dimension(:,:), allocatable :: ALE_Thickness  !> ALE thickness at new time
+   real (kind=RKIND), dimension(:,:), allocatable :: div_hu         !> divergence of (thickness*velocity)
 
    ! subroutine ocn_compute_KPP_input_fields
-   real (kind=RKIND), dimension(:,:), allocatable ::  &
-        densitySurfaceDisplaced, thermalExpansionCoeff, salineContractionCoeff
+   !---
+   ! densitySurfaceDisplaced: Density computed by displacing SST and SSS to every vertical layer within the column
+   !                   units: km m^{-3}
+   real (kind=RKIND), dimension(:,:), allocatable :: densitySurfaceDisplaced
+   ! thermalExpansionCoeff: Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign).
+   !                 units:  C^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: thermalExpansionCoeff
+   ! salineContractionCoeff: Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$.
+   !                         This is also called the haline contraction coefficient.
+   !                  units: PSU^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: salineContractionCoeff
 
    ! subroutine ocn_compute_land_ice_flux_input_fields
-   real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
+   !---
+   ! blTempScratch: temperature averaged vertically over the sub-ice-shelf boundary layer
+   !         units: degrees C
+   real (kind=RKIND), dimension(:), allocatable ::  blTempScratch
+   ! blSaltScratch: salinity averaged vertically over the sub-ice-shelf boundary layer
+   !         units: PSU
+   real (kind=RKIND), dimension(:), allocatable ::  blSaltScratch
 
 !***********************************************************************
 
@@ -196,10 +227,6 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
       real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
       real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
-
-      type (field2DReal), pointer :: kineticEnergyVertexField, kineticEnergyVertexOnCellsField
-      type (field2DReal), pointer :: normalizedRelativeVorticityVertexField, normalizedPlanetaryVorticityVertexField
-      type (field2DReal), pointer :: vorticityGradientNormalComponentField, vorticityGradientTangentialComponentField
 
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
@@ -1010,8 +1037,6 @@ contains
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      type (field1DReal), pointer :: projectedSSHField
-      type (field2DReal), pointer :: ALE_ThicknessField, div_huField
 
       err = 0
 
@@ -1466,8 +1491,6 @@ contains
       integer, pointer :: indexTempFlux, indexSaltFlux
       real (kind=RKIND) :: numerator, denominator, turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
       real (kind=RKIND) :: factor, deltaVelocitySquared, delU2, invAreaCell
-
-      type (field2DReal), pointer :: densitySurfaceDisplacedField, thermalExpansionCoeffField, salineContractionCoeffField
 
       call mpas_timer_start('KPP input fields')
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -424,8 +424,7 @@ contains
                                                     landIceTracerTransferVelocities
       integer, pointer :: indexBLT, indexBLS, indexIT, indexIS, indexHeatTrans, indexSaltTrans
 
-      type (field1DReal), pointer :: boundaryLayerTemperatureField, boundaryLayerSalinityField, &
-                                     freezeInterfaceSalinityField, freezeInterfaceTemperatureField, &
+      type (field1DReal), pointer :: freezeInterfaceSalinityField, freezeInterfaceTemperatureField, &
                                      freezeFreshwaterFluxField, freezeHeatFluxField, &
                                      freezeIceHeatFluxField
       err = 0


### PR DESCRIPTION
This PR moves all calls in `mpas_ocn_diagnostics.F` to `mpas_pool_get_config` from individual subroutines to the `ocn_diagnostics_init` subroutine.  This somewhat cleans up the individual subroutines, and prevents the calls to `mpas_pool_get_config` from unnecessarily being called every timestep.  This required moving the declarations of `config_*` variables to module-level variables

The PR also replaces all calls to `mpas_allocate_scratch_field` with straight allocates.  This should enhance the performance by reducing the amount of pointer checks.  This also necessitated moving certain variables from subroutine-level to module-level variables.  These variables can/should be moved back to subroutine level if the OpenMP implementation is modified to be more local (i.e., open the OpenMP parallel region around loops instead of before the timestep loop).

By opening this PR, I am hoping to get feedback on the modifications prior to making similar changes in other files.

This begins to address issue #394 