### PR TITLE
Add reference cell width to del2 and del4 scaling

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -204,7 +204,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_hmix_ref_cell_width" type="real" default_value="30.0e3" units="m"
-					description="Reference cell width. If config_hmix_use_ref_cell_width = .true., then hmix coefficients are set to be (for example) nu_2 = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width) where cellWidth is the effective cell width computed as 2*sqrt(areaCell/pi)"
+					description="Reference cell width. If config_hmix_use_ref_cell_width = .true., then hmix coefficients are set to be nu_{2h} = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width) and nu_{4h} = config_mom_del4*(cellWidth / config_hmix_use_ref_cell_width)^3 where cellWidth is the effective cell width computed as 2*sqrt(areaCell/pi). See Hoch et al 2020 JAMES eq 1,2. This relation applies within a simulation, but also generally among multiple simulations, so the parameters config_mom_del2, config_mom_del4, and config_hmix_use_ref_cell_width can generally remain at their standard values, and just be adjusted for fine tuning."
 					possible_values="Any positive real number, but typically a resolution number such as 30km."
 		/>
 		<nml_option name="config_apvm_scale_factor" type="real" default_value="0.0" units="unitless"
@@ -213,12 +213,12 @@
 		/>
 	</nml_record>
 	<nml_record name="hmix_del2" mode="forward">
-		<nml_option name="config_use_mom_del2" type="logical" default_value=".true." units="unitless"
+		<nml_option name="config_use_mom_del2" type="logical" default_value=".false." units="unitless"
 					description="If true, Laplacian horizontal mixing is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_mom_del2" type="real" default_value="1.0e3" units="m^2 s^{-1}"
-					description="Horizonal viscosity, $\nu_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
+					description="Horizontal viscosity, $\nu_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 		<nml_option name="config_use_tracer_del2" type="logical" default_value=".false." units="unitless"
@@ -226,12 +226,12 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_tracer_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
-					description="Horizonal diffusion, $\kappa_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
+					description="Horizontal diffusion, $\kappa_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 	</nml_record>
 	<nml_record name="hmix_del4" mode="forward">
-		<nml_option name="config_use_mom_del4" type="logical" default_value=".true." units="unitless"
+		<nml_option name="config_use_mom_del4" type="logical" default_value=".false." units="unitless"
 					description="If true, biharmonic horizontal mixing is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
@@ -1060,7 +1060,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_highFreqThick_del2" type="real" default_value="100.0" units="m^2 s^{-1}"
-					description="Horizonal high frequency thickness diffusion, $\kappa_{hhf}$."
+					description="Horizontal high frequency thickness diffusion, $\kappa_{hhf}$."
 					possible_values="any positive real"
 		/>
 	</nml_record>
@@ -1840,7 +1840,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var name="normalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
-			 description="horizonal velocity, normal component to an edge"
+			 description="horizontal velocity, normal component to an edge"
 		/>
 		<var name="layerThickness" type="real" dimensions="nVertLevels nCells Time" units="m"
 			 description="layer thickness"
@@ -2367,7 +2367,7 @@
 		/>
 
 		<var name="kineticEnergyCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-2}"
-			 description="kinetic energy of horizonal velocity on cells"
+			 description="kinetic energy of horizontal velocity on cells"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="viscosity" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-1}"
@@ -2375,7 +2375,7 @@
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="divergence" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
-			 description="divergence of horizonal velocity"
+			 description="divergence of horizontal velocity"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="circulation" type="real" dimensions="nVertLevels nVertices Time" units="m^2 s^{-1}"
@@ -3153,12 +3153,12 @@
 		<var name="kineticEnergyVertex"
 			persistence="scratch"
 			type="real" dimensions="nVertLevels nVertices Time" units="m^2 s^{-2}"
-			description="kinetic energy of horizonal velocity defined at vertices"
+			description="kinetic energy of horizontal velocity defined at vertices"
 		/>
 		<var name="kineticEnergyVertexOnCells"
 			persistence="scratch"
 			type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-2}"
