### PR TITLE
Add surfaceAirTemperature, basalHeatFlux to ascii mesh converter

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1162,17 +1162,17 @@ is the value of that variable from the *previous* time level!
                      description="X-component of observed surface velocity" />
                 <var name="observedSurfaceVelocityY" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="Y-component of observed surface velocity" />
-                <var name="observedSurfaceVelocityUncertainty" type="real" dimensions="nCells Time" units="m s^{-1}"
+                <var name="observedSurfaceVelocityUncertainty" type="real" dimensions="nCells Time" units="m s^{-1}" default_value="1.0e20"
                      description="uncertainty in observed surface velocity magnitude" />
                 <var name="observedThicknessTendency" type="real" dimensions="nCells Time" units="m s^{-1}"
                         description="observed tendency in thickness (dH/dt)" />
-                <var name="observedThicknessTendencyUncertainty" type="real" dimensions="nCells Time" units="m s^{-1}"
+                <var name="observedThicknessTendencyUncertainty" type="real" dimensions="nCells Time" units="m s^{-1}" default_value="1.0e20"
                         description="uncertainty in observed tendency in thickness (dH/dt)" />
-                <var name="sfcMassBalUncertainty" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                <var name="sfcMassBalUncertainty" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" default_value="1.0e20"
                         description="uncertainty in observed surface mass balance" />
-                <var name="thicknessUncertainty" type="real" dimensions="nCells Time" units="m"
+                <var name="thicknessUncertainty" type="real" dimensions="nCells Time" units="m" default_value="0.0"
                         description="uncertainty in observed thickness" />
-                <var name="floatingBasalMassBalUncertainty" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                <var name="floatingBasalMassBalUncertainty" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" default_value="1.0e20"
                         description="uncertainty in observed floating basal mass balance" />
         </var_struct>
 

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1120,7 +1120,7 @@ void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> gr
     if (stiffnessFactor_F != 0)
       stiffnessFactorData[index] = stiffnessFactor_F[iCell];
     if (effecPress_F != 0)
-      effecPressData[index] = effecPress_F[iCell];  
+      effecPressData[index] = effecPress_F[iCell] / unit_length;  
   }
 
   int lElemColumnShift = (Ordering == 1) ? 1 : nTriangles;
@@ -1227,7 +1227,7 @@ void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> gr
     if (stiffnessFactor_F != 0)
       stiffnessFactorData[iv] = stiffnessFactor_F[ic];
     if (effecPress_F != 0)
-      effecPressData[iv] = effecPress_F[ic];
+      effecPressData[iv] = effecPress_F[ic] / unit_length;
   }
 
 }

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1204,7 +1204,10 @@ void importFields(std::map<int, int>& floatBdyExtensionMap, std::map<int, int>& 
           } else {
             grdMarineBdyExtensionMap[iV] = c; // Save this map for use in other areas
             thicknessData[iV] = eps*2.0; // insert special small value here to make identifying these points easier in exo output
-            elevationData[iV] = (1.0 - rho_ice / rho_ocean) * thicknessData[iV];  // floating surfacea
+            //set elevation depending on whether it's floating or not (for bed_topography of the order
+            //of -eps, the ice could be grounded)
+            elevationData[iV] = std::max((1.0 - rho_ice / rho_ocean) * thicknessData[iV],
+                bedTopographyData[iV] + thicknessData[iV]);  // floating surface
           }
         } // if below sea level
       }  // floating or not

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1115,11 +1115,11 @@ void importFields(std::map<int, int> bdExtensionMap, double const* bedTopography
     if (beta_F != 0)
       betaData[index] = beta_F[iCell] / unit_length;
     if (smb_F != 0)
-      smbData[index] = smb_F[iCell] / unit_length * secondsInAYear/rho_ice;
+      smbData[index] = smb_F[iCell] * secondsInAYear/rho_ice;
     if (stiffnessFactor_F != 0)
       stiffnessFactorData[index] = stiffnessFactor_F[iCell];
     if (effecPress_F != 0)
-      effecPressData[index] = effecPress_F[iCell] / unit_length;  
+      effecPressData[index] = effecPress_F[iCell];  
   }
 
   int lElemColumnShift = (Ordering == 1) ? 1 : nTriangles;
