### PR TITLE
Ocean init mode: add subroutine for smoothing topography

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -412,7 +412,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_Redi_BLD_taper_layers" type="integer" default_value="3" units="non-dimensional"
-					description="Number of layers below boundary layer depth, over which Redi coefficient is tapered." 
+					description="Number of layers below boundary layer depth, over which Redi coefficient is tapered."
 					possible_values="Integer between 1 and nVertLevels. Use 1 for no tapering."
 		/>
 	</nml_record>
@@ -3621,6 +3621,12 @@
 			persistence="scratch"
 			type="integer" dimensions="nCells" units="unitless"
 			description="reference maxLevelCell for vertical interpolation of tracers"
+		/>
+		<!-- FIELDS FOR HORIZONTAL SMOOTHING DURING INITIALIZATION -->
+		<var name="smoothedField"
+			persistence="scratch"
+			type="real" dimensions="nCells" units="various"
+			description="the smoothed version of a field on cells during iterative smoothing"
 		/>
 		<!-- FIELDS FOR RX1 INITIALIZATION -->
 		<var name="zInterfaceScratch"

--- a/src/core_ocean/mode_init/Makefile
+++ b/src/core_ocean/mode_init/Makefile
@@ -6,7 +6,8 @@ UTILS = mpas_ocn_init_spherical_utils.o \
         mpas_ocn_init_vertical_grids.o \
         mpas_ocn_init_cell_markers.o \
         mpas_ocn_init_interpolation.o \
-	mpas_ocn_init_ssh_and_landIcePressure.o
+        mpas_ocn_init_ssh_and_landIcePressure.o \
+        mpas_ocn_init_smoothing.o
 
 TEST_CASES = mpas_ocn_init_baroclinic_channel.o \
              mpas_ocn_init_lock_exchange.o \
@@ -39,6 +40,8 @@ mpas_ocn_init_cell_markers.o:
 mpas_ocn_init_interpolation.o:
 
 mpas_ocn_init_ssh_and_landIcePressure.o: mpas_ocn_init_interpolation.o mpas_ocn_init_vertical_grids.o
+
+mpas_ocn_init_smoothing.o:
 
 mpas_ocn_init_spherical_utils.o:
 

--- a/src/core_ocean/mode_init/Registry_global_ocean.xml
+++ b/src/core_ocean/mode_init/Registry_global_ocean.xml
@@ -175,8 +175,8 @@
 			description="Method to interpolate topography data to MPAS mesh."
 			possible_values="bilinear_interpolation, nearest_neighbor"
 		/>
-		<nml_option name="config_global_ocean_smooth_topography" type="logical" default_value=".true." units="unitless"
-			description="Logical flag that controls if topograhy should be smoothed after being interpolated."
+		<nml_option name="config_global_ocean_fill_bathymetry_holes" type="logical" default_value=".true." units="unitless"
+			description="Logical flag that controls if deep holes in the bathymetry should be filled after interpolation to the MPAS mesh."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_global_ocean_deepen_critical_passages" type="logical" default_value=".true." units="unitless"

--- a/src/core_ocean/mode_init/Registry_global_ocean.xml
+++ b/src/core_ocean/mode_init/Registry_global_ocean.xml
@@ -179,6 +179,14 @@
 			description="Logical flag that controls if deep holes in the bathymetry should be filled after interpolation to the MPAS mesh."
 			possible_values=".true. or .false."
 		/>
+		<nml_option name="config_global_ocean_topography_smooth_iterations" type="integer" default_value="0" units="unitless"
+			description="How many iterations of topography smoothing by weighted averaging of cellsOnCell to perform."
+			possible_values="any non-negative integer"
+		/>
+		<nml_option name="config_global_ocean_topography_smooth_weight" type="real" default_value="0.9" units="unitless"
+			description="The weight given to the central cell during smoothing.  The n cellsOnCell are given a weight (1-weight)/n."
+			possible_values="fraction between 0 and 1"
+		/>
 		<nml_option name="config_global_ocean_deepen_critical_passages" type="logical" default_value=".true." units="unitless"
 			description="Logical flag that controls if critical passages are deepened to a minimum depth."
 			possible_values=".true. or .false."

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -1159,6 +1159,9 @@ contains
        real (kind=RKIND), pointer :: config_land_ice_flux_rho_ice
        character (len=StrKIND), pointer :: config_global_ocean_topography_method, config_iterative_init_variable
 
