### PR TITLE
Add seaice mesh pool for OpenACC- and OpenMP-based GPU offloading

### DIFF
--- a/src/core_seaice/model_forward/mpas_seaice_core.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core.F
@@ -414,6 +414,7 @@ module seaice_core
       use mpas_decomp
       use seaice_column, only: &
            seaice_column_finalize
+      use seaice_mesh_pool
 
       implicit none
 
@@ -421,6 +422,9 @@ module seaice_core
       integer :: ierr
 
       iErr = 0
+
+      call mpas_log_write(" Destruct mesh pool...")
+      call seaice_mesh_pool_destroy(iErr)
 
       ! finalize column
       call seaice_column_finalize(domain)

--- a/src/core_seaice/model_forward/mpas_seaice_core.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core.F
@@ -5,6 +5,7 @@ module seaice_core
    use seaice_analysis_driver
    use seaice_column
    use mpas_threading
+   use mpas_timer, only: mpas_timer_start, mpas_timer_stop
    use mpas_log, only: mpas_log_write
 
    private
@@ -124,7 +125,10 @@ module seaice_core
       ! bootstrap analysis has used config_do_restart: now modify for rest of code
       if (trim(config_initial_condition_type) == "restart") config_do_restart = .true.
 
+      call mpas_timer_start("seaice_init")
       call mpas_init_block(domain, dt)
+      call mpas_timer_stop("seaice_init")
+
 
    end function seaice_core_init
 
@@ -255,7 +259,6 @@ module seaice_core
       use mpas_derived_types
       use mpas_kind_types
       use mpas_stream_manager
-      use mpas_timer
       use seaice_time_integration, only: seaice_timestep_finalize
       use seaice_forcing, only: &
            seaice_forcing_get, &

--- a/src/core_seaice/seaice.cmake
+++ b/src/core_seaice/seaice.cmake
@@ -72,6 +72,7 @@ list(APPEND RAW_SOURCES
   core_seaice/shared/mpas_seaice_column.F
   core_seaice/shared/mpas_seaice_diagnostics.F
   core_seaice/shared/mpas_seaice_error.F
+  core_seaice/shared/mpas_seaice_mesh_pool.F
 )
 
 # analysis members
@@ -103,6 +104,13 @@ set(SEAICE_MODEL_FORWARD
 )
 list(APPEND RAW_SOURCES ${SEAICE_MODEL_FORWARD})
 list(APPEND DISABLE_QSMP ${SEAICE_MODEL_FORWARD})
+
+# add accelerator/gpu flags
+list(APPEND ADD_ACC_FLAGS
+  core_seaice/shared/mpas_seaice_velocity_solver_variational.f90
+  core_seaice/shared/mpas_seaice_velocity_solver.f90
+  core_seaice/shared/mpas_seaice_mesh_pool.f90
+)
 
 # Generate core input
 handle_st_nl_gen("namelist.seaice" "streams.seaice stream_list.seaice. listed" ${CORE_INPUT_DIR} ${CORE_BLDDIR})

