### PR TITLE
Add support for a prerequisite tag in COMPASS

### DIFF
--- a/testing_and_setup/compass/manage_regression_suite.py
+++ b/testing_and_setup/compass/manage_regression_suite.py
@@ -147,7 +147,7 @@ def process_test_setup(test_tag, config_file, work_dir, model_runtime,
 # }}}
 
 
-def process_test_clean(test_tag, work_dir, suite_script):  # {{{
+def process_test_clean(test_tag, work_dir):  # {{{
     dev_null = open('/dev/null', 'a')
 
     # Process test attributes
@@ -304,7 +304,7 @@ def clean_suite(suite_tag, work_dir):  # {{{
     for child in suite_tag:
         # Process <test> children within the <regression_suite>
         if child.tag == 'test':
-            process_test_clean(child, work_dir, regression_script)
+            process_test_clean(child, work_dir)
 # }}}
 
 

--- a/testing_and_setup/compass/manage_regression_suite.py
+++ b/testing_and_setup/compass/manage_regression_suite.py
@@ -502,7 +502,7 @@ if __name__ == "__main__":
                 cmd = ['cat',
                        args.work_dir + '/manage_regression_suite.py.out']
                 print('\nCase setup output:')
-                print(subprocess.check_output(cmd))
+                print(subprocess.check_output(cmd).decode('utf-8'))
             write_history = True
 
     # Write the history of this command to the command_history file, for

--- a/testing_and_setup/compass/manage_regression_suite.py
+++ b/testing_and_setup/compass/manage_regression_suite.py
@@ -456,7 +456,7 @@ def summarize_suite(testcases):  # {{{
 # }}}
 
 
-if __name__ == "__main__":
+def main ():  # {{{
     # Define and process input arguments
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
@@ -573,5 +573,10 @@ if __name__ == "__main__":
         history_file.write('**************************************************'
                            '*********************\n')
         history_file.close()
+# }}}
+
+
+if __name__ == "__main__":
+    main()
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
Several ocean test cases depend on other ocean test cases.  Currently, this is used to create a mesh and/or initial condition that are then reused by one or more other tests.

Currently, the user simply must make sure the prerequisites are present when setting up a test case.  However, this merge makes sure that prerequisites are always present a regression suite and that they run before the dependent test case.  The main motivation for this change is future support for running multiple test cases from the nightly test suite in parallel.

This is done by parsing a tag like the following example from a `config_driver.xml` for the dependent test case:
```
<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
```

These tags will be added to individual test cases in separate PRs to the individual `<core>/develop` branches.