### PR TITLE
fixed incorrect path for ocean cvmix after submodule change

### DIFF
--- a/src/core_ocean/build_options.mk
+++ b/src/core_ocean/build_options.mk
@@ -6,7 +6,7 @@ NAMELIST_SUFFIX=ocean
 FCINCLUDES += -I$(ROOT_DIR)/core_ocean/driver 
 FCINCLUDES += -I$(ROOT_DIR)/core_ocean/mode_forward -I$(ROOT_DIR)/core_ocean/mode_analysis -I$(ROOT_DIR)/core_ocean/mode_init
 FCINCLUDES += -I$(ROOT_DIR)/core_ocean/shared -I$(ROOT_DIR)/core_ocean/analysis_members
-FCINCLUDES += -I$(ROOT_DIR)/core_ocean/cvmix
+FCINCLUDES += -I$(ROOT_DIR)/core_ocean/cvmix/src/shared
 FCINCLUDES += -I$(ROOT_DIR)/core_ocean/BGC
 override CPPFLAGS += -DCORE_OCEAN
 


### PR DESCRIPTION
When changing to submodules for the ocean cvmix package, the path to cvmix source had changed, but one instance of this path was not changed, leading to build failures with PGI on Summit. This PR fixes that bad path.

Fixes #488 