### PR TITLE
Add support for custom critical passages and land blockages

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/scripts/cull_mesh.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/cull_mesh.py
@@ -37,11 +37,19 @@ from mpas_tools.viz.paraview_extractor import extract_vtk
 
 
 parser = OptionParser()
-parser.add_option("--with_cavities", action="store_true", dest="with_cavities")
+parser.add_option("--with_cavities", action="store_true", dest="with_cavities",
+                  help="Whether the mesh should include Antarctic ice-shelf"
+                       " cavities")
 parser.add_option("--with_critical_passages", action="store_true",
-                  dest="with_critical_passages")
+                  dest="with_critical_passages",
+                  help="Whether the mesh should open the standard critical "
+                       "passages and close land blockages from "
+                       "geometric_features")
 parser.add_option("--preserve_floodplain", action="store_true",
-                  dest="preserve_floodplain", default=False)
+                  dest="preserve_floodplain", default=False,
+                  help="Whether to to use the cullCells field in the base "
+                       "mesh to preserve a floodplain at elevations above z=0")
+parse
 options, args = parser.parse_args()
 
 # required for compatibility with MPAS

--- a/testing_and_setup/compass/ocean/global_ocean/scripts/cull_mesh.py
+++ b/testing_and_setup/compass/ocean/global_ocean/scripts/cull_mesh.py
@@ -45,17 +45,21 @@ parser.add_option("--with_critical_passages", action="store_true",
                   help="Whether the mesh should open the standard critical "
                        "passages and close land blockages from "
                        "geometric_features")
-parser.add_option("--custom_critical_passages", dest="custom_critical_passages",
-                  help="A geojson file with critical passages to open.  This "
-                       "file may be supplied in addition to or instead of "
-                       "the default passages (--with_critical_passages)")
-parser.add_option("--custom_land_blockages", dest="custom_land_blockages",
-                  help="A geojson file with critical land blockages to close. "
-                       "This file may be supplied in addition to or instead of "
-                       "the default blockages (--with_critical_passages)")
+parser.add_option(
+    "--custom_critical_passages",
+    dest="custom_critical_passages",
+    help="A geojson file with critical passages to open.  This "
+    "file may be supplied in addition to or instead of "
+    "the default passages (--with_critical_passages)")
+parser.add_option(
+    "--custom_land_blockages",
+    dest="custom_land_blockages",
+    help="A geojson file with critical land blockages to close. "
+    "This file may be supplied in addition to or instead of "
+    "the default blockages (--with_critical_passages)")
 parser.add_option("--preserve_floodplain", action="store_true",
                   dest="preserve_floodplain", default=False,
-                  help="Whether to to use the cellSeedMask field in the base "
+                  help="Whether to use the cellSeedMask field in the base "
                        "mesh to preserve a floodplain at elevations above z=0")
 options, args = parser.parse_args()
 


### PR DESCRIPTION
This is added to support potential addition of "custom" passages or blockages in #555 and #584.  The custom transects could come from a local file or it could be pulled in from `geometric_features`, e.g. with the `merge_features` command.