### PR TITLE
Remove single-cell pits when initializing global bathymetry

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -176,56 +176,6 @@
 		/>
 	</nml_record>
 
-	<!--**********************************-->
-	<!-- Namelists for init run mode only -->
-	<!--**********************************-->
-	<nml_record name="init_setup" mode="init">
-		<nml_option name="config_vert_levels" type="integer" default_value="-1" units="unitless"
-					description="Number of vertical levels to create within the configuration."
-					possible_values="Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition."
-		/>
-		<nml_option name="config_init_configuration" type="character" default_value="none" units="unitless"
-					description="Name of configuration to create."
-					possible_values="Any configuration name"
-		/>
-		<nml_option name="config_expand_sphere" type="logical" default_value=".false." units="unitless"
-					description="Logical flag that controls if a spherical mesh is expanded to an earth sized sphere or not."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_realistic_coriolis_parameter" type="logical" default_value=".false." units="unitless"
-					description="Logical flag that controls if a spherical mesh will get realistic coriolis parameters or not."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_write_cull_cell_mask" type="logical" default_value=".true." units="unitless"
-					description="Logicial flag that controls if the cullCell field is written to output."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_vertical_grid" type="character" default_value="uniform" units="unitless"
-					description="Name of vertical grid to use in configuration generation"
-					possible_values="'uniform', '60layerPHC', '42layerWOCE', '100layerE3SMv1', '1dCVTgenerator', ..."
-		/>
-	</nml_record>
-	<nml_record name="CVTgenerator" mode="init">
-		<nml_option name="config_1dCVTgenerator_stretch1" type="real" default_value="1.0770" units="unitless"
-					description="Parameter for the 1D CVT vertical grid generator."
-					possible_values="Any positive non-zero integer."
-		/>
-		<nml_option name="config_1dCVTgenerator_stretch2" type="real" default_value="1.0275" units="unitless"
-					description="Parameter for the 1D CVT vertical grid generator."
-					possible_values="Any positive non-zero integer."
-		/>
-		<nml_option name="config_1dCVTgenerator_dzSeed" type="real" default_value="1.2" units="unitless"
-					description="Seed thickness of the first layer for the 1D CVT vertical grid generator."
-					possible_values="Any positive non-zero integer."
-		/>
-	</nml_record>
-	<nml_record name="init_ssh_and_landIcePressure" mode="init">
-		<nml_option name="config_iterative_init_variable" type="character" default_value="landIcePressure" units="unitless"
-					description="Which variable, ssh or landIcePressure, is computed from the other.  If landIcePressure is to be computed, 'landIcePressure_from_top_density' indicates that the top density (rather than the mean density displaced by land ice) should be used to compute the landIcePressure."
-					possible_values="'ssh', 'landIcePressure_from_top_density' or 'landIcePressure'"
-		/>
-	</nml_record>
-
 
 	<!--*************************************-->
 	<!-- Namelists for forward run mode only -->
@@ -302,7 +252,7 @@
 	</nml_record>
 	<nml_record name="partial_bottom_cells" mode="init">
 		<nml_option name="config_alter_ICs_for_pbcs" type="logical" default_value=".false." units="unitless"
-					description="If true, initial conditions are altered according to the config_pbc_alteration_type flag. The alteration of layer thickness only occurs when config_do_restart is false, i.e. on an initial run."
+					description="If true, initial conditions are altered according to the config_pbc_alteration_type flag."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_pbc_alteration_type" type="character" default_value="full_cell" units="unitless"
@@ -310,7 +260,7 @@
 					possible_values="'full_cell' or 'partial_cell'"
 		/>
 		<nml_option name="config_min_pbc_fraction" type="real" default_value="0.10" units="unitless"
-					description="Determines the minimum fraction of a cell altering the initial conditions can create. The alteration of layer thickness only occurs when config_do_restart is false, i.e. on an initial run."
+					description="Determines the minimum fraction of a cell altering the initial conditions can create."
 					possible_values="Any real between 0 and 1."
 		/>
 	</nml_record>

--- a/src/core_ocean/mode_init/Registry.xml
+++ b/src/core_ocean/mode_init/Registry.xml
@@ -17,3 +17,55 @@
 #include "Registry_hurricane.xml"
 #include "Registry_tidal_boundary.xml"
 // #include "Registry_TEMPLATE.xml"
