### PR TITLE
Modify freezing temperature to match MPAS-Seaice

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -961,8 +961,8 @@
 					description="Character string to choose EOS formulation"
 					possible_values="Jackett McDougall EOS = 'jm' and Linear EOS = 'linear'"
 		/>
-		<nml_option name="config_open_ocean_freezing_temperature_coeff_0" type="real" default_value="-1.8" units="C"
-					description="The freezing temperature at zero pressure in open ocean."
+		<nml_option name="config_open_ocean_freezing_temperature_coeff_0" type="real" default_value="0.0" units="C"
+					description="The freezing temperature at zero pressure and salinity in open ocean."
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_open_ocean_freezing_temperature_coeff_S" type="real" default_value="0.0" units="C PSU^{-1}"
@@ -970,19 +970,19 @@
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_open_ocean_freezing_temperature_coeff_p" type="real" default_value="0.0" units="C Pa^{-1}"
-					description="The coefficient for the term proportional to the (limited) pressure in the freezing temperature in the open ocean."
+					description="The coefficient for the term proportional to the pressure in the freezing temperature in the open ocean."
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_open_ocean_freezing_temperature_coeff_pS" type="real" default_value="0.0" units="C PSU^{-1} Pa^{-1}"
 					description="The coefficient for the term proportional to salinity times pressure in the freezing temperature in the open ocean."
 					possible_values="Any real number"
 		/>
-		<nml_option name="config_open_ocean_freezing_temperature_reference_pressure" type="real" default_value="0.0" units="Pa"
-					description="The reference pressure above which the freezing temperature is equal to config_freezing_temperature_coeff_0 in the open ocean."
-					possible_values="Any positive real number"
+		<nml_option name="config_open_ocean_freezing_temperature_coeff_mushy_az1_liq" type="real" default_value="-18.48" units="PSU C^{-1}"
+					description="The coefficient for the mushy sea-ice physics term az1_liq in the open ocean."
+					possible_values="Any non-positive number"
 		/>
 		<nml_option name="config_land_ice_cavity_freezing_temperature_coeff_0" type="real" default_value="6.22e-2" units="C"
-					description="The freezing temperature at zero pressure in land-ice cavities."
+					description="The freezing temperature at zero pressure and salinity in land-ice cavities."
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_land_ice_cavity_freezing_temperature_coeff_S" type="real" default_value="-5.63e-2" units="C PSU^{-1}"
@@ -990,16 +990,12 @@
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_land_ice_cavity_freezing_temperature_coeff_p" type="real" default_value="-7.43e-8" units="C Pa^{-1}"
-					description="The coefficient for the term proportional to the (limited) pressure in the freezing temperature in land-ice cavities."
+					description="The coefficient for the term proportional to the pressure in the freezing temperature in land-ice cavities."
 					possible_values="Any real number"
 		/>
 		<nml_option name="config_land_ice_cavity_freezing_temperature_coeff_pS" type="real" default_value="-1.74e-10" units="C PSU^{-1} Pa^{-1}"
 					description="The coefficient for the term proportional to salinity times pressure in the freezing temperature in land-ice cavities."
 					possible_values="Any real number"
-		/>
-		<nml_option name="config_land_ice_cavity_freezing_temperature_reference_pressure" type="real" default_value="0.0" units="Pa"
-					description="The reference pressure above which the freezing temperature is equal to config_freezing_temperature_coeff_0 in land-ice cavities."
-					possible_values="Any positive real number"
 		/>
 	</nml_record>
 	<nml_record name="eos_linear">

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -309,34 +309,29 @@ contains
       logical, intent(in) :: inLandIceCavity !< Input: flag indicating if the freezing temperature is computed
                                              !         in land ice cavities or in open ocean
 
-      real (kind=RKIND), pointer :: coeff_0
-      real (kind=RKIND), pointer :: coeff_S
-      real (kind=RKIND), pointer :: coeff_p
-      real (kind=RKIND), pointer :: coeff_pS
-      real (kind=RKIND), pointer :: reference_pressure
-      real (kind=RKIND) :: pressureOffset
+      real (kind=RKIND), pointer :: coeff_0, coeff_S, coeff_p, coeff_pS, az1_liq
+      real (kind=RKIND) :: coeff_mushy
 
       if(inLandIceCavity) then
          coeff_0 => config_land_ice_cavity_freezing_temperature_coeff_0
          coeff_S => config_land_ice_cavity_freezing_temperature_coeff_S
          coeff_p => config_land_ice_cavity_freezing_temperature_coeff_p
          coeff_pS => config_land_ice_cavity_freezing_temperature_coeff_pS
