### PR TITLE
Fix missing MLD and globalStats streams

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up1.xml
@@ -32,6 +32,7 @@
 			<attribute name="output_interval">00-00-00_06:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up2.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-00_06:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up3.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up3.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-00_12:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up4.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up4.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up5.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up5.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up6.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_spin_up6.xml
@@ -34,6 +34,7 @@
 			<attribute name="output_interval">00-00-03_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_test_final_settings.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_test_final_settings.xml
@@ -33,6 +33,7 @@
 			<attribute name="output_interval">00-01-00_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_test_final_settings.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP12/spin_up/config_test_final_settings.xml
@@ -33,10 +33,7 @@
 			<attribute name="output_interval">00-01-00_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up1.xml
@@ -32,6 +32,7 @@
 			<attribute name="output_interval">00-00-00_06:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up2.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-00_06:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up3.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up3.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-00_12:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up4.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up4.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up5.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up5.xml
@@ -36,6 +36,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up6.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_spin_up6.xml
@@ -34,6 +34,7 @@
 			<attribute name="output_interval">00-00-03_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_test_final_settings.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_test_final_settings.xml
@@ -33,6 +33,7 @@
 			<attribute name="output_interval">00-01-00_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_test_final_settings.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/CUSP8/spin_up/config_test_final_settings.xml
@@ -33,10 +33,7 @@
 			<attribute name="output_interval">00-01-00_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_prep_spin_up1.xml
@@ -30,10 +30,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_prep_spin_up1.xml
@@ -30,6 +30,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_simulation.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_simulation.xml
@@ -31,6 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_prep_spin_up1.xml
@@ -30,10 +30,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_prep_spin_up1.xml
@@ -30,6 +30,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_simulation.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_simulation.xml
@@ -31,6 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/test/config_test.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/test/config_test.xml
@@ -22,9 +22,8 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_06:00:00</attribute>
 		</stream>
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_1thread.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_1thread.xml
@@ -18,8 +18,6 @@
 		</stream>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_2thread.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_2thread.xml
@@ -18,8 +18,6 @@
 		</stream>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/QU240wISC/init/config_ssh_adjustment.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240wISC/init/config_ssh_adjustment.xml
@@ -2,6 +2,7 @@
 <config case="ssh_adjustment">
 	<add_link source="../initial_state/graph.info" dest="graph.info"/>
 	<add_link source="../initial_state/initial_state.nc" dest="init0.nc"/>
+	<add_link source="../initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
 
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU240wISC/init/config_test.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240wISC/init/config_test.xml
@@ -21,9 +21,8 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_06:00:00</attribute>
 		</stream>
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_prep_spin_up1.xml
@@ -32,6 +32,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_prep_spin_up1.xml
@@ -32,10 +32,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_simulation.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU60/spin_up/config_simulation.xml
@@ -31,6 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_prep_spin_up1.xml
@@ -31,6 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_prep_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_prep_spin_up1.xml
@@ -31,10 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
-
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">

--- a/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_simulation.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_simulation.xml
@@ -31,6 +31,7 @@
 			<attribute name="output_interval">00-00-10_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_forward.xml
@@ -34,6 +34,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up1.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up1.xml
@@ -33,6 +33,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up2.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up2.xml
@@ -38,6 +38,7 @@
 			<attribute name="filename_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up3.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up3.xml
@@ -37,6 +37,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up4.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SOQU60to15/spin_up/config_spin_up4.xml
@@ -37,6 +37,7 @@
 			<attribute name="output_interval">00-00-01_00:00:00</attribute>
 		</stream>
 
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
 		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 

--- a/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_ssh_adjustment.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_ssh_adjustment.xml
@@ -2,6 +2,7 @@
 <config case="ssh_adjustment">
 	<add_link source="../initial_state/graph.info" dest="graph.info"/>
 	<add_link source="../initial_state/initial_state.nc" dest="init0.nc"/>
+	<add_link source="../initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
 
 	<add_link source_path="script_core_dir" source="iterative_ssh_landIcePressure_scripts/iterate_init.py" dest="iterate_init.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plots/plot_globalStats.py" dest="plot_globalStats.py"/>

--- a/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_test.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files_ISC/config_test.xml
@@ -21,9 +21,8 @@
 		<stream name="output">
 			<attribute name="output_interval">0000_00:30:00</attribute>
 		</stream>
-		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
-		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
 
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
 	</streams>
 
 	<run_script name="run.py">


### PR DESCRIPTION
The template for forward global_ocean runs was updated to turn on the MLD analysis member but the associated output stream was only included in some steps, not all, causing many test cases to be broken.

In many steps, the global stats analysis was being turned on in the namelist but the associated stream was missing.

This merge also adds links to `forcing_data.nc` in `ssh_adjustment` steps because, although this data should not be needed in these steps, error log files are generated because the stream points to non-existent file.

closes #521 