### PR TITLE
Replace old variable maxMeshDensity with new config_maxMeshDensity

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -415,9 +415,9 @@ end subroutine ocn_init_routines_compute_max_level!}}}
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                meshScalingDel2(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                      / maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
+                                      / config_maxMeshDensity)**(1.0_RKIND / 4.0_RKIND)  ! goes as dc**1
                meshScalingDel4(iEdge) = 1.0_RKIND / ( ((meshDensity(cell1) + meshDensity(cell2) ) / 2.0_RKIND) &
-                                      / maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
+                                      / config_maxMeshDensity)**(3.0_RKIND / 4.0_RKIND)  ! goes as dc**3
             end do
          end if
       else


### PR DESCRIPTION
This PR fixes a recently introduced problem where a variable maxMeshDenisty was partially replaced with a new name, config_maxMeshDensity. However, the old name was still be used in calculations and caused failures in debug mode in E3SM testing. Because the old variable name also had no value, it caused DIFFs in some tests