### PR TITLE
Localized OpenMP Threading

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -588,11 +588,7 @@ module ocn_forward_mode
 #ifdef MPAS_DEBUG
          call mpas_log_write( '   Computing forward time step')
 #endif
-         !$omp parallel default(firstprivate) shared(domain, dt, timeStamp)
-
          call ocn_timestep(domain, dt, timeStamp)
-
-         !$omp end parallel
 
          call mpas_timer_stop("time integration")
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -331,7 +331,6 @@ module ocn_forward_mode
          block => block % next
       end do
 
-      !$omp master
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
@@ -346,8 +345,6 @@ module ocn_forward_mode
 
          block => block % next
       end do
-      !$omp end master
-      !$omp barrier
 
       ! Update any mesh fields that may have been modified during init
       call ocn_meshUpdateFields(domain)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -127,6 +127,7 @@ module ocn_time_integration
         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+
         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
 
         block => block % next

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -110,7 +110,6 @@ module ocn_time_integration
          call ocn_time_integrator_split(domain, dt)
      endif
 
-     !$omp master
      block => domain % blocklist
      do while (associated(block))
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
@@ -132,8 +131,6 @@ module ocn_time_integration
 
         block => block % next
      end do
-     !$omp end master
-     !$omp barrier
 
    end subroutine ocn_timestep!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -252,6 +252,7 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
             do k = 1, maxLevelEdgeTop(iEdge)
@@ -267,6 +268,7 @@ module ocn_time_integration_rk4
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          call mpas_pool_begin_iteration(tracersPool)
          do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -277,6 +279,7 @@ module ocn_time_integration_rk4
                call mpas_pool_get_array(tracersPool, trim(groupItr % memberName), tracersNew, 2)
 
                if ( associated(tracersCur) .and. associated(tracersNew) ) then
+                  !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells  ! couple tracers to thickness
                      do k = 1, maxLevelCell(iCell)
@@ -284,24 +287,29 @@ module ocn_time_integration_rk4
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
             end if
          end do
 
          if (associated(highFreqThicknessCur)) then
+              !$omp parallel
               !$omp do schedule(runtime)
               do iCell = 1, nCells
                  highFreqThicknessNew(:, iCell) = highFreqThicknessCur(:, iCell)
               end do
               !$omp end do
+              !$omp end parallel
          end if
 
          if (associated(lowFreqDivergenceCur)) then
-              !$omp do schedule(runtime)
+              !$omp parallel
+              !$omp do schedule(runtime) private(iCell)
               do iCell = 1, nCells
                  lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceCur(:, iCell)
               end do
               !$omp end do
+              !$omp end parallel
          end if
 
          block => block % next
@@ -453,12 +461,14 @@ module ocn_time_integration_rk4
 
               call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
 
-              !$omp do schedule(runtime)
+              !$omp parallel
+              !$omp do schedule(runtime) private(iCell)
               do iCell = 1, nCells
                  highFreqThicknessProvis(:, iCell) = highFreqThicknessCur(:, iCell) + rk_substep_weights(rk_step) &
                     * highFreqThicknessTend(:, iCell)
               end do
               !$omp end do
+              !$omp end parallel
               block => block % next
            end do
 
@@ -675,19 +685,23 @@ module ocn_time_integration_rk4
 
 
          if (config_prescribe_velocity) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iEdge)
             do iEdge = 1, nEdges
                normalVelocityNew(:, iEdge) = normalVelocityCur(:, iEdge)
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          if (config_prescribe_thickness) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iCell)
             do iCell = 1, nCells
                layerThicknessNew(:, iCell) = layerThicknessCur(:, iCell)
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          ! direct application of tidal boundary condition
@@ -719,11 +733,13 @@ module ocn_time_integration_rk4
          ! ------------------------------------------------------------------
          ! Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iEdge)
          do iEdge = 1, nEdges
             normalTransportVelocity(:, iEdge) = normalVelocityNew(:, iEdge)
          end do
          !$omp end do
+         !$omp end parallel
 
          ! Compute normalGMBolusVelocity and the tracer transport velocity
          if (config_use_GM) then
@@ -733,11 +749,13 @@ module ocn_time_integration_rk4
          call mpas_threading_barrier()
 
          if (config_use_GM) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iEdge)
             do iEdge = 1, nEdges
                normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:, iEdge)
             end do
             !$omp end do
+            !$omp end parallel
          end if
          ! ------------------------------------------------------------------
          ! End: Accumulating various parameterizations of the transport velocity
@@ -754,7 +772,8 @@ module ocn_time_integration_rk4
                           includeHalos = .true.)
          call mpas_threading_barrier()
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
             surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)
@@ -763,6 +782,7 @@ module ocn_time_integration_rk4
             SSHGradient(indexSSHGradientMeridional, iCell) = gradSSHMeridional(iCell)
          end do
          !$omp end do
+         !$omp end parallel
 
          call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 
@@ -1163,7 +1183,8 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
       call mpas_threading_barrier()
 
-      !$omp do schedule(runtime) private(k)
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, iEdge)
       do iEdge = 1, nEdges
          do k = 1, maxLevelEdgeTop(iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkSubstepWeight &
@@ -1173,8 +1194,7 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
 
-
-      !$omp do schedule(runtime) private(k)
+      !$omp do schedule(runtime) private(k, iCell)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkSubstepWeight &
@@ -1182,6 +1202,7 @@ module ocn_time_integration_rk4
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -1196,7 +1217,8 @@ module ocn_time_integration_rk4
                modifiedGroupName = trim(groupItr % memberName) // 'Tend'
                call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
                if ( associated(tracersGroupProvis) .and. associated(tracersGroupCur) .and. associated(tracersGroupTend) ) then
-                  !$omp do schedule(runtime) private(k)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iCell)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
@@ -1206,34 +1228,41 @@ module ocn_time_integration_rk4
 
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
             end if
          end if
       end do
 
       if (associated(lowFreqDivergenceCur)) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rkSubstepWeight &
                                               * lowFreqDivergenceTend(:, iCell)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       if (config_prescribe_velocity) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iEdge)
          do iEdge = 1, nEdges
             normalVelocityProvis(:, iEdge) = normalVelocityCur(:, iEdge)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       if (config_prescribe_thickness) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             layerThicknessProvis(:, iCell) = layerThicknessCur(:, iCell)
          end do
          !$omp end do
+         !$omp end parallel
       end if
       call mpas_threading_barrier()
 
@@ -1243,11 +1272,13 @@ module ocn_time_integration_rk4
       ! ------------------------------------------------------------------
       ! Accumulating various parametrizations of the transport velocity
       ! ------------------------------------------------------------------
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iEdge)
       do iEdge = 1, nEdges
          normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
       end do
       !$omp end do
+      !$omp end parallel
 
       ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
       if (config_use_GM) then
@@ -1257,11 +1288,13 @@ module ocn_time_integration_rk4
       call mpas_threading_barrier()
 
       if (config_use_GM) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iEdge)
          do iEdge = 1, nEdges
             normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:,iEdge)
          end do
          !$omp end do
+         !$omp end parallel
       end if
       ! ------------------------------------------------------------------
       ! End: Accumulating various parametrizations of the transport velocity
@@ -1327,7 +1360,8 @@ module ocn_time_integration_rk4
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
-      !$omp do schedule(runtime) private(k)
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, iCell)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             layerThicknessNew(k, iCell) = layerThicknessNew(k, iCell) + rkWeight * layerThicknessTend(k, iCell)
@@ -1335,12 +1369,13 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
 
-      !$omp do schedule(runtime)
+      !$omp do schedule(runtime) private(iEdge)
       do iEdge = 1, nEdges
          normalVelocityNew(:, iEdge) = normalVelocityNew(:, iEdge) + rkWeight * normalVelocityTend(:, iEdge)
          normalVelocityNew(:, iEdge) = normalVelocityNew(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -1354,7 +1389,8 @@ module ocn_time_integration_rk4
                modifiedGroupName = trim(groupItr % memberName) // 'Tend'
                call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
                if ( associated(tracersGroupNew) .and. associated(tracersGroupTend) ) then
-                  !$omp do schedule(runtime) private(k)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iCell)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) + rkWeight &
@@ -1362,25 +1398,30 @@ module ocn_time_integration_rk4
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
             end if
          end if
       end do
 
       if (associated(highFreqThicknessNew)) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             highFreqThicknessNew(:, iCell) = highFreqThicknessNew(:, iCell) + rkWeight * highFreqThicknessTend(:, iCell)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       if (associated(lowFreqDivergenceNew)) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceNew(:, iCell) + rkWeight * lowFreqDivergenceTend(:, iCell)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
    end subroutine ocn_time_integrator_rk4_accumulate_update!}}}
@@ -1441,13 +1482,15 @@ module ocn_time_integration_rk4
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
             call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
             if ( associated(tracersGroupNew) ) then
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iCell)
                do iCell = 1, nCells
                  do k = 1, maxLevelCell(iCell)
                    tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) / layerThicknessNew(k, iCell)
                  end do
                end do
                !$omp end do
+               !$omp end parallel
             end if
          end if
       end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -234,7 +234,6 @@ module ocn_time_integration_rk4
 
          call mpas_pool_clone_pool(statePool, provisStatePool, 1)
          call mpas_pool_add_subpool(block % structs, 'provis_state', provisStatePool)
-         call mpas_threading_barrier()
 
          call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
          call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
@@ -346,8 +345,6 @@ module ocn_time_integration_rk4
          block => block % next
       end do
 
-      call mpas_threading_barrier()
-
       ! Fourth-order Runge-Kutta, solving dy/dt = f(t,y) is typically written as follows
       ! where h = delta t is the large time step.  Here f(t,y) is the right hand side,
       ! called the tendencies in the code below.
@@ -411,8 +408,6 @@ module ocn_time_integration_rk4
            call mpas_dmpar_field_halo_exch(domain, 'relativeVorticity')
         end if
         call mpas_timer_stop("RK4-diagnostic halo update")
-        call mpas_threading_barrier()
-
 
         ! Compute tendencies for high frequency thickness
         ! In RK4 notation, we are computing the right hand side f(t,y),
@@ -431,7 +426,6 @@ module ocn_time_integration_rk4
               call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
               call ocn_tend_freq_filtered_thickness(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
-              call mpas_threading_barrier()
               block => block % next
            end do
 
@@ -443,7 +437,6 @@ module ocn_time_integration_rk4
            call mpas_dmpar_field_halo_exch(domain, 'tendLowFreqDivergence')
 
            call mpas_timer_stop("RK4-prognostic halo update")
-           call mpas_threading_barrier()
 
 
            ! Compute next substep state for high frequency thickness.
@@ -493,7 +486,6 @@ module ocn_time_integration_rk4
              end if
 
              call mpas_timer_stop("RK4-prevent drying")
-             call mpas_threading_barrier()
         end if
 
         ! Compute tendencies for velocity, thickness, and tracers.
@@ -543,7 +535,6 @@ module ocn_time_integration_rk4
         end do
 
         call mpas_timer_stop("RK4 tracer prognostic halo update")
-        call mpas_threading_barrier()
 
         ! Compute next substep state for velocity, thickness, and tracers.
         ! In RK4 notation, we are computing y_n + a_j k_j.
@@ -559,7 +550,6 @@ module ocn_time_integration_rk4
         end if
 
         call mpas_timer_stop("RK4-update diagnostic variables")
-        call mpas_threading_barrier()
 
         ! Accumulate update.
         ! In RK4 notation, we are computing b_j k_j and adding it to an accumulating sum so that we have
@@ -576,7 +566,6 @@ module ocn_time_integration_rk4
         end do
 
         call mpas_timer_stop("RK4-accumulate update")
-        call mpas_threading_barrier()
 
       end do
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -597,11 +586,9 @@ module ocn_time_integration_rk4
         end if
 
         call mpas_timer_stop("RK4- check wet cells")
-        call mpas_threading_barrier()
       end if
 
       call mpas_timer_stop("RK4-main loop")
-      call mpas_threading_barrier()
 
       !
       !  A little clean up at the end: rescale tracer fields and compute diagnostics for new state
@@ -638,7 +625,6 @@ module ocn_time_integration_rk4
       call mpas_timer_stop("RK4-implicit vert mix halos")
 
       call mpas_timer_stop("RK4-implicit vert mix")
-      call mpas_threading_barrier()
 
       block => domain % blocklist
       do while (associated(block))
@@ -725,7 +711,6 @@ module ocn_time_integration_rk4
          end if
 
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
-         call mpas_threading_barrier()
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
@@ -746,7 +731,6 @@ module ocn_time_integration_rk4
              call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
                 meshPool, scratchPool, timeLevelIn=2)
          end if
-         call mpas_threading_barrier()
 
          if (config_use_GM) then
             !$omp parallel
@@ -770,7 +754,6 @@ module ocn_time_integration_rk4
                           gradSSHX, gradSSHY, gradSSHZ,    &
                           gradSSHZonal, gradSSHMeridional, &
                           includeHalos = .true.)
-         call mpas_threading_barrier()
 
          !$omp parallel
          !$omp do schedule(runtime) 
@@ -789,7 +772,6 @@ module ocn_time_integration_rk4
          if (config_use_GM) then
             call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
          end if
-         call mpas_threading_barrier()
 
          block => block % next
       end do
@@ -804,8 +786,6 @@ module ocn_time_integration_rk4
 
       call mpas_timer_stop("RK4-cleanup phase")
 
-      call mpas_threading_barrier()
-
       block => domain % blocklist
       do while(associated(block))
          call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
@@ -815,7 +795,6 @@ module ocn_time_integration_rk4
          call mpas_pool_remove_subpool(block % structs, 'provis_state')
          block => block % next
       end do
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4!}}}
 
@@ -878,10 +857,8 @@ module ocn_time_integration_rk4
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
@@ -942,11 +919,9 @@ module ocn_time_integration_rk4
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_thick_tends!}}}
 
@@ -1008,16 +983,13 @@ module ocn_time_integration_rk4
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
-      call mpas_threading_barrier()
 
       if (config_filter_btr_mode) then
           call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
                            scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_tracer_tends!}}}
 
@@ -1079,10 +1051,8 @@ module ocn_time_integration_rk4
             sshCur, rkWeight, &
             vertAleTransportTop, err)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
-      call mpas_threading_barrier()
 
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
@@ -1095,18 +1065,15 @@ module ocn_time_integration_rk4
             sshCur, rkWeight, &
             vertAleTransportTop, err)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 
       if (config_filter_btr_mode) then
           call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
       endif
-      call mpas_threading_barrier()
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
                            scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_tends!}}}
 
@@ -1181,7 +1148,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
 
       call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
-      call mpas_threading_barrier()
 
       !$omp parallel
       !$omp do schedule(runtime) private(k)
@@ -1264,10 +1230,8 @@ module ocn_time_integration_rk4
          !$omp end do
          !$omp end parallel
       end if
-      call mpas_threading_barrier()
 
       call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 1)
-      call mpas_threading_barrier()
 
       ! ------------------------------------------------------------------
       ! Accumulating various parametrizations of the transport velocity
@@ -1285,7 +1249,6 @@ module ocn_time_integration_rk4
          call ocn_gm_compute_Bolus_velocity(provisStatePool, diagnosticsPool, &
             meshPool, scratchPool, timeLevelIn=1)
       end if
-      call mpas_threading_barrier()
 
       if (config_use_GM) then
          !$omp parallel
@@ -1496,10 +1459,8 @@ module ocn_time_integration_rk4
       end do
 
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
-      call mpas_threading_barrier()
 
       call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
-      call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_cleanup!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -304,7 +304,7 @@ module ocn_time_integration_rk4
 
          if (associated(lowFreqDivergenceCur)) then
               !$omp parallel
-              !$omp do schedule(runtime) private(iCell)
+              !$omp do schedule(runtime) 
               do iCell = 1, nCells
                  lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceCur(:, iCell)
               end do
@@ -462,7 +462,7 @@ module ocn_time_integration_rk4
               call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
 
               !$omp parallel
-              !$omp do schedule(runtime) private(iCell)
+              !$omp do schedule(runtime) 
               do iCell = 1, nCells
                  highFreqThicknessProvis(:, iCell) = highFreqThicknessCur(:, iCell) + rk_substep_weights(rk_step) &
                     * highFreqThicknessTend(:, iCell)
@@ -686,7 +686,7 @@ module ocn_time_integration_rk4
 
          if (config_prescribe_velocity) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iEdge)
+            !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
                normalVelocityNew(:, iEdge) = normalVelocityCur(:, iEdge)
             end do
@@ -696,7 +696,7 @@ module ocn_time_integration_rk4
 
          if (config_prescribe_thickness) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iCell)
+            !$omp do schedule(runtime) 
             do iCell = 1, nCells
                layerThicknessNew(:, iCell) = layerThicknessCur(:, iCell)
             end do
@@ -734,7 +734,7 @@ module ocn_time_integration_rk4
          ! Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
          !$omp parallel
-         !$omp do schedule(runtime) private(iEdge)
+         !$omp do schedule(runtime) 
          do iEdge = 1, nEdges
             normalTransportVelocity(:, iEdge) = normalVelocityNew(:, iEdge)
          end do
@@ -750,7 +750,7 @@ module ocn_time_integration_rk4
 
          if (config_use_GM) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iEdge)
+            !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
                normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:, iEdge)
             end do
@@ -773,7 +773,7 @@ module ocn_time_integration_rk4
          call mpas_threading_barrier()
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
             surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)
@@ -1184,7 +1184,7 @@ module ocn_time_integration_rk4
       call mpas_threading_barrier()
 
       !$omp parallel
-      !$omp do schedule(runtime) private(k, iEdge)
+      !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, maxLevelEdgeTop(iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkSubstepWeight &
@@ -1194,7 +1194,7 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
 
-      !$omp do schedule(runtime) private(k, iCell)
+      !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkSubstepWeight &
@@ -1218,7 +1218,7 @@ module ocn_time_integration_rk4
                call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
                if ( associated(tracersGroupProvis) .and. associated(tracersGroupCur) .and. associated(tracersGroupTend) ) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(k, iCell)
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
@@ -1236,7 +1236,7 @@ module ocn_time_integration_rk4
 
       if (associated(lowFreqDivergenceCur)) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             lowFreqDivergenceProvis(:, iCell) = lowFreqDivergenceCur(:, iCell) + rkSubstepWeight &
                                               * lowFreqDivergenceTend(:, iCell)
@@ -1247,7 +1247,7 @@ module ocn_time_integration_rk4
 
       if (config_prescribe_velocity) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iEdge)
+         !$omp do schedule(runtime) 
          do iEdge = 1, nEdges
             normalVelocityProvis(:, iEdge) = normalVelocityCur(:, iEdge)
          end do
@@ -1257,7 +1257,7 @@ module ocn_time_integration_rk4
 
       if (config_prescribe_thickness) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             layerThicknessProvis(:, iCell) = layerThicknessCur(:, iCell)
          end do
@@ -1273,7 +1273,7 @@ module ocn_time_integration_rk4
       ! Accumulating various parametrizations of the transport velocity
       ! ------------------------------------------------------------------
       !$omp parallel
-      !$omp do schedule(runtime) private(iEdge)
+      !$omp do schedule(runtime) 
       do iEdge = 1, nEdges
          normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
       end do
@@ -1289,7 +1289,7 @@ module ocn_time_integration_rk4
 
       if (config_use_GM) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iEdge)
+         !$omp do schedule(runtime) 
          do iEdge = 1, nEdges
             normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:,iEdge)
          end do
@@ -1361,7 +1361,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       !$omp parallel
-      !$omp do schedule(runtime) private(k, iCell)
+      !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             layerThicknessNew(k, iCell) = layerThicknessNew(k, iCell) + rkWeight * layerThicknessTend(k, iCell)
@@ -1369,7 +1369,7 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
 
-      !$omp do schedule(runtime) private(iEdge)
+      !$omp do schedule(runtime) 
       do iEdge = 1, nEdges
          normalVelocityNew(:, iEdge) = normalVelocityNew(:, iEdge) + rkWeight * normalVelocityTend(:, iEdge)
          normalVelocityNew(:, iEdge) = normalVelocityNew(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
@@ -1390,7 +1390,7 @@ module ocn_time_integration_rk4
                call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
                if ( associated(tracersGroupNew) .and. associated(tracersGroupTend) ) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(k, iCell)
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) + rkWeight &
@@ -1406,7 +1406,7 @@ module ocn_time_integration_rk4
 
       if (associated(highFreqThicknessNew)) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             highFreqThicknessNew(:, iCell) = highFreqThicknessNew(:, iCell) + rkWeight * highFreqThicknessTend(:, iCell)
          end do
@@ -1416,7 +1416,7 @@ module ocn_time_integration_rk4
 
       if (associated(lowFreqDivergenceNew)) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceNew(:, iCell) + rkWeight * lowFreqDivergenceTend(:, iCell)
          end do
@@ -1483,7 +1483,7 @@ module ocn_time_integration_rk4
             call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
             if ( associated(tracersGroupNew) ) then
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iCell)
+               !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells
                  do k = 1, maxLevelCell(iCell)
                    tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) / layerThicknessNew(k, iCell)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1367,9 +1367,7 @@ module ocn_time_integration_split
             call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'barotropicThicknessFlux')
             call mpas_dmpar_exch_group_add_field(domain, finalBtrGroupName, 'normalBarotropicVelocity', timeLevel=2)
 
-            call mpas_threading_barrier()
             call mpas_dmpar_exch_group_full_halo_exch(domain, finalBtrGroupName)
-            call mpas_threading_barrier()
 
             call mpas_dmpar_exch_group_destroy(domain, finalBtrGroupName)
             call mpas_timer_stop("se halo F and btr vel")
@@ -1940,7 +1938,6 @@ module ocn_time_integration_split
 
         block => block % next
       end do
-      call mpas_threading_barrier()
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1101,7 +1101,7 @@ module ocn_time_integration_split
 
                    !$omp parallel
                    !$omp do schedule(runtime) &
-                   !$omp private(temp_mask, cell1, cell2, coriolisTerm, eoe, sshCell1, sshCell2)
+                   !$omp private(temp_mask, cell1, cell2, coriolisTerm, i, eoe, sshCell1, sshCell2)
                    do iEdge = 1, nEdges
 
                      ! asarje: added to avoid redundant computations based on mask

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -322,7 +322,8 @@ module ocn_time_integration_split
 
          ! Initialize * variables that are used to compute baroclinic tendencies below.
 
-         !$omp do schedule(runtime) private(k)
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, iEdge)
          do iEdge = 1, nEdges
             do k = 1, nVertLevels !maxLevelEdgeTop % array(iEdge)
 
@@ -341,7 +342,7 @@ module ocn_time_integration_split
          end do
          !$omp end do
 
-         !$omp do schedule(runtime) private(k)
+         !$omp do schedule(runtime) private(k, iCell)
          do iCell = 1, nCells
             sshNew(iCell) = sshCur(iCell)
             do k = 1, maxLevelCell(iCell)
@@ -351,6 +352,7 @@ module ocn_time_integration_split
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          call mpas_pool_begin_iteration(tracersPool)
          do while ( mpas_pool_get_next_member(tracersPool, groupItr))
@@ -359,32 +361,38 @@ module ocn_time_integration_split
                call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
 
                if ( associated(tracersGroupCur) .and. associated(tracersGroupNew) ) then
