### PR TITLE
Remove RediKappa from gm package

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2632,7 +2632,6 @@
 		/>
 		<var name="RediKappa" type="real" dimensions="nCells" units="m^2 s^{-1}"
 			 description="Redi isopycnal mixing Kappa value.  This is constant in time, and set at init."
-			 packages="gm"
 		/>
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of surface fluxes. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."


### PR DESCRIPTION
When RediKappa is included in the gm package, the intel 19 compiler in debug mode stops with an error when redi is off, because we try to pass it to the hmix subroutine. By removing it from the gm package, we use extra memory but code remains bit for bit. In a future PR we will put all redi and gm variables in the gm package, and make them all optional arguments.

