### PR TITLE
Move daysSinceStartOfSim calculation to master when threaded

### DIFF
--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -137,6 +137,15 @@ module ocn_analysis_mode
             simulationStartTime = startTimeStamp
          end if
 
+         block => block % next
+      end do
+
+      !$omp master
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+
          ! compute time since start of simulation, in days
          call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
          call mpas_set_time(xtime_timeType, dateTimeString=xtime)
@@ -146,6 +155,8 @@ module ocn_analysis_mode
 
          block => block % next
       end do
+      !$omp end master
+      !$omp barrier
 
    end function ocn_analysis_mode_init!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -348,6 +348,15 @@ module ocn_forward_mode
             simulationStartTime = startTimeStamp
          end if
 
+         block => block % next
+      end do
+
+      !$omp master
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+
          ! compute time since start of simulation, in days
          call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
          call mpas_set_time(xtime_timeType, dateTimeString=xtime)
@@ -357,6 +366,8 @@ module ocn_forward_mode
 
          block => block % next
       end do
+      !$omp end master
+      !$omp barrier
 
       ! Update any mesh fields that may have been modified during init
       call ocn_meshUpdateFields(domain)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -110,6 +110,7 @@ module ocn_time_integration
          call ocn_time_integrator_split(domain, dt)
      endif
 
+     !$omp master
      block => domain % blocklist
      do while (associated(block))
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
@@ -126,13 +127,12 @@ module ocn_time_integration
         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
-
-        !$omp single
         daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
-        !$omp end single
 
         block => block % next
      end do
+     !$omp end master
+     !$omp barrier
 
    end subroutine ocn_timestep!}}}
 


### PR DESCRIPTION
This PR moves the calculation of daysSinceStartOfSim, which is done in three places, to inside a loop with "omp master" pragmas around it. Previously, one was inside an "omp single" pragma, but that did not guarantee that the master thread would get the correct result. While this does not impact the results at all, it was causing random problems in testing using threaded configurations where cprnc output from globalStats files would find an error, just in the daysSinceStartOfSim field. With thanks to @amametjanov 

[BFB]

