### PR TITLE
Change output to single precision in stand-alone default streams files

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1632,6 +1632,7 @@
 
 		<stream name="output"
 				type="output"
+				precision="single"
 				filename_template="output/output.$Y-$M-$D_$h.$m.$s.nc"
 				filename_interval="01-00-00_00:00:00"
 				reference_time="0001-01-01_00:00:00"
@@ -1747,6 +1748,7 @@
 		<!-- Diagnostics streams for forward mode -->
 		<stream name="additional_output"
 				type="none"
+				precision="single"
 				filename_template="output/additional_output.$Y-$M-$D_$h.$m.$s.nc"
 				filename_interval="01-00-00_00:00:00"
 				reference_time="0001-01-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_TEMPLATE.xml
+++ b/src/core_ocean/analysis_members/Registry_TEMPLATE.xml
@@ -43,6 +43,7 @@
 	<streams>
 		<stream name="temPlateOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/temPlate.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_eddy_product_variables.xml
+++ b/src/core_ocean/analysis_members/Registry_eddy_product_variables.xml
@@ -65,6 +65,7 @@
 	<streams>
 		<stream name="eddyProductVariablesOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/eddyProductVariables.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="99-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_eliassen_palm.xml
+++ b/src/core_ocean/analysis_members/Registry_eliassen_palm.xml
@@ -603,6 +603,7 @@
 	<streams>
 		<stream name="eliassenPalmOutput" type="output"
 			mode="forward;analysis"
+			precision="single"
 			filename_template="analysis_members/eliassenPalm.$Y-$M-$D.nc"
 			filename_interval="01-00-00_00:00:00"
 			output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_harmonic_analysis.xml
+++ b/src/core_ocean/analysis_members/Registry_harmonic_analysis.xml
@@ -159,6 +159,7 @@
 		</stream>
 		<stream name="harmonicAnalysisOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/harmonicAnalysis.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_high_frequency_output.xml
+++ b/src/core_ocean/analysis_members/Registry_high_frequency_output.xml
@@ -293,6 +293,7 @@
 	<streams>
 		<stream name="highFrequencyOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/highFrequencyOutput.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-05_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
+++ b/src/core_ocean/analysis_members/Registry_lagrangian_particle_tracking.xml
@@ -122,7 +122,7 @@
 				output_interval="0002_00:00:00"
 				packages="lagrPartTrackAMPKG"
 				clobber_mode="truncate"
-			runtime_format="single_file">
+				runtime_format="single_file">
 
 			<var name="xtime"/>
 			<var name="indexToParticleID"/>

--- a/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_layer_volume_weighted_averages.xml
@@ -554,6 +554,7 @@
 		<stream name="layerVolumeWeightedAverageOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/layerVolumeWeightedAverage.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-05_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_meridional_heat_transport.xml
+++ b/src/core_ocean/analysis_members/Registry_meridional_heat_transport.xml
@@ -73,6 +73,7 @@
 	<streams>
 		<stream name="meridionalHeatTransportOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/meridionalHeatTransport.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="0001_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
+++ b/src/core_ocean/analysis_members/Registry_mixed_layer_depths.xml
@@ -89,6 +89,7 @@
   	<streams>
 		<stream name="mixedLayerDepthsOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/mixedLayerDepths.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-00_00:00:01"

--- a/src/core_ocean/analysis_members/Registry_moc_streamfunction.xml
+++ b/src/core_ocean/analysis_members/Registry_moc_streamfunction.xml
@@ -75,6 +75,7 @@
 		<stream name="mocStreamfunctionOutput"
 			type="output"
 			mode="forward;analysis"
+			precision="single"
 			filename_template="analysis_members/mocStreamfunction.$Y-$M-$D.nc"
 			filename_interval="01-00-00_00:00:00"
 			output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_ocean_heat_content.xml
+++ b/src/core_ocean/analysis_members/Registry_ocean_heat_content.xml
@@ -40,6 +40,7 @@
 	<streams>
 		<stream name="oceanHeatContentOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/oceanHeatContent.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_okubo_weiss.xml
+++ b/src/core_ocean/analysis_members/Registry_okubo_weiss.xml
@@ -159,6 +159,7 @@
 		<stream name="okuboWeissOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/okuboWeiss.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-05_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_pointwise_stats.xml
+++ b/src/core_ocean/analysis_members/Registry_pointwise_stats.xml
@@ -26,6 +26,7 @@
 	<streams>
 		<stream name="pointwiseStatsOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/pointwiseStats.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_regional_stats_custom.xml
