### PR TITLE
fixed bad array sizes in local ocean arrays

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -459,15 +459,15 @@ contains
                                   boundaryCellTmp)
 
          allocate ( &
-            edgeMask(nVertLevels, nEdgesAll), &
-            cellMask(nVertLevels, nCellsAll), &
-            vertexMask(nVertLevels, nVerticesAll), &
-            boundaryEdge(nVertLevels, nEdgesAll), &
-            boundaryCell(nVertLevels, nCellsAll), &
-            boundaryVertex(nVertLevels, nVerticesAll), &
-            edgeSignOnCell(maxEdges, nCellsAll), &
-            edgeSignOnVertex(maxEdges, nVerticesAll), &
-            highOrderAdvectionMask(nVertLevels, nEdgesAll))
+            edgeMask(nVertLevels, nEdgesAll+1), &
+            cellMask(nVertLevels, nCellsAll+1), &
+            vertexMask(nVertLevels, nVerticesAll+1), &
+            boundaryEdge(nVertLevels, nEdgesAll+1), &
+            boundaryCell(nVertLevels, nCellsAll+1), &
+            boundaryVertex(nVertLevels, nVerticesAll+1), &
+            edgeSignOnCell(maxEdges, nCellsAll+1), &
+            edgeSignOnVertex(maxEdges, nVerticesAll+1), &
+            highOrderAdvectionMask(nVertLevels, nEdgesAll+1))
 
          do n = 1, nCellsAll
          do k = 1, nVertLevels

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -1045,20 +1045,20 @@ contains
       call mpas_pool_get_array(meshPool, 'boundaryCell', &
                                boundaryCellTmp)
 
-      do n = 1, nCellsAll
+      do n = 1, nCellsAll+1
       do k = 1, nVertLevels
          cellMask(k, n) = real(cellMaskTmp(k, n), RKIND)
          boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
       end do
       end do
 
-      do n = 1, nCellsAll
+      do n = 1, nCellsAll+1
       do k = 1, maxEdges
          edgeSignOnCell(k, n) = real(edgeSignOnCellTmp(k, n), RKIND)
       end do
       end do
 
-      do n = 1, nEdgesAll
+      do n = 1, nEdgesAll+1
       do k = 1, nVertLevels
          edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
          boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
@@ -1067,14 +1067,14 @@ contains
       end do
       end do
 
-      do n = 1, nVerticesAll
+      do n = 1, nVerticesAll+1
       do k = 1, nVertLevels
          vertexMask(k, n) = real(vertexMaskTmp(k, n), RKIND)
          boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
       end do
       end do
 
-      do n = 1, nVerticesAll
+      do n = 1, nVerticesAll+1
       do k = 1, vertexDegree
          edgeSignOnVertex(k, n) = &
             real(edgeSignOnVertexTmp(k, n), RKIND)

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -469,20 +469,20 @@ contains
             edgeSignOnVertex(maxEdges, nVerticesAll+1), &
             highOrderAdvectionMask(nVertLevels, nEdgesAll+1))
 
-         do n = 1, nCellsAll
+         do n = 1, nCellsAll+1
          do k = 1, nVertLevels
             cellMask(k, n) = real(cellMaskTmp(k, n), RKIND)
             boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
          end do
          end do
 
-         do n = 1, nCellsAll
+         do n = 1, nCellsAll+1
          do k = 1, maxEdges
             edgeSignOnCell(k, n) = real(edgeSignOnCellTmp(k, n), RKIND)
          end do
          end do
 
-         do n = 1, nEdgesAll
+         do n = 1, nEdgesAll+1
          do k = 1, nVertLevels
             edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
             boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
@@ -491,14 +491,14 @@ contains
          end do
          end do
 
-         do n = 1, nVerticesAll
+         do n = 1, nVerticesAll+1
          do k = 1, nVertLevels
             vertexMask(k, n) = real(vertexMaskTmp(k, n), RKIND)
             boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
          end do
          end do
 
-         do n = 1, nVerticesAll
+         do n = 1, nVerticesAll+1
          do k = 1, vertexDegree
             edgeSignOnVertex(k, n) = real(edgeSignOnVertexTmp(k, n), RKIND)
          end do

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -231,17 +231,17 @@ module ocn_tracer_advection_mono
 
       ! allocate temporary arrays
       !$omp master
-      allocate(tracerCur   (nVertLevels  ,nCells), &
+      allocate(tracerCur   (nVertLevels  ,nCells+1), &
                tracerMin   (nVertLevels  ,nCells), &
                tracerMax   (nVertLevels  ,nCells), &
                hNewInv     (nVertLevels  ,nCells), &
                hProv       (nVertLevels  ,nCells), &
                hProvInv    (nVertLevels  ,nCells), &
-               flxIn       (nVertLevels  ,nCells), &
-               flxOut      (nVertLevels  ,nCells), &
-               workTend    (nVertLevels  ,nCells), &
-               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)), &
-               highOrderFlx(nVertLevels+1,max(nCells,nEdges)))
+               flxIn       (nVertLevels  ,nCells+1), &
+               flxOut      (nVertLevels  ,nCells+1), &
+               workTend    (nVertLevels  ,nCells+1), &
+               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
+               highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
       !$omp end master
       !$omp barrier
 
@@ -291,7 +291,7 @@ module ocn_tracer_advection_mono
 
         ! Extract current tracer and change index order to improve locality
         !$omp do schedule(runtime)
-        do iCell = 1, nCells
+        do iCell = 1, nCells+1
         do k=1, nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do ! k loop
@@ -390,12 +390,11 @@ module ocn_tracer_advection_mono
         call mpas_timer_stop('horiz flux')
         call mpas_timer_start('scale factor build')
 #endif
-        ! Need one halo of cells around owned cells
-        nCells = nCellsArray( 2 )
+        ! Initialize flux arrays for all cells
+        nCells = nCellsArray(size(nCellsArray))
 
-        ! Initialize flux arrays
         !$omp do schedule(runtime)
-        do iCell = 1, nCells
+        do iCell = 1, nCells+1
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
            flxIn   (k, iCell) = 0.0_RKIND
@@ -403,6 +402,9 @@ module ocn_tracer_advection_mono
         end do ! k loop
         end do ! iCell loop
         !$omp end do
+
+        ! Need one halo of cells around owned cells
+        nCells = nCellsArray( 2 )
 
         !$omp do schedule(runtime)
         do iCell = 1, nCells


### PR DESCRIPTION
Two ocean modules had local arrays that were not properly sized to accommodate the practice of using nCellsAll+1 (Edges, Vertices) as a location to represent non-existent cells, edges, vertices. This would result in out-of-bounds references. This fix just extends the dimension by one for the arrays that will potentially be  referenced in this way.

Fixes #597 

[b4b] in QU240 test on Summit - meaning out of bounds refs so far had fortunately no impact
