### PR TITLE
Fix atmosphere mpas_timekeeping dependencies

### DIFF
--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -53,8 +53,8 @@ module soundings
         use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type, dm_info
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_get_dimension, mpas_pool_get_array, mpas_pool_get_config
         use mpas_io_units, only :  mpas_new_unit, mpas_release_unit
-        use mpas_timekeeping, only : MPAS_timeInterval_type, MPAS_time_type, MPAS_set_timeInterval, &
-                                     MPAS_get_clock_time, MPAS_add_clock_alarm, MPAS_NOW
+        use mpas_derived_types, only : MPAS_Time_type, MPAS_TimeInterval_type, MPAS_NOW
+        use mpas_timekeeping, only : MPAS_set_timeInterval, MPAS_get_clock_time, MPAS_add_clock_alarm
         use mpas_dmpar, only : IO_NODE, mpas_dmpar_bcast_int, mpas_dmpar_bcast_logical, mpas_dmpar_bcast_char
 
         implicit none
@@ -205,8 +205,8 @@ module soundings
 
         use mpas_derived_types, only : MPAS_pool_type
         use mpas_pool_routines, only : MPAS_pool_get_dimension, MPAS_pool_get_array
-        use mpas_timekeeping, only : MPAS_time_type, MPAS_is_alarm_ringing, MPAS_reset_clock_alarm, MPAS_get_clock_time, &
-                                     MPAS_get_time, MPAS_NOW
+        use mpas_derived_types, only : MPAS_Time_type, MPAS_NOW
+        use mpas_timekeeping, only : MPAS_is_alarm_ringing, MPAS_reset_clock_alarm, MPAS_get_clock_time, MPAS_get_time
         use mpas_constants, only : rvord
 
         implicit none

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -15,8 +15,8 @@ module atm_time_integration
    use mpas_dmpar
    use mpas_vector_reconstruction
    ! Added only clause to keep xlf90 from getting confused from the overloaded abs intrinsic in mpas_timekeeping
-   use mpas_timekeeping, only: MPAS_Time_type, MPAS_TimeInterval_type, &
-                               mpas_set_time, mpas_set_timeInterval, mpas_get_time, operator(+), add_t_ti
+   use mpas_derived_types, only : MPAS_Time_type, MPAS_TimeInterval_type, MPAS_NOW
+   use mpas_timekeeping, only: mpas_set_time, mpas_set_timeInterval, mpas_get_time, operator(+)
    use mpas_timer
 
 #ifdef DO_PHYSICS


### PR DESCRIPTION
In preparation for some changes to the mpas_timekeeping module, this merge cleans up use statements in the atmosphere core that wrongly included mpas_timekeeping_types from the mpas_timekeeping module and not the mpas_derived_types module.