### PR TITLE
Create mask and mapping files for online MOC and MPAS-Analysis

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_e3sm_coupling.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_e3sm_coupling.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="e3sm_coupling">
 
-	<add_link source="../initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../ssh_adjustment/init.nc" dest="init.nc"/>
 	<add_link source="../initial_state/graph.info" dest="graph.info"/>
 	<add_link source="../culled_mesh/no_ISC_culled_mesh.nc" dest="no_ISC_culled_mesh.nc"/>
     <add_link source_path="script_configuration_dir" source="scripts/create_E3SM_coupling_files.py" dest="create_E3SM_coupling_files.py"/>

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/config_E3SM_coupling_files.ini
@@ -20,7 +20,6 @@ enable = true
 
 [transects_and_regions]
 enable = true
-transect_region_geojson = /usr/projects/climate/mpeterse/analysis_input_files/geojson_files/SingleRegionAtlanticWTransportTransects.geojson
 
 [mapping_CORE_Gcase]
 enable = true
@@ -34,7 +33,7 @@ atm_scrip_tag = JRA025
 [mapping_ne30]
 enable = false
 # need to add complete name here:
-atm_scrip_tag = ne30 
+atm_scrip_tag = ne30
 
 [domain_CORE_Gcase]
 enable = true
@@ -55,7 +54,7 @@ runoff_map_exe = /usr/projects/climate/mpeterse/repos/E3SM/compiled_cime_tools/c
 runoff_map_lnd_file = /lustre/scratch3/turquoise/mpeterse/E3SM/input_data/lnd/dlnd7/RX1/runoff.daitren.annual.090225.nc
 
 [salinity_restoring]
-enable = true 
+enable = true
 # This file needs to be added to a standard repo. Local copy for now:
 grid_Levitus_1x1_scrip_file = /usr/projects/climate/mpeterse/mapping_files/test_SSS_mapping_190821/EC60to30Rev4/genRemapFiles/grid_Levitus_1x1_scrip.nc
 # This file needs to be added to a standard repo. Local copy for now:

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/config_E3SM_coupling_files.ini
@@ -21,6 +21,20 @@ enable = true
 [transects_and_regions]
 enable = true
 
+[mapping_analysis]
+enable = true
+# The comparison lat/lon grid resolution in degrees
+comparisonLatResolution = 0.5
+comparisonLonResolution = 0.5
+
+# The comparison Antarctic polar stereographic grid size and resolution in km
+comparisonAntarcticStereoWidth = 6000.
+comparisonAntarcticStereoResolution = 10.
+
+# The comparison Arctic polar stereographic grid size and resolution in km
+comparisonArcticStereoWidth = 6000.
+comparisonArcticStereoResolution = 10.
+
 [mapping_CORE_Gcase]
 enable = true
 atm_scrip_tag = T62_040121

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -18,6 +18,7 @@ import traceback
 import sys
 # }}}
 
+
 def main():
 # {{{
 
@@ -99,7 +100,7 @@ def main():
         function_name = function.__name__
         print("****** " + function_name + " ******")
 
-        if (config.get(function_name, 'enable').lower() == 'false'):
+        if config.get(function_name, 'enable').lower() == 'false':
             print("Disabled in .ini file")
         else:
             make_dir(function_name)
@@ -120,6 +121,7 @@ def main():
     else:
         print("!!!!!! FAILURE: One or more steps failed. See output above !!!!!!")
 # }}}