--- a/src/core_seaice/seaice.cmake
+++ b/src/core_seaice/seaice.cmake
@@ -105,12 +105,5 @@ set(SEAICE_MODEL_FORWARD
 list(APPEND RAW_SOURCES ${SEAICE_MODEL_FORWARD})
 list(APPEND DISABLE_QSMP ${SEAICE_MODEL_FORWARD})
 
-# add accelerator/gpu flags
-list(APPEND ADD_ACC_FLAGS
-  core_seaice/shared/mpas_seaice_velocity_solver_variational.f90
-  core_seaice/shared/mpas_seaice_velocity_solver.f90
-  core_seaice/shared/mpas_seaice_mesh_pool.f90
-)
-
 # Generate core input
 handle_st_nl_gen("namelist.seaice" "streams.seaice stream_list.seaice. listed" ${CORE_INPUT_DIR} ${CORE_BLDDIR})

--- a/src/core_seaice/shared/Makefile
+++ b/src/core_seaice/shared/Makefile
@@ -23,13 +23,16 @@ OBJS = 	mpas_seaice_time_integration.o \
 	mpas_seaice_constants.o \
 	mpas_seaice_column.o \
 	mpas_seaice_diagnostics.o \
-	mpas_seaice_error.o
+	mpas_seaice_error.o \
+	mpas_seaice_mesh_pool.o
 
 all: $(OBJS)
 
 mpas_seaice_constants.o: 
 
 mpas_seaice_error.o:
+
+mpas_seaice_mesh_pool.o:
 
 mpas_seaice_column.o: mpas_seaice_error.o
 

--- a/src/core_seaice/shared/gpu_macros.inc
+++ b/src/core_seaice/shared/gpu_macros.inc
@@ -1,0 +1,36 @@
+#ifdef MPAS_OPENACC
+
+#define GPU  acc
+#define GPUC acc               /* continuation line macro */
+#define GPUF acc )             /* final line of GPU directive */
+#define ENTER_DATA  enter data
+#define EXIT_DATA   exit data
+#define DATA        data
+#define DATA_END    end data
+#define COPY_IN_LP  copyin(    /* for multi-line variable lists */
+#define COPY_OUT_LP copyout(   /* for multi-line variable lists */
+#define COPY_DEL_LP delete(
+#define UPDATE_D(v) update device v
+#define UPDATE_D_LP update device(
+#define UPDATE_H(v) update host v   /* !$GPU UPDATE_H((stressDivergenceU, stressDivergenceV)) -> !$acc update host (stressDivergenceU, stressDivergenceV) */
+#define UPDATE_H_LP update host(    /* for multi-line variable lists */
+
+#else
+
+#define GPU         omp
+#define GPUC        omp&
+#define GPUF        omp& )
+#define ENTER_DATA  target enter data
+#define EXIT_DATA   target exit data
+#define DATA        target data
+#define DATA_END    end target data
+#define COPY_IN_LP  map(to:
+#define COPY_OUT_LP map(from:
+#define COPY_DEL_LP map(delete:
+#define UPDATE_D(v) target update to v
+#define UPDATE_D_LP target update to(
+#define UPDATE_H(v) target update from v
+#define UPDATE_H_LP target update from(
+
+#endif
+

--- a/src/core_seaice/shared/mpas_seaice_initialize.F
+++ b/src/core_seaice/shared/mpas_seaice_initialize.F
@@ -20,6 +20,7 @@ module seaice_initialize
   use mpas_io_units
   use mpas_abort
   use mpas_log, only: mpas_log_write
+  use mpas_timer, only: mpas_timer_start, mpas_timer_stop
 
   implicit none
 
@@ -59,6 +60,7 @@ contains
     use seaice_forcing, only: seaice_forcing_init, seaice_reset_coupler_fluxes
     use seaice_diagnostics, only: &
          seaice_set_testing_system_test_arrays
+    use seaice_mesh_pool
 
     type(domain_type), intent(inout) :: &
          domain !< Input/Output:
@@ -90,6 +92,9 @@ contains
     call mpas_log_write(" Initialize mesh...")
     call seaice_init_mesh(domain)
 
+    call mpas_log_write(" Initialize mesh pool...")
+    call seaice_mesh_pool_create(domain)
+
     ! init the basic column physics package
     call mpas_log_write(" Initialize column parameters...")
     call seaice_init_column_physics_package_parameters(domain)
@@ -104,7 +109,9 @@ contains
 
     ! init dynamics
     call mpas_log_write(" Initialize velocity solver...")
+    call mpas_timer_start("Velocity solver init")
     call seaice_init_velocity_solver(domain)
+    call mpas_timer_stop("Velocity solver init")
 
     ! init advection
     call mpas_log_write(" Initialize advection...")

--- a/src/core_seaice/shared/mpas_seaice_mesh_pool.F
+++ b/src/core_seaice/shared/mpas_seaice_mesh_pool.F
@@ -1,0 +1,274 @@
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_mesh_pool
+!
+!> \brief
+!> \date 2020
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+module seaice_mesh_pool
+
+#include "gpu_macros.inc"
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_log
+
+   implicit none
+   private
+
+   integer, public :: &
+      nCells,         &
+      nVerticesSolve
+
+   integer, public, dimension(:), pointer :: & 
+      nEdgesOnCell,   &
+      solveStress,    &
+      solveVelocity
+
+   integer, public, dimension(:,:), pointer :: &
+      verticesOnCell, &
+      cellsOnVertex,  &
+      cellVerticesAtVertex
+
+   real(kind=RKIND), public, dimension(:), pointer :: &
+      areaTriangle,   &
+      tanLatVertexRotatedOverRadius, &
+      icePressure,    &
+      uVelocity,      &
+      vVelocity,      &
+      stressDivergenceU, &
+      stressDivergenceV
+
+   real(kind=RKIND), public, dimension(:,:), pointer :: &
+      stress11,       &
+      stress12,       &
+      stress22
+
+   real(kind=RKIND), public, dimension(:,:,:), pointer :: &
+      basisGradientU, &
+      basisGradientV, &
+      basisIntegralsU,&
+      basisIntegralsV,&
+      basisIntegralsMetric
+
+   public ::                   &
+      seaice_mesh_pool_create, &
+      seaice_mesh_pool_update, &
+      seaice_mesh_pool_destroy
+
+!-----------------------------------------------------------------------
+
+contains
+
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_mesh_pool_create
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_mesh_pool_create(&
+       domain)!{{{
+
+    type(domain_type) :: &
+         domain
+
+    integer :: &
+         blockCount
+
+    type(block_type), pointer :: &
+         block
+
+    type (mpas_pool_type), pointer :: &
+         meshPool,               &
+         velocitySolverPool,     &
+         velocityVariationalPool
+
+    integer, pointer ::   &
+         nCellsTmp,       &
+         nVerticesSolveTmp
+
+    blockCount = 0
+    block => domain % blocklist
+    do while ( associated(block) )
+
+       blockCount = blockCount + 1
+       if (blockCount > 1) then
+          call mpas_log_write('seaice_mesh_pool_create: more than one block is no longer supported', MPAS_LOG_CRIT)
+       endif
+
+       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+       call mpas_pool_get_subpool(block % structs, 'velocity_solver', velocitySolverPool)
+       call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
+
+       ! convert mesh dimensions from pointers to scalars
+       call mpas_pool_get_dimension(meshPool, 'nCells', nCellsTmp)
+       call MPAS_pool_get_dimension(meshPool, "nVerticesSolve", nVerticesSolveTmp)
+
+       nCells         = nCellsTmp
+       nVerticesSolve = nVerticesSolveTmp
+
+       ! point to existing arrays
+       call mpas_pool_get_array(meshPool, 'nEdgesOnCell',   nEdgesOnCell)
+       call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
+       call mpas_pool_get_array(meshPool, 'cellsOnVertex',  cellsOnVertex)
+       call mpas_pool_get_array(meshPool, 'areaTriangle',   areaTriangle)
+
+       call MPAS_pool_get_array(velocitySolverPool, "solveStress",       solveStress)
+       call MPAS_pool_get_array(velocitySolverPool, "solveVelocity",     solveVelocity)
+       call MPAS_pool_get_array(velocitySolverPool, "icePressure",       icePressure)
+       call MPAS_pool_get_array(velocitySolverPool, "uVelocity",         uVelocity)
+       call MPAS_pool_get_array(velocitySolverPool, "vVelocity",         vVelocity)
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientU",       basisGradientU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientV",       basisGradientV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsU",      basisIntegralsU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsV",      basisIntegralsV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
+       call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
+       call MPAS_pool_get_array(velocityVariationalPool, "cellVerticesAtVertex", cellVerticesAtVertex)
+       call MPAS_pool_get_array(velocityVariationalPool, "stress11",             stress11)
+       call MPAS_pool_get_array(velocityVariationalPool, "stress22",             stress22)
+       call MPAS_pool_get_array(velocityVariationalPool, "stress12",             stress12)
+
+!$GPU ENTER_DATA COPY_IN_LP             &
+!$GPUC   nCells,                        &
+!$GPUC   nVerticesSolve,                &
+!$GPUC   nEdgesOnCell,                  &
+!$GPUC   verticesOnCell,                &
+!$GPUC   cellsOnVertex,                 &
+!$GPUC   areaTriangle,                  &
+!$GPUC   solveStress,                   &
+!$GPUC   solveVelocity,                 &
+!$GPUC   icePressure,                   &
+!$GPUC   uVelocity,                     &
+!$GPUC   vVelocity,                     &
+!$GPUC   stressDivergenceU,             &
+!$GPUC   stressDivergenceV,             &
+!$GPUC   basisGradientU,                &
+!$GPUC   basisGradientV,                &
+!$GPUC   basisIntegralsU,               &
+!$GPUC   basisIntegralsV,               &
+!$GPUC   basisIntegralsMetric,          &
+!$GPUC   tanLatVertexRotatedOverRadius, &
+!$GPUC   cellVerticesAtVertex,          &
+!$GPUC   stress11,                      &
+!$GPUC   stress12,                      &
+!$GPUC   stress22                       &
+!$GPUF
+
+       block => block % next
+    end do
+
+  end subroutine seaice_mesh_pool_create!}}}
+!-----------------------------------------------------------------------
+
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_mesh_pool_destroy
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_mesh_pool_destroy(&
+       err)!{{{
+
+    integer, intent(out) :: &
+      err                   ! returned error flag
+
+    err = 0
+
+    ! first delete on device
+!$GPU EXIT_DATA COPY_DEL_LP             &
+!$GPUC   nCells,                        &
+!$GPUC   nVerticesSolve,                &
+!$GPUC   nEdgesOnCell,                  &
+!$GPUC   verticesOnCell,                &
+!$GPUC   cellsOnVertex,                 &
+!$GPUC   areaTriangle,                  &
+!$GPUC   solveStress,                   &
+!$GPUC   solveVelocity,                 &
+!$GPUC   icePressure,                   &
+!$GPUC   uVelocity,                     &
+!$GPUC   vVelocity,                     &
+!$GPUC   stressDivergenceU,             &
+!$GPUC   stressDivergenceV,             &
+!$GPUC   basisGradientU,                &
+!$GPUC   basisGradientV,                &
+!$GPUC   basisIntegralsU,               &
+!$GPUC   basisIntegralsV,               &
+!$GPUC   basisIntegralsMetric,          &
+!$GPUC   tanLatVertexRotatedOverRadius, &
+!$GPUC   cellVerticesAtVertex,          &
+!$GPUC   stress11,                      &
+!$GPUC   stress12,                      &
+!$GPUC   stress22                       &
+!$GPUF
+
+    ! then nullify on host
+    nullify(nEdgesOnCell,      &
+         verticesOnCell,       &
+         cellsOnVertex,        &
+         areaTriangle,         &
+         solveStress,          &
+         solveVelocity,        &
+         icePressure,          &
+         uVelocity,            &
+         vVelocity,            &
+         stressDivergenceU,    &
+         stressDivergenceV,    &
+         basisGradientU,       &
+         basisGradientV,       &
+         basisIntegralsU,      &
+         basisIntegralsV,      &
+         basisIntegralsMetric, &
+         tanLatVertexRotatedOverRadius, &
+         cellVerticesAtVertex, &
+         stress11,             &
+         stress12,             &
+         stress22              &
+    )
+
+  end subroutine seaice_mesh_pool_destroy!}}}
+!-----------------------------------------------------------------------
+
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_mesh_pool_update
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_mesh_pool_update(&
+       domain)!{{{
+
+    type(domain_type) :: &
+         domain
+
+    ! update arrays on device
+!$GPU UPDATE_D_LP       &
+!$GPUC   solveStress,   &
+!$GPUC   solveVelocity, &
+!$GPUC   icePressure,   &
+!$GPUC   uVelocity,     &
+!$GPUC   vVelocity,     &
+!$GPUC   stress11,      &
+!$GPUC   stress12,      &
+!$GPUC   stress22       &
+!$GPUF
+
+  end subroutine seaice_mesh_pool_update!}}}
+!-----------------------------------------------------------------------
+
+
+
+end module seaice_mesh_pool

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver.F
@@ -12,12 +12,15 @@
 
 module seaice_velocity_solver
 
+#include "gpu_macros.inc"
+
   use mpas_derived_types
   use mpas_pool_routines
   use mpas_timekeeping
   use mpas_dmpar
   use mpas_timer
-  use mpas_log, only: mpas_log_write
+  use mpas_log, only: mpas_log_write, mpas_log_info
+  use seaice_mesh_pool
 
   implicit none
 
@@ -592,6 +595,11 @@ contains
     call mpas_timer_start("init subcycle var")
     call init_subcycle_variables(domain)
     call mpas_timer_stop("init subcycle var")
+
+    ! update mesh pool variables
+    call mpas_timer_start("update mesh pool")
+    call seaice_mesh_pool_update(domain)
+    call mpas_timer_stop("update mesh pool")
 
   end subroutine velocity_solver_pre_subcycle
 
@@ -2339,6 +2347,23 @@ contains
     integer :: &
          iElasticSubcycle
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
+    type (MPAS_pool_type), pointer :: &
+         velocityVariationalPool
+
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         replacementPressure
+
+    call MPAS_pool_get_subpool(domain % blocklist % structs, "velocity_variational", velocityVariationalPool)
+    call MPAS_pool_get_array(velocityVariationalPool, "replacementPressure", replacementPressure)
+
+    call mpas_timer_start("Velocity solver memcpy HtoD")
+!$GPU DATA COPY_OUT_LP &
+!$GPUC  replacementPressure &
+!$GPUF
+    call mpas_timer_stop("Velocity solver memcpy HtoD")
+#endif
+
     call MPAS_pool_get_config(domain % configs, "config_elastic_subcycle_number", config_elastic_subcycle_number)
 
     do iElasticSubcycle = 1, config_elastic_subcycle_number
@@ -2349,6 +2374,8 @@ contains
             iElasticSubcycle)
 
     enddo
