### PR TITLE
GPU implementation of ocean baroclinic velocity tendencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,36 @@ pgi:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
+pgi-summit:
+	( $(MAKE) all \
+	"FC_PARALLEL = mpif90" \
+	"CC_PARALLEL = mpicc" \
+	"CXX_PARALLEL = mpicxx" \
+	"FC_SERIAL = pgf90" \
+	"CC_SERIAL = pgcc" \
+	"CXX_SERIAL = pgc++" \
+	"FFLAGS_PROMOTION = -r8" \
+	"FFLAGS_OPT = -g -O3 -byteswapio -Mfree" \
+	"CFLAGS_OPT = -O3 " \
+	"CXXFLAGS_OPT = -O3 " \
+	"LDFLAGS_OPT = -O3 " \
+	"FFLAGS_ACC = -acc -Minfo=accel -ta=tesla:cc70,cc60,deepcopy,nollvm " \
+	"CFLAGS_ACC = -acc -Minfo=accel -ta=tesla:cc70,cc60,deepcopy,nollvm "  \
+	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback" \
+	"CFLAGS_DEBUG = -O0 -g -traceback" \
+	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
+	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback" \
+	"FFLAGS_OMP = -mp" \
+	"CFLAGS_OMP = -mp" \
+	"PICFLAG = -fpic" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"CPPFLAGS = -DpgiFortran -D_MPI -DUNDERSCORE" )
+
 pgi-nersc:
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
@@ -582,6 +612,14 @@ ifeq "$(OPENMP)" "true"
 	LDFLAGS += $(FFLAGS_OMP)
 endif #OPENMP IF
 
+ifeq "$(OPENACC)" "true"
+        FFLAGS += $(FFLAGS_ACC)
+        CFLAGS += $(CFLAGS_ACC)
+        CXXFLAGS += $(CFLAGS_ACC)
+        override CPPFLAGS += "-DMPAS_OPENACC"
+        LDFLAGS += $(FFLAGS_ACC)
+endif #OPENACC IF
+
 ifeq "$(PRECISION)" "single"
 	CFLAGS += "-DSINGLE_PRECISION"
 	CXXFLAGS += "-DSINGLE_PRECISION"
@@ -670,6 +708,12 @@ ifeq "$(OPENMP)" "true"
 	OPENMP_MESSAGE="MPAS was built with OpenMP enabled."
 else
 	OPENMP_MESSAGE="MPAS was built without OpenMP support."
+endif
+
+ifeq "$(OPENACC)" "true"
+	OPENACC_MESSAGE="MPAS was built with OpenACC accelerator support enabled."
+else
+	OPENACC_MESSAGE="MPAS was built without OpenACC accelerator support."
 endif
 
 ifneq ($(wildcard .mpas_core_*), ) # CHECK FOR BUILT CORE
@@ -849,6 +893,7 @@ endif
 	@echo $(PAPI_MESSAGE)
 	@echo $(TAU_MESSAGE)
 	@echo $(OPENMP_MESSAGE)
+	@echo $(OPENACC_MESSAGE)
 	@echo $(SHAREDLIB_MESSAGE)
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -860,7 +860,8 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, &
+                        diagnosticsPool, 1, dt)
       call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
@@ -1061,7 +1062,8 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, &
+                        diagnosticsPool, 1, dt)
       call mpas_threading_barrier()
 
       if (associated(highFreqThicknessProvis)) then

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -494,30 +494,29 @@ module ocn_time_integration_split
          call mpas_timer_start("se bcl vel")
 
          call mpas_timer_start('se bcl vel tend')
+
+         ! Need to retain this until we've eliminated pools and blocks
+         ! But we now have only one block, so get the pointers.
          block => domain % blocklist
-         do while (associated(block))
-           call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-           call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-           call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-           call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
-           call mpas_pool_get_subpool(block % structs, 'state', statePool)
-           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-           call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-           call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-           call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
-           call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
-           call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, stage1_tend_time)
-           call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+         call mpas_pool_get_subpool(block%structs, 'tend', &
+                                                    tendPool)
+         call mpas_pool_get_subpool(tendPool,      'tracersTend', &
+                                                    tracersTendPool)
+         call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
+                                                    verticalMeshPool)
+         call mpas_pool_get_subpool(block%structs, 'state', &
+                                                    statePool)
+         call mpas_pool_get_subpool(statePool,     'tracers', &
+                                                    tracersPool)
+         call mpas_pool_get_subpool(block%structs, 'diagnostics', &
+                                                    diagnosticsPool)
+         call mpas_pool_get_subpool(block%structs, 'forcing', &
+                                                    forcingPool)
 
-           call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
+         call ocn_tend_vel(tendPool, statePool, forcingPool, &
+                           diagnosticsPool, stage1_tend_time, dt)
 
-           call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-
-           call ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, stage1_tend_time, dt)
-
-           block => block % next
-         end do
          call mpas_timer_stop('se bcl vel tend')
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -95,25 +95,25 @@ mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_
 
 mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_hmix.o: mpas_ocn_vel_hmix_del2.o mpas_ocn_vel_hmix_leith.o mpas_ocn_vel_hmix_del4.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hmix.o: mpas_ocn_vel_hmix_del2.o mpas_ocn_vel_hmix_leith.o mpas_ocn_vel_hmix_del4.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_hmix_leith.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hmix_leith.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forcing_explicit_bottom_drag.o mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forcing_explicit_bottom_drag.o mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 
@@ -167,7 +167,7 @@ mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_rest
 
 mpas_ocn_surface_bulk_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
+mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o mpas_ocn_mesh.o
 
 mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
@@ -205,7 +205,7 @@ mpas_ocn_time_varying_forcing.o:
 
 mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o
 
-mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -5,18 +5,18 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_surface_bulk_forcing
 !
 !> \brief MPAS ocean bulk forcing
-!> \author Doug Jacobsen
-!> \date   04/25/12
+!> \author Doug Jacobsen, Phil Jones, Rob Aulwes
+!> \date   04/25/12, updated May 2020
 !> \details
 !>  This module contains routines for building the forcing arrays,
 !>  if bulk forcing is used.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_surface_bulk_forcing
 
@@ -27,41 +27,38 @@ module ocn_surface_bulk_forcing
    use mpas_timekeeping
    use ocn_constants
    use ocn_equation_of_state
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_surface_bulk_forcing_tracers, &
-             ocn_surface_bulk_forcing_vel, &
-             ocn_surface_bulk_forcing_thick, &
+             ocn_surface_bulk_forcing_vel,     &
+             ocn_surface_bulk_forcing_thick,   &
              ocn_surface_bulk_forcing_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   logical :: bulkWindStressOn, bulkThicknessFluxOn
+   logical :: bulkWindStressOn    ! on/off switch for wind stress
+   logical :: bulkThicknessFluxOn ! on/off switch for thickness flux
 
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_bulk_forcing_tracers
 !
@@ -124,104 +121,124 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_bulk_forcing_vel
 !
-!> \brief   Determines the velocity forcing array used for the bulk forcing.
+!> \brief   Determines the velocity forcing used for the bulk forcing.
 !> \author  Doug Jacobsen
 !> \date    04/25/12
 !> \details
-!>  This routine computes the velocity forcing arrays used later in MPAS.
+!>  This routine computes the velocity forcing tendency term based on
+!>  a bulk forcing formulation and using fields from driver/coupler.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)!{{{
+   subroutine ocn_surface_bulk_forcing_vel( &
+                                  windStressZonal, windStressMeridional, &
+                                  surfaceStress, surfaceStressMagnitude, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         windStressZonal,     &! zonal      wind stress from forcing
+         windStressMeridional  ! meridional wind stress from forcing
+
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
-      real (kind=RKIND), dimension(:), intent(inout) :: surfaceStress, & !< Input/Output: Array for surface stress
-                                                  surfaceStressMagnitude !< Input/Output: Array for magnitude of surface stress
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         surfaceStress,       & !< [inout] surface stress
+         surfaceStressMagnitude !< [inout] magnitude of surface stress
+
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: Error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, iCell, nCells, nEdges
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray
+      integer ::         &
+         iEdge, iCell,   &! loop iterators for cells, edges
+         nCells, nEdges, &! final index for extended domain
+         cell1, cell2     ! neighbor cell indices across edge
 
-      integer, dimension(:,:), pointer :: cellsOnEdge
+      real (kind=RKIND) :: &
+         meridionalAverage, &! avg of meridional stress across edge
+         zonalAverage        ! avg of zonal      stress across edge
 
-      real (kind=RKIND) :: meridionalAverage, zonalAverage
-      real (kind=RKIND), dimension(:), pointer :: angleEdge
-      real (kind=RKIND), dimension(:), pointer :: windStressZonal, windStressMeridional
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Exit if not turned on. Otherwise, start timer
 
       err = 0
-
       if ( .not. bulkWindStressOn ) return
 
       call mpas_timer_start("bulk_ws", .false.)
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-
-      call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-
-      call mpas_pool_get_array(forcingPool, 'windStressZonal', windStressZonal)
-      call mpas_pool_get_array(forcingPool, 'windStressMeridional', windStressMeridional)
-
-      nEdges = nEdgesArray( 4 )
-      nCells = nCellsArray( 3 )
+      nEdges = nEdgesHalo( 3 )
+      nCells = nCellsHalo( 2 )
 
       ! Convert coupled climate model wind stress to MPAS-O wind stress
-      !$omp do schedule(runtime) private(cell1, cell2, zonalAverage, meridionalAverage)
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, surfaceStress, angleEdge, &
+      !$acc            windStressZonal, windStressMeridional) &
+      !$acc    private(cell1, cell2, zonalAverage, meridionalAverage)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, zonalAverage, meridionalAverage)
+#endif
       do iEdge = 1, nEdges
-        cell1 = cellsOnEdge(1, iEdge)
-        cell2 = cellsOnEdge(2, iEdge)
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
 
-        zonalAverage = 0.5_RKIND * (windStressZonal(cell1) + windStressZonal(cell2))
-        meridionalAverage = 0.5_RKIND * (windStressMeridional(cell1) + windStressMeridional(cell2))
+         zonalAverage      = 0.5_RKIND*(windStressZonal(cell1) + &
+                                        windStressZonal(cell2))
+         meridionalAverage = 0.5_RKIND*(windStressMeridional(cell1) + &
+                                        windStressMeridional(cell2))
 
-        surfaceStress(iEdge) = surfaceStress(iEdge) + cos(angleEdge(iEdge)) * zonalAverage + sin(angleEdge(iEdge)) &
-                             * meridionalAverage
+         surfaceStress(iEdge) = surfaceStress(iEdge) + &
+                                cos(angleEdge(iEdge))*zonalAverage + &
+                                sin(angleEdge(iEdge))* meridionalAverage
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
       ! Build surface fluxes at cell centers
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(surfaceStressMagnitude, &
+      !$acc            windStressZonal, windStressMeridional)
+#else
       !$omp do schedule(runtime)
+#endif
       do iCell = 1, nCells
-        surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + sqrt( windStressZonal(iCell)**2 &
+         surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) &
+                                     + sqrt( windStressZonal(iCell)**2 &
                                       + windStressMeridional(iCell)**2 )
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
       call mpas_timer_stop("bulk_ws")
 
    end subroutine ocn_surface_bulk_forcing_vel!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_bulk_forcing_thick
 !
@@ -306,42 +323,51 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_thick!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_bulk_forcing_init
 !
 !> \brief   Initializes bulk forcing module
-!> \author  Doug Jacobsen
-!> \date    04/25/12
+!> \author  Doug Jacobsen, Phil Jones
+!> \date    04/25/12, udpate May 2020
 !> \details
 !>  This routine initializes the bulk forcing module.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_surface_bulk_forcing_init(err)!{{{
+   subroutine ocn_surface_bulk_forcing_init(err)
 
-      integer, intent(out) :: err !< Output: error flag
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
 
-      logical, pointer :: config_use_bulk_wind_stress, config_use_bulk_thickness_flux
+      integer, intent(out) :: err !< [out] error flag
+
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
+
+      ! End preamble
+      !-------------
+      ! Begin code
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_use_bulk_wind_stress', config_use_bulk_wind_stress)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_bulk_thickness_flux', config_use_bulk_thickness_flux)
-
-      bulkWindStressOn = config_use_bulk_wind_stress
+      ! Set on/off flags base on input configuration (in ocn_config)
+      bulkWindStressOn    = config_use_bulk_wind_stress
       bulkThicknessFluxOn = config_use_bulk_thickness_flux
 
    end subroutine ocn_surface_bulk_forcing_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 ! Private module subroutines
 !
-!***********************************************************************
+!*******************************************************************************
 
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_bulk_forcing_active_tracers
 !
@@ -503,8 +529,9 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
 
+!*******************************************************************************
+
 end module ocn_surface_bulk_forcing
 
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -5,18 +5,18 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_surface_land_ice_fluxes
 !
 !> \brief MPAS ocean surface land-ice fluxes
 !> \author Xylar Asay-Davis
-!> \date   10/02/2014
+!> \date   10/02/2014, updated May 2020
 !> \details
 !>  This module contains routines for computing surface flux related
 !>  melting under land-ice.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_surface_land_ice_fluxes
 
@@ -26,6 +26,8 @@ module ocn_surface_land_ice_fluxes
    use mpas_pool_routines
 
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
    use ocn_equation_of_state
 
    implicit none
@@ -33,15 +35,11 @@ module ocn_surface_land_ice_fluxes
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_surface_land_ice_fluxes_tracers, &
@@ -51,21 +49,25 @@ module ocn_surface_land_ice_fluxes
              ocn_surface_land_ice_fluxes_init
 
    !--------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
-   logical :: landIceFluxesOn, standaloneOn, isomipOn, jenkinsOn, hollandJenkinsOn
+   logical ::          &! logical switches 
+      landIceFluxesOn, &! on/off switch to include land ice fluxes
+      standaloneOn,    &! on/off switch for standalone runs (vs coupled)
+      isomipOn,        &! use isomip ice flux formulation
+      jenkinsOn,       &! use Jenkins ice flux formulation
+      hollandJenkinsOn  ! use Jenkins-Holland ice flux formulation
 
-   real (kind=RKIND) :: cp_land_ice, rho_land_ice
+   real (kind=RKIND) :: &
+      cp_land_ice,      &! specific heat for land ice melt
+      rho_land_ice       ! density of ice (not currently used)
 
-
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_land_ice_fluxes_tracers
 !
@@ -124,7 +126,7 @@ contains
 
    end subroutine ocn_surface_land_ice_fluxes_tracers!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_land_ice_fluxes_vel
 !
@@ -135,76 +137,88 @@ contains
 !>  This routine computes the top-drag tendency for momentum
 !>  based on current state.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)!{{{
+   subroutine ocn_surface_land_ice_fluxes_vel(topDrag, topDragMagnitude, &
+                                  surfaceStress, surfaceStressMagnitude, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         topDrag,              &! drag stress at top due to land ice
+         topDragMagnitude       ! magnitude of stress at cell centers
+
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
-      real (kind=RKIND), dimension(:), intent(inout) :: surfaceStress, & !< Input/Output: Array for total surface stress
-                                                  surfaceStressMagnitude !< Input/Output: Array for magnitude of surface stress
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         surfaceStress,        &!< [inout] total surface stress
+         surfaceStressMagnitude !< [inout] magnitude of surface stress
+
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: Error flag
+      integer, intent(out) :: err !< [out] Error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
-      integer :: iEdge, iCell
-      integer, pointer :: nCells, nEdges
+      !-------------------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:), pointer :: topDrag, topDragMagnitude
+      integer :: iEdge, iCell  ! loop iterators for edge, cell loops
+
+      ! End of preamble
+      !----------------
+      ! Begin code
+
+      ! Exit if not turned on. Otherwise, start timer.
 
       err = 0
-
       if ( .not. landIceFluxesOn ) return
 
       call mpas_timer_start("top_drag", .false.)
 
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
-
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(surfaceStress, topDrag)
+#else
+      !$omp parallel
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-        surfaceStress(iEdge) = surfaceStress(iEdge) + topDrag(iEdge)
+#endif
+      do iEdge = 1, nEdgesAll
+         surfaceStress(iEdge) = surfaceStress(iEdge) + topDrag(iEdge)
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
       ! Build surface stress magnitude at cell centers
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(surfaceStressMagnitude, topDragMagnitude)
+#else
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
-        surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + topDragMagnitude(iCell)
+#endif
+      do iCell = 1, nCellsAll
+         surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + &
+                                               topDragMagnitude(iCell)
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
       call mpas_timer_stop("top_drag")
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_surface_land_ice_fluxes_vel!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_land_ice_fluxes_thick
 !
@@ -630,7 +644,7 @@ contains
 
    end subroutine ocn_surface_land_ice_fluxes_build_arrays!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_surface_land_ice_fluxes_init
 !
@@ -641,57 +655,83 @@ contains
 !>  This routine initializes a variety of quantities related to
 !>  land-ice forcing.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_init(err)!{{{
+   subroutine ocn_surface_land_ice_fluxes_init(err)
 
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
 
-      character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
 
-      real (kind=RKIND), pointer :: config_land_ice_flux_cp_ice, &
-                                    config_land_ice_flux_rho_ice
+      ! End of preamble
+      !----------------
+      ! Begin code
 
-
+      ! Set default flags and values
       err = 0
-      isomipOn = .false.
-      jenkinsOn = .false.
+      landIceFluxesOn  = .false.
+      standaloneOn     = .false.
+      isomipOn         = .false.
+      jenkinsOn        = .false.
       hollandJenkinsOn = .false.
+      cp_land_ice      = 0.0_RKIND
+      rho_land_ice     = 0.0_RKIND
 
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
-      landIceFluxesOn = (trim(config_land_ice_flux_mode) == 'standalone')  &
-           .or. (trim(config_land_ice_flux_mode) == 'coupled')
+      ! Define variables based on user input in ocn_config
+
+      select case (trim(config_land_ice_flux_mode))
+      case ('standalone','STANDALONE','StandAlone','standAlone')
+         landIceFluxesOn  = .true.
+         standaloneOn     = .true.
+      case ('coupled','COUPLED','Coupled')
+         landIceFluxesOn  = .true.
+         standaloneOn     = .false.
+      case ('off','OFF','Off','none','None','NONE')
+         landIceFluxesOn  = .false.
+         standaloneOn     = .false.
+      case default
+         landIceFluxesOn  = .false.
+         standaloneOn     = .false.
+      end select
+
+      ! skip rest of init if turned off
       if(.not. landIceFluxesOn) return
 
-      standaloneOn = trim(config_land_ice_flux_mode) == 'standalone'
 
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
-
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_cp_ice', config_land_ice_flux_cp_ice)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_rho_ice', config_land_ice_flux_rho_ice)
-
-      if ( trim(config_land_ice_flux_formulation) == 'ISOMIP' ) then
+      ! Set the formulation to be used
+      select case (trim(config_land_ice_flux_formulation))
+      case ('ISOMIP','isomip','Isomip')
          isomipOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
+
+      case ('Jenkins','jenkins','JENKINS')
          jenkinsOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
+
+      case ('HollandJenkins','hollandjenkins','HOLLANDJENKINS')
          hollandJenkinsOn = .true.
-      else
+
+      case default
          call mpas_log_write( &
-            "config_land_ice_flux_formulation not one of 'ISOMIP', 'Jenkins', " &
-               // "or 'HollandJenkins'.", &
+            "config_land_ice_flux_formulation not one of 'ISOMIP', " &
+               // "'Jenkins', or 'HollandJenkins'.", &
                MPAS_LOG_CRIT)
          err = 1
-      end if
+      end select
 
-      cp_land_ice = config_land_ice_flux_cp_ice
+      ! Set some physical constants
+      cp_land_ice  = config_land_ice_flux_cp_ice
       rho_land_ice = config_land_ice_flux_rho_ice
 
-   !--------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
    end subroutine ocn_surface_land_ice_fluxes_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_forcing_compute_melt_fluxes
 !
@@ -974,7 +1014,6 @@ contains
   !--------------------------------------------------------------------
 
   end subroutine compute_HJ99_melt_fluxes !}}}
-
 
 !***********************************************************************
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -5,18 +5,19 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_tendency
 !
 !> \brief MPAS ocean tendency driver
-!> \author Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date   September 2011
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones, Rob Aulwes
+!> \date   September 2011, update May 2020
 !> \details
-!>  This module contains the routines for computing
-!>  tendency terms for the ocean primitive equations.
+!>  This module contains the routines for computing tendency terms 
+!>  defined as the terms on the right-hand-side of the ocean primitive
+!>  equations.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_tendency
 
@@ -27,6 +28,8 @@ module ocn_tendency
    use mpas_threading
    use ocn_diagnostics
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    use ocn_surface_bulk_forcing
    use ocn_surface_land_ice_fluxes
@@ -65,17 +68,13 @@ module ocn_tendency
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_tend_thick, &
              ocn_tend_vel, &
@@ -83,19 +82,17 @@ module ocn_tendency
              ocn_tend_freq_filtered_thickness, &
              ocn_tendency_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   integer :: apply_Dhf_to_hhf, use_highFreqThick_restore
+   integer :: use_highFreqThick_restore ! on/off switch for high freq restoring
 
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_tend_thick
 !
@@ -197,219 +194,358 @@ contains
 
    end subroutine ocn_tend_thick!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_tend_vel
 !
 !> \brief   Computes velocity tendency
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones, Rob Aulwes
+!> \date    September 2011, update May 2020
 !> \details
 !>  This routine computes the velocity tendency for the ocean
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, timeLevelIn, dt)!{{{
-      implicit none
+   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, &
+                           timeLevelIn, dt)
 
-      type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
-      type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      real (kind=RKIND), intent(in) :: dt
-      type (mpas_pool_type), intent(inout) :: scratchPool !< Input: Scratch structure
-      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
+      !-------------------------------------------------------------------------
+      ! input variables
+      !-------------------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         statePool,         &!< [in] State information
+         diagnosticsPool     !< [in] Diagnostic information
+
+      real (kind=RKIND), intent(in) :: &
+         dt                  !< [in] time step (seconds)
+
+      integer, intent(in), optional :: &
+         timeLevelIn         !< [in] Time level for state fields
+
+      !-------------------------------------------------------------------------
+      ! input/output variables
+      !-------------------------------------------------------------------------
+
+      type (mpas_pool_type), intent(inout) :: &
+         tendPool,          &!< [inout] Tendency structure
+         forcingPool         !< [inout] Forcing information
+
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
+
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
+
+      integer ::           &
+         err,              &! local error flag
+         iEdge, iCell, k,  &! loop iterators for edges, cells, layers
+         timeLevel,        &! time index for prognostic variables
+         indexTemperature, &! tracer index for temperature
+         indexSalinity      ! tracer index for salinity
+
+      integer, pointer :: &
+         indexTempPtr, indexSaltPtr ! tracer index pointers for retrieval
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh
-      real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta 
+      ! tendency variable (primary output from this routine)
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThicknessEdge, normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
-        layerThickness, &
-        tend_normalVelocity, circulation, relativeVorticity, viscosity, kineticEnergyCell, &
-        normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-        montgomeryPotential, vertAleTransportTop, divergence, vertViscTopOfEdge, &
-        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
-      real (kind=RKIND), dimension(:,:), pointer :: tidalPotentialZMid
-      real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+        tend_normalVelocity  ! total tendency for normal velocity
 
-      integer :: timeLevel
+      ! state variables
+      real (kind=RKIND), dimension(:), pointer :: &
+         ssh              ! sea surface height
 
-      integer :: err, iEdge, iCell, k
-      integer, pointer :: indexTemperature, indexSalinity, nEdges, nCells
-      integer, dimension(:), pointer :: maxLevelCell
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         normalVelocity   ! velocity normal to edge 
 
-      logical, pointer :: config_disable_vel_all_tend
-      logical, pointer :: config_use_wetting_drying
-      logical, pointer :: config_prevent_drying
-      logical, pointer :: config_use_tidal_potential_forcing
-      character (len=StrKIND), pointer :: config_pressure_gradient_type
-      character (len=StrKIND), pointer :: config_time_integrator
-      real (kind=RKIND), pointer :: config_self_attraction_and_loading_beta 
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+         activeTracers    ! active tracers
 
+      ! forcing fields
+      real (kind=RKIND), dimension(:), pointer :: &
+         windStressZonal,     &! zonal      wind stress from forcing
+         windStressMeridional,&! meridional wind stress from forcing
+         surfaceStress,       &! total surface stress on edges
+         surfaceStressMagnitude ! mag of surface stress at cell center
+
+      ! diagnostic fields
+      real (kind=RKIND), dimension(:), pointer :: &
+         topDrag,             &! top drag from land ice (diagnostics)
+         topDragMagnitude,    &! top drag magnitude in cells (diagnostics)
+         tidalPotentialEta,   &! tidal potential factor 
+         surfaceFluxAttenuationCoefficient
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         kineticEnergyCell,   &! kinetic energy at cell center
+         layerThicknessEdge,  &! layer thickness at edge
+         vertAleTransportTop, &! vertical transport due to ALE at top
+         zMid,                &! depth at middle of layer
+         tidalPotentialZMid,  &! modified depth due to tidal changes
+         divergence,          &! velocity divergence
+         density,             &! density
+         potentialDensity,    &! potential density
+         pressure,            &! pressure
+         montgomeryPotential, &! Montgomery potential
+         wettingVelocity,     &! velocity associated with wetting/drying
+         relVorticity,        &! relative vorticity
+         normalizedRelativeVorticityEdge,  &! depth-normalized vorticity
+         normalizedPlanetaryVorticityEdge, &! depth-normalized vorticity
+         inSituThermalExpansionCoeff,      &! thermal expansion coeff
+         inSituSalineContractionCoeff       ! salinity contraction coeff
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Set time level for state variables - defaults to 1
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
       else
          timeLevel = 1
       end if
 
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_all_tend', config_disable_vel_all_tend)
-      call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_wetting_drying', config_use_wetting_drying)
-      call mpas_pool_get_config(ocnConfigs, 'config_prevent_drying', config_prevent_drying)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing', config_use_tidal_potential_forcing)
-      call mpas_pool_get_config(ocnConfigs, 'config_self_attraction_and_loading_beta',config_self_attraction_and_loading_beta)
-      call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
+      ! Extract various fields from pools
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_array(statePool,   'normalVelocity', &
+                                             normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool,   'ssh', &
+                                             ssh, timeLevel)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                             activeTracers, timeLevel)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTempPtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSaltPtr)
+      indexTemperature = indexTempPtr
+      indexSalinity    = indexSaltPtr
 
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
+      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', &
+                                                 kineticEnergyCell)
+      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', &
+                                                 layerThicknessEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', &
+                                                 vertAleTransportTop)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', &
+                                                 relVorticity)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', &
+                                                 normalizedRelativeVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', &
+                                                 normalizedPlanetaryVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'divergence', &
+                                                 divergence)
+      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', &
+                                                 montgomeryPotential)
+      call mpas_pool_get_array(diagnosticsPool, 'pressure', &
+                                                 pressure)
+      call mpas_pool_get_array(diagnosticsPool, 'density', &
+                                                 density)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
+                                                 potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', &
+                                                 surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', &
+                                                 wettingVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'topDrag', &
+                                                 topDrag)
+      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', &
+                                                 topDragMagnitude)
+      call mpas_pool_get_array(diagnosticsPool, & 
+                                      'inSituThermalExpansionCoeff', &
+                                       inSituThermalExpansionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, &
+                                     'inSituSalineContractionCoeff', &
+                                      inSituSalineContractionCoeff)
 
