### PR TITLE
Ocean/compute slope taper on edge

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -394,7 +394,15 @@
 		<nml_option name="config_Redi_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="The Redi diffusion coefficient"
 					possible_values="Positive real numbers"
-		/>
+    />
+    <nml_option name="config_REDI_half_slope" type="real" default_value="0.004" units="non-dimensional"
+        description="value of slope where set to half max"
+        possible_values="positive real numbers less than slope max"
+    />
+    <nml_option name="config_REDI_half_width" type="real" default_value="0.001" units="non-dimensional"
+        description="value of half width of tanh function limiter"
+        possible_values="very small positive real numbers"
+    />
 		<nml_option name="config_Redi_closure" type="character" default_value="constant" units="unitless"
 					description="Control what type of function is used for Redi $\kappa$. Only 'constant' is currently supported."
 					possible_values="'constant', 'data', 'match_GM'"
@@ -2753,7 +2761,11 @@
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"
     />
-    <var name="slopeTaperEdge" type="real" dimensions="nVertLevels nEdges Time" units="non-dimensional"
+    <var name="slopeTaperEdgeUp" type="real" dimensions="nVertLevels nEdges Time" units="non-dimensional"
+       description="tapering of Redi mixing at cell edges"
+       packages="forwardMode;analysisMode"
+    />
+   <var name="slopeTaperEdgeDown" type="real" dimensions="nVertLevels nEdges Time" units="non-dimensional"
        description="tapering of Redi mixing at cell edges"
        packages="forwardMode;analysisMode"
     />

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2752,7 +2752,11 @@
 		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"
-		/>
+    />
+    <var name="slopeTaperEdge" type="real" dimensions="nVertLevels nEdges Time" units="non-dimensional"
+       description="tapering of Redi mixing at cell edges"
+       packages="forwardMode;analysisMode"
+    />
 		<var name="k33" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="The (3,3) entry of the Redi diffusion tensor. Added to the model vertical diffusion. Defined at the top of cell k"
 			 packages="forwardMode;analysisMode"

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -404,7 +404,7 @@ contains
 
       !compute the slope taper on edges
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdge
+      do iEdge = 1, nEdges
   ! Add bottom taper slope for this column.
          ! Top taper slope is computed before the cell loop, because it is the same
          ! for all cells.
@@ -529,7 +529,6 @@ contains
       deallocate(dTdzTop)
       deallocate(dSdzTop)
       deallocate(k33Norm)
-      deallocate(slopeTaper)
       deallocate(slopeTaperSurface)
 
       ! allow disabling of K33 for testing

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -108,7 +108,7 @@ contains
 
       real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa,  cGMphaseSpeed, bottomDepth, indexBoundaryLayerDepth
       real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
-      real(kind=RKIND), dimension(:,:), pointer :: slopeTaperEdge
+      real(kind=RKIND), dimension(:,:), pointer :: slopeTaperEdgeUp, slopeTaperEdgeDown
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
       integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
@@ -119,7 +119,7 @@ contains
       real(kind=RKIND) :: surfaceTaperCoef, bottomTaperCoef, bldEdge
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND), dimension(:), allocatable :: slopeTaper, slopeTaperSurface
-
+      
       ! Dimensions
       integer :: nCells, nEdges
       integer, pointer :: nVertLevels
@@ -159,7 +159,8 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTaperEdge', slopeTaperEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTaperEdgeUp', slopeTaperEdgeUp)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTaperEdgeDown', slopeTaperEdgeDown)
       call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
@@ -397,42 +398,43 @@ contains
       bottomTaperCoef = 1.0_RKIND/config_Redi_bottom_taper_layers
       slopeTaperSurface(:) = 1.0_RKIND
       slopeTaperSurface(1) = 0.0_RKIND