-			description="kinetic energy of horizonal velocity defined at vertices"
+			description="kinetic energy of horizontal velocity defined at vertices"
 		/>
 		<var name="densitySurfaceDisplaced"
 			persistence="scratch"
@@ -3180,12 +3180,12 @@
 		<var name="normalVelocityTest"
 			 persistence="scratch"
 			 type="real" dimensions="nVertLevels nEdges" units="m s^{-1}"
-			 description="horizonal velocity, normal component to an edge, for testing"
+			 description="horizontal velocity, normal component to an edge, for testing"
 		/>
 		<var name="tangentialVelocityTest"
 			 persistence="scratch"
 			 type="real" dimensions="nVertLevels nEdges" units="m s^{-1}"
-			 description="horizonal velocity, tangential component to an edge, for testing"
+			 description="horizontal velocity, tangential component to an edge, for testing"
 		/>
 		<var name="strainRateR3Cell"
 			 persistence="scratch"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1972,9 +1972,6 @@
 		<var name="meshScalingDel4" type="real" dimensions="nEdges" units="unitless"
 			 description="Coefficient to biharmonic mixing terms in momentum and tracer equations, so that biharmonic viscosity and diffusion coefficients scale with mesh."
 		/>
-		<var name="meshScaling" type="real" dimensions="nEdges" units="unitless"
-			 description="Coefficient used for mesh scaling, such as the Leith parameter."
-		/>
 		<var name="cellsOnEdge" type="integer" dimensions="TWO nEdges" units="unitless"
 			 description="List of cells that straddle each edge."
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -213,39 +213,39 @@
 		/>
 	</nml_record>
 	<nml_record name="hmix_del2" mode="forward">
-		<nml_option name="config_use_mom_del2" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_use_mom_del2" type="logical" default_value=".true." units="unitless"
 					description="If true, Laplacian horizontal mixing is used on the momentum equation."
 					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_mom_del2" type="real" default_value="1.0e3" units="m^2 s^{-1}"
+					description="Horizonal viscosity, $\nu_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
+					possible_values="any positive real"
 		/>
 		<nml_option name="config_use_tracer_del2" type="logical" default_value=".false." units="unitless"
 					description="If true, Laplacian horizontal mixing is used on the tracer equation."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_mom_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
-					description="Horizonal viscosity, $\nu_h$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
-					possible_values="any positive real"
-		/>
 		<nml_option name="config_tracer_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
-					description="Horizonal diffusion, $\kappa_h$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
+					description="Horizonal diffusion, $\kappa_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 	</nml_record>
 	<nml_record name="hmix_del4" mode="forward">
-		<nml_option name="config_use_mom_del4" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_use_mom_del4" type="logical" default_value=".true." units="unitless"
 					description="If true, biharmonic horizontal mixing is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_use_tracer_del4" type="logical" default_value=".false." units="unitless"
-					description="If true, biharmonic horizontal mixing is used on the tracer equation."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_mom_del4" type="real" default_value="5.0e13" units="m^4 s^{-1}"
+		<nml_option name="config_mom_del4" type="real" default_value="1.2e11" units="m^4 s^{-1}"
 					description="Coefficient for horizontal biharmonic operator on momentum.  If config_hmix_use_ref_cell_width = .true. then $\nu_{4h}$ = config_mom_del4*(cellWidth / config_hmix_use_ref_cell_width)^3. If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 		<nml_option name="config_mom_del4_div_factor" type="real" default_value="1.0" units="non-dimensional"
 					description="The divergence portion of the del4 operator is scaled by this factor."
 					possible_values="any positive real"
+		/>
+		<nml_option name="config_use_tracer_del4" type="logical" default_value=".false." units="unitless"
+					description="If true, biharmonic horizontal mixing is used on the tracer equation."
+					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_tracer_del4" type="real" default_value="0.0" units="m^4 s^{-1}"
 					description="Coefficient for horizontal biharmonic operator on tracers.  If config_hmix_use_ref_cell_width = .true. then $\nu_{4h}$ = config_tracer_del4*(cellWidth / config_hmix_use_ref_cell_width)^3. If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -199,6 +199,14 @@
 					description="Global maximum of the mesh density"
 					possible_values="Any positive real number. If set any negative real number, config_maxMeshDensity is computed during the initialization of each simulation."
 		/>