@@ -1218,11 +1218,11 @@ void importFields(std::map<int, int> bdExtensionMap, double const* bedTopography
     if (beta_F != 0)
       betaData[iv] = beta_F[ic] / unit_length;
     if (smb_F != 0)
-      smbData[iv] = smb_F[ic] / unit_length * secondsInAYear/rho_ice;
+      smbData[iv] = smb_F[ic] * secondsInAYear/rho_ice;
     if (stiffnessFactor_F != 0)
       stiffnessFactorData[iv] = stiffnessFactor_F[ic];
     if (effecPress_F != 0)
-      effecPressData[iv] = effecPress_F[ic] / unit_length;
+      effecPressData[iv] = effecPress_F[ic];
   }
 
 }
@@ -1259,16 +1259,16 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
     int iCell = vertexToFCell[index];
 
     thicknessUncertaintyData[index] = thicknessUncertainty_F[iCell] / unit_length;
-    smbUncertaintyData[index] = smbUncertainty_F[iCell] / unit_length * secondsInAYear / rho_ice;
-    bmbData[index] = bmb_F[iCell] / unit_length * secondsInAYear / rho_ice;
-    bmbUncertaintyData[index] = bmbUncertainty_F[iCell] / unit_length * secondsInAYear / rho_ice;
+    smbUncertaintyData[index] = smbUncertainty_F[iCell] * secondsInAYear / rho_ice;
+    bmbData[index] = bmb_F[iCell] * secondsInAYear / rho_ice;
+    bmbUncertaintyData[index] = bmbUncertainty_F[iCell] * secondsInAYear / rho_ice;
 
     observedVeloXData[index] = observedSurfaceVelocityX_F[iCell] * secondsInAYear;
     observedVeloYData[index] = observedSurfaceVelocityY_F[iCell] * secondsInAYear;
     observedVeloUncertaintyData[index] = observedSurfaceVelocityUncertainty_F[iCell] * secondsInAYear;
 
-    observedDHDtData[index] = observedThicknessTendency_F[iCell] / unit_length * secondsInAYear;
-    observedDHDtUncertaintyData[index] = observedThicknessTendencyUncertainty_F[iCell] / unit_length * secondsInAYear;
+    observedDHDtData[index] = observedThicknessTendency_F[iCell] * secondsInAYear;
+    observedDHDtUncertaintyData[index] = observedThicknessTendencyUncertainty_F[iCell] * secondsInAYear;
 
     surfaceAirTemperatureData[index] = surfaceAirTemperature_F[iCell];
     basalHeatFluxData[index] = basalHeatFlux_F[iCell];
@@ -1283,16 +1283,16 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
     int ic = it->second;
 
     thicknessUncertaintyData[iv] = thicknessUncertainty_F[ic] / unit_length;
-    smbUncertaintyData[iv] = smbUncertainty_F[ic] / unit_length * secondsInAYear / rho_ice;
-    bmbData[iv] = bmb_F[ic] / unit_length * secondsInAYear / rho_ice;
-    bmbUncertaintyData[iv] = bmbUncertainty_F[ic] / unit_length * secondsInAYear / rho_ice;
+    smbUncertaintyData[iv] = smbUncertainty_F[ic] * secondsInAYear / rho_ice;
+    bmbData[iv] = bmb_F[ic] * secondsInAYear / rho_ice;
+    bmbUncertaintyData[iv] = bmbUncertainty_F[ic] * secondsInAYear / rho_ice;
 
     observedVeloXData[iv] = observedSurfaceVelocityX_F[ic] * secondsInAYear;
     observedVeloYData[iv] = observedSurfaceVelocityY_F[ic] * secondsInAYear;
     observedVeloUncertaintyData[iv] = observedSurfaceVelocityUncertainty_F[ic] * secondsInAYear;
 
