### PR TITLE
Fixes bugs in tracer_advection_std

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -150,7 +150,7 @@ module ocn_tracer_advection
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
             nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
-            layerThickness, dt, meshPool, scratchPool, tend, maxLevelCell, maxLevelEdgeTop, &
+            layerThickness, dt, meshPool, tend, maxLevelCell, maxLevelEdgeTop, &
             highOrderAdvectionMask, edgeSignOnCell)
       endif
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -65,7 +65,7 @@ module ocn_tracer_advection_std
 !-----------------------------------------------------------------------
    subroutine ocn_tracer_advection_std_tend(tracers, adv_coefs, adv_coefs_3rd, nAdvCellsForEdge, advCellsForEdge, &!{{{
                                              normalThicknessFlux, w, layerThickness, verticalCellSize, dt, meshPool, &
-                                             scratchPool, tend, maxLevelCell, maxLevelEdgeTop, &
+                                             tend, maxLevelCell, maxLevelEdgeTop, &
                                              highOrderAdvectionMask, edgeSignOnCell)
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input: current tracer values
@@ -79,7 +79,6 @@ module ocn_tracer_advection_std
       real (kind=RKIND), dimension(:,:), intent(in) :: verticalCellSize !< Input: Distance between vertical interfaces of a cell
       real (kind=RKIND), intent(in) :: dt !< Input: Timestep
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch fields
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: tend !< Input/Output: Tracer tendency
       integer, dimension(:), pointer :: maxLevelCell !< Input: Index to max level at cell center
       integer, dimension(:), pointer :: maxLevelEdgeTop !< Input: Index to max level at edge with non-land cells on both sides
@@ -95,9 +94,7 @@ module ocn_tracer_advection_std
       real (kind=RKIND) :: tracer_weight, invAreaCell1
       real (kind=RKIND) :: verticalWeightK, verticalWeightKm1
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell, verticalDivergenceFactor
-      real (kind=RKIND), dimension(:,:), pointer :: tracer_cur, high_order_horiz_flux, high_order_vert_flux
-
-      type (field2DReal), pointer :: highOrderHorizFluxField, tracerCurField, highOrderVertFluxField
+      real (kind=RKIND), dimension(:,:), allocatable :: tracer_cur, high_order_horiz_flux, high_order_vert_flux
 
       real (kind=RKIND), parameter :: eps = 1.e-10_RKIND
 
@@ -120,18 +117,11 @@ module ocn_tracer_advection_std
       allocate(verticalDivergenceFactor(nVertLevels))
       verticalDivergenceFactor = 1.0_RKIND
 
-      call mpas_pool_get_field(scratchPool, 'highOrderHorizFlux', highOrderHorizFluxField)
-      call mpas_pool_get_field(scratchPool, 'tracerValue', tracerCurField, 1)
-      call mpas_pool_get_field(scratchPool, 'highOrderVertFlux', highOrderVertFluxField)
+      allocate(high_order_horiz_flux(nVertLevels,nEdges))
+      allocate(tracer_cur(nVertLevels,nCells+1))
+      allocate(high_order_vert_flux(nVertLevels+1,nCells))
 
-      call mpas_allocate_scratch_field(highOrderHorizFluxField, .true.)
-      call mpas_allocate_scratch_field(tracerCurField, .true.)
-      call mpas_allocate_scratch_field(highOrderVertFluxField, .true.)
       call mpas_threading_barrier()
-
-      high_order_horiz_flux => highOrderHorizFluxField % array
-      tracer_cur => tracerCurField % array
-      high_order_vert_flux => highOrderVertFluxField % array
 
       ! Loop over tracers. One tracer is advected at a time. It is copied into a temporary array in order to improve locality
       do iTracer = 1, num_tracers
@@ -236,10 +226,8 @@ module ocn_tracer_advection_std
       end do ! iTracer loop
 
       call mpas_threading_barrier()
-      call mpas_deallocate_scratch_field(highOrderHorizFluxField, .true.)
-      call mpas_deallocate_scratch_field(tracerCurField, .true.)
-      call mpas_deallocate_scratch_field(highOrderVertFluxField, .true.)
 
+      deallocate(tracer_cur, high_order_horiz_flux, high_order_vert_flux)
       deallocate(verticalDivergenceFactor)
 
    end subroutine ocn_tracer_advection_std_tend!}}}


### PR DESCRIPTION
Currently there are calls in tracer_advection_std to scratch pool arrays
that have been removed from registry.  This commit makes std advection
functional again.

