### PR TITLE
fixes for redi to work for BGC

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -447,7 +447,6 @@ contains
       ! additional pools
       !
       type (mpas_pool_type), pointer :: tracersPool, tracersTendPool            ! tracers and their tendency
-      type (mpas_pool_type), pointer :: redi1Pool, redi2Pool, redi3Pool
       type (mpas_pool_type), pointer :: tracersSurfaceFluxPool                  ! surface fluxes
       type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool       ! surface restoring
       type (mpas_pool_type), pointer :: tracersInteriorRestoringFieldsPool      ! interior restoring
@@ -497,8 +496,7 @@ contains
       ! three dimensional pointers
       !
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-        tracerGroup, tracerGroupTend, redi_term1, redi_term2, redi_term3, &
-        vertNonLocalFlux
+        tracerGroup, tracerGroupTend, vertNonLocalFlux
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
         activeTracers, &  !  need T, S for ecosys
@@ -546,9 +544,6 @@ contains
       !
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
       call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-      call mpas_pool_get_subpool(rediPool, 'tracers_redi_term1', redi1Pool)
-      call mpas_pool_get_subpool(rediPool, 'tracers_redi_term2', redi2Pool)
-      call mpas_pool_get_subpool(rediPool, 'tracers_redi_term3', redi3Pool)
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
 
       !
@@ -661,15 +656,6 @@ contains
                modifiedGroupName = trim(groupItr % memberName) // "Tend"
                call mpas_pool_get_array(tracersTendPool, trim(modifiedGroupName), tracerGroupTend)
 
-               modifiedGroupName = trim(groupItr % memberName) // "_redi_term1"
-               call mpas_pool_get_array(redi1Pool, trim(modifiedGroupName), redi_term1)
-
-               modifiedGroupName = trim(groupItr % memberName) // "_redi_term2"
-               call mpas_pool_get_array(redi2Pool, trim(modifiedGroupName), redi_term2)
-
-               modifiedGroupName = trim(groupItr % memberName) // "_redi_term3"
-               call mpas_pool_get_array(redi3Pool, trim(modifiedGroupName), redi_term3)
-
                ! Get surface flux array
                modifiedGroupName = trim(groupItr % memberName) // "SurfaceFlux"
                call mpas_pool_get_array(tracersSurfaceFluxPool, trim(modifiedGroupName), tracerGroupSurfaceFlux)
@@ -694,9 +680,6 @@ contains
                do iCell = 1, nCells
                  tracerGroupTend(:,:, iCell) = 0.0_RKIND
                  tracerGroupSurfaceFlux(:, iCell) = 0.0_RKIND
-                 redi_term1(:,:,iCell) = 0.0_RKIND
-                 redi_term2(:,:,iCell) = 0.0_RKIND
-                 redi_term3(:,:,iCell) = 0.0_RKIND
                end do
                !$omp end do
 
@@ -893,7 +876,6 @@ contains
                isActiveTracer = .false.
                if(trim(groupItr % memberName)=='activeTracers') isActiveTracer = .true.
                call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
-                                         redi_term1, redi_term2, redi_term3, &
                                          RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer, &
                                          kappaRediSfcTaper, kappaGMCell, rediLimiterCount, tracerGroupTend, err)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -80,7 +80,6 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracers, &
