### PR TITLE
Fix landIceMask in EC60to30wISC

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state.xml
@@ -8,7 +8,6 @@
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
-
 	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
@@ -25,6 +24,7 @@
 	<add_link source="../culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
 	<add_link source="../culled_mesh/culled_graph.info" dest="graph.info"/>
 	<add_link source="../culled_mesh/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
+	<add_link source="../culled_mesh/land_ice_mask.nc" dest="land_ice_mask.nc"/>
     <add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="layer_depth.nc"/>
 	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
 	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
@@ -47,6 +47,7 @@
 	<streams name="streams.ocean" keep="immutable" mode="init">
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<template file="template_init_with_land_ice.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">


### PR DESCRIPTION
The land-ice mask (and fraction) was not being read in from the file generated during cell culling, as required.  This resulted in a land-ice mask of all zeros (the default) and problems!

Somehow this got missed in #433 