### PR TITLE
Change from oceans11 to lcrc in compass/ocean

### DIFF
--- a/testing_and_setup/compass/README_ocean.md
+++ b/testing_and_setup/compass/README_ocean.md
@@ -56,28 +56,17 @@ On LANL IC, a full checkout is already available at:
 geometric_data = /usr/projects/regionalclimate/COMMON_MPAS/ocean/grids/geometric_data_v0.1
 ```
 
-### mesh_database and initial_condition_database
+### mesh_database, initial_condition_database and bathymetry_database
 
-These are directories for storing pre-generated mesh files and data sets for
-creating initial conditions. These can be empty directories, in which case
+These are directories for storing pre-generated mesh files, data sets for
+creating initial conditions, and bathymetry data. These can be empty directories, in which case
 meshes and other data sets will be downloaded as required during test-case
 setup.  (If a test case appears to hang during setup, it is most likely
-downloading mesh or initial-condition data.)
+downloading mesh, initial-condition or bathymetry data.)
 
 On LANL IC, the shared data bases can be found at:
 ```
 mesh_database = /usr/projects/regionalclimate/COMMON_MPAS/ocean/grids/mesh_database
 initial_condition_database = /usr/projects/regionalclimate/COMMON_MPAS/ocean/grids/initial_condition_database