+
 
 def initial_condition_ocean(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -176,6 +178,7 @@ def graph_partition_ocean(config, mesh_name, date_string, ice_shelf_cavities):
         make_link('../../../../../graph_partition_ocean/' + file, './' + file)
 # }}}
 
+
 def initial_condition_seaice(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
 
@@ -203,6 +206,7 @@ def initial_condition_seaice(config, mesh_name, date_string, ice_shelf_cavities)
     make_link('../../../../../initial_condition_seaice/seaice.' +
               mesh_name + '.nc', 'seaice.' + mesh_name + '.nc')
 # }}}
+
 
 def scrip(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -238,6 +242,7 @@ def scrip(config, mesh_name, date_string, ice_shelf_cavities):
         make_link('../../../../../scrip/' + scrip_file_mask, scrip_file_mask)
 # }}}
 
+
 def transects_and_regions(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
 
@@ -266,6 +271,7 @@ def transects_and_regions(config, mesh_name, date_string, ice_shelf_cavities):
         'masks_SingleRegionAtlanticWTransportTransects.' + mesh_name + '.nc')
 # }}}
 
+
 def mapping_CORE_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
     atm_scrip_tag = config.get('mapping_CORE_Gcase', 'atm_scrip_tag')
@@ -277,6 +283,7 @@ def mapping_CORE_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
     for file in files:
         make_link('../../../../mapping_CORE_Gcase/' + file, './' + file)
 # }}}
+
 
 def mapping_JRA_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -290,6 +297,7 @@ def mapping_JRA_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
         make_link('../../../../mapping_JRA_Gcase/' + file, './' + file)
 # }}}
 
+
 def mapping_ne30(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
     atm_scrip_tag = config.get('mapping_ne30', 'atm_scrip_tag')
@@ -301,6 +309,7 @@ def mapping_ne30(config, mesh_name, date_string, ice_shelf_cavities):
     for file in files:
         make_link('../../../../mapping_CORE_Gcase/' + file, './' + file)
 # }}}
+
 
 def mapping(config, mesh_name, date_string, ice_shelf_cavities, atm_scrip_tag):
 # {{{
@@ -380,6 +389,7 @@ def mapping(config, mesh_name, date_string, ice_shelf_cavities, atm_scrip_tag):
             print('mapping_CORE_Gcase must be run on one compute node')
 # }}}
 
+
 def domain_CORE_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
     # obtain configuration settings
@@ -406,6 +416,7 @@ def domain_CORE_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
     for file in files:
         make_link('../../../../domain/' + file, './' + file)
 # }}}
+
 
 def domain_JRA_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -434,6 +445,7 @@ def domain_JRA_Gcase(config, mesh_name, date_string, ice_shelf_cavities):
         make_link('../../../../domain/' + file, './' + file)
 # }}}
 
+
 def domain_ne30(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
     # obtain configuration settings
@@ -460,6 +472,7 @@ def domain_ne30(config, mesh_name, date_string, ice_shelf_cavities):
     for file in files:
         make_link('../../../../domain/' + file, './' + file)
 # }}}
+
 
 def mapping_runoff(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -531,6 +544,7 @@ def mapping_runoff(config, mesh_name, date_string, ice_shelf_cavities):
     for file in files:
         make_link('../../../../mapping_runoff/' + file, './' + file)
 # }}}
+
 
 def salinity_restoring(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
@@ -638,6 +652,7 @@ def write_command_history(text):
         pass
 # }}}
 
+
 def run_command(args):
 # {{{
     try:
@@ -649,6 +664,7 @@ def run_command(args):
     except OSError:
         pass
 # }}}
+
 
 if __name__ == '__main__':
     # If called as a primary module, run main

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -5,7 +5,7 @@ MPAS-seaice within E3SM.
 
 Load the lastest e3sm-unified conda package.
 """
-# import modules # {{{ 
+# import modules # {{{
 import os
 import shutil
 import subprocess
@@ -508,7 +508,7 @@ def mapping_runoff(config, mesh_name, date_string, ice_shelf_cavities):
 
     # Alter runoff mapping so runoff does not go under ice shelves
     # WARNING: this is not hooked up yet. I need to know which mapping files this applies to.
-    # Also, this is pointing to the correct -w and -n flags, but it only works if I 
+    # Also, this is pointing to the correct -w and -n flags, but it only works if I
     # switch those files.
     if ice_shelf_cavities:
         make_link('../copy_cell_indices_ISC.py', 'copy_cell_indices_ISC.py')
@@ -521,7 +521,7 @@ def mapping_runoff(config, mesh_name, date_string, ice_shelf_cavities):
             '-n', 'no_ISC_culled_mesh.nc.nc'
             ]
         run_command(args)
-   
+
     # make links in output directories
     files = glob.glob('map*.nc')
     os.chdir('../assembled_files_for_upload/inputdata/cpl/cpl6')
@@ -572,7 +572,7 @@ def salinity_restoring(config, mesh_name, date_string, ice_shelf_cavities):
         print('salinity_restoring must be run on compute node')
 
     # remap from 1x1 to model grid
-    args = ['ncremap', 
+    args = ['ncremap',
         '-i', 'salinity_restoring_input_file.nc',
         '-o', 'intermediate_file.nc',
         '-m', map_Levitus_file,

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -14,6 +14,8 @@ import argparse
 import numpy as np
 import glob
 from datetime import datetime
+import traceback
+import sys
 # }}}
 
 def main():
@@ -108,6 +110,7 @@ def main():
                 print('SUCCESS')
             except BaseException:
                 print('!!! FAILURE !!!')
+                traceback.print_exc(file=sys.stdout)
                 success = False
             os.chdir(currentDir)
         print(" ")

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -272,6 +272,9 @@ def transects_and_regions(config, mesh_name, date_string, ice_shelf_cavities):
     fcMask = gf.read('ocean', 'region', features)
     make_region_masks(mesh_name, suffix='antarcticRegions', fcMask=fcMask)
 
+    fcMask = gf.read('ocean', 'region', tags=['Arctic'])
+    make_region_masks(mesh_name, suffix='arcticRegions', fcMask=fcMask)
+
     fcMask = make_ocean_basins_masks(gf)
     make_region_masks(mesh_name, suffix='oceanBasins', fcMask=fcMask)
 

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -16,6 +16,8 @@ import glob
 from datetime import datetime
 import traceback
 import sys
+from geometric_features import GeometricFeatures
+from mpas_tools.ocean.moc import make_moc_basins_and_transects
 # }}}
 
 
@@ -246,29 +248,28 @@ def scrip(config, mesh_name, date_string, ice_shelf_cavities):
 def transects_and_regions(config, mesh_name, date_string, ice_shelf_cavities):
 # {{{
 
-    # obtain configuration settings
-    transect_region_geojson = config.get(
-        'transects_and_regions',
-        'transect_region_geojson')
+    # make the geojson file
+    gf = GeometricFeatures()
 
-    maskfile = 'masks_SingleRegionAtlanticWTransportTransects.' + mesh_name + '.nc'
+    mesh_filename = '../init.nc'
 
-    # make links
-    make_link('../init.nc', mesh_name + '.nc')
-    make_link(transect_region_geojson,
-              'SingleRegionAtlanticWTransportTransects.geojson')
+    mask_filename = '{}_moc_masks.nc'.format(mesh_name)
+    mask_and_transect_filename = '{}_moc_masks_and_transects.nc'.format(
+        mesh_name)
 
-    # check: how does this call MpasMaskCreator?
-    args = ['MpasMaskCreator.x', mesh_name + '.nc', maskfile,
-            '-f', 'SingleRegionAtlanticWTransportTransects.geojson']
-    run_command(args)
+    geojson_filename = 'moc_basins.geojson'
 
+    make_moc_basins_and_transects(gf, mesh_filename, mask_and_transect_filename,
+                                  geojson_filename=geojson_filename,
+                                  mask_filename=mask_filename)
+
+    output_dir = '../assembled_files_for_upload/inputdata/ocn/mpas-o/{}'.format(
+        mesh_name)
     # make links in output directory
-    os.chdir('../assembled_files_for_upload/inputdata/ocn/mpas-o/' + mesh_name)
     make_link(
-        '../../../../../transects_and_regions/masks_SingleRegionAtlanticWTransportTransects.' +
-        mesh_name + '.nc',
-        'masks_SingleRegionAtlanticWTransportTransects.' + mesh_name + '.nc')
+        '../../../../../transects_and_regions/{}'.format(
+            mask_and_transect_filename),
+        '{}/{}'.format(output_dir, mask_and_transect_filename))
 # }}}
 
 

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/create_E3SM_coupling_files.py
@@ -680,11 +680,11 @@ def make_moc_masks(mesh_name): # {{{
 
     mesh_filename = '../init.nc'
 
-    mask_filename = '{}_mocMasks.nc'.format(mesh_name)
-    mask_and_transect_filename = '{}_mocMasksAndTransects.nc'.format(
+    mask_filename = '{}_moc_masks.nc'.format(mesh_name)
+    mask_and_transect_filename = '{}_moc_masks_and_transects.nc'.format(
         mesh_name)
 
-    geojson_filename = 'mocBasins.geojson'
+    geojson_filename = 'moc_basins.geojson'
 
     make_moc_basins_and_transects(gf, mesh_filename, mask_and_transect_filename,
                                   geojson_filename=geojson_filename,


### PR DESCRIPTION
This merge adds functionality for creating MOC, Antarctic-region, ocean-basin, ice-shelf and transport-transect masks using `mpas_tools` and `geometric_features`.  It does not require any pre-cached files other than those already part of `geometric_features` (which now includes all the geometric data when it is installed as part of the `compass` conda environment).

Mapping files between the mesh and the default comparison grids in MPAS-Analysis are now also created and staged for uploading.

This merge also performs some clean-up:
* Fixes a typo in `ocean_initial_state`
* Removes trailing white space and performs some other PEP8 clean-up (mostly 2 new lines between functions)
* Points to the initial condition from `ssh_adjustment` rather than `initial_state` for test cases with ice-shelf cavities. (This should eventually point to the last restart file from spin-up for most runs, so this is only an intermediate fix.)