+
+!$GPU DATA_END
 
   end subroutine subcycle_velocity_solver!}}}
 
@@ -2417,6 +2444,8 @@ contains
 
     endif
 
+!$GPU UPDATE_H((stressDivergenceU, stressDivergenceV))
+
     ! ocean stress coefficient
     call mpas_timer_start("ocn stress coef")
     call ocean_stress_coefficient(domain)
@@ -2481,6 +2510,8 @@ contains
     call mpas_timer_stop("Velocity solver halo")
 
     call seaice_load_balance_timers(domain, "vel after")
+
+!$GPU UPDATE_D((uVelocity, vVelocity))
 
   end subroutine single_subcycle_velocity_solver!}}}
 
@@ -2565,7 +2596,6 @@ contains
              endif
 
           enddo ! iVertex
-
        else
 
           ! no ocean stress
@@ -2608,8 +2638,6 @@ contains
     real(kind=RKIND), dimension(:), pointer :: &
          uVelocity, &
          vVelocity, &
-         uVelocityInitial, &
-         vVelocityInitial, &
          totalMassVertex, &
          totalMassVertexfVertex, &
          stressDivergenceU, &
@@ -2654,8 +2682,6 @@ contains
        call MPAS_pool_get_array(velocitySolverPool, "solveVelocity", solveVelocity)
        call MPAS_pool_get_array(velocitySolverPool, "uVelocity", uVelocity)
        call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "uVelocityInitial", uVelocityInitial)
