### PR TITLE
Rename 60-layer initial state for EC60to30wISC

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state_60_layers.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/init/config_initial_state_60_layers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config case="initial_state">
+<config case="initial_state_60_levels">
 	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>


### PR DESCRIPTION
One more fix not picked up in #502 