-    observedDHDtData[iv] = observedThicknessTendency_F[ic] / unit_length * secondsInAYear;
-    observedDHDtUncertaintyData[iv] = observedThicknessTendencyUncertainty_F[ic] / unit_length * secondsInAYear;
+    observedDHDtData[iv] = observedThicknessTendency_F[ic] * secondsInAYear;
+    observedDHDtUncertaintyData[iv] = observedThicknessTendencyUncertainty_F[ic] * secondsInAYear;
 
     surfaceAirTemperatureData[iv] = surfaceAirTemperature_F[ic];
     basalHeatFluxData[iv] = basalHeatFlux_F[ic];

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1705,6 +1705,17 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
                     surfaceAirTemperature_F, basalHeatFlux_F,
                     indexToCellID_F);
 
+    // apparent mass balance
+    std::vector<double> appMbData(smbData.size()),
+                        appMbUncertaintyData(smbData.size());
+ 
+    for (int i=0; i<smbData.size(); ++i) {
+      appMbData[i] = smbData[i]+bmbData[i]- observedDHDtData[i];
+      //assuming fields are uncorrelated
+      double variance = std::pow(smbUncertaintyData[i],2)+std::pow(bmbUncertaintyData[i],2)+std::pow(observedDHDtUncertaintyData[i],2);
+      appMbUncertaintyData[i] =std::sqrt(variance);
+    }
+   
 
     // Write out individual fields
     write_ascii_mesh_field_int(indexToCellIDData, "mpas_cellID");
@@ -1724,6 +1735,14 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
 
     write_ascii_mesh_field(bmbData, "basal_mass_balance");
     write_ascii_mesh_field(bmbUncertaintyData, "basal_mass_balance_uncertainty");
+    
+    write_ascii_mesh_field(observedDHDtData, "dhdt");
+    write_ascii_mesh_field(observedDHDtUncertaintyData, "dhdt_uncertainty");
+    
+    write_ascii_mesh_field(appMbData, "apparent_mass_balance");
+    write_ascii_mesh_field(appMbUncertaintyData, "apparent_mass_balance_uncertainty");
+    
+    write_ascii_mesh_field(observedVeloUncertaintyData, "surface_velocity_uncertainty");
 
     write_ascii_mesh_field(effecPressData, "effective_pressure");
 
@@ -1767,10 +1786,6 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
        std::cout << "Failed to open surface velocity ascii file!"<< std::endl;
     }
 
-    write_ascii_mesh_field(observedVeloUncertaintyData, "surface_velocity_uncertainty");
-
-    write_ascii_mesh_field(observedDHDtData, "dhdt");
-    write_ascii_mesh_field(observedDHDtUncertaintyData, "dhdt_uncertainty");
 
     std::cout << "\nWriting of all Albany fields complete." << std::endl;
 

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1770,7 +1770,7 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
       outfile.close();
     }
     else {
-       std::cout << "Failed to open tempertature ascii file!"<< std::endl;
+       std::cout << "Failed to open temperature ascii file!"<< std::endl;
     }
 
     std::cout << "Writing surface_velocity.ascii." << std::endl;
@@ -1781,6 +1781,27 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
          outfile << observedVeloXData[i] << "\n";
        for(int i = 0; i<nVertices; ++i)
          outfile << observedVeloYData[i] << "\n";
+       outfile.close();
+    }
+    else {
+       std::cout << "Failed to open surface velocity ascii file!"<< std::endl;
+    }
+
+    //here we save the surface velocity as an extruded field,
+    //having two levels at sigma coords 0 and 1
+    //this enables Albany to prescribe surface velocity as Dirichlet BC
+    std::cout << "Writing extruded_surface_velocity.ascii." << std::endl;
+    outfile.open ("extruded_surface_velocity.ascii", std::ios::out | std::ios::trunc);
+    if (outfile.is_open()) {
+       outfile << nVertices << " " << 2 << " " << 2 << "\n";  //number of vertices, number of levels, number of components per vertex
+       outfile << 0.0 << "\n";
+       outfile << 1.0 << "\n";  // sigma coordinates for velocity
+       for(int il=0; il<2; ++il) {
+         for(int i = 0; i<nVertices; ++i)
+           outfile << observedVeloXData[i] << "\n";
+         for(int i = 0; i<nVertices; ++i)
+           outfile << observedVeloYData[i] << "\n";
+       }
        outfile.close();
     }
     else {

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1087,7 +1087,7 @@ double signedTriangleAreaOnSphere(const double* x, const double* y,
 }
 
 
-void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> grdMarineBdyExtensionMap,  double const* bedTopography_F, double const * lowerSurface_F, double const * thickness_F,
+void importFields(std::map<int, int>& floatBdyExtensionMap, std::map<int, int>& grdMarineBdyExtensionMap,  double const* bedTopography_F, double const * lowerSurface_F, double const * thickness_F,
     double const * beta_F, double const* stiffnessFactor_F, double const* effecPress_F,
     double const * temperature_F, double const * smb_F, double eps) {
 
@@ -1205,7 +1205,6 @@ void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> gr
             grdMarineBdyExtensionMap[iV] = c; // Save this map for use in other areas
             thicknessData[iV] = eps*2.0; // insert special small value here to make identifying these points easier in exo output
             elevationData[iV] = (1.0 - rho_ice / rho_ocean) * thicknessData[iV];  // floating surfacea
-            betaData[iV] = minBeta; // floating so no friction
           }
         } // if below sea level
       }  // floating or not