-      slopeTaperEdge(:,:) = 0.0_RKIND
+      slopeTaperEdgeUp(:,:) = 0.0_RKIND
+      slopeTaperEdgeDown(:,:) = 0.0_RKIND
       do k = 2, config_Redi_surface_taper_layers
           slopeTaperSurface(k) = slopeTaperSurface(k)*(k-1)*surfaceTaperCoef
       end do
 
       !compute the slope taper on edges
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-  ! Add bottom taper slope for this column.
-         ! Top taper slope is computed before the cell loop, because it is the same
-         ! for all cells.
-         slopeTaperEdge(iEdge,:maxLevelEdgeTop(iEdge)) = slopeTaperSurface(:maxLevelEdgeTop(iEdge))
-         do k = max(maxLevelEdgeTop(iEdge) - config_Redi_bottom_taper_layers, 2), maxLevelEdgeTop(iEdge)
-            slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge) &
-                * (maxLevelEdgeTop(iEdge)-k)*bottomTaperCoef
-         end do
-
-         ! Add taper for boundary layer
-         if (config_Redi_zero_in_boundary_layer) then
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-
-            !Take maximum boundary layer dpeth for surface
-            bldEdge = max(indexBoundaryLayerDepth(cell1),indexBoundaryLayerDepth(cell2))
-            iBLD = int(bldEdge)
-            do k = 2, iBLD
-               slopeTaperEdge(k,iEdge) = 0.0_RKIND
-            end do
-            do k = iBLD + 1, &
-                   min(iBLD + config_Redi_BLD_taper_layers, maxLevelEdgeTop(iEdge))
-               slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge)*(k-iBLD) / config_Redi_BLD_taper_layers
-            end do
-         end if
-
-      enddo !iEdge loop for slopeTaper
-      !$omp end do
+ !     !$omp do schedule(runtime)
+ !     do iEdge = 1, nEdges
+ ! ! Add bottom taper slope for this column.
+ !        ! Top taper slope is computed before the cell loop, because it is the same
+ !        ! for all cells.
+ !        slopeTaperEdge(iEdge,:maxLevelEdgeTop(iEdge)) = slopeTaperSurface(:maxLevelEdgeTop(iEdge))
+ !        do k = max(maxLevelEdgeTop(iEdge) - config_Redi_bottom_taper_layers, 2), maxLevelEdgeTop(iEdge)
+ !           slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge) &
+ !               * (maxLevelEdgeTop(iEdge)-k)*bottomTaperCoef
+ !        end do
+!
+!         ! Add taper for boundary layer
+!         if (config_Redi_zero_in_boundary_layer) then
+!            cell1 = cellsOnEdge(1,iEdge)
+!            cell2 = cellsOnEdge(2,iEdge)
+!
+!            !Take maximum boundary layer dpeth for surface
+!            bldEdge = max(indexBoundaryLayerDepth(cell1),indexBoundaryLayerDepth(cell2))
+!            iBLD = int(bldEdge)
+!            do k = 2, iBLD
+!               slopeTaperEdge(k,iEdge) = 0.0_RKIND
+!            end do
+!            do k = iBLD + 1, &
+!                   min(iBLD + config_Redi_BLD_taper_layers, maxLevelEdgeTop(iEdge))
+!               slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge)*(k-iBLD) / config_Redi_BLD_taper_layers
+!            end do
+!         end if
+!
+!      enddo !iEdge loop for slopeTaper
+!      !$omp end do
 
       !$omp do schedule(runtime)
       do iCell = 1, nCells
@@ -494,16 +496,22 @@ contains
                   (  drhoDT * dTdzTop(k+1) &
                    + drhoDS * dSdzTop(k+1) )
 
+               ! set taper of slope ('F' function from Danabasoglu and McWilliams 95)
+               slopeTaperEdgeUp(k,iEdge) = 0.5_RKIND*(1.0 - tanh((-abs(slopeTriadUp(k,iCellSelf,iEdge)) + &
+                  config_REDI_half_slope)/config_REDI_half_width))
+               slopeTaperEdgeDown(k,iEdge) = 0.5_RKIND*(1.0 - tanh((-abs(slopeTriadDown(k,iCellSelf,iEdge)) + &
+                  config_REDI_half_slope)/config_REDI_half_width))
+
                ! Slope can be unbounded in regions of neutral stability.
                ! Reset slope to maximum slope limit.
                slopeTriadUp(k,iCellSelf,iEdge) = &
