### PR TITLE
Set SHELL explicitly in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 MODEL_FORMULATION = 
 
+ifneq "${MPAS_SHELL}" ""
+        SHELL = ${MPAS_SHELL}
+endif
+
 
 dummy:
 	( $(MAKE) error )


### PR DESCRIPTION
This merge allows the shell used by Make to be set with the `$MPAS_SHELL` environment variable.

Without this fix or if not using `MPAS_SHELL=/bin/bash`, `make` will use `/bin/sh`, which points to `dash` (not `bash`) under Ubuntu.  This results in the following cryptic but non-fatal error message early in the build when `USE_PIO2=true`:
```
Checking for a usable PIO library...
=> PIO 1 detected
x86_64-conda_cos6-linux-gnu-gfortran.bin: error: pio1.f90: No such file or directory
x86_64-conda_cos6-linux-gnu-gfortran.bin: error: pio2.f90: No such file or directory
```
But the build goes on to complete successfully using PIO2.