### PR TITLE
Smooth topography before interp to MPAS

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state.xml
@@ -8,7 +8,6 @@
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
-
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
@@ -25,12 +24,15 @@
 	<add_link source="../culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
 	<add_link source="../culled_mesh/culled_graph.info" dest="graph.info"/>
 	<add_link source="../culled_mesh/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
-    <add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="layer_depth.nc"/>
+	<add_link source="../culled_mesh/land_ice_mask.nc" dest="land_ice_mask.nc"/>
+	<add_link source="../base_mesh/cellWidthVsLatLon.nc" dest="cellWidthVsLatLon.nc"/>
+	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="layer_depth.nc"/>
 	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
 	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
 	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
 	<add_link source_path="bathymetry_database" source="BedMachineAntarctica_and_GEBCO_2019_0.05_degree.200128.nc" dest="topography.nc"/>
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+	<add_link source_path="script_configuration_dir" source="scripts/smooth_topo.py" dest="smooth_topo.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
@@ -40,20 +42,28 @@
 		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
-        	<option name="config_global_ocean_depth_conversion_factor">0.01</option>
-        	<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_topography_file">'topography_smoothed.nc'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">
+		<step executable="./smooth_topo.py">
+			<argument flag="--iter">100</argument>
+			<argument flag="--smoothing">1.0</argument>
+			<argument flag="--mpi_tasks">4</argument>
+			<argument flag="--include_cavities"></argument>
+		</step>
 		<step executable="gpmetis">
 			<argument flag="graph.info">4</argument>
 		</step>
 		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
-    </run_script>
+	</run_script>
 
 </config>

--- a/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_initial_state.xml
@@ -29,12 +29,14 @@
 	<add_link source="../culled_mesh/culled_graph.info" dest="graph.info"/>
 	<add_link source="../culled_mesh/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
 	<add_link source="../culled_mesh/land_ice_mask.nc" dest="land_ice_mask.nc"/>
+	<add_link source="../base_mesh/cellWidthVsLatLon.nc" dest="cellWidthVsLatLon.nc"/>
 	<add_link source_path="initial_condition_database" source="layer_depth.80Layer.180619.nc" dest="layer_depth.nc"/>
 	<add_link source_path="initial_condition_database" source="PTemp.Jan_p3.filled.mpas100levs.160127.nc" dest="temperature.nc"/>
 	<add_link source_path="initial_condition_database" source="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc" dest="salinity.nc"/>
 	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
 	<add_link source_path="bathymetry_database" source="BedMachineAntarctica_and_GEBCO_2019_0.05_degree.200128.nc" dest="topography.nc"/>
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+    <add_link source_path="script_configuration_dir" source="scripts/smooth_topo.py" dest="smooth_topo.py"/>
 
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
@@ -44,6 +46,7 @@
 		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
+		<option name="config_global_ocean_topography_file">'topography_smoothed.nc'</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
@@ -53,6 +56,12 @@
 	</streams>
 
 	<run_script name="run.py">