-       call MPAS_pool_get_array(velocitySolverPool, "vVelocityInitial", vVelocityInitial)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
        call MPAS_pool_get_array(velocitySolverPool, "airStressVertexU", airStressVertexU)
@@ -2667,7 +2693,9 @@ contains
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressV", oceanStressV)
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressCoeff", oceanStressCoeff)
 
-       !$omp parallel do default(shared) private(iVertex, leftMatrix, rightHandSide, solutionDenominator)
+#ifdef MPAS_OPENMP
+!$omp parallel do default(shared) private(iVertex, leftMatrix, rightHandSide, solutionDenominator)
+#endif
        do iVertex = 1, nVerticesSolve
 
           if (solveVelocity(iVertex) == 1) then

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_constitutive_relation.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_constitutive_relation.F
@@ -30,14 +30,13 @@ module seaice_velocity_solver_constitutive_relation
   ! general EVP parameters
   real(kind=RKIND), parameter, private :: &
        eccentricity = 2.0_RKIND, &
-       dampingTimescaleParameter = 0.36_RKIND, &
-       puny = 1.0e-11_RKIND
+       dampingTimescaleParameter = 0.36_RKIND
 
   real(kind=RKIND), parameter, public :: &
-       eccentricitySquared = eccentricity**2
+       eccentricitySquared = eccentricity**2, &
+       puny = 1.0e-11_RKIND
 
   real(kind=RKIND), private :: &
-       dampingTimescale, &
        evpDampingCriterion
 
   ! Bouillon et al. 2013 parameters
@@ -46,6 +45,7 @@ module seaice_velocity_solver_constitutive_relation
        dampingRatio = 5.5e-3_RKIND  ! xi = Sv/Sc < 1
 
   real(kind=RKIND), public :: &
+       dampingTimescale, &
        numericalInertiaCoefficient ! brlx
 
 contains
@@ -159,8 +159,9 @@ contains
        replacementPressure, &
        areaCell, &
        dtElastic)
-#if !defined(__GFORTRAN__) && !defined(CPRGNU)
-!$omp declare simd(seaice_evp_constitutive_relation)
+#ifdef CPRINTEL
+!$omp declare simd(seaice_evp_constitutive_relation) uniform(dtElastic), notinbranch &
+!$omp& linear(ref(stress11,stress22,stress12,strain11,strain22,strain12,replacementPressure,icePressure,areaCell))
 #endif
 
     real(kind=RKIND), intent(inout) :: &
@@ -241,8 +242,9 @@ contains
        icePressure, &
        replacementPressure, &
        areaCell)
-#if !defined(__GFORTRAN__) && !defined(CPRGNU)
-!$omp declare simd(seaice_evp_constitutive_relation_revised)
+#ifdef CPRINTEL
+!$omp declare simd(seaice_evp_constitutive_relation_revised) uniform(icePressure,areaCell), notinbranch &
+!$omp& linear(ref(stress11,stress22,stress12,strain11,strain22,strain12,replacementPressure))
 #endif
 
     real(kind=RKIND), intent(inout) :: &
@@ -319,8 +321,9 @@ contains
        strain11, &
        strain22, &
        strain12)
-#if !defined(__GFORTRAN__) && !defined(CPRGNU)
-!$omp declare simd(seaice_linear_constitutive_relation)
+#ifdef CPRINTEL
+!$omp declare simd(seaice_linear_constitutive_relation) notinbranch &
+!$omp& linear(ref(stress11,stress22,stress12,strain11,strain22,strain12))
 #endif
 
     real(kind=RKIND), intent(out) :: &

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_variational.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_variational.F
@@ -12,9 +12,13 @@
 
 module seaice_velocity_solver_variational
 
+#include "gpu_macros.inc"
+
   use mpas_derived_types
   use mpas_pool_routines
   use mpas_timer
+  use mpas_log, only: mpas_log_write
+  use seaice_mesh_pool
 
   implicit none
 
@@ -136,9 +140,6 @@ contains
          velocitySolverPool
 
     real(kind=RKIND), dimension(:), pointer :: &
-         uVelocity, &
-         vVelocity, &
-         icePressure, &
          stressDivergenceU, &
          stressDivergenceV
 
@@ -148,31 +149,11 @@ contains
     logical, pointer :: &
          revisedEVP
 
-    integer, dimension(:), pointer :: &
-         solveStress, &
-         solveVelocity
-
-    integer, dimension(:,:), pointer :: &
-         cellVerticesAtVertex
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         tanLatVertexRotatedOverRadius
-
     real(kind=RKIND), dimension(:,:), pointer :: &
          replacementPressure, &
          strain11, &
          strain22, &
-         strain12, &
-         stress11, &
-         stress22, &
-         stress12
-
-    real(kind=RKIND), dimension(:,:,:), pointer :: &
-         basisGradientU, &
-         basisGradientV, &
-         basisIntegralsU, &
-         basisIntegralsV, &
-         basisIntegralsMetric
+         strain12
 
     block => domain % blocklist
     do while (associated(block))
@@ -183,11 +164,6 @@ contains
        call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
        call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
 
-       call MPAS_pool_get_array(velocitySolverPool, "solveStress", solveStress)
-       call MPAS_pool_get_array(velocitySolverPool, "solveVelocity", solveVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "uVelocity", uVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "icePressure", icePressure)
        call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
