### PR TITLE
Fixes implicitCd computation bug in mpas_ocn_vmix.F

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -754,7 +754,7 @@ contains
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
          implicitCd = gravity*(0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2)))**2.0 * &
-           0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2))**(-1.0_RKIND/3.0_RKIND)
+          (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
 
          ! A is lower diagonal term
          do k = 2, N


### PR DESCRIPTION
This PR fixes a bug in the computation of **implicitCd** in shared/mpas_ocn_vmix.F subroutine
**subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings**

The original code is
>`implicitCd = gravity*(0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2)))**2.0 * &
             0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2))**(-1.0_RKIND/3.0_RKIND)`

and should be 

> `implicitCd = gravity*(0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2)))**2.0 * &
            (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)`