-                  !$omp do schedule(runtime) private(k)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iCell)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupNew(:,k,iCell) = tracersGroupCur(:,k,iCell)
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
             end if
          end do
 
 
          if (associated(highFreqThicknessNew)) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iCell)
             do iCell = 1, nCells
                highFreqThicknessNew(:, iCell) = highFreqThicknessCur(:, iCell)
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          if (associated(lowFreqDivergenceNew)) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iCell)
             do iCell = 1, nCells
                lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceCur(:, iCell)
             end do
             !$omp end do
+            !$omp end parallel
          endif
 
          block => block % next
@@ -477,7 +485,8 @@ module ocn_time_integration_split
 
                nCells = nCellsPtr
 
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iCell)
                do iCell = 1, nCells
                   do k = 1, maxLevelCell(iCell)
                      ! this is h^{hf}_{n+1}
@@ -485,6 +494,7 @@ module ocn_time_integration_split
                   end do
                end do
                !$omp end do
+               !$omp end parallel
 
                block => block % next
             end do
@@ -569,7 +579,9 @@ module ocn_time_integration_split
 
                allocate(uTemp(nVertLevels))
 
-               !$omp do schedule(runtime)
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(iEdge, cell1, cell2, uTemp, k, normalThicknessFluxSum, thicknessSum)
                do iEdge = 1, nEdges
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
@@ -612,6 +624,7 @@ module ocn_time_integration_split
 
                enddo ! iEdge
                !$omp end do
+               !$omp end parallel
 
                deallocate(uTemp)
 
@@ -674,7 +687,8 @@ module ocn_time_integration_split
                ! For Split_Explicit unsplit, simply set normalBarotropicVelocityNew=0, normalBarotropicVelocitySubcycle=0, and
                ! uNew=normalBaroclinicVelocityNew
 
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iEdge)
                do iEdge = 1, nEdges
                   normalBarotropicVelocityNew(iEdge) = 0.0_RKIND
                   do k = 1, nVertLevels
@@ -689,6 +703,7 @@ module ocn_time_integration_split
                   enddo
                end do  ! iEdge
                !$omp end do
+               !$omp end parallel
 
                block => block % next
             end do  ! block
@@ -723,21 +738,24 @@ module ocn_time_integration_split
                nEdges = nEdgesPtr
 
                if (config_filter_btr_mode) then
-                  !$omp do schedule(runtime)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(iEdge)
                   do iEdge = 1, nEdges
                      barotropicForcing(iEdge) = 0.0_RKIND
                   end do
                   !$omp end do
+                  !$omp end parallel
                endif
 
-               !$omp do schedule(runtime)
+               !$omp parallel
+               !$omp do schedule(runtime) private(iCell)
                do iCell = 1, nCells
                   ! sshSubcycleOld = sshOld
                   sshSubcycleCur(iCell) = sshCur(iCell)
                end do
                !$omp end do
 
-               !$omp do schedule(runtime)
+               !$omp do schedule(runtime) private(iEdge)
                do iEdge = 1, nEdges
 
                   ! normalBarotropicVelocitySubcycleOld = normalBarotropicVelocityOld
@@ -750,6 +768,7 @@ module ocn_time_integration_split
                   barotropicThicknessFlux(iEdge) = 0.0_RKIND
                end do
                !$omp end do
+               !$omp end parallel
 
                block => block % next
             end do  ! block
@@ -834,7 +853,9 @@ module ocn_time_integration_split
                      nEdges = nEdgesPtr
                      nEdges = nEdgesArray( edgeHaloComputeCounter )
 
-                     !$omp do schedule(runtime)
+                     !$omp parallel
+                     !$omp do schedule(runtime) &
+                     !$omp private(iEdge, temp_mask, cell1, cell2, CoriolisTerm, i, eoe)
                      do iEdge = 1, nEdges
 
                         temp_mask = edgeMask(1, iEdge)
@@ -859,6 +880,7 @@ module ocn_time_integration_split
 
                      end do
                      !$omp end do
+                     !$omp end parallel
 
                      block => block % next
                   end do  ! block
@@ -916,7 +938,9 @@ module ocn_time_integration_split
                 ! config_btr_gam1_velWt1=0.5     flux = 1/2*(normalBarotropicVelocityNew+normalBarotropicVelocityOld)*H
                 ! config_btr_gam1_velWt1=  0     flux = normalBarotropicVelocityOld*H
 
-                !$omp do schedule(runtime) private(i, iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
+                !$omp parallel
+                !$omp do schedule(runtime) &
+                !$omp private(iCell, i, iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
                 do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
                   do i = 1, nEdgesOnCell(iCell)
@@ -951,6 +975,7 @@ module ocn_time_integration_split
                                           + dt / nBtrSubcycles * sshTend(iCell) / areaCell(iCell)
                 end do
                 !$omp end do
+                !$omp end parallel
 
                 !! asarje: changed to avoid redundant computations when config_btr_solve_SSH2 is true
 
@@ -968,7 +993,9 @@ module ocn_time_integration_split
                   ! otherwise, DO accumulate barotropicThicknessFlux in this SSH predictor section
                   barotropicThicknessFlux_coeff = 1.0_RKIND
 
-                  !$omp do schedule(runtime)
+                  !$omp parallel
+                  !$omp do schedule(runtime) &
+                  !$omp private(iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
                   do iEdge = 1, nEdges
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
@@ -985,6 +1012,7 @@ module ocn_time_integration_split
                      barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) + flux
                   end do
                   !$omp end do
+                  !$omp end parallel
 
                 endif
 
@@ -1061,15 +1089,19 @@ module ocn_time_integration_split
 
                    nEdges = nEdgesArray( min(edgeHaloComputeCounter + 1, config_num_halos + 1) )
 
-                   !$omp do schedule(runtime)
+                   !$omp parallel
+                   !$omp do schedule(runtime) private(iEdge)
                    do iEdge = 1, nEdges+1
                       btrvel_temp(iEdge) = normalBarotropicVelocitySubcycleNew(iEdge)
                    end do
                    !$omp end do
+                   !$omp end parallel
 
                    nEdges = nEdgesArray( edgeHaloComputeCounter )
 
-                   !$omp do schedule(runtime)
+                   !$omp parallel
+                   !$omp do schedule(runtime) &
+                   !$omp private(iEdge, temp_mask, cell1, cell2, coriolisTerm, eoe, sshCell1, sshCell2)
                    do iEdge = 1, nEdges
 
                      ! asarje: added to avoid redundant computations based on mask
@@ -1103,6 +1135,7 @@ module ocn_time_integration_split
 
                    end do
                    !$omp end do
+                   !$omp end parallel
 
                    block => block % next
                 end do  ! block
@@ -1164,7 +1197,9 @@ module ocn_time_integration_split
                    ! config_btr_gam3_velWt2=0.5     flux = 1/2*(normalBarotropicVelocityNew+normalBarotropicVelocityOld)*H
                    ! config_btr_gam3_velWt2=  0     flux = normalBarotropicVelocityOld*H
 
-                   !$omp do schedule(runtime) private(i, iEdge, cell1, cell2, sshCell1, sshCell2, sshEdge, thicknessSum, flux)
+                   !$omp parallel
+                   !$omp do schedule(runtime) &
+                   !$omp private(i, iEdge, cell1, cell2, sshCell1, sshCell2, sshEdge, thicknessSum, flux)
                    do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
@@ -1206,7 +1241,8 @@ module ocn_time_integration_split
                    end do
                    !$omp end do
 
-                   !$omp do schedule(runtime) private(cell1, cell2, sshCell1, sshCell2, sshEdge, thicknessSum, flux)
+                   !$omp do schedule(runtime) &
+                   !$omp private(cell1, cell2, sshCell1, sshCell2, sshEdge, thicknessSum, flux)
                    do iEdge = 1, nEdges
                       cell1 = cellsOnEdge(1,iEdge)
                       cell2 = cellsOnEdge(2,iEdge)
@@ -1233,6 +1269,7 @@ module ocn_time_integration_split
                       barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) + flux
                    end do
                    !$omp end do
+                   !$omp end parallel
 
                    block => block % next
                 end do  ! block
@@ -1262,12 +1299,14 @@ module ocn_time_integration_split
 
                   nEdges = nEdgesPtr
 
-                  !$omp do schedule(runtime)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(iEdge)
                   do iEdge = 1, nEdges
                        normalBarotropicVelocityNew(iEdge) = normalBarotropicVelocityNew(iEdge) &
                                                           + normalBarotropicVelocitySubcycleNew(iEdge)
                   end do  ! iEdge
                   !$omp end do
+                  !$omp end parallel
 
                   block => block % next
                end do  ! block
@@ -1305,7 +1344,8 @@ module ocn_time_integration_split
 
                nEdges = nEdgesArray(1)
 
-               !$omp do schedule(runtime)
+               !$omp parallel
+               !$omp do schedule(runtime) private(iEdge)
                do iEdge = 1, nEdges
                   barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) &
                       / (nBtrSubcycles * config_btr_subcycle_loop_factor)
@@ -1314,6 +1354,7 @@ module ocn_time_integration_split
                      / (nBtrSubcycles * config_btr_subcycle_loop_factor + 1)
                end do
                !$omp end do
+               !$omp end parallel
 
                block => block % next
             end do  ! block
@@ -1378,7 +1419,10 @@ module ocn_time_integration_split
                   useVelocityCorrection = 0
                endif
 
-               !$omp do schedule(runtime)
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(iEdge, uTemp, normalThicknessFluxSum, thicknessSum, k, &
+               !$omp         normalVelocityCorrection)
                do iEdge = 1, nEdges
 
                   ! velocity for normalVelocityCorrectionection is normalBarotropicVelocity + normalBaroclinicVelocity + uBolus
@@ -1415,6 +1459,7 @@ module ocn_time_integration_split
 
                end do ! iEdge
                !$omp end do
+               !$omp end parallel
 
                deallocate(uTemp)
 
@@ -1586,7 +1631,8 @@ module ocn_time_integration_split
                ! Only need T & S for earlier iterations,
                ! then all the tracers needed the last time through.
 
-               !$omp do schedule(runtime) private(k, temp_h, temp, i)
+               !$omp parallel
+               !$omp do schedule(runtime) private(iCell, k, temp_h, temp, i)
                do iCell = 1, nCells
                   ! sshNew is a pointer, defined above.
                   do k = 1, maxLevelCell(iCell)
@@ -1608,9 +1654,11 @@ module ocn_time_integration_split
                   end do
                end do ! iCell
                !$omp end do
+               !$omp end parallel
 
                if (config_use_freq_filtered_thickness) then
-                  !$omp do schedule(runtime) private(k, temp)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(iCell, k, temp)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
 
@@ -1628,9 +1676,11 @@ module ocn_time_integration_split
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
 
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iEdge)
                do iEdge = 1, nEdges
 
                   do k = 1, nVertLevels
@@ -1645,6 +1695,7 @@ module ocn_time_integration_split
 
                end do ! iEdge
                !$omp end do
+               !$omp end parallel
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
@@ -1657,7 +1708,8 @@ module ocn_time_integration_split
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             elseif (split_explicit_step == config_n_ts_iter) then
 
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iCell)
                do iCell = 1, nCells
                   do k = 1, maxLevelCell(iCell)
                      ! this is h_{n+1}
@@ -1665,6 +1717,7 @@ module ocn_time_integration_split
                   end do
                end do
                !$omp end do
+               !$omp end parallel
 
                if (config_compute_active_tracer_budgets) then
                   call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
@@ -1679,7 +1732,8 @@ module ocn_time_integration_split
                           activeTracerHorizontalAdvectionEdgeFlux)
                   call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-                  !$omp do schedule(runtime) private(k)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iEdge)
                   do iEdge = 1, nEdges
                      do k= 1, maxLevelEdgeTop(iEdge)
                         activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
@@ -1689,7 +1743,7 @@ module ocn_time_integration_split
                   enddo
                   !$omp end do
 
-                  !$omp do schedule(runtime) private(k)
+                  !$omp do schedule(runtime) private(k, iCell)
                   do iCell = 1, nCells
                      do k= 1, maxLevelCell(iCell)
                         activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
@@ -1718,6 +1772,7 @@ module ocn_time_integration_split
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                endif
 
                call mpas_pool_begin_iteration(tracersPool)
@@ -1733,7 +1788,8 @@ module ocn_time_integration_split
                         modifiedGroupName = trim(groupItr % memberName) // 'Tend'
                         call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
 
-                        !$omp do schedule(runtime) private(k)
+                        !$omp parallel
+                        !$omp do schedule(runtime) private(k, iCell)
                         do iCell = 1, nCells
                            do k = 1, maxLevelCell(iCell)
                               tracersGroupNew(:,k,iCell) = (tracersGroupCur(:,k,iCell) * layerThicknessCur(k,iCell) + dt &
@@ -1741,16 +1797,19 @@ module ocn_time_integration_split
                            end do
                         end do
                         !$omp end do
+                        !$omp end parallel
 
                         ! limit salinity in separate loop
                         if ( trim(groupItr % memberName) == 'activeTracers' ) then
-                           !$omp do schedule(runtime) private(k)
+                           !$omp parallel
+                           !$omp do schedule(runtime) private(k, iCell)
                            do iCell = 1, nCells
                               do k = 1, maxLevelCell(iCell)
                                  tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
                               end do
                            end do
                            !$omp end do
+                           !$omp end parallel
                         end if
 
                         ! Reset debugTracers to fixed value at the surface
@@ -1758,7 +1817,8 @@ module ocn_time_integration_split
                            call mpas_pool_get_array(meshPool, 'latCell', latCell)
                            call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
                            if (config_reset_debugTracers_near_surface) then
-                              !$omp do schedule(runtime)
+                              !$omp parallel
+                              !$omp do schedule(runtime) private(iCell, k, lat)
                               do iCell = 1, nCells
 
                                 ! Reset tracer1 to 2 in top n layers
@@ -1802,6 +1862,7 @@ module ocn_time_integration_split
                                 end if
                               end do
                               !$omp end do
+                              !$omp end parallel
                            end if
                         end if
 
@@ -1810,7 +1871,8 @@ module ocn_time_integration_split
                end do
 
                if (config_use_freq_filtered_thickness) then
-                  !$omp do schedule(runtime) private(k)
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, iCell)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
 
@@ -1821,6 +1883,7 @@ module ocn_time_integration_split
                      end do
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
 
                ! Recompute final u to go on to next step.
@@ -1832,7 +1895,8 @@ module ocn_time_integration_split
                ! note that normalBaroclinicVelocity is recomputed at the beginning of the next timestep due to Imp Vert mixing,
                ! so normalBaroclinicVelocity does not have to be recomputed here.
 
-               !$omp do schedule(runtime) private(k)
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, iEdge)
                do iEdge = 1, nEdges
                   do k = 1, maxLevelEdgeTop(iEdge)
                      normalVelocityNew(k,iEdge) = normalBarotropicVelocityNew(iEdge) + 2 * normalBaroclinicVelocityNew(k,iEdge) &
@@ -1840,6 +1904,7 @@ module ocn_time_integration_split
                   end do
                end do ! iEdges
                !$omp end do
+               !$omp end parallel
 
             endif ! split_explicit_step
 
@@ -1966,19 +2031,23 @@ module ocn_time_integration_split
          nEdges = nEdgesPtr
 
          if (config_prescribe_velocity) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iEdge)
             do iEdge = 1, nEdges
                normalVelocityNew(:, iEdge) = normalVelocityCur(:, iEdge)
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          if (config_prescribe_thickness) then
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) private(iCell)
             do iCell = 1, nCells
                layerThicknessNew(:, iCell) = layerThicknessCur(:, iCell)
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
@@ -2006,7 +2075,8 @@ module ocn_time_integration_split
 
          call mpas_timer_stop('se final mpas reconstruct')
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell)
          do iCell = 1, nCells
             surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
             surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)
@@ -2015,6 +2085,7 @@ module ocn_time_integration_split
             SSHGradient(indexSSHGradientMeridional, iCell) = gradSSHMeridional(iCell)
          end do
          !$omp end do
+         !$omp end parallel
 
          call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -323,7 +323,7 @@ module ocn_time_integration_split
          ! Initialize * variables that are used to compute baroclinic tendencies below.
 
          !$omp parallel
-         !$omp do schedule(runtime) private(k, iEdge)
+         !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
             do k = 1, nVertLevels !maxLevelEdgeTop % array(iEdge)
 
@@ -342,7 +342,7 @@ module ocn_time_integration_split
          end do
          !$omp end do
 
-         !$omp do schedule(runtime) private(k, iCell)
+         !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
             sshNew(iCell) = sshCur(iCell)
             do k = 1, maxLevelCell(iCell)
@@ -362,7 +362,7 @@ module ocn_time_integration_split
 
                if ( associated(tracersGroupCur) .and. associated(tracersGroupNew) ) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(k, iCell)
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
                         tracersGroupNew(:,k,iCell) = tracersGroupCur(:,k,iCell)
@@ -377,7 +377,7 @@ module ocn_time_integration_split
 
          if (associated(highFreqThicknessNew)) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iCell)
+            !$omp do schedule(runtime) 
             do iCell = 1, nCells
                highFreqThicknessNew(:, iCell) = highFreqThicknessCur(:, iCell)
             end do
@@ -387,7 +387,7 @@ module ocn_time_integration_split
 
          if (associated(lowFreqDivergenceNew)) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iCell)
+            !$omp do schedule(runtime) 
             do iCell = 1, nCells
                lowFreqDivergenceNew(:, iCell) = lowFreqDivergenceCur(:, iCell)
             end do
@@ -486,7 +486,7 @@ module ocn_time_integration_split
                nCells = nCellsPtr
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iCell)
+               !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells
                   do k = 1, maxLevelCell(iCell)
                      ! this is h^{hf}_{n+1}
@@ -581,7 +581,7 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(iEdge, cell1, cell2, uTemp, k, normalThicknessFluxSum, thicknessSum)
+               !$omp private(cell1, cell2, uTemp, k, normalThicknessFluxSum, thicknessSum)
                do iEdge = 1, nEdges
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
@@ -688,7 +688,7 @@ module ocn_time_integration_split
                ! uNew=normalBaroclinicVelocityNew
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iEdge)
+               !$omp do schedule(runtime) private(k)
                do iEdge = 1, nEdges
                   normalBarotropicVelocityNew(iEdge) = 0.0_RKIND
                   do k = 1, nVertLevels
@@ -739,7 +739,7 @@ module ocn_time_integration_split
 
                if (config_filter_btr_mode) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(iEdge)
+                  !$omp do schedule(runtime) 
                   do iEdge = 1, nEdges
                      barotropicForcing(iEdge) = 0.0_RKIND
                   end do
@@ -748,14 +748,14 @@ module ocn_time_integration_split
                endif
 
                !$omp parallel
-               !$omp do schedule(runtime) private(iCell)
+               !$omp do schedule(runtime) 
                do iCell = 1, nCells
                   ! sshSubcycleOld = sshOld
                   sshSubcycleCur(iCell) = sshCur(iCell)
                end do
                !$omp end do
 
-               !$omp do schedule(runtime) private(iEdge)
+               !$omp do schedule(runtime) 
                do iEdge = 1, nEdges
 
                   ! normalBarotropicVelocitySubcycleOld = normalBarotropicVelocityOld
@@ -855,7 +855,7 @@ module ocn_time_integration_split
 
                      !$omp parallel
                      !$omp do schedule(runtime) &
-                     !$omp private(iEdge, temp_mask, cell1, cell2, CoriolisTerm, i, eoe)
+                     !$omp private(temp_mask, cell1, cell2, CoriolisTerm, i, eoe)
                      do iEdge = 1, nEdges
 
                         temp_mask = edgeMask(1, iEdge)
@@ -940,7 +940,7 @@ module ocn_time_integration_split
 
                 !$omp parallel
                 !$omp do schedule(runtime) &