+++ b/src/core_ocean/analysis_members/Registry_regional_stats_custom.xml
@@ -121,6 +121,7 @@
 		<stream name="regionalStatsCustomOutput"
 				type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/regionalStatsCustom.$Y-$M-$D.nc"
 				filename_interval="00-00-01_00:00:00"
 				output_interval="00-00-00_01:00:00"

--- a/src/core_ocean/analysis_members/Registry_regional_stats_daily.xml
+++ b/src/core_ocean/analysis_members/Registry_regional_stats_daily.xml
@@ -120,6 +120,7 @@
 		<stream name="regionalStatsDailyOutput"
 				type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/regionalStatsDaily.$Y-$M.nc"
 				filename_interval="00-01-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_regional_stats_monthly.xml
+++ b/src/core_ocean/analysis_members/Registry_regional_stats_monthly.xml
@@ -121,6 +121,7 @@
 		<stream name="regionalStatsMonthlyOutput"
 				type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/regionalStatsMonthly.$Y.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-01-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_regional_stats_weekly.xml
+++ b/src/core_ocean/analysis_members/Registry_regional_stats_weekly.xml
@@ -121,6 +121,7 @@
 		<stream name="regionalStatsWeeklyOutput"
 				type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/regionalStatsWeekly.$Y-$M.nc"
 				filename_interval="00-03-00_00:00:00"
 				output_interval="00-00-07_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_sediment_flux_index.xml
+++ b/src/core_ocean/analysis_members/Registry_sediment_flux_index.xml
@@ -84,6 +84,7 @@
 		<stream name="sedimentFluxIndexOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/sedimentFluxIndex.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-00_00:01:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_sediment_transport.xml
+++ b/src/core_ocean/analysis_members/Registry_sediment_transport.xml
@@ -245,6 +245,7 @@
 		<stream name="sedimentTransportOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/sedimentTransport.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-00_00:01:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
+++ b/src/core_ocean/analysis_members/Registry_surface_area_weighted_averages.xml
@@ -368,6 +368,7 @@
 		<stream name="surfaceAreaWeightedAveragesOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/surfaceAreaWeightedAverages.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-05_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_climatology.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_climatology.xml
@@ -92,6 +92,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsClimatology.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_custom.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_custom.xml
@@ -92,6 +92,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsCustom.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"
 				filename_interval="00-01-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_daily.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_daily.xml
@@ -105,6 +105,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"
 				filename_interval="00-01-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_monthly_max.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_monthly_max.xml
@@ -105,6 +105,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsMonthlyMax.$Y-$M-$D.nc"
 				filename_interval="00-01-00_00:00:00"
 				reference_time="01-01-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_time_series_stats_monthly_min.xml
+++ b/src/core_ocean/analysis_members/Registry_time_series_stats_monthly_min.xml
@@ -105,6 +105,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsMonthlyMin.$Y-$M-$D.nc"
 				filename_interval="00-01-00_00:00:00"
 				reference_time="01-01-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_transect_transport.xml
+++ b/src/core_ocean/analysis_members/Registry_transect_transport.xml
@@ -41,6 +41,7 @@
 	<streams>
 		<stream name="transectTransportOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/transectTransport.$Y-$M-$D.nc"
 				filename_interval="01-00-00_00:00:00"
 				output_interval="00-00-01_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_water_mass_census.xml
+++ b/src/core_ocean/analysis_members/Registry_water_mass_census.xml
@@ -130,6 +130,7 @@
 		<stream name="waterMassCensusOutput"
 				mode="forward;analysis"
 				type="output"
+				precision="single"
 				filename_template="analysis_members/waterMassCensus.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="00-00-05_00:00:00"
 				filename_interval="01-00-00_00:00:00"

--- a/src/core_ocean/analysis_members/Registry_zonal_mean.xml
+++ b/src/core_ocean/analysis_members/Registry_zonal_mean.xml
@@ -71,6 +71,7 @@
 	<streams>
 		<stream name="zonalMeanOutput" type="output"
 				mode="forward;analysis"
+				precision="single"
 				filename_template="analysis_members/zonalMeans.$Y-$M-$D_$h.$m.$s.nc"
 				output_interval="0000_12:00:00"
 				filename_interval="01-00-00_00:00:00"


### PR DESCRIPTION
This adds the flag
```
precision="single"
```
to the default streams file for output files. It does not alter restart streams. Bit-for-bit testing in the nightly regression remains 8-byte reals because that is specified in compass.

The purpose of adding single precision to the default streams is to remind users that single precision is sufficient and would typically be used for output. This does not affect E3SM, as the streams files are created from a script there. We are changing to single precision analysis output there as well, see https://github.com/E3SM-Project/E3SM/pull/3360
