### PR TITLE
Fix race condition for ezxml library in parallel builds

### DIFF
--- a/src/external/Makefile
+++ b/src/external/Makefile
@@ -6,7 +6,7 @@ esmf_time:
 	( cd esmf_time_f90; $(MAKE) FC="$(FC) $(FFLAGS)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS) -DHIDE_MPI" GEN_F90=$(GEN_F90) )
 
 ezxml-lib:
-	( cd ezxml; $(MAKE) )
+	( cd ezxml; $(MAKE) OBJFILE="ezxml.o" )
 
 clean:
 	( cd esmf_time_f90; $(MAKE) clean )

--- a/src/external/ezxml/Makefile
+++ b/src/external/ezxml/Makefile
@@ -1,14 +1,5 @@
-.SUFFIXES: .c .o
-
-OBJS = ezxml.o
-
-all: clean
-	$(MAKE) -j 1 library
-
-library: $(OBJS)
+$(OBJFILE): ezxml.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $(OBJFILE)
 
 clean:
 	$(RM) *.o *.i
-
-.c.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<

--- a/src/tools/input_gen/Makefile
+++ b/src/tools/input_gen/Makefile
@@ -4,14 +4,14 @@ EZXML_PATH= ../../external/ezxml
 
 NL_OBJS = namelist_gen.o test_functions.o
 ST_OBJS = streams_gen.o test_functions.o
-XML_OBJS = $(EZXML_PATH)/ezxml.o
+XML_OBJS = $(EZXML_PATH)/ezxml_tools.o
 
 all: ezxml
 	($(MAKE) -j 1 namelist_gen CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 	($(MAKE) -j 1 streams_gen CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 
 ezxml:
-	(cd $(EZXML_PATH); $(MAKE) CFLAGS="$(CFLAGS) $(TOOL_TARGET_ARCH)")
+	(cd $(EZXML_PATH); $(MAKE) CFLAGS="$(CFLAGS) $(TOOL_TARGET_ARCH)" OBJFILE="ezxml_tools.o")
 
 namelist_gen: ezxml $(NL_OBJS) $(XML_OBJS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(EZXML_PATH) -o $@ $(NL_OBJS) $(XML_OBJS)

--- a/src/tools/registry/Makefile
+++ b/src/tools/registry/Makefile
@@ -9,10 +9,10 @@ all: ezxml
 	($(MAKE) parse CPPFLAGS="$(CPPFLAGS)" CPPINCLUDES="$(CPPINCLUDES)")
 
 ezxml:
-	(cd $(EZXML_PATH); $(MAKE) CFLAGS="$(CFLAGS) $(TOOL_TARGET_ARCH)")
+	(cd $(EZXML_PATH); $(MAKE) CFLAGS="$(CFLAGS) $(TOOL_TARGET_ARCH)" OBJFILE="ezxml_tools.o")
 
 parse: $(OBJS)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(EZXML_PATH)/ezxml.o  -I$(EZXML_PATH) -o $@ $(OBJS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(EZXML_PATH)/ezxml_tools.o -I$(EZXML_PATH) -o $@ $(OBJS)
 
 parse.o:
 


### PR DESCRIPTION
This merge fixes a race condition affecting the ezxml library when using
a parallel build to compile MPAS.

Under the right conditions, a race condition in the compilation of the ezxml
library could lead to a failed build. The race condition occurs when the MPAS
build tools (input_gen, parse) try to build the ezxml library for use on
login nodes, while the MPAS framework simultaneously tries to build the ezxml
library for use on batch nodes.

The fix implemented in this merge resolves this issue by modifying the Makefile
for the ezxml library to compile an object file with a specified name. The MPAS
tools specify an object file name of ezxml_tools.o, while the framework
specifies an object file name of ezxml.o.