### PR TITLE
Fix COMPASS links from ARM mesh

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/ARM60to10/init/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/ARM60to10/init/config_base_mesh.xml
@@ -1,1 +1,15 @@
-../../config_files/config_base_mesh.xml
+<?xml version="1.0"?>
+<config case="base_mesh">
+
+	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
+	<copy_file source_path="script_test_dir" source="define_base_mesh.py" dest="define_base_mesh.py"/>
+	<add_link source_path="script_test_dir" source="Atlantic_region.geojson" dest="Atlantic_region.geojson"/>
+	<add_link source_path="script_test_dir" source="Americas_land_mask.geojson" dest="Americas_land_mask.geojson"/>
+	<add_link source_path="script_test_dir" source="Europe_Africa_land_mask.geojson" dest="Europe_Africa_land_mask.geojson"/>
+
+	<run_script name="run.py">
+		<step executable="python">
+			<argument flag="-m">jigsaw_to_MPAS.build_mesh</argument>
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/config_files/config_base_mesh.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/config_files/config_base_mesh.xml
@@ -3,9 +3,6 @@
 
 	<add_link source_path="mpas_model" source="testing_and_setup/compass/ocean/jigsaw_to_MPAS" dest="jigsaw_to_MPAS"/>
 	<copy_file source_path="script_test_dir" source="define_base_mesh.py" dest="define_base_mesh.py"/>
-	<add_link source_path="script_test_dir" source="Atlantic_region.geojson" dest="Atlantic_region.geojson"/>
-	<add_link source_path="script_test_dir" source="Americas_land_mask.geojson" dest="Americas_land_mask.geojson"/>
-	<add_link source_path="script_test_dir" source="Europe_Africa_land_mask.geojson" dest="Europe_Africa_land_mask.geojson"/>
 
 	<run_script name="run.py">
 		<step executable="python">


### PR DESCRIPTION
These links were previously copied into a number of other cases because it used a shared version of `config_base_mesh.xml`.