+		<nml_option name="config_hmix_use_ref_cell_width" type="logical" default_value=".false." units="unitless"
+					description="If true, hmix coefficient values are set with reference to config_hmix_ref_cell_width. If false, hmix coefficient values are referenced to smallest gridcell in the mesh. The false setting is for backwards compatilibity. When false, hmix coefficient flags must be adjusted for every new mesh with a different minimum-sized cell."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_hmix_ref_cell_width" type="real" default_value="30.0e3" units="m"
+					description="Reference cell width. If config_hmix_use_ref_cell_width = .true., then hmix coefficients are set to be (for example) nu_2 = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width) where cellWidth is the effective cell width computed as 2*sqrt(areaCell/pi)"
+					possible_values="Any positive real number, but typically a resolution number such as 30km."
+		/>
 		<nml_option name="config_apvm_scale_factor" type="real" default_value="0.0" units="unitless"
 					description="Anticipated potential vorticity (APV) method scale factor, $c_{apv}$. When zero, APV is off."
 					possible_values="Any non-negative number, typically between zero and one."
@@ -214,11 +222,11 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_mom_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
-					description="Horizonal viscosity, $\nu_h$."
+					description="Horizonal viscosity, $\nu_h$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 		<nml_option name="config_tracer_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
-					description="Horizonal diffusion, $\kappa_h$."
+					description="Horizonal diffusion, $\kappa_h$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 	</nml_record>
@@ -232,7 +240,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_mom_del4" type="real" default_value="5.0e13" units="m^4 s^{-1}"
-					description="Coefficient for horizontal biharmonic operator on momentum."
+					description="Coefficient for horizontal biharmonic operator on momentum.  If config_hmix_use_ref_cell_width = .true. then $\nu_{4h}$ = config_mom_del4*(cellWidth / config_hmix_use_ref_cell_width)^3. If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 		<nml_option name="config_mom_del4_div_factor" type="real" default_value="1.0" units="non-dimensional"
@@ -240,7 +248,7 @@
 					possible_values="any positive real"
 		/>
 		<nml_option name="config_tracer_del4" type="real" default_value="0.0" units="m^4 s^{-1}"
-					description="Coefficient for horizontal biharmonic operator on tracers."
+					description="Coefficient for horizontal biharmonic operator on tracers.  If config_hmix_use_ref_cell_width = .true. then $\nu_{4h}$ = config_tracer_del4*(cellWidth / config_hmix_use_ref_cell_width)^3. If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
 		/>
 	</nml_record>

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -347,6 +347,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       if (config_hmix_scaleWithMesh) then
          if (config_hmix_use_ref_cell_width) then
             ! Mesh scaling is set by areaCell and config_hmix_ref_cell_width