@@ -195,16 +171,6 @@ contains
        call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
        call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
        call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress11", stress11)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress22", stress22)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress12", stress12)
-       call MPAS_pool_get_array(velocityVariationalPool, "cellVerticesAtVertex", cellVerticesAtVertex)
-       call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientU", basisGradientU)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientV", basisGradientV)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsU", basisIntegralsU)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsV", basisIntegralsV)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
        call MPAS_pool_get_array(velocityVariationalPool, "replacementPressure", replacementPressure)
 
        call mpas_timer_start("Velocity solver strain tensor")
@@ -285,35 +251,13 @@ contains
          velocitySolverPool
 
     real(kind=RKIND), dimension(:), pointer :: &
-         uVelocity, &
-         vVelocity, &
          stressDivergenceU, &
          stressDivergenceV
-
-    integer, dimension(:), pointer :: &
-         solveStress, &
-         solveVelocity
-
-    integer, dimension(:,:), pointer :: &
-         cellVerticesAtVertex
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         tanLatVertexRotatedOverRadius
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          strain11, &
          strain22, &
-         strain12, &
-         stress11, &
-         stress22, &
-         stress12
-
-    real(kind=RKIND), dimension(:,:,:), pointer :: &
-         basisGradientU, &
-         basisGradientV, &
-         basisIntegralsU, &
-         basisIntegralsV, &
-         basisIntegralsMetric
+         strain12
 
     block => domain % blocklist
     do while (associated(block))
@@ -322,26 +266,12 @@ contains
        call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
        call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
 
-       call MPAS_pool_get_array(velocitySolverPool, "solveStress", solveStress)
-       call MPAS_pool_get_array(velocitySolverPool, "solveVelocity", solveVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "uVelocity", uVelocity)
-       call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
 
        call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
        call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
        call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress11", stress11)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress22", stress22)
-       call MPAS_pool_get_array(velocityVariationalPool, "stress12", stress12)
-       call MPAS_pool_get_array(velocityVariationalPool, "cellVerticesAtVertex", cellVerticesAtVertex)
-       call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientU", basisGradientU)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientV", basisGradientV)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsU", basisIntegralsU)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsV", basisIntegralsV)
-       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
 
        call mpas_timer_start("Velocity solver strain tensor")
        call seaice_strain_tensor_variational(&
@@ -446,24 +376,15 @@ contains
          strain22Tmp, &
          strain12Tmp
 
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), contiguous, pointer :: &
-         verticesOnCell
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-
     ! loop over cells
-    !$omp parallel do default(shared) private(iCell, iGradientVertex, iBasisVertex, iVertex, jVertex,&
-    !$omp&                                    strain11Tmp, strain22Tmp, strain12Tmp)
+#ifdef MPAS_OPENMP_OFFLOAD
+!$omp target teams distribute parallel do
+#elif MPAS_OPENACC
+!$acc parallel loop gang worker
+#else
+!$omp parallel do default(shared) private(iGradientVertex, iBasisVertex, iVertex, jVertex, &
+!$omp&                                    strain11Tmp, strain22Tmp, strain12Tmp)
+#endif
     do iCell = 1, nCells
 
        if (solveStress(iCell) == 1) then
@@ -531,6 +452,7 @@ contains
 
     use seaice_velocity_solver_constitutive_relation, only: &
          seaice_evp_constitutive_relation, &
+         eccentricitySquared, puny, dampingTimescale, &
          seaice_evp_constitutive_relation_revised
 
     type(MPAS_pool_type), pointer, intent(in) :: &
@@ -565,30 +487,70 @@ contains
          iCell, &
          iVertexOnCell
 
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
     real(kind=RKIND), dimension(:), pointer :: &
          areaCell
 
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+    real(kind=RKIND) :: &
+         strainDivergence,    &
+         strainTension,       &
+         strainShearing,      &
+         stress1,             &
+         stress2,             &
+         Delta,               &
+         pressureCoefficient, &
+         denominator
 
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
+    ! init variables
     call MPAS_pool_get_array(mesh, "areaCell", areaCell)
 
     if (.not. revisedEVP) then
 
-       !$omp parallel do default(shared) private(iCell, iVertexOnCell)
+       denominator = 1.0_RKIND + (0.5_RKIND * dtElastic) / dampingTimescale
+
+#ifdef MPAS_OPENMP_OFFLOAD
+!$omp target teams distribute parallel do
+#elif MPAS_OPENACC
+!$acc parallel loop gang worker
+#else
+!$omp parallel do default(shared) private(iVertexOnCell)
+#endif
        do iCell = 1, nCells
 
           replacementPressure(:,iCell) = 0.0_RKIND
 
           if (solveStress(iCell) == 1) then
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
+             ! inline call to seaice_evp_constitutive_relation for GPUs
+             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+                ! convert from stress11 to stress1 etc
+                strainDivergence = strain11(iVertexOnCell,iCell) + strain22(iVertexOnCell,iCell)
+                strainTension    = strain11(iVertexOnCell,iCell) - strain22(iVertexOnCell,iCell)
+                strainShearing   = strain12(iVertexOnCell,iCell) * 2.0_RKIND
+
+                stress1 = stress11(iVertexOnCell,iCell) + stress22(iVertexOnCell,iCell)
+                stress2 = stress11(iVertexOnCell,iCell) - stress22(iVertexOnCell,iCell)
+
+                ! perform the constituitive relation
+                Delta = sqrt(strainDivergence*strainDivergence + &
+                             (strainTension*strainTension + strainShearing*strainShearing) / eccentricitySquared)
+
+                pressureCoefficient                      = icePressure(iCell) / max(Delta,puny)
+                replacementPressure(iVertexOnCell,iCell) = pressureCoefficient * Delta
+
+                pressureCoefficient = (pressureCoefficient * dtElastic) / (2.0_RKIND * dampingTimescale)
+
+                stress1  = (stress1  +  pressureCoefficient                        * (strainDivergence - Delta)) / denominator
+                stress2  = (stress2  + (pressureCoefficient / eccentricitySquared) *  strainTension            ) / denominator
+                stress12(iVertexOnCell,iCell) = (stress12(iVertexOnCell,iCell) &
+                                     + (pressureCoefficient / eccentricitysquared) * strainShearing * 0.5_RKIND) / denominator
+
+                ! convert back
+                stress11(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 + stress2)
+                stress22(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 - stress2)
+
+#else
              !$omp simd
              do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
