### PR TITLE
Add _FillValue to all active and debug tracer fields

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -28,6 +28,7 @@ module ocn_diagnostics
    use mpas_vector_reconstruction
    use mpas_stream_manager
    use mpas_io_units
+   use mpas_io, only : MPAS_REAL_FILLVAL
 
    use ocn_constants
    use ocn_config
@@ -168,7 +169,7 @@ contains
       !                                       (positive points from vertex1 to vertex2)
       !                                units: s^{-1} m^{-1}
       real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
-   
+
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
@@ -331,8 +332,8 @@ contains
 
       normalVelocity(:,nEdges+1) = -1e34
       layerThickness(:,nCells+1) = -1e34
-      activeTracers(indexTemperature,:,nCells+1) = -1e34
-      activeTracers(indexSalinity,:,nCells+1) = -1e34
+      activeTracers(indexTemperature,:,nCells+1) = MPAS_REAL_FILLVAL
+      activeTracers(indexSalinity,:,nCells+1) = MPAS_REAL_FILLVAL
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -27,6 +27,7 @@ module ocn_init_routines
    use mpas_timer
    use mpas_dmpar
    use mpas_constants
+   use mpas_io, only : MPAS_REAL_FILLVAL
 
    use mpas_rbf_interpolation
    use mpas_vector_operations
@@ -539,7 +540,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
               do iCell = 1,nCells
                  if (landIceMask(iCell)==0.and.abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
-                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', & 
+                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
                     call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
                        intArgs=(/iCell, maxLevelCell(iCell) /), &
@@ -550,7 +551,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
               do iCell = 1,nCells
                  if (abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
-                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', & 
+                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
                     call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
                        intArgs=(/iCell, maxLevelCell(iCell) /), &
@@ -704,7 +705,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
             call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroup, 1)
             if ( associated(tracersGroup) ) then
                do iCell=1,nCells
-                  tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) =  -1.0e34_RKIND
+                  tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) = MPAS_REAL_FILLVAL
                end do
             end if
          end if

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -25,6 +25,7 @@ module ocn_vmix
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_timer
+   use mpas_io, only : MPAS_REAL_FILLVAL
 
    use mpas_constants
    use ocn_constants
@@ -986,7 +987,7 @@ contains
               tracersTemp, N, nVertLevels, num_tracers)
 
          tracers(:,1:N,iCell) = tracersTemp(:,1:N)
-         tracers(:,N+1:nVertLevels,iCell) = -1e34
+         tracers(:,N+1:nVertLevels,iCell) = MPAS_REAL_FILLVAL
       end do
       !$omp end do
       !$omp end parallel

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -61,7 +61,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" >
+			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" missing_value="FILLVAL">
 				<var name="temperature" array_group="activeGRP" units="degrees Celsius"
 			 description="potential temperature"
 				/>

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -74,7 +74,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG" missing_value="FILLVAL">
 				<var name="temperatureTend" array_group="activeGRP" units="^\circ C s^{-1}"
 			 description="time tendency of potential temperature"
 				/>
@@ -139,7 +139,7 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
-			<var_array name="activeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG">
+			<var_array name="activeTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG" missing_value="FILLVAL">
 				<var name="temperatureInteriorRestoringRate" array_group="activeGRP" units="{s}^-1"
 			 description="A non-negative field controlling the rate at which temperature is restored to temperatureInteriorRestoringValue"
 				/>
@@ -147,7 +147,7 @@
 			 description="A non-negative field controlling the rate at which salinity is restored to salinityInteriorRestoringValue"
 				/>
 			</var_array>
-			<var_array name="activeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG">
+			<var_array name="activeTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersInteriorRestoringPKG" missing_value="FILLVAL">
 				<var name="temperatureInteriorRestoringValue" array_group="activeGRP" units="^\circ C"
 			 description="Temperature is restored toward this field at a rate controlled by temperatureInteriorRestoringRate."
 				/>

--- a/src/core_ocean/tracer_groups/Registry_activeTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_activeTracers.xml
@@ -74,7 +74,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG" missing_value="FILLVAL">
+			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
 				<var name="temperatureTend" array_group="activeGRP" units="^\circ C s^{-1}"
 			 description="time tendency of potential temperature"
 				/>

--- a/src/core_ocean/tracer_groups/Registry_debugTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_debugTracers.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0">
+			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0" missing_value="FILLVAL">
 				<var name="tracer1" array_group="debugGRP" units="tracer1"
 			 description="tracer for debugging purposes"
 				/>


### PR DESCRIPTION
1, Added the `_FillValue` attribute to active and debug tracers in the output NetCDF files.
2, Replaced `-1e34` with `_FillValue` in active and debug tracers.