+       real (kind=RKIND), pointer :: config_global_ocean_topography_smooth_weight
+       integer, pointer :: config_global_ocean_topography_smooth_iterations
+
        integer :: iCell
 
        iErr = 0
@@ -1167,30 +1170,24 @@ contains
                                  config_global_ocean_topography_method)
        call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_rho_ice', config_land_ice_flux_rho_ice)
        call mpas_pool_get_config(domain % configs, 'config_iterative_init_variable', config_iterative_init_variable)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_smooth_iterations', &
+                                 config_global_ocean_topography_smooth_iterations)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_smooth_weight', &
+                                 config_global_ocean_topography_smooth_weight)
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
 
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
           call mpas_pool_get_array(meshPool, 'latCell', latCell)
           call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
-          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
-          call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
 
           if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
 
@@ -1240,6 +1237,50 @@ contains
              iErr = 1
              call mpas_dmpar_finalize(domain % dminfo)
           endif
+
+          block_ptr => block_ptr % next
+       end do
+
+
+       ! Iteratively smooth landIceDraftObserved, landIceThkObserved, landIceFracObserved,
+       ! and landIceGroundedFracObserved before using them to adjust SSH, compute
+       ! land-ice pressure, etc.
+       call ocn_init_smooth_field(domain, 'landIceDraftObserved', 'landIceInit', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       call ocn_init_smooth_field(domain, 'landIceThkObserved', 'landIceInit', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       call ocn_init_smooth_field(domain, 'landIceFracObserved', 'landIceInit', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       call ocn_init_smooth_field(domain, 'landIceGroundedFracObserved', 'landIceInit', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+
+          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+          call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
+          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+          call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
 
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -856,7 +856,7 @@ contains
        integer :: minimum_levels
 
        character (len=StrKIND), pointer :: config_global_ocean_topography_method
-       logical, pointer :: config_global_ocean_smooth_topography, config_global_ocean_topography_has_ocean_frac, &
+       logical, pointer :: config_global_ocean_fill_bathymetry_holes, config_global_ocean_topography_has_ocean_frac, &
                            config_global_ocean_deepen_critical_passages
        real (kind=RKIND), pointer :: config_global_ocean_minimum_depth
 
@@ -866,7 +866,7 @@ contains
 
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_method', config_global_ocean_topography_method)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_minimum_depth', config_global_ocean_minimum_depth)
-       call mpas_pool_get_config(domain % configs, 'config_global_ocean_smooth_topography', config_global_ocean_smooth_topography)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_fill_bathymetry_holes', config_global_ocean_fill_bathymetry_holes)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_deepen_critical_passages', &
                                  config_global_ocean_deepen_critical_passages)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_has_ocean_frac', &
@@ -975,7 +975,7 @@ contains
 
           ! Smooth depth levels. Enforce different in maxLevelCell to only be a maximum
           ! of 1 vertical level between two neighboring cells.
-          if (config_global_ocean_smooth_topography) then
+          if (config_global_ocean_fill_bathymetry_holes) then
              call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
              call mpas_pool_get_field(scratchPool, 'smoothedLevels', smoothedLevelsField)

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -37,6 +37,7 @@ module ocn_init_global_ocean
    use ocn_init_vertical_grids
    use ocn_init_interpolation
    use ocn_init_ssh_and_landIcePressure
+   use ocn_init_smoothing
 
    implicit none
    private
@@ -849,6 +850,7 @@ contains
        integer, pointer :: nCells, nCellsSolve, nVertLevels
 
        type (field1DInteger), pointer :: maxLevelCellField, smoothedLevelsField
+       type (field1DReal), pointer :: bottomDepthObservedField
        integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
        integer, dimension(:, :), pointer :: cellsOnCell
 
@@ -858,7 +860,8 @@ contains
        character (len=StrKIND), pointer :: config_global_ocean_topography_method
        logical, pointer :: config_global_ocean_fill_bathymetry_holes, config_global_ocean_topography_has_ocean_frac, &
                            config_global_ocean_deepen_critical_passages
-       real (kind=RKIND), pointer :: config_global_ocean_minimum_depth
+       real (kind=RKIND), pointer :: config_global_ocean_minimum_depth, config_global_ocean_topography_smooth_weight
+       integer, pointer :: config_global_ocean_topography_smooth_iterations
 
        logical :: isOcean
 
@@ -866,7 +869,12 @@ contains
 
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_method', config_global_ocean_topography_method)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_minimum_depth', config_global_ocean_minimum_depth)
-       call mpas_pool_get_config(domain % configs, 'config_global_ocean_fill_bathymetry_holes', config_global_ocean_fill_bathymetry_holes)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_fill_bathymetry_holes', &
+                                 config_global_ocean_fill_bathymetry_holes)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_smooth_iterations', &
+                                 config_global_ocean_topography_smooth_iterations)
+       call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_smooth_weight', &
+                                 config_global_ocean_topography_smooth_weight)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_deepen_critical_passages', &
                                  config_global_ocean_deepen_critical_passages)
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_has_ocean_frac', &
@@ -879,17 +887,13 @@ contains
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
           call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
           call mpas_pool_get_array(meshPool, 'latCell', latCell)
           call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
           call mpas_pool_get_array(meshPool, 'bottomDepthObserved', bottomDepthObserved)
           call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
           call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
 
           do k = 1, nVertLevels
              if (refBottomDepth(k).gt.config_global_ocean_minimum_depth) then