@@ -603,7 +565,7 @@ contains
                      replacementPressure(iVertexOnCell,iCell), &
                      areaCell(iCell), &
                      dtElastic)
-
+#endif
              enddo ! iVertexOnCell
 
           endif ! solveStress
@@ -612,7 +574,9 @@ contains
 
     else
 
-       !$omp parallel do default(shared) private(iCell, iVertexOnCell)
+#ifdef MPAS_OPENMP
+!$omp parallel do default(shared) private(iVertexOnCell)
+#endif
        do iCell = 1, nCells
 
           if (solveStress(iCell) == 1) then
@@ -686,18 +650,9 @@ contains
          iCell, &
          iVertexOnCell
 
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-
-    !$omp parallel do default(shared) private(iCell, iVertexOnCell)
+#ifdef MPAS_OPENMP
+!$omp parallel do default(shared) private(iCell, iVertexOnCell)
+#endif
     do iCell = 1, nCells
 
        if (solveStress(iCell) == 1) then
@@ -774,6 +729,8 @@ contains
          solveVelocity !< Input:
 
     real(kind=RKIND) :: &
+         stressDivergenceUVertex, &
+         stressDivergenceVVertex, &
          stressDivergenceUCell, &
          stressDivergenceVCell
 
@@ -784,38 +741,24 @@ contains
          iStressVertex, &
          iVelocityVertex
 
-    integer, pointer :: &
-         nVertices, &
-         vertexDegree
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), pointer :: &
-         cellsOnVertex
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         areaTriangle
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
-    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
-    call MPAS_pool_get_array(mesh, "areaTriangle", areaTriangle)
-
     ! loop over velocity positions
-    !$omp parallel do default(shared) private(iVertex, iSurroundingCell, iCell, iVelocityVertex, stressDivergenceUCell, stressDivergenceVCell, iStressVertex)
-    do iVertex = 1, nVertices
+#ifdef MPAS_OPENMP_OFFLOAD
+!$omp target teams distribute parallel do
+#elif MPAS_OPENACC
+!$acc parallel loop gang worker
+#else
+!$omp parallel do default(shared) private(stressDivergenceUVertex, stressDivergenceVVertex, &
+!$omp&   iSurroundingCell, iCell, iVelocityVertex, stressDivergenceUCell, stressDivergenceVCell, iStressVertex)
+#endif
+    do iVertex = 1, nVerticesSolve
 
        if (solveVelocity(iVertex) == 1) then
 
-          stressDivergenceU(iVertex) = 0.0_RKIND
-          stressDivergenceV(iVertex) = 0.0_RKIND
+          stressDivergenceUVertex = 0.0_RKIND
+          stressDivergenceVVertex = 0.0_RKIND
 
           ! loop over surrounding cells
-          do iSurroundingCell = 1, vertexDegree
+          do iSurroundingCell = 1, 3 !vertexDegree
 
              ! get the cell number of this cell
              iCell = cellsOnVertex(iSurroundingCell, iVertex)
@@ -844,13 +787,13 @@ contains
 
              enddo ! iStressVertex
 
-             stressDivergenceU(iVertex) = stressDivergenceU(iVertex) + stressDivergenceUCell
-             stressDivergenceV(iVertex) = stressDivergenceV(iVertex) + stressDivergenceVCell
+             stressDivergenceUVertex = stressDivergenceUVertex + stressDivergenceUCell
+             stressDivergenceVVertex = stressDivergenceVVertex + stressDivergenceVCell
 
           enddo ! iSurroundingCell
 
-          stressDivergenceU(iVertex) = stressDivergenceU(iVertex) / areaTriangle(iVertex)
-          stressDivergenceV(iVertex) = stressDivergenceV(iVertex) / areaTriangle(iVertex)
+          stressDivergenceU(iVertex) = stressDivergenceUVertex / areaTriangle(iVertex)
+          stressDivergenceV(iVertex) = stressDivergenceVVertex / areaTriangle(iVertex)
 
        endif ! solveVelocity
 
@@ -879,17 +822,9 @@ contains
          block
 
     type(MPAS_pool_type), pointer :: &
-         meshPool, &
          velocityVariationalPool, &
          velocitySolverPool, &
          ridgingPool
-
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell, &
-         solveStress
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          strain11, &
@@ -921,13 +856,8 @@ contains
          iCell, &
          iVertexOnCell
 
-    call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
     call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
     call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-
-    call MPAS_pool_get_dimension(meshPool, "nCells", nCells)
-
-    call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
 
     call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
     call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
@@ -935,7 +865,6 @@ contains
 
     call MPAS_pool_get_array(velocitySolverPool, "divergence", divergence)
     call MPAS_pool_get_array(velocitySolverPool, "shear", shear)
-    call MPAS_pool_get_array(velocitySolverPool, "solveStress", solveStress)
 
     allocate(DeltaAverage(nCells))
 

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_variational_shared.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_variational_shared.F
@@ -221,6 +221,11 @@ contains
 
     do iCell = 1, nCells
 
+       call seaice_grid_rotation_forward(&
+            xCellRotated, yCellRotated, zCellRotated, &
+            xCell(iCell), yCell(iCell), zCell(iCell), &
+            rotateCartesianGrid)
+
        do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
           iVertex = verticesOnCell(iVertexOnCell, iCell)