@@ -1232,8 +1231,8 @@ void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> gr
 
 }
 
-void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
-            std::map<int, int> grdMarineBdyExtensionMap,
+void import2DFieldsObservations(std::map<int, int>& floatBdyExtensionMap,
+            std::map<int, int>& grdMarineBdyExtensionMap,
             double const * thicknessUncertainty_F,
             double const * smbUncertainty_F,
             double const * bmb_F, double const * bmbUncertainty_F,
@@ -1282,6 +1281,8 @@ void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
     indexToCellIDData[index] = indexToCellID_F[iCell];
   }
 
+  /* for now disable the extension, it is not clear whether it is useful
+
   //extend to the border for floating vertices (using map created by importFields above)
   for (std::map<int, int>::iterator it = floatBdyExtensionMap.begin();
       it != floatBdyExtensionMap.end(); ++it) {
@@ -1302,7 +1303,6 @@ void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
 
     surfaceAirTemperatureData[iv] = surfaceAirTemperature_F[ic];
     basalHeatFluxData[iv] = basalHeatFlux_F[ic];
-
   }
 
   //extend to the border for grounded marine vertices (using map created by importFields above)
@@ -1327,6 +1327,7 @@ void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
     surfaceAirTemperatureData[iv] = surfaceAirTemperature_F[ic];
     basalHeatFluxData[iv] = 0.0; // no geothermal under floating ice
   }
+  */
 }
 
 void exportDissipationHeat(double * dissipationHeat_F) {

--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -76,6 +76,7 @@ std::vector<double> smbUncertaintyData;
 std::vector<double> bmbData, bmbUncertaintyData;
 std::vector<double> observedVeloXData, observedVeloYData, observedVeloUncertaintyData;
 std::vector<double> observedDHDtData, observedDHDtUncertaintyData;
+std::vector<double> surfaceAirTemperatureData, basalHeatFluxData;
 std::vector<int> indexToCellIDData;
 
 int numBoundaryEdges;
@@ -1233,6 +1234,10 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
             double const * observedSurfaceVelocityX_F, double const * observedSurfaceVelocityY_F,
             double const * observedSurfaceVelocityUncertainty_F,
             double const * observedThicknessTendency_F, double const * observedThicknessTendencyUncertainty_F,
+            // these last 2 thermal fields are not necessarily observations but
+            // they are not needed except for exporting to ascii format, so including
+            // them in this function.
+            double const* surfaceAirTemperature_F, double const* basalHeatFlux_F,
             int const * indexToCellID_F) {
 
   thicknessUncertaintyData.assign(nVertices, 1e10);
@@ -1244,6 +1249,8 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
   observedVeloUncertaintyData.assign(nVertices, 1e10);
   observedDHDtData.assign(nVertices, 1e10);
   observedDHDtUncertaintyData.assign(nVertices, 1e10);
+  surfaceAirTemperatureData.assign(nVertices, 1e10);
+  basalHeatFluxData.assign(nVertices, 1e10);
   indexToCellIDData.assign(nVertices, -1);
 
 
@@ -1262,6 +1269,9 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
 
     observedDHDtData[index] = observedThicknessTendency_F[iCell] / unit_length * secondsInAYear;
     observedDHDtUncertaintyData[index] = observedThicknessTendencyUncertainty_F[iCell] / unit_length * secondsInAYear;
+
+    surfaceAirTemperatureData[index] = surfaceAirTemperature_F[iCell];
+    basalHeatFluxData[index] = basalHeatFlux_F[iCell];
 
     indexToCellIDData[index] = indexToCellID_F[iCell];
   }