+
+
+	<!--**********************************-->
+	<!-- Namelists for init run mode only -->
+	<!--**********************************-->
+	<nml_record name="init_setup" mode="init">
+		<nml_option name="config_vert_levels" type="integer" default_value="-1" units="unitless"
+					description="Number of vertical levels to create within the configuration."
+					possible_values="Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition."
+		/>
+		<nml_option name="config_init_configuration" type="character" default_value="none" units="unitless"
+					description="Name of configuration to create."
+					possible_values="Any configuration name"
+		/>
+		<nml_option name="config_expand_sphere" type="logical" default_value=".false." units="unitless"
+					description="Logical flag that controls if a spherical mesh is expanded to an earth sized sphere or not."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_realistic_coriolis_parameter" type="logical" default_value=".false." units="unitless"
+					description="Logical flag that controls if a spherical mesh will get realistic coriolis parameters or not."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_write_cull_cell_mask" type="logical" default_value=".true." units="unitless"
+					description="Logicial flag that controls if the cullCell field is written to output."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_vertical_grid" type="character" default_value="uniform" units="unitless"
+					description="Name of vertical grid to use in configuration generation"
+					possible_values="'uniform', '60layerPHC', '42layerWOCE', '100layerE3SMv1', '1dCVTgenerator', ..."
+		/>
+	</nml_record>
+	<nml_record name="CVTgenerator" mode="init">
+		<nml_option name="config_1dCVTgenerator_stretch1" type="real" default_value="1.0770" units="unitless"
+					description="Parameter for the 1D CVT vertical grid generator."
+					possible_values="Any positive non-zero integer."
+		/>
+		<nml_option name="config_1dCVTgenerator_stretch2" type="real" default_value="1.0275" units="unitless"
+					description="Parameter for the 1D CVT vertical grid generator."
+					possible_values="Any positive non-zero integer."
+		/>
+		<nml_option name="config_1dCVTgenerator_dzSeed" type="real" default_value="1.2" units="unitless"
+					description="Seed thickness of the first layer for the 1D CVT vertical grid generator."
+					possible_values="Any positive non-zero integer."
+		/>
+	</nml_record>
+	<nml_record name="init_ssh_and_landIcePressure" mode="init">
+		<nml_option name="config_iterative_init_variable" type="character" default_value="landIcePressure" units="unitless"
+					description="Which variable, ssh or landIcePressure, is computed from the other.  If landIcePressure is to be computed, 'landIcePressure_from_top_density' indicates that the top density (rather than the mean density displaced by land ice) should be used to compute the landIcePressure."
+					possible_values="'ssh', 'landIcePressure_from_top_density' or 'landIcePressure'"
+		/>
+	</nml_record>
+

--- a/src/core_ocean/mode_init/Registry_global_ocean.xml
+++ b/src/core_ocean/mode_init/Registry_global_ocean.xml
@@ -345,10 +345,6 @@
 		/>
 	</nml_record>
 	<var_struct name="scratch" time_levs="1">
-		<var name="smoothedLevels" type="integer" dimensions="nCells" persistence="scratch"
-			 default_value="0" units="unitless"
-			 description="Temporary space to hold smoothed maxLevelCell to allow bit-reproducibility."
-		/>
 		<var name="cullStack" type="integer" dimensions="nCells" persistence="scratch"
 			 default_value="0" units="unitless"
 			 description="Temporary space to hold a stack for culling inland seas."

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -214,7 +214,7 @@ contains
 
       call mpas_log_write( 'Initializing vertical coordinate with ssh = 0.')
       ! compute the vertical grid (layerThickness, restingThickness, maxLevelCell, zMid)
-      ! based on bottomDepth and refBottomDepth and apply PBCS if requested
+      ! based on bottomDepth and refBottomDepth and apply PBCs if requested
       call ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)
 
       if(iErr .ne. 0) then
@@ -842,19 +842,19 @@ contains
 
        type (block_type), pointer :: block_ptr
 
-       type (mpas_pool_type), pointer :: meshPool, scratchPool, verticalMeshPool, criticalPassagesPool
+       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool, criticalPassagesPool
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell, bottomDepth, bottomDepthObserved, &
             refBottomDepth, refLayerThickness, refZMid, oceanFracObserved
 
        integer, pointer :: nCells, nCellsSolve, nVertLevels
 
