### PR TITLE
Fix threading flag typo for XL compiler in CMake builds

### DIFF
--- a/src/build_core.cmake
+++ b/src/build_core.cmake
@@ -57,7 +57,7 @@ function(build_core CORE)
     foreach(DISABLE_QSMP_FILE IN LISTS DISABLE_QSMP)
       get_filename_component(SOURCE_EXT ${DISABLE_QSMP_FILE} EXT)
       string(REPLACE "${SOURCE_EXT}" ".f90" SOURCE_F90 ${DISABLE_QSMP_FILE})
-      set_property(SOURCE ${CMAKE_BINARY_DIR}/${SOURCE_F90} APPEND_STRING PROPERTY COMPILE_FLAGS " -nosmp")
+      set_property(SOURCE ${CMAKE_BINARY_DIR}/${SOURCE_F90} APPEND_STRING PROPERTY COMPILE_FLAGS " -qnosmp")
     endforeach()
   endif()
 


### PR DESCRIPTION
There was a typo during Make-to-CMake conversion: correct flag is `-qnosmp`. This reduces threaded build times on Summit and only affects E3SM CMake builds. Additional discussion is at E3SM-Project/MPAS#6.

[bit-for-bit]