@@ -934,6 +938,27 @@ contains
              iErr = 1
              call mpas_dmpar_finalize(domain % dminfo)
           endif
+          block_ptr => block_ptr % next
+       end do
+
+       ! Iteratively smooth bottomDepthObserved before using it to construct the vertical grid
+       call ocn_init_smooth_field(domain, 'bottomDepthObserved', 'mesh', &
+                                  config_global_ocean_topography_smooth_iterations, &
+                                  config_global_ocean_topography_smooth_weight)
+
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+          call mpas_pool_get_array(meshPool, 'bottomDepthObserved', bottomDepthObserved)
+          call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
+          call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
           do iCell = 1, nCells
              ! Record depth of the bottom of the ocean, before any alterations for modeling purposes.
@@ -973,8 +998,8 @@ contains
              call ocn_init_setup_global_ocean_deepen_critical_passages(meshPool, criticalPassagesPool, iErr)
           end if
 
-          ! Smooth depth levels. Enforce different in maxLevelCell to only be a maximum
-          ! of 1 vertical level between two neighboring cells.
+          ! Fill holes. Enforce that no cell has maxLevelCell that is more than
+          ! 1 vertical level higher than its neighbors.
           if (config_global_ocean_fill_bathymetry_holes) then
              call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_smoothing.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_smoothing.F
@@ -77,7 +77,7 @@ contains
 
        real (kind=RKIND), dimension(:), pointer :: array, smoothedArray
 
-       integer, pointer :: nCellsSolve
+       integer, pointer :: nCells, nCellsSolve
 
        type (field1DReal), pointer :: field, smoothedField
        integer, dimension(:), pointer :: nEdgesOnCell
@@ -94,6 +94,7 @@ contains
              call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
              call mpas_pool_get_subpool(block_ptr % structs, fieldPoolName, fieldPool)
 
+             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
              call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
              call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
              call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -105,17 +106,19 @@ contains
              call mpas_pool_get_array(scratchPool, 'smoothedField', smoothedArray)
 
              do iCell = 1, nCellsSolve