@@ -228,11 +233,6 @@ contains
           call seaice_grid_rotation_forward(&
                normalVector3D(1), normalVector3D(2), normalVector3D(3), &
                xVertex(iVertex),  yVertex(iVertex),  zVertex(iVertex), &
-               rotateCartesianGrid)
-
-          call seaice_grid_rotation_forward(&
-               xCellRotated, yCellRotated, zCellRotated, &
-               xCell(iCell), yCell(iCell), zCell(iCell), &
                rotateCartesianGrid)
 
           call seaice_project_3D_vector_onto_local_2D(&

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
@@ -134,18 +134,23 @@ contains
     allocate(wachspressA(maxEdges,nCells))
     allocate(wachspressB(maxEdges,nCells))
 
+    call mpas_timer_start("wachpress calc_local_coords")
     call seaice_calc_local_coords(&
          mesh, &
          xLocal, &
          yLocal, &
          rotateCartesianGrid)
+    call mpas_timer_stop("wachpress calc_local_coords")
 
+    call mpas_timer_start("wachpress calc_metric_terms")
     call seaice_calc_variational_metric_terms(&
          mesh, &
          tanLatVertexRotatedOverRadius, &
          rotateCartesianGrid, &
          includeMetricTerms)
+    call mpas_timer_stop("wachpress calc_metric_terms")
 
+    call mpas_timer_start("wachpress calc_coefficients")
     call calc_wachspress_coefficients(&
          mesh, &
          wachspressKappa, &
@@ -153,7 +158,9 @@ contains
          wachspressB, &
          xLocal, &
          yLocal)
+    call mpas_timer_stop("wachpress calc_coefficients")
 
+    call mpas_timer_start("wachpress calc_derivatives")
     call calculate_wachspress_derivatives(&
          mesh, &
          basisGradientU, &
@@ -163,7 +170,9 @@ contains
          wachspressA, &
          wachspressB, &
          wachspressKappa)
+    call mpas_timer_stop("wachpress calc_derivatives")
 
+    call mpas_timer_start("wachpress integrate")
     call integrate_wachspress(&
          mesh, &
          basisIntegralsU, &
@@ -176,10 +185,13 @@ contains
          wachspressKappa, &
          integrationType, &
          integrationOrder)
+    call mpas_timer_stop("wachpress integrate")
 
+    call mpas_timer_start("wachpress vertices_at_vertex")
     call seaice_cell_vertices_at_vertex(&
          mesh, &
          cellVerticesAtVertex)
+    call mpas_timer_stop("wachpress vertices_at_vertex")
 
     deallocate(xLocal)
     deallocate(yLocal)
@@ -396,19 +408,15 @@ contains
     real(kind=RKIND), dimension(:), intent(out) :: &
          wachpress !< Output:
 
-    real(kind=RKIND), dimension(:,:), allocatable :: &
+    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
          numerator
 
-    real(kind=RKIND), dimension(:), allocatable :: &
+    real(kind=RKIND), dimension(size(x)) :: &
          denominator, &
          edgeEquation
 
     integer :: &
          jVertex
-
-    allocate(denominator(size(x)))
-    allocate(numerator(size(x),nEdgesOnCell))
-    allocate(edgeEquation(size(x)))
 
     ! sum over numerators to get denominator
     denominator(:) = 0.0_RKIND
@@ -427,10 +435,6 @@ contains
     enddo ! jVertex
 
     wachpress(:) = numerator(:,iVertex) / denominator(:)
-
-    deallocate(denominator)
-    deallocate(numerator)
-    deallocate(edgeEquation)
 
   end subroutine wachspress_basis_function!}}}
 
@@ -484,29 +488,23 @@ contains
          wachspressU, & !< Output:
          wachspressV !< Output:
 
-    real(kind=RKIND), dimension(:,:,:), allocatable :: &
+    real(kind=RKIND), dimension(size(x),2,nEdgesOnCell) :: &
          derivative
 
-    real(kind=RKIND), dimension(:,:), allocatable :: &
-         numerator, &
+    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
+         numerator
+
+    real(kind=RKIND), dimension(size(x),2) :: &
          sum_of_derivatives, &
          sum_of_products, &
          product
 
-    real(kind=RKIND), dimension(:), allocatable :: &
+    real(kind=RKIND), dimension(size(x)) :: &
          denominator, &
          edgeEquation
 
     integer :: &
          jVertex
-
-    allocate(denominator(size(x)))
-    allocate(sum_of_derivatives(size(x),2))
-    allocate(numerator(size(x),nEdgesOnCell))
-    allocate(derivative(size(x),2,nEdgesOnCell))
-    allocate(sum_of_products(size(x),2))
-    allocate(product(size(x),2))
-    allocate(edgeEquation(size(x)))
 
     ! sum over numerators to get denominator
     denominator(:) = 0.0_RKIND
@@ -538,14 +536,6 @@ contains
          (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,1)
     wachspressV(:) = derivative(:,2,iVertex) / denominator(:) - &
          (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,2)
-
-    deallocate(denominator)
-    deallocate(sum_of_derivatives)
-    deallocate(numerator)
-    deallocate(derivative)
-    deallocate(sum_of_products)
-    deallocate(product)
-    deallocate(edgeEquation)
 
   end subroutine wachspress_basis_derivative!}}}
 