-       type (field1DInteger), pointer :: maxLevelCellField, smoothedLevelsField
+       type (field1DInteger), pointer :: maxLevelCellField
        type (field1DReal), pointer :: bottomDepthObservedField
        integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
        integer, dimension(:, :), pointer :: cellsOnCell
 
-       integer :: iCell, coc, j, k, maxLevel
+       integer :: iCell, coc, j, k, maxLevelNeighbors
        integer :: minimum_levels
 
        character (len=StrKIND), pointer :: config_global_ocean_topography_method
@@ -880,7 +880,6 @@ contains
        call mpas_pool_get_config(domain % configs, 'config_global_ocean_topography_has_ocean_frac', &
                                  config_global_ocean_topography_has_ocean_frac)
 
-       call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
@@ -895,13 +894,10 @@ contains
           call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
           call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
 
+          ! Alter bathymetry for minimum depth
           do k = 1, nVertLevels
              if (refBottomDepth(k).gt.config_global_ocean_minimum_depth) then
                 minimum_levels = k
-                print '(a,f8.2,2a,i5,a,f8.2,a)', 'config_global_ocean_minimum_depth=', &
-                   config_global_ocean_minimum_depth,' m.  ', 'Setting minimum layer index to ', &
-                   minimum_levels, ' with a bottom depth of ', refBottomDepth(k), ' m.'
-                exit
              end if
           end do
 
@@ -998,37 +994,35 @@ contains
              call ocn_init_setup_global_ocean_deepen_critical_passages(meshPool, criticalPassagesPool, iErr)
           end if
 
-          ! Fill holes. Enforce that no cell has maxLevelCell that is more than
-          ! 1 vertical level higher than its neighbors.
+          ! Alter cells for partial bottom cells before filling in bathymetry
+          ! holes.
+          do iCell = 1, nCells
+             call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
+          end do
+
+          ! Fill bathymetry holes, i.e. single cells that are deeper than all neighbors.
+          ! These cells can collect tracer extrema and are not able to use
+          ! horizontal diffusion or advection to clear them out. Reduce pits to
+          ! make them level with the next deepest neighbor cell.
           if (config_global_ocean_fill_bathymetry_holes) then
-             call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-
-             call mpas_pool_get_field(scratchPool, 'smoothedLevels', smoothedLevelsField)
-
              call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
              call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
 
-             call mpas_allocate_scratch_field(smoothedLevelsField, .true.)
-
              maxLevelCell(nCells+1) = -1
-             smoothedLevelsField % array = maxLevelCell
 
              do iCell = 1, nCellsSolve
-                maxLevel = 0
+                maxLevelNeighbors = 0
                 do j = 1, nEdgesOnCell(iCell)
                    coc = cellsOnCell(j, iCell)
-                   maxLevel = max(maxLevel, maxLevelCell(coc))
+                   maxLevelNeighbors = max(maxLevelNeighbors, maxLevelCell(coc))
                 end do
 
-                if (maxLevel < maxLevelCell(iCell) ) then
-                   smoothedLevelsField % array(iCell) = maxLevel + 1
-                   bottomDepth(iCell) = refBottomDepth(maxLevel + 1)
+                if (maxLevelCell(iCell) > maxLevelNeighbors) then
+                   maxLevelCell(iCell) = maxLevelNeighbors
+                   bottomDepth(iCell) = refBottomDepth(maxLevelNeighbors)
                 end if
              end do
 
-             maxLevelCell(:) = smoothedLevelsField % array(:)
-
-             call mpas_deallocate_scratch_field(smoothedLevelsField, .true.)
           end if
 
           block_ptr => block_ptr % next
@@ -1042,7 +1036,6 @@ contains
        do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
@@ -1069,7 +1062,7 @@ contains
 !> \author  Xylar Asay-Davis
 !> \date    5 April 2016
 !> \details
-!>   Deepen cirtical passages in model grid so that relevant seas are included.
+!>   Deepen critical passages in model grid so that relevant seas are included.
 !
 !-----------------------------------------------------------------------
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -898,6 +898,7 @@ contains
           do k = 1, nVertLevels
              if (refBottomDepth(k).gt.config_global_ocean_minimum_depth) then
                 minimum_levels = k
