### PR TITLE
Autogenerate ocean config declarations and get commands

### DIFF
--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -37,6 +37,7 @@ module ocn_analysis_mode
    use ocn_diagnostics
    use ocn_equation_of_state
    use ocn_constants
+   use ocn_config
 
    private
 
@@ -87,8 +88,11 @@ module ocn_analysis_mode
       call mpas_get_time(startTime, dateTimeString=startTimeStamp)
       ierr = ior(ierr, err_tmp)
 
-      ! Setup ocean config pool
+      ! Set up ocean constants
       call ocn_constants_init(domain % configs, domain % packages)
+
+      ! Setup ocean config pool
+      call ocn_config_init(domain % configs)
 
       !
       ! Read input data for model

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -81,6 +81,7 @@ module ocn_forward_mode
    use ocn_time_varying_forcing
 
    use ocn_constants
+   use ocn_config
 
    implicit none
    private
@@ -141,8 +142,11 @@ module ocn_forward_mode
       call mpas_get_time(startTime, dateTimeString=startTimeStamp)
       ierr = ior(ierr, err_tmp)
 
-      ! Setup ocean config pool
+      ! Set up ocean constants
       call ocn_constants_init(domain % configs, domain % packages)
+
+      ! Setup ocean config pool
+      call ocn_config_init(domain % configs)
 
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(domain % configs, 'config_read_nearest_restart', config_read_nearest_restart)

--- a/src/core_ocean/mode_init/mpas_ocn_init_mode.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_mode.F
@@ -36,6 +36,7 @@ module ocn_init_mode
    use ocn_equation_of_state
 
    use ocn_constants
+   use ocn_config
 
    use ocn_init_spherical_utils
 
@@ -114,8 +115,11 @@ module ocn_init_mode
       call mpas_get_time(startTime, dateTimeString=startTimeStamp)
       ierr = ior(ierr, err_tmp)
 
-      ! Setup ocean config pool
+      ! Set up ocean constants
       call ocn_constants_init(domain % configs, domain % packages)
+
+      ! Setup ocean config pool
+      call ocn_config_init(domain % configs)
 
       !
       ! Read input data for model

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -55,6 +55,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_tracer_surface_flux_to_tend.o \
 	   mpas_ocn_test.o \
 	   mpas_ocn_constants.o \
+	   mpas_ocn_config.o \
 	   mpas_ocn_forcing.o \
 	   mpas_ocn_surface_bulk_forcing.o \
 	   mpas_ocn_surface_land_ice_fluxes.o \
@@ -71,137 +72,137 @@ OBJS = mpas_ocn_init_routines.o \
 
 all: $(OBJS)
 
-mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
+mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
-mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o
+mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o
 
-mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o
+mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_thick_ale.o: mpas_ocn_constants.o
+mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o
+mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_thick_hadv.o: mpas_ocn_constants.o
+mpas_ocn_thick_hadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_thick_vadv.o: mpas_ocn_constants.o
+mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o
+mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_gm.o:  mpas_ocn_constants.o
+mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o
+mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_vadv.o: mpas_ocn_constants.o
+mpas_ocn_vel_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hmix.o: mpas_ocn_vel_hmix_del2.o mpas_ocn_vel_hmix_leith.o mpas_ocn_vel_hmix_del4.o mpas_ocn_constants.o
+mpas_ocn_vel_hmix.o: mpas_ocn_vel_hmix_del2.o mpas_ocn_vel_hmix_leith.o mpas_ocn_vel_hmix_del4.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o
+mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hmix_leith.o: mpas_ocn_constants.o
+mpas_ocn_vel_hmix_leith.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hmix_del4.o: mpas_ocn_constants.o
+mpas_ocn_vel_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forcing_explicit_bottom_drag.o mpas_ocn_forcing.o mpas_ocn_constants.o
+mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forcing_explicit_bottom_drag.o mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o
+mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o
+mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o
+mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 
-mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o
+mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o
+mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o
+mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o
 
-mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o
+mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o
+mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o
+mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_high_freq_thickness_hmix_del2.o: mpas_ocn_constants.o
+mpas_ocn_high_freq_thickness_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_nonlocalflux.o: mpas_ocn_constants.o
+mpas_ocn_tracer_nonlocalflux.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o
+mpas_ocn_tracer_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_short_wave_absorption.o: mpas_ocn_tracer_short_wave_absorption_jerlov.o mpas_ocn_tracer_short_wave_absorption_variable.o mpas_ocn_constants.o
+mpas_ocn_tracer_short_wave_absorption.o: mpas_ocn_tracer_short_wave_absorption_jerlov.o mpas_ocn_tracer_short_wave_absorption_variable.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_short_wave_absorption_variable.o: mpas_ocn_constants.o mpas_ocn_framework_forcing.o
+mpas_ocn_tracer_short_wave_absorption_variable.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o
 
