### PR TITLE
Update the compass conda env to 0.1.4

### DIFF
--- a/testing_and_setup/compass/README_ocean.md
+++ b/testing_and_setup/compass/README_ocean.md
@@ -6,11 +6,11 @@ To set up and run ocean test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_0.1.3 -c conda-forge -c e3sm python=3.7 compass=0.1.3
+conda create -n compass_0.1.4 -c conda-forge -c e3sm python=3.7 compass=0.1.4
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_0.1.3
+conda activate compass_0.1.4
 ```
 
 An appropriate conda environment is already available on Los Alamos National

--- a/testing_and_setup/compass/load_compass_env.sh
+++ b/testing_and_setup/compass/load_compass_env.sh
@@ -13,7 +13,8 @@ elif [[ $HOSTNAME = "cooley"* ]]; then
   base_path="/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base"
 elif [[ $HOSTNAME = "compy"* ]]; then
   base_path="/share/apps/E3SM/conda_envs/base"
-elif [[ $HOSTNAME = "gr-fe"* ]] || [[ $HOSTNAME = "ba-fe"* ]]; then
+elif [[ $HOSTNAME = "gr-fe"* ]] || [[ $HOSTNAME = "ba-fe"* ]] || \
+    [[ $HOSTNAME =~ ^gr[0-9]{4}$ ]] || [[ $HOSTNAME =~ ^ba[0-9]{3}$ ]]; then
   base_path="/usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base"
 else
   echo "Unknown host name $HOSTNAME.  Add base_path for this machine to the script."

--- a/testing_and_setup/compass/load_compass_env.sh
+++ b/testing_and_setup/compass/load_compass_env.sh
@@ -1,4 +1,4 @@
-version=0.1.3
+version=0.1.4
 
 # The rest of the script should not need to be modified
 if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then


### PR DESCRIPTION
This version of the `compass` environment includes a critical land blockage that prevents the Black Sea from being part of ocean meshes.