+                exit
              end if
           end do
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -850,7 +850,7 @@ contains
        integer, pointer :: nCells, nCellsSolve, nVertLevels
 
        type (field1DInteger), pointer :: maxLevelCellField
-       type (field1DReal), pointer :: bottomDepthObservedField
+       type (field1DReal), pointer :: bottomDepthObservedField, bottomDepthField
        integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
        integer, dimension(:, :), pointer :: cellsOnCell
 
@@ -1032,6 +1032,8 @@ contains
        call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
        call mpas_pool_get_field(meshPool, 'maxLevelCell', maxLevelCellField)
        call mpas_dmpar_exch_halo_field(maxLevelCellField)
+       call mpas_pool_get_field(meshPool, 'bottomDepth', bottomDepthField)
+       call mpas_dmpar_exch_halo_field(bottomDepthField)
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -786,6 +786,7 @@ contains
       type (field2DReal), pointer :: zInterfaceField, goalStretchField, goalWeightField, &
                                      verticalStretchField
       type (field1DReal), pointer :: zTopField, zBotField, zBotNewField
+      type (field1DInteger), pointer :: maxLevelCellField
       type (field1DInteger), pointer :: smoothingMaskField, smoothingMaskNewField
 
       real (kind=RKIND), dimension(:,:), pointer :: zMid, layerThickness, restingThickness, zInterface, &
@@ -796,11 +797,11 @@ contains
 
       real (kind=RKIND), pointer :: globalRx1Max, globalVerticalStretchMax, globalVerticalStretchMin
 
-      integer, pointer :: nCells, nVertLevels, nEdges
+      integer, pointer :: nCells, nVertLevels, nEdges, nCellsSolve
       integer, dimension(:), pointer :: maxLevelCell, cullCell, nEdgesOnCell, smoothingMask, smoothingMaskNew
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
 
-      integer :: iCell, iEdge, coc, c1, c2, k, maxLevelEdge, iSmooth, iterIndex
+      integer :: iCell, iEdge, coc, c1, c2, k, maxLevelEdge, iSmooth, iterIndex, maxLevelNeighbors
 
       real (kind=RKIND) :: dzEdgeK, dzEdgeKp1, dzEdgeMean, dzVertGoal, &
                            zMean, weight, rx1Goal, dzVertMean, &
@@ -1205,6 +1206,28 @@ contains
           call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
           call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
+          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+
+          ! Fill bathymetry holes, i.e. single cells that are deeper than all neighbors.
+          ! These cells can collect tracer extrema and are not able to use
+          ! horizontal diffusion or advection to clear them out. Reduce pits to
+          ! make them level with the next deepest neighbor cell.
+
+          maxLevelCell(nCells+1) = -1
+
+          do iCell = 1, nCellsSolve
+             maxLevelNeighbors = 0
+             do iEdge = 1, nEdgesOnCell(iCell)
+                coc = cellsOnCell(iEdge, iCell)
+                maxLevelNeighbors = max(maxLevelNeighbors, maxLevelCell(coc))
+             end do
+
+             if (maxLevelCell(iCell) > maxLevelNeighbors) then
+                maxLevelCell(iCell) = maxLevelNeighbors
+             end if
+          end do
 
           where((smoothingMask(:) == 1) .and. (maxLevelCell(:) == nVertLevels+1))
             ! we never found the bottom, so it must be the last level
@@ -1214,10 +1237,13 @@ contains
           block_ptr => block_ptr % next
         end do
 
+       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+       call mpas_pool_get_field(meshPool, 'maxLevelCell', maxLevelCellField)
+       call mpas_dmpar_exch_halo_field(maxLevelCellField)
+
         localMaxRx1Edge = -1e30_RKIND
         localStretchMin = 1e30_RKIND
         localStretchMax = -1e30_RKIND
-
 
         block_ptr => domain % blocklist
         do while(associated(block_ptr))


### PR DESCRIPTION
Before this, single-cell pits were allowed to be one layer deeper than all surrounding cells. These cells can collect tracer extrema and are not able to use horizontal diffusion or advection to clear them out. This PR reduces pits to make them level with the next deepest neighbor cell.