### PR TITLE
Correct misspelling of 'surface' in atmosphere Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3009,7 +3009,7 @@
                      description="terrain height"/>
 
                 <var name="albedo12m" type="real" dimensions="nMonths nCells" units="unitless"
-                     description="monthly-mean climatological aurface albedo"/>
+                     description="monthly-mean climatological surface albedo"/>
 
                 <var name="greenfrac" type="real" dimensions="nMonths nCells" units="unitless"
                      description="monthly-mean climatological greeness fraction"/>


### PR DESCRIPTION
This merge corrects the misspelling of 'surface' in the description of the albedo12m field in the atmosphere core's Registry.xml file.