### PR TITLE
Fix land-ice fluxes regression suite

### DIFF
--- a/testing_and_setup/compass/ocean/regression_suites/land_ice_fluxes.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/land_ice_fluxes.xml
@@ -32,10 +32,7 @@
 	<test name="sub-ice-shelf 2D - restart test" core="ocean" configuration="sub_ice_shelf_2D" resolution="5km" test="restart_test">
 		<script name="run_test.py"/>
 	</test>
-	<test name="QU 240km - Smoke Test" core="ocean" configuration="global_ocean_V1" resolution="QU240" test="with_land_ice">
-		<script name="run_test.py"/>
-	</test>
-	<test name="QU 120km - Smoke Test" core="ocean" configuration="global_ocean_V1" resolution="QU120" test="with_land_ice">
-		<script name="run_test.py"/>
+	<test name="QU 240km - Smoke Test" core="ocean" configuration="global_ocean" resolution="QU240wISC" test="init">
+		<script name="run.py"/>
 	</test>
 </regression_suite>

--- a/testing_and_setup/compass/ocean/regression_suites/light.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/light.xml
@@ -1,4 +1,4 @@
-<regression_suite name="nightly_ocean_test_suite">
+<regression_suite name="light_test_suite">
 	<test name="Periodic Planar 20km - LIGHT particle general test" core="ocean" configuration="periodic_planar" resolution="20km" test="default_light">
 		<script name="run_test.py"/>
 	</test>


### PR DESCRIPTION
It previously pointed to the old (E3SM v1) location for the QU240 test case with ice-shelf cavities.

Also, fix the name of the LIGHT regression suite.