-                !$omp private(iCell, i, iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
+                !$omp private(i, iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
                 do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
                   do i = 1, nEdgesOnCell(iCell)
@@ -995,7 +995,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(iEdge, cell1, cell2, sshEdge, thicknessSum, flux)
+                  !$omp private(cell1, cell2, sshEdge, thicknessSum, flux)
                   do iEdge = 1, nEdges
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
@@ -1090,7 +1090,7 @@ module ocn_time_integration_split
                    nEdges = nEdgesArray( min(edgeHaloComputeCounter + 1, config_num_halos + 1) )
 
                    !$omp parallel
-                   !$omp do schedule(runtime) private(iEdge)
+                   !$omp do schedule(runtime) 
                    do iEdge = 1, nEdges+1
                       btrvel_temp(iEdge) = normalBarotropicVelocitySubcycleNew(iEdge)
                    end do
@@ -1101,7 +1101,7 @@ module ocn_time_integration_split
 
                    !$omp parallel
                    !$omp do schedule(runtime) &
-                   !$omp private(iEdge, temp_mask, cell1, cell2, coriolisTerm, eoe, sshCell1, sshCell2)
+                   !$omp private(temp_mask, cell1, cell2, coriolisTerm, eoe, sshCell1, sshCell2)
                    do iEdge = 1, nEdges
 
                      ! asarje: added to avoid redundant computations based on mask
@@ -1300,7 +1300,7 @@ module ocn_time_integration_split
                   nEdges = nEdgesPtr
 
                   !$omp parallel
-                  !$omp do schedule(runtime) private(iEdge)
+                  !$omp do schedule(runtime) 
                   do iEdge = 1, nEdges
                        normalBarotropicVelocityNew(iEdge) = normalBarotropicVelocityNew(iEdge) &
                                                           + normalBarotropicVelocitySubcycleNew(iEdge)
@@ -1345,7 +1345,7 @@ module ocn_time_integration_split
                nEdges = nEdgesArray(1)
 
                !$omp parallel
-               !$omp do schedule(runtime) private(iEdge)
+               !$omp do schedule(runtime) 
                do iEdge = 1, nEdges
                   barotropicThicknessFlux(iEdge) = barotropicThicknessFlux(iEdge) &
                       / (nBtrSubcycles * config_btr_subcycle_loop_factor)
@@ -1421,7 +1421,7 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(iEdge, uTemp, normalThicknessFluxSum, thicknessSum, k, &
+               !$omp private(uTemp, normalThicknessFluxSum, thicknessSum, k, &
                !$omp         normalVelocityCorrection)
                do iEdge = 1, nEdges
 
@@ -1632,7 +1632,7 @@ module ocn_time_integration_split
                ! then all the tracers needed the last time through.
 
                !$omp parallel
-               !$omp do schedule(runtime) private(iCell, k, temp_h, temp, i)
+               !$omp do schedule(runtime) private(k, temp_h, temp, i)
                do iCell = 1, nCells
                   ! sshNew is a pointer, defined above.
                   do k = 1, maxLevelCell(iCell)
@@ -1658,7 +1658,7 @@ module ocn_time_integration_split
 
                if (config_use_freq_filtered_thickness) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(iCell, k, temp)
+                  !$omp do schedule(runtime) private(k, temp)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
 
@@ -1680,7 +1680,7 @@ module ocn_time_integration_split
                end if
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iEdge)
+               !$omp do schedule(runtime) private(k)
                do iEdge = 1, nEdges
 
                   do k = 1, nVertLevels
@@ -1709,7 +1709,7 @@ module ocn_time_integration_split
             elseif (split_explicit_step == config_n_ts_iter) then
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iCell)
+               !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells
                   do k = 1, maxLevelCell(iCell)
                      ! this is h_{n+1}
@@ -1733,7 +1733,7 @@ module ocn_time_integration_split
                   call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
                   !$omp parallel
-                  !$omp do schedule(runtime) private(k, iEdge)
+                  !$omp do schedule(runtime) private(k)
                   do iEdge = 1, nEdges
                      do k= 1, maxLevelEdgeTop(iEdge)
                         activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
@@ -1743,7 +1743,7 @@ module ocn_time_integration_split
                   enddo
                   !$omp end do
 
-                  !$omp do schedule(runtime) private(k, iCell)
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k= 1, maxLevelCell(iCell)
                         activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
@@ -1789,7 +1789,7 @@ module ocn_time_integration_split
                         call mpas_pool_get_array(tracersTendPool, modifiedGroupName, tracersGroupTend)
 
                         !$omp parallel
-                        !$omp do schedule(runtime) private(k, iCell)
+                        !$omp do schedule(runtime) private(k)
                         do iCell = 1, nCells
                            do k = 1, maxLevelCell(iCell)
                               tracersGroupNew(:,k,iCell) = (tracersGroupCur(:,k,iCell) * layerThicknessCur(k,iCell) + dt &
@@ -1802,7 +1802,7 @@ module ocn_time_integration_split
                         ! limit salinity in separate loop
                         if ( trim(groupItr % memberName) == 'activeTracers' ) then
                            !$omp parallel
-                           !$omp do schedule(runtime) private(k, iCell)
+                           !$omp do schedule(runtime) private(k)
                            do iCell = 1, nCells
                               do k = 1, maxLevelCell(iCell)
                                  tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
@@ -1818,7 +1818,7 @@ module ocn_time_integration_split
                            call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
                            if (config_reset_debugTracers_near_surface) then
                               !$omp parallel
-                              !$omp do schedule(runtime) private(iCell, k, lat)
+                              !$omp do schedule(runtime) private(k, lat)
                               do iCell = 1, nCells
 
                                 ! Reset tracer1 to 2 in top n layers
@@ -1872,7 +1872,7 @@ module ocn_time_integration_split
 
                if (config_use_freq_filtered_thickness) then
                   !$omp parallel
-                  !$omp do schedule(runtime) private(k, iCell)
+                  !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
                      do k = 1, maxLevelCell(iCell)
 
@@ -1896,7 +1896,7 @@ module ocn_time_integration_split
                ! so normalBaroclinicVelocity does not have to be recomputed here.
 
                !$omp parallel
-               !$omp do schedule(runtime) private(k, iEdge)
+               !$omp do schedule(runtime) private(k)
                do iEdge = 1, nEdges
                   do k = 1, maxLevelEdgeTop(iEdge)
                      normalVelocityNew(k,iEdge) = normalBarotropicVelocityNew(iEdge) + 2 * normalBaroclinicVelocityNew(k,iEdge) &
@@ -2032,7 +2032,7 @@ module ocn_time_integration_split
 
          if (config_prescribe_velocity) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iEdge)
+            !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
                normalVelocityNew(:, iEdge) = normalVelocityCur(:, iEdge)
             end do
@@ -2042,7 +2042,7 @@ module ocn_time_integration_split
 
          if (config_prescribe_thickness) then
             !$omp parallel
-            !$omp do schedule(runtime) private(iCell)
+            !$omp do schedule(runtime) 
             do iCell = 1, nCells
                layerThicknessNew(:, iCell) = layerThicknessCur(:, iCell)
             end do
@@ -2076,7 +2076,7 @@ module ocn_time_integration_split
          call mpas_timer_stop('se final mpas reconstruct')
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell)
+         !$omp do schedule(runtime) 
          do iCell = 1, nCells
             surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
             surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -315,7 +315,8 @@ contains
       nVertices = nVerticesArray( size(nVerticesArray) )
 
       if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
-        !$omp do schedule(runtime) private(cell1, cell2, k)
+        !$omp parallel
+        !$omp do schedule(runtime) private(cell1, cell2, k, iEdge)
         do iEdge = 1, nEdges
           ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
           layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
@@ -327,10 +328,12 @@ contains
           end do
         end do
         !$omp end do
+        !$omp end parallel
       else
         if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
           if ( trim(config_thickness_flux_type) .eq. 'upwind') then
-            !$omp do schedule(runtime) private(cell1, cell2, k)
+            !$omp parallel
+            !$omp do schedule(runtime) private(cell1, cell2, k, iEdge)
             do iEdge = 1, nEdges
               ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
               layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
@@ -348,6 +351,7 @@ contains
               end do
             end do
             !$omp end do
+            !$omp end parallel
           end if
         else
           call mpas_log_write('Thickness flux option of ' // trim(config_thickness_flux_type) // 'is not known', MPAS_LOG_CRIT)
@@ -361,20 +365,18 @@ contains
       !    used -1e34 so error clearly occurs if these values are used.
       !
 
-      !$omp master
       normalVelocity(:,nEdges+1) = -1e34
       layerThickness(:,nCells+1) = -1e34
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
-      !$omp end master
-      call mpas_threading_barrier()
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsArray( 1 )
 
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex, iCell)
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -389,6 +391,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       ! Need 0,1,2 halo cells
       nCells = nCellsArray( 3 )
@@ -397,7 +400,10 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
-      !$omp do schedule(runtime) private(invAreaCell1, i, k, iEdge, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, r_tmp)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+      !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -436,12 +442,14 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
       nEdges = nEdgesArray( 2 )
 
-      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iEdge, i, eoe, weightsOnEdge_temp, k)
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -455,6 +463,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       ! Need 0,1,2 halo cells
       nCells = nCellsArray( 3 )
@@ -469,6 +478,7 @@ contains
          !$omp end master
          !$omp barrier
 
+         !$omp parallel
          !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
          do iVertex = 1, nVertices
            kineticEnergyVertex(:, iVertex) = 0.0_RKIND
@@ -508,6 +518,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          !$omp barrier
          !$omp master
@@ -527,6 +538,7 @@ contains
 
       nVertices = nVerticesArray( 3 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -543,9 +555,11 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nEdges = nEdgesArray( 3 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(vertex1, vertex2, k)
       do iEdge = 1, nEdges
         normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
@@ -560,9 +574,11 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray( 2 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
       do iCell = 1, nCells
         normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
@@ -578,6 +594,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray( size(nCellsArray) )
       nVertices = nVerticesArray( size(nVerticesArray) )
@@ -594,6 +611,7 @@ contains
 
          nEdges = nEdgesArray( 2 )
 
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
          do iEdge = 1,nEdges
             cell1 = cellsOnEdge(1, iEdge)
@@ -633,6 +651,7 @@ contains
             enddo
          enddo
          !$omp end do
+         !$omp end parallel
 
          !$omp barrier
          !$omp master
@@ -687,7 +706,8 @@ contains
 
         allocate(pTop(nVertLevels))
 
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, pTop, k)
         do iCell = 1, nCells
 
            ! assume atmospheric pressure at the surface is zero for now.
@@ -707,11 +727,13 @@ contains
 
         end do
         !$omp end do
+        !$omp end parallel
 
         deallocate(pTop)
 
       else
 
+        !$omp parallel
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
            ! Pressure for generalized coordinates.
@@ -749,6 +771,7 @@ contains
 
         end do
         !$omp end do
+        !$omp end parallel
 
       endif
 
@@ -758,6 +781,7 @@ contains
       ! Brunt-Vaisala frequency (this has units of s^{-2})
       !
       coef = -gravity / rho_sw
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          BruntVaisalaFreqTop(1,iCell) = 0.0_RKIND
@@ -810,6 +834,7 @@ contains
          normalVelocitySurfaceLayer(iEdge) = normalVelocity(1, iEdge)
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       ! average tracer values over the ocean surface layer
@@ -818,7 +843,8 @@ contains
 
         nCells = nCellsArray( 1 )
 
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
         do iCell=1,nCells
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
@@ -844,6 +870,7 @@ contains
                                             * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
         enddo
         !$omp end do
+        !$omp end parallel
 
         nEdges = nEdgesArray( 1 )
 
@@ -852,6 +879,7 @@ contains
         ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
         !
 
+        !$omp parallel
         !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
         do iEdge=1,nEdges
           normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
@@ -881,18 +909,21 @@ contains
           end if
         enddo
         !$omp end do
+        !$omp end parallel
 
       endif
 
       nCells = nCellsArray( 2 )
 
       ! compute the attenuation coefficient for surface fluxes
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          surfaceFluxAttenuationCoefficient(iCell) = config_flux_attenuation_coefficient
          surfaceFluxAttenuationCoefficientRunoff(iCell) = config_flux_attenuation_coefficient_runoff
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
@@ -900,13 +931,15 @@ contains
                                          diagnosticsPool, timeLevel)
 
       nCells = nCellsArray( 2 )
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
       end do
-      !$omp end do
+      !$omp end parallel
 
       if(associated(landIceDraft)) then
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
             ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
@@ -914,10 +947,12 @@ contains
             pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       nEdges = nEdgesArray( 2 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
@@ -926,6 +961,7 @@ contains
          gradSSH(iEdge) = edgeMask(1, iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop('diagnostic solve')
 
@@ -1039,6 +1075,7 @@ contains
       ! thickness-weighted divergence and barotropic divergence
       !
       ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux, div_hu_btr)
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
@@ -1057,6 +1094,7 @@ contains
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       ! Compute desired thickness at new time
@@ -1076,6 +1114,7 @@ contains
       ! Here we are using solving the continuity equation for vertAleTransportTop ($w^t$),
       ! and using ALE_Thickness for thickness at the new time.
 
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1,nCells
          vertAleTransportTop(1,iCell) = 0.0_RKIND
@@ -1086,6 +1125,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       !$omp barrier
       !$omp master
@@ -1152,6 +1192,7 @@ contains
       !
       ! Put f*normalBaroclinicVelocity^{perp} in u as a work variable
       !
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
       do iEdge = 1, nEdgesSolve
          cell1 = cellsOnEdge(1,iEdge)
@@ -1168,6 +1209,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("ocn_fuperp")
 
@@ -1215,7 +1257,8 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iEdge, normalThicknessFluxSum, thicknessSum, k, vertSum)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1235,6 +1278,7 @@ contains
         enddo
       enddo ! iEdge
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("ocn_filter_btr_mode_vel")
 
@@ -1284,7 +1328,8 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iEdge, normalThicknessFluxSum, thicknessSum, k, vertSum)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1304,6 +1349,7 @@ contains
         enddo
       enddo ! iEdge
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("ocn_filter_btr_mode_tend_vel")
 
@@ -1491,7 +1537,10 @@ contains
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iCell, invAreaCell, fracAbsorbed, fracAbsorbedRunoff, deltaVelocitySquared, i, &
+      !$omp         iEdge, factor, delU2)
       do iCell = 1, nCells
          ! compute surface buoyancy forcing based on surface fluxes of mass, temperature, salinity and frazil
          !                                (frazil to be added later)
@@ -1549,6 +1598,7 @@ contains
 
       enddo
       !$omp end do
+      !$omp end parallel
 
       ! deallocate scratch space
       !$omp barrier
@@ -1704,6 +1754,7 @@ contains
       end if
 
       ! Compute top drag
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, velocityMagnitude, landIceEdgeFraction)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
@@ -1733,10 +1784,8 @@ contains
       end do
       !$omp end do
 
-
-
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
-      !$omp do schedule(runtime)
+      !$omp do schedule(runtime) private(iCell, blThickness, iLevel, dz)
       do iCell = 1, nCells
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND
@@ -1774,8 +1823,10 @@ contains
          end if
       end do
       !$omp end do
+      !$omp end parallel
 
       if(jenkinsOn) then
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
             ! transfer coefficients from namelist
@@ -1785,7 +1836,9 @@ contains
                                              * config_land_ice_flux_jenkins_salt_transfer_coefficient
          end do
          !$omp end do
+         !$omp end parallel
       else if(hollandJenkinsOn) then
+         !$omp parallel
          !$omp do schedule(runtime) private(h_nu, Gamma_turb)
          do iCell = 1, nCells
             ! friction-velocity dependent non-dimensional transfer coefficients from
@@ -1804,6 +1857,7 @@ contains
                                                                    * Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       !$omp barrier
@@ -1813,6 +1867,7 @@ contains
       !$omp end master
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          if(landIceMask(iCell) == 1) then
@@ -1820,6 +1875,7 @@ contains
          end if
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("land_ice_diagnostic_fields")
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -75,66 +75,6 @@ module ocn_diagnostics
 
    logical :: jenkinsOn, hollandJenkinsOn
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the 
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! Subroutine ocn_diagnostic_solve
-   ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
-   !               units: m^2 s^{-2}
-   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
-   ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
-   !                      units: m^2 s^{-2}
-   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
-   ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
-   !                                     divided by layer thickness, defined at vertices
-   !                              units: s^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
-   ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
-   !                                    defined at vertices
-   !                             units: s^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
-   ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
-   !                                   (positive points from cell1 to cell2)
-   !                            units: s^{-1} m^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
-   ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
-   !                                       (positive points from vertex1 to vertex2)
-   !                                units: s^{-1} m^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
-
-   ! Subroutine ocn_vert_transport_velocity_top
-   ! projectedSSH: projected SSH at a new time
-   !        units: none
-   real (kind=RKIND), dimension(:), allocatable ::  projectedSSH
-   ! div_hu: divergence of (thickness*velocity)
-   !  units: none
-   real (kind=RKIND), dimension(:,:), allocatable :: div_hu
-   ! ALE_Thickness: ALE thickness at new time
-   !         units: none
-   real (kind=RKIND), dimension(:,:), allocatable :: ALE_Thickness
-
-   ! subroutine ocn_compute_KPP_input_fields
-   ! densitySurfaceDisplaced: Density computed by displacing SST and SSS to every vertical
-   !                          layer within the column
-   !                   units: kg m^{-3}
-   real (kind=RKIND), dimension(:,:), allocatable :: densitySurfaceDisplaced
-   ! thermalExpansionCoeff: Thermal expansion coefficient (alpha), defined as $-1/\rho
-   !                        d\rho/dT$ (note negative sign)
-   !                 units: C^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: thermalExpansionCoeff
-   ! salineContractionCoeff: Saline contraction coefficient (beta), defined as $1/\rho
-   !                         d\rho/dS$.  This is also called the haline contraction coefficient.
-   !                  units: PSU^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: salineContractionCoeff
-
-   ! subroutine ocn_compute_land_ice_flux_input_fields
-   real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
-
 !***********************************************************************
 
 contains
@@ -205,6 +145,30 @@ contains
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
 
+      ! Scratch Arrays
+      ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
+      !               units: m^2 s^{-2}
+      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
+      ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
+      !                      units: m^2 s^{-2}
+      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
+      ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
+      !                                     divided by layer thickness, defined at vertices
+      !                              units: s^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
+      ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
+      !                                    defined at vertices
+      !                             units: s^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
+      ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
+      !                                   (positive points from cell1 to cell2)
+      !                            units: s^{-1} m^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
+      ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
+      !                                       (positive points from vertex1 to vertex2)
+      !                                units: s^{-1} m^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
+   
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
@@ -472,11 +436,8 @@ contains
       !
       if ( ke_vertex_flag == 1 ) then
 
-         !$omp master
          allocate(kineticEnergyVertex(nVertLevels, nVertices), &
                   kineticEnergyVertexOnCells(nVertLevels, nCells))
-         !$omp end master
-         !$omp barrier
 
          !$omp parallel
          !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
@@ -520,21 +481,15 @@ contains
          !$omp end do
          !$omp end parallel
 
-         !$omp barrier
-         !$omp master
          deallocate(kineticEnergyVertex, &
                     kineticEnergyVertexOnCells)
-         !$omp end master
       end if
 
       !
       ! Compute normalized relative and planetary vorticity
       !
-      !$omp master
       allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVertices), &
                normalizedRelativeVorticityVertex(nVertLevels, nVertices))
-      !$omp end master
-      !$omp barrier
 
       nVertices = nVerticesArray( 3 )
 
@@ -603,11 +558,8 @@ contains
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
       if (config_apvm_scale_factor>1e-10) then
 
-         !$omp master
          allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
                   vorticityGradientTangentialComponent(nVertLevels, nEdges))
-         !$omp end master
-         !$omp barrier
 
          nEdges = nEdgesArray( 2 )
 
@@ -653,19 +605,13 @@ contains
          !$omp end do
          !$omp end parallel
 
-         !$omp barrier
-         !$omp master
          deallocate(vorticityGradientNormalComponent, &
                     vorticityGradientTangentialComponent)
-         !$omp end master
 
       endif
 
-      !$omp barrier
-      !$omp master
       deallocate(normalizedPlanetaryVorticityVertex, &
                  normalizedRelativeVorticityVertex)
-      !$omp end master
 
       !
       ! equation of state
@@ -1042,6 +988,17 @@ contains
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
 
+      ! Scratch Arrays
+      ! projectedSSH: projected SSH at a new time
+      !        units: none
+      real (kind=RKIND), dimension(:), allocatable ::  projectedSSH
+      ! div_hu: divergence of (thickness*velocity)
+      !  units: none
+      real (kind=RKIND), dimension(:,:), allocatable :: div_hu
+      ! ALE_Thickness: ALE thickness at new time
+      !         units: none
+      real (kind=RKIND), dimension(:,:), allocatable :: ALE_Thickness
+
       err = 0
 
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
@@ -1062,12 +1019,9 @@ contains
 
       ncells = nCellsArray(size(nCellsArray))
 
-      !$omp master
       allocate(div_hu(nVertLevels, nCells), &
                projectedSSH(nCells), &
                ALE_Thickness(nVertLevels, nCells))
-      !$omp end master
-      !$omp barrier
 
       ! Only need to compute over 0 and 1 halos
       nCells = nCellsArray( 2 )
@@ -1126,12 +1080,9 @@ contains
       !$omp end do
       !$omp end parallel
 
-      !$omp barrier
-      !$omp master
       deallocate(div_hu, &
                  projectedSSH, &
                  ALE_Thickness)
-      !$omp end master
 
    end subroutine ocn_vert_transport_velocity_top!}}}
 
@@ -1466,6 +1417,20 @@ contains
       real (kind=RKIND) :: numerator, denominator, turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
       real (kind=RKIND) :: sumSurfaceStressSquared
 
+      ! Scratch Arrays
+      ! densitySurfaceDisplaced: Density computed by displacing SST and SSS to every vertical
+      !                          layer within the column
+      !                   units: kg m^{-3}
+      real (kind=RKIND), dimension(:,:), allocatable :: densitySurfaceDisplaced
+      ! thermalExpansionCoeff: Thermal expansion coefficient (alpha), defined as $-1/\rho
+      !                        d\rho/dT$ (note negative sign)
+      !                 units: C^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: thermalExpansionCoeff
+      ! salineContractionCoeff: Saline contraction coefficient (beta), defined as $1/\rho
+      !                         d\rho/dS$.  This is also called the haline contraction coefficient.
+      !                  units: PSU^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: salineContractionCoeff
+
       call mpas_timer_start('KPP input fields')
 
       if (present(timeLevelIn)) then
@@ -1521,12 +1486,10 @@ contains
 
       ! allocate scratch space displaced density computation
       ncells = nCellsArray(size(nCellsArray))
-      !$omp master
+
       allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
                thermalExpansionCoeff(nVertLevels, nCells), &
                salineContractionCoeff(nVertLevels, nCells))
-      !$omp end master
-      !$omp barrier
 
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsArray( 3 )
@@ -1599,12 +1562,9 @@ contains
       !$omp end parallel
 
       ! deallocate scratch space
-      !$omp barrier
-      !$omp master
       deallocate(thermalExpansionCoeff, &
                  salineContractionCoeff, &
                  densitySurfaceDisplaced)
-      !$omp end master
 
       call mpas_timer_stop('KPP input fields')
 
@@ -1665,6 +1625,10 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity, &
                                                     landIceBoundaryLayerTracers, landIceTracerTransferVelocities
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
+
 
       ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
       real (kind=RKIND), parameter :: &
@@ -1741,11 +1705,8 @@ contains
       end if
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
-      !$omp master
       allocate(blTempScratch(nCells), &
                blSaltScratch(nCells))
-      !$omp end master
-      !$omp barrier
 
       if(hollandJenkinsOn) then
          call mpas_pool_get_array(meshPool, 'fCell', fCell)
@@ -1858,11 +1819,8 @@ contains
          !$omp end parallel
       end if
 
-      !$omp barrier
-      !$omp master
       deallocate(blTempScratch, &
                  blSaltScratch)
-      !$omp end master
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
       !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -316,7 +316,7 @@ contains
 
       if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
         !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k, iEdge)
+        !$omp do schedule(runtime) private(cell1, cell2, k)
         do iEdge = 1, nEdges
           ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
           layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
@@ -333,7 +333,7 @@ contains
         if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
           if ( trim(config_thickness_flux_type) .eq. 'upwind') then
             !$omp parallel
-            !$omp do schedule(runtime) private(cell1, cell2, k, iEdge)
+            !$omp do schedule(runtime) private(cell1, cell2, k)
             do iEdge = 1, nEdges
               ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
               layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
@@ -376,7 +376,7 @@ contains
       nCells = nCellsArray( 1 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex, iCell)
+      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -449,7 +449,7 @@ contains
       nEdges = nEdgesArray( 2 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iEdge, i, eoe, weightsOnEdge_temp, k)
+      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -707,7 +707,7 @@ contains
         allocate(pTop(nVertLevels))
 
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, pTop, k)
+        !$omp do schedule(runtime) private(pTop, k)
         do iCell = 1, nCells
 
            ! assume atmospheric pressure at the surface is zero for now.
@@ -844,7 +844,7 @@ contains
         nCells = nCellsArray( 1 )
 
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
         do iCell=1,nCells
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
@@ -1258,7 +1258,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iEdge, normalThicknessFluxSum, thicknessSum, k, vertSum)
+      !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1329,7 +1329,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iEdge, normalThicknessFluxSum, thicknessSum, k, vertSum)
+      !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
       do iEdge = 1, nEdges
 
         ! thicknessSum is initialized outside the loop because on land boundaries
@@ -1539,7 +1539,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iCell, invAreaCell, fracAbsorbed, fracAbsorbedRunoff, deltaVelocitySquared, i, &
+      !$omp private(invAreaCell, fracAbsorbed, fracAbsorbedRunoff, deltaVelocitySquared, i, &
       !$omp         iEdge, factor, delU2)
       do iCell = 1, nCells
          ! compute surface buoyancy forcing based on surface fluxes of mass, temperature, salinity and frazil
@@ -1785,7 +1785,7 @@ contains
       !$omp end do
 
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
-      !$omp do schedule(runtime) private(iCell, blThickness, iLevel, dz)
+      !$omp do schedule(runtime) private(blThickness, iLevel, dz)
       do iCell = 1, nCells
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -936,6 +936,7 @@ contains
       do iCell = 1, nCells
          pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
       end do
