### PR TITLE
Revert some COMPASS changes intended to support conda MPI

### DIFF
--- a/testing_and_setup/compass/README_ocean.md
+++ b/testing_and_setup/compass/README_ocean.md
@@ -6,11 +6,11 @@ To set up and run ocean test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_0.1.4 -c conda-forge -c e3sm python=3.7 compass=0.1.4
+conda create -n compass_0.1.5 -c conda-forge -c e3sm python=3.7 compass=0.1.5
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_0.1.4
+conda activate compass_0.1.5
 ```
 
 An appropriate conda environment is already available on Los Alamos National

--- a/testing_and_setup/compass/load_compass_env.sh
+++ b/testing_and_setup/compass/load_compass_env.sh
@@ -1,4 +1,4 @@
-version=0.1.4
+version=0.1.5
 
 # The rest of the script should not need to be modified
 if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then

--- a/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/10km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">16</argument>
 			<argument flag="--ny">50</argument>
 			<argument flag="--dc">10000.0</argument>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/1km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">160</argument>
 			<argument flag="--ny">500</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/baroclinic_channel/4km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">40</argument>
 			<argument flag="--ny">126</argument>
 			<argument flag="--dc">4000.0</argument>

--- a/testing_and_setup/compass/ocean/dam_break/default/004m/config_init1.xml
+++ b/testing_and_setup/compass/ocean/dam_break/default/004m/config_init1.xml
@@ -42,7 +42,7 @@
 		</stream>
 	</streams>
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">325</argument>
 			<argument flag="--ny">700</argument>
 			<argument flag="--dc">0.04</argument>

--- a/testing_and_setup/compass/ocean/dam_break/default/012m/config_init1.xml
+++ b/testing_and_setup/compass/ocean/dam_break/default/012m/config_init1.xml
@@ -41,7 +41,7 @@
 		</stream>
 	</streams>
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">108</argument>
 			<argument flag="--ny">232</argument>
 			<argument flag="--dc">0.12</argument>

--- a/testing_and_setup/compass/ocean/drying_slope/meshes/1km/config_init.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/meshes/1km/config_init.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="build_1km_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">6</argument>
 			<argument flag="--ny">28</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/ocean/drying_slope/meshes/250m/config_init.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/meshes/250m/config_init.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="build_250m_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">6</argument>
 			<argument flag="--ny">114</argument>
 			<argument flag="--dc">250.0</argument>

--- a/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/internal_waves/5km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">4</argument>
 			<argument flag="--ny">50</argument>
 			<argument flag="--dc">5000.0</argument>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/default/config_init1.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/default/config_init1.xml
@@ -47,7 +47,7 @@ v		<option name="config_vert_levels">1</option>
 	</streams>
 
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">6</argument>
 			<argument flag="--ny">30</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/lock_exchange/0.5km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">4</argument>
 			<argument flag="--ny">128</argument>
 			<argument flag="--dc">500.0</argument>

--- a/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_mpas_mesh.xml
+++ b/testing_and_setup/compass/ocean/overflow/1km/rpe_test/config_mpas_mesh.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config case="mpas_mesh">
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">4</argument>
 			<argument flag="--ny">200</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/ocean/surface_waves/direct/1km/config_init1.xml
+++ b/testing_and_setup/compass/ocean/surface_waves/direct/1km/config_init1.xml
@@ -54,7 +54,7 @@
 	</streams>
 
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">6</argument>
 			<argument flag="--ny">30</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/ocean/surface_waves/thickness_source/1km/config_init1.xml
+++ b/testing_and_setup/compass/ocean/surface_waves/thickness_source/1km/config_init1.xml
@@ -54,7 +54,7 @@
 	</streams>
 
 	<run_script name="run.py">
-		<step executable="planar_hex" conda_mpi="true">
+		<step executable="planar_hex">
 			<argument flag="--nx">6</argument>
 			<argument flag="--ny">30</argument>
 			<argument flag="--dc">1000.0</argument>

--- a/testing_and_setup/compass/setup_testcase.py
+++ b/testing_and_setup/compass/setup_testcase.py
@@ -26,6 +26,7 @@ from six.moves import configparser
 import textwrap
 import netCDF4
 import shutil
+import errno
 
 try:
     from collections import defaultdict

--- a/testing_and_setup/compass/setup_testcase.py
+++ b/testing_and_setup/compass/setup_testcase.py
@@ -593,7 +593,7 @@ def generate_driver_scripts(config_file, configs):  # {{{
                     # Process <step> tags
                     if grandchild.tag == 'step':
                         process_script_step(grandchild, configs, '    ',
-                                            script, conda_mpi=False)
+                                            script)
                     # Process <define_env_var> tags
                     elif grandchild.tag == 'define_env_var':
                         process_env_define_step(grandchild, configs, '    ',
@@ -663,8 +663,7 @@ def process_env_define_step(var_tag, configs, indentation, script_file):  # {{{
 # }}}
 
 
-def process_script_step(step, configs, indentation, script_file,
-                        conda_mpi=None):  # {{{
+def process_script_step(step, configs, indentation, script_file):  # {{{
     # Determine step attributes.
     if 'executable_name' in step.attrib.keys() and 'executable' in \
             step.attrib.keys():
@@ -700,15 +699,6 @@ def process_script_step(step, configs, indentation, script_file,
     except KeyError:
         executable = step.attrib['executable']
 
-    if 'conda_mpi' in step.attrib:
-        # This step explicitly asks says whether to use conda MPI
-        conda_mpi = step.attrib['conda_mpi'] == "true"
-    elif conda_mpi is None:
-        # if not set explicitly, we will try to use conda MPI for executables
-        # start with "python" or end with ".py"
-        basename = os.path.basename(executable)
-        conda_mpi = (basename.startswith('python') or basename.endswith('.py'))
-
     # Write step header
     script_file.write("\n")
 
@@ -720,7 +710,7 @@ def process_script_step(step, configs, indentation, script_file,
 
     script_file.write("{}# Run command is:\n".format(indentation))
 
-    command_args = add_executable_prefix(executable, configs, conda_mpi)
+    command_args = [executable]
     # Process step arguments
     for argument in step:
         if argument.tag == 'argument':
@@ -888,10 +878,6 @@ def process_field_definition(field_tag, configs, script, file1, file2,
     # Build the base command to compare the fields
     command_args = [compare_executable, '-q', '-1', file1, '-2', file2, '-v',
                     field_name]
-
-    if configs.getboolean('conda', 'use_conda_mpi'):
-        prefix = configs.get('conda', 'python_prefix').split(' ')
-        command_args = prefix + command_args
 
     # Determine norm thresholds
     if baseline_comp:
@@ -1566,19 +1552,6 @@ def get_case_name(config_file):  # {{{
     return name
 # }}}
 
-
-def add_executable_prefix(executable, configs, conda_mpi):  # {{{
-    """
-    Prepend a prefix to the executable if conda MPI is requested and MPI is
-    present in the conda environment
-    """
-    command_args = [executable]
-    if conda_mpi and configs.getboolean('conda', 'use_conda_mpi'):
-        prefix = configs.get('conda', 'python_prefix').split(' ')
-        command_args = prefix + command_args
-    return command_args
-# }}}
-
 def link_load_compass_env(init_path, configs):  # {{{
 
     if configs.getboolean('conda', 'link_load_compass'):
@@ -1729,15 +1702,6 @@ if __name__ == "__main__":
 
     if not config.has_section('conda'):
         config.add_section('conda')
-
-    config.set('conda', 'use_conda_mpi', 'False')
-    if 'CONDA_PREFIX' in os.environ:
-        # We're running from a conda environment
-        mpirun_path = '{}/bin/mpirun'.format(os.environ['CONDA_PREFIX'])
-        if os.path.exists(mpirun_path):
-            # MPI is installed in that conda environment
-            config.set('conda', 'use_conda_mpi', 'True')
-            config.set('conda', 'python_prefix', '{} -np 1'.format(mpirun_path))
 
     if not config.has_option('conda', 'link_load_compass'):
         config.set('conda', 'link_load_compass', 'False')


### PR DESCRIPTION
It turns out not to be necessary to run python scripts with `mpirun` as long as we don't use the MPI version of `netcdf4`.  This is possible even if we want to use the MPI version of `esmf` (which we do because `ESMF_RegridWeightGen` is way too slow in serial for certain mesh combinations).

This PR reverts:
* 8217097, which modified `setup_testcase.py` to add `mpirun` to python scripts in certain circumstances
* 190338d, which made sure `planar_hex` (which wasn't obviously a python script) also got run in this way.

This merge also updates to `compass` env. 0.1.5, which makes sure we always get the `nompi` variant of `netcdf4`, so that the shenanigans with `mpirun` isn't needed.