@@ -1283,6 +1293,9 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
 
     observedDHDtData[iv] = observedThicknessTendency_F[ic] / unit_length * secondsInAYear;
     observedDHDtUncertaintyData[iv] = observedThicknessTendencyUncertainty_F[ic] / unit_length * secondsInAYear;
+
+    surfaceAirTemperatureData[iv] = surfaceAirTemperature_F[ic];
+    basalHeatFluxData[iv] = basalHeatFlux_F[ic];
 
   }
 }
@@ -1570,6 +1583,7 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
   void write_ascii_mesh(int const* indexToCellID_F,
     double const* bedTopography_F, double const* lowerSurface_F,
     double const* beta_F, double const* temperature_F,
+    double const* surfaceAirTemperature_F, double const* basalHeatFlux_F,
     double const* stiffnessFactor_F,
     double const* effecPress_F,
     double const* thickness_F, double const* thicknessUncertainty_F,
@@ -1657,6 +1671,7 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
                     bmb_F, bmbUncertainty_F,
                     observedSurfaceVelocityX_F, observedSurfaceVelocityY_F, observedSurfaceVelocityUncertainty_F,
                     observedThicknessTendency_F, observedThicknessTendencyUncertainty_F,
+                    surfaceAirTemperature_F, basalHeatFlux_F,
                     indexToCellID_F);
 
 
