### PR TITLE
Correct misspelling of 'coefficients' and 'fields' in atmosphere Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1352,10 +1352,10 @@
                      description="weights for cell-centered second derivative, normal to edge, for transport scheme"/>
 
                 <var name="adv_coefs" type="real" dimensions="FIFTEEN nEdges" units="unitless"
-                     description="Weighting coefficents used for reconstructing cell-based foelds at edges"/>
+                     description="Weighting coefficients used for reconstructing cell-based fields at edges"/>
 
                 <var name="adv_coefs_3rd" type="real" dimensions="FIFTEEN nEdges" units="unitless"
-                     description="Weighting coefficents used for reconstructing cell-based foelds at edges"/>
+                     description="Weighting coefficients used for reconstructing cell-based fields at edges"/>
 
                 <var name="advCellsForEdge" type="integer" dimensions="FIFTEEN nEdges" units="-"
                      description="Cells used to reconstruct a cell-based field at an edge"/>


### PR DESCRIPTION
This merge corrects the misspelling of 'coefficients' and 'fields' in the descriptions
for the adv_coefs and adv_coefs_3rd fields in the atmosphere core's Registry.xml file.