### PR TITLE
Update compass env to v0.1.6

### DIFF
--- a/testing_and_setup/compass/README_ocean.md
+++ b/testing_and_setup/compass/README_ocean.md
@@ -6,11 +6,11 @@ To set up and run ocean test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_0.1.5 -c conda-forge -c e3sm python=3.7 compass=0.1.5
+conda create -n compass_0.1.6 -c conda-forge -c e3sm python=3.7 compass=0.1.6
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_0.1.5
+conda activate compass_0.1.6
 ```
 
 An appropriate conda environment is already available on Los Alamos National

--- a/testing_and_setup/compass/load_compass_env.sh
+++ b/testing_and_setup/compass/load_compass_env.sh
@@ -1,4 +1,4 @@
-version=0.1.5
+version=0.1.6
 
 # The rest of the script should not need to be modified
 if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then


### PR DESCRIPTION
This version of compass fixes an issue on LANL IC compute nodes that was occurring when `ESMF_RegridWeightGen` wasn't getting called with the conda version of `mpirun`.  (This bug was uncovered right before the COMPASS tutorial last week.)