+      !$omp end do
       !$omp end parallel
 
       if(associated(landIceDraft)) then

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1538,8 +1538,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(invAreaCell, fracAbsorbed, fracAbsorbedRunoff, deltaVelocitySquared, i, &
-      !$omp         iEdge, factor, delU2)
+      !$omp private(fracAbsorbed, fracAbsorbedRunoff, sumSurfaceStressSquared, i, iEdge)
       do iCell = 1, nCells
          ! compute surface buoyancy forcing based on surface fluxes of mass, temperature, salinity and frazil
          !                                (frazil to be added later)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -679,7 +679,6 @@ contains
                                          nCells, 0, 'relative', density, err, &
                                          inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
                                          timeLevelIn=timeLevel)
-      call mpas_threading_barrier()
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
@@ -691,7 +690,6 @@ contains
       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
-      call mpas_threading_barrier()
 
       !
       ! Pressure
@@ -1106,8 +1104,6 @@ contains
       else
         call ocn_ALE_thickness(meshPool, verticalMeshPool, projectedSSH, ALE_thickness, err)
       endif
-
-      call mpas_threading_barrier()
 
       !
       ! Vertical transport through layer interfaces

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -791,12 +791,14 @@ contains
           end do
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       ! Gradient Richardson number
       !
 
       nCells = nCellsArray(3)
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_routines.F
@@ -120,6 +120,7 @@ contains
 
       err = 0
 
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
       do iVertex = 1, nVertices
          circulation(:, iVertex) = 0.0_RKIND
@@ -136,6 +137,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -182,6 +182,7 @@ contains
          effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/weightSum
       end do
       !$omp end do
+      !$omp end parallel
 
       !$omp barrier
       !$omp master

--- a/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -154,6 +154,7 @@ contains
       !$omp end master
       !$omp barrier
 
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          ! TODO: should only apply to floating land ice, once wetting/drying is supported

--- a/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -52,19 +52,6 @@ module ocn_effective_density_in_land_ice
    !
    !--------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_effective_density_in_land_ice_update
-   ! effectiveDensityScratch: effective seawater density in land ice before horizontal averaging
-   !                   units: kg m^{-3}
-   real (kind=RKIND), dimension(:), allocatable :: effectiveDensityScratch
-
 !***********************************************************************
 
 contains
@@ -131,6 +118,11 @@ contains
 
       integer, dimension(:), pointer :: nEdgesOnCell
 
+      ! Scratch Arrays
+      ! effectiveDensityScratch: effective seawater density in land ice before horizontal averaging
+      !                   units: kg m^{-3}
+      real (kind=RKIND), dimension(:), allocatable :: effectiveDensityScratch
+
       ierr = 0
 
       if ( (trim(config_land_ice_flux_mode) .ne. 'coupled') ) then
@@ -149,10 +141,7 @@ contains
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityCur, 1)
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityNew, 2)
 
-      !$omp master
       allocate(effectiveDensityScratch(nCells))
-      !$omp end master
-      !$omp barrier
 
       !$omp parallel
       !$omp do schedule(runtime)
@@ -184,10 +173,7 @@ contains
       !$omp end do
       !$omp end parallel
 
-      !$omp barrier
-      !$omp master
       deallocate(effectiveDensityScratch)
-      !$omp end master
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -299,15 +299,13 @@ contains
       !*** compute modified T,S to account for displacement and
       !*** valid range
 
-      !$omp master
       allocate(tracerTemp(nVertLevels,nCells))
       allocate(tracerSalt(nVertLevels,nCells))
-      !$omp end master
-      !$omp barrier
 
       if (displacementType == 'surfaceDisplaced') then
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell, k, tq, sq)
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -319,10 +317,12 @@ contains
          enddo
          end do
          !$omp end do
+         !$omp end parallel
 
       else
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell, k, tq, sq)
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -332,16 +332,18 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       endif
 
 #ifdef MPAS_OPENACC
-      !$omp master
       !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt)
       !$acc parallel loop gang vector collapse(2) &
       !$acc&   present(density, p, p2, tracerTemp, tracerSalt)
 #else
-      !$omp  do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iCell, k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod)
 #endif
       do iCell=1,nCells
       do k=1,nVertLevels
@@ -392,17 +394,14 @@ contains
 #ifdef MPAS_OPENACC
       !$acc update host(density)
       !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt)
-      !$omp end master
-      !$omp barrier
 #else
       !$omp end do
+      !$omp end parallel
 #endif
 
       deallocate(p,p2)
-      !$omp master
       deallocate(tracerTemp)
       deallocate(tracerSalt)
-      !$omp end master
 
    !--------------------------------------------------------------------
 
@@ -571,15 +570,13 @@ contains
       !*** compute modified T,S to account for displacement and
       !*** valid range
 
-      !$omp master
       allocate(tracerTemp(nVertLevels,nCells))
       allocate(tracerSalt(nVertLevels,nCells))
-      !$omp end master
-      !$omp barrier
 
       if (displacementType == 'surfaceDisplaced') then
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell, k, tq, sq)
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -591,10 +588,12 @@ contains
          enddo
          end do
          !$omp end do
+         !$omp end parallel
 
       else
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell, k, tq, sq)
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -604,11 +603,11 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       endif
 
 #ifdef MPAS_OPENACC
-      !$omp master
       !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt, &
       !$acc&                  thermalExpansionCoeff,  &
       !$acc&                  salineContractionCoeff)
@@ -617,7 +616,10 @@ contains
       !$acc&           thermalExpansionCoeff,         &
       !$acc&           salineContractionCoeff)
 #else
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iCell, k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod, &
+      !$omp         denomk, drdt0, dkdt, drhodt, drds0, dkds, drhods)
 #endif
       do iCell=1,nCells
       do k=1,nVertLevels
@@ -717,17 +719,14 @@ contains
       !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt, &
       !$acc&                 thermalExpansionCoeff,  &
       !$acc&                 salineContractionCoeff)
-      !$omp end master
-      !$omp barrier
 #else
       !$omp end do
+      !$omp end parallel
 #endif
 
       deallocate(p,p2)
-      !$omp master
       deallocate(tracerTemp)
       deallocate(tracerSalt)
-      !$omp end master
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -305,7 +305,7 @@ contains
       if (displacementType == 'surfaceDisplaced') then
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell, k, tq, sq)
+         !$omp do schedule(runtime) private(k, tq, sq)
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -322,7 +322,7 @@ contains
       else
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell, k, tq, sq)
+         !$omp do schedule(runtime) private(k, tq, sq)
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -343,7 +343,7 @@ contains
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iCell, k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod)
+      !$omp private(k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod)
 #endif
       do iCell=1,nCells
       do k=1,nVertLevels
@@ -576,7 +576,7 @@ contains
       if (displacementType == 'surfaceDisplaced') then
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell, k, tq, sq)
+         !$omp do schedule(runtime) private(k, tq, sq)
          do iCell=1,nCells
          do k=1,nVertLevels
             tq = min(tracersSurfaceLayerValue(indexT,iCell), &
@@ -593,7 +593,7 @@ contains
       else
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell, k, tq, sq)
+         !$omp do schedule(runtime) private(k, tq, sq)
          do iCell=1,nCells
          do k = 1, nVertLevels
             tq = min(tracers(indexT,k,iCell), ocnEqStateTmax)
@@ -618,7 +618,7 @@ contains
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iCell, k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod, &
+      !$omp private(k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod, &
       !$omp         denomk, drdt0, dkdt, drhodt, drds0, dkds, drhods)
 #endif
       do iCell=1,nCells

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_linear.F
@@ -172,6 +172,7 @@ contains
 
       if (trim(displacementType) == 'surfaceDisplaced') then
 
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
          do k = 1, nVertLevels
@@ -186,9 +187,11 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       else  ! all other displacement types
 
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
          do k = 1, nVertLevels
@@ -203,6 +206,7 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       endif
 
@@ -306,6 +310,7 @@ contains
 
       if (trim(displacementType) == 'surfaceDisplaced') then
 
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
          do k = 1, nVertLevels
@@ -326,9 +331,11 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       else  ! all other displacement types
 
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
          do k = 1, nVertLevels
@@ -349,6 +356,7 @@ contains
          end do
          end do
          !$omp end do
+         !$omp end parallel
 
       endif
 

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -183,6 +183,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! Build surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
         do k = 1, maxLevelCell(iCell)
@@ -190,6 +191,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("frazil thickness tendency")
 
@@ -266,6 +268,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! add to surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
         do k = 1, maxLevelCell(iCell)
@@ -275,6 +278,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
    end subroutine ocn_frazil_forcing_active_tracers!}}}
 
@@ -427,7 +431,13 @@ contains
       nCells = nCellsArray( 2 )
 
       ! loop over all columns
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
+      !$omp         sumNewThicknessWeightedSaltContent, oceanFreezingTemperature, potential, &
+      !$omp         freezingEnergy, meltingEnergy, frazilSalinity, newFrazilIceThickness, &
+      !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, &
+      !$omp         meltedThicknessWeightedSaltContent)
       do iCell=1,nCells
 
         underLandIce = .false.
@@ -583,13 +593,16 @@ contains
 
       enddo   ! do iCell = 1, nCells
       !$omp end do
+      !$omp end parallel
 
       if ( config_frazil_use_surface_pressure ) then
+        !$omp parallel
         !$omp do schedule(runtime)
         do iCell = 1, nCells
            frazilSurfacePressure(iCell) = accumulatedFrazilIceMassNew(iCell) * gravity
         end do
         !$omp end do
+        !$omp end parallel
       end if
 
       call mpas_timer_stop("frazil")

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -462,7 +462,7 @@ contains
          nEdges = nEdgesArray(3)
          !$omp parallel
          !$omp do schedule(runtime) private(k, cell1, cell2, dcEdgeInv, &
-         !$omp& drhoDT, drhoDS, dTdx, dSdx, drhoDx)
+         !$omp       drhoDT, drhoDS, dTdx, dSdx, drhoDx)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -658,16 +658,16 @@ contains
          endif
 
          nEdges = nEdgesArray(3)
-         !$omp parallel
+         !!$omp parallel
 
          allocate (rightHandSide(nVertLevels))
          allocate (tridiagA(nVertLevels))
          allocate (tridiagB(nVertLevels))
          allocate (tridiagC(nVertLevels))
 
-         !$omp do schedule(runtime) &
-         !$omp private(cell1, cell2, k,  gradDensityTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge) &
-         !$omp firstprivate(tridiagA, tridiagB, tridiagC, rightHandSide, N)
+         !!$omp do schedule(runtime) &
+         !!$omp private(cell1, cell2, k,  gradDensityTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge) &
+         !!$omp firstprivate(tridiagA, tridiagB, tridiagC, rightHandSide, N)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -751,8 +751,8 @@ contains
                                       gmStreamFuncTopOfEdge(2:maxLevelEdgeTop(iEdge), iEdge), N)
             end if
          end do
-         !$omp end do
-         !$omp end parallel
+         !!$omp end do
+         !!$omp end parallel
 
          nEdges = nEdgesArray(3)
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -226,11 +226,7 @@ contains
       !$omp end master
       !$omp barrier
 
-      allocate (rightHandSide(nVertLevels))
-      allocate (tridiagA(nVertLevels))
-      allocate (tridiagB(nVertLevels))
-      allocate (tridiagC(nVertLevels))
-
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, nVertLevels
@@ -258,11 +254,6 @@ contains
          end do
       end do
       !$omp end do
-      allocate (dzTop(nVertLevels + 1))
-      allocate (dTdzTop(nVertLevels + 1))
-      allocate (dSdzTop(nVertLevels + 1))
-      allocate (k33Norm(nVertLevels + 1))
-
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          RediKappaScaling(:, iCell) = 1.0_RKIND
@@ -270,6 +261,12 @@ contains
          RediKappaSfcTaper(:, iCell) = 1.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
+
+      allocate (dzTop(nVertLevels + 1))
+      allocate (dTdzTop(nVertLevels + 1))
+      allocate (dSdzTop(nVertLevels + 1))
+      allocate (k33Norm(nVertLevels + 1))
 
       ! The following code computes scaling for Redi mixing terms and the slope triads
       ! It is only needed when redi mixing is enabled.
@@ -277,7 +274,9 @@ contains
 
       if ( config_Redi_use_N2_based_taper .and. .not. local_config_GM_kappa_lat_depth_variable ) then
 
-         !$omp do schedule(runtime) private(maxLocation, cell1, cell2, k, BruntVaisalaFreqTopEdge, maxN)
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(k, maxN, maxLocation, BruntVaisalaFreqTopEdge)
          do iCell = 1, nCells
             k = min(maxLevelCell(iCell) - 1, max(1, indMLD(iCell)))
             maxN = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
@@ -296,9 +295,11 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       if (config_Redi_use_surface_taper) then
+         !$omp parallel
          !$omp do schedule (runtime) private(zMLD, k)
          do iCell = 1, nCells
             k = max(1, indMLD(iCell))
@@ -309,12 +310,15 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       nCells = nCellsArray(3)
-      !$omp do schedule(runtime) private(i, k, iEdge, cell1, cell2, iCellSelf, &
-      !$omp& invAreaCell, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
-      !$omp& sfcTaper, sfcTaperUp, sfcTaperDown, slopeTaperDown, slopeTaperUp)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, k33Norm, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
+      !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
+      !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
@@ -427,6 +431,7 @@ contains
          k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
       end do ! iCell
       !$omp end do
+      !$omp end parallel
 
       endif  !config_use_redi
 
@@ -438,11 +443,13 @@ contains
       ! allow disabling of K33 for testing
       if (config_disable_redi_k33) then
          nCells = nCellsArray(size(nCellsArray))
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
             k33(:, iCell) = 0.0_RKIND
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       !--------------------------------------------------------------------
@@ -453,6 +460,7 @@ contains
 
       if (config_use_GM) then
          nEdges = nEdgesArray(3)
+         !$omp parallel
          !$omp do schedule(runtime) private(k, cell1, cell2, dcEdgeInv, &
          !$omp& drhoDT, drhoDS, dTdx, dSdx, drhoDx)
          do iEdge = 1, nEdges
@@ -515,6 +523,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
          ! based on stratification relative to the maximum in the column
@@ -544,6 +553,7 @@ contains
          ! For config_GM_closure = 'N2_dependent' or 'visbeck' compute a spatially variable
          ! baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
+            !$omp parallel
             !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, BruntVaisalaFreqTopEdge)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
@@ -573,13 +583,16 @@ contains
 
             end do
             !$omp end do
+            !$omp end parallel
 
          else !constant phase speed for config_GM_closure = 'constant'
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                cGMphaseSpeed(iEdge) = config_GM_constant_gravWaveSpeed
             end do
             !$omp end do
+            !$omp end parallel
          end if
 
          ! When config_GM_closure = 'visbeck' actually modify the value of gmBolusKappa based on
@@ -645,8 +658,16 @@ contains
          endif
 
          nEdges = nEdgesArray(3)
-         !$omp do schedule(runtime) private(cell1, cell2, k,  gradDensityTopOfEdge, &
-         !$omp& kappaGMEdge, BruntVaisalaFreqTopEdge, N)
+         !$omp parallel
+
+         allocate (rightHandSide(nVertLevels))
+         allocate (tridiagA(nVertLevels))
+         allocate (tridiagB(nVertLevels))
+         allocate (tridiagC(nVertLevels))
+
+         !$omp do schedule(runtime) &
+         !$omp private(cell1, cell2, k,  gradDensityTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge) &
+         !$omp firstprivate(tridiagA, tridiagB, tridiagC, rightHandSide, N)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -731,9 +752,11 @@ contains
             end if
          end do
          !$omp end do
+         !$omp end parallel
 
          nEdges = nEdgesArray(3)
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here
+         !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
             do k = 1, maxLevelEdgeTop(iEdge)
@@ -742,10 +765,12 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          nCells = nCellsArray(1)
 
          ! Interpolate gmStreamFuncTopOfEdge to cell centers for visualization
+         !$omp parallel
          !$omp do schedule(runtime) private(i, iEdge, areaEdge, k, rtmp)
          do iCell = 1, nCells
             gmStreamFuncTopOfCell(:, iCell) = 0.0_RKIND
@@ -767,11 +792,7 @@ contains
             gmStreamFuncTopOfCell(:, iCell) = gmStreamFuncTopOfCell(:, iCell)/areaCell(iCell)
          end do
          !$omp end do
-
-         deallocate (rightHandSide)
-         deallocate (tridiagA)
-         deallocate (tridiagB)
-         deallocate (tridiagC)
+         !$omp end parallel
 
       end if !end config_use_GM
 
@@ -919,11 +940,13 @@ contains
             local_config_GM_lat_variable_c2 = .false.
             local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_visbeck = .false.
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                gmBolusKappa(iEdge) = config_GM_kappa
             end do
             !$omp end do
+            !$omp end parallel
             RediGMinitValue = 1.0_RKIND
          else if (config_GM_closure == 'N2_dependent') then
             local_config_GM_lat_variable_c2 = .true.
@@ -931,11 +954,13 @@ contains
             local_config_GM_compute_visbeck = .false.
             RediGMinitValue = 0.0_RKIND
             ! for N2 dependence, we still assign Kappa as a constant.
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                gmBolusKappa(iEdge) = config_GM_kappa
             end do
             !$omp end do
+            !$omp end parallel
          else if (config_GM_closure == 'visbeck') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .false.
@@ -950,6 +975,7 @@ contains
               gmBolusKappa(iEdge) = config_GM_visbeck_max_kappa
             end do
             !$omp end do
+            !$omp end parallel
          else
             call mpas_log_write('Invalid choice of config_GM_closure.', MPAS_LOG_CRIT)
             err = 1
@@ -965,7 +991,8 @@ contains
             !$omp end do
             ! Nothing to do, as we just keep the same assignment as above.
          else if (config_eddying_resolution_taper == 'ramp') then
-            !$omp do schedule(runtime) 
+            !$omp parallel
+            !$omp do schedule(runtime) private( avgCellDiameter)
             do iEdge = 1, nEdges
                if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
                   gmResolutionTaper(iEdge) = 0.0_RKIND
@@ -978,6 +1005,7 @@ contains
                end if
             end do
             !$omp end do
+            !$omp end parallel
          else
             call mpas_log_write('Invalid choice of config_eddying_resolution_taper.', MPAS_LOG_CRIT)
             err = 1

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -52,23 +52,6 @@ module ocn_gm
    logical :: local_config_GM_kappa_lat_depth_variable
    real(kind=RKIND) :: slopeTaperFactor, sfcTaperFactor, rediGMinitValue
 
-   !--------------------------------------------------------------------                                          
-   !                                                                                                              
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.                                        
-   ! These variables were moved from the subroutines, but will be moved back once the                             
-   ! threading implementation is changed to more localized threading                                              
-   !                                                                                                              
-   !--------------------------------------------------------------------
-   ! gradDensityEdge: Normal gradient of density
-   !           units: none
-   real(kind=RKIND), dimension(:, :), allocatable :: gradDensityEdge
-   ! drhoDzTopOfEdge: Gradient of density in vertical on edges
-   !           units: None
-   real(kind=RKIND), dimension(:, :), allocatable :: drhoDzTopOfEdge
-   ! dzdxEdge: Gradient of depth at constant cell indes
-   !    units: None
-   real(kind=RKIND), dimension(:, :), allocatable :: dzdxEdge
-
 !***********************************************************************
 
 contains
@@ -159,6 +142,16 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
+      ! gradDensityEdge: Normal gradient of density
+      !           units: none
+      real(kind=RKIND), dimension(:, :), allocatable :: gradDensityEdge
+      ! drhoDzTopOfEdge: Gradient of density in vertical on edges
+      !           units: None
+      real(kind=RKIND), dimension(:, :), allocatable :: drhoDzTopOfEdge
+      ! dzdxEdge: Gradient of depth at constant cell indes
+      !    units: None
+      real(kind=RKIND), dimension(:, :), allocatable :: dzdxEdge
+
       type(mpas_pool_type), pointer :: tracersPool
       real(kind=RKIND), dimension(:, :, :), pointer :: activeTracers
       integer, pointer :: indexTemperature, indexSalinity
@@ -224,12 +217,9 @@ contains
       nCells = nCellsArray(size(nCellsArray))
       nEdges = nEdgesArray(size(nEdgesArray))
 
-      !$omp master
       allocate(gradDensityEdge(nVertLevels, nEdges), &
                dzdxEdge(nVertLevels, nEdges), &
                drhoDzTopOfEdge(nVertLevels, nEdges))
-      !$omp end master
-      !$omp barrier
 
       !$omp parallel
       !$omp do schedule(runtime) private(k)
@@ -808,12 +798,9 @@ contains
       end if !end config_use_GM
 
       ! Deallocate scratch variables
-      !!$omp barrier
-      !!$omp master
       deallocate(dzdxEdge, &
                  drhoDzTopOfEdge, &
                  gradDensityEdge)
-      !!$omp end master
       call mpas_timer_stop('gm bolus velocity')
 
    end subroutine ocn_GM_compute_Bolus_velocity!}}}

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -561,7 +561,8 @@ contains
          ! baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, BruntVaisalaFreqTopEdge)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, &
+            !$omp             BruntVaisalaFreqTopEdge, lt1, lt2)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
@@ -612,9 +613,9 @@ contains
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
            call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
            call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
-!           !$omp parallel
+           !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
-           !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge)
+           !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2)
            do iEdge = 1, nEdges
               k=1
               sumN2 = 0.0_RKIND
@@ -654,8 +655,8 @@ contains
                 gmBolusKappa(iEdge) = config_GM_visbeck_min_kappa
              end if
            end do
-           !omp end do
-!           !omp end parallel
+           !$omp end do
+           !$omp end parallel
          end if
 
          if(config_Redi_set_RediKappa_to_GMKappa) then
@@ -669,10 +670,10 @@ contains
          endif
 
          nEdges = nEdgesArray(3)
-!         !$omp parallel
-!         !$omp do schedule(runtime) private(cell1, cell2, k, gradDensityTopOfEdge, dzdxTopOfEdge, &
-!         !$omp             gradDensityConstZTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge, N) &
-!         !$omp firstprivate(tridiagB, tridiagC, rightHandSide, tridiagA)
+         !!$omp parallel
+         !!$omp do schedule(runtime) private(cell1, cell2, k, gradDensityTopOfEdge, dzdxTopOfEdge, &
+         !!$omp             gradDensityConstZTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge, N) &
+         !!$omp firstprivate(tridiagB, tridiagC, rightHandSide, tridiagA)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -756,8 +757,8 @@ contains
                                       gmStreamFuncTopOfEdge(2:maxLevelEdgeTop(iEdge), iEdge), N)
             end if
          end do
-!         !$omp end do
-!         !$omp end parallel
+         !!$omp end do
+         !!$omp end parallel
 
          nEdges = nEdgesArray(3)
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here
@@ -807,12 +808,12 @@ contains
       end if !end config_use_GM
 
       ! Deallocate scratch variables
-      !$omp barrier
-      !$omp master
+      !!$omp barrier
+      !!$omp master
       deallocate(dzdxEdge, &
                  drhoDzTopOfEdge, &
                  gradDensityEdge)