-                  slopeTaperEdge(k,iEdge) * &
-                  max( min( slopeTriadUp(k,iCellSelf,iEdge), &
-                  config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
+                  slopeTaperEdgeUp(k,iEdge) * slopeTriadUp(k,iCellSelf,iEdge) !&
+!                  max( min( slopeTriadUp(k,iCellSelf,iEdge), &
+!                  config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
                slopeTriadDown(k,iCellSelf,iEdge) = &
-                  slopeTaperEdge(k,iEdge) * &
-                  max( min( slopeTriadDown(k,iCellSelf,iEdge), &
-                  config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
+                  slopeTaperEdgeDown(k,iEdge) * slopeTriadDown(k,iCellSelf,iEdge) !&
+!                  max( min( slopeTriadDown(k,iCellSelf,iEdge), &
+!                  config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
 
                ! Griffies 1998 eqn 34
                k33(k  ,iCell) = k33(k  ,iCell) + areaEdge*dzTop(k  )*slopeTriadUp(k,iCellSelf,iEdge)**2

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -108,6 +108,7 @@ contains
 
       real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa,  cGMphaseSpeed, bottomDepth, indexBoundaryLayerDepth
       real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
+      real(kind=RKIND), dimension(:,:), pointer :: slopeTaperEdge
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
       integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
@@ -115,7 +116,7 @@ contains
       real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp, stmp, maxSlopeK33
       real(kind=RKIND)                 :: bottomAv, sumN2, countN2, maxN, kappaSum, ltSum
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx
-      real(kind=RKIND) :: surfaceTaperCoef, bottomTaperCoef
+      real(kind=RKIND) :: surfaceTaperCoef, bottomTaperCoef, bldEdge
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND), dimension(:), allocatable :: slopeTaper, slopeTaperSurface
 
@@ -158,6 +159,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTaperEdge', slopeTaperEdge)
       call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
@@ -389,16 +391,48 @@ contains
       allocate(dTdzTop(nVertLevels+1))
       allocate(dSdzTop(nVertLevels+1))
       allocate(k33Norm(nVertLevels+1))
-      allocate(slopeTaper(nVertLevels))
       allocate(slopeTaperSurface(nVertLevels))
       ! Prepare tapering for this cell. This is the slope of the bottom taper line.
       surfaceTaperCoef = 1.0_RKIND/config_Redi_surface_taper_layers
       bottomTaperCoef = 1.0_RKIND/config_Redi_bottom_taper_layers
       slopeTaperSurface(:) = 1.0_RKIND
       slopeTaperSurface(1) = 0.0_RKIND
+      slopeTaperEdge(:,:) = 0.0_RKIND
       do k = 2, config_Redi_surface_taper_layers
           slopeTaperSurface(k) = slopeTaperSurface(k)*(k-1)*surfaceTaperCoef
       end do
+
+      !compute the slope taper on edges
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdge
+  ! Add bottom taper slope for this column.
+         ! Top taper slope is computed before the cell loop, because it is the same
+         ! for all cells.
+         slopeTaperEdge(iEdge,:maxLevelEdgeTop(iEdge)) = slopeTaperSurface(:maxLevelEdgeTop(iEdge))
+         do k = max(maxLevelEdgeTop(iEdge) - config_Redi_bottom_taper_layers, 2), maxLevelEdgeTop(iEdge)
+            slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge) &
+                * (maxLevelEdgeTop(iEdge)-k)*bottomTaperCoef
+         end do
+
+         ! Add taper for boundary layer
+         if (config_Redi_zero_in_boundary_layer) then
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+
+            !Take maximum boundary layer dpeth for surface
+            bldEdge = max(indexBoundaryLayerDepth(cell1),indexBoundaryLayerDepth(cell2))
+            iBLD = int(bldEdge)
+            do k = 2, iBLD
+               slopeTaperEdge(k,iEdge) = 0.0_RKIND
+            end do
+            do k = iBLD + 1, &
+                   min(iBLD + config_Redi_BLD_taper_layers, maxLevelEdgeTop(iEdge))
+               slopeTaperEdge(k,iEdge) = slopeTaperEdge(k,iEdge)*(k-iBLD) / config_Redi_BLD_taper_layers
+            end do
+         end if
+
+      enddo !iEdge loop for slopeTaper
+      !$omp end do
 
       !$omp do schedule(runtime)
       do iCell = 1, nCells
@@ -419,27 +453,6 @@ contains
          dzTop(maxLevelCell(iCell)+1) = -1e34_RKIND
          dTdzTop(maxLevelCell(iCell)+1) = -1e34_RKIND
          dSdzTop(maxLevelCell(iCell)+1) = -1e34_RKIND
-
-         ! Add bottom taper slope for this column.
-         ! Top taper slope is computed before the cell loop, because it is the same
-         ! for all cells.
-         slopeTaper(:) = slopeTaperSurface(:)
-         do k = max(maxLevelCell(iCell) - config_Redi_bottom_taper_layers, 2), maxLevelCell(iCell)
-            slopeTaper(k) = slopeTaper(k) &
-                * (maxLevelCell(iCell)-k)*bottomTaperCoef
-         end do
-
-         ! Add taper for boundary layer
-         if (config_Redi_zero_in_boundary_layer) then
-            iBLD = int(indexBoundaryLayerDepth(iCell))
-            do k = 2, iBLD
-               slopeTaper(k) = 0.0_RKIND
-            end do
-            do k = iBLD + 1, &
-                   min(iBLD + config_Redi_BLD_taper_layers, maxLevelCell(iCell))
-               slopeTaper(k) = slopeTaper(k)*(k-iBLD) / config_Redi_BLD_taper_layers
-            end do
-         end if
 
          k33(1:maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
          k33Norm(1:maxLevelCell(iCell)+1) = epsGM
@@ -484,11 +497,11 @@ contains
                ! Slope can be unbounded in regions of neutral stability.
                ! Reset slope to maximum slope limit.
                slopeTriadUp(k,iCellSelf,iEdge) = &
-                  slopeTaper(k) * &
+                  slopeTaperEdge(k,iEdge) * &
                   max( min( slopeTriadUp(k,iCellSelf,iEdge), &
                   config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
                slopeTriadDown(k,iCellSelf,iEdge) = &
-                  slopeTaper(k) * &
+                  slopeTaperEdge(k,iEdge) * &
                   max( min( slopeTriadDown(k,iCellSelf,iEdge), &
                   config_mesoscale_eddy_isopycnal_slope_limit), -config_mesoscale_eddy_isopycnal_slope_limit)
 


### PR DESCRIPTION
In the current ocean/develop the slope tapering is computed at cell centers and then is used directly at edges without interpolation.  At the bottom, near sloping bathymetry, there are cases where values of slopeTaper are used past maxLevelCell and this value was set to one in the code.  So the tapering was going to zero then artificially jumped to one causing issues with global min.  This PR computes slopeTaper on edges.