-mpas_ocn_tracer_short_wave_absorption_jerlov.o: mpas_ocn_constants.o
+mpas_ocn_tracer_short_wave_absorption_jerlov.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix.o: mpas_ocn_vmix_coefs_const.o mpas_ocn_vmix_coefs_rich.o mpas_ocn_vmix_coefs_tanh.o mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o
+mpas_ocn_vmix.o: mpas_ocn_vmix_coefs_const.o mpas_ocn_vmix_coefs_rich.o mpas_ocn_vmix_coefs_tanh.o mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_coefs_const.o: mpas_ocn_constants.o
+mpas_ocn_vmix_coefs_const.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_coefs_rich.o: mpas_ocn_equation_of_state.o mpas_ocn_constants.o
+mpas_ocn_vmix_coefs_rich.o: mpas_ocn_equation_of_state.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_coefs_tanh.o: mpas_ocn_constants.o
+mpas_ocn_vmix_coefs_tanh.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o
+mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o
+mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o
+mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_equation_of_state_jm.o: mpas_ocn_constants.o
+mpas_ocn_equation_of_state_jm.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_equation_of_state_linear.o: mpas_ocn_constants.o
+mpas_ocn_equation_of_state_linear.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_test.o:  mpas_ocn_constants.o
+mpas_ocn_test.o:  mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_constants.o:
+mpas_ocn_constants.o mpas_ocn_config.o:
 
-mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_forcing_restoring.o
+mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_restoring.o
 
-mpas_ocn_surface_bulk_forcing.o: mpas_ocn_constants.o mpas_ocn_equation_of_state.o
+mpas_ocn_surface_bulk_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_equation_of_state.o
+mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_equation_of_state.o
+mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_equation_of_state.o
+mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o
+mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o
+mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_sea_ice.o: mpas_ocn_constants.o mpas_ocn_equation_of_state.o
+mpas_ocn_sea_ice.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_framework_forcing.o
+mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o
 
-mpas_ocn_tracer_interior_restoring.o: mpas_ocn_constants.o
+mpas_ocn_tracer_interior_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_exponential_decay.o: mpas_ocn_constants.o
+mpas_ocn_tracer_exponential_decay.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_ideal_age.o: mpas_ocn_constants.o
+mpas_ocn_tracer_ideal_age.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_TTD.o: mpas_ocn_constants.o
+mpas_ocn_tracer_TTD.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_ecosys.o: mpas_ocn_constants.o mpas_ocn_framework_forcing.o
+mpas_ocn_tracer_ecosys.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o
 
-mpas_ocn_tracer_DMS.o: mpas_ocn_constants.o
+mpas_ocn_tracer_DMS.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_MacroMolecules.o: mpas_ocn_constants.o
+mpas_ocn_tracer_MacroMolecules.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_surface_flux_to_tend.o: mpas_ocn_constants.o
+mpas_ocn_tracer_surface_flux_to_tend.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o
+mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_framework_forcing.o:
 
-mpas_ocn_time_varying_forcing.o:  
+mpas_ocn_time_varying_forcing.o:
 
 mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o
 
-mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o 
+mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/shared/mpas_ocn_config.F
+++ b/src/core_ocean/shared/mpas_ocn_config.F
@@ -1,0 +1,55 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_config
+!
+!> \brief MPAS ocean specific config
+!> \details
+!>  This module contains config specific to the ocean model.
+!
+!-----------------------------------------------------------------------
+
+module ocn_config
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_kind_types
+
+   implicit none
+   public
+   save
+
+#include "../inc/config_declare.inc"
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_config_init
+!
+!> \brief   Initializes the ocean config
+!> \details
+!>  This routine sets up config for use in the ocean model.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_config_init(configPool)!{{{
+       type (mpas_pool_type), pointer :: configPool
+
+#include "../inc/config_get.inc"
+
+   end subroutine ocn_config_init!}}}
+
+!***********************************************************************
+
+end module ocn_config
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -26,6 +26,7 @@ module ocn_tracer_hmix
    use mpas_derived_types
    use mpas_pool_routines
    use ocn_constants
+   use ocn_config
    use ocn_tracer_hmix_del2
    use ocn_tracer_hmix_del4
    use ocn_tracer_hmix_redi
@@ -179,10 +180,6 @@ contains
       integer, intent(out) :: err !< Output: error flag
 
       integer :: err1, err2
-
-      logical, pointer :: config_disable_tr_hmix
-
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_tr_hmix', config_disable_tr_hmix)
 
       tracerHmixOn = .true.
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -28,6 +28,7 @@ module ocn_tracer_hmix_del2
    use mpas_threading
 
    use ocn_constants
+   use ocn_config
 
    implicit none
    private
@@ -209,13 +210,7 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
-      logical, pointer :: config_use_tracer_del2
-      real (kind=RKIND), pointer :: config_tracer_del2
-
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tracer_del2', config_use_tracer_del2)
-      call mpas_pool_get_config(ocnConfigs, 'config_tracer_del2', config_tracer_del2)
 
       del2on = .false.
 


### PR DESCRIPTION
Add a new module ocn_config that has public declarations of all config flag variables. These are autogenerated by the framework (see #409) and added to mpas_ocn_config.F using:
```
#include "../inc/config_declare.inc"
#include "../inc/config_get.inc"
```

With these changes, we may delete config lines such as:
```
real (kind=RKIND), pointer :: config_tracer_del2
call mpas_pool_get_config(ocnConfigs, 'config_tracer_del2', config_tracer_del2)
```
from all other modules. All variables in the ocnConfig pool will be available by simply adding
```
use ocn_config
```
to the top of the module. Importantly, this change can be done to the modules one-by-one. This PR includes the changes to `mpas_ocn_tracer_hmix_del2.F` as an example.