-      !$omp end master
+      !!$omp end master
       call mpas_timer_stop('gm bolus velocity')
 
    end subroutine ocn_GM_compute_Bolus_velocity!}}}

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -970,6 +970,7 @@ contains
             call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge=1,nEdges
               betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
@@ -993,7 +994,7 @@ contains
             ! Nothing to do, as we just keep the same assignment as above.
          else if (config_eddying_resolution_taper == 'ramp') then
             !$omp parallel
-            !$omp do schedule(runtime) private( avgCellDiameter)
+            !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
                if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
                   gmResolutionTaper(iEdge) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -318,8 +318,8 @@ contains
       !$omp do schedule(runtime) &
       !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
       !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
-      !$omp         slopeTriadUp, slopeTriadDown, &
-      !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
+      !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper) &
+      !$omp firstprivate(slopeTriadUp, slopeTriadDown)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -216,6 +216,11 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
+      allocate (rightHandSide(nVertLevels))
+      allocate (tridiagA(nVertLevels))
+      allocate (tridiagB(nVertLevels))
+      allocate (tridiagC(nVertLevels))
+
       nCells = nCellsArray(size(nCellsArray))
       nEdges = nEdgesArray(size(nEdgesArray))
 
@@ -254,6 +259,7 @@ contains
          end do
       end do
       !$omp end do
+
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          RediKappaScaling(:, iCell) = 1.0_RKIND
@@ -275,8 +281,7 @@ contains
       if ( config_Redi_use_N2_based_taper .and. .not. local_config_GM_kappa_lat_depth_variable ) then
 
          !$omp parallel
-         !$omp do schedule(runtime) &
-         !$omp private(k, maxN, maxLocation, BruntVaisalaFreqTopEdge)
+         !$omp do schedule(runtime) private(maxLocation, k, BruntVaisalaFreqTopEdge, maxN)
          do iCell = 1, nCells
             k = min(maxLevelCell(iCell) - 1, max(1, indMLD(iCell)))
             maxN = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
@@ -315,7 +320,7 @@ contains
 
       nCells = nCellsArray(3)
       !$omp parallel
-      !$omp do schedule(runtime) &
+      !$omp do schedule(runtime)  &
       !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
       !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
       !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper) &
@@ -462,8 +467,9 @@ contains
       if (config_use_GM) then
          nEdges = nEdgesArray(3)
          !$omp parallel
-         !$omp do schedule(runtime) private(k, cell1, cell2, dcEdgeInv, &
-         !$omp       drhoDT, drhoDS, dTdx, dSdx, drhoDx)
+         !$omp do schedule(runtime) &
+         !$omp private(cell1, cell2, dcEdgeInv, k, drhoDT, drhoDS, dTdx, dSdx, drhoDx, dTdz, dSdz, &
+         !$omp         drhodz1, drhodz2)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -606,8 +612,9 @@ contains
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
            call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
            call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
+!           !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
-           !$omp& zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge)
+           !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge)
            do iEdge = 1, nEdges
               k=1
               sumN2 = 0.0_RKIND
@@ -633,7 +640,7 @@ contains
                 zEdge = zEdge - layerThicknessEdge(k-1,iEdge)
               end do
 
-             if (countN2 > 0) then
+              if (countN2 > 0) then
                 c_visbeck(iEdge) = sqrt(sumN2*ltsum)
                 sumRi = sumRi / (ltsum + 1.0E-11_RKIND)
 
@@ -648,27 +655,24 @@ contains
              end if
            end do
            !omp end do
+!           !omp end parallel
          end if
 
          if(config_Redi_set_RediKappa_to_GMKappa) then
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                RediKappa(iEdge) = gmResolutionTaper(iEdge)*gmBolusKappa(iEdge)
             end do
             !$omp end do
+            !$omp end parallel
          endif
 
          nEdges = nEdgesArray(3)
-         !!$omp parallel
-
-         allocate (rightHandSide(nVertLevels))
-         allocate (tridiagA(nVertLevels))
-         allocate (tridiagB(nVertLevels))
-         allocate (tridiagC(nVertLevels))
-
-         !!$omp do schedule(runtime) &
-         !!$omp private(cell1, cell2, k,  gradDensityTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge) &
-         !!$omp firstprivate(tridiagA, tridiagB, tridiagC, rightHandSide, N)
+!         !$omp parallel
+!         !$omp do schedule(runtime) private(cell1, cell2, k, gradDensityTopOfEdge, dzdxTopOfEdge, &
+!         !$omp             gradDensityConstZTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge, N) &
+!         !$omp firstprivate(tridiagB, tridiagC, rightHandSide, tridiagA)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
@@ -752,8 +756,8 @@ contains
                                       gmStreamFuncTopOfEdge(2:maxLevelEdgeTop(iEdge), iEdge), N)
             end if
          end do
-         !!$omp end do
-         !!$omp end parallel
+!         !$omp end do
+!         !$omp end parallel
 
          nEdges = nEdgesArray(3)
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here
@@ -794,6 +798,11 @@ contains
          end do
          !$omp end do
          !$omp end parallel
+
+         deallocate (rightHandSide)
+         deallocate (tridiagA)
+         deallocate (tridiagB)
+         deallocate (tridiagC)
 
       end if !end config_use_GM
 
@@ -986,11 +995,13 @@ contains
 
          ! Add resolution taper
          if (config_eddying_resolution_taper == 'none') then
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1,nEdges
                gmResolutionTaper(iEdge) = 1.0_RKIND
             end do
             !$omp end do
+            !$omp end parallel
             ! Nothing to do, as we just keep the same assignment as above.
          else if (config_eddying_resolution_taper == 'ramp') then
             !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -316,8 +316,9 @@ contains
       nCells = nCellsArray(3)
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(invAreaCell, k33Norm, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
+      !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
       !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
+      !$omp         slopeTriadUp, slopeTriadDown, &
       !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_high_freq_thickness_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_high_freq_thickness_hmix_del2.F
@@ -136,6 +136,7 @@ contains
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, hhf_turb_flux, flux)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND / areaCell(iCell)
@@ -159,6 +160,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("thick hmix del2")
 

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -227,8 +227,6 @@ contains
       !*** end of preamble, begin code
       !***
 
-      !$omp master
-
       blockCount = 0
       block => domain%blocklist
       do while (associated(block))
@@ -593,9 +591,6 @@ contains
          block => block%next
       end do
 
-      !$omp end master
-      !$omp barrier
-
 !-------------------------------------------------------------------------------
 
    end subroutine ocn_meshCreate !}}}
@@ -634,9 +629,6 @@ contains
       !***
 
       err = 0
-
-      !$omp barrier
-      !$omp master
 
       ! First remove data from the device. Must remove components first,
       ! then remove the mesh type itself.
@@ -820,8 +812,6 @@ contains
                   edgeSignOnVertex, &
                   highOrderAdvectionMask)
 
-      !$omp end master
-
 !-------------------------------------------------------------------------------
 
    end subroutine ocn_meshDestroy !}}}
@@ -873,8 +863,6 @@ contains
       !***
       !*** end of preamble, begin code
       !***
-
-      !$omp master
 
       ! already check during create that there should only be one block
       block => domain%blocklist
@@ -1162,9 +1150,6 @@ contains
       !$acc               derivTwo,                 &
       !$acc               cellTangentPlane,         &
       !$acc               coeffs_reconstruct)
-
-      !$omp end master
-      !$omp barrier
 
 !-------------------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_sea_ice.F
@@ -136,7 +136,10 @@ contains
 
       density_ice = rho_ice
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iCell, maxLevel, netEnergyChange, k, freezingTemp, availableEnergyChange, &
+      !$omp         energyChange, temperatureChange, thicknessChange, iceThicknessChange, iTracer)
       do iCell = 1, nCellsSolve ! Check performance of these two loop definitions
 !     do iCell = nCellsSolve, 1, -1
          maxLevel = min(maxLevelCell(iCell), verticalLevelCap)
@@ -242,6 +245,7 @@ contains
          end if
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(iceTracer)
 

--- a/src/core_ocean/shared/mpas_ocn_sea_ice.F
+++ b/src/core_ocean/shared/mpas_ocn_sea_ice.F
@@ -138,7 +138,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iCell, maxLevel, netEnergyChange, k, freezingTemp, availableEnergyChange, &
+      !$omp private(maxLevel, netEnergyChange, k, freezingTemp, availableEnergyChange, &
       !$omp         energyChange, temperatureChange, thicknessChange, iceThicknessChange, iTracer)
       do iCell = 1, nCellsSolve ! Check performance of these two loop definitions
 !     do iCell = nCellsSolve, 1, -1

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -197,6 +197,7 @@ contains
       nCells = nCellsArray( 3 )
 
       ! Convert coupled climate model wind stress to MPAS-O wind stress
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, zonalAverage, meridionalAverage)
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1, iEdge)
@@ -217,6 +218,7 @@ contains
                                       + windStressMeridional(iCell)**2 )
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("bulk_ws")
 
@@ -295,6 +297,7 @@ contains
       nCells = nCellsArray( 3 )
 
       ! Build surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
         surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + ( snowFlux(iCell) + rainFlux(iCell) + evaporationFlux(iCell) &
@@ -302,6 +305,7 @@ contains
         surfaceThicknessFluxRunoff(iCell) = riverRunoffFlux(iCell) / rho_sw
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("bulk_thick")
 
@@ -429,6 +433,7 @@ contains
       nCells = nCellsArray( 3 )
 
       ! Build surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime) private(allowedSalt, requiredSalt)
       do iCell = 1, nCells
         tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
@@ -457,6 +462,7 @@ contains
         end if
       end do
       !$omp end do
+      !$omp end parallel
       ! assume that snow comes in at 0 C
 
       ! Surface fluxes of water have an associated heat content, but the coupled system does not account for this
@@ -465,6 +471,7 @@ contains
       ! Only include this heat forcing when bulk thickness is turned on
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (bulkThicknessFluxOn) then
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
 
@@ -488,14 +495,17 @@ contains
 
          end do
          !$omp end do
+         !$omp end parallel
       endif ! bulkThicknessFluxOn
 
       ! convert short wave heat flux to a temperature flux
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          penetrativeTemperatureFlux(iCell) = shortWaveHeatFlux(iCell) * hflux_factor
       end do
       !$omp end do
+      !$omp end parallel
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -927,8 +927,8 @@ contains
     err = 0
     cpRatio = cp_land_ice/cp_sw
     !$omp parallel
-    !$omp do schedule(runtime) reduction(+:err) &
-    !$omp private(T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c)
+    !$omp do schedule(runtime) &
+    !$omp private(T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c, err)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -495,7 +495,7 @@ contains
 
       if(isomipOn) then
          !$omp parallel
-         !$omp do schedule(runtime) private(iCell, freshwaterFlux, heatFlux)
+         !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
             if (landIceMask(iCell) == 0) cycle
 
@@ -780,7 +780,7 @@ contains
     Tlatent = latent_heat_fusion_mks/cp_sw
 
     !$omp parallel
-    !$omp do schedule(runtime) private(iCell, T0, dTf_dS, transferVelocityRatio, a, b, c)
+    !$omp do schedule(runtime) private(T0, dTf_dS, transferVelocityRatio, a, b, c)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 
@@ -928,7 +928,7 @@ contains
     cpRatio = cp_land_ice/cp_sw
     !$omp parallel
     !$omp do schedule(runtime) reduction(+:err) &
-    !$omp private(iCell, T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c)
+    !$omp private(T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -205,6 +205,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
       call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
 
+      !$omp parallel
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         surfaceStress(iEdge) = surfaceStress(iEdge) + topDrag(iEdge)
@@ -217,6 +218,7 @@ contains
         surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + topDragMagnitude(iCell)
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("top_drag")
 
@@ -284,11 +286,13 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
 
       ! Build surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
         surfaceThicknessFlux(iCell) = surfaceThicknessFlux(iCell) + landIceFreshwaterFlux(iCell) / rho_sw
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("land_ice_thick")
 
@@ -352,11 +356,13 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
 
       ! add to surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
         tracersSurfaceFlux(1, iCell) = tracersSurfaceFlux(1, iCell) + landIceHeatFlux(iCell)/(rho_sw*cp_sw)
       end do
       !$omp end do
+      !$omp end parallel
 
    end subroutine ocn_surface_land_ice_fluxes_active_tracers!}}}
 
@@ -488,7 +494,8 @@ contains
       nCells = nCellsArray( size(nCellsArray) )
 
       if(isomipOn) then
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iCell, freshwaterFlux, heatFlux)
          do iCell = 1, nCells
             if (landIceMask(iCell) == 0) cycle
 
@@ -518,6 +525,7 @@ contains
 
          end do
          !$omp end do
+         !$omp end parallel
       end if
 
       if(jenkinsOn .or. hollandJenkinsOn) then
@@ -771,7 +779,8 @@ contains
     err = 0
     Tlatent = latent_heat_fusion_mks/cp_sw
 
-    !$omp do schedule(runtime)
+    !$omp parallel
+    !$omp do schedule(runtime) private(iCell, T0, dTf_dS, transferVelocityRatio, a, b, c)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 
@@ -815,6 +824,7 @@ contains
       outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*outInterfaceTemperature(iCell)
     end do
     !$omp end do
+    !$omp end parallel
 
   !--------------------------------------------------------------------
 
@@ -916,7 +926,9 @@ contains
 
     err = 0
     cpRatio = cp_land_ice/cp_sw
-    !$omp do schedule(runtime) reduction(+:err)
+    !$omp parallel
+    !$omp do schedule(runtime) reduction(+:err) &
+    !$omp private(iCell, T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c)
     do iCell = 1, nCells
       if (mask(iCell) == 0) cycle
 
@@ -958,6 +970,7 @@ contains
       outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*iceTemperature(iCell)
     end do
     !$omp end do
+    !$omp end parallel
 
   !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -61,26 +61,6 @@ module ocn_surface_land_ice_fluxes
 
    real (kind=RKIND) :: cp_land_ice, rho_land_ice
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_surface_land_ice_fluxes_build_arrays
-   !---
-   ! freezeInterfaceSalinity: salinity at land ice-ocean interface where freezing is occurring
-   !                   units: PSU
-   real (kind=RKIND), dimension(:), allocatable :: freezeInterfaceSalinity
-   ! freezeInterfaceTemperature: temperature at land ice-ocean interface where freezing is occurring
-   !                      units: degrees C
-   real (kind=RKIND), dimension(:), allocatable :: freezeInterfaceTemperature
-   real (kind=RKIND), dimension(:), allocatable :: freezeFreshwaterFlux
-   real (kind=RKIND), dimension(:), allocatable :: freezeHeatFlux
-   real (kind=RKIND), dimension(:), allocatable :: freezeIceHeatFlux
-
 !***********************************************************************
 
 contains
@@ -442,6 +422,18 @@ contains
                                                     landIceTracerTransferVelocities
       integer, pointer :: indexBLT, indexBLS, indexIT, indexIS, indexHeatTrans, indexSaltTrans
 
+      ! Scratch Arrays
+      !---
+      ! freezeInterfaceSalinity: salinity at land ice-ocean interface where freezing is occurring
+      !                   units: PSU
+      real (kind=RKIND), dimension(:), allocatable :: freezeInterfaceSalinity
+      ! freezeInterfaceTemperature: temperature at land ice-ocean interface where freezing is occurring
+      !                      units: degrees C
+      real (kind=RKIND), dimension(:), allocatable :: freezeInterfaceTemperature
+      real (kind=RKIND), dimension(:), allocatable :: freezeFreshwaterFlux
+      real (kind=RKIND), dimension(:), allocatable :: freezeHeatFlux
+      real (kind=RKIND), dimension(:), allocatable :: freezeIceHeatFlux
+
       err = 0
 
       if ( .not. standaloneOn ) return
@@ -481,14 +473,11 @@ contains
       if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
 
-         !$omp master
          allocate(freezeInterfaceSalinity(nCells), &
                   freezeInterfaceTemperature(nCells), &
                   freezeFreshwaterFlux(nCells), &
                   freezeHeatFlux(nCells), &
                   freezeIceHeatFlux(nCells))
-         !$omp end master
-         !$omp barrier
       end if
 
       nCells = nCellsArray( size(nCellsArray) )
@@ -616,14 +605,11 @@ contains
       end if
 
       if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
-         !$omp barrier
-         !$omp master
          deallocate(freezeInterfaceSalinity, &
                     freezeInterfaceTemperature, &
                     freezeFreshwaterFlux, &
                     freezeHeatFlux, &
                     freezeIceHeatFlux)
-         !$omp end master
       end if
 
       ! accumulate land-ice mass and heat

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -92,19 +92,6 @@ module ocn_tendency
 
    integer :: apply_Dhf_to_hhf, use_highFreqThick_restore
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_tend_tracer
-   ! normalThicknessFlux: Flux of thickness through an edge
-   !               units: m^{2} s^{-1}
-   real (kind=RKIND), dimension(:,:), allocatable :: normalThicknessFlux
-
 !***********************************************************************
 
 contains
@@ -516,6 +503,11 @@ contains
       integer :: err, iCell, iEdge, k, timeLevel, nTracersEcosys
       logical :: activeTracersOnly, isActiveTracer    ! if true, only compute for active tracers
 
+      ! Scratch Arrays
+      ! normalThicknessFlux: Flux of thickness through an edge
+      !               units: m^{2} s^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: normalThicknessFlux
+
       !
       ! set time level of optional argument is present
       !
@@ -588,10 +580,7 @@ contains
 
       call mpas_timer_start("ocn_tend_tracer")
 
-      !$omp master
       allocate(normalThicknessFlux(nVertLevels, nEdges+1))
-      !$omp end master
-      !$omp barrier
 
       !
       ! transport velocity for the tracer.
@@ -979,10 +968,7 @@ contains
          end if
       end do
 
-      !$omp barrier
-      !$omp master
       deallocate(normalThicknessFlux)
-      !$omp end master
 
       call mpas_timer_stop("ocn_tend_tracer")
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -153,6 +153,7 @@ contains
       !
       ! height tendency: start accumulating tendency terms
       !
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          tend_layerThickness(:, iCell) = 0.0_RKIND
@@ -160,6 +161,7 @@ contains
          surfaceThicknessFluxRunoff(iCell) = 0.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
 
       if(config_disable_thick_all_tend) return
 
@@ -296,6 +298,7 @@ contains
       !
       ! velocity tendency: start accumulating tendency terms
       !
+      !$omp parallel
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          tend_normalVelocity(:, iEdge) = 0.0_RKIND
@@ -308,6 +311,7 @@ contains
          surfaceStressMagnitude(iCell) = 0.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
 
       if(config_disable_vel_all_tend) return
 
@@ -394,11 +398,13 @@ contains
       !
       ! velocity tendency: zero if drying
       !
+      !$omp parallel
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          tend_normalVelocity(:, iEdge) = tend_normalVelocity(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       ! velocity tendency: vertical mixing d/dz( nu_v du/dz))
@@ -590,6 +596,7 @@ contains
       !
       ! transport velocity for the tracer.
       !
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, nVertLevels
@@ -597,6 +604,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       !
       ! begin iterate over tracer categories
@@ -654,31 +662,32 @@ contains
                !
                ! initialize tracer surface flux and tendency to zero.
                !
+               !$omp parallel
                !$omp do schedule(runtime)
                do iCell = 1, nCells
                  tracerGroupTend(:,:, iCell) = 0.0_RKIND
                  tracerGroupSurfaceFlux(:, iCell) = 0.0_RKIND
                end do
                !$omp end do
+               !$omp end parallel
 
                !
                ! fill components of surface tracer flux
                !
                if (config_use_tracerGroup_surface_bulk_forcing) then
+                  !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
                     tracerGroupSurfaceFluxRunoff(:, iCell) = 0.0_RKIND
                     tracerGroupSurfaceFluxRemoved(:, iCell) = 0.0_RKIND
                   end do
                   !$omp end do
+                  !$omp end parallel
 
                   call ocn_surface_bulk_forcing_tracers(meshPool, groupItr % memberName, forcingPool, tracerGroup, &
                                                         tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff, &
                                                         tracerGroupSurfaceFluxRemoved, dt, layerThickness, err)
                end if
-
-
-               !$omp master
 
                !
                ! compute ecosystem source-sink tendencies and net surface fluxes
@@ -725,10 +734,6 @@ contains
                      nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                endif
 
-               !$omp end master
-               call mpas_threading_barrier()
-
-               !
                ! ocean surface restoring
                !
                  if (config_use_tracerGroup_surface_restoring) then
@@ -880,11 +885,13 @@ contains
                !
                if (config_compute_active_tracer_budgets) then
                   if ( trim(groupItr % memberName) == 'activeTracers' ) then
+                     !$omp parallel
                      !$omp do schedule(runtime)
                      do iCell = 1, nCells
                         activeTracerSurfaceFluxTendency(:,:,iCell) = tracerGroupTend(:,:,iCell)
                      end do
                      !$omp end do
+                     !$omp end parallel
                   endif
                endif
 
@@ -898,6 +905,7 @@ contains
                if ( trim(groupItr % memberName) == 'activeTracers' ) then
 
                   if (config_compute_active_tracer_budgets) then
+                     !$omp parallel
                      !$omp do schedule(runtime)
                      do iCell = 1, nCells
                         activeTracerSurfaceFluxTendency(:,:,iCell) = tracerGroupTend(:,:,iCell) &
@@ -905,18 +913,21 @@ contains
                         temperatureShortWaveTendency(:,iCell) = tracerGroupTend(indexTemperature,:,iCell)
                      end do
                      !$omp end do
+                     !$omp end parallel
                   endif
 
                   call ocn_tracer_short_wave_absorption_tend(meshPool, swForcingPool, forcingPool, indexTemperature, &
                            layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tracerGroupTend, err)
 
                   if (config_compute_active_tracer_budgets) then
+                     !$omp parallel
                      !$omp do schedule(runtime)
                      do iCell = 1, nCells
                         temperatureShortWaveTendency(:,iCell) = tracerGroupTend(indexTemperature,:,iCell) - &
                                         temperatureShortWaveTendency(:,iCell)
                      end do
                      !$omp end do
+                     !$omp end parallel
                   endif
                endif
 
@@ -929,19 +940,23 @@ contains
                   if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
                      if( trim(groupItr % memberName) == 'activeTracers' ) then
                         if (config_compute_active_tracer_budgets) then
+                           !$omp parallel
                            !$omp do schedule(runtime)
                            do iCell = 1, nCells
                               activeTracerNonLocalTendency(:,:,iCell) = tracerGroupTend(:,:,iCell)
                            end do
                            !$omp end do
+                           !$omp end parallel
                         endif
                         call ocn_tracer_nonlocalflux_tend(meshPool, vertNonLocalFlux, nonLocalSurfaceTracerFlux, tracerGroupTend, err)
                         if (config_compute_active_tracer_budgets) then
+                           !$omp parallel
                            !$omp do schedule(runtime)
                            do iCell = 1, nCells
                               activeTracerNonLocalTendency(:,:,iCell) = tracerGroupTend(:,:,iCell)-activeTracerNonLocalTendency(:,:,iCell)
                            end do
                            !$omp end do
+                           !$omp end parallel
                         endif
                      else
                         call ocn_tracer_nonlocalflux_tend(meshPool, vertNonLocalFlux, tracerGroupSurfaceFlux, tracerGroupTend, err)
