### PR TITLE
Fix bug in pointwiseStats locations for Sandy cases

### DIFF
--- a/testing_and_setup/compass/ocean/hurricane/create_pointstats_file.py
+++ b/testing_and_setup/compass/ocean/hurricane/create_pointstats_file.py
@@ -76,7 +76,7 @@ def create_pointstats_file(mesh_file,stations_files):
   pnt_ids = data_nc.createVariable('pointCellGlobalID',np.int32,(npts,))
   
   # Set variables
-  pnt_ids[:] = idx[:]
+  pnt_ids[:] = idx[:]+1
   data_nc.close()
 
 ######################################################################################


### PR DESCRIPTION
Add missing +1 offset to cell IDs used in the points.nc file generated in the init step of the hurricane Sandy cases.