@@ -1667,6 +1682,9 @@ bool belongToTria(double const* x, double const* t, double bcoords[3], double ep
 
     write_ascii_mesh_field(elevationData, "surface_height");
     write_ascii_mesh_field(bedTopographyData, "bed_topography");
+
+    write_ascii_mesh_field(surfaceAirTemperatureData, "surface_air_temperature");
+    write_ascii_mesh_field(basalHeatFluxData, "basal_heat_flux");
 
     write_ascii_mesh_field(betaData, "basal_friction");
 

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -202,12 +202,12 @@ double signedTriangleArea(const double* x, const double* y, const double* z);
 
 void createReducedMPI(int nLocalEntities, MPI_Comm& reduced_comm_id);
 
-void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> grdMarineBdyExtensionMap, 
+void importFields(std::map<int, int>& floatBdyExtensionMap, std::map<int, int>& grdMarineBdyExtensionMap, 
                 double const* bedTopography_F, double const* lowerSurface_F, double const* thickness_F,
     double const* beta_F = 0, double const* stiffnessFactor_F = 0, double const* effecPress_F = 0, double const* temperature_F = 0, double const* smb_F = 0, double eps = 0);
 
-void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
-            std::map<int, int> grdMarineBdyExtensionMap, 
+void import2DFieldsObservations(std::map<int, int>& floatBdyExtensionMap,
+            std::map<int, int>& grdMarineBdyExtensionMap, 
             double const * lowerSurface_F, 
             double const * thickness_F, double const * thicknessUncertainty_F,
             double const * smbUncertainty_F,

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -130,6 +130,7 @@ void interface_reset_stdout();
 void write_ascii_mesh(int const* indexToCellID_F,
     double const* bedTopography_F, double const* lowerSurface_F,
     double const* beta_F, double const* temperature_F,
+    double const* surfaceAirTemperature_F, double const* basalHeatFlux_F,
     double const* stiffnessFactor_F,
     double const* effecPress_F,
     double const* thickness_F, double const* thicknessUncertainty_F,
@@ -212,6 +213,7 @@ void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
             double const * observedSurfaceVelocityX_F, double const * observedSurfaceVelocityY_F,
             double const * observedSurfaceVelocityUncertainty_F,
             double const * observedThicknessTendency_F, double const * observedThicknessTendencyUncertainty_F,
+            double const* surfaceAirTemperature_F, double const* basalHeatFlux_F,
             int const * indexToCellID_F);
  
 void write_ascii_mesh_field(std::vector<double> fieldData, std::string filenamebase);

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -202,10 +202,12 @@ double signedTriangleArea(const double* x, const double* y, const double* z);
 
 void createReducedMPI(int nLocalEntities, MPI_Comm& reduced_comm_id);
 
-void importFields(std::map<int, int> bdExtensionMap, double const* bedTopography_F, double const* lowerSurface_F, double const* thickness_F,
+void importFields(std::map<int, int> floatBdyExtensionMap, std::map<int, int> grdMarineBdyExtensionMap, 
+                double const* bedTopography_F, double const* lowerSurface_F, double const* thickness_F,
     double const* beta_F = 0, double const* stiffnessFactor_F = 0, double const* effecPress_F = 0, double const* temperature_F = 0, double const* smb_F = 0, double eps = 0);
 
-void import2DFieldsObservations(std::map<int, int> bdExtensionMap,
+void import2DFieldsObservations(std::map<int, int> floatBdyExtensionMap,
+            std::map<int, int> grdMarineBdyExtensionMap, 
             double const * lowerSurface_F, 
             double const * thickness_F, double const * thicknessUncertainty_F,
             double const * smbUncertainty_F,

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -747,6 +747,7 @@ subroutine li_velocity_external_write_albany_mesh(domain)
          observedSurfaceVelocityX, observedSurfaceVelocityY, observedSurfaceVelocityUncertainty
       real (kind=RKIND), dimension(:), pointer :: observedThicknessTendency, observedThicknessTendencyUncertainty
       real (kind=RKIND), dimension(:,:), pointer :: temperature
+      real (kind=RKIND), dimension(:), pointer :: surfaceAirTemperature, basalHeatFlux
       integer, dimension(:), pointer :: vertexMask, cellMask, edgeMask, floatingEdges, indexToCellID
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
@@ -817,6 +818,8 @@ subroutine li_velocity_external_write_albany_mesh(domain)
 
       ! Thermal variables
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+      call mpas_pool_get_array(thermalPool, 'basalHeatFlux', basalHeatFlux)
 
       ! hydro variables
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
@@ -859,6 +862,7 @@ subroutine li_velocity_external_write_albany_mesh(domain)
       call mpas_log_write("Writing Albany ASCII mesh.", flushNow=.true.)
       call write_ascii_mesh(indexToCellID, bedTopography, lowerSurface, &
               beta, temperature, &
+              surfaceAirTemperature, basalHeatFlux, &
               stiffnessFactor, &
               effectivePressure, &
               thickness, thicknessUncertainty, &

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -852,7 +852,11 @@ subroutine li_velocity_external_write_albany_mesh(domain)
       floatingEdges = li_mask_is_floating_ice_int(edgeMask)
       call li_calculate_extrapolate_floating_edgemask(meshPool, vertexMask, floatingEdges)
 
-
+      ! Ensure BMB uncertainty is 0 for grounded ice (and no ice locations)
+      where (.not. (li_mask_is_floating_ice(cellMask)))
+         floatingBasalMassBalUncertainty = 0.0_RKIND
+      end where
+      
       ! Create FEM mesh
       call mpas_log_write("Generating new external velocity solver FEM grid.", flushNow=.true.)
       call generate_fem_grid(config_velocity_solver, vertexMask, cellMask, dirichletVelocityMask, &

--- a/testing_and_setup/compass/landice/dome/albany_input.yaml
+++ b/testing_and_setup/compass/landice/dome/albany_input.yaml
@@ -2,6 +2,7 @@
 ---
 ANONYMOUS:
   Problem: 
+    Use MDField Memoization: true
     Solution Method: Steady
     Parameters: 
       Number: 1


### PR DESCRIPTION
This adds the surfaceAirTemperature, basalHeatFlux fields to the ascii mesh converter
used to convert an MPAS input file to the ascii format that Albany can ingest.

Also pass maps of floating/marine boundaries by reference, but then comment out their usage for observational fields  - for now it seems the extension for floating/marine boundaries may not be needed.

Other minor fixes useful for the ascii mesh converter.