@@ -1045,7 +1060,9 @@ contains
 
       allocate(div_hu(nVertLevels))
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(div_hu, div_hu_btr, invAreaCell, i, iEdge, k, flux, totalThickness)
       do iCell = 1, nCells
         tend_lowFreqDivergence(:, iCell) = 0.0_RKIND
         tend_highFreqThickness(:, iCell) = 0.0_RKIND
@@ -1078,6 +1095,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(div_hu)
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -298,7 +298,7 @@ contains
       !
       ! velocity tendency: start accumulating tendency terms
       !
-      !$omp parallel
+      !$omp Parallel
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          tend_normalVelocity(:, iEdge) = 0.0_RKIND
@@ -734,6 +734,7 @@ contains
                      nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                endif
 
+               !
                ! ocean surface restoring
                !
                  if (config_use_tracerGroup_surface_restoring) then
@@ -856,11 +857,13 @@ contains
                if(trim(groupItr % memberName)=='activeTracers') then
                  isActiveTracer = .true.
                  if (config_compute_active_tracer_budgets) then
+                    !$omp parallel
                     !$omp do schedule(runtime)
                     do iCell = 1, nCells
                       activeTracerHorMixTendency(:,:,iCell) = tracerGroupTend(:,:,iCell)
                     enddo
                     !$omp end do
+                    !$omp end parallel
                  endif
                endif
                call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
@@ -870,12 +873,14 @@ contains
                if(trim(groupItr % memberName)=='activeTracers') then
                  isActiveTracer = .true.
                  if (config_compute_active_tracer_budgets) then
+                    !$omp parallel
                     !$omp do schedule(runtime)
                     do iCell = 1, nCells
                       activeTracerHorMixTendency(:,:,iCell) = tracerGroupTend(:,:,iCell) - &
                                   activeTracerHorMixTendency(:,:,iCell)
                     enddo
                     !$omp end do
+                    !$omp end parallel
                  endif
                endif
  
@@ -1061,8 +1066,8 @@ contains
       allocate(div_hu(nVertLevels))
 
       !$omp parallel
-      !$omp do schedule(runtime) &
-      !$omp private(div_hu, div_hu_btr, invAreaCell, i, iEdge, k, flux, totalThickness)
+      !$omp do schedule(runtime) private(div_hu_btr, invAreaCell, i, iEdge, k, flux, totalThickness) &
+      !$omp firstprivate(div_hu)
       do iCell = 1, nCells
         tend_lowFreqDivergence(:, iCell) = 0.0_RKIND
         tend_highFreqThickness(:, iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_test.F
+++ b/src/core_ocean/shared/mpas_ocn_test.F
@@ -59,23 +59,6 @@ module ocn_test
 
    logical :: hmixOn
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! yGMStreamFuncSolution: GM stream function reconstructured to the cell centers,
-   !                        for analytic solution
-   !                 units: m^2
-   real(kind=RKIND), dimension(:,:), allocatable :: yGMStreamFuncSolution
-   ! yGMBolusVelocitySolution: Bolus velocity in Gent-McWilliams eddy parameterization,
-   !                           y-direction, for analytic solution
-   !                    units: m s
-   real(kind=RKIND), dimension(:,:), allocatable :: yGMBolusVelocitySolution
-
 !***********************************************************************
 
 contains
@@ -299,6 +282,16 @@ contains
       real(kind=RKIND), dimension(:), pointer   :: bottomDepth, refBottomDepthTopOfCell, yCell, yEdge
       real(kind=RKIND), dimension(:,:), pointer :: zMid
 
+      ! Scratch Arrays
+      ! yGMStreamFuncSolution: GM stream function reconstructured to the cell centers,
+      !                        for analytic solution
+      !                 units: m^2
+      real(kind=RKIND), dimension(:,:), allocatable :: yGMStreamFuncSolution
+      ! yGMBolusVelocitySolution: Bolus velocity in Gent-McWilliams eddy parameterization,
+      !                           y-direction, for analytic solution
+      !                    units: m s
+      real(kind=RKIND), dimension(:,:), allocatable :: yGMBolusVelocitySolution
+
       integer :: nVertLevels
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -312,11 +305,8 @@ contains
 
       nVertLevels = maxval(maxLevelCell)
 
-      !$omp master
       allocate(yGMStreamFuncSolution(nVertLevels + 1, nCells), &
                yGMBolusVelocitySolution(nVertLevels, nCells))
-      !$omp end master
-      !$omp barrier
 
       ! These are flags that must match your initial conditions settings.  See gm_analytic initial condition in mode_init.
       config_gm_analytic_temperature2 = 10
@@ -360,11 +350,8 @@ contains
       !$omp end do
       !$omp end parallel
 
-      !$omp barrier
-      !$omp master
       deallocate(yGMStreamFuncSolution, &
                  yGMBolusVelocitySolution)
-      !$omp end master
 
    end subroutine ocn_init_gm_test_functions!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_test.F
+++ b/src/core_ocean/shared/mpas_ocn_test.F
@@ -335,6 +335,7 @@ contains
       c1 = R*(1-exp(-zBot/L))/(exp(zBot/L) - exp(-zBot/L))
       c2 = R-c1
 
+      !$omp parallel
       !$omp do schedule(runtime) private(k, zTop)
       do iCell = 1, nCells
 
@@ -357,6 +358,7 @@ contains
 
       end do
       !$omp end do
+      !$omp end parallel
 
       !$omp barrier
       !$omp master

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -211,7 +211,7 @@ contains
 
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp private(iCell, kMax, prelim_ALE_Thickness, remainder, k, newThickness, &
+         !$omp private(kMax, prelim_ALE_Thickness, remainder, k, newThickness, &
          !$omp         min_ALE_thickness_down, min_ALE_thickness_up)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -144,6 +144,7 @@ contains
       !
       if (configALEthicknessProportionality==1) then ! restingThickness_times_weights
 
+         !$omp parallel
          !$omp do schedule(runtime) private(kMax, thicknessSum, k)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
@@ -162,8 +163,10 @@ contains
             end do
          enddo
          !$omp end do
+         !$omp end parallel
    
          elseif (configALEthicknessProportionality==2) then ! weights_only
+         !$omp parallel
          !$omp do schedule(runtime) private(kMax, weightSum, k)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
@@ -184,9 +187,11 @@ contains
             end do
          enddo
          !$omp end do
+         !$omp end parallel
       endif
 
       if (thicknessFilterActive) then
+         !$omp parallel
          !$omp do schedule(runtime) private(kMax)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
@@ -196,6 +201,7 @@ contains
               + newHighFreqThickness(1:kMax,iCell)
          enddo
          !$omp end do
+         !$omp end parallel
       end if
 
       !
@@ -203,7 +209,10 @@ contains
       !
       if (config_use_min_max_thickness) then
 
-         !$omp do schedule(runtime) private(kMax, remainder, k, newThickness)
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(iCell, kMax, prelim_ALE_Thickness, remainder, k, newThickness, &
+         !$omp         min_ALE_thickness_down, min_ALE_thickness_up)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
 
@@ -235,6 +244,7 @@ contains
 
          enddo
          !$omp end do
+         !$omp end parallel
 
       endif ! config_use_min_max_thickness
 

--- a/src/core_ocean/shared/mpas_ocn_thick_hadv.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_hadv.F
@@ -149,6 +149,7 @@ contains
 
       nCells = nCellsArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
@@ -161,6 +162,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("thick hadv")
 

--- a/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
@@ -134,6 +134,7 @@ contains
 
       nCells = nCellsArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(remainingFlux, remainingFluxRunoff, k)
       do iCell = 1, nCells
         remainingFlux = 1.0_RKIND
@@ -156,6 +157,7 @@ contains
         end if
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("thick surface flux")
 

--- a/src/core_ocean/shared/mpas_ocn_thick_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_vadv.F
@@ -133,6 +133,7 @@ contains
 
       nCells = nCellsArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
@@ -140,6 +141,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("thick vadv")
 

--- a/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
@@ -124,6 +124,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! Build surface fluxes at cell centers
+      !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
         do k = 1, maxLevelCell(iCell)
@@ -133,6 +134,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("tidal thickness tendency")
 

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -86,6 +86,7 @@ module ocn_time_average_coupled
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
 
+        !$omp parallel
         !$omp do schedule(runtime)
         do iCell = 1, nCells
            avgSurfaceVelocity(:, iCell) = 0.0_RKIND
@@ -93,12 +94,14 @@ module ocn_time_average_coupled
            avgSSHGradient(:, iCell) = 0.0_RKIND
         end do
         !$omp end do
+        !$omp end parallel
 
         if(trim(config_land_ice_flux_mode) == 'coupled') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)
            call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
            call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgLandIceBoundaryLayerTracers(:, iCell) = 0.0_RKIND
@@ -106,6 +109,7 @@ module ocn_time_average_coupled
               avgEffectiveDensityInLandIce(iCell) = 0.0_RKIND
            end do
            !$omp end do
+           !$omp end parallel
         end if
 
         !  set up BGC coupling fields if necessary
@@ -125,6 +129,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgCO2_gas_flux(iCell) = 0.0_RKIND
@@ -140,6 +145,7 @@ module ocn_time_average_coupled
               avgOceanSurfaceFeDissolved(iCell) = 0.0_RKIND
            end do
            !$omp end do
+           !$omp end parallel
         end if
 
         if (config_use_DMSTracers) then
@@ -148,12 +154,14 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(DMSSeaIceCoupling, 'avgOceanSurfaceDMS', avgOceanSurfaceDMS)
            call mpas_pool_get_array(DMSSeaIceCoupling, 'avgOceanSurfaceDMSP', avgOceanSurfaceDMSP)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgOceanSurfaceDMS(iCell) = 0.0_RKIND
               avgOceanSurfaceDMSP(iCell) = 0.0_RKIND
            end do
            !$omp end do
+           !$omp end parallel
         endif
         if (config_use_MacroMoleculesTracers) then
            call mpas_pool_get_subpool(forcingPool, 'MacroMoleculesSeaIceCoupling', MacroMoleculesSeaIceCoupling)
@@ -161,20 +169,17 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(MacroMoleculesSeaIceCoupling, 'avgOceanSurfaceDOC', avgOceanSurfaceDOC)
            call mpas_pool_get_array(MacroMoleculesSeaIceCoupling, 'avgOceanSurfaceDON', avgOceanSurfaceDON)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgOceanSurfaceDOC(:,iCell) = 0.0_RKIND
               avgOceanSurfaceDON(iCell) = 0.0_RKIND
            end do
            !$omp end do
+           !$omp end parallel
         endif
 
-        !$omp master
-
         nAccumulatedCoupled = 0
-
-        !$omp end master
-        call mpas_threading_barrier()
 
     end subroutine ocn_time_average_coupled_init!}}}
 
@@ -249,6 +254,7 @@ module ocn_time_average_coupled
 
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
 
+        !$omp parallel
         !$omp do schedule(runtime)
         do iCell = 1, nCells
            avgTracersSurfaceValue(:, iCell) = avgTracersSurfaceValue(:, iCell) * nAccumulatedCoupled &
@@ -264,6 +270,7 @@ module ocn_time_average_coupled
                                         / ( nAccumulatedCoupled + 1 )
         end do
         !$omp end do
+        !$omp end parallel
 
         if(trim(config_land_ice_flux_mode) == 'coupled') then
            call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
@@ -274,6 +281,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(forcingPool, 'avgLandIceTracerTransferVelocities', avgLandIceTracerTransferVelocities)
            call mpas_pool_get_array(forcingPool, 'avgEffectiveDensityInLandIce', avgEffectiveDensityInLandIce)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
               avgLandIceBoundaryLayerTracers(:, iCell) = ( avgLandIceBoundaryLayerTracers(:, iCell) * nAccumulatedCoupled &
@@ -284,6 +292,7 @@ module ocn_time_average_coupled
                  + effectiveDensityInLandIce(iCell) ) / ( nAccumulatedCoupled + 1)
            end do
            !$omp end do
+           !$omp end parallel
         end if
 
         !  accumulate BGC coupling fields if necessary
@@ -307,6 +316,7 @@ module ocn_time_average_coupled
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, 1)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
 
@@ -338,6 +348,7 @@ module ocn_time_average_coupled
 
            end do
            !$omp end do
+           !$omp end parallel
         end if
 
         if (config_use_DMSTracers) then
@@ -349,6 +360,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
            call mpas_pool_get_array(tracersPool, 'DMSTracers', DMSTracers, 1)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
            avgOceanSurfaceDMS(iCell) = ( avgOceanSurfaceDMS(iCell) * nAccumulatedCoupled &
@@ -357,6 +369,7 @@ module ocn_time_average_coupled
               + DMSTracers(dmsIndices%dmsp_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
            end do
            !$omp end do
+           !$omp end parallel
         endif
 
         if (config_use_MacroMoleculesTracers) then
@@ -368,6 +381,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
            call mpas_pool_get_array(tracersPool, 'MacroMoleculesTracers', MacroMoleculesTracers, 1)
 
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
            avgOceanSurfaceDOC(1,iCell) = ( avgOceanSurfaceDOC(1,iCell) * nAccumulatedCoupled &
@@ -379,14 +393,10 @@ module ocn_time_average_coupled
               + MacroMoleculesTracers(macrosIndices%prot_ind,1,iCell) ) / ( nAccumulatedCoupled + 1)
            end do
            !$omp end do
+           !$omp end parallel
         endif
 
-        !$omp master
-
         nAccumulatedCoupled = nAccumulatedCoupled + 1
-
-        !$omp end master
-        call mpas_threading_barrier()
 
     end subroutine ocn_time_average_coupled_accumulate!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
@@ -366,6 +366,7 @@ contains
 
     ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/config_time_varying_atmospheric_forcing_ramp)
 
+    !$omp parallel
     !$omp do schedule(runtime) private(iCell, windStressCoefficient)
     do iCell = 1, nCells
 
@@ -384,6 +385,7 @@ contains
 
     enddo
     !$omp end do
+    !$omp end parallel
 
   end subroutine post_atmospheric_forcing!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
@@ -367,7 +367,7 @@ contains
     ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/config_time_varying_atmospheric_forcing_ramp)
 
     !$omp parallel
-    !$omp do schedule(runtime) private(iCell, windStressCoefficient)
+    !$omp do schedule(runtime) private(windStressCoefficient)
     do iCell = 1, nCells
 
        windSpeedU(iCell) = ramp*windSpeedU(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_TTD.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_TTD.F
@@ -120,11 +120,13 @@ contains
 
       ! zero tracers at surface to TTDMask at top-most layer
       ! TTDMask should be 1 within region of interest and zero elsewhere
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCellsSolve
          tracers(:, 1, iCell) = TTDMask(:, iCell)
       end do
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -479,7 +479,7 @@ module ocn_tracer_advection_mono
         nEdges = nEdgesArray( 2 )
         !  rescale the high order horizontal fluxes
         !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k, flux)
+        !$omp do schedule(runtime) private(cell1, cell2, k)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
@@ -500,7 +500,7 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
         !$omp parallel
-        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, flux, k)
+        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, k)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -230,7 +230,6 @@ module ocn_tracer_advection_mono
       nEdges = nEdgesArray(size(nEdgesArray))
 
       ! allocate temporary arrays
-      !$omp master
       allocate(tracerCur   (nVertLevels  ,nCells+1), &
                tracerMin   (nVertLevels  ,nCells), &
                tracerMax   (nVertLevels  ,nCells), &
@@ -242,8 +241,6 @@ module ocn_tracer_advection_mono
                workTend    (nVertLevels  ,nCells+1), &
                lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
                highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
-      !$omp end master
-      !$omp barrier
 
       ! Compute some provisional layer thicknesses
       ! Note: This assumes we are in the first part of the horizontal/
@@ -251,7 +248,8 @@ module ocn_tracer_advection_mono
       ! we dont flip order and horizontal is always first.
       ! See notes in commit 2cd4a89d.
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iCell, invAreaCell1, kmax, k, i, iEdge, signedFactor)
       do iCell = 1, nCells
         invAreaCell1 = dt/areaCell(iCell)
         kmax = maxLevelCell(iCell)
@@ -275,6 +273,7 @@ module ocn_tracer_advection_mono
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
 #ifdef _ADV_TIMERS
       call mpas_timer_stop('startup')
@@ -290,13 +289,15 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( size(nCellsArray) )
 
         ! Extract current tracer and change index order to improve locality
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells+1
         do k=1, nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do ! k loop
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 
         ! Compute the high and low order horizontal fluxes.
 #ifdef _ADV_TIMERS
@@ -310,7 +311,8 @@ module ocn_tracer_advection_mono
         ! Determine bounds on tracer (tracerMin and tracerMax) from
         ! surrounding cells for later limiting.
 
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, k, i, cell2, kmax)
         do iCell = 1, nCells
           do k=1, maxLevelCell(iCell)
             tracerMin(k,iCell) = tracerCur(k,iCell)
@@ -329,13 +331,17 @@ module ocn_tracer_advection_mono
           end do ! i loop over nEdgesOnCell
         end do
         !$omp end do
+        !$omp end parallel
 
         ! Need all the edges around the 1 halo cells and owned cells
         nEdges = nEdgesArray( 3 )
 
         ! Compute the high order horizontal flux
 
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(iEdge, cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
+        !$omp         tracerWeight)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1, iEdge)
           cell2 = cellsOnEdge(2, iEdge)
@@ -386,6 +392,8 @@ module ocn_tracer_advection_mono
           end do ! k loop
         end do ! iEdge loop
         !$omp end do
+        !$omp end parallel
+
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('horiz flux')
         call mpas_timer_start('scale factor build')
@@ -393,6 +401,7 @@ module ocn_tracer_advection_mono
         ! Initialize flux arrays for all cells
         nCells = nCellsArray(size(nCellsArray))
 
+        !$omp parallel
         !$omp do schedule(runtime)
         do iCell = 1, nCells+1
         do k=1, nVertLevels
@@ -402,11 +411,15 @@ module ocn_tracer_advection_mono
         end do ! k loop
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
 
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(iCell, invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
+        !$omp         tracerUpwindNew, tracerMinNew, tracerMaxNew, scaleFactor)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -456,6 +469,8 @@ module ocn_tracer_advection_mono
           end do ! k loop
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
+
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
         call mpas_timer_start('rescale horiz fluxes')
@@ -463,6 +478,7 @@ module ocn_tracer_advection_mono
         ! Need all of the edges around owned cells
         nEdges = nEdgesArray( 2 )
         !  rescale the high order horizontal fluxes
+        !$omp parallel
         !$omp do schedule(runtime) private(cell1, cell2, k, flux)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1,iEdge)
@@ -475,6 +491,7 @@ module ocn_tracer_advection_mono
           end do ! k loop
         end do ! iEdge loop
         !$omp end do
+        !$omp end parallel
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
         call mpas_timer_start('flux accumulate')
@@ -482,6 +499,7 @@ module ocn_tracer_advection_mono
 
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
+        !$omp parallel
         !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, flux, k)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -508,6 +526,7 @@ module ocn_tracer_advection_mono
 
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
@@ -516,7 +535,8 @@ module ocn_tracer_advection_mono
         ! Compute budget and monotonicity diagnostics if needed
         if (computeBudgets) then
 
-           !$omp do schedule(runtime)
+           !$omp parallel
+           !$omp do schedule(runtime) private(iEdge, k)
            do iEdge = 1,nEdgesArray( 2 )
            do k = 1,maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
@@ -527,7 +547,7 @@ module ocn_tracer_advection_mono
            enddo
            !$omp end do
 
-           !$omp do schedule(runtime)
+           !$omp do schedule(runtime) private(iCell, k)
            do iCell = 1, nCellsArray( 1 )
            do k = 1, maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
@@ -535,6 +555,7 @@ module ocn_tracer_advection_mono
            end do
            end do ! iCell loop
            !$omp end do
+           !$omp end parallel
 
         end if ! computeBudgets
 
@@ -542,7 +563,8 @@ module ocn_tracer_advection_mono
            nCells = nCellsArray( 1 )
            ! Check tracer values against local min,max to detect
            ! non-monotone values and write warning if found
-           !$omp do schedule(runtime)
+           !$omp parallel
+           !$omp do schedule(runtime) private(iCell, k)
            do iCell = 1, nCells
            do k = 1, maxLevelCell(iCell)
               if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
@@ -561,6 +583,7 @@ module ocn_tracer_advection_mono
            end do
            end do
            !$omp end do
+           !$omp end parallel
         end if ! monotonicity check
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('advect diags')
@@ -578,6 +601,7 @@ module ocn_tracer_advection_mono
 #endif
         nCells = nCellsArray( size(nCellsArray) )
         ! Initialize variables for use in this iTracer iteration
+        !$omp parallel
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
           do k=1, nVertLevels
@@ -588,6 +612,7 @@ module ocn_tracer_advection_mono
 
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('cell init')
 #endif
@@ -600,7 +625,8 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( 2 )
 
         ! Determine bounds on tracerCur from neighbor values for limiting
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, kmax, k)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
 
@@ -624,6 +650,7 @@ module ocn_tracer_advection_mono
                                       tracerCur(kmax-1,iCell))
         end do ! cell loop
         !$omp end do
+        !$omp end parallel
 
         ! Compute the high order vertical fluxes based on order selected.
         ! Special cases for top and bottom layers handled in following loop.
@@ -631,7 +658,8 @@ module ocn_tracer_advection_mono
         select case (vertOrder)
         case (vertOrder4)
 
-          !$omp do schedule(runtime)
+          !$omp parallel
+          !$omp do schedule(runtime) private(iCell, kmax, k)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -643,10 +671,12 @@ module ocn_tracer_advection_mono
             end do
           end do ! cell loop
           !$omp end do
+          !$omp end parallel
 
         case (vertOrder3)
 
-          !$omp do schedule(runtime)
+          !$omp parallel
+          !$omp do schedule(runtime) private(iCell, kmax, k)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -662,10 +692,12 @@ module ocn_tracer_advection_mono
             end do
           end do ! cell loop
           !$omp end do
+          !$omp end parallel
 
        case (vertOrder2)
 
-          !$omp do schedule(runtime)
+          !$omp parallel
+          !$omp do schedule(runtime) private(iCell, kmax, k, verticalWeightK, verticalWeightKm1)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -679,6 +711,7 @@ module ocn_tracer_advection_mono
             end do
           end do ! cell loop
           !$omp end do
+          !$omp end parallel
 
         end select ! vertical order
 
@@ -686,7 +719,8 @@ module ocn_tracer_advection_mono
         ! Compute low order upwind vertical flux (monotonic and diffused)
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, kmax, verticalWeightK, verticalWeightKm1, k)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
           ! Next-to-top cell in column is second-order
@@ -737,6 +771,7 @@ module ocn_tracer_advection_mono
           end do ! k Loop
         end do ! iCell Loop
         !$omp end do
+        !$omp end parallel
 
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('vertical flux')
@@ -744,7 +779,9 @@ module ocn_tracer_advection_mono
 #endif
         ! Need one halo of cells around owned cells
         nCells = nCellsArray( 2 )
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(iCell, k, tracerMinNew, tracerMaxNew, tracerUpwindNew, scaleFactor)
         do iCell = 1, nCells
 
           ! Build the scale factors to limit flux for FCT