-```
-
-### bathymetry_database
-
-This is a database for bathymetry data sets that can be used at various phases
-of mesh generation and test-case initialization.  Currently, only a few test
-cases require these data sets and they are not downloaded automatically.  Thus,
-there is not a good way for users to access these datasets.
-
-On LANL IC, the shared location of the bathymetry database is at:
-```
 bathymetry_database = /usr/projects/regionalclimate/COMMON_MPAS/ocean/grids/bathymetry_database
 ```

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/decomp_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/decomp_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="ut8mre2rir" dest_path="mesh_database" file_name="doubly_periodic_10km_160x500km_planar.151001.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_160x500km_planar.151001.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="ut8mre2rir" dest_path="mesh_database" file_name="doubly_periodic_10km_160x500km_planar.151001.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_160x500km_planar.151001.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/restart_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/restart_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="ut8mre2rir" dest_path="mesh_database" file_name="doubly_periodic_10km_160x500km_planar.151001.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_160x500km_planar.151001.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/threads_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/threads_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="ut8mre2rir" dest_path="mesh_database" file_name="doubly_periodic_10km_160x500km_planar.151001.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_160x500km_planar.151001.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/coastal/USDEQU120cr10rr2/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/coastal/USDEQU120cr10rr2/build_mesh/config_base_mesh.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
 	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="python">

--- a/testing_and_setup/compass/ocean/coastal/USDEQU120cr10rr2/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/coastal/USDEQU120cr10rr2/build_mesh/config_culled_mesh.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <config case="culled_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
 	<add_link source_path="geometric_data" source="." dest="geometric_data"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="./cull_mesh.py">

--- a/testing_and_setup/compass/ocean/gaussian_hump/USDEQU120cr10rr2/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/gaussian_hump/USDEQU120cr10rr2/build_mesh/config_base_mesh.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
 	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="python">

--- a/testing_and_setup/compass/ocean/gaussian_hump/USDEQU120cr10rr2/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/gaussian_hump/USDEQU120cr10rr2/build_mesh/config_culled_mesh.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <config case="culled_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
 	<add_link source_path="geometric_data" source="." dest="geometric_data"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="./cull_mesh.py">

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/init/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/init/config_base_mesh.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/init/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/init/config_base_mesh.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state.xml
@@ -2,23 +2,23 @@
 <config case="initial_state">
 
 	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 

--- a/testing_and_setup/compass/ocean/global_ocean/config_files/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files/config_initial_state.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
 <config case="initial_state">
 	<get_file dest_path="initial_condition_database" file_name="layer_depth.80Layer.180619.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 

--- a/testing_and_setup/compass/ocean/global_ocean/config_files/config_initial_state_60_layers.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files/config_initial_state_60_layers.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 <config case="initial_state">
 	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<add_link source="../culled_mesh/culled_mesh.nc" dest="mesh.nc"/>

--- a/testing_and_setup/compass/ocean/global_ocean/config_files/config_mesh_metrics.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files/config_mesh_metrics.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <config case="mesh_metrics">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
 	<add_link source="../culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/inject_bathymetry.py" dest="inject_bathymetry.py"/>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_initial_state.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
 <config case="initial_state">
 	<get_file dest_path="initial_condition_database" file_name="layer_depth.80Layer.180619.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="landIceTopo_0.1deg_smooth_0.1deg.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_base_mesh.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.m" dest="jigsaw_driver.m"/>
-        <add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
-        <add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.m" dest="jigsaw_driver.m"/>
+	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
-        <run_script name="run.py">
-                <step executable="python">
-                        <argument flag="-m">jigsaw_to_MPAS.build_mesh</argument>
-                </step>
-        </run_script>
+	<run_script name="run.py">
+		<step executable="python">
+			<argument flag="-m">jigsaw_to_MPAS.build_mesh</argument>
+		</step>
+	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/build_mesh/config_culled_mesh.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0"?>
 <config case="culled_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
-        <add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
+	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-        <add_link source_path="geometric_data" source="." dest="geometric_data"/>
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="geometric_data" source="." dest="geometric_data"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="./cull_mesh.py">
 			<argument flag="-p">geometric_data</argument>
 			<argument flag="--with_critical_passages"></argument>
 		</step>
-                <step executable="python">
-                        <argument flag="-m">jigsaw_to_MPAS.inject_bathymetry</argument>
-                        <argument flag="">culled_mesh.nc</argument>
-                </step>
+		<step executable="python">
+			<argument flag="-m">jigsaw_to_MPAS.inject_bathymetry</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
 
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/build_mesh/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/build_mesh/config_base_mesh.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
 <config case="base_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.m" dest="jigsaw_driver.m"/>
-        <add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
-        <add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS/jigsaw_driver.m" dest="jigsaw_driver.m"/>
+	<add_link source_path="script_test_dir" source="." dest="define_base_mesh"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
-        <run_script name="run.py">
-                <step executable="python">
-                        <argument flag="-m">jigsaw_to_MPAS.build_mesh</argument>
-                </step>
-        </run_script>
+	<run_script name="run.py">
+		<step executable="python">
+			<argument flag="-m">jigsaw_to_MPAS.build_mesh</argument>
+		</step>
+	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/build_mesh/config_culled_mesh.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/build_mesh/config_culled_mesh.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0"?>
 <config case="culled_mesh">
+	<get_file dest_path="bathymetry_database" file_name="SRTM15_plus_earth_relief_15s.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/bathymetry_database/"/>
+	</get_file>
 
-        <add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
+	<add_link source="../base_mesh/base_mesh.nc" dest="base_mesh.nc"/>
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
-        <add_link source_path="geometric_data" source="." dest="geometric_data"/>
-        <add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
-	<add_link source_path="bathymetry_database" source="SRTM15_plus/earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
+	<add_link source_path="geometric_data" source="." dest="geometric_data"/>
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/global_ocean/cull_mesh.py" dest="cull_mesh.py"/>
+	<add_link source_path="bathymetry_database" source="SRTM15_plus_earth_relief_15s.nc" dest="earth_relief_15s.nc"/>
 
 	<run_script name="run.py">
 		<step executable="./cull_mesh.py">
 			<argument flag="-p">geometric_data</argument>
 			<argument flag="--with_critical_passages"></argument>
 		</step>
-                <step executable="python">
-                        <argument flag="-m">jigsaw_to_MPAS.inject_bathymetry</argument>
-                        <argument flag="">culled_mesh.nc</argument>
-                </step>
+		<step executable="python">
+			<argument flag="-m">jigsaw_to_MPAS.inject_bathymetry</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
 
 	</run_script>
 </config>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="7x332mn9jw" dest_path="mesh_database" file_name="doubly_periodic_5km_20x250km_planar.170206.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_20x250km_planar.170206.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/ten-day/config_init1.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/ten-day/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="7x332mn9jw" dest_path="mesh_database" file_name="doubly_periodic_5km_20x250km_planar.170206.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_20x250km_planar.170206.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/isomip/10km/expt1.01/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip/10km/expt1.01/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="pkxjnxy4c6" dest_path="mesh_database" file_name="doubly_periodic_10km_540x1040km_planar.151225.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_540x1040km_planar.151225.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/isomip/10km/expt2.01/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip/10km/expt2.01/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="pkxjnxy4c6" dest_path="mesh_database" file_name="doubly_periodic_10km_540x1040km_planar.151225.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_540x1040km_planar.151225.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean0/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_2km_488x87km_planar.151226.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean1_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean1/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_2km_488x87km_planar.151226.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean1_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/Ocean2/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_2km_488x87km_planar.151226.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean2_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/2km/time_varying_Ocean0/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_2km_488x87km_planar.151226.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean1_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean0/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_5km_100x20km_planar.160926.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean1_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean1/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_5km_100x20km_planar.160926.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean1_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
+++ b/testing_and_setup/compass/ocean/isomip_plus/5km/Ocean2/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="kpqjir3tne" dest_path="mesh_database" file_name="doubly_periodic_5km_100x20km_planar.160926.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="Ocean2_input_geom_v1.01.nc">

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="ccb8wxfwaz" dest_path="mesh_database" file_name="doubly_periodic_0.5km_2x64km_planar.160120.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_0.5km_2x64km_planar.160120.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/lock_exchange/16km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/16km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="4a831vp0yh" dest_path="mesh_database" file_name="doubly_periodic_16km_64x64km_planar.160120.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_16km_64x64km_planar.160120.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/overflow/10km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/overflow/10km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="d4umuzo339" dest_path="mesh_database" file_name="doubly_periodic_10km_40x240km_planar.151217.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_40x240km_planar.151217.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/default_light/config_forward.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/default_light/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="particle_full.171212.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="mesh_database" file_name="graph.info.part.6.doubly_periodic_20km_1000x2000km_planar.151113">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="particle_full.171212.nc" dest="particle_full.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/default_light/config_init1.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/default_light/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="9k5rpoi0lg" dest_path="mesh_database" file_name="doubly_periodic_20km_1000x2000km_planar.151027.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151027.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/region_reset_light_test/config_forward.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/region_reset_light_test/config_forward.xml
@@ -5,15 +5,15 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="particle_resets_region.151113.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="initial_condition_database" file_name="particle_regions.151113.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="mesh_database" file_name="graph.info.part.6.doubly_periodic_20km_1000x2000km_planar.151113">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="particle_regions.151113.nc" dest="particle_regions.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/region_reset_light_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/region_reset_light_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="9k5rpoi0lg" dest_path="mesh_database" file_name="doubly_periodic_20km_1000x2000km_planar.151027.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151027.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/time_reset_light_test/config_forward.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/time_reset_light_test/config_forward.xml
@@ -5,11 +5,11 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="particle_resets_time.151113.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
 	<get_file dest_path="mesh_database" file_name="graph.info.part.6.doubly_periodic_20km_1000x2000km_planar.151113">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="particle_resets_time.151113.nc" dest="particle_resets.nc"/>

--- a/testing_and_setup/compass/ocean/periodic_planar/20km/time_reset_light_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/20km/time_reset_light_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="9k5rpoi0lg" dest_path="mesh_database" file_name="doubly_periodic_20km_1000x2000km_planar.151027.nc">
-    <mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+    <mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151027.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sea_mount/6.7km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sea_mount/6.7km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="3ycwtvh88u" dest_path="mesh_database" file_name="doubly_periodic_6.7km_320x320km_planar.151215.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_6.7km_320x320km_planar.151215.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/single_column_model/planar/cvmix_test/config_init.xml
+++ b/testing_and_setup/compass/ocean/single_column_model/planar/cvmix_test/config_init.xml
@@ -2,7 +2,7 @@
 <config case="init_step">
 
 	<get_file hash="7q1krpgdiu" dest_path="mesh_database" file_name="doubly_periodic_1920km_7680x7680km.151124.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_executable source="model" dest="ocean_model"/>
@@ -100,7 +100,7 @@
                 <member name="rainFlux" type="var"/>
 			</add_contents>
 		</stream>
- 
+
 	</streams>
 
 	<run_script name="run.py">
@@ -108,7 +108,7 @@
 			<argument flag="">base_mesh.nc</argument>
 			<argument flag="">mesh.nc</argument>
 		</step>
-		
+
 		<step executable="mpirun">
 			<argument flag="-n">1</argument>
 			<argument flag="">./ocean_model</argument>

--- a/testing_and_setup/compass/ocean/single_column_model/sphere/cvmix_test/config_init.xml
+++ b/testing_and_setup/compass/ocean/single_column_model/sphere/cvmix_test/config_init.xml
@@ -2,7 +2,7 @@
 <config case="init_step">
 
 	<get_file hash="rku96q0z66" dest_path="mesh_database" file_name="mesh.QU.1920km.151026.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_executable source="model" dest="ocean_model"/>
@@ -101,7 +101,7 @@
                 <member name="rainFlux" type="var"/>
 			</add_contents>
 		</stream>
- 
+
 	</streams>
 
 	<run_script name="run.py">
@@ -109,7 +109,7 @@
 			<argument flag="">base_mesh.nc</argument>
 			<argument flag="">mesh.nc</argument>
 		</step>
-		
+
 		<step executable="mpirun">
 			<argument flag="-n">1</argument>
 			<argument flag="">./ocean_model</argument>

--- a/testing_and_setup/compass/ocean/soma/16km/3layer/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/3layer/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/16km/3layer/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/3layer/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="rrjluykyy8" file_name="SOMA_16km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_16km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/16km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/16km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="rrjluykyy8" file_name="SOMA_16km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_16km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/16km/surface_restoring/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/surface_restoring/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/16km/surface_restoring/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/16km/surface_restoring/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="rrjluykyy8" file_name="SOMA_16km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_16km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/32km/3layer/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/3layer/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/32km/3layer/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/3layer/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="tfo7phwbtr" file_name="SOMA_32km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_32km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/32km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/32km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="tfo7phwbtr" file_name="SOMA_32km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_32km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/32km/surface_restoring/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/surface_restoring/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/32km/surface_restoring/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/surface_restoring/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="tfo7phwbtr" file_name="SOMA_32km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_32km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/32km/time_varying_wind/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/32km/time_varying_wind/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="tfo7phwbtr" file_name="SOMA_32km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_32km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/4km/32to4km/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/32to4km/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/4km/3layer/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/3layer/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/4km/3layer/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/3layer/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="qgqmstl9ig" file_name="SOMA_4km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_4km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/4km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/4km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="qgqmstl9ig" file_name="SOMA_4km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_4km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/4km/surface_restoring/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/surface_restoring/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/4km/surface_restoring/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/4km/surface_restoring/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="qgqmstl9ig" file_name="SOMA_4km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_4km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/8km/32to8km/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/32to8km/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/8km/3layer/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/3layer/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/8km/3layer/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/3layer/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="njzco4hyy4" file_name="SOMA_8km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_8km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/8km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/8km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="njzco4hyy4" file_name="SOMA_8km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_8km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/soma/8km/surface_restoring/config_forward.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/surface_restoring/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/soma/8km/surface_restoring/config_init1.xml
+++ b/testing_and_setup/compass/ocean/soma/8km/surface_restoring/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="njzco4hyy4" file_name="SOMA_8km_grid.161202.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="SOMA_8km_grid.161202.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/Haney_number_init/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/Haney_number_iterative_init/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/iterative_init/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/restart_test/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
+++ b/testing_and_setup/compass/ocean/sub_ice_shelf_2D/5km/with_frazil/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file hash="qfdrqh616l" dest_path="mesh_database" file_name="doubly_periodic_5km_50x230km_planar.151218.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database/"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database/"/>
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_50x230km_planar.151218.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/ziso/10km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/ziso/10km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/ziso/10km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/ziso/10km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="gom47qx4qu" file_name="doubly_periodic_10km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_10km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/ziso/2.5km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/ziso/2.5km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/ziso/2.5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/ziso/2.5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="sp3d6v0wir" file_name="doubly_periodic_2.5km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_2.5km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/ziso/20km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/ziso/20km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="yu8hv6txi0" file_name="doubly_periodic_20km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/ziso/20km/with_frazil/config_forward.xml
+++ b/testing_and_setup/compass/ocean/ziso/20km/with_frazil/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/ziso/20km/with_frazil/config_init1.xml
+++ b/testing_and_setup/compass/ocean/ziso/20km/with_frazil/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="yu8hv6txi0" file_name="doubly_periodic_20km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_20km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>

--- a/testing_and_setup/compass/ocean/ziso/5km/default/config_forward.xml
+++ b/testing_and_setup/compass/ocean/ziso/5km/default/config_forward.xml
@@ -6,7 +6,7 @@
 	<add_link source="../init_step2/graph.info" dest="graph.info"/>
 
 	<get_file dest_path="initial_condition_database" file_name="make_particle_resets.151222.py">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/initial_condition_database"/>
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database"/>
 	</get_file>
 
 	<add_link source_path="initial_condition_database" source="make_particle_resets.151222.py" dest="make_particle_resets.py"/>

--- a/testing_and_setup/compass/ocean/ziso/5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/ziso/5km/default/config_init1.xml
@@ -2,7 +2,7 @@
 <config case="init_step1">
 
 	<get_file dest_path="mesh_database" hash="qfp5x0blpj" file_name="doubly_periodic_5km_1000x2000km_planar.151117.nc">
-		<mirror protocol="wget" url="http://oceans11.lanl.gov/mpas_data/mesh_database" />
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/mesh_database" />
 	</get_file>
 
 	<add_link source_path="mesh_database" source="doubly_periodic_5km_1000x2000km_planar.151117.nc" dest="base_mesh.nc"/>


### PR DESCRIPTION
All references to:
https://oceans11.lanl.gov/mpas_data/
are changed to:
https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/

Add mirror for `bathymetry_database`.  Since the mirror infrastructure doesn't handle subdirectories,
rename the bathymetry file:
`SRTM15_plus/earth_relief_15s.nc` --> `SRTM15_plus_earth_relief_15s.nc`

closes #240
closes #294 