-                                   redi_term1, redi_term2, redi_term3, &
                                    RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
                                    kappaRediSfcTaper, kappaGMCell, rediLimiterCount, tend, err)!{{{
 
@@ -119,7 +118,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-         tend, redi_term1, redi_term2, redi_term3          !< Input/Output: velocity tendency
+         tend
 
       !-----------------------------------------------------------------
       !
@@ -152,7 +151,6 @@ contains
       call ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err1)
       call ocn_tracer_hmix_del4_tend(meshPool, scratchPool, layerThicknessEdge, tracers, tend, err2)
       call ocn_tracer_hmix_Redi_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
-                                     redi_term1, redi_term2, redi_term3,  &
                                      RediKappa, dt, isActiveTracer,        &
                                      slopeTriadUp, slopeTriadDown, kappaRediSfcTaper, &
                                      kappaGMCell, rediLimiterCount, tend, err1)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -73,7 +73,6 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_hmix_Redi_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
-                                        redi_term1, redi_term2, redi_term3, &
                                         RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
                                         kappaRediSfcTaper, kappaGMCell, rediLimiterCount, tend, err)!{{{
 
@@ -113,7 +112,7 @@ contains
       !-----------------------------------------------------------------
 
       real(kind=RKIND), dimension(:, :, :), intent(inout) :: &
-         tend, redi_term1, redi_term2, redi_term3     !< Input/Output: velocity tendency
+         tend
 
       !-----------------------------------------------------------------
       !
@@ -143,6 +142,7 @@ contains
       real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
       real(kind=RKIND), dimension(:), allocatable :: minimumVal
       real(kind=RKIND), dimension(:, :), allocatable :: fluxRediZTop
+      real(kind=RKIND), dimension(:,:,:), allocatable :: redi_term1, redi_term2, redi_term3
       err = 0
 
       if (.not. config_use_Redi) return
@@ -172,6 +172,9 @@ contains
       allocate (minimumVal(nTracers))
       allocate (fluxRediZTop(nTracers, nVertLevels + 1))
       !$omp master
+      allocate (redi_term1(nTracers, nVertLevels, nCells))
+      allocate (redi_term2(nTracers, nVertLevels, nCells))
+      allocate (redi_term3(nTracers, nVertLevels, nCells))
       allocate (redi_term2_edge(nTracers, nVertLevels, nEdges))
       allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
       !$omp end master
@@ -398,6 +401,9 @@ contains
       deallocate (fluxRediZTop)
       deallocate (minimumVal)
       !$omp master
+      deallocate (redi_term1)
+      deallocate (redi_term2)
+      deallocate (redi_term3)
       deallocate (redi_term2_edge)
       deallocate (redi_term3_topOfCell)
       !$omp end master

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -56,6 +56,7 @@ module ocn_tracer_hmix_Redi
 
    real(kind=RKIND) :: term1TaperFactor
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term2_edge, redi_term3_topOfCell
+   real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term1, redi_term2, redi_term3
 
 !***********************************************************************
 
@@ -142,7 +143,6 @@ contains
       real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
       real(kind=RKIND), dimension(:), allocatable :: minimumVal
       real(kind=RKIND), dimension(:, :), allocatable :: fluxRediZTop
-      real(kind=RKIND), dimension(:,:,:), allocatable :: redi_term1, redi_term2, redi_term3
       err = 0
 
       if (.not. config_use_Redi) return

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -85,41 +85,6 @@
 		</var_struct>
 	</var_struct>
 
-  <var_struct name="redi" time_levs="1">
-    <var_struct name="tracers_redi_term1" time_levs="1">
-      <var_array name="activeTracers_redi_term1" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
-        <var name="temperature_redi_term1" array_group="activeGRP" units="^\circ C s^{-1}"
-          description="time tendency of redi term 1 (straight horizontal mixing)"
-        />
-      
-        <var name="salinity_redi_term1" array_group="activeGRP" units="PSU s^{-1}"
-          description="time tendency of redi term 1 (straight horizontal mixing)"
-          />
-        </var_array> 
-    </var_struct>
-    <var_struct name="tracers_redi_term2" time_levs="1">
-      <var_array name="activeTracers_redi_term2" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
-        <var name="temperature_redi_term2" array_group="activeGRP" units="^\circ C s^{-1}"
-          description="time tendency of redi term 2 (cross term)"
-        />
-      
-        <var name="salinity_redi_term2" array_group="activeGRP" units="PSU s^{-1}"
-          description="time tendency of redi term 2 (cross term)"
-          />
-        </var_array> 
-    </var_struct>
-   <var_struct name="tracers_redi_term3" time_levs="1">
-      <var_array name="activeTracers_redi_term3" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
-        <var name="temperature_redi_term3" array_group="activeGRP" units="^\circ C s^{-1}"
-          description="time tendency of redi term 3 (cross term)"
-        />
-      
-        <var name="salinity_redi_term3" array_group="activeGRP" units="PSU s^{-1}"
-          description="time tendency of redi term 3 (cross term)"
-          />
-        </var_array> 
-    </var_struct>
- </var_struct>
 	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
 			<var_array name="activeTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="activeTracersPKG">

--- a/src/core_ocean/tracer_groups/Registry_debugTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_debugTracers.xml
@@ -79,57 +79,7 @@
 		</var_struct>
 	</var_struct>
 
-   <var_struct name="redi" time_levs="1">
-     <var_struct name="tracers_redi_term1" time_levs="1">
-       <var_array name="debugTracers_redi_term1" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG">
-         <var name="tracer1_redi_term1" array_group="debugGRP" units="tracer1"
-           description="time tendency of redi term 1 (straight horizontal mixing)"
-         />
-
-         <var name="tracer2_redi_term1" array_group="debugGRP" units="tracer2"
-           description="time tendency of redi term 1 (straight horizontal mixing)"
-         />
-
-         <var name="tracer3_redi_term1" array_group="debugGRP" units="tracer3"
-           description="time tendency of redi term 1 (straight horizontal mixing)"
-           />
-         </var_array>
-
-     </var_struct>
-     <var_struct name="tracers_redi_term2" time_levs="1">
-       <var_array name="debugTracers_redi_term2" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG">
-         <var name="tracer1_redi_term2" array_group="debugGRP" units="tracer1"
-           description="time tendency of redi term 2 (cross term)"
-         />
-
-         <var name="tracer2_redi_term2" array_group="debugGRP" units="tracer2"
-           description="time tendency of redi term 2 (cross term)"
-         />
-
-         <var name="tracer3_redi_term2" array_group="debugGRP" units="tracer3"
-           description="time tendency of redi term 2 (cross term)"
-           />
-         </var_array>
-
-     </var_struct>
-    <var_struct name="tracers_redi_term3" time_levs="1">
-       <var_array name="debugTracers_redi_term3" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG">
-         <var name="tracer1_redi_term3" array_group="debugGRP" units="tracer1"
-           description="time tendency of redi term 3 (cross term)"
-         />
-
-         <var name="tracer2_redi_term3" array_group="debugGRP" units="tracer2"
-           description="time tendency of redi term 3 (cross term)"
-         />
-
-         <var name="tracer3_redi_term3" array_group="debugGRP" units="tracer3"
-           description="time tendency of redi term 3 (cross term)"
-         />
-     </var_array>
-     </var_struct>
-  </var_struct>
-
-	<var_struct name="forcing" time_levs="1">
+   	<var_struct name="forcing" time_levs="1">
 		<var_struct name="tracersSurfaceFlux" time_levs="1">
 			<var_array name="debugTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="debugTracersPKG">
 				<var name="tracer1SurfaceFlux" array_group="debugTracerFluxGRP" units="tracer1 m s^{-1}"

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_driver.xml
@@ -1,0 +1,17 @@
+<driver_script name="run.py">
+	<case name="initial_state">
+		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message=" - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+			<template file="ecosys_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+		<compare_timers rundir1="forward">
+			<timer name="time integration"/>
+		</compare_timers>
+	</validation>
+</driver_script>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_forward.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../initial_state/graph.info" dest="graph.info"/>
+	<add_link source="../initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+		<option name="config_pio_num_iotasks">1</option>
+		<option name="config_pio_stride">4</option>
+		<option name="config_use_ecosysTracers">.true.</option>
+		<option name="config_use_DMSTracers">.true.</option>
+		<option name="config_use_MacroMoleculesTracers">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="shortwave_forcing_data.xml" path_base="script_core_dir" path="templates/streams"/>
+		<template file="global_stats.xml" path_base="script_core_dir" path="templates/analysis_members"/>
+		<stream name="output">
+			<attribute name="output_interval">0000_06:00:00</attribute>
+		</stream>
+		<stream name="ecosys_monthly_flux">
+			<attribute name="filename_template">init.nc</attribute>
+			<attribute name="input_interval">none</attribute>
+			<attribute name="type">input</attribute>
+			<attribute name="packages">ecosysTracersPKG</attribute>
+			<add_contents>
+				<member name="xtime" type="var" />
+				<member name="depositionFluzNO3" type="var" />
+				<member name="depositionFluzNH4" type="var" />
+				<member name="IRON_FLUZ_IN" type="var" />
+				<member name="dust_FLUZ_IN" type="var" />
+				<member name="riverFluzNO3" type="var" />
+				<member name="riverFluzPO4" type="var" />
+				<member name="riverFluzDON" type="var" />
+				<member name="riverFluzDOP" type="var" />
+				<member name="riverFluzSiO3" type="var" />
+				<member name="riverFluzFe" type="var" />
+				<member name="riverFluzDIC" type="var" />
+				<member name="riverFluzALK" type="var" />
+				<member name="riverFluzDOC" type="var" />
+			</add_contents>
+		</stream>
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_initial_state.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<config case="initial_state">
+	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ETOPO2v2c_f4_151106.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="chlorophyllA_monthly_averages_1deg.151201.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ecosys_jan_IC_360x180x60_corrO2_Dec2014phaeo.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="ecoForcingAllSurface.forMPASO.interp360x180.1timeLevel.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<add_link source="../../init/culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
+	<add_link source="../../init/culled_mesh/culled_graph.info" dest="graph.info"/>
+	<add_link source="../../init/culled_mesh/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
+	<add_link source_path="script_core_dir" source="scripts/plots/plot_initial_state.py" dest="plot_initial_state.py"/>
+	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="layer_depth.nc"/>
+	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
+	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
+	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
+	<add_link source_path="initial_condition_database" source="ecosys_jan_IC_360x180x60_corrO2_Dec2014phaeo.nc" dest="ecosys.nc"/>
+	<add_link source_path="initial_condition_database" source="ecoForcingAllSurface.forMPASO.interp360x180.1timeLevel.nc" dest="ecosys_forcing.nc"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
+		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_minimum_depth">10</option>
+		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
+		<option name="config_use_ecosysTracers">.true.</option>
+		<option name="config_use_DMSTracers">.true.</option>
+		<option name="config_use_MacroMoleculesTracers">.true.</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
+		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">4</argument>
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./plot_initial_state.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/regression_suites/nightly.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/nightly.xml
@@ -20,6 +20,9 @@
 	<test name="Global Ocean 240km - Analysis Test" core="ocean" configuration="global_ocean" resolution="QU240" test="analysis_test">
 		<script name="run.py"/>
 	</test>
+	<test name="Global Ocean 240km - BGC Ecosys Test" core="ocean" configuration="global_ocean" resolution="QU240" test="bgc_ecosys_test">
+		<script name="run.py"/>
+	</test>
 	<test name="ZISO 20km - Smoke Test" core="ocean" configuration="ziso" resolution="20km" test="default">
 		<script name="run_test.py"/>
 	</test>


### PR DESCRIPTION
redi_term{1-3} were declared in the activeTracers and debugTracers pool for output while testing.  These were never added to the BGC pools.  This PR makes those allocatable arrays in the Redi routine instead of in the pools