-                n = nEdgesOnCell(iCell)
-
-                coc_weight = (1.0_RKIND - weight)/n
-
-                smoothedArray(iCell) = weight * array(iCell)
-
-                do j = 1, n
+                smoothedArray(iCell) = 0.0_RKIND
+                n = 0
+                do j = 1, nEdgesOnCell(iCell)
                    coc = cellsOnCell(j, iCell)
-                   smoothedArray(iCell) = smoothedArray(iCell) + coc_weight * array(coc)
+                   if (coc < nCells+1) then
+                      smoothedArray(iCell) = smoothedArray(iCell) + array(coc)
+                      n = n + 1
+                   end if
                 end do
+                coc_weight = (1.0_RKIND - weight)/n
+                smoothedArray(iCell) = coc_weight * smoothedArray(iCell) + weight * array(iCell)
              end do
+
 
              do iCell = 1, nCellsSolve
                 array(iCell) = smoothedArray(iCell)

--- a/src/core_ocean/mode_init/mpas_ocn_init_smoothing.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_smoothing.F
@@ -1,0 +1,143 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_init_smoothing
+!
+!> \brief MPAS ocean horizontal smoothing
+!> \author Xylar Asay-Davis
+!> \date   02/02/2020
+!> \details
+!>  This module contains the routines for horizontally smoothing 2D fields.
+!
+!-----------------------------------------------------------------------
+module ocn_init_smoothing
+
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_field_routines
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_init_smooth_field
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+!***********************************************************************
+
+contains
+
+   !***********************************************************************
+   !
+   !  routine ocn_init_smooth_field
+   !
+   !> \brief  Horizontally smooth a field
+   !> \author Xylar Asay-Davis
+   !> \date   02/02/2020
+   !> \details
+   !>  This routine smooths the given field on cells from the given pool by
+   !>  iteratively perform a nearest-neighbor weighted average.
+   !
+   !-----------------------------------------------------------------------
+   subroutine ocn_init_smooth_field(domain, fieldName, fieldPoolName, iterations, weight)!{{{
+
+       type (domain_type), intent(inout) :: domain
+       character (len=*), intent(in) :: fieldName, fieldPoolName
+       integer, intent(in) :: iterations
+       real (kind=RKIND), intent(in) :: weight
+
+       type (block_type), pointer :: block_ptr
+
+       type (mpas_pool_type), pointer :: meshPool, scratchPool, fieldPool
+
+       real (kind=RKIND), dimension(:), pointer :: array, smoothedArray
+
+       integer, pointer :: nCellsSolve
+
+       type (field1DReal), pointer :: field, smoothedField
+       integer, dimension(:), pointer :: nEdgesOnCell
+       integer, dimension(:, :), pointer :: cellsOnCell
+
+       integer :: iCell, coc, j, iIter, n
+
+       real (kind=RKIND) :: coc_weight
+
+       do iIter = 1, iterations
+          block_ptr => domain % blocklist
+          do while(associated(block_ptr))
+             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+             call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
+             call mpas_pool_get_subpool(block_ptr % structs, fieldPoolName, fieldPool)
+
+             call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+             call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+             call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+
+             call mpas_pool_get_field(scratchPool, 'smoothedField', smoothedField)
+             call mpas_allocate_scratch_field(smoothedField, .true.)
+
+             call mpas_pool_get_array(fieldPool, fieldName, array)
+             call mpas_pool_get_array(scratchPool, 'smoothedField', smoothedArray)
+
+             do iCell = 1, nCellsSolve
+                n = nEdgesOnCell(iCell)
+
+                coc_weight = (1.0_RKIND - weight)/n
+
+                smoothedArray(iCell) = weight * array(iCell)
+
+                do j = 1, n
+                   coc = cellsOnCell(j, iCell)
+                   smoothedArray(iCell) = smoothedArray(iCell) + coc_weight * array(coc)
+                end do
+             end do
+
+             do iCell = 1, nCellsSolve
+                array(iCell) = smoothedArray(iCell)
+             end do
+
+             call mpas_deallocate_scratch_field(smoothedField, .true.)
+             block_ptr => block_ptr % next
+          end do
+
+          ! do a halo exchange
+          call mpas_pool_get_subpool(domain % blocklist % structs, fieldPoolName, fieldPool)
+          call mpas_pool_get_field(fieldPool, fieldName, field)
+          call mpas_dmpar_exch_halo_field(field)
+
+      end do
+
+   end subroutine ocn_init_smooth_field!}}}
+
+!***********************************************************************
+
+end module ocn_init_smoothing
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker et ts=3 tw=132