+            ! See description of config_hmix_ref_cell_width in Registry.xml for
+            ! more detail.
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -319,42 +319,62 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 !>  This routine initializes meshScalingDel2 and meshScalingDel4
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_init_routines_compute_mesh_scaling(meshPool, scaleHmixWithMesh, maxMeshDensity)!{{{
+   subroutine ocn_init_routines_compute_mesh_scaling(meshPool, & !{{{
+                 config_hmix_scaleWithMesh, config_maxMeshDensity, &
+                 config_hmix_use_ref_cell_width, config_hmix_ref_cell_width)
 
       type (mpas_pool_type), intent(inout) :: meshPool
-      logical, intent(in) :: scaleHmixWithMesh
-      real (kind=RKIND), intent(in) :: maxMeshDensity
+      logical, intent(in) :: config_hmix_scaleWithMesh
+      real (kind=RKIND), intent(in) :: config_maxMeshDensity
+      logical, intent(in) :: config_hmix_use_ref_cell_width
+      real (kind=RKIND), intent(in) :: config_hmix_ref_cell_width
 
       integer :: iEdge, cell1, cell2
       integer, pointer :: nEdges
       integer, dimension(:,:), pointer :: cellsOnEdge
+      real (kind=RKIND) :: cellWidth
       real (kind=RKIND), dimension(:), pointer :: meshDensity, meshScalingDel2, meshScalingDel4, meshScaling
+      real (kind=RKIND), dimension(:), pointer :: areaCell
 
       call mpas_pool_get_array(meshPool, 'meshDensity', meshDensity)
       call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
       call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !
-      ! Compute the scaling factors to be used in the del2 and del4 dissipation
-      !
-      ! Typical use cases have the minval(meshScaling)==1.
-      ! meshScaling values of approximately 1 indicate the highest resolution of the domain.
-
-      meshScalingDel2(:) = 1.0_RKIND
-      meshScalingDel4(:) = 1.0_RKIND
-
-      if (scaleHmixWithMesh) then
-         do iEdge = 1, nEdges
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-            meshScalingDel2(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                   / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
-            meshScalingDel4(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                   / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
-         end do
+      if (config_hmix_scaleWithMesh) then
+         if (config_hmix_use_ref_cell_width) then
+            ! Mesh scaling is set by areaCell and config_hmix_ref_cell_width
+            do iEdge = 1, nEdges
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               ! Effective cell width at edge iEdge, assuming neighboring cells
+               ! are circles for this calculation.
+               cellWidth = 2.0_RKIND * sqrt((areaCell(cell1) + areaCell(cell2) ) / 2.0_RKIND / pii)
+               meshScalingDel2(iEdge) = cellWidth / config_hmix_ref_cell_width
+               meshScalingDel4(iEdge) = ( cellWidth / config_hmix_ref_cell_width )**3
+            end do
+         else
+            ! Mesh scaling is set by meshDensity. This is both confusing and
+            ! inconvenient, as the flags like config_mom_del2 need to be reset
+            ! for every resolution. It is kept for backwards compatibility, but
+            ! should become defunct.
+            do iEdge = 1, nEdges
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               meshScalingDel2(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
+                                      / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
+               meshScalingDel4(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
+                                      / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
+            end do
+         end if
+      else
+         ! If config_hmix_scaleWithMesh is false, hmix coefficients do not vary with
+         ! cell size but remain constant across the domain.
+         meshScalingDel2(:) = 1.0_RKIND
+         meshScalingDel4(:) = 1.0_RKIND
       end if
 
    end subroutine ocn_init_routines_compute_mesh_scaling!}}}
@@ -567,7 +587,9 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       logical, pointer :: config_hmix_scaleWithMesh, config_do_restart
       logical, pointer :: config_use_GM
       logical, pointer :: config_use_Redi
+      logical, pointer :: config_hmix_use_ref_cell_width
       real (kind=RKIND), pointer :: config_maxMeshDensity
+      real (kind=RKIND), pointer :: config_hmix_ref_cell_width
 
       type (mpas_pool_iterator_type) :: groupItr
 
@@ -614,6 +636,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_config(block % configs, 'config_horiz_tracer_adv_order', config_horiz_tracer_adv_order)
       call mpas_pool_get_config(block % configs, 'config_hmix_scaleWithMesh', config_hmix_scaleWithMesh)
       call mpas_pool_get_config(block % configs, 'config_maxMeshDensity', config_maxMeshDensity)
+      call mpas_pool_get_config(block % configs, 'config_hmix_use_ref_cell_width', config_hmix_use_ref_cell_width)
+      call mpas_pool_get_config(block % configs, 'config_hmix_ref_cell_width', config_hmix_ref_cell_width)
       call mpas_pool_get_config(block % configs, 'config_use_GM', config_use_GM)
       call mpas_pool_get_config(block % configs, 'config_use_Redi', config_use_Redi)
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
@@ -671,7 +695,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       ! End: Accumulating various parametrizations of the transport velocity
       ! ------------------------------------------------------------------
 
-      call ocn_init_routines_compute_mesh_scaling(meshPool, config_hmix_scaleWithMesh, config_maxMeshDensity)
+      call ocn_init_routines_compute_mesh_scaling(meshPool, config_hmix_scaleWithMesh, config_maxMeshDensity, &
+              config_hmix_use_ref_cell_width, config_hmix_ref_cell_width)
 
       call mpas_rbf_interp_initialize(meshPool)
       call mpas_initialize_tangent_vectors(meshPool, edgeTangentVectors)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -316,8 +316,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 !> \author Doug Jacobsen, Mark Petersen, Todd Ringler
 !> \date   September 2011
 !> \details
-!>  This routine initializes meshScaling, meshScalingDel2, and
-!>   meshScalingDel4
+!>  This routine initializes meshScalingDel2 and meshScalingDel4
 !
 !-----------------------------------------------------------------------
    subroutine ocn_init_routines_compute_mesh_scaling(meshPool, scaleHmixWithMesh, maxMeshDensity)!{{{
@@ -334,7 +333,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_array(meshPool, 'meshDensity', meshDensity)
       call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
       call mpas_pool_get_array(meshPool, 'meshScalingDel4', meshScalingDel4)
-      call mpas_pool_get_array(meshPool, 'meshScaling', meshScaling)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -347,7 +345,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
       meshScalingDel2(:) = 1.0_RKIND
       meshScalingDel4(:) = 1.0_RKIND
-      meshScaling(:)     = 1.0_RKIND
 
       if (scaleHmixWithMesh) then
          do iEdge = 1, nEdges
@@ -357,8 +354,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
                                    / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
             meshScalingDel4(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
                                    / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
-            meshScaling(iEdge)     = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                   / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)
          end do
       end if
 

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -113,7 +113,6 @@ module ocn_mesh
       vertCoordMovementWeights, &! weights for distributing height perturb
       meshScalingDel2, &! mesh scaling factor for use in del2 diffusion
       meshScalingDel4, &! mesh scaling factor for use in del4 diffusion
-      meshScaling, &! general scaling of mesh size
       meshDensity, &! density of mesh
       angleEdge        ! angle the edge normal makes with local east
 
@@ -408,8 +407,6 @@ contains
                                   meshScalingDel2)
          call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
                                   meshScalingDel4)
-         call mpas_pool_get_array(meshPool, 'meshScaling', &
-                                  meshScaling)
          call mpas_pool_get_array(meshPool, 'meshDensity', &
                                   meshDensity)
          call mpas_pool_get_array(meshPool, 'angleEdge', &
@@ -571,7 +568,6 @@ contains
          !$acc                   vertCoordMovementWeights, &
          !$acc                   meshScalingDel2,          &
          !$acc                   meshScalingDel4,          &
-         !$acc                   meshScaling,              &
          !$acc                   meshDensity,              &
          !$acc                   angleEdge,                &
          !$acc                   edgeMask,                 &
@@ -709,7 +705,6 @@ contains
       !$acc                  vertCoordMovementWeights, &
       !$acc                  meshScalingDel2,   &
       !$acc                  meshScalingDel4,   &
-      !$acc                  meshScaling,       &
       !$acc                  meshDensity,       &
       !$acc                  angleEdge,         &
       !$acc                  edgeMask,          &
@@ -799,7 +794,6 @@ contains
                vertCoordMovementWeights, &
                meshScalingDel2, &
                meshScalingDel4, &
-               meshScaling, &
                meshDensity, &
                angleEdge, &
                weightsOnEdge, &
@@ -995,8 +989,6 @@ contains
       !                                    meshScalingDel2)
       !call mpas_pool_get_array(meshPool, 'meshScalingDel4',   &
       !                                    meshScalingDel4)
-      !call mpas_pool_get_array(meshPool, 'meshScaling',       &
-      !                                    meshScaling)
       !call mpas_pool_get_array(meshPool, 'meshDensity',       &
       !                                    meshDensity)
       !call mpas_pool_get_array(meshPool, 'angleEdge',         &
@@ -1149,7 +1141,6 @@ contains
       !$acc               vertCoordMovementWeights, &
       !$acc               meshScalingDel2,          &
       !$acc               meshScalingDel4,          &
-      !$acc               meshScaling,              &
       !$acc               meshDensity,              &
       !$acc               angleEdge,                &
       !$acc               edgeMask,                 &

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
@@ -130,7 +130,7 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge, verticesOnEdge, edgeMask
 
       real (kind=RKIND) :: u_diffusion, invLength_dc, invLength_dv, visc2
-      real (kind=RKIND), dimension(:), pointer :: meshScaling, &
+      real (kind=RKIND), dimension(:), pointer :: meshScalingDel2, &
               dcEdge, dvEdge
 
       real (kind=RKIND), pointer :: config_leith_parameter, config_leith_dx, config_leith_visc2_max
@@ -156,7 +156,7 @@ contains
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'meshScaling', meshScaling)
+      call mpas_pool_get_array(meshPool, 'meshScalingDel2', meshScalingDel2)
       call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -185,7 +185,7 @@ contains
             ! Here the first line is (\delta x)^3
             ! the second line is |\nabla \omega|
             ! and u_diffusion is \nabla^2 u (see formula for $\bf{D}$ above).
-            visc2 = ( config_leith_parameter * config_leith_dx * meshScaling(iEdge) / pii)**3 &
+            visc2 = ( config_leith_parameter * config_leith_dx * meshScalingDel2(iEdge) / pii)**3 &
                      * abs( relativeVorticity(k,vertex2) - relativeVorticity(k,vertex1) ) * invLength_dc * sqrt(3.0_RKIND)
             visc2 = min(visc2, config_leith_visc2_max)
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/template_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/template_forward.xml
@@ -3,8 +3,8 @@
 		<option name="config_dt">'02:00:00'</option>
 		<option name="config_btr_dt">'00:06:00'</option>
 		<option name="config_run_duration">'0000_06:00:00'</option>
+		<option name="config_hmix_use_ref_cell_width">.true.</option>
 		<option name="config_write_output_on_startup">.false.</option>
-		<option name="config_mom_del4">2.0e14</option>
 		<option name="config_use_debugTracers">.true.</option>
 	</namelist>
 </template>

--- a/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
@@ -3,8 +3,6 @@
 		<option name="config_ocean_run_mode">'forward'</option>
 		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
 		<option name="config_time_integrator">'split_explicit'</option>
-		<option name="config_use_mom_del2">.true.</option>
-		<option name="config_use_mom_del4">.true.</option>
 		<option name="config_use_cvmix">.true.</option>
 		<option name="config_use_cvmix_background">.true.</option>
 		<option name="config_use_cvmix_convection">.true.</option>

--- a/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/template_forward.xml
@@ -3,6 +3,8 @@
 		<option name="config_ocean_run_mode">'forward'</option>
 		<option name="config_block_decomp_file_prefix">'graph.info.part.'</option>
 		<option name="config_time_integrator">'split_explicit'</option>
+		<option name="config_use_mom_del2">.true.</option>
+		<option name="config_use_mom_del4">.true.</option>
 		<option name="config_use_cvmix">.true.</option>
 		<option name="config_use_cvmix_background">.true.</option>
 		<option name="config_use_cvmix_convection">.true.</option>


### PR DESCRIPTION
Currently, the values of horizontal viscosity and tracer diffusion are referenced to the smallest grid cell in the domain. This means that their values must be adjusted for every new resolution. 

This PR adds the flags
```
config_hmix_use_ref_cell_width (default false)
config_hmix_ref_cell_width
```
If `config_hmix_use_ref_cell_width` is false, there is no change, so we have backwards compatibility for MPAS and E3SM simulations. If `config_hmix_use_ref_cell_width` is true, then the values of
```
config_mom_del2
config_mom_del4
config_tracer_del2
config_tracer_del4
```
are now referenced to the length `config_hmix_ref_cell_width`, where del2 values are proportional to the cell width, and del4 values are proportional to cell width^3. With this new capability, the del2 and del4 flags will not need to change, except for fine tuning.