@@ -773,6 +810,7 @@ module ocn_tracer_advection_mono
           end do ! k loop
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
         call mpas_timer_start('flux accumulate')
@@ -781,7 +819,8 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
-        !$omp do schedule(runtime)
+        !$omp parallel
+        !$omp do schedule(runtime) private(iCell, kmax, k, flux)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
           ! rescale the high order vertical flux
@@ -806,6 +845,7 @@ module ocn_tracer_advection_mono
 
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
 
         ! Compute advection diagnostics and monotonicity checks if requested
 #ifdef _ADV_TIMERS
@@ -813,7 +853,8 @@ module ocn_tracer_advection_mono
         call mpas_timer_start('advect diags')
 #endif
         if (computeBudgets) then
-           !$omp do schedule(runtime)
+           !$omp parallel
+           !$omp do schedule(runtime) private(iCell, k)
            do iCell = 1, nCells
               do k = 2, maxLevelCell(iCell)
                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
@@ -825,12 +866,14 @@ module ocn_tracer_advection_mono
               end do
            end do ! iCell loop
            !$omp end do
+           !$omp end parallel
         end if ! computeBudgets
 
         if (monotonicityCheck) then
           nCells = nCellsArray( 1 )
           ! Check for monotonicity of new tracer value
-          !$omp do schedule(runtime)
+          !$omp parallel
+          !$omp do schedule(runtime) private(iCell, k, tracerNew)
           do iCell = 1, nCells
           do k = 1, maxLevelCell(iCell)
              ! workTend on the RHS is the total vertical advection tendency
@@ -853,6 +896,7 @@ module ocn_tracer_advection_mono
           end do
           end do
           !$omp end do
+          !$omp end parallel
         end if ! monotonicity check
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('advect diags')
@@ -862,8 +906,6 @@ module ocn_tracer_advection_mono
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif
-      !$omp barrier
-      !$omp master
       deallocate(tracerCur,    &
                  tracerMin,    &
                  tracerMax,    &
@@ -875,7 +917,6 @@ module ocn_tracer_advection_mono
                  workTend,     &
                  lowOrderFlx,  &
                  highOrderFlx)
-      !$omp end master
 
 #ifdef _ADV_TIMERS
       call mpas_timer_stop('deallocates')

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -249,7 +249,7 @@ module ocn_tracer_advection_mono
       ! See notes in commit 2cd4a89d.
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iCell, invAreaCell1, kmax, k, i, iEdge, signedFactor)
+      !$omp do schedule(runtime) private(invAreaCell1, kmax, k, i, iEdge, signedFactor)
       do iCell = 1, nCells
         invAreaCell1 = dt/areaCell(iCell)
         kmax = maxLevelCell(iCell)
@@ -312,7 +312,7 @@ module ocn_tracer_advection_mono
         ! surrounding cells for later limiting.
 
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, k, i, cell2, kmax)
+        !$omp do schedule(runtime) private(k, i, cell2, kmax)
         do iCell = 1, nCells
           do k=1, maxLevelCell(iCell)
             tracerMin(k,iCell) = tracerCur(k,iCell)
@@ -340,7 +340,7 @@ module ocn_tracer_advection_mono
 
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(iEdge, cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
+        !$omp private(cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
         !$omp         tracerWeight)
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1, iEdge)
@@ -418,7 +418,7 @@ module ocn_tracer_advection_mono
 
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(iCell, invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
+        !$omp private(invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
         !$omp         tracerUpwindNew, tracerMinNew, tracerMaxNew, scaleFactor)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -536,7 +536,7 @@ module ocn_tracer_advection_mono
         if (computeBudgets) then
 
            !$omp parallel
-           !$omp do schedule(runtime) private(iEdge, k)
+           !$omp do schedule(runtime) private(k)
            do iEdge = 1,nEdgesArray( 2 )
            do k = 1,maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
@@ -547,7 +547,7 @@ module ocn_tracer_advection_mono
            enddo
            !$omp end do
 
-           !$omp do schedule(runtime) private(iCell, k)
+           !$omp do schedule(runtime) private(k)
            do iCell = 1, nCellsArray( 1 )
            do k = 1, maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
@@ -564,7 +564,7 @@ module ocn_tracer_advection_mono
            ! Check tracer values against local min,max to detect
            ! non-monotone values and write warning if found
            !$omp parallel
-           !$omp do schedule(runtime) private(iCell, k)
+           !$omp do schedule(runtime) private(k)
            do iCell = 1, nCells
            do k = 1, maxLevelCell(iCell)
               if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
@@ -626,7 +626,7 @@ module ocn_tracer_advection_mono
 
         ! Determine bounds on tracerCur from neighbor values for limiting
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, kmax, k)
+        !$omp do schedule(runtime) private(kmax, k)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
 
@@ -659,7 +659,7 @@ module ocn_tracer_advection_mono
         case (vertOrder4)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(iCell, kmax, k)
+          !$omp do schedule(runtime) private(kmax, k)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -676,7 +676,7 @@ module ocn_tracer_advection_mono
         case (vertOrder3)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(iCell, kmax, k)
+          !$omp do schedule(runtime) private(kmax, k)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -697,7 +697,7 @@ module ocn_tracer_advection_mono
        case (vertOrder2)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(iCell, kmax, k, verticalWeightK, verticalWeightKm1)
+          !$omp do schedule(runtime) private(kmax, k, verticalWeightK, verticalWeightKm1)
           do iCell = 1, nCells
             kmax = maxLevelCell(iCell)
             do k=3,kmax-1
@@ -720,7 +720,7 @@ module ocn_tracer_advection_mono
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, kmax, verticalWeightK, verticalWeightKm1, k)
+        !$omp do schedule(runtime) private(kmax, verticalWeightK, verticalWeightKm1, k)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
           ! Next-to-top cell in column is second-order
@@ -781,7 +781,7 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( 2 )
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(iCell, k, tracerMinNew, tracerMaxNew, tracerUpwindNew, scaleFactor)
+        !$omp private(k, tracerMinNew, tracerMaxNew, tracerUpwindNew, scaleFactor)
         do iCell = 1, nCells
 
           ! Build the scale factors to limit flux for FCT
@@ -820,7 +820,7 @@ module ocn_tracer_advection_mono
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
         !$omp parallel
-        !$omp do schedule(runtime) private(iCell, kmax, k, flux)
+        !$omp do schedule(runtime) private(kmax, k, flux)
         do iCell = 1, nCells
           kmax = maxLevelCell(iCell)
           ! rescale the high order vertical flux
@@ -854,7 +854,7 @@ module ocn_tracer_advection_mono
 #endif
         if (computeBudgets) then
            !$omp parallel
-           !$omp do schedule(runtime) private(iCell, k)
+           !$omp do schedule(runtime) private(k)
            do iCell = 1, nCells
               do k = 2, maxLevelCell(iCell)
                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
@@ -873,7 +873,7 @@ module ocn_tracer_advection_mono
           nCells = nCellsArray( 1 )
           ! Check for monotonicity of new tracer value
           !$omp parallel
-          !$omp do schedule(runtime) private(iCell, k, tracerNew)
+          !$omp do schedule(runtime) private(k, tracerNew)
           do iCell = 1, nCells
           do k = 1, maxLevelCell(iCell)
              ! workTend on the RHS is the total vertical advection tendency

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -139,6 +139,7 @@ module ocn_tracer_advection_std
       ! Loop over tracers. One tracer is advected at a time. It is copied into a temporary array in order to improve locality
       do iTracer = 1, num_tracers
         ! Initialize variables for use in this iTracer iteration
+        !$omp parallel
         !$omp do schedule(runtime)
         do iCell = 1, nCells
            tracer_cur(:, iCell) = tracers(iTracer, :, iCell)
@@ -236,6 +237,7 @@ module ocn_tracer_advection_std
           end do ! k loop
         end do ! iCell loop
         !$omp end do
+        !$omp end parallel
       end do ! iTracer loop
 
       !$omp barrier

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -49,19 +49,6 @@ module ocn_tracer_advection_std
    public :: ocn_tracer_advection_std_tend, &
              ocn_tracer_advection_std_init
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_tracer_advection_std_tend
-   real (kind=RKIND), dimension(:,:), allocatable :: tracer_cur
-   real (kind=RKIND), dimension(:,:), allocatable :: high_order_horiz_flux
-   real (kind=RKIND), dimension(:,:), allocatable :: high_order_vert_flux
-
    contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -108,6 +95,10 @@ module ocn_tracer_advection_std
       real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell, verticalDivergenceFactor
 
+      real (kind=RKIND), dimension(:,:), allocatable :: tracer_cur
+      real (kind=RKIND), dimension(:,:), allocatable :: high_order_horiz_flux
+      real (kind=RKIND), dimension(:,:), allocatable :: high_order_vert_flux
+
       real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
 
       ! Get dimensions
@@ -129,12 +120,9 @@ module ocn_tracer_advection_std
       allocate(verticalDivergenceFactor(nVertLevels))
       verticalDivergenceFactor = 1.0_RKIND
 
-      !$omp master
       allocate(high_order_horiz_flux(nVertLevels, nEdges), &
                tracer_cur(nVertLevels, nCells), &
                high_order_vert_flux(nVertLevels, nCells))
-      !$omp end master
-      !$omp barrier
 
       ! Loop over tracers. One tracer is advected at a time. It is copied into a temporary array in order to improve locality
       do iTracer = 1, num_tracers
@@ -239,13 +227,6 @@ module ocn_tracer_advection_std
         !$omp end do
         !$omp end parallel
       end do ! iTracer loop
-
-      !$omp barrier
-      !$omp master
-      deallocate(high_order_horiz_flux, &
-                 high_order_vert_flux, &
-                 tracer_cur)
-      !$omp end master
 
       deallocate(tracer_cur, high_order_horiz_flux, high_order_vert_flux)
       deallocate(verticalDivergenceFactor)

--- a/src/core_ocean/shared/mpas_ocn_tracer_exponential_decay.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_exponential_decay.F
@@ -119,6 +119,7 @@ contains
 
       err = 0
 
+      !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
          do iLevel=1,maxLevelCell(iCell)
@@ -131,6 +132,7 @@ contains
          enddo
       enddo
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -155,7 +155,7 @@ contains
       !
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iCell, invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, iTracer, &
+      !$omp private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, iTracer, &
       !$omp         tracer_turb_flux, flux)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -153,7 +153,10 @@ contains
       !
       ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
       !
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iCell, invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, iTracer, &
+      !$omp         tracer_turb_flux, flux)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)
@@ -178,6 +181,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("tracer del2")
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
@@ -58,17 +58,6 @@ module ocn_tracer_hmix_del4
 
    real (kind=RKIND) :: eddyDiff4
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_vel_hmix_del4_tensor_tend
-   real (kind=RKIND), dimension(:,:,:), allocatable :: delsq_tracer
-
 !***********************************************************************
 
 contains
@@ -138,6 +127,8 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, meshScalingDel4
 
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:,:), allocatable :: delsq_tracer
 
       !-----------------------------------------------------------------
       !
@@ -173,10 +164,7 @@ contains
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
-      !$omp master
       allocate(delsq_tracer(num_tracers, nVertLevels, nCells))
-      !$omp end master
-      !$omp barrier
 
       ! Need 1 halo around owned cells
       nCells = nCellsArray( 2 )
@@ -237,10 +225,7 @@ contains
       !$omp end do
       !$omp end parallel
 
-      !$omp barrier
-      !$omp master
       deallocate(delsq_tracer)
-      !$omp end master
 
       call mpas_timer_stop("tracer del4")
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
@@ -182,6 +182,7 @@ contains
       nCells = nCellsArray( 2 )
 
       ! first del2: div(h \nabla \phi) at cell center
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, invdcEdge, cell1, cell2, k, iTracer, r_tmp1, r_tmp2)
       do iCell = 1, nCells
         delsq_tracer(:, :, iCell) = 0.0_RKIND
@@ -205,11 +206,13 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       ! Only need tendency on owned cells
       nCells = nCellsArray( 1 )
 
       ! second del2: div(h \nabla [delsq_tracer]) at cell center
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, cell1, cell2, invdcEdge, k, iTracer, tracer_turb_flux, flux)
       do iCell = 1, nCells
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -232,6 +235,7 @@ contains
         end do
       end do
       !$omp end do
+      !$omp end parallel
 
       !$omp barrier
       !$omp master

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -387,10 +387,8 @@ contains
          end do
       end do ! iCell
       !$omp end do
-      !$omp end parallel
 
       !now go back and reapply all tendencies
-      !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -23,7 +23,6 @@ module ocn_tracer_hmix_Redi
    use mpas_timer
    use mpas_derived_types
    use mpas_pool_routines
-   use mpas_threading
    use mpas_constants
 
    use ocn_config
@@ -177,6 +176,7 @@ contains
       allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
 
       nCells = nCellsArray(2)
+      !$omp parallel
       !$omp do schedule(runtime) private(i, iEdge)
       do iCell = 1,nCells
         rediKappaCell(iCell) = 0.0_RKIND
@@ -187,6 +187,7 @@ contains
         rediKappaCell(iCell) = rediKappaCell(iCell) / areaCell(iCell)
       enddo
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray(1)
       nCellsP1 = nCellsArray(size(nCellsArray)) + 1
@@ -362,8 +363,7 @@ contains
       endif
 
       !$omp parallel
-      !$omp do schedule(runtime) &
-      !$omp private(k, iTr, tempTracer, iEdge)
+      !$omp do schedule(runtime) private(k, iTr, tempTracer, iEdge)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             do iTr = 1, ntracers
@@ -387,10 +387,11 @@ contains
          end do
       end do ! iCell
       !$omp end do
+      !$omp end parallel
 
       !now go back and reapply all tendencies
-      !$omp do schedule(runtime) &
-      !$omp private(invAreaCell, k, iTr, i, iEdge)
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do k = 1, maxLevelCell(iCell)
@@ -490,7 +491,7 @@ contains
             end do
             !$omp end do
             !$omp end parallel
-         else if (config_Redi_closure == 'data') then
+          else if (config_Redi_closure == 'data') then
             ! read RediKappa in from input
             call mpas_log_write("config_Redi_closure = 'data'. "// &
                                 "Make sure that the variable RediKappa is read in from an input file.")

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -169,15 +169,12 @@ contains
 
       allocate (minimumVal(nTracers))
       allocate (fluxRediZTop(nTracers, nVertLevels + 1))
-      !$omp master
       allocate (rediKappaCell(nCells))
       allocate (redi_term1(nTracers, nVertLevels, nCells))
       allocate (redi_term2(nTracers, nVertLevels, nCells))
       allocate (redi_term3(nTracers, nVertLevels, nCells))
       allocate (redi_term2_edge(nTracers, nVertLevels, nEdges))
       allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
-      !$omp end master
-      !$omp barrier
 
       nCells = nCellsArray(2)
       !$omp do schedule(runtime) private(i, iEdge)
@@ -196,8 +193,11 @@ contains
 
       ! Term 1: this is the "standard" horizontal del2 term, but with RediKappa coefficient.
       ! \kappa_2 \nabla \phi on edge
-      !$omp do schedule(runtime) private(invAreaCell, i, k, iTr, iEdge, cell1, cell2, iCellSelf, &
-      !$omp& r_tmp, coef, kappaRediEdgeVal, tracer_turb_flux, flux, flux_term2, flux_term3, dTracerDx)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(fluxRediZTop, invAreaCell, i, iEdge, cell1, cell2, iCellSelf, r_tmp, coef, k, &
+      !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
+      !$omp         dTracerDx)
       do iCell = 1, nCells
          redi_term1(:, :, iCell) = 0.0_RKIND
          redi_term2(:, :, iCell) = 0.0_RKIND
@@ -344,22 +344,26 @@ contains
          end do
       end do ! iCell
       !$omp end do
-      !$omp barrier
+      !$omp end parallel
 
       !loop over cells and check for out of bounds
       if (isActiveTracer) then
          minimumVal(1) = -2.0_RKIND
          minimumVal(2:nTracers) = 0.0_RKIND
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
             rediLimiterCount(:, iCell) = 0
          end do
          !$omp end do
+         !$omp end parallel
       else
          minimumVal(:) = 0.0_RKIND
       endif
 
-      !$omp do schedule(runtime) private(k, iTr, tempTracer, iEdge)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, iTr, tempTracer, iEdge)
       do iCell = 1, nCells
          do k = 1, maxLevelCell(iCell)
             do iTr = 1, ntracers
@@ -383,10 +387,12 @@ contains
          end do
       end do ! iCell
       !$omp end do
-      !$omp barrier
+      !$omp end parallel
 
       !now go back and reapply all tendencies
-      !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do k = 1, maxLevelCell(iCell)
@@ -410,18 +416,16 @@ contains
          end do
       end do ! iCell
       !$omp end do
+      !$omp end parallel
 
       deallocate (fluxRediZTop)
       deallocate (minimumVal)
-      !$omp master
       deallocate (rediKappaCell)
       deallocate (redi_term1)
       deallocate (redi_term2)
       deallocate (redi_term3)
       deallocate (redi_term2_edge)
       deallocate (redi_term3_topOfCell)
-      !$omp end master
-      !$omp barrier
 
       call mpas_timer_stop("tracer redi")
 
@@ -481,12 +485,14 @@ contains
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          ! initialize Redi kappa array
          if (config_Redi_closure == 'constant') then
+            !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                RediKappa(iEdge) = config_Redi_kappa
             end do
             !$omp end do
-          else if (config_Redi_closure == 'data') then
+            !$omp end parallel
+         else if (config_Redi_closure == 'data') then
             ! read RediKappa in from input
             call mpas_log_write("config_Redi_closure = 'data'. "// &
                                 "Make sure that the variable RediKappa is read in from an input file.")
@@ -500,6 +506,7 @@ contains
          if (config_eddying_resolution_taper == 'none') then
             ! Nothing to do, as we just keep the same assignment as above.
          else if (config_eddying_resolution_taper == 'ramp') then
+            !$omp parallel
             !$omp do schedule(runtime) 
             do iEdge=1,nEdges
                if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
@@ -513,6 +520,7 @@ contains
                end if
             end do ! iCell
             !$omp end do
+            !$omp end parallel
          else
             call mpas_log_write('Invalid choice of config_eddying_resolution_taper.', MPAS_LOG_CRIT)
             err = 1

--- a/src/core_ocean/shared/mpas_ocn_tracer_ideal_age.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_ideal_age.F
@@ -118,6 +118,7 @@ contains
 
       err = 0
 
+      !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
         do iLevel=1,maxLevelCell(iCell)
@@ -133,6 +134,7 @@ contains
         enddo
       enddo
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_interior_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_interior_restoring.F
@@ -118,6 +118,7 @@ contains
 
       err = 0
 
+      !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
         do iLevel=1,maxLevelCell(iCell)
@@ -130,6 +131,7 @@ contains
         enddo
       enddo
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -129,6 +129,7 @@ contains
 
       nCells = nCellsArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(k, iTracer, fluxTopOfCell, fluxBottomOfCell)
       do iCell = 1, nCells
         do k = 2, maxLevelCell(iCell)-1
@@ -159,6 +160,7 @@ contains
 
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop('non-local flux')
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -145,7 +145,7 @@ contains
       nCells = nCellsArray( 3 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iCell, depth, k, weights, depLev)
+      !$omp do schedule(runtime) private(depth, k, weights, depLev)
       do iCell = 1, nCells
          depth = 0.0_RKIND
          do k = 1, maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -144,7 +144,8 @@ contains
 
       nCells = nCellsArray( 3 )
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iCell, depth, k, weights, depLev)
       do iCell = 1, nCells
          depth = 0.0_RKIND
          do k = 1, maxLevelCell(iCell)
