### PR TITLE
Optimizations for tracer horizontal mixing

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -149,10 +149,10 @@ contains
 
       call mpas_timer_start("tracer hmix")
 
-      call ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err1)
-      call ocn_tracer_hmix_del4_tend(meshPool, layerThicknessEdge, tracers, tend, err2)
+      call ocn_tracer_hmix_del2_tend(layerThicknessEdge, tracers, tend, err1)
+      call ocn_tracer_hmix_del4_tend(layerThicknessEdge, tracers, tend, err2)
       if (config_use_Redi) then
-        call ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+        call ocn_tracer_hmix_Redi_tend(layerThickness, layerThicknessEdge, zMid, tracers, &
                                      RediKappa, dt, isActiveTracer,        &
                                      slopeTriadUp, slopeTriadDown, RediKappaSfcTaper, &
                                      RediKappaScaling, rediLimiterCount, tend, err1)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -29,6 +29,7 @@ module ocn_tracer_hmix_del2
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -76,14 +77,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err)!{{{
+   subroutine ocn_tracer_hmix_del2_tend(layerThicknessEdge, tracers, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThicknessEdge !< Input: thickness at edges
@@ -116,11 +115,6 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2
       integer :: i, k, iTracer, num_tracers, nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: invAreaCell
       real (kind=RKIND) :: tracer_turb_flux, flux, r_tmp
@@ -134,21 +128,9 @@ contains
 
       call mpas_timer_start("tracer del2")
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       num_tracers = size(tracers, dim=1)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-
-      nCells = nCellsArray( 1 )
+      nCells = nCellsOwned
 
       !
       ! compute a boundary mask to enforce insulating boundary conditions in the horizontal

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
@@ -28,6 +28,7 @@ module ocn_tracer_hmix_del4
    use mpas_threading
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -75,7 +76,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_del4_tend(meshPool, layerThicknessEdge, tracers, tend, err)!{{{
+   subroutine ocn_tracer_hmix_del4_tend(layerThicknessEdge, tracers, tend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -85,9 +86,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThicknessEdge    !< Input: thickness at edge
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         tracers !< Input: tracer quantities
@@ -117,15 +115,8 @@ contains
 
       integer :: iEdge, num_tracers, nCells, nEdges
       integer :: iTracer, k, iCell, cell1, cell2, i
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
-      integer, dimension(:,:), pointer :: edgeMask, cellsOnEdge, edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: invAreaCell1, invAreaCell2, tracer_turb_flux, flux, invdcEdge, r_tmp1, r_tmp2
-
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, meshScalingDel4
 
       ! Scratch Arrays
       real (kind=RKIND), dimension(:,:,:), allocatable :: delsq_tracer
@@ -144,30 +135,12 @@ contains
 
       call mpas_timer_start("tracer del4")
 
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       num_tracers = size(tracers, dim=1)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
-
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
       allocate(delsq_tracer(num_tracers, nVertLevels, nCells))
 
       ! Need 1 halo around owned cells
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
 
       ! first del2: div(h \nabla \phi) at cell center
       !$omp parallel
@@ -197,7 +170,7 @@ contains
       !$omp end parallel
 
       ! Only need tendency on owned cells
-      nCells = nCellsArray( 1 )
+      nCells = nCellsOwned
 
       ! second del2: div(h \nabla [delsq_tracer]) at cell center
       !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -27,6 +27,7 @@ module ocn_tracer_hmix_Redi
 
    use ocn_config
    use ocn_constants
+   use ocn_mesh
 
    implicit none
    private
@@ -73,7 +74,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+   subroutine ocn_tracer_hmix_Redi_tend(layerThickness, layerThicknessEdge, zMid, tracers, &
                                         RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
                                         RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
@@ -82,8 +83,6 @@ contains
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type(mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real(kind=RKIND), dimension(:), intent(in) :: &
          RediKappa
@@ -130,41 +129,21 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iCellSelf
       integer :: i, k, iTr, nTracers, nCells, nEdges, km1, kp1, nCellsP1
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell, maxLevelCell
-      integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell, cellsOnCell
 
       real(kind=RKIND) :: tempTracer, invAreaCell1, invAreaCell2, invAreaCell, areaEdge
       real(kind=RKIND) :: flux, flux_term1, flux_term2, flux_term3, dTracerDx, coef
       real(kind=RKIND) :: r_tmp, tracer_turb_flux, kappaRediEdgeVal
-      real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
       real(kind=RKIND), dimension(:), allocatable :: minimumVal
       real(kind=RKIND), dimension(:, :), allocatable :: fluxRediZTop
+      real(kind=RKIND) :: coef1, coef2
       err = 0
 
       call mpas_timer_start("tracer redi")
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tracers, dim=1)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-
-      nCells = nCellsArray(size(nCellsArray))
-      nEdges = nEdgesArray(size(nEdgesArray))
+      nCells = nCellsAll
+      nEdges = nEdgesAll
 
       allocate (minimumVal(nTracers))
       allocate (fluxRediZTop(nTracers, nVertLevels + 1))
@@ -175,7 +154,7 @@ contains
       allocate (redi_term2_edge(nTracers, nVertLevels, nEdges))
       allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
 
-      nCells = nCellsArray(2)
+      nCells = nCellsHalo(1)
       !$omp parallel
       !$omp do schedule(runtime) private(i, iEdge)
       do iCell = 1,nCells
@@ -189,8 +168,8 @@ contains
       !$omp end do
       !$omp end parallel
 
-      nCells = nCellsArray(1)
-      nCellsP1 = nCellsArray(size(nCellsArray)) + 1
+      nCells = nCellsOwned
+      nCellsP1 = nCellsAll + 1
 
       ! Term 1: this is the "standard" horizontal del2 term, but with RediKappa coefficient.
       ! \kappa_2 \nabla \phi on edge
@@ -198,7 +177,7 @@ contains
       !$omp do schedule(runtime) &
       !$omp private(fluxRediZTop, invAreaCell, i, iEdge, cell1, cell2, iCellSelf, r_tmp, coef, k, &
       !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
-      !$omp         dTracerDx)
+      !$omp         dTracerDx, coef1, coef2)
       do iCell = 1, nCells
          redi_term1(:, :, iCell) = 0.0_RKIND
          redi_term2(:, :, iCell) = 0.0_RKIND
@@ -450,16 +429,12 @@ contains
       integer, intent(out) :: err !< Output: error flag
 
       type(block_type), pointer :: block
-      type(mpas_pool_type), pointer :: meshPool
       type(mpas_pool_type), pointer :: diagnosticsPool
       type(mpas_pool_type), pointer :: forcingPool
 
       real(kind=RKIND), dimension(:), pointer :: RediKappa, RediKappaData
-      real(kind=RKIND), dimension(:), pointer :: dcEdge
-      integer, dimension(:,:), pointer :: cellsOnEdge
 
       integer :: k, iEdge
-      integer, pointer :: nVertLevels, nEdges
 
       err = 0
 
@@ -473,20 +448,15 @@ contains
 
       block => domain%blocklist
       do while (associated(block))
-         call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
-         call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
          call mpas_pool_get_array(forcingPool, 'RediKappaData', RediKappaData)
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          ! initialize Redi kappa array
          if (config_Redi_closure == 'constant') then
             !$omp parallel
             !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
+            do iEdge = 1, nEdgesAll
                RediKappa(iEdge) = config_Redi_constant_kappa
             end do
             !$omp end do
@@ -507,7 +477,7 @@ contains
          else if (config_eddying_resolution_taper == 'ramp') then
             !$omp parallel
             !$omp do schedule(runtime) 
-            do iEdge=1,nEdges
+            do iEdge=1,nEdgesAll
                if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
                   RediKappa(iEdge) = 0.0_RKIND
                else if (dcEdge(iEdge) >= config_eddying_resolution_ramp_max) then

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -197,8 +197,9 @@ contains
                iCellSelf = 2
             endif
 
-            r_tmp = dvEdge(iEdge)/dcEdge(iEdge)
             coef = dvEdge(iEdge)
+            coef1 = edgeSignOnCell(i, iCell) * invAreaCell
+            coef2 = dvEdge(iEdge)/dcEdge(iEdge) * RediKappa(iEdge)
 
             k = 1
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
@@ -208,9 +209,9 @@ contains
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*coef2
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
-                                           (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+                                           (kappaRediEdgeVal - 1.0_RKIND))*coef1*flux
 
                flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
                             0.25_RKIND* &
@@ -235,10 +236,10 @@ contains
                   tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
 
                   ! div(h \kappa_2 \nabla \phi) at cell center
-                  flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+                  flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*coef2
 
                   redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
-                                              (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+                                              (kappaRediEdgeVal - 1.0_RKIND))*coef1*flux
 
                   flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThicknessEdge(k, iEdge)* &
                                0.25_RKIND* &
@@ -253,7 +254,7 @@ contains
                   redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - flux_term2*invAreaCell
                   redi_term2_edge(iTr, k, iEdge) = -flux_term2
 
-                  dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
+                  dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*coef*0.25_RKIND
                   fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                          0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
                                          *dTracerDx
@@ -268,9 +269,9 @@ contains
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*coef2
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
-                                           (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
+                                           (kappaRediEdgeVal - 1.0_RKIND))*coef1*flux
 
                ! For bottom layer, only use triads pointing up:
                flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
@@ -293,7 +294,7 @@ contains
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
 
-               dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
+               dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*coef*0.25_RKIND
                fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                       0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
                                       *dTracerDx


### PR DESCRIPTION
Optimizations to tracer horizontal mixing that include

- Removing pointer retrievals
- Trimming argument lists to remove Pool variables (no longer used in these routines)
- Replace mesh variables (previously retrieved from meshPool) with module-level variables in `ocn_mesh` module (relies on PR #496 being merged)

This PR requires the following PRs be merged first:

-  #496
-  #457
-  #513

Some of the changes in those PRs were either git cherry-pick'ed or manually added. As a result, once those PRs are merged there might need to be some commits squashed or changes reverted in this PR.