-      call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
+      call mpas_pool_get_array(tendPool,    'normalVelocity', &
+                                             tend_normalVelocity)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
-      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
+      call mpas_pool_get_array(forcingPool, 'surfaceStress', &
+                                             surfaceStress)
+      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
+                                             surfaceStressMagnitude)
+      call mpas_pool_get_array(forcingPool, 'windStressZonal', &
+                                             windStressZonal)
+      call mpas_pool_get_array(forcingPool, 'windStressMeridional', &
+                                             windStressMeridional)
 
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
+      ! Transfer data to device
+      !$acc enter data &
+      !$acc   copyin(tend_normalVelocity, activeTracers,         &
+      !$acc          surfaceStress, surfaceStressMagnitude,      &
+      !$acc          windStressZonal, windStressMeridional,      &
+      !$acc          topDrag, topDragMagnitude, wettingVelocity, &
+      !$acc          normalVelocity, layerThicknessEdge, ssh,    &
+      !$acc          kineticEnergyCell, divergence, zMid,        &
+      !$acc          density, potentialDensity, pressure,        &
+      !$acc          montgomeryPotential, vertAleTransportTop,   &
+      !$acc          inSituThermalExpansionCoeff,                &
+      !$acc          inSituSalineContractionCoeff, relVorticity, &
+      !$acc          normalizedRelativeVorticityEdge,            &
+      !$acc          normalizedPlanetaryVorticityEdge,           &
+      !$acc          surfaceFluxAttenuationCoefficient)
+
       !
       ! velocity tendency: start accumulating tendency terms
       !
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(tend_normalVelocity, surfaceStress)
+#else
+      !$omp parallel
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
+#endif
+      do iEdge = 1, nEdgesAll
          tend_normalVelocity(:, iEdge) = 0.0_RKIND
          surfaceStress(iEdge) = 0.0_RKIND
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(surfaceStressMagnitude)
+#else
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+#endif
+      do iCell = 1, nCellsAll
          surfaceStressMagnitude(iCell) = 0.0_RKIND
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
       if(config_disable_vel_all_tend) return
 
       call mpas_timer_start("ocn_tend_vel")
 
       ! Build bulk forcing surface stress
-      call ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)
+      call ocn_surface_bulk_forcing_vel( &
+                            windStressZonal, windStressMeridional, &
+                            surfaceStress, surfaceStressMagnitude, err)
 
       ! Add top drag to surface stress
-      call ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)
+      call ocn_surface_land_ice_fluxes_vel(topDrag, topDragMagnitude, &
+                            surfaceStress, surfaceStressMagnitude, err)
 
-      !
       ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
-      !
-      call ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, layerThicknessEdge, &
-         normalVelocity, kineticEnergyCell, tend_normalVelocity, err)
+      call ocn_vel_hadv_coriolis_tend(                     &
+                       normalizedRelativeVorticityEdge,    &
+                       normalizedPlanetaryVorticityEdge,   &
+                       layerThicknessEdge, normalVelocity, &
+                       kineticEnergyCell, tend_normalVelocity, err)
 
-      !
       ! velocity tendency: vertical advection term -w du/dz
-      !
-      call ocn_vel_vadv_tend(meshPool, normalVelocity, layerThicknessEdge, vertAleTransportTop, tend_normalVelocity, err)
+      call ocn_vel_vadv_tend(normalVelocity, layerThicknessEdge, &
+                   vertAleTransportTop, tend_normalVelocity, err)
 
-      !
       ! velocity tendency: tidal potential (if needed) 
-      !   For RK4, subtract the tidal potential from the zMid array and store in a work array, 
-      !   Then point zMid to work array so the tidal potential terms are included inside the grad computed in ocn_vel_pressure_grad_tend
-      !   zMid is pointed back to the typical value afterward, so the work array is not used in place of zMid elsewhere.
+      !   For RK4, subtract the tidal potential from the zMid array 
+      !   and store in a work array, then point zMid to work array so 
+      !   the tidal potential terms are included inside the grad 
+      !   computed in ocn_vel_pressure_grad_tend. zMid is pointed back
+      !   to the typical value afterward, so the work array is not used
+      !    in place of zMid elsewhere.
       !
       if (config_use_tidal_potential_forcing) then
-        call ocn_compute_tidal_potential_forcing(meshPool, forcingPool, diagnosticsPool, err)
+#ifdef MPAS_OPENACC
+         call mpas_log_write( &
+            'vel tendency: tidal forcing not supported for GPU', &
+            MPAS_LOG_CRIT)
+#endif
+         call ocn_compute_tidal_potential_forcing(forcingPool, &
+                                                  diagnosticsPool, err)
+
+         if (config_time_integrator == 'RK4') then
+            call mpas_pool_get_array(forcingPool, 'tidalPotentialZMid',&
+                                                   tidalPotentialZMid)
+            call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', &
+                                                   tidalPotentialEta)
+
+            do iCell = 1, nCellsAll
+            do k = 1, maxLevelCell(iCell)
+               tidalPotentialZMid(k,iCell) = zMid(k,iCell)            &
+                          - tidalPotentialEta(iCell)                  &
+                          - config_self_attraction_and_loading_beta * &
+                            zMid(k,iCell)
+            end do 
+            end do
+
+            ! change pointer so zMid points to tidalPotentialZMid instead
+            call mpas_pool_get_array(forcingPool, 'tidalPotentialZMid', &
+                                                  zMid)
+         end if
       end if
 
-      if (config_use_tidal_potential_forcing .and. config_time_integrator == 'RK4') then
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialZMid', tidalPotentialZMid)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', tidalPotentialEta)
-        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-        do iCell = 1, nCells
-          do k = 1, maxLevelCell(iCell)
-            tidalPotentialZMid(k,iCell) = zMid(k,iCell) - tidalPotentialEta(iCell) &
-                                        - config_self_attraction_and_loading_beta * zMid(k,iCell)
-          end do 
-        end do
-
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialZMid', zMid)
-      end if
-
-      !
       ! velocity tendency: pressure gradient
-      !
-      if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
-         ! only pass EOS derivatives if needed.
-         call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-         call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
-         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
-              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
-              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
-      else
-         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
-              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
-              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
-      endif
+      call ocn_vel_pressure_grad_tend(ssh, pressure,                  &
+           montgomeryPotential, zMid, density, potentialDensity,      &
+           indexTemperature, indexSalinity, activeTracers,            &
+           inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
+           tend_normalVelocity, err)
 
       if (config_use_tidal_potential_forcing .and. config_time_integrator == 'RK4') then
         ! point zMid back to usual array, to be safe
         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
       end if
 
-      !
-      ! velocity tendency: del2 dissipation, \nu_2 \nabla^2 u
-      !   computed as \nu( \nabla divergence + k \times \nabla relativeVorticity )
-      !   strictly only valid for config_mom_del2 == constant
-      !
-      call ocn_vel_hmix_tend(meshPool, scratchPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, viscosity, &
-         tend_normalVelocity, err)
+      ! velocity tendency: horizontal mixing/dissipation
+      call ocn_vel_hmix_tend(divergence, relVorticity,           &
+                             tend_normalVelocity, err)
 
-      !
       ! velocity tendency: forcing and bottom drag
-      !
-      call ocn_vel_forcing_tend(meshPool, normalVelocity, surfaceFluxAttenuationCoefficient, &
-              surfaceStress, kineticEnergyCell, layerThicknessEdge, &
+      call ocn_vel_forcing_tend(normalVelocity,                    &
+                                surfaceFluxAttenuationCoefficient, &
+                                surfaceStress, kineticEnergyCell,  &
+                                layerThicknessEdge,                & 
                                 tend_normalVelocity, err)
 
-      !
       ! velocity tendency: zero if drying
-      !
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         tend_normalVelocity(:, iEdge) = tend_normalVelocity(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
+#ifdef MPAS_OPENACC
+      !$acc parallel loop collapse(2) &
+      !$acc    present(tend_normalVelocity, wettingVelocity)
+#else
+      !$omp parallel do schedule(runtime)
+#endif
+      do iEdge = 1, nEdgesAll
+      do k=1,nVertLevels
+         tend_normalVelocity(k, iEdge) = tend_normalVelocity(k, iEdge)* &
+                                (1.0_RKIND - wettingVelocity(k, iEdge))
       end do
-      !$omp end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end parallel do
+#endif
 
-      !
-      ! velocity tendency: vertical mixing d/dz( nu_v du/dz))
-      !
+      ! velocity tendency: vertical mixing is computed later
+
+      ! Transfer data back from device
+      !$acc exit data &
+      !$acc   copyout(tend_normalVelocity,                       &
+      !$acc           surfaceStress, surfaceStressMagnitude)     &
+      !$acc   delete(windStressZonal, windStressMeridional,      &
+      !$acc          topDrag, topDragMagnitude, wettingVelocity, &
+      !$acc          normalVelocity, layerThicknessEdge, ssh,    &
+      !$acc          kineticEnergyCell, divergence, zMid,        &
+      !$acc          density, potentialDensity, pressure,        &
+      !$acc          montgomeryPotential, vertAleTransportTop,   &
+      !$acc          inSituThermalExpansionCoeff, activeTracers, &
+      !$acc          inSituSalineContractionCoeff, relVorticity, &
+      !$acc          normalizedRelativeVorticityEdge,            &
+      !$acc          normalizedPlanetaryVorticityEdge,           &
+      !$acc          surfaceFluxAttenuationCoefficient)
+
       call mpas_timer_stop("ocn_tend_vel")
+
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_tend_vel!}}}
 
@@ -1096,7 +1232,7 @@ contains
 
    end subroutine ocn_tend_freq_filtered_thickness!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_tendency_init
 !
@@ -1107,27 +1243,42 @@ contains
 !>  This routine initializes flags related to quantities computed within
 !>  other tendency routines.
 !
-!-----------------------------------------------------------------------
-    subroutine ocn_tendency_init(err)!{{{
-        integer, intent(out) :: err !< Output: Error flag
+!-------------------------------------------------------------------------------
 
-        logical, pointer :: config_use_highFreqThick_restore
+   subroutine ocn_tendency_init(err)
 
-        err = 0
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
 
-        call mpas_pool_get_config(ocnConfigs, 'config_use_highFreqThick_restore', config_use_highFreqThick_restore)
+      integer, intent(out) :: err !< Output: Error flag
 
-        if (config_use_highFreqThick_restore) then
-           use_highFreqThick_restore = 1
-        else
-           use_highFreqThick_restore = 0
-        endif
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
 
-    end subroutine ocn_tendency_init!}}}
+      ! End preamble
+      !-------------
+      ! Begin code
 
-!***********************************************************************
+      err = 0
+
+      ! set module variables based on user input in ocn_config
+
+      if (config_use_highFreqThick_restore) then
+         use_highFreqThick_restore = 1
+      else
+         use_highFreqThick_restore = 0
+      endif
+
+   !----------------------------------------------------------------------------
+
+   end subroutine ocn_tendency_init!}}}
+
+!*******************************************************************************
 
 end module ocn_tendency
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_tidal_potential_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_potential_forcing.F
@@ -27,7 +27,10 @@ module ocn_tidal_potential_forcing
    use mpas_pool_routines
    use mpas_timekeeping
    use mpas_timer
