### PR TITLE
Adds depth-variable bottom drag to hurricane cases

### DIFF
--- a/src/core_ocean/mode_init/Registry_hurricane.xml
+++ b/src/core_ocean/mode_init/Registry_hurricane.xml
@@ -39,4 +39,24 @@
 			description="Amplitude of sea level rise."
 			possible_values="Any real number."
 		/>
+		<nml_option name="config_hurricane_land_z_limit" type="real" default_value="-2.0" units="m"
+			description="Vertical elevation corresponding to increased drag on land (bottom depth positive)."
+			possible_values="Any real number."
+		/>
+		<nml_option name="config_hurricane_marsh_z_limit" type="real" default_value="2.0" units="m"
+			description="Vertical elevation corresponding to increased drag on marsh (bottom depth positive)."
+			possible_values="Any real number."
+		/>
+		<nml_option name="config_hurricane_land_drag" type="real" default_value="0.1" units="non-dimensional or Manning's n"
+			description="Value of land drag for either Cd or Manning's n above config_land_z_limit."
+			possible_values="Any real number."
+		/>
+		<nml_option name="config_hurricane_marsh_drag" type="real" default_value="0.05" units="non-dimensional or Manning's n"
+			description="Value of marsh drag between config_marsh_z_limit and config_land_z_limit for either Cd or Manning's n."
+			possible_values="Any real number."
+		/>
+		<nml_option name="config_hurricane_channel_drag" type="real" default_value="0.02" units="non-dimensional or Manning's n"
+			description="Value of channel drag below config_marsh_z_limit for either Cd or Manning's n."
+			possible_values="Any real number."
+		/>
 	</nml_record>

--- a/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
@@ -82,6 +82,7 @@ contains
 
     type (block_type), pointer :: block_ptr
     type (mpas_pool_type), pointer :: meshPool
+    type (mpas_pool_type), pointer :: forcingPool
     type (mpas_pool_type), pointer :: statePool
     type (mpas_pool_type), pointer :: tracersPool
     type (mpas_pool_type), pointer :: verticalMeshPool
@@ -109,6 +110,12 @@ contains
     logical, pointer :: config_use_wetting_drying
     real (kind=RKIND), pointer :: config_drying_min_cell_height
 
+    real (kind=RKIND), pointer :: config_land_z_limit, config_land_drag, &
+                                  config_marsh_z_limit, config_marsh_drag, &
+                                  config_channel_drag
+
+    logical, pointer :: config_use_variable_drag
+
     ! Define dimension pointers
     integer, pointer :: nCellsSolve, nEdgesSolve, nVerticesSolve, nVertLevels, nVertLevelsP1
     integer, pointer :: index_temperature, index_salinity
@@ -117,6 +124,7 @@ contains
     logical, pointer :: on_a_sphere
     integer, dimension(:), pointer :: maxLevelCell
     real (kind=RKIND), dimension(:), pointer :: ssh
+    real (kind=RKIND), dimension(:), pointer :: bottomDrag
     real (kind=RKIND), dimension(:), pointer :: refBottomDepth, refZMid, &
          vertCoordMovementWeights, bottomDepth, bottomDepthObserved, &
          fCell, fEdge, fVertex, &
@@ -144,9 +152,17 @@ contains
     call mpas_pool_get_config(ocnConfigs, 'config_hurricane_gaussian_hump_amplitude', config_hurricane_gaussian_hump_amplitude)
     call mpas_pool_get_config(ocnConfigs, 'config_hurricane_gaussian_slr_amp', config_hurricane_gaussian_slr_amp)
 
+    call mpas_pool_get_config(ocnConfigs, 'config_hurricane_land_z_limit', config_land_z_limit)
+    call mpas_pool_get_config(ocnConfigs, 'config_hurricane_marsh_z_limit', config_marsh_z_limit)
+    call mpas_pool_get_config(ocnConfigs, 'config_hurricane_land_drag', config_land_drag)
+    call mpas_pool_get_config(ocnConfigs, 'config_hurricane_marsh_drag', config_marsh_drag)
+    call mpas_pool_get_config(ocnConfigs, 'config_hurricane_channel_drag', config_channel_drag)
+
     ! wetting and drying parameters
     call mpas_pool_get_config(ocnConfigs, 'config_drying_min_cell_height', config_drying_min_cell_height)
     call mpas_pool_get_config(ocnConfigs, 'config_use_wetting_drying', config_use_wetting_drying)
+
+    call mpas_pool_get_config(ocnConfigs, 'config_use_variable_drag', config_use_variable_drag)
 
     ! Determine vertical grid for configuration
     call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
@@ -212,6 +228,7 @@ contains
     do while(associated(block_ptr))
        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+       call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
@@ -394,6 +411,25 @@ contains
        do iVertex = 1, nVerticesSolve
          fVertex(iVertex) = 2.0_RKIND * omega * sin(latVertex(iVertex))
        end do
