### PR TITLE
Add prerequisite tags to all necessary test cases

### DIFF
--- a/testing_and_setup/compass/ocean/Gaussian_hump/USDEQU120cr10rr2/delaware/config_driver.xml
+++ b/testing_and_setup/compass/ocean/Gaussian_hump/USDEQU120cr10rr2/delaware/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="Gaussian_hump" resolution="USDEQU120cr10rr2" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/Redi_verification/SouthernOceanSlice40/se_blocks_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/Redi_verification/SouthernOceanSlice40/se_blocks_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="Redi_verification" resolution="SouthernOceanSlice40" test="all"/>
 	<case name="4blocks_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 4blocks_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/Redi_verification/SouthernOceanSlice40/thread_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/Redi_verification/SouthernOceanSlice40/thread_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="Redi_verification" resolution="SouthernOceanSlice40" test="all"/>
 	<case name="1thread_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 1thread_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/hybrid/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/hybrid/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/hybrid/250m/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/hybrid/250m/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="250m"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/marsh_flooding/idealized_transect/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/marsh_flooding/idealized_transect/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="idealized_transect"/>
 	<case name="init_step1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/sigma/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/sigma/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/sigma/250m/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/sigma/250m/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="250m"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/zstar/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/zstar/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/zstar/250m/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/zstar/250m/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="250m"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/zstar_above_land/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/zstar_above_land/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/zstar_variableCd/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/zstar_variableCd/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/drying_slope/zstar_variableManningn/1km/config_driver.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/zstar_variableManningn/1km/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="drying_slope" resolution="meshes" test="1km"/>
 	<case name="init_step1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init_step1" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/spin_up/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="EC60to30" test="init"/>
 	<case name="prep_spin_up1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running prep_spin_up1" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30wISC/spin_up/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="EC60to30wISC" test="init"/>
 	<case name="prep_spin_up1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running prep_spin_up1" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/analysis_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/analysis_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="forward">
 		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/bgc_ecosys_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="initial_state">
 		<step executable="./run.py" quiet="true" pre_message=" * Initializing ocean state with bathymetry and tracers..." post_message="     complete!  Created file:  initial_state/initial_state.nc"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/daily_output_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/daily_output_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="test">
 		<step executable="./run.py" quiet="true" pre_message=" * Running test" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/performance_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/performance_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="forward">
 		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/restart_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/restart_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="full_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running full_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_blocks_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_blocks_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="4blocks_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 4blocks_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/rk4_thread_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="1thread_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 1thread_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/se_blocks_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/se_blocks_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="4blocks_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 4blocks_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/test/config_driver.xml
@@ -1,1 +1,11 @@
-../../config_files/config_driver_test.xml
+<driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
+	<case name="test">
+		<step executable="./run.py" quiet="true" pre_message=" * Running short test of ocean model..." post_message="     complete!"/>
+	</case>
+	<validation>
+		<compare_fields file1="forward/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/thread_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="QU240" test="init"/>
 	<case name="1thread_run">
 		<step executable="./run.py" quiet="true" pre_message=" * Running 1thread_run" post_message="  - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/SO60to10wISC/spin_up/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="SO60to10wISC" test="init"/>
 	<case name="prep_spin_up1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running prep_spin_up1" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/WC12/spin_up/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/WC12/spin_up/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="WC12" test="init"/>
 	<case name="spin_up1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up1" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/global_ocean/WC14/spin_up/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/WC14/spin_up/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run.py">
+	<prerequisite core="ocean" configuration="global_ocean" resolution="WC14" test="init"/>
 	<case name="spin_up1">
 		<step executable="./run.py" quiet="true" pre_message=" * Running spin_up1" post_message=" - Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/sandy/config_driver.xml
@@ -1,1 +1,9 @@
-../../config_files/config_driver.xml
+<driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU120at30cr10rr2" test="build_mesh"/>
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/synthetic_sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2/synthetic_sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU120at30cr10rr2" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2WD/sandy/config_driver.xml
@@ -1,1 +1,9 @@
-../../config_files_WD/config_driver.xml
+<driver_script name="run.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU120at30cr10rr2WD" test="build_mesh"/>
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward_RK4">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward RK4" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2WD_veg/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU120at30cr10rr2WD_veg/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU120at30cr10rr2WD_veg" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU240at60cr20rr4" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4/synthetic_sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4/synthetic_sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU240at60cr20rr4" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD/sandy/config_driver.xml
@@ -1,1 +1,9 @@
-../../config_files_WD/config_driver.xml
+<driver_script name="run.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU240at60cr20rr4WD" test="build_mesh"/>
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward_RK4">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward RK4" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD/synthetic_sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD/synthetic_sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU240at60cr20rr4WD" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD_veg/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU240at60cr20rr4WD_veg/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU240at60cr20rr4WD_veg" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1/sandy/config_driver.xml
@@ -1,1 +1,9 @@
-../../config_files/config_driver.xml
+<driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr1" test="build_mesh"/>
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr100WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr100WD/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr100WD" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1WD/sandy/config_driver.xml
@@ -1,1 +1,9 @@
-../../config_files_WD/config_driver.xml
+<driver_script name="run.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr1WD" test="build_mesh"/>
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward_RK4">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward RK4" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1WD_veg/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr1WD_veg/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr1WD_veg" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr250WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr250WD/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr250WD" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr500WD/sandy/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/USDEQU60at15cr5rr500WD/sandy/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="hurricane" resolution="USDEQU60at15cr5rr500WD" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>

--- a/testing_and_setup/compass/ocean/hurricane/config_files/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/config_files/config_driver.xml
@@ -1,8 +1,0 @@
-<driver_script name="run_test.py">
-	<case name="init">
-		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
-	</case>
-	<case name="forward">
-		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
-	</case>
-</driver_script>

--- a/testing_and_setup/compass/ocean/hurricane/config_files_WD/config_driver.xml
+++ b/testing_and_setup/compass/ocean/hurricane/config_files_WD/config_driver.xml
@@ -1,8 +1,0 @@
-<driver_script name="run.py">
-	<case name="init">
-		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
-	</case>
-	<case name="forward_RK4">
-		<step executable="./run.py" quiet="true" pre_message=" * Running forward RK4" post_message="     Complete"/>
-	</case>
-</driver_script>

--- a/testing_and_setup/compass/ocean/tides/USDEQU120at30cr10/harmonic_analysis_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/tides/USDEQU120at30cr10/harmonic_analysis_test/config_driver.xml
@@ -1,4 +1,5 @@
 <driver_script name="run_test.py">
+	<prerequisite core="ocean" configuration="tides" resolution="USDEQU120at30cr10" test="build_mesh"/>
 	<case name="init">
 		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
 	</case>


### PR DESCRIPTION
These test cases depend on other test cases to run properly. Before this change, the only way to know that is via symlinks to directories outside of this test case.  With this change, it will be easier for regression test suites to make sure prerequisites are present and that they always run before the test cases that depend on them (even if we run tests cases in parallel).

This PR should be tested in conjunction with #559 but can be merged independently of that PR without doing any harm.  The new `prerequisite` tags simply will be ignored until the changes to `manage_regression_suite.py` make their way into `ocean/develop`.