--- a/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
@@ -15,7 +15,7 @@
 		<option name="config_global_ocean_topography_has_ocean_frac">.false.</option>
 		<option name="config_global_ocean_topography_ocean_frac_varname">'ocean_mask'</option>
 		<option name="config_global_ocean_topography_method">'bilinear_interpolation'</option>
-		<option name="config_global_ocean_smooth_topography">.true.</option>
+		<option name="config_global_ocean_fill_bathymetry_holes">.true.</option>
 		<option name="config_global_ocean_depress_by_land_ice">.true.</option>
 		<option name="config_global_ocean_land_ice_topo_file">'topography.nc'</option>
 		<option name="config_global_ocean_land_ice_topo_nlat_dimname">'y'</option>

--- a/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
@@ -16,6 +16,8 @@
 		<option name="config_global_ocean_topography_ocean_frac_varname">'ocean_mask'</option>
 		<option name="config_global_ocean_topography_method">'bilinear_interpolation'</option>
 		<option name="config_global_ocean_fill_bathymetry_holes">.true.</option>
+		<option name="config_global_ocean_topography_smooth_iterations">6</option>
+		<option name="config_global_ocean_topography_smooth_weight">0.9</option>
 		<option name="config_global_ocean_depress_by_land_ice">.true.</option>
 		<option name="config_global_ocean_land_ice_topo_file">'topography.nc'</option>
 		<option name="config_global_ocean_land_ice_topo_nlat_dimname">'y'</option>

--- a/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_init_with_land_ice.xml
@@ -16,7 +16,7 @@
 		<option name="config_global_ocean_topography_ocean_frac_varname">'ocean_mask'</option>
 		<option name="config_global_ocean_topography_method">'bilinear_interpolation'</option>
 		<option name="config_global_ocean_fill_bathymetry_holes">.true.</option>
-		<option name="config_global_ocean_topography_smooth_iterations">6</option>
+		<option name="config_global_ocean_topography_smooth_iterations">0</option>
 		<option name="config_global_ocean_topography_smooth_weight">0.9</option>
 		<option name="config_global_ocean_depress_by_land_ice">.true.</option>
 		<option name="config_global_ocean_land_ice_topo_file">'topography.nc'</option>

--- a/testing_and_setup/compass/ocean/global_ocean/template_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_initial_state.xml
@@ -55,7 +55,7 @@
 		<option name="config_global_ocean_topography_lon_varname">'x'</option>
 		<option name="config_global_ocean_topography_varname">'z'</option>
 		<option name="config_global_ocean_topography_method">'bilinear_interpolation'</option>
-		<option name="config_global_ocean_smooth_topography">.true.</option>
+		<option name="config_global_ocean_fill_bathymetry_holes">.true.</option>
 		<option name="config_global_ocean_cull_inland_seas">.false.</option>
 		<option name="config_global_ocean_windstress_file">'wind_stress.nc'</option>
 		<option name="config_global_ocean_windstress_nlat_dimname">'u_lat'</option>


### PR DESCRIPTION
This feature performs an iterative weighted average of a field with a given smoothing weight and for a given number of iterations.  Currently, it is only used for Cryosphere test cases (with ice-shelf cavities, `wISC`).

Also renames config option `...fill_bathymetry_holes` from `...smooth_topography` because this is a more accurate description of what is done when this flag is `.true.`

closes #436 