+
+       ! Set depth-variable drag
+       if (config_use_variable_drag) then
+         call mpas_pool_get_array(forcingPool, 'bottomDrag', bottomDrag)
+         do iCell = 1, nCellsSolve
+           if (bottomDepth(iCell) < config_land_z_limit) then
+             call mpas_log_write('here')
+             bottomDrag(iCell) = config_land_drag
+           else if (config_land_z_limit < bottomDepth(iCell) .and. bottomDepth(iCell) < config_marsh_z_limit) then
+             bottomDrag(iCell) = config_marsh_drag
+           else if (config_marsh_z_limit < bottomDepth(iCell)) then
+             bottomDrag(iCell) = config_channel_drag
+           else
+             call mpas_log_write('Default value for drag is not selected' &
+               // ' properly for bottomDepth of $r in cell $i!', &
+             realArgs=(/bottomDepth(iCell)/), intArgs=(/iCell/))
+           end if
+         end do
+       end if
 
 
        block_ptr => block_ptr % next

--- a/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
@@ -417,7 +417,6 @@ contains
          call mpas_pool_get_array(forcingPool, 'bottomDrag', bottomDrag)
          do iCell = 1, nCellsSolve
            if (bottomDepth(iCell) < config_land_z_limit) then
-             call mpas_log_write('here')
              bottomDrag(iCell) = config_land_drag
            else if (config_land_z_limit < bottomDepth(iCell) .and. bottomDepth(iCell) < config_marsh_z_limit) then
              bottomDrag(iCell) = config_marsh_drag

--- a/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
@@ -137,7 +137,6 @@ contains
     call mpas_pool_get_config(ocnConfigs, 'config_init_configuration', config_init_configuration)
     call mpas_pool_get_config(ocnConfigs, 'config_tidal_boundary_layer_type', config_tidal_boundary_layer_type)
 
-    call mpas_log_write('here')
     if(config_init_configuration .ne. trim('tidal_boundary')) return
 
     call mpas_pool_get_config(ocnConfigs, 'config_vertical_grid', config_vertical_grid)

--- a/testing_and_setup/compass/ocean/hurricane/forward_template.xml
+++ b/testing_and_setup/compass/ocean/hurricane/forward_template.xml
@@ -15,6 +15,8 @@
 		<option name="config_ALE_thickness_proportionality">'weights_only'</option>
 		<option name="config_vert_coord_movement">'uniform_stretching'</option>
 
+		<option name="config_use_variable_drag">.true.</option>
+
                 <option name="config_use_const_visc">.true.</option>
                 <option name="config_vert_visc">1.0e4</option>
 
@@ -39,6 +41,9 @@
 		</stream>
 		<stream name="input">
 			<attribute name="filename_template">input.nc</attribute>
+			<add_contents>
+				<member name="bottomDrag" type="var"/>
+			</add_contents>
 		</stream>
 		<stream name="pointLocationsInput">
 			<attribute name="filename_template">points.nc</attribute>

--- a/testing_and_setup/compass/ocean/hurricane/forward_template.xml
+++ b/testing_and_setup/compass/ocean/hurricane/forward_template.xml
@@ -15,7 +15,7 @@
 		<option name="config_ALE_thickness_proportionality">'weights_only'</option>
 		<option name="config_vert_coord_movement">'uniform_stretching'</option>
 
-		<option name="config_use_variable_drag">.true.</option>
+		<option name="config_use_variable_drag">.false.</option>
 
                 <option name="config_use_const_visc">.true.</option>
                 <option name="config_vert_visc">1.0e4</option>

--- a/testing_and_setup/compass/ocean/hurricane/init_template.xml
+++ b/testing_and_setup/compass/ocean/hurricane/init_template.xml
@@ -10,6 +10,11 @@
 		<option name="config_hurricane_min_depth">10.0</option>
 		<option name="config_hurricane_max_depth">6000.0</option>
 		<option name="config_use_variable_drag">.true.</option>
+		<option name="config_hurricane_land_z_limit">-2.0</option>
+		<option name="config_hurricane_marsh_z_limit">2.0</option>
+		<option name="config_hurricane_land_drag">0.1</option>
+		<option name="config_hurricane_marsh_drag">0.05</option>
+		<option name="config_hurricane_channel_drag">0.02</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">

--- a/testing_and_setup/compass/ocean/hurricane/init_template.xml
+++ b/testing_and_setup/compass/ocean/hurricane/init_template.xml
@@ -9,6 +9,7 @@
 		<option name="config_hurricane_vert_levels">100</option>
 		<option name="config_hurricane_min_depth">10.0</option>
 		<option name="config_hurricane_max_depth">6000.0</option>
+		<option name="config_use_variable_drag">.true.</option>
 	</namelist>
 
 	<streams name="streams.ocean" keep="immutable" mode="init">
@@ -41,6 +42,7 @@
 				<member name="maxLevelCell" type="var"/>
 				<member name="vertCoordMovementWeights" type="var"/>
 				<member name="ssh" type="var"/>
+				<member name="bottomDrag" type="var"/>
 			</add_contents>
 		</stream>
 	</streams>


### PR DESCRIPTION
This provides a depth-variable Manning's n value for hurricane cases with defaults of

0.02 for < -2 depth for open water
0.05 for -2 to 2 depth for marshes
0.1 for > 2m depth for inland flow