@@ -170,6 +171,7 @@ contains
 
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(weights)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -145,7 +145,8 @@ contains
       nCells = nCellsArray( 3 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(depth, k, weights, depLev)
+      !$omp do schedule(runtime) private(depth, k, depLev) &
+      !$omp firstprivate(weights)
       do iCell = 1, nCells
          depth = 0.0_RKIND
          do k = 1, maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -154,7 +154,7 @@ contains
       nCells = nCellsArray( 3 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(depth, cloudRatio, k, depLev)
+      !$omp do schedule(runtime) private(depth, cloudRatio, k, depLev, Avals, Kvals, weights)
       do iCell = 1, nCells
         depth = 0.0_RKIND
         cloudRatio = min(1.0_RKIND, 1.0_RKIND - penetrativeTemperatureFlux(iCell)/(hflux_factor*(1.0E-15_RKIND + &

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -154,7 +154,7 @@ contains
       nCells = nCellsArray( 3 )
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iCell, depth, cloudRatio, k, depLev)
+      !$omp do schedule(runtime) private(depth, cloudRatio, k, depLev)
       do iCell = 1, nCells
         depth = 0.0_RKIND
         cloudRatio = min(1.0_RKIND, 1.0_RKIND - penetrativeTemperatureFlux(iCell)/(hflux_factor*(1.0E-15_RKIND + &

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -153,7 +153,8 @@ contains
 
       nCells = nCellsArray( 3 )
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iCell, depth, cloudRatio, k, depLev)
       do iCell = 1, nCells
         depth = 0.0_RKIND
         cloudRatio = min(1.0_RKIND, 1.0_RKIND - penetrativeTemperatureFlux(iCell)/(hflux_factor*(1.0E-15_RKIND + &
@@ -185,6 +186,7 @@ contains
 
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(weights)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -141,6 +141,7 @@ contains
 
       nCells = nCellsArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
       do iCell = 1, nCells
         remainingFlux = 1.0_RKIND
@@ -160,6 +161,7 @@ contains
         end if
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("surface_tracer_flux")
 
@@ -168,6 +170,7 @@ contains
       if (associated(surfaceTracerFluxRunoff)) then
         call mpas_timer_start("surface_tracer_runoff_flux")
 
+        !$omp parallel
         !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
         do iCell = 1, nCells
           remainingFlux = 1.0_RKIND
@@ -188,6 +191,7 @@ contains
           end if
         end do
         !$omp end do
+        !$omp end parallel
 
         call mpas_timer_stop("surface_tracer_runoff_flux")
       end if

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
@@ -136,6 +136,7 @@ contains
 
       iLevel = 1  ! base surface flux restoring on tracer fields in the top layer
 
+      !$omp parallel
       !$omp do schedule(runtime) private(iTracer)
       do iCell=1,nCells
         do iTracer=1,nTracers
@@ -155,6 +156,7 @@ contains
         enddo
       enddo
       !$omp end do
+      !$omp end parallel
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -130,6 +130,7 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(k, cell1, cell2)
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1,iEdge)
@@ -148,6 +149,7 @@ contains
 
       enddo
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop('vel explicit bottom drag')
 

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -146,7 +146,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iEdge, zTop, cell1, cell2, attenuationCoeff, transmissionCoeffTop, &
+      !$omp private(zTop, cell1, cell2, attenuationCoeff, transmissionCoeffTop, &
       !$omp         remainingStress, k, zBot)
       do iEdge = 1, nEdges
         zTop = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -144,7 +144,10 @@ contains
 
       nEdges = nEdgesArray ( 1 )
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, zTop, cell1, cell2, attenuationCoeff, transmissionCoeffTop, &
+      !$omp         remainingStress, k, zBot)
       do iEdge = 1, nEdges
         zTop = 0.0_RKIND
         cell1 = cellsOnEdge(1,iEdge)
@@ -174,6 +177,7 @@ contains
         end if
       enddo
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop('vel surface stress')
 

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -147,7 +147,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(zTop, cell1, cell2, attenuationCoeff, transmissionCoeffTop, &
-      !$omp         remainingStress, k, zBot)
+      !$omp         remainingStress, k, zBot, transmissionCoeffBot)
       do iEdge = 1, nEdges
         zTop = 0.0_RKIND
         cell1 = cellsOnEdge(1,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -151,7 +151,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iEdge, cell1, cell2, invLength, k, qArr, j, eoe, edgeWeight, workVorticity)
+      !$omp private(cell1, cell2, invLength, k, qArr, j, eoe, edgeWeight, workVorticity)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -149,7 +149,9 @@ contains
 
       allocate( qArr(nVertLevels) )
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, cell1, cell2, invLength, k, qArr, j, eoe, edgeWeight, workVorticity)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -180,6 +182,7 @@ contains
 
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate( qArr )
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
@@ -153,6 +153,7 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength1, invLength2, k, u_diffusion, visc2)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
@@ -181,6 +182,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("vel del2")
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -56,19 +56,6 @@ module ocn_vel_hmix_del4
 
    logical :: hmixDel4On       !< local flag to determine whether del4 chosen
 
-   !--------------------------------------------------------------------
-   !
-   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the
-   ! threading implementation is changed to more localized threading
-   !
-   !--------------------------------------------------------------------
-
-   ! subroutine ocn_vel_hmix_del4_tend
-   real (kind=RKIND), dimension(:,:), allocatable :: delsq_divergence
-   real (kind=RKIND), dimension(:,:), allocatable :: delsq_relativeVorticity
-   real (kind=RKIND), dimension(:,:), allocatable :: delsq_u
-
 !***********************************************************************
 
 contains
@@ -147,6 +134,11 @@ contains
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaTriangle, &
             meshScalingDel4, areaCell
 
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:), allocatable :: delsq_divergence
+      real (kind=RKIND), dimension(:,:), allocatable :: delsq_relativeVorticity
+      real (kind=RKIND), dimension(:,:), allocatable :: delsq_u
+
       err = 0
 
       if(.not.hmixDel4On) return
@@ -179,12 +171,9 @@ contains
       nEdges = nEdgesArray(size(nEdgesArray))
       nCells = nCellsArray(size(nCellsArray))
       nVertices = nVerticesArray(size(nVerticesArray))
-      !$omp master
       allocate(delsq_u(nVertLevels, nEdges + 1), &
                delsq_divergence(nVertLevels, nCells + 1), &
                delsq_relativeVorticity(nVertLevels, nVertices + 1))
-      !$omp end master
-      !$omp barrier
 
       nEdges = nEdgesArray( 3 )
 
@@ -277,12 +266,9 @@ contains
       !$omp end do
       !$omp end parallel
 
-      !$omp barrier
-      !$omp master
       deallocate(delsq_u, &
                  delsq_divergence, &
                  delsq_relativeVorticity)
-      !$omp end master
 
       call mpas_timer_stop("vel del4")
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -189,7 +189,9 @@ contains
       nEdges = nEdgesArray( 3 )
 
       !Compute delsq_u
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, k)
       do iEdge = 1, nEdges
          delsq_u(:, iEdge) = 0.0_RKIND
          cell1 = cellsOnEdge(1,iEdge)
@@ -208,11 +210,13 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nVertices = nVerticesArray( 2 )
 
       ! Compute delsq_relativeVorticity
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iVertex, invAreaTri1, i, iEdge, k)
       do iVertex = 1, nVertices
          delsq_relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -225,11 +229,13 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray( 2 )
 
       ! Compute delsq_divergence
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iCell, invAreaCell1, i, iEdge, k)
       do iCell = 1, nCells
          delsq_divergence(:, iCell) = 0.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -242,12 +248,15 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       nEdges = nEdgesArray( 1 )
 
       ! Compute - \kappa \nabla^4 u
       ! as  \nabla div(\nabla^2 u) + k \times \nabla ( k \cross curl(\nabla^2 u) )
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, r_tmp, k, u_diffusion)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -266,6 +275,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       !$omp barrier
       !$omp master

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -191,7 +191,7 @@ contains
       !Compute delsq_u
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iEdge, cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, k)
+      !$omp private(cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, k)
       do iEdge = 1, nEdges
          delsq_u(:, iEdge) = 0.0_RKIND
          cell1 = cellsOnEdge(1,iEdge)
@@ -216,7 +216,7 @@ contains
 
       ! Compute delsq_relativeVorticity
       !$omp parallel
-      !$omp do schedule(runtime) private(iVertex, invAreaTri1, i, iEdge, k)
+      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k)
       do iVertex = 1, nVertices
          delsq_relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -235,7 +235,7 @@ contains
 
       ! Compute delsq_divergence
       !$omp parallel
-      !$omp do schedule(runtime) private(iCell, invAreaCell1, i, iEdge, k)
+      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k)
       do iCell = 1, nCells
          delsq_divergence(:, iCell) = 0.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -256,7 +256,7 @@ contains
       ! as  \nabla div(\nabla^2 u) + k \times \nabla ( k \cross curl(\nabla^2 u) )
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iEdge, cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, r_tmp, k, u_diffusion)
+      !$omp private(cell1, cell2, vertex1, vertex2, invDcEdge, invDvEdge, r_tmp, k, u_diffusion)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
@@ -158,6 +158,7 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
+      !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength_dc, invLength_dv, k, u_diffusion, visc2)
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1,iEdge)
@@ -191,6 +192,7 @@ contains
          end do
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop("vel leith")
 

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -163,6 +163,7 @@ contains
          ! pressure for sea surface height
          ! - g grad ssh
 
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
@@ -174,12 +175,14 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
       elseif (config_pressure_gradient_type.eq.'pressure_and_zmid') then
 
          ! pressure for generalized coordinates
          ! -1/density_0 (grad p_k + density g grad z_k^{mid})
 
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
@@ -193,12 +196,14 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
       elseif (config_pressure_gradient_type.eq.'MontgomeryPotential') then
 
          ! For pure isopycnal coordinates, this is just grad(M),
          ! the gradient of Montgomery Potential
 
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
@@ -211,6 +216,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
       elseif (config_pressure_gradient_type.eq.'MontgomeryPotential_and_density') then
 
@@ -220,6 +226,7 @@ contains
          ! Where rho is the potential density.
          ! See Bleck (2002) equation 1, and last equation in Appendix A.
 
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
@@ -234,12 +241,14 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
       elseif (config_pressure_gradient_type.eq.'Jacobian_from_density') then
 
          allocate(JacobianDxDs(nVertLevels))
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) private(iEdge, cell1, cell2, invdcEdge, k, pGrad)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -269,6 +278,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          deallocate(JacobianDxDs)
 
@@ -277,7 +287,10 @@ contains
          allocate(JacobianDxDs(nVertLevels),JacobianTz(nVertLevels),JacobianSz(nVertLevels), T1(nVertLevels))
          allocate(T2(nVertLevels), S1(nVertLevels), S2(nVertLevels))
 
-         !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(iEdge, cell1, cell2, invdcEdge, kMax, T1, T2, S1, S2, k, alpha, beta, &
+         !$omp         pGrad, JacobianDxDs, JacobianTz, JacobianSz)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -330,6 +343,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
 
          deallocate(JacobianDxDs,JacobianTz,JacobianSz, T1, T2, S1, S2)
 

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -248,7 +248,7 @@ contains
          allocate(JacobianDxDs(nVertLevels))
 
          !$omp parallel
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k, pGrad)
+         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k, pGrad, JacobianDxDs)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -248,7 +248,7 @@ contains
          allocate(JacobianDxDs(nVertLevels))
 
          !$omp parallel
-         !$omp do schedule(runtime) private(iEdge, cell1, cell2, invdcEdge, k, pGrad)
+         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k, pGrad)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
@@ -289,7 +289,7 @@ contains
 
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp private(iEdge, cell1, cell2, invdcEdge, kMax, T1, T2, S1, S2, k, alpha, beta, &
+         !$omp private(cell1, cell2, invdcEdge, kMax, T1, T2, S1, S2, k, alpha, beta, &
          !$omp         pGrad, JacobianDxDs, JacobianTz, JacobianSz)
          do iEdge=1,nEdges
             cell1 = cellsOnEdge(1,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -138,7 +138,10 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, cell1, cell2, k, vertAleTransportTopEdge) &
+      !$omp firstprivate(w_dudzTopEdge)
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)
@@ -159,6 +162,7 @@ contains
         enddo
       enddo
       !$omp end do
+      !$omp end parallel
 
       deallocate(w_dudzTopEdge)
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -430,7 +430,7 @@ contains
       A(1)=0.0_RKIND
 
       !$omp parallel
-      !$omp do schedule(runtime) private(N, cell1, cell2, A, B, C, velTemp)
+      !$omp do schedule(runtime) private(N, cell1, cell2, A, B, C, velTemp, k)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -574,7 +574,7 @@ contains
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
       !$omp parallel
-      !$omp do schedule(runtime) private(N, A, B, C, rhs, tracersTemp)
+      !$omp do schedule(runtime) private(N, A, B, C, rhs, tracersTemp, k)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
          N = maxLevelCell(iCell)
@@ -1001,7 +1001,7 @@ subroutine ocn_compute_kpp_rhs(tracers, rhs, dt, maxLevelCell, nTracers, &
   real (kind=RKIND), intent(in) :: dt
   real (kind=RKIND), dimension(:,:), intent(in) :: vertNonLocalFlux, tracers
   real (kind=RKIND), dimension(:), intent(in) :: layerThickness, tracerGroupSurfaceFlux
-  real (kind=RKIND), dimension(:,:), intent(inout) :: rhs
+  real (kind=RKIND), dimension(:,:), intent(out) :: rhs
   integer, intent(in) :: maxLevelCell, nTracers
   integer :: iTracer, k
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -277,7 +277,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(iEdge, N, cell1, cell2, edgeThicknessTotal, k, A, B, C, velTemp)
+      !$omp private(N, cell1, cell2, edgeThicknessTotal, k, A, B, C, velTemp)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -430,7 +430,7 @@ contains
       A(1)=0.0_RKIND
 
       !$omp parallel
-      !$omp do schedule(runtime) private(iEdge, N, cell1, cell2, A, B, C, velTemp)
+      !$omp do schedule(runtime) private(N, cell1, cell2, A, B, C, velTemp)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -574,7 +574,7 @@ contains
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
       !$omp parallel
-      !$omp do schedule(runtime) private(iCell, N, A, B, C, rhs, tracersTemp)
+      !$omp do schedule(runtime) private(N, A, B, C, rhs, tracersTemp)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
          N = maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -159,19 +159,23 @@ contains
 
       nEdges = nEdgesArray( 2 )
 
+      !$omp parallel
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
          vertViscTopOfEdge(:, iEdge) = 0.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray( 2 )
 
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          vertDiffTopOfCell(:, iCell) = 0.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
 
       call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, diagnosticsPool, err1, timeLevel)
       call ocn_vmix_coefs_redi_build(meshPool, statePool, diagnosticsPool, err2, timeLevel)
@@ -271,7 +275,9 @@ contains
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
       A(1)=0.0_RKIND
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(iEdge, N, cell1, cell2, edgeThicknessTotal, k, A, B, C, velTemp)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -327,6 +333,7 @@ contains
         end if
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(A,B,C,velTemp)
 
@@ -422,7 +429,8 @@ contains
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
       A(1)=0.0_RKIND
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iEdge, N, cell1, cell2, A, B, C, velTemp)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
@@ -469,6 +477,7 @@ contains
         end if
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(A,B,C,velTemp)
 
@@ -564,7 +573,8 @@ contains
       nCells = nCellsArray( 1 )
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(iCell, N, A, B, C, rhs, tracersTemp)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
          N = maxLevelCell(iCell)
@@ -603,6 +613,7 @@ contains
          tracers(:,N+1:nVertLevels,iCell) = -1e34
       end do
       !$omp end do
+      !$omp end parallel
       call mpas_timer_stop('vmix tracers tend imp loop')
 
       deallocate(A, B, C, tracersTemp, rhs)
@@ -695,6 +706,7 @@ contains
 
          nEdges = nEdgesArray( 1 )
          call mpas_timer_start('CVMix avg', .false.)
+         !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, k)
          do iEdge=1,nEdges
             vertViscTopOfEdge(:, iEdge) = 0.0_RKIND
@@ -705,6 +717,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
          call mpas_timer_stop('CVMix avg')
       endif
 
@@ -736,11 +749,13 @@ contains
             ! store tracers
             if (trim(groupItr % memberName) == 'activeTracers') then
                if (config_compute_active_tracer_budgets) then
+                  !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
                      activeTracerVertMixTendency(:,:,iCell)=tracersGroup(:,:,iCell)
                   end do
                   !$omp end do
+                  !$omp end parallel
                endif
             endif
 
@@ -762,12 +777,14 @@ contains
             ! difference tracers to compute influence of vertical mixing and divide by dt
             if (trim(groupItr % memberName) == 'activeTracers') then
                if (config_compute_active_tracer_budgets) then
+                  !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
                      activeTracerVertMixTendency(:,:,iCell) = &
                         (tracersGroup(:,:,iCell) - activeTracerVertMixTendency(:,:,iCell)) / dt
                   end do
                   !$omp end do
+                  !$omp end parallel
                endif
             endif
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -209,6 +209,7 @@ contains
 
       nCells = nCellsArray(1)
 
+      !$omp parallel
       !$omp do schedule(runtime) private(i, rediKappaCell, iEdge)
       do iCell = 1, nCells
          rediKappaCell = 0.0_RKIND
@@ -221,6 +222,7 @@ contains
                         / areaCell(iCell)
       end do
       !$omp end do
+      !$omp end parallel
 
       call mpas_timer_stop('tracer redi coef')
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -340,15 +340,15 @@ contains
       call mpas_timer_start('cvmix cell loop', .false.)
       do kpp_stage = 1,2
       ! TODO, mdt: determine where the openmp data race is coming from in this loop
-      !!$omp parallel
-      !!$omp do schedule(runtime) &
-      !!$omp private(iCell, invAreaCell, k, RiSmoothed, RiTemp, BVFSmoothed, nsmooth, &
-      !!$omp         langmuirNumber, langmuirEnhancementFactor, bulkRichardsonNumberStop, &
-      !!$omp         bulkRichardsonFlag, topIndex, kIndexOBL, deltaVelocitySquared, sigma, &
-      !!$omp         OBLDepths, interfaceForcings, surfaceAverageIndex, sfc_layer_depth, kav, &
-      !!$omp         i, iEdge, factor, normalVelocitySum, NormalVelocityAv, &
-      !!$omp         delU2, potentialDensitySum, blTemp) &
-      !!$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
+!      !$omp parallel
+!      !$omp do schedule(runtime) &
+!      !$omp private(k, RiSmoothed, RiTemp, nsmooth, BVFSmoothed, langmuirNumber, &
+!      !$omp         langmuirEnhancementFactor, bulkRichardsonNumberStop, bulkRichardsonFlag, &
+!      !$omp         topIndex, kIndexOBL, deltaVelocitySquared, sigma, OBLDepths, interfaceForcings, &
+!      !$omp         surfaceAverageIndex, sfc_layer_depth, kav, i, iEdge, &
+!      !$omp         normalVelocitySum, layerThicknessEdgeSum, normalVelocityAv, delU2, potentialDensitySum, &
+!      !$omp         layerThicknessSum, blTemp) &
+!      !$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
       do iCell = 1, nCells
 
          ! specify geometry/location
@@ -745,8 +745,8 @@ contains
 
  endif ! kpp stage 2 convection calc
       end do  ! do iCell=1,mesh%nCells
-      !!$omp end do
-      !!$omp end parallel
+!      !$omp end do
+!      !$omp end parallel
 
       if (kpp_stage == 1 .and. config_cvmix_use_BLD_smoothing) then ! smooth boundary layer
          nCells = nCellsArray(2)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -285,7 +285,7 @@ contains
       !
       if (cvmixBackgroundOn) then
          !$omp parallel
-         !$omp do schedule(runtime)
+         !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
             do k = 1, nVertLevelsP1
                vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + config_cvmix_background_viscosity

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -268,6 +268,7 @@ contains
 
       nCells = nCellsArray( size(nCellsArray) )
 
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          vertViscTopOfCell(:, iCell) = 0.0_RKIND
@@ -275,6 +276,7 @@ contains
          vertNonLocalFlux(:, :, iCell) = 0.0_RKIND
       end do
       !$omp end do
+      !$omp end parallel
 
       nCells = nCellsArray( 3 )
 
@@ -282,6 +284,7 @@ contains
       ! start by adding the mininum background values to the viscocity/diffusivity arrays
       !
       if (cvmixBackgroundOn) then
+         !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCells
             do k = 1, nVertLevelsP1
@@ -290,6 +293,7 @@ contains
             end do
          end do
          !$omp end do
+         !$omp end parallel
       endif
 
       !
@@ -335,7 +339,16 @@ contains
 
       call mpas_timer_start('cvmix cell loop', .false.)
       do kpp_stage = 1,2
-      !$omp do schedule(runtime)
+      ! TODO, mdt: determine where the openmp data race is coming from in this loop
+      !!$omp parallel
+      !!$omp do schedule(runtime) &
+      !!$omp private(iCell, invAreaCell, k, RiSmoothed, RiTemp, BVFSmoothed, nsmooth, &
+      !!$omp         langmuirNumber, langmuirEnhancementFactor, bulkRichardsonNumberStop, &
+      !!$omp         bulkRichardsonFlag, topIndex, kIndexOBL, deltaVelocitySquared, sigma, &
+      !!$omp         OBLDepths, interfaceForcings, surfaceAverageIndex, sfc_layer_depth, kav, &
+      !!$omp         i, iEdge, factor, normalVelocitySum, NormalVelocityAv, &
+      !!$omp         delU2, potentialDensitySum, blTemp) &
+      !!$omp firstprivate(cvmix_variables, Nsqr_iface, turbulentScalarVelocityScale)
       do iCell = 1, nCells
 
          ! specify geometry/location
@@ -732,11 +745,13 @@ contains
 
  endif ! kpp stage 2 convection calc
       end do  ! do iCell=1,mesh%nCells
-      !$omp end do
+      !!$omp end do
+      !!$omp end parallel
 
       if (kpp_stage == 1 .and. config_cvmix_use_BLD_smoothing) then ! smooth boundary layer
          nCells = nCellsArray(2)
 
+         !$omp parallel
          !$omp do schedule(runtime) private(nEdges, areaSum, edgeCount, iEdge, iNeighbor)
          do iCell=1,nCells
             nEdges = nEdgesOnCell(iCell)
@@ -764,6 +779,7 @@ contains
              boundaryLayerDepth(iCell) = boundaryLayerDepthSmooth(iCell)
           enddo
          !$omp end do
+         !$omp end parallel
 
        endif !stage 1 BLD smoothing
       end do ! kpp_stage

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -402,7 +402,7 @@ contains
 
       ! need predicted transport velocity to limit drying flux
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k)
+      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, divOutFlux, layerThickness)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         ! can switch with maxLevelEdgeBot(iEdge)

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -286,7 +286,7 @@ contains
 
      ! prevent drying from happening with selective wettingVelocity
      !$omp parallel
-     !$omp do schedule(runtime) private(iEdge, k)
+     !$omp do schedule(runtime) private(k)
      do iEdge = 1, nEdges
        do k = 1, maxLevelEdgeBot(iEdge)
          if (abs(normalTransportVelocity(k,iEdge) + wettingVelocity(k,iEdge)) < eps)  then

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -400,8 +400,6 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
-      call mpas_threading_barrier()
-
       ! need predicted transport velocity to limit drying flux
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k)

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -271,13 +271,13 @@ contains
      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
 
-
+     !$omp parallel
      !$omp do schedule(runtime)
      do iEdge = 1, nEdges
        wettingVelocity(:, iEdge) = 0.0_RKIND
      end do
      !$omp end do
-     call mpas_threading_barrier()
+     !$omp end parallel
 
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
@@ -285,7 +285,8 @@ contains
                                              normalTransportVelocity, rkSubstepWeight, wettingVelocity, err)
 
      ! prevent drying from happening with selective wettingVelocity
-     !$omp do schedule(runtime)
+     !$omp parallel
+     !$omp do schedule(runtime) private(iEdge, k)
      do iEdge = 1, nEdges
        do k = 1, maxLevelEdgeBot(iEdge)
          if (abs(normalTransportVelocity(k,iEdge) + wettingVelocity(k,iEdge)) < eps)  then
@@ -305,7 +306,7 @@ contains
        end do
      end do
      !$omp end do
-     call mpas_threading_barrier()
+     !$omp end parallel
 
    end subroutine ocn_prevent_drying_rk4 !}}}
 
@@ -402,6 +403,7 @@ contains
       call mpas_threading_barrier()
 
       ! need predicted transport velocity to limit drying flux
+      !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k)
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
@@ -445,8 +447,7 @@ contains
         end do
       end do
       !$omp end do
-
-      call mpas_threading_barrier()
+      !$omp end parallel
 
    end subroutine ocn_wetting_drying_wettingVelocity !}}}
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_1thread.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_1thread.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<config case="1thread_run">
+	<add_link source="../../init/initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../../init/initial_state/graph.info" dest="graph.info"/>
+	<add_link source="../../init/initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_dt">'0000_00:05:00'</option>
+		<option name="config_run_duration">'0000_00:10:00'</option>
+		<option name="config_time_integrator">'RK4'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_2thread.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_2thread.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<config case="2thread_run">
+	<add_link source="../../init/initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../../init/initial_state/graph.info" dest="graph.info"/>
+	<add_link source="../../init/initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_dt">'0000_00:05:00'</option>
+		<option name="config_run_duration">'0000_00:10:00'</option>
+		<option name="config_time_integrator">'RK4'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="2" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_driver.xml
@@ -1,0 +1,13 @@
+<driver_script name="run.py">
+	<case name="1thread_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running 1thread_run" post_message="  - Complete"/>
+	</case>
+	<case name="2thread_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running 2thread_run" post_message="  - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="1thread_run/output.nc" file2="2thread_run/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/testing_and_setup/compass/ocean/regression_suites/nightly.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/nightly.xml
@@ -14,6 +14,9 @@
 	<test name="Global Ocean 240km - Thread Test" core="ocean" configuration="global_ocean" resolution="QU240" test="thread_test">
 		<script name="run.py"/>
 	</test>
+	<test name="Global Ocean 240km - RK4 Thread Test" core="ocean" configuration="global_ocean" resolution="QU240" test="rk4_thread_test">
+		<script name="run.py"/>
+	</test>
 	<test name="Global Ocean 240km - Analysis Test" core="ocean" configuration="global_ocean" resolution="QU240" test="analysis_test">
 		<script name="run.py"/>
 	</test>


### PR DESCRIPTION
This PR replaces the OpenMP threading implementation with the parallel region being initiated before the timestep loop with a new implementation that created parallel regions around each OpenMP loop (i.e., more localized threading regions instead of a global region).