+
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -78,14 +81,15 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_compute_tidal_potential_forcing(meshPool, forcingPool, diagnosticsPool, err)!{{{
+   subroutine ocn_compute_tidal_potential_forcing(forcingPool, &
+                                              diagnosticsPool, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
       type (mpas_pool_type), intent(in) :: diagnosticsPool 
 
       !-----------------------------------------------------------------
@@ -109,10 +113,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer, pointer :: nCells
       real (kind=RKIND), pointer :: tidalPotentialRamp
-      real (kind=RKIND), dimension(:), pointer :: lonCell
-      integer, dimension(:), pointer ::  maxLevelCell
 
       integer, pointer :: nTidalConstituents
       real (kind=RKIND), dimension(:), pointer :: amplitude, frequency, loveNumbers
@@ -133,8 +134,6 @@ contains
       if ( .not. tidalPotentialOn ) return
 
       call mpas_pool_get_config(ocnConfigs, 'config_tidal_potential_ramp', tidalPotentialRamp)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
       call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
       call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', amplitude)
       call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', frequency)
@@ -150,7 +149,7 @@ contains
       ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotentialRamp)
       t = daysSinceStartOfSim*86400.0_RKIND
 
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
         eta(iCell) = 0.0_RKIND
       end do
 
@@ -159,7 +158,7 @@ contains
         nCycles = real(int(t/period),RKIND)
         targ = frequency(jCon)*(t - nCycles*period) + nodalFactorPhase(jCon) + astronomicalArgument(jCon)
         conType = constituentType(jCon)
-        do iCell = 1, nCells
+        do iCell = 1, nCellsAll
           lon = lonCell(iCell)
           eta(iCell) = eta(iCell) + ramp &
                                   * amplitude(jCon) &

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing.F
@@ -5,26 +5,24 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_vel_forcing
 !
-!> \brief MPAS ocean forcing driver
-!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date   September 2011
+!> \brief MPAS ocean velocity forcing driver
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date   September 2011, updated May 2020
 !> \details
-!>  This module contains the main driver routine for computing
-!>  tendencies from forcings.
+!>  This module contains the main driver routine for computing momentum (vel)
+!>  tendencies from forcing at top and bottom boundaries.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_vel_forcing
 
    use mpas_derived_types
 
    use ocn_constants
-   use ocn_forcing
-
    use ocn_vel_forcing_surface_stress
    use ocn_vel_forcing_explicit_bottom_drag
 
@@ -32,39 +30,33 @@ module ocn_vel_forcing
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_vel_forcing_tend, &
              ocn_vel_forcing_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
 
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_tend
 !
 !> \brief   Computes tendency term from forcings
-!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date    15 September 2011
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date    15 September 2011, updated May 2020
 !> \details
 !>  This routine computes the forcing tendency for momentum
 !>  based on current state and user choices of forcings.
@@ -73,120 +65,122 @@ contains
 !>  for the chosen forcing, so this routine is primarily a
 !>  driver for managing these choices.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_tend(meshPool, normalVelocity, surfaceFluxAttenuationCoefficient, &
-                                   surfaceStress, kineticEnergyCell, layerThicknessEdge, tend, err)!{{{
+   subroutine ocn_vel_forcing_tend(normalVelocity,                    &
+                                   surfaceFluxAttenuationCoefficient, &
+                                   surfaceStress, kineticEnergyCell,  & 
+                                   layerThicknessEdge, tend, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity, &    !< Input: Normal velocity at edges
-         kineticEnergyCell        !< Input: kinetic energy at cell
+         normalVelocity,    &!< [in] Normal velocity at edges
+         kineticEnergyCell   !< [in] kinetic energy at cell
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         surfaceFluxAttenuationCoefficient, & !< Input: attenuation coefficient for surface fluxes at cell centers
-         surfaceStress     !< Input: surface stress at edges
+         surfaceFluxAttenuationCoefficient, & !< [in] attenuation coef for sfc flx
+         surfaceStress       !< [in] surface stress at edges
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: thickness at edge
+         layerThicknessEdge  !< [in] thickness at edge
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer :: err1
+      integer :: err1 ! local error flag
 
-      !-----------------------------------------------------------------
-      !
+      ! End preamble
+      !-------------
+      ! Begin code
+
       ! call relevant routines for computing tendencies
       ! note that the user can choose multiple options and the
       !   tendencies will be added together
-      !
-      !-----------------------------------------------------------------
 
       err = 0
 
-      call ocn_vel_forcing_surface_stress_tend(meshPool, surfaceFluxAttenuationCoefficient, &
-                                               surfaceStress, layerThicknessEdge, tend, err1)
+      call ocn_vel_forcing_surface_stress_tend( &
+                                   surfaceFluxAttenuationCoefficient, &
+                                   surfaceStress, layerThicknessEdge, &
+                                   tend, err1)
       err = ior(err, err1)
 
-      call ocn_vel_forcing_explicit_bottom_drag_tend(meshPool, normalVelocity, &
-              kineticEnergyCell, layerThicknessEdge, tend, err1)
+      call ocn_vel_forcing_explicit_bottom_drag_tend(normalVelocity, &
+                  kineticEnergyCell, layerThicknessEdge, tend, err1)
 
       err = ior(err, err1)
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_tend!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_init
 !
 !> \brief   Initializes ocean forcings
-!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date    September 2011
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date    September 2011, May 2020
 !> \details
-!>  This routine initializes quantities related to forcings
-!>  in the ocean. Since a multiple forcings are available,
-!>  this routine primarily calls the
-!>  individual init routines for each forcing.
+!>  This routine initializes quantities related to forcing at the top and
+!>  bottome of the ocean. Since a multiple forcings are available,
+!>  this routine primarily calls the individual init routines for each.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_init(err)!{{{
+   subroutine ocn_vel_forcing_init(err)
 
-   !--------------------------------------------------------------------
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
+      integer, intent(out) :: err !< [out] error flag
+
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
+
+      integer :: err1, err2  ! local error flags
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
       ! call individual init routines for each parameterization
-      !
-      !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
 
-      integer :: err1, err2
 
       call ocn_vel_forcing_surface_stress_init(err1)
       call ocn_vel_forcing_explicit_bottom_drag_init(err2)
 
       err = ior(err1, err2)
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 
 end module ocn_vel_forcing
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -5,206 +5,205 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_vel_forcing_explicit_bottom_drag
 !
 !> \brief MPAS ocean explicit bottom drag
-!> \author Mark Petersen
-!> \date   August 2017
+!> \author Mark Petersen, Phil Jones
+!> \date   August 2017, updated May 2020
 !> \details
 !>  This module contains the routine for computing
 !>  tendencies from explicit bottom drag.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_vel_forcing_explicit_bottom_drag
 
-   use mpas_derived_types
-   use mpas_pool_routines
    use mpas_timer
 
    use ocn_constants
-   use ocn_forcing
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_vel_forcing_explicit_bottom_drag_tend, &
              ocn_vel_forcing_explicit_bottom_drag_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   logical :: explicitBottomDragOn
-   real (kind=RKIND) :: explicitBottomDragCoef
+   logical :: explicitBottomDragOn  ! on/off switch for explicit bottom drag
 
-!***********************************************************************
+   real (kind=RKIND) :: explicitBottomDragCoef ! drag coefficient
+
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_explicit_bottom_drag_tend
 !
 !> \brief   Computes tendency term from explicit bottom drag
-!> \author  Mark Petersen
-!> \date    15 August 2017
+!> \author  Mark Petersen, Phil Jones
+!> \date    15 August 2017, updated May 2020
 !> \details
 !>  This routine computes the explicit bottom drag tendency for momentum
 !>  based on current state.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_explicit_bottom_drag_tend(meshPool, normalVelocity, & !{{{
-                                     kineticEnergyCell, layerThicknessEdge, tend, err)
+   subroutine ocn_vel_forcing_explicit_bottom_drag_tend(normalVelocity,    &
+                                    kineticEnergyCell, layerThicknessEdge, &
+                                    tend, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity,       &!< Input: velocity
-         kineticEnergyCell,    &!< Input: kinetic energy at cell
-         layerThicknessEdge     !< Input: thickness at edge
+         normalVelocity,       &!< [in] velocity
+         kineticEnergyCell,    &!< [in] kinetic energy at cell
+         layerThicknessEdge     !< [in] thickness at edge
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, nEdges
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: cellsOnEdge
+      integer ::      &
+         iEdge,       &! edge loop iterator
+         kBot,        &! bottom level index for each edge
+         cell1, cell2  ! neighbor cell indices across edge
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Exit if not selected. Otherwise, start timer
 
       err = 0
-
       if ( .not. explicitBottomDragOn ) return
 
       call mpas_timer_start('vel explicit bottom drag')
 
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
-      nEdges = nEdgesArray( 1 )
+      ! Explicit bottom drag term:
+      ! du/dt = ... - c |u| u / h
+      ! appied to bottom layer only.
+      ! This term comes from the bottom boundary condition in the 
+      ! vertical momentum mixing, and is explicit if both |u| and u 
+      ! are chosen to be at time level n. 
 
-      !$omp do schedule(runtime) private(k, cell1, cell2)
-      do iEdge = 1, nEdges
-        cell1 = cellsOnEdge(1,iEdge)
-        cell2 = cellsOnEdge(2,iEdge)
-        k =  maxLevelEdgeTop(iEdge)
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, maxLevelEdgeTop, tend, &
+      !$acc            kineticEnergyCell, normalVelocity,  &
+      !$acc            layerThicknessEdge)                 &
+      !$acc    private(kBot, cell1, cell2)
+#else
+      !$omp parallel do schedule(runtime) &
+#endif
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         kBot  = maxLevelEdgeTop(iEdge)
 
-        ! Explicit bottom drag term:
-        ! du/dt = ... - c |u| u / h
-        ! appied to bottom layer only.
-        ! This term comes from the bottom boundary condition in the vertical
-        ! momentum mixing, and is explicit if both |u| and u are chosen to be at
-        ! time level n. 
-
-        tend(k,iEdge) = tend(k,iEdge) - explicitBottomDragCoef * & 
-           sqrt(kineticEnergyCell(k,cell1) + kineticEnergyCell(k,cell2)) * normalVelocity(k,iEdge) / layerThicknessEdge(k,iEdge)
-
+         tend(kBot,iEdge) = tend(kBot,iEdge) - explicitBottomDragCoef * & 
+                            sqrt(kineticEnergyCell(kBot,cell1) +  &
+                                 kineticEnergyCell(kBot,cell2)) * &
+                            normalVelocity(kBot,iEdge)/           &
+                            layerThicknessEdge(kBot,iEdge)
       enddo
-      !$omp end do
+#ifdef MPAS_OPENACC
+      !$omp end parallel do
+#endif
 
       call mpas_timer_stop('vel explicit bottom drag')
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_explicit_bottom_drag_tend!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_explicit_bottom_drag_init
 !
 !> \brief   Initializes ocean explicit bottom drag forcing
-!> \author  Mark Petersen
-!> \date    August 2017
+!> \author  Mark Petersen, Phil Jones
+!> \date    August 2017, updated May 2020
 !> \details
 !>  This routine initializes quantities related to explicit bottom drag
 !>  in the ocean.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_explicit_bottom_drag_init(err)!{{{
+   subroutine ocn_vel_forcing_explicit_bottom_drag_init(err)
 
-   !--------------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: error flag
 
-      logical, pointer :: config_disable_vel_explicit_bottom_drag
-      logical, pointer :: config_use_explicit_bottom_drag
-      real (kind=RKIND), pointer :: config_explicit_bottom_drag_coeff
+      !{{{
+      !-------------------------------------------------------------------------
+      ! local variables
+      !-------------------------------------------------------------------------
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Set default values for module variables
 
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_use_explicit_bottom_drag', config_use_explicit_bottom_drag)
-      call mpas_pool_get_config(ocnConfigs, 'config_explicit_bottom_drag_coeff', config_explicit_bottom_drag_coeff)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_explicit_bottom_drag', config_disable_vel_explicit_bottom_drag)
-
+      explicitBottomDragOn   = .false.
       explicitBottomDragCoef = 0.0_RKIND
 
+      ! Revise values based on user input in ocn_config
+
       if (config_use_explicit_bottom_drag) then
-          explicitBottomDragOn = .true.
-          explicitBottomDragCoef = config_explicit_bottom_drag_coeff
+         explicitBottomDragOn   = .true.
+         explicitBottomDragCoef = config_explicit_bottom_drag_coeff
       endif
 
-      if (config_disable_vel_explicit_bottom_drag) explicitBottomDragOn = .false.
+      if (config_disable_vel_explicit_bottom_drag) &
+         explicitBottomDragOn = .false.
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_explicit_bottom_drag_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 
 end module ocn_vel_forcing_explicit_bottom_drag
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -5,223 +5,261 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_vel_forcing_surface_stress
 !
 !> \brief MPAS ocean surface stress
-!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date   September 2011
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date   September 2011, updated May 2020
 !> \details
 !>  This module contains the routine for computing
 !>  tendencies from surface stress.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_vel_forcing_surface_stress
 
-   use mpas_derived_types
-   use mpas_pool_routines
    use mpas_timer
 
    use ocn_constants
-   use ocn_forcing
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_vel_forcing_surface_stress_tend, &
              ocn_vel_forcing_surface_stress_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   logical :: surfaceStressOn
+   logical :: surfaceStressOn ! on/off switch for surface stress
 
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_surface_stress_tend
 !
 !> \brief   Computes tendency term from surface stress
-!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date    15 September 2011
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date    15 September 2011, updated May 2020
 !> \details
 !>  This routine computes the surface stress tendency for momentum
-!>  based on current state.
+!>  based on current state and adds it to the total velocity tendency
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_surface_stress_tend(meshPool, surfaceFluxAttenuationCoefficient, surfaceStress, & !{{{
-                                                  layerThicknessEdge, tend, err)
+   subroutine ocn_vel_forcing_surface_stress_tend( &
+                                    surfaceFluxAttenuationCoefficient, &
+                                    surfaceStress, layerThicknessEdge, &
+                                    tend, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         surfaceStress, & !< Input: Wind stress at surface
-         surfaceFluxAttenuationCoefficient !< Input: attenuation coefficient for surface fluxes
+         surfaceStress, & !< [in] Wind stress at surface
+         surfaceFluxAttenuationCoefficient !< [in] attenuation coef for sfc flux
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: thickness at edge
+         layerThicknessEdge     !< [in] thickness at edge
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, nEdges
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: edgeMask, cellsOnEdge
+      integer ::      &
+         iEdge, k,    &! edge and vertical loop iterators
+         kMax,        &! index of bottom most edge
+         cell1, cell2  ! neighbor cell indices across edge
 
-      real (kind=RKIND) :: transmissionCoeffTop, transmissionCoeffBot, zTop, zBot, remainingStress, &
-                           attenuationCoeff
+      real (kind=RKIND) :: &
+         transmissionCoeffTop, &! frac of flux transmitted thru top
+         transmissionCoeffBot, &! frac of flux transmitted thru bottom
+         zTop, zBot,           &! depth at top, bot of layer
+         remainingStress,      &! fraction of stress not absorbed
+         attenuationCoeff       ! local attenuation coeff
 
-      !-----------------------------------------------------------------
-      !
-      ! call relevant routines for computing tendencies
-      ! note that the user can choose multiple options and the
-      !   tendencies will be added together
-      !
-      !-----------------------------------------------------------------
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         absorbFrac      ! local fraction of flux absorbed in the layer
 
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Exit if not turned on. Otherwise, start timer
       err = 0
 
       if ( .not. surfaceStressOn ) return
-
       call mpas_timer_start('vel surface stress')
 
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      ! allocate space and transfer data
+      allocate(absorbFrac (nVertLevels,nEdgesOwned))
+      !$acc enter data create(absorbFrac)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      !NOTE: For performance reasons, the ocn_forcing_transmission
+      !      function has been manually in-lined here. This 
+      !      exponential transmission function should be identical
+      !      to that used by other forcing so any modification should
+      !      be made to other forcing fields as well.
 
-      nEdges = nEdgesArray ( 1 )
+      ! Compute the absorption at each level
 
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-        zTop = 0.0_RKIND
-        cell1 = cellsOnEdge(1,iEdge)
-        cell2 = cellsOnEdge(2,iEdge)
-        attenuationCoeff = 0.5_RKIND * (surfaceFluxAttenuationCoefficient(cell1) &
-                                      + surfaceFluxAttenuationCoefficient(cell2))
-        transmissionCoeffTop = ocn_forcing_transmission(zTop, attenuationCoeff)
-        remainingStress = 1.0_RKIND
-        do k = 1, maxLevelEdgeTop(iEdge)
-           zBot = zTop - layerThicknessEdge(k, iEdge)
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, maxLevelEdgeTop, absorbFrac, &
+      !$acc            surfaceFluxAttenuationCoefficient,        &
+      !$acc            layerThicknessEdge)                       &
+      !$acc    private(k, kMax, cell1, cell2, zTop, zBot, &
+      !$acc            remainingStress, attenuationCoeff, &
+      !$acc            transmissionCoeffTop, transmissionCoeffBot)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kMax, cell1, cell2, zTop, zBot, &
+      !$omp            remainingStress, attenuationCoeff, &
+      !$omp            transmissionCoeffTop, transmissionCoeffBot)
+#endif
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         kMax  = maxLevelEdgeTop(iEdge)
 
-           transmissionCoeffBot = ocn_forcing_transmission(zBot, attenuationCoeff)
+         zTop = 0.0_RKIND
+         remainingStress = 1.0_RKIND
+         transmissionCoeffTop = 1.0_RKIND
+         attenuationCoeff = 0.5_RKIND * &
+                           (surfaceFluxAttenuationCoefficient(cell1) + &
+                            surfaceFluxAttenuationCoefficient(cell2))
 
-           remainingStress = remainingStress - (transmissionCoeffTop - transmissionCoeffBot)
+         do k = 1, kMax
 
-           tend(k,iEdge) =  tend(k,iEdge) + edgeMask(k, iEdge) * surfaceStress(iEdge) &
-                         * (transmissionCoeffTop - transmissionCoeffBot) / rho_sw / layerThicknessEdge(k,iEdge)
+            zBot = zTop - layerThicknessEdge(k, iEdge)
+            transmissionCoeffBot = &
+                      exp( max(zBot/attenuationCoeff, -100.0_RKIND) )
 
-           zTop = zBot
-           transmissionCoeffTop = transmissionCoeffBot
-        enddo
+            absorbFrac(k,iEdge) = transmissionCoeffTop - &
+                                  transmissionCoeffBot
+            remainingStress = remainingStress - absorbFrac(k,iEdge)
 
-        if ( maxLevelEdgeTop(iEdge) > 0 .and. remainingStress > 0.0_RKIND) then
-           tend(maxLevelEdgeTop(iEdge), iEdge) = tend(maxLevelEdgeTop(iEdge), iEdge) &
-                         + edgeMask(maxLevelEdgeTop(iEdge), iEdge) * surfaceStress(iEdge) * remainingStress &
-                         / rho_sw / layerThicknessEdge(maxLevelEdgeTop(iEdge), iEdge)
-        end if
+            zTop = zBot
+            transmissionCoeffTop = transmissionCoeffBot
+         enddo
+         ! If fluxes not absorbed before hitting the bottom
+         ! absorb the remaining in the bottom layer
+         if (kMax > 0) &
+            absorbFrac(kMax,iEdge) = absorbFrac(kMax,iEdge) + &
+                                     max(remainingStress,0.0_RKIND) 
       enddo
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
+
+      ! Distribute surface flux tendency throughout according
+      ! to the absorbed flux at each level
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(tend, surfaceStress, absorbFrac, &
+      !$acc            layerThicknessEdge, maxLevelEdgeTop) &
+      !$acc    private(k)
+#else
+      !$omp do schedule(runtime) &
+      !$acc    private(k)
+#endif
+      do iEdge = 1, nEdgesOwned
+      do k = 1, maxLevelEdgeTop(iEdge)
+         tend(k,iEdge) =  tend(k,iEdge) + surfaceStress(iEdge)* &
+            absorbFrac(k,iEdge)/rho_sw/layerThicknessEdge(k,iEdge)
+      enddo
+      enddo
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      ! deallocate space and remove data from device
+      !$acc exit data delete(absorbFrac)
+      deallocate(absorbFrac)
 
       call mpas_timer_stop('vel surface stress')
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_surface_stress_tend!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_forcing_surface_stress_init
 !
 !> \brief   Initializes ocean surface stress forcing
-!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date    September 2011
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler, Phil Jones
+!> \date    September 2011, updated May 2020
 !> \details
 !>  This routine initializes quantities related to surface stress
 !>  in the ocean.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_surface_stress_init(err)!{{{
+   subroutine ocn_vel_forcing_surface_stress_init(err)
 
-   !--------------------------------------------------------------------
+      !-------------------------------------------------------------------------
+      ! output variables
+      !-------------------------------------------------------------------------
 
-      !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
-      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< [out] error flag
 
-      integer, intent(out) :: err !< Output: error flag
+      !{{{
+      ! End of preamble
+      !----------------
+      ! Begin code
 
-      logical, pointer :: config_disable_vel_surface_stress
-
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_surface_stress', config_disable_vel_surface_stress)
-
-      surfaceStressOn = .true.
-
-      if(config_disable_vel_surface_stress) surfaceStressOn = .false.
+      ! Set default values
 
       err = 0
+      surfaceStressOn = .true.
 
-   !--------------------------------------------------------------------
+      ! Change default based on user input in ocn_config
+
+      if (config_disable_vel_surface_stress) surfaceStressOn = .false.
+
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_forcing_surface_stress_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 
 end module ocn_vel_forcing_surface_stress
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -5,242 +5,261 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_vel_hadv_coriolis
 !
-!> \brief MPAS ocean horizontal momentum mixing driver
-!> \author Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date   September 2011
+!> \brief MPAS ocean horizontal velocity advection coriolis tendencies
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones, Rob Aulwes
+!> \date   September 2011, updated May 2020
 !> \details
 !>  This module contains the routine for computing
 !>  tendencies from the horizontal advection and coriolis force.
 !>
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_vel_hadv_coriolis
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_vel_hadv_coriolis_tend, &
              ocn_vel_hadv_coriolis_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   logical :: hadvAndCoriolisOn
-   integer :: RK4On
+   logical :: hadvAndCoriolisOn ! main on/off switch forr hadv
 
-!***********************************************************************
+   real (kind=RKIND) :: RK4Mask ! some terms masked when RK4 is on/off
+
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_hadv_coriolis_tend
 !
 !> \brief   Computes tendency term for horizontal advection and coriolis force
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones, Rob Aulwes
+!> \date    September 2011, updated May 2020
 !> \details
-
-!>  This routine computes the horizontal advection and coriolis and
-!>  advection tendencies for momentum based on current state.
-
+!>  This routine computes the horizontal momentum advection and coriolis
+!>  tendencies based on current state and adds them to the total vel tendency
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-                                    layerThicknessEdge, normalVelocity, kineticEnergyCell, tend, err)!{{{
+   subroutine ocn_vel_hadv_coriolis_tend(normalizedRelativeVorticityEdge,    &
+                                         normalizedPlanetaryVorticityEdge,   &
+                                         layerThicknessEdge, normalVelocity, &
+                                         kineticEnergyCell, tend, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalizedRelativeVorticityEdge, &!< Input: relative vorticity over thickness, on an edge
-         normalizedPlanetaryVorticityEdge,&!< Input: planetary vorticity over thickness, on an edge
-         layerThicknessEdge,&!< Input: Thickness on edge
-         normalVelocity,&    !< Input: Horizontal velocity
-         kineticEnergyCell   !< Input: Kinetic Energy
+         normalizedRelativeVorticityEdge, &!< [in] rel vorticity/thick on edge
+         normalizedPlanetaryVorticityEdge,&!< [in] planetary vorticity/thick
+         layerThicknessEdge,              &!< [in] Thickness on edge
+         normalVelocity,                  &!< [in] Horizontal velocity
+         kineticEnergyCell                 !< [in] Kinetic Energy
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnEdge
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnEdge, edgeMask
-      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
-      real (kind=RKIND), dimension(:), pointer :: dcEdge
+      integer ::       &
+         j, k, iEdge,  &! loop counters
+         cell1, cell2, &! neighboring cell indices
+         kmax,         &! deepest vertical level
+         eoe            ! edge on edge index
 
-      integer :: j, k
-      integer :: cell1, cell2, iEdge, eoe, nEdges
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nEdgesArray
-      real (kind=RKIND) :: workVorticity, invLength, edgeWeight, r_tmp
-      real (kind=RKIND), dimension(:), allocatable :: qArr
+      real (kind=RKIND) :: &
+         workVorticity,    &! temporary vorticity factor
+         invLength,        &! inverse of dcEdge
+         edgeWeight         ! weight for each edge contribution
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         qArr               ! temporary for vorticity term
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Set error and return if this tendency has been turned off
+      ! Otherwise, start timer
 
       err = 0
-
       if ( .not. hadvAndCoriolisOn ) return
 
       call mpas_timer_start("coriolis")
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      allocate( qArr(nVertLevels,nEdgesOwned) )
+      !$acc enter data create(qArr)
 
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      ! Loop over edges. Tendencies are only needed for owned edges
 
-      nEdges = nEdgesArray( 1 )
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(maxLevelEdgeTop, qArr, nEdgesOnEdge, & 
+      !$acc            edgesOnEdge, weightsOnEdge,          &
+      !$acc            normalizedRelativeVorticityEdge,     &
+      !$acc            normalizedPlanetaryVorticityEdge,    &
+      !$acc            normalVelocity, layerThicknessEdge)  &
+      !$acc    private(j, k, kmax, eoe, edgeWeight, workVorticity)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(j, k, kmax, eoe, edgeWeight, workVorticity)
+#endif
+      do iEdge = 1, nEdgesOwned
+         kmax = maxLevelEdgeTop(iEdge)
 
-      allocate( qArr(nVertLevels) )
-
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-
-         invLength = 1.0_RKIND / dcEdge(iEdge)
-
-         do k = 1, maxLevelEdgeTop(iEdge)
-            qArr(k) = 0.0_RKIND
+         do k = 1, kmax
+            qArr(k,iEdge) = 0.0_RKIND
          end do
 
          do j = 1, nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(j, iEdge)
             edgeWeight = weightsOnEdge(j, iEdge)
 
-            do k = 1, maxLevelEdgeTop(iEdge)
-               workVorticity = 0.5_RKIND &
-                  * (  normalizedRelativeVorticityEdge(k, iEdge) + RK4On * normalizedPlanetaryVorticityEdge(k, iEdge) &
-                     + normalizedRelativeVorticityEdge(k, eoe)   + RK4On * normalizedPlanetaryVorticityEdge(k, eoe))
-               qArr(k) = qArr(k) + edgeWeight * normalVelocity(k, eoe) * workVorticity * layerThicknessEdge(k, eoe)
+            do k = 1, kmax
+               workVorticity = 0.5_RKIND* &
+                  (normalizedRelativeVorticityEdge (k,iEdge) + &
+                   normalizedPlanetaryVorticityEdge(k,iEdge)*RK4Mask + &
+                   normalizedRelativeVorticityEdge (k,eoe)   + &
+                   normalizedPlanetaryVorticityEdge(k,eoe)*RK4Mask)
+               qArr(k,iEdge) = &
+               qArr(k,iEdge) + edgeWeight*normalVelocity(k,eoe)* &
+                        workVorticity*layerThicknessEdge(k,eoe)
             end do
 
          end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+#endif
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(maxLevelEdgeTop, cellsOnEdge,          & 
+      !$acc            dcEdge, tend, qArr, kineticEnergyCell) &
+      !$acc    private(k, cell1, cell2, invLength)
+#else
+      !$omp do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, invLength)
+#endif
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         invLength = 1.0_RKIND / dcEdge(iEdge)
 
          do k = 1, maxLevelEdgeTop(iEdge)
-            tend(k, iEdge) = tend(k, iEdge) + edgeMask(k, iEdge) * ( qArr(k) - ( kineticEnergyCell(k, cell2) &
-                          - kineticEnergyCell(k, cell1) ) * invLength )
+            tend(k, iEdge) = tend(k, iEdge) + (qArr(k,iEdge) - &
+                             (kineticEnergyCell(k, cell2) &
+                            - kineticEnergyCell(k, cell1) ) * invLength)
          end do
-
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
+      !$acc exit data delete(qArr)
       deallocate( qArr )
 
       call mpas_timer_stop("coriolis")
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_hadv_coriolis_tend!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_hadv_coriolis_init
 !
-!> \brief   Initializes ocean momentum horizontal advection and
-!>  coriolis tendencies
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \brief  Initializes momentum horizontal advection and coriolis tendencies
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones, Rob Aulwes
+!> \date   September 2011, updated May 2020
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_hadv_coriolis_init(err)!{{{
+   subroutine ocn_vel_hadv_coriolis_init(err)
 
-   !--------------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! Output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: error flag
 
-      logical, pointer :: config_disable_vel_coriolis
-      character (len=StrKIND), pointer :: config_time_integrator
+      !{{{
+      !-------------------------------------------------------------------------
+      ! Local variables
+      !-------------------------------------------------------------------------
+
+      ! End preamble
+      !-------------
+      ! Begin code
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_coriolis', config_disable_vel_coriolis)
-      call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
+      ! Set main on/off flag based on input config flag
 
       hadvAndCoriolisOn = .true.
-
       if ( config_disable_vel_coriolis ) hadvAndCoriolisOn = .false.
+
+      ! Coriolis term is treated differently depending on time
+      ! integration algorithm
 
       if ( trim( config_time_integrator ) == 'RK4') then
          ! For RK4, coriolis tendency term includes f: (eta+f)/h.
-         RK4On = 1
+         RK4Mask = 1.0_RKIND
       elseif ( trim( config_time_integrator ) == 'split_explicit' &
-        .or. trim( config_time_integrator ) == 'unsplit_explicit') then
-         ! For split explicit, Coriolis tendency uses eta/h because the Coriolis term
-         ! is added separately to the momentum tendencies.
-         RK4On = 0
+          .or. trim( config_time_integrator ) == 'unsplit_explicit') then
+         ! For split explicit, Coriolis tendency uses eta/h because the 
+         ! Coriolis term is added separately to the momentum tendencies.
+         RK4Mask = 0.0_RKIND
       end if
 
-
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_hadv_coriolis_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 
 end module ocn_vel_hadv_coriolis
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix.F
@@ -10,50 +10,40 @@
 !  ocn_vel_hmix
 !
 !> \brief MPAS ocean horizontal momentum mixing driver
-!> \author Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date   September 2011
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date   September 2011, update April 2020
 !> \details
 !>  This module contains the main driver routine for computing
-!>  horizontal mixing tendencies.
+!>  horizontal velocity mixing tendencies.
 !>
-!>  It provides an init and a tend function. Each are described below.
-!
 !-----------------------------------------------------------------------
 
 module ocn_vel_hmix
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_threading
    use ocn_vel_hmix_del2
    use ocn_vel_hmix_leith
    use ocn_vel_hmix_del4
    use ocn_constants
+   use ocn_config
 
    implicit none
    private
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_tend, &
              ocn_vel_hmix_init
 
    !--------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
    logical :: hmixOn
@@ -67,8 +57,8 @@ contains
 !  routine ocn_vel_hmix_tend
 !
 !> \brief   Computes tendency term for horizontal momentum mixing
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date    September 2011, updated April 2020
 !> \details
 !>  This routine computes the horizontal mixing tendency for momentum
 !>  based on current state and user choices of mixing parameterization.
@@ -79,88 +69,68 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_tend(meshPool, scratchPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, &
-                                viscosity, tend, err)!{{{
+   subroutine ocn_vel_hmix_tend(divergence, relVorticity, tend, err)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      type (mpas_pool_type), intent(inout) :: scratchPool !< Input: scratch variables
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         divergence      !< [in] velocity divergence
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         divergence    !< Input: velocity divergence
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity     !< Input: relative vorticity
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: velocity normal to an edge
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         tangentialVelocity     !< Input: velocity, tangent to an edge
+         relVorticity    !< [in] relative vorticity
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity     !< Input: viscosity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] accumulated velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
+      !{{{
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: err1
+      integer :: err1  ! temp for managing multiple error codes
 
-      !-----------------------------------------------------------------
-      !
-      ! call relevant routines for computing tendencies
-      ! note that the user can choose multiple options and the
-      !   tendencies will be added together
-      !
-      !-----------------------------------------------------------------
+      ! end preamble
+      !-------------
+      ! begin code
 
-      if(.not.hmixOn) return
+      ! return if no mixing is turned on, otherwise start timer
+
+      err = 0
+      if (.not. hmixOn) return
 
       call mpas_timer_start("vel hmix")
 
-      viscosity = 0.0_RKIND
-      err = 0
+      !-----------------------------------------------------------------
+      ! call relevant routines for computing tendencies
+      ! note that the user can choose multiple options and the
+      !   tendencies will be added together
+      ! if OpenACC is enabled, the subroutine arguments are assumed
+      !   to have been copied to the device in the calling tendency
+      !   routine and retained there along with any synchronization 
+      !   with the host. That also means all the routines called below
+      !   must also be GPU enabled so that the tendency is added on
+      !   the device and not the host.
+      !-----------------------------------------------------------------
 
-      call ocn_vel_hmix_del2_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
+      call ocn_vel_hmix_del2_tend(divergence, relVorticity, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_del2_tensor_tend(meshPool, normalVelocity, tangentialVelocity, viscosity, scratchPool, tend, err1)
+      call ocn_vel_hmix_leith_tend(divergence, relVorticity, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_leith_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
-      err = ior(err1, err)
-
-      call ocn_vel_hmix_del4_tend(meshPool, scratchPool, divergence, relativeVorticity, tend, err1)
-      err = ior(err1, err)
-
-      call ocn_vel_hmix_del4_tensor_tend(meshPool, normalVelocity, tangentialVelocity, viscosity, scratchPool, tend, err1)
+      call ocn_vel_hmix_del4_tend(divergence, relVorticity, tend, err1)
       err = ior(err1, err)
 
       call mpas_timer_stop("vel hmix")
@@ -175,7 +145,7 @@ contains
 !
 !> \brief   Initializes ocean momentum horizontal mixing quantities
 !> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \date    September 2011, updated April 2020
 !> \details
 !>  This routine initializes a variety of quantities related to
 !>  horizontal velocity mixing in the ocean. Since a variety of
@@ -184,33 +154,44 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_init(err)!{{{
-
-   !--------------------------------------------------------------------
+   subroutine ocn_vel_hmix_init(err)
 
       !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
+      ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      integer :: err1, err2, err3
+      !{{{
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
 
-      logical, pointer :: config_disable_vel_hmix
+      integer :: err1, err2, err3 ! error codes from each init
 
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_hmix', config_disable_vel_hmix)
+      ! end preamble
+      !-------------
+      ! begin code
+
+      err = 0
+
+      !-----------------------------------------------------------------
+      ! set overall mixing flag - on by default
+      !-----------------------------------------------------------------
 
       hmixOn = .true.
+      if (config_disable_vel_hmix) hmixOn = .false.
 
-      call ocn_vel_hmix_del2_init(err1)
-      call ocn_vel_hmix_leith_init(err2)
-      call ocn_vel_hmix_del4_init(err3)
+      !-----------------------------------------------------------------
+      ! call individual init routines for each parameterization
+      !-----------------------------------------------------------------
 
-      err = ior(ior(err1, err2),err3)
-
-      if(config_disable_vel_hmix) hmixOn = .false.
+      if (hmixOn) then
+         call ocn_vel_hmix_del2_init(err1)
+         call ocn_vel_hmix_leith_init(err2)
+         call ocn_vel_hmix_del4_init(err3)
+         err = ior(ior(err1, err2),err3)
+      endif
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
@@ -10,8 +10,8 @@
 !  ocn_vel_hmix_del2
 !
 !> \brief Ocean horizontal mixing - Laplacian parameterization
-!> \author Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date   September 2011
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date   September 2011, updated April 2020
 !> \details
 !>  This module contains routines for computing horizontal mixing
 !>  tendencies using a Laplacian formulation.
@@ -21,41 +21,33 @@
 module ocn_vel_hmix_del2
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_threading
    use mpas_vector_operations
    use mpas_matrix_operations
-   use mpas_tensor_operations
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_del2_tend, &
-             ocn_vel_hmix_del2_tensor_tend, &
              ocn_vel_hmix_del2_init
 
    !-------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
-   logical ::  hmixDel2On  !< integer flag to determine whether del2 chosen
+   logical :: hmixDel2On       !< flag to determine whether del2 chosen
+   real (kind=RKIND) :: visc2  !< del2 viscosity coefficient
 
 !***********************************************************************
 
@@ -66,8 +58,8 @@ contains
 !  routine ocn_vel_hmix_del2_tend
 !
 !> \brief   Computes tendency term for Laplacian horizontal momentum mixing
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    22 August 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date    22 August 2011, updated April 2020
 !> \details
 !>  This routine computes the horizontal mixing tendency for momentum
 !>  based on a Laplacian form for the mixing, \f$\nu_2 \nabla^2 u\f$
@@ -78,114 +70,107 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_del2_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err)!{{{
+   subroutine ocn_vel_hmix_del2_tend(divergence, relVorticity, tend, err)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         divergence      !< Input: velocity divergence
+         divergence      !< [in] velocity divergence
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity       !< Input: relative vorticity
+         relVorticity    !< [in] relative vorticity
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool            !< Input: mesh information
-
-      !------ -----------------------------------------------------------
-      !
+      !-----------------------------------------------------------------
       ! input /output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity       !< Input: viscosity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend             !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
+      !{{{
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, vertex1, vertex2, k, nEdges
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgeMask
+      integer :: &
+         iEdge, k,       &! edge and verical loop indices
+         cell1, cell2,   &! neighbor cell   indices across edge
+         vertex1, vertex2 ! neighbor vertex indices across edge
 
-      real (kind=RKIND) :: u_diffusion, invLength1, invLength2, visc2
-      real (kind=RKIND), dimension(:), pointer :: meshScalingDel2, &
-              dcEdge, dvEdge
+      real (kind=RKIND) :: &
+         u_diffusion,      &!
+         invDcEdge,        &! inverse length between centers
+         invDvEdge,        &! inverse length between vertices 
+         viscDel2           ! scaled viscosity coefficient
 
-      real (kind=RKIND), pointer :: config_mom_del2
+      ! End of preamble
+      !----------------
+      ! Begin code
 
       !-----------------------------------------------------------------
-      !
       ! exit if this mixing is not selected
-      !
       !-----------------------------------------------------------------
 
       err = 0
 
-      if(.not.hmixDel2On) return
+      if (.not. hmixDel2On) return
 
       call mpas_timer_start("vel del2")
 
-      call mpas_pool_get_config(ocnConfigs, 'config_mom_del2', config_mom_del2)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-
-      nEdges = nEdgesArray( 1 )
-
-      !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength1, invLength2, k, u_diffusion, visc2)
-      do iEdge = 1, nEdges
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(nEdgesOwned, maxLevelEdgeTop, &
+      !$acc            cellsOnEdge, verticesOnEdge, &
+      !$acc            dcEdge, dvEdge, meshScalingDel2, &
+      !$acc            divergence, relVorticity, tend)   &
+      !$acc    private(cell1, cell2, vertex1, vertex2, k, invDcEdge, &
+      !$acc            invDvEdge, u_diffusion, viscDel2)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(cell1, cell2, vertex1, vertex2, k, invDcEdge, &
+      !$omp            invDvEdge, u_diffusion, viscDel2)
+#endif
+      do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          vertex1 = verticesOnEdge(1,iEdge)
          vertex2 = verticesOnEdge(2,iEdge)
 
-         invLength1 = 1.0_RKIND / dcEdge(iEdge)
-         invLength2 = 1.0_RKIND / dvEdge(iEdge)
+         invDcEdge = 1.0_RKIND / dcEdge(iEdge)
+         invDvEdge = 1.0_RKIND / dvEdge(iEdge)
+
+         viscDel2 =  visc2 * meshScalingDel2(iEdge)
 
          do k = 1, maxLevelEdgeTop(iEdge)
 
-            ! Here -( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) / dvEdge(iEdge)
-            ! is - \nabla relativeVorticity pointing from vertex 2 to vertex 1, or equivalently
-            !    + k \times \nabla relativeVorticity pointing from cell1 to cell2.
+            ! Here -( relVorticity(k,vertex2) - 
+            !         relVorticity(k,vertex1) )/ dvEdge(iEdge)
+            ! is - \nabla relVorticity pointing from vertex 2 to 
+            !       vertex 1, or equivalently
+            !    + k \times \nabla relVorticity pointing from 
+            !       cell1 to cell2.
 
-            u_diffusion = ( divergence(k,cell2)  - divergence(k,cell1) ) * invLength1 &
-                         -( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) * invLength2
+            u_diffusion = & 
+               (divergence(k,cell2) - divergence(k,cell1))*invDcEdge - &
+               (relVorticity(k,vertex2) - relVorticity(k,vertex1))*invDvEdge
 
-            visc2 =  config_mom_del2 * meshScalingDel2(iEdge)
-
-            tend(k,iEdge) = tend(k,iEdge) + edgeMask(k, iEdge) * visc2 * u_diffusion
-
-            viscosity(k,iEdge) = viscosity(k,iEdge) + visc2
+            tend(k,iEdge) = tend(k,iEdge) + viscDel2*u_diffusion
 
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
       call mpas_timer_stop("vel del2")
 
@@ -195,218 +180,62 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_vel_hmix_del2_tensor_tend
-!
-!> \brief   Computes tendency term for Laplacian horizontal momentum mixing
-!> \author  Mark Petersen
-!> \date    July 2013
-!> \details
-!>  This routine computes the horizontal mixing tendency for momentum
-!>  using tensor operations,
-!>  based on a Laplacian form for the mixing, \f$\nabla\cdot( \nu_2 \nabla(u))\f$
-!>  where \f$\nu_2\f$ is a viscosity.
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_vel_hmix_del2_tensor_tend(meshPool, normalVelocity, tangentialVelocity, viscosity, scratchPool, tend, err)!{{{
-
-      !-----------------------------------------------------------------
-      !
-      ! input variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: velocity normal to an edge
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         tangentialVelocity     !< Input: velocity, tangent to an edge
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool            !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity       !< Input/Output: viscosity
-
-      type (mpas_pool_type), intent(inout) :: &
-         scratchPool !< Input/Output: Scratch structure
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend             !< Input/Output: velocity tendency
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-      !
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-
-      integer :: iEdge, k, nEdges
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: edgeMask, edgeSignOnCell
-
-      real (kind=RKIND) :: visc2
-      real (kind=RKIND), dimension(:), pointer :: meshScalingDel2
-      real (kind=RKIND), dimension(:,:), pointer :: normalVectorEdge, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-         strainRateR3Cell, strainRateR3Edge, divTensorR3Cell, outerProductEdge
-
-      type (field2DReal), pointer :: normalVectorEdgeField
-      type (field3DReal), pointer :: strainRateR3CellField, strainRateR3EdgeField, divTensorR3CellField, outerProductEdgeField
-
-      logical, pointer :: config_use_mom_del2_tensor
-      real (kind=RKIND), pointer :: config_mom_del2_tensor
-
-      !-----------------------------------------------------------------
-      !
-      ! exit if this mixing is not selected
-      !
-      !-----------------------------------------------------------------
-
-      err = 0
-      call mpas_pool_get_config(ocnConfigs, 'config_use_mom_del2_tensor', config_use_mom_del2_tensor)
-
-      if ( .not. config_use_mom_del2_tensor ) return
-
-      call mpas_timer_start("vel del2_tensor")
-
-      call mpas_pool_get_config(ocnConfigs, 'config_mom_del2_tensor ', config_mom_del2_tensor )
-
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
-
-      call mpas_pool_get_field(scratchPool, 'strainRateR3Cell',strainRateR3CellField)
-      call mpas_pool_get_field(scratchPool, 'strainRateR3Edge',strainRateR3EdgeField)
-      call mpas_pool_get_field(scratchPool, 'divTensorR3Cell', divTensorR3CellField)
-      call mpas_pool_get_field(scratchPool, 'outerProductEdge',outerProductEdgeField)
-      call mpas_pool_get_field(scratchPool, 'normalVectorEdge',normalVectorEdgeField)
-
-      call mpas_allocate_scratch_field(strainRateR3CellField, .true.)
-      call mpas_allocate_scratch_field(strainRateR3EdgeField, .true.)
-      call mpas_allocate_scratch_field(divTensorR3CellField, .true.)
-      call mpas_allocate_scratch_field(outerProductEdgeField, .true.)
-      call mpas_allocate_scratch_field(normalVectorEdgeField, .true.)
-
-      strainRateR3Cell => strainRateR3CellField % array
-      strainRateR3Edge => strainRateR3EdgeField % array
-      divTensorR3Cell  => divTensorR3CellField % array
-      outerProductEdge => outerProductEdgeField % array
-      normalVectorEdge => normalVectorEdgeField % array
-
-      call mpas_strain_rate_R3Cell(normalVelocity, tangentialVelocity, &
-         meshPool, edgeSignOnCell, edgeTangentVectors, .true., &
-         outerProductEdge, strainRateR3Cell)
-
-      call mpas_matrix_cell_to_edge(strainRateR3Cell, meshPool, .true., strainRateR3Edge)
-
-      ! Need to compute strain rate and viscosity for all edges.
-      nEdges = nEdgesArray( size(nEdgesArray) )
-
-      ! The following loop could possibly be reduced to nEdgesSolve
-      !$omp do schedule(runtime) private(visc2, k)
-      do iEdge = 1, nEdges
-         visc2 = config_mom_del2_tensor * meshScalingDel2(iEdge)
-         do k = 1, maxLevelEdgeTop(iEdge)
-            strainRateR3Edge(:,k,iEdge) = visc2 * strainRateR3Edge(:,k,iEdge)
-            viscosity(k,iEdge) = viscosity(k,iEdge) + visc2
-         end do
-         ! Impose zero strain rate at land boundaries
-         do k = maxLevelEdgeTop(iEdge)+1, nVertLevels
-            strainRateR3Edge(:,k,iEdge) = 0.0_RKIND
-         end do
-      end do
-      !$omp end do
-
-      ! may change boundaries to false later
-      call mpas_divergence_of_tensor_R3Cell(strainRateR3Edge, meshPool, edgeSignOnCell, .true., divTensorR3Cell)
-
-      call mpas_vector_R3Cell_to_normalVectorEdge(divTensorR3Cell, meshPool, .true., normalVectorEdge)
-
-      ! Only need tendency on owned edges
-      nEdges = nEdgesArray( 1 )
-
-      ! The following loop could possibly be reduced to nEdgesSolve
-      !$omp do schedule(runtime) private(k)
-      do iEdge = 1, nEdges
-         do k = 1, maxLevelEdgeTop(iEdge)
-            tend(k,iEdge) = tend(k,iEdge) + edgeMask(k, iEdge) * normalVectorEdge(k,iEdge)
-         end do
-      end do
-      !$omp end do
-
-      call mpas_deallocate_scratch_field(strainRateR3CellField, .true.)
-      call mpas_deallocate_scratch_field(strainRateR3EdgeField, .true.)
-      call mpas_deallocate_scratch_field(divTensorR3CellField, .true.)
-      call mpas_deallocate_scratch_field(outerProductEdgeField, .true.)
-      call mpas_deallocate_scratch_field(normalVectorEdgeField, .true.)
-
-      call mpas_timer_stop("vel del2_tensor")
-
-   !--------------------------------------------------------------------
-
-   end subroutine ocn_vel_hmix_del2_tensor_tend!}}}
-
-!***********************************************************************
-!
 !  routine ocn_vel_hmix_del2_init
 !
 !> \brief   Initializes ocean momentum Laplacian horizontal mixing
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date    September 2011, updated April 2020
 !> \details
 !>  This routine initializes a variety of quantities related to
 !>  Laplacian horizontal momentum mixing in the ocean.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_del2_init(err)!{{{
-
-
-   integer, intent(out) :: err !< Output: error flag
-
-   real (kind=RKIND), pointer :: config_mom_del2
-   logical, pointer :: config_use_mom_del2
+   subroutine ocn_vel_hmix_del2_init(err)
 
    !--------------------------------------------------------------------
-   !
-   ! set some local module variables based on input config choices
-   !
+   ! Output variables
+   !--------------------------------------------------------------------
+
+   integer, intent(out) :: err !< [out] error flag
+
+   !{{{
+   !--------------------------------------------------------------------
+   ! local variables
+   !--------------------------------------------------------------------
+
+   ! None
+
+   ! End preamble
+   !-------------
+   ! Begin code
+
+   !--------------------------------------------------------------------
+   ! set default values for module variables and constants
    !--------------------------------------------------------------------
 
    err = 0
 
-   call mpas_pool_get_config(ocnConfigs, 'config_mom_del2', config_mom_del2)
-   call mpas_pool_get_config(ocnConfigs, 'config_use_mom_del2', config_use_mom_del2)
+   hmixDel2On       = .false.
+   visc2            = 0.0_RKIND
 
-   hmixDel2On = .false.
+   !--------------------------------------------------------------------
+   ! override defaults with input choices
+   !--------------------------------------------------------------------
 
-   if ( config_mom_del2 > 0.0_RKIND ) then
-      hmixDel2On = .true.
+   hmixDel2On       = config_use_mom_del2
+   visc2            = config_mom_del2
+
+   !--------------------------------------------------------------------
+   ! perform some error checks on inputs
+   !--------------------------------------------------------------------
+
+   if (hmixDel2On .and. visc2 <= 0.0_RKIND) then
+      err = -1
+      call mpas_log_write(&
+         'ocn_vel_hmix_del2: invalid viscosity coeff for del2', &
+         MPAS_LOG_CRIT)
    endif
-
-   if ( .not. config_use_mom_del2 ) hmixDel2On = .false.
-
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -10,52 +10,46 @@
 !  ocn_vel_hmix_del4
 !
 !> \brief Ocean horizontal mixing - biharmonic parameterization
-!> \author Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date   September 2011
+!> \author Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date   September 2011, updated April 2020
 !> \details
 !>  This module contains routines and variables for computing
-!>  horizontal mixing tendencies using a biharmonic formulation.
+!>  horizontal momentum mixing tendencies using a biharmonic formulation.
 !
 !-----------------------------------------------------------------------
 
 module ocn_vel_hmix_del4
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_threading
+   use mpas_log
    use mpas_vector_operations
    use mpas_matrix_operations
-   use mpas_tensor_operations
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_del4_tend, &
-             ocn_vel_hmix_del4_tensor_tend, &
              ocn_vel_hmix_del4_init
 
    !--------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
-   logical :: hmixDel4On       !< local flag to determine whether del4 chosen
+   logical :: hmixDel4On       !< flag to determine whether del4 chosen
+   real (kind=RKIND) :: visc4     !< base momentum del4 diffusion coeff
+   real (kind=RKIND) :: divFactor !< factor to use for divergence term
 
 !***********************************************************************
 
@@ -66,8 +60,8 @@ contains
 !  routine ocn_vel_hmix_del4_tend
 !
 !> \brief   Computes tendency term for biharmonic horizontal momentum mixing
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date    September 2011, updated April 2020
 !> \details
 !>  This routine computes the horizontal mixing tendency for momentum
 !>  based on a biharmonic form for the mixing.  This mixing tendency
@@ -79,68 +73,56 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_del4_tend(meshPool, scratchPool, divergence, relativeVorticity, tend, err)!{{{
+   subroutine ocn_vel_hmix_del4_tend(divergence, relVorticity, tend, err)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         divergence      !< Input: velocity divergence
-
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
+         divergence      !< [in] velocity divergence
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity       !< Input: relative vorticity
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: mesh information
+         relVorticity    !< [in] relative vorticity
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend       !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
+      !{{{
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, vertex1, vertex2, k, i
-      integer :: iCell, iVertex, nEdges, nCells, nVertices
-      integer, pointer :: nVertLevels, vertexDegree
-      integer, dimension(:), pointer :: nEdgesArray, nCellsArray, nVerticesArray
+      integer :: i,k,iEdge,iCell,iVertex               ! loop iterators
+      integer :: imax, kmax, nEdges, nCells, nVertices ! loop limits
+      integer :: cell1, cell2, vertex1, vertex2        ! nbr addresses
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelVertexTop, &
-            maxLevelCell, nEdgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgeMask, edgesOnVertex, edgesOnCell, edgeSignOnVertex, &
-                                          edgeSignOnCell
+      real (kind=RKIND) :: &
+         invAreaCell1, invAreaCell2, &! temp reciprocals
+         invAreaTri1,  invAreaTri2,  &! temp reciprocals
+         invDcEdge,    invDvEdge,    &! temp reciprocals
+         del2Factor,                 &! temp for holding common factors
+         delsqSum,                   &! temp for holding local sums
+         viscTmp                      ! scaled visc
 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         delsqDiv,          &! Laplacian on divergence field
+         delsqRelVort,      &! Laplacian on relative vorticity
+         delsqU              ! Laplacian on velocity
 
-      real (kind=RKIND) :: u_diffusion, invAreaCell1, invAreaCell2, invAreaTri1, &
-            invAreaTri2, invDcEdge, invDvEdge, r_tmp
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaTriangle, &
-            meshScalingDel4, areaCell
-
-      real (kind=RKIND), dimension(:,:), pointer :: delsq_divergence, delsq_relativeVorticity, delsq_u
-      type (field2DReal), pointer :: delsq_uField, delsq_divergenceField, delsq_relativeVorticityField
-
-      real (kind=RKIND), pointer :: config_mom_del4, config_mom_del4_div_factor
+      ! end preamble
+      !-----------------------------------------------------------------
+      ! begin code
 
       err = 0
 
@@ -148,49 +130,30 @@ contains
 
       call mpas_timer_start("vel del4")
 
-      call mpas_pool_get_config(ocnConfigs, 'config_mom_del4', config_mom_del4)
-      call mpas_pool_get_config(ocnConfigs, 'config_mom_del4_div_factor', config_mom_del4_div_factor)
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVerticesArray', nVerticesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', maxLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-
-      call mpas_pool_get_field(scratchPool, 'delsq_u', delsq_uField)
-      call mpas_pool_get_field(scratchPool, 'delsq_divergence', delsq_divergenceField)
-      call mpas_pool_get_field(scratchPool, 'delsq_relativeVorticity', delsq_relativeVorticityField)
-      call mpas_allocate_scratch_field(delsq_uField, .true., .false.)
-      call mpas_allocate_scratch_field(delsq_divergenceField, .true., .false.)
-      call mpas_allocate_scratch_field(delsq_relativeVorticityField, .true., .false.)
-
-      delsq_u => delsq_uField % array
-      delsq_divergence => delsq_divergenceField % array
-      delsq_relativeVorticity => delsq_relativeVorticityField % array
-
-      nEdges = nEdgesArray( 3 )
+      allocate(delsqDiv    (nVertLevels,nCellsAll   ), &
+               delsqRelVort(nVertLevels,nVerticesAll), &
+               delsqU      (nVertLevels,nEdgesAll   ))
+      !$acc enter data &
+      !$acc  create(delsqDiv, delsqRelVort, delsqU)
 
       !Compute delsq_u
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         delsq_u(:, iEdge) = 0.0_RKIND
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(delsqU, nEdgesHalo, &
+      !$acc            cellsOnEdge, verticesOnEdge, &
+      !$acc            dcEdge, dvEdge, divergence, &
+      !$acc            maxLevelEdgeTop, relVorticity)   &
+      !$acc    private(k, kmax, cell1, cell2, vertex1, vertex2, &
+      !$acc            invDcEdge, invDvEdge)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kmax, cell1, cell2, vertex1, vertex2, &
+      !$omp            invDcEdge, invDvEdge)
+#endif
+      do iEdge = 1, nEdgesHalo(2)
+         delsqU(:, iEdge) = 0.0_RKIND
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
@@ -198,332 +161,197 @@ contains
          vertex2 = verticesOnEdge(2,iEdge)
 
          invDcEdge = 1.0_RKIND / dcEdge(iEdge)
-         invDvEdge = 1.0_RKIND / max(dvEdge(iEdge), 0.25_RKIND*dcEdge(iEdge))
+         invDvEdge = 1.0_RKIND / max(dvEdge(iEdge), &
+                          0.25_RKIND*dcEdge(iEdge))
+         kmax = maxLevelEdgeTop(iEdge)
 
-         do k=1,maxLevelEdgeTop(iEdge)
-            ! Compute \nabla^2 u = \nabla divergence + k \times \nabla relativeVorticity
-            delsq_u(k, iEdge) = ( divergence(k,cell2)  - divergence(k,cell1) ) * invDcEdge  &
-                               -( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1)) * invDvEdge
+         do k=1,kmax
+            ! Compute \nabla^2 u = \nabla divergence + 
+            !                      k \times \nabla relativeVorticity
+            delsqU(k, iEdge) = &
+               (divergence(k,cell2) - divergence(k,cell1))*invDcEdge - &
+               (relVorticity(k,vertex2) - relVorticity(k,vertex1))*invDvEdge
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
-      nVertices = nVerticesArray( 2 )
+      ! Compute delsq of relativeVorticity
 
-      ! Compute delsq_relativeVorticity
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(delsqRelVort, delsqU,  &
+      !$acc            nVerticesHalo, &
+      !$acc            maxLevelVertexTop, &
+      !$acc            dcEdge, areaTriangle,  &
+      !$acc            vertexDegree, edgesOnVertex, &
+      !$acc            edgeSignOnVertex) &
+      !$acc    private(i, iEdge, k, kmax, invAreaTri1, del2Factor)
+#else
       !$omp do schedule(runtime)
-      do iVertex = 1, nVertices
-         delsq_relativeVorticity(:, iVertex) = 0.0_RKIND
+      !$omp    private(i, iEdge, k, kmax, invAreaTri1, del2Factor)
+#endif
+      do iVertex = 1, nVerticesHalo(1) ! compute out to one halo level
+
+         delsqRelVort(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+         kmax = maxLevelVertexTop(iVertex)
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
-            do k = 1, maxLevelVertexTop(iVertex)
-               delsq_relativeVorticity(k, iVertex) = delsq_relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) &
-                                                   * dcEdge(iEdge) * delsq_u(k, iEdge) * invAreaTri1
+            del2Factor = edgeSignOnVertex(i,iVertex) * &
+                         dcEdge(iEdge)*invAreaTri1
+            do k = 1, kmax
+               delsqRelVort(k, iVertex) = &
+               delsqRelVort(k, iVertex) + del2Factor*delsqU(k,iEdge)
             end do
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
-
-      nCells = nCellsArray( 2 )
+#endif
 
       ! Compute delsq_divergence
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(delsqDiv, delsqU,  &
+      !$acc            nCellsHalo, maxLevelCell, &
+      !$acc            dvEdge, areaCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, &
+      !$acc            edgeSignOnCell) &
+      !$acc    private(i, imax, iEdge, k, kmax, invAreaCell1, del2Factor)
+#else
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         delsq_divergence(:, iCell) = 0.0_RKIND
+      !$omp    private(i, imax, iEdge, k, kmax, invAreaCell1, del2Factor)
+#endif
+      do iCell = 1, nCellsHalo(1)
+
+         delsqDiv(:, iCell) = 0.0_RKIND
          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-         do i = 1, nEdgesOnCell(iCell)
+         kmax = maxLevelCell(iCell)
+         imax = nEdgesOnCell(iCell)
+
+         do i = 1,imax
             iEdge = edgesOnCell(i, iCell)
-            do k = 1, maxLevelCell(iCell)
-               delsq_divergence(k, iCell) = delsq_divergence(k, iCell) - edgeSignOnCell(i, iCell) * dvEdge(iEdge) &
-                                          * delsq_u(k, iEdge) * invAreaCell1
+            del2Factor = edgeSignOnCell(i, iCell) * &
+                         dvEdge(iEdge)*invAreaCell1
+            do k = 1, kmax
+               delsqDiv(k, iCell) = &
+               delsqDiv(k, iCell) - del2Factor*delsqU(k,iEdge)
             end do
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
-
-      nEdges = nEdgesArray( 1 )
+#endif
 
       ! Compute - \kappa \nabla^4 u
       ! as  \nabla div(\nabla^2 u) + k \times \nabla ( k \cross curl(\nabla^2 u) )
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop                          &
+      !$acc    present(delsqDiv, delsqRelVort, tend,        &
+      !$acc            cellsOnEdge, verticesOnEdge, &
+      !$acc            maxLevelEdgeTop,                     &
+      !$acc            dcEdge, dvEdge,              &
+      !$acc            nEdgesOwned, meshScalingDel4)&
+      !$acc    private(k, kmax, cell2, cell2, vertex1, vertex2,     &
+      !$acc            invDcEdge, invDvEdge, viscTmp)
+#else
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
+      !$omp    private(k, kmax, cell2, cell2, vertex1, vertex2, &
+      !$omp            invDcEdge, invDvEdge, viscTmp)
+#endif
+      do iEdge = 1, nEdgesOwned
+
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          vertex1 = verticesOnEdge(1,iEdge)
          vertex2 = verticesOnEdge(2,iEdge)
+         kmax    = maxLevelEdgeTop(iEdge)
 
-         invDcEdge = 1.0_RKIND / dcEdge(iEdge)
+         invDcEdge = divFactor / dcEdge(iEdge)
          invDvEdge = 1.0_RKIND / dvEdge(iEdge)
-         r_tmp = config_mom_del4 * meshScalingDel4(iEdge)
+         viscTmp  = visc4*meshScalingDel4(iEdge)
 
-         do k=1,maxLevelEdgeTop(iEdge)
-            u_diffusion = config_mom_del4_div_factor*(delsq_divergence(k,cell2) - delsq_divergence(k,cell1)) * invDcEdge  &
-                        - (delsq_relativeVorticity(k,vertex2) - delsq_relativeVorticity(k,vertex1) ) * invDvEdge
-
-            tend(k,iEdge) = tend(k,iEdge) - edgeMask(k, iEdge) * u_diffusion * r_tmp
+         do k=1,kmax
+            tend(k,iEdge) = &
+            tend(k,iEdge) - viscTmp*   &
+                            ((delsqDiv(k,cell2) -                &
+                              delsqDiv(k,cell1))*invDcEdge  -    &
+                             (delsqRelVort(k,vertex2) -          &
+                              delsqRelVort(k,vertex1))*invDvEdge)
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
 
-      call mpas_deallocate_scratch_field(delsq_uField, .true.)
-      call mpas_deallocate_scratch_field(delsq_divergenceField, .true.)
-      call mpas_deallocate_scratch_field(delsq_relativeVorticityField, .true.)
+      !$acc exit data &
+      !$acc  delete(delsqDiv, delsqRelVort, delsqU)
+      deallocate(delsqDiv    , &
+                 delsqRelVort, &
+                 delsqU        )
 
       call mpas_timer_stop("vel del4")
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_hmix_del4_tend!}}}
-
-!***********************************************************************
-!
-!  routine ocn_vel_hmix_del4_tensor_tend
-!
-!> \brief   Computes tendency term for Laplacian horizontal momentum mixing
-!> \author  Mark Petersen
-!> \date    July 2013
-!> \details
-!>  This routine computes the horizontal mixing tendency for momentum
-!>  using tensor operations,
-!>  based on a Laplacian form for the mixing,
-!>  \f$-\nabla\cdot( \sqrt{\nu_4} \nabla(\nabla\cdot( \sqrt{\nu_4} \nabla(u))))\f$
-!>  where \f$\nu_4\f$ is the del4 viscosity.
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_vel_hmix_del4_tensor_tend(meshPool, normalVelocity, tangentialVelocity, viscosity, scratchPool, tend, err)!{{{
-
-      !-----------------------------------------------------------------
-      !
-      ! input variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: velocity normal to an edge
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         tangentialVelocity     !< Input: velocity, tangent to an edge
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool            !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity       !< Input/Output: viscosity
-
-      type (mpas_pool_type), intent(inout) :: &
-         scratchPool !< Input/Output: Scratch structure
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend             !< Input/Output: velocity tendency
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-      !
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-
-      integer :: iEdge, k, nEdges
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: edgeMask, edgeSignOnCell
-
-      real (kind=RKIND) :: visc4_sqrt
-      real (kind=RKIND), dimension(:), pointer :: meshScalingDel4
-      real (kind=RKIND), dimension(:,:), pointer :: normalVectorEdge, tangentialVectorEdge, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-         strainRateR3Cell, strainRateR3Edge, divTensorR3Cell, outerProductEdge
-
-      type (field2DReal), pointer :: normalVectorEdgeField, tangentialVectorEdgeField
-      type (field3DReal), pointer :: strainRateR3CellField, strainRateR3EdgeField, divTensorR3CellField, outerProductEdgeField
-
-      logical, pointer :: config_use_mom_del4_tensor
-      real (kind=RKIND), pointer :: config_mom_del4_tensor
-
-
-      !-----------------------------------------------------------------
-      !
-      ! exit if this mixing is not selected
-      !
-      !-----------------------------------------------------------------
-
-      err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_use_mom_del4_tensor', config_use_mom_del4_tensor)
-
-      if(.not.config_use_mom_del4_tensor) return
-
-      call mpas_timer_start("vel del4_tensor")
-
-      call mpas_pool_get_config(ocnConfigs, 'config_mom_del4_tensor', config_mom_del4_tensor)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
-
-      call mpas_pool_get_field(scratchPool, 'strainRateR3Cell', strainRateR3CellField)
-      call mpas_pool_get_field(scratchPool, 'strainRateR3Edge', strainRateR3EdgeField)
-      call mpas_pool_get_field(scratchPool, 'divTensorR3Cell', divTensorR3CellField)
-      call mpas_pool_get_field(scratchPool, 'outerProductEdge', outerProductEdgeField)
-      call mpas_pool_get_field(scratchPool, 'normalVectorEdge', normalVectorEdgeField)
-      call mpas_pool_get_field(scratchPool, 'tangentialVectorEdge', tangentialVectorEdgeField)
-
-      call mpas_allocate_scratch_field(strainRateR3CellField, .true.)
-      call mpas_allocate_scratch_field(strainRateR3EdgeField, .true.)
-      call mpas_allocate_scratch_field(divTensorR3CellField, .true.)
-      call mpas_allocate_scratch_field(outerProductEdgeField, .true.)
-      call mpas_allocate_scratch_field(normalVectorEdgeField, .true.)
-      call mpas_allocate_scratch_field(tangentialVectorEdgeField, .true.)
-
-      strainRateR3Cell => strainRateR3CellField % array
-      strainRateR3Edge => strainRateR3EdgeField % array
-      divTensorR3Cell  => divTensorR3CellField % array
-      outerProductEdge => outerProductEdgeField % array
-      normalVectorEdge => normalVectorEdgeField % array
-      tangentialVectorEdge => tangentialVectorEdgeField % array
-
-      !!!!!!! first div(grad())
-
-      call mpas_strain_rate_R3Cell(normalVelocity, tangentialVelocity, &
-         meshPool, edgeSignOnCell, edgeTangentVectors, .true., &
-         outerProductEdge, strainRateR3Cell)
-
-      call mpas_matrix_cell_to_edge(strainRateR3Cell, meshPool, .true., strainRateR3Edge)
-
-      ! Need to compute strain rate on all edges
-      nEdges = nEdgesArray( size(nEdgesArray) )
-
-      ! The following loop could possibly be reduced to nEdgesSolve
-      !$omp do schedule(runtime) private(visc4_sqrt, k)
-      do iEdge = 1, nEdges
-         visc4_sqrt = sqrt(config_mom_del4_tensor * meshScalingDel4(iEdge))
-         do k = 1, maxLevelEdgeTop(iEdge)
-            strainRateR3Edge(:,k,iEdge) = visc4_sqrt * strainRateR3Edge(:,k,iEdge)
-         end do
-         ! Impose zero strain rate at land boundaries
-         do k = maxLevelEdgeTop(iEdge)+1, nVertLevels
-            strainRateR3Edge(:,k,iEdge) = 0.0_RKIND
-         end do
-      end do
-      !$omp end do
-
-      ! may change boundaries to false later
-      call mpas_divergence_of_tensor_R3Cell(strainRateR3Edge, meshPool, edgeSignOnCell, .true., divTensorR3Cell)
-
-      call mpas_vector_R3Cell_to_2DEdge(divTensorR3Cell, meshPool, edgeTangentVectors, .true., normalVectorEdge, &
-                                        tangentialVectorEdge)
-
-      !!!!!!! second div(grad())
-
-      call mpas_strain_rate_R3Cell(normalVectorEdge, tangentialVectorEdge, &
-         meshPool, edgeSignOnCell, edgeTangentVectors, .true., &
-         outerProductEdge, strainRateR3Cell)
-
-      call mpas_matrix_cell_to_edge(strainRateR3Cell, meshPool, .true., strainRateR3Edge)
-
-      ! The following loop could possibly be reduced to nEdgesSolve
-      !$omp do schedule(runtime) private(visc4_sqrt, k)
-      do iEdge = 1, nEdges
-         visc4_sqrt = sqrt(config_mom_del4_tensor * meshScalingDel4(iEdge))
-         viscosity(:,iEdge) = viscosity(:,iEdge) + config_mom_del4_tensor * meshScalingDel4(iEdge)
-         do k = 1, maxLevelEdgeTop(iEdge)
-            strainRateR3Edge(:,k,iEdge) = visc4_sqrt * strainRateR3Edge(:,k,iEdge)
-         end do
-         ! Impose zero strain rate at land boundaries
-         do k = maxLevelEdgeTop(iEdge)+1, nVertLevels
-            strainRateR3Edge(:,k,iEdge) = 0.0_RKIND
-         end do
-      end do
-      !$omp end do
-
-      ! may change boundaries to false later
-      call mpas_divergence_of_tensor_R3Cell(strainRateR3Edge, meshPool, edgeSignOnCell, .true., divTensorR3Cell)
-
-      call mpas_vector_R3Cell_to_normalVectorEdge(divTensorR3Cell, meshPool, .true., normalVectorEdge)
-
-      ! only need to compute tendency on owned edges
-      nEdges = nEdgesArray( 1 )
-
-      ! The following loop could possibly be reduced to nEdgesSolve
-      !$omp do schedule(runtime) private(k)
-      do iEdge = 1,nEdges
-         do k = 1,maxLevelEdgeTop(iEdge)
-            tend(k,iEdge) = tend(k,iEdge) - edgeMask(k, iEdge) * normalVectorEdge(k,iEdge)
-         end do
-      end do
-      !$omp end do
-
-      call mpas_deallocate_scratch_field(strainRateR3CellField, .true.)
-      call mpas_deallocate_scratch_field(strainRateR3EdgeField, .true.)
-      call mpas_deallocate_scratch_field(divTensorR3CellField, .true.)
-      call mpas_deallocate_scratch_field(outerProductEdgeField, .true.)
-      call mpas_deallocate_scratch_field(normalVectorEdgeField, .true.)
-      call mpas_deallocate_scratch_field(tangentialVectorEdgeField, .true.)
-
-      call mpas_timer_stop("vel del4_tensor")
-
-   !--------------------------------------------------------------------
-
-   end subroutine ocn_vel_hmix_del4_tensor_tend!}}}
+   end subroutine ocn_vel_hmix_del4_tend !}}}
 
 !***********************************************************************
 !
 !  routine ocn_vel_hmix_del4_init
 !
 !> \brief   Initializes ocean momentum biharmonic horizontal mixing
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
-!> \date    September 2011
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Phil Jones
+!> \date    September 2011, updated April 2020
 !> \details
 !>  This routine initializes a variety of quantities related to
-!>  biharmonic horizontal tracer mixing in the ocean.
+!>  biharmonic horizontal momentum mixing in the ocean.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_del4_init(err)!{{{
+   subroutine ocn_vel_hmix_del4_init(err)
+
+   !--------------------------------------------------------------------
+   ! output variables
+   !--------------------------------------------------------------------
 
    integer, intent(out) :: err !< Output: error flag
 
+   !{{{
    !--------------------------------------------------------------------
-   !
-   ! set some local module variables based on input config choices
-   !
+   ! set default values for module variables and constants
    !--------------------------------------------------------------------
-
-   real (kind=RKIND), pointer :: config_mom_del4
-   logical, pointer :: config_use_mom_del4
 
    err = 0
 
-   call mpas_pool_get_config(ocnConfigs, 'config_mom_del4', config_mom_del4)
-   call mpas_pool_get_config(ocnConfigs, 'config_use_mom_del4', config_use_mom_del4)
+   hmixDel4On       = .false.
+   visc4            = 0.0_RKIND
+   divFactor        = 1.0_RKIND
 
-   hmixDel4On = .false.
+   !--------------------------------------------------------------------
+   ! override any variables with choices from input configuration file
+   !--------------------------------------------------------------------
 
-   if ( config_mom_del4 > 0.0_RKIND ) then
-      hmixDel4On = .true.
+   hmixDel4On       = config_use_mom_del4
+
+   visc4            = config_mom_del4
+   divFactor        = config_mom_del4_div_factor
+
+   !--------------------------------------------------------------------
+   ! Perform some error checks on input choices
+   !--------------------------------------------------------------------
+
+   if (hmixDel4On .and. visc4 <= 0.0_RKIND) then
+      err = -1
+      call mpas_log_write(&
+         'ocn_vel_hmix_del4: invalid viscosity coeff for del4', &
+         MPAS_LOG_CRIT)
    endif
-
-   if(.not.config_use_mom_del4) hmixDel4On = .false.
 
    !--------------------------------------------------------------------
 
@@ -533,5 +361,6 @@ contains
 
 end module ocn_vel_hmix_del4
 
-!||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
@@ -11,7 +11,7 @@
 !
 !> \brief Ocean horizontal mixing - Leith parameterization
 !> \author Mark Petersen
-!> \date   22 October 2012
+!> \date   22 October 2012, updated April 2020
 !> \details
 !>  This module contains routines for computing horizontal mixing
 !>  tendencies using the Leith parameterization.
@@ -21,37 +21,35 @@
 module ocn_vel_hmix_leith
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
    use mpas_constants
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_vel_hmix_leith_tend, &
              ocn_vel_hmix_leith_init
 
    !-------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
-   logical ::  hmixLeithOn  !< integer flag to determine whether leith chosen
+   logical :: hmixLeithOn  !< flag to determine whether Leith chosen
+
+   real (kind=RKIND) :: &
+      hmixLeithFactor,  &!< precomputed Leith viscosity factor
+      hmixLeithVisc2max  !< Leith viscosity coefficient
 
 !***********************************************************************
 
@@ -63,139 +61,130 @@ contains
 !
 !> \brief  Computes tendency term for horizontal momentum mixing with Leith parameterization
 !> \author Mark Petersen, Todd Ringler
-!> \date   22 October 2012
+!> \date   22 October 2012, updated April 2020
 !> \details
 !> This routine computes the horizontal mixing tendency for momentum
 !> based on the Leith closure.  The Leith closure is the
 !> enstrophy-cascade analogy to the Smagorinsky (1963) energy-cascade
-!> closure, i.e. Leith (1996) assumes an inertial range of enstrophy flux
-!> moving toward the mesh scale. The assumption of an enstrophy cascade
-!> and dimensional analysis produces right-hand-side dissipation,
-!> $\bf{D}$, of velocity of the form
+!> closure, i.e. Leith (1996) assumes an inertial range of enstrophy 
+!> flux moving toward the mesh scale. The assumption of an enstrophy 
+!> cascade and dimensional analysis produces right-hand-side 
+!> dissipation, !$\bf{D}$, of velocity of the form
 !> $ {\bf D} = \nabla \cdot \left( \nu_\ast \nabla {\bf u} \right)
 !>    = \nabla \cdot \left( \gamma \left| \nabla \omega  \right|
 !>      \left( \Delta x \right)^3 \nabla \bf{u} \right)
-!> where $\omega$ is the relative vorticity and $\gamma$ is a non-dimensional,
-!> $O(1)$ parameter. We set $\gamma=1$.
-
+!> where $\omega$ is the relative vorticity and $\gamma$ is a 
+!> non-dimensional, $O(1)$ parameter. We set $\gamma=1$.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_leith_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err)!{{{
+   subroutine ocn_vel_hmix_leith_tend(divergence, relVorticity, tend, &
+                                      err)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         divergence      !< Input: velocity divergence
+         divergence      !< [in] velocity divergence
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity       !< Input: relative vorticity
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool            !< Input: mesh information
+         relVorticity    !< [in] relative vorticity
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend             !< Input/Output: velocity tendency
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity       !< Input: viscosity
+         tend            !< [inout] velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
+      !{{{
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, vertex1, vertex2, k, nEdges
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgeMask
+      integer ::         &
+         iEdge, k,       &! loop indices for edge, vertical
+         cell1, cell2,   &! neighbor cell   indices across edge
+         vertex1, vertex2 ! neighbor vertex indices across edge
 
-      real (kind=RKIND) :: u_diffusion, invLength_dc, invLength_dv, visc2
-      real (kind=RKIND), dimension(:), pointer :: meshScaling, &
-              dcEdge, dvEdge
+      real (kind=RKIND) :: &
+         uDiff,          &! temporary u diffusion calculation
+         vortDiff,       &! temporary vorticity difference
+         invLengthDc,    &! inverse dist between centers 
+         invLengthDv,    &! inverse dist between vertices
+         scaleFactor,    &! precomputed dx^3
+         visc2            ! intermediate viscosity temp
 
-      real (kind=RKIND), pointer :: config_leith_parameter, config_leith_dx, config_leith_visc2_max
+      ! end preamble
+      !-------------
+      ! begin code
 
-      !-----------------------------------------------------------------
-      !
-      ! exit if this mixing is not selected
-      !
-      !-----------------------------------------------------------------
+      ! exit if Leith mixing is not selected
 
       err = 0
-
-      if(.not.hmixLeithOn) return
+      if (.not. hmixLeithOn) return
 
       call mpas_timer_start("vel leith")
 
-      call mpas_pool_get_config(ocnConfigs, 'config_Leith_parameter', config_leith_parameter)
-      call mpas_pool_get_config(ocnConfigs, 'config_Leith_dx', config_leith_dx)
-      call mpas_pool_get_config(ocnConfigs, 'config_Leith_visc2_max', config_leith_visc2_max)
+      ! Compute the tendency
 
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'meshScaling', meshScaling)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-
-      nEdges = nEdgesArray( 1 )
-
-      !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength_dc, invLength_dv, k, u_diffusion, visc2)
-      do iEdge = 1, nEdges
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(nEdgesOwned, &
+      !$acc            cellsOnEdge, verticesOnEdge, &
+      !$acc            dcEdge, dvEdge, meshScaling, &
+      !$acc            divergence, relVorticity, &
+      !$acc            maxLevelEdgeTop, tend)   &
+      !$acc    private(k, cell1, cell2, vertex1, vertex2, scaleFactor, &
+      !$acc         invLengthDc, invLengthDv, uDiff, visc2, vortDiff)
+#else
+      !$omp parallel do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, vertex1, vertex2, scaleFactor, &
+      !$omp         invLengthDc, invLengthDv, uDiff, visc2, vortDiff)
+#endif
+      do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          vertex1 = verticesOnEdge(1,iEdge)
          vertex2 = verticesOnEdge(2,iEdge)
 
-         invLength_dc = 1.0_RKIND / dcEdge(iEdge)
-         invLength_dv = 1.0_RKIND / dvEdge(iEdge)
+         invLengthDc = 1.0_RKIND / dcEdge(iEdge)
+         invLengthDv = 1.0_RKIND / dvEdge(iEdge)
+
+         scaleFactor = hmixLeithFactor* &
+                       (meshScaling(iEdge))**3
 
          do k = 1, maxLevelEdgeTop(iEdge)
 
-            ! Here -( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) / dvEdge(iEdge)
-            ! is - \nabla relativeVorticity pointing from vertex 2 to vertex 1, or equivalently
-            !    + k \times \nabla relativeVorticity pointing from cell1 to cell2.
+            ! Here -( relVorticity(k,vertex2) - relVorticity(k,vertex1) ) / dvEdge(iEdge)
+            ! is - \nabla relVorticity pointing from vertex 2 to vertex 1, or equivalently
+            !    + k \times \nabla relVorticity pointing from cell1 to cell2.
+            ! uDiff is \nabla^2 u (see formula for $\bf{D}$ above).
 
-            u_diffusion = ( divergence(k,cell2)  - divergence(k,cell1) ) * invLength_dc &
-                         -( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) * invLength_dv
+            vortDiff = relVorticity(k,vertex2) - relVorticity(k,vertex1)
 
-            ! Here the first line is (\delta x)^3
-            ! the second line is |\nabla \omega|
-            ! and u_diffusion is \nabla^2 u (see formula for $\bf{D}$ above).
-            visc2 = ( config_leith_parameter * config_leith_dx * meshScaling(iEdge) / pii)**3 &
-                     * abs( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) * invLength_dc * sqrt(3.0_RKIND)
-            visc2 = min(visc2, config_leith_visc2_max)
+            uDiff = (divergence(k,cell2) - divergence(k,cell1))*invLengthDc &
+                   - vortDiff*invLengthDv
 
-            tend(k,iEdge) = tend(k,iEdge) + edgeMask(k, iEdge) * visc2 * u_diffusion
+            ! Here the scale factor is (\delta x)^3 (precomputed)
+            ! the second factor is |\nabla \omega|
+            visc2 = scaleFactor*abs(vortDiff)*invLengthDc
+            visc2 = min(visc2, hmixLeithVisc2max)
 
-            viscosity(k,iEdge) = viscosity(k,iEdge) + visc2
+            tend(k,iEdge) = tend(k,iEdge) + visc2*uDiff
 
          end do
       end do
-      !$omp end do
+#ifndef MPAS_OPENACC
+      !$omp end parallel do
+#endif
 
       call mpas_timer_stop("vel leith")
 
@@ -209,34 +198,66 @@ contains
 !
 !> \brief   Initializes ocean momentum horizontal mixing with Leith parameterization
 !> \author Mark Petersen
-!> \date   22 October 2012
+!> \date   22 October 2012, updated April 2020
 !> \details
 !>  This routine initializes a variety of quantities related to
 !>  Leith parameterization for horizontal momentum mixing in the ocean.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_leith_init(err)!{{{
+   subroutine ocn_vel_hmix_leith_init(err)
 
+      integer, intent(out) :: err !< [out] error flag
 
-   integer, intent(out) :: err !< Output: error flag
+      !{{{
+      !-----------------------------------------------------------------
+      ! set defaults for module variables
+      !-----------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
-   ! set some local module variables based on input config choices
-   !
-   !--------------------------------------------------------------------
-   logical, pointer :: config_use_Leith_del2
+      err = 0
 
-   err = 0
+      hmixLeithOn       = .false.
+      hmixLeithFactor   = 0.0
+      hmixLeithVisc2max = 0.0
 
-   call mpas_pool_get_config(ocnConfigs, 'config_use_Leith_del2', config_use_Leith_del2)
+      !-----------------------------------------------------------------
+      ! override defaults with input selections
+      !-----------------------------------------------------------------
 
-   hmixLeithOn = .false.
+      hmixLeithOn       = config_use_leith_del2 
+      hmixLeithVisc2max = config_leith_visc2_max
 
-   if (config_use_leith_del2) then
-      hmixLeithOn = .true.
-   endif
+      !-----------------------------------------------------------------
+      ! Leith viscosity is of the form:
+      !   visc2 = 
+      !      (hmixLeithParam*hmixLeithDx*meshScaling(iEdge)/pii)**3 &
+      !      * abs(relVorticity(k,vertex2)-relVorticity(k,vertex1))*
+      !       invLength_dc(iEdge) * sqrt(3.0_RKIND)
+      ! We precompute several common constant factors here for better
+      ! performance
+      !-----------------------------------------------------------------
+
+      hmixLeithFactor = sqrt(3.0_RKIND)* &
+                        (config_leith_parameter*config_leith_dx/pii)**3
+
+      !-----------------------------------------------------------------
+      ! Perform some error checking on inputs
+      !-----------------------------------------------------------------
+
+      if (hmixLeithOn) then
+         if (config_leith_parameter  == 0.0) then
+            err = -1
+            call mpas_log_write(&
+            'ocn_vel_hmix_leith: leith parameter must be non-zero', &
+            MPAS_LOG_CRIT)
+         endif
+         if (hmixLeithVisc2max == 0.0) then
+            err = -1
+            call mpas_log_write(&
+            'ocn_vel_hmix_leith: invalid max viscosity (visc2max)', &
+            MPAS_LOG_CRIT)
+         endif
+      endif
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -10,13 +10,12 @@
 !  ocn_vel_pressure_grad
 !
 !> \brief MPAS ocean pressure gradient module
-!> \author Mark Petersen
-!> \date   September 2011
+!> \author Mark Petersen, Phil Jones, Rob Aulwes
+!> \date   September 2011, updated May 2020
 !> \details
-!>  This module contains the routine for computing
-!>  tendencie from the horizontal pressure gradient.
+!>  This module contains routines for computing velocity
+!>  tendency from the horizontal pressure gradient.
 !>
-!
 !-----------------------------------------------------------------------
 
 module ocn_vel_pressure_grad
@@ -28,37 +27,46 @@ module ocn_vel_pressure_grad
    use mpas_log
 
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
    !--------------------------------------------------------------------
-   !
    ! Public parameters
-   !
    !--------------------------------------------------------------------
 
+   ! Supported method for pressure gradient
+   integer, public, parameter ::         &
+      ocnPGradMethodNone            = 0, &!< No press gradient computed
+      ocnPGradMethodSSH             = 1, &!< ssh gradient
+      ocnPGradMethodPZMid           = 2, &!< pressure and zmid
+      ocnPGradMethodMontgomery      = 3, &!< Montgomery potential
+      ocnPGradMethodMontgomeryDens  = 4, &!< Montgomery Pot anddensity
+      ocnPGradMethodJacobianDens    = 5, &!< Jacobian from density
+      ocnPGradMethodJacobianTS      = 6   !< Jacobian from T and S
+
+   integer, public :: &
+      ocnPGradMethod  !< Selected method for computing pressure gradient
+
    !--------------------------------------------------------------------
-   !
    ! Public member functions
-   !
    !--------------------------------------------------------------------
 
    public :: ocn_vel_pressure_grad_tend, &
              ocn_vel_pressure_grad_init
 
    !--------------------------------------------------------------------
-   !
    ! Private module variables
-   !
    !--------------------------------------------------------------------
 
-   character (len=StrKIND), pointer :: config_pressure_gradient_type
-   real (kind=RKIND), pointer :: config_common_level_weight
-   logical :: pgradOn
-   real (kind=RKIND) :: density0Inv, gdensity0Inv, inv12
+   logical :: pgradOn  !< flag to determine if press gradient computed
 
+   real (kind=RKIND) :: density0Inv  !< inverse reference density rho_0
+   real (kind=RKIND) :: gdensity0Inv !< gravity (g)/rho_0
+   real (kind=RKIND) :: pGradLvlWgt  !< level weighting factor
 
 !***********************************************************************
 
@@ -69,276 +77,561 @@ contains
 !  routine ocn_vel_pressure_grad_tend
 !
 !> \brief   Computes tendency term for horizontal pressure gradient
-!> \author  Mark Petersen
-!> \date    February 2014
+!> \author  Mark Petersen, Phil Jones, Rob Aulwes
+!> \date    February 2014, updated May 2020
 !> \details
 !>  This routine computes the pressure gradient tendency for momentum
 !>  based on current state.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
-      indexT, indexS, tracers, tend, err, inSituThermalExpansionCoeff,inSituSalineContractionCoeff)!{{{
+   subroutine ocn_vel_pressure_grad_tend(ssh, pressure,              &
+               montgomeryPotential, zMid, density, potentialDensity, &
+               indexT, indexS, tracers, inSituThermalExpansionCoeff, &
+               inSituSalineContractionCoeff, tend, err)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(in) :: indexT, indexS
+      integer, intent(in) :: indexT !< [in] temperature index in tracer
+      integer, intent(in) :: indexS !< [in] salt index in tracer array
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         ssh !< Input: Sea surface height
+         ssh             !< [in] Sea surface height
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         pressure, & !< Input: Pressure field
-         montgomeryPotential, & !< Input: Mongomery potential
-         zMid, &     !< Input: z-coordinate at mid-depth of layer
-         density, &      !< Input: density
-         potentialDensity         !< Input: potentialDensity
+         pressure,            & !< [in] Pressure field
+         montgomeryPotential, & !< [in] Mongomery potential
+         zMid,                & !< [in] z-coord at mid-depth of layer
+         density,             & !< [in] density
+         potentialDensity       !< [in] potentialDensity
 
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
-         inSituThermalExpansionCoeff, &
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         inSituThermalExpansionCoeff, &!< [in] EOS derivatives
          inSituSalineContractionCoeff
 
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers         !< [in] tracer array
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
+      !{{{
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, iCell, kMax, nEdges
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask
+      integer ::           &
+         iCell, iEdge, k,  &! loop indices for cells, edges, vertical
+         kMax,             &! bottom vert level
+         cell1, cell2       ! neighbor cell indices
 
-      real (kind=RKIND), dimension(:), pointer :: dcEdge
-      real (kind=RKIND), dimension(:), allocatable :: JacobianDxDs,JacobianTz,JacobianSz,T1,T2,S1,S2
-      real (kind=RKIND), dimension(:,:), allocatable :: FXTop, work1, work2
-      real (kind=RKIND) :: invdcEdge, pGrad, sumAJTop, AJTop, FC, FCPrev, alpha, beta
+      real (kind=RKIND) :: &! useful scalar temps
+         Area,             &! area for Jacobian interpolation
+         TL, TR, SL, SR,   &! temporary neighbor T,S values
+         rhoL, rhoR,       &! temporary neighbor density values
+         zStar, zC, zGamma,&! depth related temporaries
+         z1, z2, z1m, z2m, &! depth related interpolation vars
+         invdcEdge,        &! 1/dcEdge
+         pGrad,            &! accumulated pressure gradiant
+         alpha, beta,      &! equation of state coefficients
+         JacobianDxDs       ! local Jacobian result
 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         Temp, Salt,             &! temp and salt temporaries
+         pGradLvl,               &! temp for the level contrib to pgrad
+         JacobianDxDsZ,          &! Jacobian at every point
+         JacobianTz, JacobianSz   ! temps to calc Jacobian
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      ! start up or return if pgrad is not on
       err = 0
 
       if (.not. pgradOn) return
 
       call mpas_timer_start("pressure grad")
 
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels',nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      !-----------------------------------------------------------------
+      ! Compute pressure gradient based on selected method
+      !-----------------------------------------------------------------
+      select case (ocnPGradMethod)
 
-      nEdges = nEdgesArray( 1 )
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodSSH)   ! ssh gradient
 
-      if (config_pressure_gradient_type.eq.'ssh_gradient') then
-
-         ! pressure for sea surface height
+         ! pressure from sea surface height
          ! - g grad ssh
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
-         do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc      present(ssh, tend, cellsOnEdge,  &
+         !$acc              maxLevelEdgeTop, dcEdge) &
+         !$acc      private(cell1, cell2, invdcEdge, k)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            invdcEdge = gravity / dcEdge(iEdge)
 
             do k=1,maxLevelEdgeTop(iEdge)
-               tend(k,iEdge) = tend(k,iEdge) - gravity * edgeMask(k,iEdge) * invdcEdge * ( ssh(cell2) - ssh(cell1) )
+               tend(k,iEdge) = tend(k,iEdge) - invdcEdge* &
+                               ( ssh(cell2) - ssh(cell1) )
             end do
          end do
-         !$omp end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
 
-      elseif (config_pressure_gradient_type.eq.'pressure_and_zmid') then
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodPZMid)  !  pressure and zmid
 
          ! pressure for generalized coordinates
          ! -1/density_0 (grad p_k + density g grad z_k^{mid})
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
-         do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc      present(tend, pressure, density, zmid, &
+         !$acc              cellsOnEdge, dcEdge, maxLevelEdgeTop) &
+         !$acc      private(cell1, cell2, invdcEdge, k)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
 
             do k=1,maxLevelEdgeTop(iEdge)
-               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
-                 - density0Inv * ( pressure(k,cell2) - pressure(k,cell1) ) &
-                 - gdensity0Inv * 0.5_RKIND*(density(k,cell1)+density(k,cell2)) * ( zMid(k,cell2) - zMid(k,cell1) ) )
+               tend(k,iEdge) = tend(k,iEdge) + invdcEdge*( &
+                             - density0Inv* &
+                               (pressure(k,cell2)-pressure(k,cell1)) &
+                             - gdensity0Inv*0.5_RKIND* &
+                               (density(k,cell1)+density(k,cell2))* &
+                               (   zMid(k,cell2)-   zMid(k,cell1)))
             end do
          end do
-         !$omp end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
 
-      elseif (config_pressure_gradient_type.eq.'MontgomeryPotential') then
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodMontgomery)  ! Montgomery potential
 
          ! For pure isopycnal coordinates, this is just grad(M),
          ! the gradient of Montgomery Potential
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
-         do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc      present(tend, montgomeryPotential,            &
+         !$acc              cellsOnEdge, maxLevelEdgeTop, dcEdge) & 
+         !$acc      private(cell1, cell2, invdcEdge, k)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp      private(cell1, cell2, invdcEdge, k)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
 
             do k=1,maxLevelEdgeTop(iEdge)
-               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
-                  - ( montgomeryPotential(k,cell2) - montgomeryPotential(k,cell1) ) )
+               tend(k,iEdge) = tend(k,iEdge) + invdcEdge*( &
+                             - (montgomeryPotential(k,cell2) - &
+                                montgomeryPotential(k,cell1)))
             end do
          end do
-         !$omp end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
 
-      elseif (config_pressure_gradient_type.eq.'MontgomeryPotential_and_density') then
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodMontgomeryDens) ! Montgomery Pot and density
 
-         ! This formulation has not been extensively tested and is not supported at this time.
+         ! This formulation has not been extensively tested and is not
+         ! supported at this time.
 
          ! This is -grad(M)+p grad(1/rho)
          ! Where rho is the potential density.
          ! See Bleck (2002) equation 1, and last equation in Appendix A.
 
-         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
-         do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(tend, montgomeryPotential,  &
+         !$acc            pressure, potentialDensity, &
+         !$acc            cellsOnEdge, maxLevelEdgeTop, dcEdge) &
+         !$acc    private(cell1, cell2, invdcEdge, k)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp    private(cell1, cell2, invdcEdge, k)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
 
             do k=1,maxLevelEdgeTop(iEdge)
-               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
-                  - ( montgomeryPotential(k,cell2) - montgomeryPotential(k,cell1) ) &
-                  +  0.5_RKIND*(pressure(k,cell1)+pressure(k,cell2)) * ( 1.0_RKIND/potentialDensity(k,cell2) &
-                  - 1.0_RKIND/potentialDensity(k,cell1) ) )
+               tend(k,iEdge) = tend(k,iEdge) + invdcEdge*( &
+                             - (montgomeryPotential(k,cell2) - &
+                                montgomeryPotential(k,cell1)) &
+                  +  0.5_RKIND*(pressure(k,cell1)+pressure(k,cell2))* &
+                               (1.0_RKIND/potentialDensity(k,cell2) &
+                              - 1.0_RKIND/potentialDensity(k,cell1)) )
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
+
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodJacobianDens) ! Jacobian from density
+
+         allocate(JacobianDxDsZ(nVertLevels,nEdgesOwned), &
+                       pGradLvl(nVertLevels,nEdgesOwned))
+
+         !$acc enter data create(JacobianDxDsZ, pGradLvl)
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(cellsOnEdge, maxLevelEdgeTop, zMid, &
+         !$acc            density, JacobianDxDsZ)             &
+         !$acc    private(k, cell1, cell2, z1, z1m, z2, z2m,  &
+         !$acc            Area, zStar, zC, zGamma, rhoL, rhoR)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp    private(k, cell1, cell2, z1, z1m, z2, z2m,  &
+         !$omp            Area, zStar, zC, zGamma, rhoL, rhoR)
+#endif
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+
+            ! compute J(rho,z) as in Shchepetkin and McWilliams (2003) (7.16)
+            ! the following is an in-lined version of the
+            ! pGrad_Jacobian_common_level routine
+            do k=2,maxLevelEdgeTop(iEdge)
+
+               ! define some vert coordinate values
+               z1  = zMid(k  ,Cell1)
+               z1m = zMid(k-1,Cell1)
+               z2  = zMid(k  ,Cell2)
+               z2m = zMid(k-1,Cell2)
+
+               ! eqn 2.7 in Shchepetkin and McWilliams (2003)
+               ! Note delta x was removed.  It must be an error in the paper,
+               ! as it makes the units incorrect.
+               Area = 0.5_RKIND*(z1m - z1 + z2m - z2 )
+
+               ! eqn 2.8
+               zStar = (z2m*z1m - z2*z1)/ &
+                       (z2m - z2 + z1m - z1)
+
+               ! eqn 3.2
+               zC = 0.25_RKIND*( z1 + z1m + z2 + z2m )
+
+               ! eqn 4.1
+               zGamma = (1.0_RKIND - pGradLvlWgt)*zStar + &
+                                     pGradLvlWgt *zC
+
+               rhoL = (density(k  ,cell1)*(z1m-zGamma) + &
+                       density(k-1,cell1)*(zGamma-z1))/(z1m - z1)
+               rhoR = (density(k  ,cell2)*(z2m-zGamma) + &
+                       density(k-1,cell2)*(zGamma-z2))/(z2m - z2)
+
+               ! eqn 2.6 in Shchepetkin and McWilliams (2003)
+               JacobianDxDsZ(k,iEdge) = Area * (rhoL - rhoR)
             end do
          end do
          !$omp end do
 
-      elseif (config_pressure_gradient_type.eq.'Jacobian_from_density') then
-
-         allocate(JacobianDxDs(nVertLevels))
-
-         !$omp do schedule(runtime)
-         do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(cellsOnEdge, edgeMask, dcEdge,     &
+         !$acc            pressure, density, zMid, pGradLvl, & 
+         !$acc            maxLevelEdgeTop, JacobianDxDsZ)    &
+         !$acc    private(k, cell1, cell2, invdcEdge, pGrad)
+#else
+         !$omp parallel do schedule(runtime) &
+         !$omp    private(k, cell1, cell2, invdcEdge, pGrad)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
 
-            call pGrad_Jacobian_common_level(density(:,cell1),density(:,cell2),zMid(:,cell1),zMid(:,cell2), &
-               maxLevelEdgeTop(iEdge), config_common_level_weight, JacobianDxDs)
-
             ! In layer 1, use pressure for generalized coordinates
             ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
             k = 1
-            pGrad = edgeMask(k,iEdge) * invdcEdge * ( &
+            pGradLvl(k,iEdge) = edgeMask(k,iEdge) * invdcEdge * ( &
                  - density0Inv * ( pressure(k,cell2) - pressure(k,cell1) ) &
-                 - gdensity0Inv * 0.5_RKIND*(density(k,cell1)+density(k,cell2)) * ( zMid(k,cell2) - zMid(k,cell1) ) )
+                 - gdensity0Inv * 0.5_RKIND* &
+                           (density(k,cell1)+density(k,cell2)) * &
+                           ( zMid(k,cell2) - zMid(k,cell1) ) )
 
-            tend(k,iEdge) = tend(k,iEdge) + pGrad
 
             do k=2,maxLevelEdgeTop(iEdge)
 
                ! note JacobianDxDs includes negative sign, so
                ! pGrad is - g/rho_0 dP/dx
 
-               pGrad = pGrad + gdensity0Inv * JacobianDxDs(k) * invdcEdge
-
-               tend(k,iEdge) = tend(k,iEdge) + pGrad
+               pGradLvl(k,iEdge) = &
+                     gdensity0Inv*JacobianDxDsZ(k,iEdge)*invdcEdge
 
             end do
          end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
+
+         ! the final pressure gradient tendency is an integral from the 
+         ! surface down of each of the layer contributions
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(tend, pGradLvl, maxLevelEdgeTop) &
+         !$acc    private(k, pGrad)
+#else
+         !$omp parallel do schedule(runtime)
+         !$acc    private(k, pGrad)
+#endif
+         do iEdge=1,nEdgesOwned
+            pGrad = pGradLvl(1,iEdge)
+            tend(1,iEdge) = tend(1,iEdge) + pGrad
+
+            do k=2,maxLevelEdgeTop(iEdge)
+               pGrad = pGrad + pGradLvl(k,iEdge)
+               tend(k,iEdge) = tend(k,iEdge) + pGrad
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end parallel do
+#endif
+
+         !$acc exit data delete(JacobianDxDsZ, pGradLvl)
+         deallocate(JacobianDxDsZ, pGradLvl)
+
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodJacobianTS) ! Jacobian from T and S
+
+         ! Allocate local vars
+         allocate(Temp(nVertLevels,nCellsAll), &
+                  Salt(nVertLevels,nCellsAll), &
+                  pGradLvl  (nVertLevels,nEdgesOwned), &
+                  JacobianTz(nVertLevels,nEdgesOwned), &
+                  JacobianSz(nVertLevels,nEdgesOwned))
+
+         !$acc enter data &
+         !$acc    create(Temp, Salt, JacobianTz, JacobianSz, pGradLvl)
+
+         ! Extract temperature and salinity
+#ifdef MPAS_OPENACC
+         !$acc parallel loop collapse(2) &
+         !$acc    present(tracers, Temp, Salt)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime), private(k)
+#endif
+         do iCell=1,nCellsAll
+         do k=1,nVertLevels
+            Temp(k,iCell) = tracers(indexT,k,iCell)
+            Salt(k,iCell) = tracers(indexS,k,iCell)
+         end do
+         end do
+#ifndef MPAS_OPENACC
          !$omp end do
+#endif
 
-         deallocate(JacobianDxDs)
+         ! compute J(T,z) and J(S,z) in Shchepetkin and McWilliams (2003) (7.16)
+         ! the following is an in-lined version of the
+         ! pGrad_Jacobian_common_level routine
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(Temp, Salt, JacobianTz, JacobianSz, zMid,   &
+         !$acc            cellsOnEdge, maxLevelEdgeTop)  &
+         !$acc    private(k, kMax, cell1, cell2, z1, z1m, z2, z2m,    &
+         !$acc            Area, zStar, zC, zGamma, TL, TR, SL, SR) 
+#else
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMax, cell1, cell2, z1, z1m, z2, z2m,    &
+         !$omp            Area, zStar, zC, zGamma, TL, TR, SL, SR) 
+#endif
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
 
-     elseif (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
+            ! compute J(T,z) and J(S,z) in Shchepetkin and McWilliams (2003) (7.16)
+            ! the following is an in-lined version of the
+            ! pGrad_Jacobian_common_level routine
+            do k=2,kMax
 
-         allocate(JacobianDxDs(nVertLevels),JacobianTz(nVertLevels),JacobianSz(nVertLevels), T1(nVertLevels))
-         allocate(T2(nVertLevels), S1(nVertLevels), S2(nVertLevels))
+               ! define some vert coordinate values
+               z1  = zMid(k  ,Cell1)
+               z1m = zMid(k-1,Cell1)
+               z2  = zMid(k  ,Cell2)
+               z2m = zMid(k-1,Cell2)
 
+               ! eqn 2.7 in Shchepetkin and McWilliams (2003)
+               ! Note delta x was removed.  It must be an error in the paper,
+               ! as it makes the units incorrect.
+               Area = 0.5_RKIND*(z1m - z1 + z2m - z2 )
+
+               ! eqn 2.8
+               zStar = (z2m*z1m - z2*z1)/ &
+                       (z2m -z2 + z1m -z1)
+
+               ! eqn 3.2
+               zC = 0.25_RKIND*( z1 + z1m + z2 + z2m )
+
+               ! eqn 4.1
+               zGamma = (1.0_RKIND - pGradLvlWgt)*zStar + &
+                                     pGradLvlWgt *zC
+
+               TL = (Temp(k  ,cell1)*(z1m-zGamma) + &
+                     Temp(k-1,cell1)*(zGamma-z1))/(z1m - z1)
+               TR = (Temp(k  ,cell2)*(z2m-zGamma) + &
+                     Temp(k-1,cell2)*(zGamma-z2))/(z2m - z2)
+
+               SL = (Salt(k  ,cell1)*(z1m-zGamma) + &
+                     Salt(k-1,cell1)*(zGamma-z1))/(z1m - z1)
+               SR = (Salt(k  ,cell2)*(z2m-zGamma) + &
+                     Salt(k-1,cell2)*(zGamma-z2))/(z2m - z2)
+
+               ! eqn 2.6 in Shchepetkin and McWilliams (2003)
+               JacobianTz(k,iEdge) = Area * (TL - TR)
+               JacobianSz(k,iEdge) = Area * (SL - SR)
+            end do
+         end do
+#ifndef MPAS_OPENACC
          !$omp do schedule(runtime)
-         do iEdge=1,nEdges
+#endif
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(pressure, density, JacobianTz, JacobianSz,  &
+         !$acc            pGradLvl, zMid,  dcEdge, edgeMask,          &
+         !$acc            cellsOnEdge, maxLevelEdgeTop,  &
+         !$acc            inSituThermalExpansionCoeff,   &
+         !$acc            inSituSalineContractionCoeff)  &
+         !$acc    private(k, kMax, cell1, cell2, invdcEdge, &
+         !$acc            alpha, beta, JacobianDxDs)
+#else
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMax, cell1, cell2, invdcEdge, &
+         !$omp            alpha, beta, JacobianDxDs)
+#endif
+         do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
-
-            ! copy T and S to local column arrays
-            T1(1:kMax) = tracers(indexT,1:kMax,cell1)
-            T2(1:kMax) = tracers(indexT,1:kMax,cell2)
-            S1(1:kMax) = tracers(indexS,1:kMax,cell1)
-            S2(1:kMax) = tracers(indexS,1:kMax,cell2)
-
-            ! compute J(T,z) and J(S,z) in Shchepetkin and McWilliams (2003) (7.16)
-            call pGrad_Jacobian_common_level(T1, T2 ,zMid(:,cell1),zMid(:,cell2),kMax,config_common_level_weight, JacobianTz)
-            call pGrad_Jacobian_common_level(S1, S2 ,zMid(:,cell1),zMid(:,cell2),kMax,config_common_level_weight, JacobianSz)
+            pGradLvl(:,iEdge) = 0.0_RKIND
 
             ! In layer 1, use pressure for generalized coordinates
             ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
             k = 1
-            pGrad = edgeMask(k,iEdge) * invdcEdge * ( &
-                 - density0Inv * ( pressure(k,cell2) - pressure(k,cell1) ) &
-                 - gdensity0Inv * 0.5_RKIND*(density(k,cell1)+density(k,cell2)) * ( zMid(k,cell2) - zMid(k,cell1) ) )
-
-            tend(k,iEdge) = tend(k,iEdge) + pGrad
+            pGradLvl(k,iEdge) = edgeMask(k,iEdge) * invdcEdge * ( &
+                 -  density0Inv*( pressure(k,cell2) - pressure(k,cell1) ) &
+                 - gdensity0Inv*0.5_RKIND*(density(k,cell1)+density(k,cell2))*&
+                                          (   zMid(k,cell2)-   zMid(k,cell1)))
 
             do k=2,kMax
-
                ! Average alpha and beta over four data points of the Jacobian cell.
-               ! Note that inSituThermalExpansionCoeff and inSituSalineContractionCoeff include a 1/density factor,
-               ! so must multiply by density here.
-               alpha = 0.25_RKIND*(  density(k,cell1)*inSituThermalExpansionCoeff (k,cell1) &
-                                   + density(k-1,cell1)*inSituThermalExpansionCoeff (k-1,cell1) &
-                                   + density(k,cell2)*inSituThermalExpansionCoeff (k,cell2) &
-                                   + density(k-1,cell2)*inSituThermalExpansionCoeff (k-1,cell2) )
-               beta  = 0.25_RKIND*(  density(k,cell1)*inSituSalineContractionCoeff(k,cell1) &
-                                   + density(k-1,cell1)*inSituSalineContractionCoeff(k-1,cell1) &
-                                   + density(k,cell2)*inSituSalineContractionCoeff(k,cell2) &
-                                   + density(k-1,cell2)*inSituSalineContractionCoeff(k-1,cell2) )
+               ! Note that inSituThermalExpansionCoeff and 
+               ! inSituSalineContractionCoeff include a 1/density factor,
+               ! so must multiplied by density here.
+               alpha = 0.25_RKIND* &
+                     ( density(k  ,cell1)* &
+                       inSituThermalExpansionCoeff (k  ,cell1) &
+                     + density(k-1,cell1)* &
+                       inSituThermalExpansionCoeff (k-1,cell1) &
+                     + density(k  ,cell2)* &
+                       inSituThermalExpansionCoeff (k,cell2) &
+                     + density(k-1,cell2)* &
+                       inSituThermalExpansionCoeff (k-1,cell2) )
+               beta  = 0.25_RKIND* &
+                     ( density(k  ,cell1)* &
+                       inSituSalineContractionCoeff(k,cell1) &
+                     + density(k-1,cell1)* &
+                       inSituSalineContractionCoeff(k-1,cell1) &
+                     + density(k  ,cell2)* &
+                       inSituSalineContractionCoeff(k,cell2) &
+                     + density(k-1,cell2)* &
+                       inSituSalineContractionCoeff(k-1,cell2) )
 
                ! Shchepetkin and McWilliams (2003) (7.16)
-               JacobianDxDs(k) = -alpha*JacobianTz(k) + beta*JacobianSz(k)
+               JacobianDxDs = -alpha*JacobianTz(k,iEdge) + &
+                                beta*JacobianSz(k,iEdge)
 
+               ! the contribution to the pressure gradient from this lvl
                ! note JacobianDxDs includes negative sign, so
                ! pGrad is - g/rho_0 dP/dx
-
-               pGrad = pGrad + gdensity0Inv * JacobianDxDs(k) * invdcEdge
-
-               tend(k,iEdge) = tend(k,iEdge) + pGrad
-
+               pGradLvl(k,iEdge) = gdensity0Inv*JacobianDxDs*invdcEdge
             end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
+#endif
 
-         deallocate(JacobianDxDs,JacobianTz,JacobianSz, T1, T2, S1, S2)
+         ! the final pressure gradient tendency is an integral from the 
+         ! surface down of each of the layer contributions
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(pGradLvl, tend, maxLevelEdgeTop)  &
+         !$acc    private(k, kMax, pGrad)
+#else
+         !$omp do schedule(runtime)
+#endif
+         do iEdge=1,nEdgesOwned
+            kMax = maxLevelEdgeTop(iEdge)
 
-      else
+            pGrad = pGradLvl(1,iEdge)
+            tend(1,iEdge) = tend(1,iEdge) + pGrad
 
-         call mpas_log_write(' Pressure type is: '//trim(config_pressure_gradient_type))
-         call mpas_log_write(' Incorrect choice of config_pressure_gradient_type.',MPAS_LOG_CRIT)
+            do k=2,kMax
+               pGrad = pGrad + pGradLvl(k,iEdge)
+               tend(k,iEdge) = tend(k,iEdge) + pGrad
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+
+#ifdef MPAS_OPENACC
+         !$acc exit data &
+         !$acc   delete(Temp, Salt, JacobianTz, JacobianSz, pGradLvl)
+#endif
+
+         deallocate(Temp, Salt, JacobianTz, JacobianSz, pGradLvl)
+
+      !-----------------------------------------------------------------
+      case (ocnPGradMethodNone) ! No press gradient computed
+
+         ! Do not add anything to tendency
+
+      case default
+
+         ! Bad selection - caught during initialization
          err = 1
 
-      endif
+      end select
 
       call mpas_timer_stop("pressure grad")
 
@@ -362,9 +655,7 @@ contains
    subroutine pGrad_Jacobian_common_level(rho1,rho2,z1,z2,kMax,gamma,JacobianDxDs)
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
@@ -380,24 +671,18 @@ contains
          kMax
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(out) :: &
          JacobianDxDs  ! - Delta x Delta s J(rho,z)
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
       integer :: k
@@ -413,7 +698,8 @@ contains
          Area = 0.5_RKIND*(z1(k-1) - z1(k) + z2(k-1) - z2(k) )
 
          ! eqn 2.8
-         zStar = ( z2(k-1)*z1(k-1) - z2(k)*z1(k) )/(z2(k-1)-z2(k) + z1(k-1)-z1(k))
+         zStar = (z2(k-1)*z1(k-1) - z2(k)*z1(k) )/ &
+                 (z2(k-1)-z2(k)+z1(k-1)-z1(k))
 
          ! eqn 3.2
          zC = 0.25_RKIND*( z1(k) + z1(k-1) + z2(k) + z2(k-1) )
@@ -421,8 +707,10 @@ contains
          ! eqn 4.1
          zGamma = (1.0_RKIND - gamma)*zStar + gamma*zC
 
-         rhoL = (rho1(k)*(z1(k-1)-zGamma) + rho1(k-1)*(zGamma-z1(k)))/(z1(k-1) - z1(k))
-         rhoR = (rho2(k)*(z2(k-1)-zGamma) + rho2(k-1)*(zGamma-z2(k)))/(z2(k-1) - z2(k))
+         rhoL = (rho1(k)*(z1(k-1)-zGamma) + rho1(k-1)*(zGamma-z1(k)))/&
+                (z1(k-1) - z1(k))
+         rhoR = (rho2(k)*(z2(k-1)-zGamma) + rho2(k-1)*(zGamma-z2(k)))/&
+                (z2(k-1) - z2(k))
 
          ! eqn 2.6 in Shchepetkin and McWilliams (2003)
          JacobianDxDs(k) = Area * (rhoL - rhoR)
@@ -634,50 +922,77 @@ contains
 !  routine ocn_vel_pressure_grad_init
 !
 !> \brief   Initializes ocean momentum horizontal pressure gradient
-!> \author  Mark Petersen
-!> \date    September 2011
+!> \author  Mark Petersen, Phil Jones, Rob Aulwes
+!> \date    September 2011, updated May 2020
 !> \details
-!>  This routine initializes parameters required for the computation of the
-!>  horizontal pressure gradient.
+!>  This routine initializes parameters required for the computation
+!>  of the horizontal pressure gradient.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_pressure_grad_init(err)!{{{
-
-   !--------------------------------------------------------------------
-
+   subroutine ocn_vel_pressure_grad_init(err)
 
       !-----------------------------------------------------------------
-      !
       ! Output Variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-
+      !{{{
       !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
+      ! Set some default values for module constants
       !-----------------------------------------------------------------
-      logical, pointer :: config_disable_vel_pgrad
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
-      call mpas_pool_get_config(ocnConfigs, 'config_common_level_weight', config_common_level_weight)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_pgrad', config_disable_vel_pgrad)
+      pgradOn         = .true.
+      ocnPGradMethod  = ocnPGradMethodNone
 
-      pgradOn = .true.
-
-      density0Inv = 1.0_RKIND / rho_sw
+      ! Set some common constants
+      density0Inv  = 1.0_RKIND / rho_sw
       gdensity0Inv = gravity / rho_sw
-      inv12 = 1.0_RKIND / 12.0_RKIND
+      pGradLvlWgt  = config_common_level_weight
 
-      if (config_disable_vel_pgrad) pgradOn = .false.
+      !-----------------------------------------------------------------
+      ! if pressure gradient disabled, turn it off and ignore the rest
+      !-----------------------------------------------------------------
 
-      call mpas_log_write(' Pressure type is: '//trim(config_pressure_gradient_type))
+      if (config_disable_vel_pgrad) then
+         pgradOn = .false.
+         ocnPGradMethod  = ocnPGradMethodNone
+         call mpas_log_write(' Pressure gradient is disabled ')
+         return
+      endif
+
+      !-----------------------------------------------------------------
+      ! Determine choice of method for computing pressure gradient
+      !-----------------------------------------------------------------
+
+      call mpas_log_write( &
+         ' Pressure type is: '//trim(config_pressure_gradient_type))
+
+      select case (trim(config_pressure_gradient_type))
+      case ('ssh_gradient')
+         ocnPGradMethod  = ocnPGradMethodSSH
+      case ('pressure_and_zmid')
+         ocnPGradMethod  = ocnPGradMethodPZMid
+      case ('MontgomeryPotential')
+         ocnPGradMethod  = ocnPGradMethodMontgomery
+      case ('MontgomeryPotential_and_density')
+         ocnPGradMethod  = ocnPGradMethodMontgomeryDens
+         call mpas_log_write( &
+           ' Montgomery and density for pgrad not fully supported.', &
+           MPAS_LOG_WARN)
+      case ('Jacobian_from_density')
+         ocnPGradMethod  = ocnPGradMethodJacobianDens
+      case ('Jacobian_from_TS')
+         ocnPGradMethod  = ocnPGradMethodJacobianTS
+      case default
+         ocnPGradMethod  = ocnPGradMethodNone
+         call mpas_log_write( &
+            ' Incorrect choice of config_pressure_gradient_type.', &
+            MPAS_LOG_CRIT)
+      end select
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -5,60 +5,52 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  ocn_vel_vadv
 !
 !> \brief MPAS ocean vertical advection
-!> \author Mark Petersen
-!> \date   September 2011
+!> \author Mark Petersen, Phil Jones, Rob Aulwes
+!> \date   September 2011, updated May 2020
 !> \details
 !>  This module contains the routine for computing
-!>  tendencies for vertical advection.
+!>  tendencies for momentum vertical advection.
 !>
-!
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 module ocn_vel_vadv
 
    use mpas_timer
-   use mpas_derived_types
-   use mpas_pool_routines
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
 
    implicit none
    private
    save
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public parameters
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Public member functions
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    public :: ocn_vel_vadv_tend, &
              ocn_vel_vadv_init
 
-   !--------------------------------------------------------------------
-   !
+   !----------------------------------------------------------------------------
    ! Private module variables
-   !
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
-   logical :: velVadvOn
+   logical :: velVadvOn  ! on/off flag for this tendency
 
-
-!***********************************************************************
+!*******************************************************************************
 
 contains
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_vadv_tend
 !
@@ -67,154 +59,185 @@ contains
 !> \date    September 2011
 !> \details
 !>  This routine computes the vertical advection tendency for momentum
-!>  based on current state.
+!>  based on current state and adds to the sum of velocity tendencies.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_vadv_tend(meshPool, normalVelocity, layerThicknessEdge, vertAleTransportTop, tend, err)!{{{
+   subroutine ocn_vel_vadv_tend(normalVelocity, layerThicknessEdge, &
+                                vertAleTransportTop, tend, err)
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity    !< Input: Horizontal velocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge,&!< Input: thickness at edge
-         vertAleTransportTop  !< Input: Vertical velocity on top layer
+         normalVelocity,     &!< [in] Horizontal velocity
+         layerThicknessEdge, &!< [in] thickness at edge
+         vertAleTransportTop  !< [in] Vertical velocity on top layer
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! input/output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] velocity tendency
 
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      !-----------------------------------------------------------------
-      !
+      !{{{
+      !-------------------------------------------------------------------------
       ! local variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, k, nEdges
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask
+      integer ::        &
+         iEdge, k,      &! loop counters
+         kmax,          &! max vertical level on edge
+         cell1, cell2    ! neighbor cell indices across edge
 
-      real (kind=RKIND) :: vertAleTransportTopEdge
-      real (kind=RKIND), dimension(:), allocatable :: w_dudzTopEdge
+      real (kind=RKIND) :: &
+         vertAleTransportTopEdge  ! vertical transport at top of edge
 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         w_dudzTopEdge   ! vertical advection tendency at top of edge
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Return if not turned on, otherwise start timer
+
+      err = 0
       if (.not. velVadvOn) return
 
       call mpas_timer_start("vel vadv")
 
-      err = 0
+      ! allocate a temporary for vertical velocity
+      allocate(w_dudzTopEdge(nVertLevels+1,nEdgesOwned))
 
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      ! transfer data to the device
+      !$acc enter data create(w_dudzTopEdge)
 
-      allocate(w_dudzTopEdge(nVertLevels+1))
-      w_dudzTopEdge = 0.0_RKIND
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, maxLevelEdgeTop,       &
+      !$acc            w_dudzTopEdge, vertAleTransportTop, &
+      !$acc            normalVelocity, layerThicknessEdge) &
+      !$acc    private(k, kmax, cell1, cell2, vertAleTransportTopEdge)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, kmax, cell1, cell2, vertAleTransportTopEdge)
+#endif
+      do iEdge = 1, nEdgesOwned
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         kmax  = maxLevelEdgeTop(iEdge)
+         w_dudzTopEdge(1,iEdge) = 0.0_RKIND
 
-      nEdges = nEdgesArray( 1 )
+         do k = 2, kmax
 
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-        cell1 = cellsOnEdge(1,iEdge)
-        cell2 = cellsOnEdge(2,iEdge)
+            ! Average w from cell center to edge
+            vertAleTransportTopEdge = 0.5_RKIND* &
+                                      (vertAleTransportTop(k,cell1) + &
+                                       vertAleTransportTop(k,cell2))
 
-        do k = 2, maxLevelEdgeTop(iEdge)
-          ! Average w from cell center to edge
-          vertAleTransportTopEdge = 0.5_RKIND*(vertAleTransportTop(k,cell1) + vertAleTransportTop(k,cell2))
+            ! compute dudz at vertical interface with first order derivative.
+            w_dudzTopEdge(k,iEdge) = vertAleTransportTopEdge*         &
+                               (normalVelocity(k-1,iEdge) -     &
+                                normalVelocity(k  ,iEdge))/     &
+                    (0.5_RKIND*(layerThicknessEdge(k-1,iEdge) + &
+                                layerThicknessEdge(k  ,iEdge)))
+ 
+         end do
+         w_dudzTopEdge(kmax+1,iEdge) = 0.0_RKIND
+      end do
 
-          ! compute dudz at vertical interface with first order derivative.
-          w_dudzTopEdge(k) = vertAleTransportTopEdge * (normalVelocity(k-1,iEdge)-normalVelocity(k,iEdge)) &
-                       / (0.5_RKIND*(layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)))
-        end do
-        w_dudzTopEdge(maxLevelEdgeTop(iEdge)+1) = 0.0_RKIND
-        ! Average w*du/dz from vertical interface to vertical middle of cell
-        do k = 1, maxLevelEdgeTop(iEdge)
-
-          tend(k,iEdge) = tend(k,iEdge) - edgeMask(k, iEdge) * 0.5 * (w_dudzTopEdge(k) + w_dudzTopEdge(k+1))
-        enddo
+      ! Tendency is the average w*du/dz from vertical interface to 
+      ! vertical middle of cell
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(maxLevelEdgeTop, w_dudzTopEdge) &
+      !$acc    private(k)
+#else
+      !$omp do schedule(runtime) &
+      !$omp    private(k)
+#endif
+      do iEdge = 1, nEdgesOwned
+      do k = 1, maxLevelEdgeTop(iEdge)
+         tend(k,iEdge) = tend(k,iEdge) -                 &
+                         0.5*(w_dudzTopEdge(k  ,iEdge) + &
+                              w_dudzTopEdge(k+1,iEdge))
       enddo
+      enddo
+#ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
+#endif
+
+      ! remove/transfer data from the device
+      !$acc exit data delete(w_dudzTopEdge)
 
       deallocate(w_dudzTopEdge)
 
       call mpas_timer_stop("vel vadv")
 
-   !--------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_vadv_tend!}}}
 
-!***********************************************************************
+!*******************************************************************************
 !
 !  routine ocn_vel_vadv_init
 !
 !> \brief   Initializes ocean momentum vertical advection
-!> \author  Mark Petersen
-!> \date    September 2011
+!> \author  Mark Petersen, Phil Jones, Rob Aulwes
+!> \date    September 2011, update May 2020
 !> \details
 !>  This routine initializes a variety of quantities related to
 !>  vertical velocity advection in the ocean.
 !
-!-----------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-   subroutine ocn_vel_vadv_init(err)!{{{
+   subroutine ocn_vel_vadv_init(err)
 
-   !--------------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      !
+      !-------------------------------------------------------------------------
       ! Output variables
-      !
-      !-----------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
-      character (len=StrKIND), pointer :: config_vert_coord_movement
-      logical, pointer :: config_disable_vel_vadv
+      !{{{
+      !-------------------------------------------------------------------------
+      ! Local variables
+      !-------------------------------------------------------------------------
+
+      ! End preamble
+      !-------------
+      ! Begin code
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_vert_coord_movement', config_vert_coord_movement)
-      call mpas_pool_get_config(ocnConfigs, 'config_disable_vel_vadv', config_disable_vel_vadv)
+      ! Set on/off flag based on input configuration options
 
-      velVadvOn = .false.
-
-      if (config_vert_coord_movement .ne.'impermeable_interfaces') then
-          velVadvOn = .true.
-      end if
-
+      ! Explicit switch
+      velVadvOn = .true.
       if ( config_disable_vel_vadv ) velVadvOn = .false.
 
-   !--------------------------------------------------------------------
+      ! Some vertical coordinate choices disable vertical advection
+      if (trim(config_vert_coord_movement) == 'impermeable_interfaces') &
+          velVadvOn = .false.
+
+   !----------------------------------------------------------------------------
 
    end subroutine ocn_vel_vadv_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
 
 end module ocn_vel_vadv
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker


### PR DESCRIPTION
This PR is a substantial modification to all the ocean baroclinic velocity tendencies and includes:
- a complete GPU implementation in which all tendencies - except tidal for now - are computed on the accelerator (using OpenACC) and all data is transfered at the top level driver (ocn_tend_vel)
-   a number of CPU optimizations performed along the way
-   elimination of meshPool, configPool
-   misc cleanup of comments and stuff

This PR contains similar changes that are in #513 #536 #569 at least so will need to modify/rebase once those are merged.

Performance speedup for this part of the code was 2.8x using 2 GPUs on Summit compared with an 8-rank MPI only case. Details of performance will depend on configuration. CPU performance improved by ~20% in the same 8-rank QU240 test. More speedup is expected as we migrate more data to the device elsewhere. The computational part excluding data transfer showed a 10x speedup.

This is not quite b4b due to changes in order of operations in a couple of routines and not b4b using the accelerator (different chip architecture). But in both cases, the differences are at roundoff level. Tested most of the options (eg for hmix, pgrad), though since it was tested in standalone QU240, the forcing routines really didn't get much of a workout.