@@ -966,37 +956,6 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  use_triangle_mapping
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine use_triangle_mapping(&
-       u, v, &
-       x, y, &
-       mapping)!{{{
-
-    real(kind=RKIND), intent(out) :: &
-         u, v !< Output:
-
-    real(kind=RKIND), intent(in) :: &
-         x, y !< Input:
-
-    real(kind=RKIND), dimension(2,2), intent(in) :: &
-         mapping !< Input:
-
-    u = mapping(1,1) * x + mapping(1,2) * y
-    v = mapping(2,1) * x + mapping(2,2) * y
-
-  end subroutine use_triangle_mapping!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
 !  integrate_wachspress
 !
 !> \brief
@@ -1051,9 +1010,6 @@ contains
     integer, intent(in) :: &
          integrationOrder !< Input:
 
-    real(kind=RKIND) :: &
-         integration
-
     integer :: &
          iCell, &
          iStressVertex, &
@@ -1089,11 +1045,12 @@ contains
          integrationWeights, &
          normalizationFactor)
 
+    !$omp parallel do default(shared) private(iStressVertex, iVelocityVertex)
     do iCell = 1, nCells
 
-       do iStressVertex = 1, nEdgesOnCell(iCell)
+       do iVelocityVertex = 1, nEdgesOnCell(iCell)
 
-          do iVelocityVertex = 1, nEdgesOnCell(iCell)
+          do iStressVertex = 1, nEdgesOnCell(iCell)
 
              basisIntegralsU(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
              basisIntegralsV(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
@@ -1883,8 +1840,6 @@ contains
        integrationWeights, &
        normalizationFactor)!{{{
 
-    use seaice_constants, only: pii
-
     use seaice_velocity_solver_variational_shared, only: &
          seaice_wrapped_index
 
@@ -1920,18 +1875,19 @@ contains
     real(kind=RKIND), intent(in) :: &
          normalizationFactor !< Input:
 
-    integer, dimension(:), allocatable :: &
+    integer, dimension(nEdgesOnCell) :: &
          nEdgesOnCellSubset
 
-    integer, dimension(:,:), allocatable :: &
+    integer, dimension(nEdgesOnCell,nEdgesOnCell) :: &
          vertexIndexSubset
 
     real(kind=RKIND) :: &
+         basisIntegralsSubTriangleTmp, &
          basisIntegralsUSubTriangle, &
          basisIntegralsVSubTriangle, &
          basisIntegralsMetricSubTriangle
 
-    real(kind=RKIND), dimension(:), allocatable :: &
+    real(kind=RKIND), dimension(nIntegrationPoints) :: &
          x, &
          y, &
          stressBasisFunction, &
@@ -1939,35 +1895,22 @@ contains
          velocityBasisDerivativeU, &
          velocityBasisDerivativeV
 
-    real(kind=RKIND) :: &
-         u, &
-         v
-
-    integer :: &
-         iIntegrationPoint
-
     real(kind=RKIND), dimension(2,2) :: &
          mapping
 
-    real(kind=RKIND), dimension(:), allocatable :: &
+    real(kind=RKIND), dimension(nEdgesOnCell) :: &
          jacobian
 
     integer :: &
+         iIntegrationPoint, &
          iSubTriangle, &
          i1, &
          i2
-
-    character(len=strKIND) :: filename
-
-    allocate(nEdgesOnCellSubset(nEdgesOnCell))
-    allocate(vertexIndexSubset(nEdgesOnCell,nEdgesOnCell))
 
     call wachspress_indexes(&
          nEdgesOnCell, &
          nEdgesOnCellSubset, &
          vertexIndexSubset)
-
-    allocate(jacobian(nEdgesOnCell))
 
     do iSubTriangle = 1, nEdgesOnCell
 
@@ -1982,22 +1925,15 @@ contains
             xLocal(i1), yLocal(i1), &
             xLocal(i2), yLocal(i2))
 
-       allocate(x(nIntegrationPoints))
-       allocate(y(nIntegrationPoints))
-
+       !in-lined use_triangle_mapping
        do iIntegrationPoint = 1, nIntegrationPoints
 
-          call use_triangle_mapping(&
-               x(iIntegrationPoint),            y(iIntegrationPoint), &
-               integrationU(iIntegrationPoint), integrationV(iIntegrationPoint), &
-               mapping)
+          x(iIntegrationPoint) = mapping(1,1) * integrationU(iIntegrationPoint) + &
+                                 mapping(1,2) * integrationV(iIntegrationPoint)
+          y(iIntegrationPoint) = mapping(2,1) * integrationU(iIntegrationPoint) + &
+                                 mapping(2,2) * integrationV(iIntegrationPoint)
 
        enddo ! iIntegrationPoint
-
-       allocate(stressBasisFunction(nIntegrationPoints))
-       allocate(velocityBasisFunction(nIntegrationPoints))
-       allocate(velocityBasisDerivativeU(nIntegrationPoints))
-       allocate(velocityBasisDerivativeV(nIntegrationPoints))
 
        call wachspress_basis_function(&
             nEdgesOnCell, iStressVertex, x, y, &
@@ -2024,22 +1960,21 @@ contains
 
        do iIntegrationPoint = 1, nIntegrationPoints
 
-          basisIntegralsUSubTriangle = basisIntegralsUSubTriangle + &
+          basisIntegralsSubTriangleTmp = &
                jacobian(iSubTriangle) * &
                integrationWeights(iIntegrationPoint) * &
-               stressBasisFunction(iIntegrationPoint) * &
+               stressBasisFunction(iIntegrationPoint)
+
+          basisIntegralsUSubTriangle = basisIntegralsUSubTriangle + &
+               basisIntegralsSubTriangleTmp * &
                velocityBasisDerivativeU(iIntegrationPoint)
 
           basisIntegralsVSubTriangle = basisIntegralsVSubTriangle + &
-               jacobian(iSubTriangle) * &
-               integrationWeights(iIntegrationPoint) * &
-               stressBasisFunction(iIntegrationPoint) * &
+               basisIntegralsSubTriangleTmp * &
                velocityBasisDerivativeV(iIntegrationPoint)
 
           basisIntegralsMetricSubTriangle = basisIntegralsMetricSubTriangle + &
-               jacobian(iSubTriangle) * &
-               integrationWeights(iIntegrationPoint) * &
-               stressBasisFunction(iIntegrationPoint) * &
+               basisIntegralsSubTriangleTmp * &
                velocityBasisFunction(iIntegrationPoint)
 
        enddo ! iIntegrationPoint
@@ -2048,20 +1983,7 @@ contains
        basisIntegralsV      = basisIntegralsV      + basisIntegralsVSubTriangle      / normalizationFactor
        basisIntegralsMetric = basisIntegralsMetric + basisIntegralsMetricSubTriangle / normalizationFactor
 
-       deallocate(stressBasisFunction)
-       deallocate(velocityBasisFunction)
-       deallocate(velocityBasisDerivativeU)
-       deallocate(velocityBasisDerivativeV)
-
-       deallocate(x)
-       deallocate(y)
-
     enddo ! iSubTriangle
-
-    deallocate(nEdgesOnCellSubset)
-    deallocate(vertexIndexSubset)
-
-    deallocate(jacobian)
 
   end subroutine integrate_wachspress_polygon!}}}
 


### PR DESCRIPTION
This adds a `seaice_mesh_pool` module that replicates seaice data onto GPUs. CPP preprocessor macros are defined to avoid `acc` and `omp` duplication.

Single Summit node, 42 MPI-rank, 2 GPU, 5-day runs with oEC60to30v3 mesh show 14% GPU speedup with PGI and 20% speedup with IBM. IBM is faster than PGI by 40% in both cpu-to-cpu and gpu-to-gpu runs.

[not bit-for-bit] - between CPU and GPU runs