-         reference_pressure => config_land_ice_cavity_freezing_temperature_reference_pressure
+         coeff_mushy = 0.0_RKIND
       else
          coeff_0 => config_open_ocean_freezing_temperature_coeff_0
          coeff_S => config_open_ocean_freezing_temperature_coeff_S
          coeff_p => config_open_ocean_freezing_temperature_coeff_p
          coeff_pS => config_open_ocean_freezing_temperature_coeff_pS
-         reference_pressure => config_open_ocean_freezing_temperature_reference_pressure
+         az1_liq => config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+         coeff_mushy = 1.0_RKIND / az1_liq
       end if
-
-
-      pressureOffset = max(pressure - reference_pressure, 0.0_RKIND)
 
       ocn_freezing_temperature = coeff_0 &
          + coeff_S * salinity &
-         + coeff_p * pressureOffset &
-         + coeff_pS * pressureOffset * salinity
+         + coeff_p * pressure &
+         + coeff_pS * pressure * salinity &
+         + coeff_mushy * salinity / (1.0_RKIND - salinity / 1e3_RKIND)
 
     end function ocn_freezing_temperature!}}}
 
@@ -359,24 +354,23 @@ contains
       logical, intent(in) :: inLandIceCavity !< Input: flag indicating if the freezing temperature is computed
                                              !         in land ice cavities or in open ocean
 
-      real (kind=RKIND), pointer :: coeff_S
-      real (kind=RKIND), pointer :: coeff_pS
-      real (kind=RKIND), pointer :: reference_pressure
-      real (kind=RKIND) :: pressureOffset
+      real (kind=RKIND), pointer :: coeff_S, coeff_p, coeff_pS, az1_liq
+      real (kind=RKIND) :: coeff_mushy
+
 
       if(inLandIceCavity) then
          coeff_S => config_land_ice_cavity_freezing_temperature_coeff_S
          coeff_pS => config_land_ice_cavity_freezing_temperature_coeff_pS
-         reference_pressure => config_land_ice_cavity_freezing_temperature_reference_pressure
+         coeff_mushy = 0.0_RKIND
       else
          coeff_S => config_open_ocean_freezing_temperature_coeff_S
          coeff_pS => config_open_ocean_freezing_temperature_coeff_pS
-         reference_pressure => config_open_ocean_freezing_temperature_reference_pressure
+         az1_liq => config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+         coeff_mushy = 1.0_RKIND / az1_liq
       end if
 
-      pressureOffset = max(pressure - reference_pressure, 0.0_RKIND)
-
-      ocn_freezing_temperature_salinity_deriv = coeff_S + coeff_pS * pressureOffset
+      ocn_freezing_temperature_salinity_deriv = coeff_S + coeff_pS * pressure &
+         + coeff_mushy / (1.0_RKIND - salinity/1e3_RKIND)**2
 
     end function ocn_freezing_temperature_salinity_deriv!}}}
 


### PR DESCRIPTION
To match the "mushy" formulation of the freezing temperature as
a function of salinity in MPAS-Seaice (the high-temperature limit
only), a new "mushy_az1_liq" coefficient has been added, multiplying
a new term with the appropriate value and associated functional form:
```
Tf(S) = (1/mushy_az1_liq)*(S/(1 - S/1000))
```

The value `config_open_ocean_freezing_temperature_coeff_mushy_az1_liq = -18.48` is taken from:
 https://github.com/MPAS-Dev/MPAS-Model/blob/seaice/develop/src/core_seaice/column/ice_mushy_physics.F90#L34

This merge also gets rid of support for a reference pressure in the freezing temperature, which we have not made use of since initial testing.  (To my knowledge, the value has always been set to zero).  I do not see the need to keep this added complexity if we are not using it.