+		<step executable="./smooth_topo.py">
+			<argument flag="--iter">100</argument>
+			<argument flag="--smoothing">1.0</argument>
+			<argument flag="--mpi_tasks">4</argument>
+			<argument flag="--include_cavities"></argument>
+		</step>
 		<step executable="gpmetis">
 			<argument flag="graph.info">4</argument>
 		</step>

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/smooth_topo.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/smooth_topo.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+"""
+A script for smoothing bathymetry at the resolution of the MPAS mesh before
+it is resampled to MPAS cell centers
+"""
+
+import argparse
+import xarray
+import numpy
+from mpas_tools.io import write_netcdf
+from pyremap import LatLonGridDescriptor, Remapper
+from progressbar import ProgressBar, Percentage, Bar, ETA
+
+
+def remap_widths_to_topo_grid(dsWidth, dsTopo, mpiTasks):
+    """
+    Remap widths from the lon/lat grid used to create the base mesh to the
+    topography grid
+
+    Parameters
+    ----------
+    dsWidth : xarray.Dataset
+        Dataset contain the widths of cells as a function of lon/lat
+
+    dsTopo : xarray.Dataset
+        Dataset with the lat/lon for topography
+
+    mpiTasks : int
+        The number of MPI tasks to use for remapping
+
+    Returns
+    -------
+    dsWidth : xarray.Dataset
+        The same cell widths remapped to the lon/lat of teh topography grid
+    """
+    _add_degrees(dsTopo)
+    _add_degrees(dsWidth)
+    inDescriptor = LatLonGridDescriptor.read(ds=dsWidth)
+    outDescriptor = LatLonGridDescriptor.read(ds=dsTopo)
+    mappingFileName = 'map_{}_to_{}_bilinear.nc'.format(inDescriptor.meshName,
+                                                        outDescriptor.meshName)
+
+    remapper = Remapper(inDescriptor, outDescriptor, mappingFileName)
+    remapper.build_mapping_file(method='bilinear', mpiTasks=mpiTasks)
+
+    dsWidth = remapper.remap(dsWidth, renormalizationThreshold=0.01)
+    return dsWidth
+
+
+def compute_smooth_weights(dsWidth, dsTopo, smoothing, iters,
+                           earth_radius=6371.229):
+    """
+    Remap widths from the lon/lat grid used to create the base mesh to the
+    topography grid
+
+    Parameters
+    ----------
+    dsWidth : xarray.Dataset
+        Dataset contain the widths (in km) of cells as a function of lon/lat
+
+    dsTopo : xarray.Dataset
+        Dataset with the lat/lon for topography
+
+    smoothing : float
+        Number of MPAS cell widths to smooth
+
+    iters : int
+        Number of iterations of smoothing
+
+    earth_radius : float
+        Radius of the Earth in km
+
+    Returns
+    -------
+    weights_x, weights_y : xarray.DataArray
+        The weights to be used for smoothing at each location
+    """
+
+    # assume constant dlon and dlat
+    dlon = dsTopo.lon[1].values - dsTopo.lon[0].values
+    dlat = dsTopo.lat[1].values - dsTopo.lat[0].values
+
+    dx = earth_radius*numpy.deg2rad(dlon)*numpy.cos(numpy.deg2rad(dsTopo.lat))
+    dy = earth_radius*numpy.deg2rad(dlat)
+
+    cell_width_x = numpy.minimum(smoothing*dsWidth.cellWidth/dx,
+                                 len(dsTopo.lon.values))
+    cell_width_y = smoothing*dsWidth.cellWidth/dy
+
+    # "magic" numbers found by curve fitting to smoothing of a discrete delta
+    # function over various numbers of iterations and with various weights
+    A = 2.65
+    p_iter = 0.5
+    p_width = 2.25
+
+    factor = (1./(A*iters**p_iter))**p_width
+
+    weights_x = numpy.minimum(factor*cell_width_x**p_width, 1.0)
+    weights_y = numpy.minimum(factor*cell_width_y**p_width, 1.0)
+
+    return weights_x, weights_y
+
+
+def smooth_topo(dsTopo, iters, weights_x, weights_y, mask_field, threshold):
+    """
+    Remap widths from the lon/lat grid used to create the base mesh to the
+    topography grid
+
+    Parameters
+    ----------
+    dsTopo : xarray.Dataset
+        Topography dataset
+
+    iters : int
+        Number of iterations of smoothing
+
+    weights_x, weights_y : xarray.DataArray
+        The weights to be used for smoothing at each location
+
+    mask_field : str
+        A field in ``input_file`` that contains a mask for where ocean
+        (vs. land or grounded ice) is present
+
+    threshold : float
+        Fraction below which normalizaiton by the mask is not performed and
+        the result is instead masked out
+
+    Returns
+    -------
+    dsTopoSmooth : xarray.Dataset
+        Smoothed topography dataset
+    """
+
+    dims = dsTopo.lon.dims + dsTopo.lat.dims
+    variables = []
+    for var in dsTopo.data_vars:
+        if all([dim in dsTopo[var].dims for dim in dims]):
+            variables.append(var)
+
+    ocean_frac = dsTopo[mask_field]
+    mask = ocean_frac > threshold
+    ocean_frac = ocean_frac.where(mask, other=0.0)
+
+    renorm = ocean_frac.where(mask, other=1.0)
+    renorm = (1.0/renorm).where(mask, other=0.0)
+
+    for var in variables:
+        if 'mask' in var:
+            # needs to be renormalized to only the ocean part
+            dsTopo[var] = renorm*dsTopo[var]
+
+    after_x = _smooth_x(ocean_frac, weights_x)
+    after_xy = _smooth_y(after_x, weights_y)
+    renorm = after_xy.where(mask, other=1.0)
+    renorm = (1.0/renorm).where(mask, other=0.0)
+
+    print('Smoothing topography:')
+    pbar = ProgressBar(widgets=[Percentage(), Bar(), ETA()],
+                       maxval=iters*len(variables)).start()
+
+    dsTopoSmooth = dsTopo
+    for outer in range(iters):
+        for inner, var in enumerate(variables):
+            da = _smooth_x(ocean_frac*dsTopoSmooth[var], weights_x)
+            dsTopoSmooth[var] = renorm*_smooth_y(da, weights_y)
+            pbar.update(outer*len(variables) + inner + 1)
+
+    pbar.finish()
+
+    for var in variables:
+        if 'mask' in var:
+            # back to including the ocean fraction
+            dsTopo[var] = ocean_frac*dsTopo[var]
+
+    return dsTopoSmooth
+
+
+def smooth_topo_from_cell_widths(input_file='topography.nc',
+                                 cell_width_file='cellWidthVsLatLon.nc',
+                                 output_file='topography_smoothed.nc',
+                                 include_cavities=False, threshold=0.01,
+                                 iters=100, smoothing=1.0, mpi_tasks=1):
+    """
+    Smooth the topographic dataset based on the widths of cells on the MPAS
+    mesh.
+
+    Parameters
+    ----------
+    input_file : str
+        Input topography file
+
+    cell_width_file : str
+        Cell widths file from base_mesh
+
+    output_file : str
+        Output topography file after smoothing
+
+    include_cavities : bool
+        Whether to include ice-shelf cavities in the ocean domain
+
+    threshold : float
+        Fraction below which normalizaiton by the mask is not performed and
+        the result is instead masked out
+
+    iters : int
+        Number of iterations of smoothing
+
+    smoothing : float
+        Number of MPAS cell widths to smooth
+
+    mpi_tasks : int
+        Number of MPI tasks to ues for remapping
+    """
+
+    dsTopo = xarray.open_dataset(input_file)
+    if 'x' in dsTopo.dims:
+        dsTopo = dsTopo.rename({'x': 'lon'})
+    if 'y' in dsTopo.dims:
+        dsTopo = dsTopo.rename({'y': 'lat'})
+    dsTopo = dsTopo.set_coords(['lon', 'lat'])
+
+    if include_cavities:
+        grounded_mask = dsTopo.grounded_mask
+        dsTopo['floating_mask'] = dsTopo.ice_mask - grounded_mask
+        dsTopo = dsTopo.drop_vars(['ice_mask', 'grounded_mask', 'water_column'])
+    else:
+        dsTopo['ocean_mask'] = numpy.minimum(1.0 - dsTopo.ice_mask,
+                                             dsTopo.ocean_mask)
+        dsTopo = dsTopo[['bathymetry', 'ocean_mask']]
+        grounded_mask = None
+
+    dsWidth = xarray.open_dataset(cell_width_file)
+    dsWidth = remap_widths_to_topo_grid(dsWidth, dsTopo, mpi_tasks)
+
+    weights_x, weights_y = compute_smooth_weights(dsWidth, dsTopo, smoothing,
+                                                  iters)
+
+    mask_field = 'ocean_mask'
+    dsTopoSmooth = smooth_topo(dsTopo, iters, weights_x, weights_y, mask_field,
+                               threshold)
+
+    if include_cavities:
+        dsTopoSmooth['grounded_mask'] = grounded_mask
+        dsTopoSmooth['ice_mask'] = grounded_mask + dsTopoSmooth.floating_mask
+    write_netcdf(dsTopoSmooth, output_file, format='NETCDF3_64BIT')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input_file', dest='input_file',
+                        default='topography.nc',
+                        help='Input topography file')
+    parser.add_argument('-w', '--cell_width_file', dest='cell_width_file',
+                        default='cellWidthVsLatLon.nc',
+                        help='Cell widths file from base_mesh')
+    parser.add_argument('-o', '--output_file', dest='output_file',
+                        default='topography_smoothed.nc',
+                        help='Output topography file after smoothing')
+    parser.add_argument('--include_cavities', dest='include_cavities',
+                        action='store_true',
+                        help='Whether to include ice-shelf cavities in the '
+                             'ocean domain')
+    parser.add_argument('--iters', dest='iters', type=int, default=100,
+                        help='Number of iterations of smoothing')
+    parser.add_argument('-s', '--smoothing', dest='smoothing', type=float,
+                        default=1.0,
+                        help='Number of MPAS cell widths to smooth')
+    parser.add_argument('--mpi_tasks', dest='mpi_tasks', type=int,
+                        default=1,
+                        help='Number of MPI tasks to ues for remapping')
+    parser.add_argument('--threshold', dest='threshold', type=float,
+                        default=0.01,
+                        help='Fraction below which normalizaiton by the mask '
+                             'is not performed')
+
+    args = parser.parse_args()
+
+    smooth_topo_from_cell_widths(args.input_file, args.cell_width_file,
+                                 args.output_file, args.include_cavities,
+                                 args.threshold, args.iters, args.smoothing,
+                                 args.mpi_tasks)
+
+
+def _smooth_x(da, weights_x):
+    """ Smooth the data array in the x direction, accounting for periodicity """
+    da_p = da.roll(lon=1, roll_coords=False)
+    da_m = da.roll(lon=-1, roll_coords=False)
+
+    da = weights_x*(da_m + da_p) + da
+    return da
+
+
+def _smooth_y(da, weights_y):
+    """ Smooth the data array in the x direction, accounting for periodicity """
+    da_p = da.shift(lat=1, fill_value=0.)
+    da_m = da.shift(lat=-1, fill_value=0.)
+
+    da = weights_y*(da_m + da_p) + da
+    return da
+
+
+def _add_degrees(ds):
+    """
+    Modifies the dataset to add "degrees" as the "units" for lon and lat
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset with lon/lat
+    """
+    for coord in ['lon', 'lat']:
+        if 'units' not in ds[coord].attrs:
+            ds[coord].attrs['units'] = 'degrees'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This merge adds a python script for iteratively smoothing topograpthy (from for now, the dataset combining BedMachine and GEBCO) proportional to the resolution of the MPAS mesh, as determined in the base_mesh step.

Local weights for the iterative smoothing are determined based on the resolution of the lon/lat grid, the MPAS mesh resolution, the number of iterations of smoothing and a constant multiplicative factor `smoothing` that can be increased or decreased to provide more or less smoothing overall.  The default value, `smoothing = 1.0`, smooths the topography by one MPAS cell width.

Increasing the number of iterations will typically not increase the amount of smoothing, since less smoothing is performed at each iteration.  The exception is that the maximum amount of smoothing is an unweighted nearest-neighbor averaging at each iteration.  If a region (commonly the poles) is so stretched on the lon/lat grid that an MPAS cell covers more grid cells than the number of smoothing iterations, it is not possible to smooth over the full width of an MPAS grid cell.  In practice, this is not likely to be an important issue.

The cost of this approach is significant, taking several minutes even for coarse MPAS meshes (it is performed on the topographic grid, so is largely agnostic to the MPAS resolution).  We may
need to make the QU240wISC test case a special case where we either skip this process or simplify it in some way to reduce runtime of regression testing.

Currently, the approach is only being used for test cases with ice-shelf cavities (the same ones using BedMachine/GEBCO bathymetry).  It could be expanded to other test cases if it proves useful.
