### PR TITLE
Replace diagnosticsPool with module-level variables

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -3095,7 +3095,6 @@
 		/>
 		<var name="RediKappaData" type="real" dimensions="nCells" units="m^2 s^{-1}"
 			 description="Redi isopycnal mixing Kappa value. This is the data field specified at init."
-			 packages="gm"
 		/>
 	</var_struct>
 	<var_struct name="timeVaryingForcing" time_levs="1">

--- a/src/core_ocean/analysis_members/mpas_ocn_debug_diagnostics.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_debug_diagnostics.F
@@ -29,6 +29,7 @@ module ocn_debug_diagnostics
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -159,7 +160,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       !type (mpas_pool_type), pointer :: debugDiagnosticsAM
 
       ! Here are some example variables which may be needed for your analysis member
@@ -169,9 +169,6 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       real (kind=RKIND) :: dzVert1, dzVert2, dzEdgeK, dzEdgeKp1, rx1, localMaxRx1
-      real (kind=RKIND), pointer :: globalRx1Max
-      real (kind=RKIND), dimension(:), pointer :: rx1MaxCell
-      real (kind=RKIND), dimension(:,:), pointer :: zMid
 
       logical, pointer :: config_AM_debugDiagnostics_check_state
 
@@ -188,11 +185,10 @@ contains
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          !call mpas_pool_get_subpool(block % structs, 'debugDiagnosticsAM', debugDiagnosticsAMPool)
 
          if ( config_AM_debugDiagnostics_check_state ) then
-            call ocn_test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)
+            call ocn_test_ocean_state(dminfo, meshPool, statePool)
          end if
 
          ! Here are some example variables which may be needed for your analysis member
@@ -200,21 +196,13 @@ contains
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-
          !-----------------------------------------------------------------
          !
          ! Compute Haney number, rx1
          !
          !-----------------------------------------------------------------
 
-         call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', rx1MaxCell)
-         call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max)
-
         ! These could be included for edge or cell fields with depth:
-        ! call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge)
-        ! call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell)
-        ! call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge)
         ! rx1Edge(:,:) = 0.0_RKIND
         ! rx1Cell(:,:) = 0.0_RKIND
         ! rx1MaxEdge(:) = 0.0_RKIND
@@ -344,14 +332,12 @@ contains
 
    end subroutine ocn_finalize_debug_diagnostics!}}}
 
-   subroutine ocn_test_ocean_state(dminfo, meshPool, diagnosticsPool, statePool)!{{{
+   subroutine ocn_test_ocean_state(dminfo, meshPool, statePool)!{{{
 
       type (dm_info) :: dminfo
-      type (mpas_pool_type), pointer :: statePool, meshPool, diagnosticsPool, tracersPool
-      character (len=StrKIND), pointer :: xtime
+      type (mpas_pool_type), pointer :: statePool, meshPool, tracersPool
       real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer, dimension(:), pointer :: maxLevelCell
@@ -370,8 +356,6 @@ contains
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
       call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 2)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 2)
 

--- a/src/core_ocean/analysis_members/mpas_ocn_eddy_product_variables.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eddy_product_variables.F
@@ -46,6 +46,7 @@ module ocn_eddy_product_variables
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -176,7 +177,6 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: tracersPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
       integer, pointer :: nEdges, nVertLevels, nCellsSolve
       integer :: iTracer, k, iCell, iEdge, cell1, cell2
@@ -185,10 +185,10 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       real (kind=RKIND), dimension(:), pointer :: ssh, SSHSquared
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional, GMBolusVelocityZonal, GMBolusVelocityMeridional, &
+      real (kind=RKIND), dimension(:,:), pointer :: &
            velocityZonalSquared, velocityMeridionalSquared, velocityZonalTimesTemperature, velocityMeridionalTimesTemperature, &
            velocityZonalTimesTemperature_GM, velocityMeridionalTimesTemperature_GM, normalVelocity, normalVelocitySquared, &
-           normalVelocityTimesTemperature, normalGMBolusVelocity, normalGMBolusVelocityTimesTemperature, normalGMBolusVelocitySquared
+           normalVelocityTimesTemperature, normalGMBolusVelocityTimesTemperature, normalGMBolusVelocitySquared
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       err = 0
@@ -200,7 +200,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'eddyProductVariablesAM', eddyProductVariablesAMPool)
 
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
@@ -212,8 +211,6 @@ contains
          call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
 
          call mpas_pool_get_array(statePool, 'ssh',ssh, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
@@ -231,9 +228,6 @@ contains
          ! I repeated the block of code here for better performance, rather than
          ! split the GM and non-GM variables into separate loops.
          if (config_use_GM) then
-            call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-            call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal',GMBolusVelocityZonal)
-            call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
             call mpas_pool_get_array(eddyProductVariablesAMPool,'velocityZonalTimesTemperature_GM', velocityZonalTimesTemperature_GM)
             call mpas_pool_get_array(eddyProductVariablesAMPool,'velocityMeridionalTimesTemperature_GM', &
                velocityMeridionalTimesTemperature_GM)

--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -29,6 +29,7 @@ module ocn_eliassen_palm
    use mpas_pool_routines
    use mpas_constants
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_diagnostics_routines
    use ocn_equation_of_state
 
@@ -267,7 +268,6 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: forcingPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
       !-----------------------------------------------------------------
       ! define pointers to namelist config variables local to the EPFT module
@@ -450,14 +450,6 @@ contains
       ! define some arrays in z-coordinates, obtained from diagnostics and forcing
       !-----------------------------------------------------------------
       real(KIND=RKIND), dimension(:), pointer :: atmosphericPressure
-      real(KIND=RKIND), dimension(:,:), pointer :: zMid
-      real(KIND=RKIND), dimension(:,:), pointer :: zTop
-      real(KIND=RKIND), dimension(:,:), pointer :: density
-      real(KIND=RKIND), dimension(:,:), pointer :: potentialDensity
-      real(KIND=RKIND), dimension(:,:), pointer :: pressure
-      real(KIND=RKIND), dimension(:,:), pointer :: velocityZonal
-      real(KIND=RKIND), dimension(:,:), pointer :: velocityMeridional
-      real(KIND=RKIND), dimension(:,:), pointer :: relativeVorticityCell ! jas used for testing
       !real(KIND=RKIND), dimension(:,:), pointer :: wCellCenter
 
       !-----------------------------------------------------------------
@@ -514,7 +506,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'eliassenPalmAMPKGScratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
          !--------------------------------------------------
          ! assign pointers for mesh-related variables
@@ -667,17 +658,6 @@ contains
          call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
 
          !--------------------------------------------------
-         ! get diagnostic variables
-         !--------------------------------------------------
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-         call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-         call mpas_pool_get_array(diagnosticsPool, 'density', density)
-         call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-         call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-
-         !--------------------------------------------------
          ! variables that define the vertical coordinate system in density/buoyancy space
          !--------------------------------------------------
          call mpas_pool_get_dimension(block % dimensions, 'nBuoyancyLayers', nBuoyancyLayers)
@@ -745,7 +725,7 @@ contains
          call mpas_pool_get_array(am_epftPool, 'ErtelPVGradMerid', ErtelPVGradMerid)
 
          ! Compute potentialDensity over the entire block to ensure it's valid for EPFT computation
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
+         call ocn_equation_of_state_density(statePool, tracersSurfaceValue, scratchPool, &
                                             nCells, 1, 'absolute', potentialDensity, &
                                             err) !, timeLevelIn=1)
 
@@ -1177,8 +1157,6 @@ contains
          ! calculate potential vorticity fluxes using curl of u
          !-------------------------------------------------------------
          if(config_AM_eliassenPalm_debug) then
-
-            call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
 
             ! store relVortMidBuoyCoor in array1_3Dbuoy
             call linear_interp_1d_field_along_column(nVertLevels, nCells, nBuoyancyLayers, &

--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -745,7 +745,7 @@ contains
          call mpas_pool_get_array(am_epftPool, 'ErtelPVGradMerid', ErtelPVGradMerid)
 
          ! Compute potentialDensity over the entire block to ensure it's valid for EPFT computation
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+         call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
                                             nCells, 1, 'absolute', potentialDensity, &
                                             err) !, timeLevelIn=1)
 

--- a/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_global_stats.F
@@ -27,6 +27,7 @@ module ocn_global_stats
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -225,7 +226,6 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: tracersSurfaceFluxPool
       type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool
@@ -241,7 +241,6 @@ contains
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, maxLevelVertexBot, &
          landiceMask
 
-      character (len=StrKIND), pointer :: xtime, simulationStartTime
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
 
@@ -251,11 +250,9 @@ contains
                                     absoluteFreshWaterConservation, relativeFreshWaterConservation, &
                                     landIceFloatingAreaSum
       real (kind=RKIND), dimension(:), pointer ::  areaCell, dcEdge, dvEdge, areaTriangle, areaEdge, landIceFloatingArea
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity, tangentialVelocity, layerThicknessEdge, &
-            relativeVorticity, kineticEnergyCell, normalizedRelativeVorticityEdge, &
-            normalizedPlanetaryVorticityEdge, pressure, montgomeryPotential, &
-            vertAleTransportTop, vertVelocityTop, lowFreqDivergence, highFreqThickness, &
-            density, layerThicknessPreviousTimestep, activeTracersSurfaceFlux, &
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity, &
+            lowFreqDivergence, highFreqThickness, &
+            layerThicknessPreviousTimestep, activeTracersSurfaceFlux, &
             activeTracersPistonVelocity, activeTracersSurfaceRestoringValue
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
@@ -268,7 +265,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), pointer :: frazilLayerThicknessTendency
 
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
       real (kind=RKIND), dimension(:), pointer :: minGlobalStats,maxGlobalStats,sumGlobalStats, averages, rms, verticalSumMins, &
           verticalSumMaxes
       real (kind=RKIND), dimension(kMaxVariables) :: sumSquares, reductions, sums, mins, maxes
@@ -339,7 +335,6 @@ contains
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'globalStatsAM', globalStatsAMPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
@@ -364,21 +359,6 @@ contains
             call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergence, 1)
             call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThickness, 1)
          end if
-
-         call mpas_pool_get_array(diagnosticsPool, 'density', density)
-         call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-         call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime',simulationStartTime)
-         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
 
          call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
          call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
@@ -1371,9 +1351,6 @@ contains
       call mpas_pool_get_config(domain % configs, 'config_AM_globalStats_text_file', config_AM_globalStats_text_file)
       call mpas_pool_get_config(domain % configs, 'config_AM_globalStats_directory', config_AM_globalStats_directory)
       if (config_AM_globalStats_text_file) then
-
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
 
          ! write out the data to files
          if (dminfo % my_proc_id == IO_NODE) then

--- a/src/core_ocean/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_high_frequency_output.F
@@ -27,6 +27,7 @@ module ocn_high_frequency_output
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -155,7 +156,6 @@ contains
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: highFrequencyOutputAMPool
       type (mpas_pool_type), pointer :: tracersPool
@@ -203,14 +203,11 @@ contains
       real (kind=RKIND), dimension(:), pointer :: vertTransportVelocityAt250m, vertGMvelocityAt250m
       real (kind=RKIND), dimension(:), pointer :: vertVelSFC, vertTransportVelocitySFC, vertGMvelocitySFC
       real (kind=RKIND), dimension(:), pointer :: barotropicSpeed, columnIntegratedSpeed, dvEdge, dcEdge, areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, relativeVorticityCell
       real (kind=RKIND), dimension(:,:), pointer :: activeTracersAt250m, activeTracersAvgTopto0100, activeTracersAvg0100to0250
       real (kind=RKIND), dimension(:,:), pointer :: activeTracersAtSurface, activeTracersAtBottom
       real (kind=RKIND), dimension(:,:), pointer :: activeTracersAvg0250to0700, activeTracersAvg0700to2000, activeTracersAvg2000toBottom
-      real (kind=RKIND), dimension(:,:), pointer :: relativeVorticity, divergence, layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, tangentialVelocity, BruntVaisalaFreqTop
-      real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop, vertGMBolusVelocityTop, vertTransportVelocityTop
-      real (kind=RKIND), dimension(:,:), pointer :: normalGMBolusVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: normalBaroclinicVelocity ! baroclinic/barotropic pressume split explicit
       real (kind=RKIND), dimension(:), pointer :: normalBarotropicVelocity ! baroclinic/barotropic pressume split explicit
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
@@ -244,7 +241,6 @@ contains
          ! get pointers to pools
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(domain % blocklist % structs, 'highFrequencyOutputAM', highFrequencyOutputAMPool)
@@ -253,17 +249,7 @@ contains
          call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
 
          ! get arrays that will be 'sliced' and put into high frequency output
-         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence, timeLevel)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
 
          ! get arrays that can be written to output at high freqency
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'kineticEnergyAt250m', kineticEnergyAt250m)

--- a/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -37,6 +37,7 @@ module ocn_lagrangian_particle_tracking
    use mpas_stream_manager
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    use ocn_particle_list
    use ocn_lagrangian_particle_tracking_interpolations
@@ -252,7 +253,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackCellsPool, lagrPartTrackScratchPool
       integer, dimension(:), pointer :: cellOwnerBlock
@@ -266,12 +266,12 @@ contains
       real (kind=RKIND), pointer :: lonParticle, latParticle
       real (kind=RKIND), dimension(3) :: xSubStep, diffSubStep, diffParticlePosition
       real (kind=RKIND), pointer :: zLevelParticle
-      real (kind=RKIND), dimension(:,:), pointer :: zTop, vertVelocityTop, zMid, areaBArray
+      real (kind=RKIND), dimension(:,:), pointer :: areaBArray
       real (kind=RKIND), dimension(:), pointer :: bottomDepth, ssh
       type (field2DReal), pointer :: normalVelocity, uVertexVelocity, vVertexVelocity, wVertexVelocity, layerThickness
 
       real (kind=RKIND), dimension(:,:), pointer :: uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, &
-                                                    buoyancyTimeInterp, potentialDensity
+                                                    buoyancyTimeInterp
 
       real(kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
       real(kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
@@ -426,7 +426,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
@@ -442,10 +441,6 @@ contains
         call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
         call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
         call mpas_pool_get_array(lagrPartTrackCellsPool, 'wachspressAreaB', areaBArray)
-        call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-        call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-        call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancyTimeInterp)
 
         ! note, originally this was diagnostics % state % normalVelocity (without time level), but
         ! now there is a time level so selection of the correct time level appears to be tricky
@@ -758,7 +753,7 @@ contains
               call mpas_timer_start("velocity_time_interpolationLPT")
 #endif
               call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
-                diagnosticsPool, lagrPartTrackFieldsPool, &
+                lagrPartTrackFieldsPool, &
                 timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
                 verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
                 xSubStep, zSubStep, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, meshPool, areaBArray)
@@ -1062,7 +1057,7 @@ contains
 !          call mpas_timer_start("velocity_time_interpolationLPT")
 !#endif
 !          call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
-!            diagnosticsPool, lagrPartTrackFieldsPool, &
+!            lagrPartTrackFieldsPool, &
 !            timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
 !            verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
 !            particlePosition, zLevelParticle, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, &
@@ -1606,13 +1601,11 @@ contains
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackScratchPool, lagrPartTrackCellsPool
       real(kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
       integer :: timeLev
       integer, pointer :: filterNum
       type (field2DReal), pointer :: uVV, vVV, wVV
-      real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
 
       !call mpas_log_write( 'inialize_vertex_velocity start')
 
@@ -1627,7 +1620,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
         !! initialize field for RBF (needed depending upon calling pattern of analysis member)
         !call mpas_initialize_vectors(meshPool)
@@ -1824,11 +1816,11 @@ contains
       ! local variables
       !-----------------------------------------------------------------
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: meshPool, diagnosticsPool, lagrPartTrackCellsPool
-      real (kind=RKIND), dimension(:,:), pointer :: zonVel, merVel, depth, normalVelocityMer, normalVelocityZon
+      type (mpas_pool_type), pointer :: meshPool, lagrPartTrackCellsPool
+      real (kind=RKIND), dimension(:,:), pointer :: zonVel, merVel, depth
       real (kind=RKIND), dimension(:), pointer :: buoyancySurfaceValues
       integer, pointer :: nBuoyancySurfaces, nCells
-      real (kind=RKIND), dimension(:,:), pointer :: buoyancy, zMid
+      real (kind=RKIND), dimension(:,:), pointer :: buoyancy
       integer :: iLevel, aBuoyancySurface, iCell
       integer, dimension(:), pointer :: maxLevelCell
       real (kind=RKIND) :: phiInterp                       !< location to interpolate
@@ -1840,20 +1832,18 @@ contains
 
       err = 0
 
+      ! Have `buoyancy` pointer point to potentialDensity from ocn_diagnostics module
+      buoyancy => potentialDensity
+
       block => domain % blocklist
       do while (associated(block))
         ! get pools
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         ! connect variables to pointer array
-        call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', normalVelocityMer)
-        call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', normalVelocityZon)
         call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceVelocityZonal', zonVel)
         call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceVelocityMeridional', merVel)
         call mpas_pool_get_array(lagrPartTrackCellsPool, 'buoyancySurfaceDepth', depth)
-        call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancy)
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
         call mpas_pool_get_dimension(meshPool, 'nBuoyancySurfaces', nBuoyancySurfaces)
         call mpas_pool_get_array(lagrPartTrackCellsPool,'buoyancySurfaceValues', buoyancySurfaceValues)
@@ -1884,8 +1874,8 @@ contains
               else if (iLevel == -1) then
                 aval = minloc(buoyancy(1:maxLevelCell(iCell),iCell),1)
               end if
-              zonVel(aBuoyancySurface, iCell) = normalVelocityZon(aval,iCell)
-              merVel(aBuoyancySurface, iCell) = normalVelocityMer(aval,iCell)
+              zonVel(aBuoyancySurface, iCell) = velocityZonal(aval,iCell)
+              merVel(aBuoyancySurface, iCell) = velocityMeridional(aval,iCell)
               depth(aBuoyancySurface, iCell)  = zMid(aval,iCell)
             else
               ! perform the interpolation
@@ -1900,10 +1890,10 @@ contains
               end if
 
               ! interpolate to the correct surface
-              zonVel(aBuoyancySurface, iCell) = alpha * normalVelocityZon(iHigh, iCell) + &
-                                  (1.0_RKIND - alpha) * normalVelocityZon(iLow, iCell)
-              merVel(aBuoyancySurface, iCell) = alpha * normalVelocityMer(iHigh, iCell) + &
-                                  (1.0_RKIND - alpha) * normalVelocityMer(iLow, iCell)
+              zonVel(aBuoyancySurface, iCell) = alpha * velocityZonal(iHigh, iCell) + &
+                                  (1.0_RKIND - alpha) * velocityZonal(iLow, iCell)
+              merVel(aBuoyancySurface, iCell) = alpha * velocityMeridional(iHigh, iCell) + &
+                                  (1.0_RKIND - alpha) * velocityMeridional(iLow, iCell)
               depth(aBuoyancySurface, iCell)  = alpha * zMid(iHigh, iCell) + &
                                   (1.0_RKIND - alpha) * zMid(iLow, iCell)
             end if
@@ -1968,7 +1958,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: lagrPartTrackFieldsPool, lagrPartTrackCellsPool, lagrPartTrackScratchPool
       integer, dimension(:), pointer :: cellOwnerBlock
       integer, pointer :: currentBlock, ioBlock, indexToParticleID, transfered
@@ -1982,12 +1971,12 @@ contains
       real (kind=RKIND), pointer :: lonParticle, latParticle
       real (kind=RKIND), dimension(3) :: xSubStep, diffSubStep, diffParticlePosition
       real (kind=RKIND), pointer :: zLevelParticle
-      real (kind=RKIND), dimension(:,:), pointer :: zTop, vertVelocityTop, zMid, areaBArray
+      real (kind=RKIND), dimension(:,:), pointer :: areaBArray
       real (kind=RKIND), dimension(:), pointer :: bottomDepth
       type (field2DReal), pointer :: normalVelocity, uVertexVelocity, vVertexVelocity, wVertexVelocity, layerThickness
 
       real (kind=RKIND), dimension(:,:), pointer :: uVertexVelocityArray, vVertexVelocityArray, wVertexVelocityArray, buoyancy, &
-                                                    buoyancyTimeInterp, potentialDensity
+                                                    buoyancyTimeInterp
 
       real(kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
       real(kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
@@ -2080,7 +2069,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackFields', lagrPartTrackFieldsPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackScratch', lagrPartTrackScratchPool)
         call mpas_pool_get_subpool(block % structs, 'lagrPartTrackCells', lagrPartTrackCellsPool)
@@ -2088,6 +2076,9 @@ contains
 
         ! particlelist should be stored in the structs pool probably (need to seriously rework the code!)
         particlelist => block % particlelist
+
+        ! Have buoyancyTimeInterp point to potentialDensity from ocn_diagnostics module
+        buoyancyTimeInterp => potentialDensity
 
         call mpas_pool_get_array(meshPool, 'xCell', xCell)
         call mpas_pool_get_array(meshPool, 'yCell', yCell)
@@ -2097,10 +2088,6 @@ contains
         call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
         call mpas_pool_get_array(lagrPartTrackCellsPool, 'wachspressAreaB', areaBArray)
-        call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-        call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-        call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancyTimeInterp)
 
         call mpas_pool_get_field(statePool, 'normalVelocity', normalVelocity, timeLevel=timeLevel)
         call mpas_dmpar_exch_halo_field(normalVelocity)
@@ -2227,7 +2214,7 @@ contains
           ! return interpolated horizontal velocity "particleVelocity" and vertical velocity "particleVelocityVert"
           ! noting we use the final positions
           call velocity_time_interpolation(particleVelocity, particleVelocityVert, &
-            diagnosticsPool, lagrPartTrackFieldsPool, &
+            lagrPartTrackFieldsPool, &
             timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
             verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
             particlePosition, zLevelParticle, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex,  &
@@ -2621,7 +2608,7 @@ contains
 !
 !-----------------------------------------------------------------------
   subroutine velocity_time_interpolation(particleVelocity, particleVelocityVert, &
-      diagnosticsPool,  lagrPartTrackFieldsPool, &
+      lagrPartTrackFieldsPool, &
       timeInterpOrder, timeCoeff, iCell, iLevel, buoyancyInterp, maxLevelCell, &
       verticalTreatment, indexLevel, nCellVertices, verticesOnCell, boundaryVertex, &
       xSubStep, zSubStep, zMid, zTop, vertVelocityTop, xVertex, yVertex, zVertex, meshPool, areaBArray) !{{{
@@ -2630,7 +2617,7 @@ contains
     !-----------------------------------------------------------------
     ! input variables
     !-----------------------------------------------------------------
-    type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool, lagrPartTrackFieldsPool
+    type (mpas_pool_type), pointer, intent(in) :: lagrPartTrackFieldsPool
     integer, intent(in) :: timeInterpOrder
     real (kind=RKIND), dimension(2), intent(in) :: timeCoeff
     integer, intent(in) :: iCell
@@ -2707,11 +2694,13 @@ contains
     ! general interpolation for the velocity field
     do aTimeLevel = 1, timeInterpOrder
 
+      ! Have buoyancy point to potentialDensity from ocn_diagnostics module
+      buoyancy => potentialDensity
+
       ! define arrays!{{{
       call mpas_pool_get_array(lagrPartTrackFieldsPool, 'uVertexVelocity', uVertexVelocityArray, timeLevel=aTimeLevel)
       call mpas_pool_get_array(lagrPartTrackFieldsPool, 'vVertexVelocity', vVertexVelocityArray, timeLevel=aTimeLevel)
       call mpas_pool_get_array(lagrPartTrackFieldsPool, 'wVertexVelocity', wVertexVelocityArray, timeLevel=aTimeLevel)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', buoyancy)
       !}}}
 
       ! get final, interpolated particle velocity at this point (collapse to point)
@@ -3022,6 +3011,8 @@ contains
 
      ! compute zLevelParticle and iLevel ! {{{
      if(verticalTreatment == 4) then  !('buoyancySurface')
+       ! Point buoyancyTimeInterp to potentialDensity from diagnostics_variables module
+       buoyancyTimeInterp => potentialDensity
        iLevel = mpas_get_vertical_id(maxLevelCell(iCell), buoyancyParticle, buoyancyTimeInterp(:,iCell))
 
        ! get zLevelParticle by interpolating the scalars now (assumes that

--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -28,6 +28,7 @@ module ocn_layer_volume_weighted_averages
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -166,7 +167,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: tracersPool
 
@@ -179,22 +179,7 @@ contains
 
       ! pointers to data in pools to be analyzed
       real (kind=RKIND), dimension(:,:),   pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:),   pointer :: density
-      real (kind=RKIND), dimension(:,:),   pointer :: potentialDensity
-      real (kind=RKIND), dimension(:,:),   pointer :: BruntVaisalaFreqTop
-      real (kind=RKIND), dimension(:,:),   pointer :: velocityZonal
-      real (kind=RKIND), dimension(:,:),   pointer :: velocityMeridional
-      real (kind=RKIND), dimension(:,:),   pointer :: vertVelocityTop
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      real (kind=RKIND),dimension(:,:,:),pointer::activeTracerVertMixTendency
-      real (kind=RKIND),dimension(:,:,:),pointer::activeTracerHorizontalAdvectionTendency
-      real (kind=RKIND),dimension(:,:,:),pointer::activeTracerVerticalAdvectionTendency
-      real (kind=RKIND),dimension(:,:,:),pointer::activeTracerSurfaceFluxTendency
-      real (kind=RKIND),dimension(:,:),pointer::temperatureShortWaveTendency
-      real (kind=RKIND),dimension(:,:,:),pointer::activeTracerNonLocalTendency
-      real (kind=RKIND), dimension(:,:),   pointer :: kineticEnergyCell
-      real (kind=RKIND), dimension(:,:),   pointer :: relativeVorticityCell
-      real (kind=RKIND), dimension(:,:),   pointer :: divergence
 
       ! pointers to data in mesh pool
       integer, pointer :: nVertLevels, nCells, nCellsSolve, nLayerVolWeightedAvgFields, nOceanRegionsTmp
@@ -283,7 +268,6 @@ contains
          ! get pointers to pools
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
@@ -310,26 +294,7 @@ contains
          ! get pointers to data that will be analyzed
          ! listed in the order in which the fields appear in {avg,min,max}ValueWithinOceanLayerRegion
          call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'density', density)
-         call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-         call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
-         call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-         if ( computeActiveTracerBudgetsOn ) then
-           call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
-                   activeTracerHorizontalAdvectionTendency)
-           call mpas_pool_get_array(diagnosticsPool,'activeTracerVerticalAdvectionTendency', &
-                   activeTracerVerticalAdvectionTendency)
-           call mpas_pool_get_array(diagnosticsPool,'activeTracerVertMixTendency',activeTracerVertMixTendency)
-           call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
-           call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
-           call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-         end if
 
          ! initialize buffers
          workBufferSum(:) = 0.0_RKIND

--- a/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -28,6 +28,7 @@ module ocn_meridional_heat_transport
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -330,7 +331,6 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       ! REGION POOL
       type (mpas_pool_type), pointer :: regionPool
 
@@ -343,7 +343,6 @@ contains
       real (kind=RKIND) :: div_huT
       real (kind=RKIND), dimension(:), pointer ::  areaCell, binVariable, binBoundaryMerHeatTrans, dvEdge
       real (kind=RKIND), dimension(:), pointer ::  merHeatTransLat
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalTransportVelocity
       real (kind=RKIND), dimension(:,:), pointer :: merHeatTransLatZ
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       real (kind=RKIND), dimension(:,:), allocatable :: mht_meridional_integral
@@ -448,7 +447,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
@@ -464,8 +462,6 @@ contains
          call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
          if(additionalRegion /= '') then
             call mpas_pool_get_array(regionPool, 'regionCellMasks', regionCellMasks)

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -29,6 +29,7 @@ module ocn_mixed_layer_depths
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -158,7 +159,6 @@ contains
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: mixedLayerDepthsAM
       type (mpas_pool_type), pointer :: forcingPool
@@ -179,10 +179,8 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dThreshMLD, dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceMask, indMLD
+      integer, dimension(:), pointer :: landIceMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
-      real (kind=RKIND), dimension(:,:), pointer :: zTop, zMid, pressure
-      real (kind=RKIND), dimension(:,:), pointer :: potentialDensity
       real (kind=RKIND), pointer :: tempThresh
       real (kind=RKIND), pointer :: tempGrad
       real (kind=RKIND), pointer :: denThresh
@@ -221,7 +219,6 @@ contains
 
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(block % structs, 'mixedLayerDepthsAM', mixedLayerDepthsAMPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
@@ -240,14 +237,9 @@ contains
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
-                        potentialDensity)
-         call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-         call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -321,7 +313,6 @@ contains
 
          if(dThresholdFlag) then
             call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD',dThreshMLD)
-            call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
 
             !$omp do schedule(runtime) private( k, refIndex, found_den_mld, localVals, interp_local, den_ref_lev, dV, dVp1, mldTemp)
             do iCell = 1,nCells

--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -28,6 +28,7 @@ module ocn_okubo_weiss
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
    use mpas_matrix_operations
    use iso_c_binding
 
@@ -804,7 +805,6 @@ contains
 
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
       real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:,:), pointer ::  layerThickness, zMid
@@ -820,11 +820,9 @@ contains
       integer k, iCell, i, curCC, iIdx, curI, curK, iOtherCell, maxNumCCs
 
       integer, dimension(size(OW_thresh,1), size(OW_thresh,2)) :: OW_thresh_local
-      character (len=StrKIND), pointer :: xtime
 
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
       call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(ocnConfigs, 'config_AM_okuboWeiss_use_lat_lon_coords', use_lat_lon_coords)
@@ -840,17 +838,14 @@ contains
       if (use_lat_lon_coords) then
          call mpas_pool_get_array(meshPool, 'lonCell', posX)
          call mpas_pool_get_array(meshPool, 'latCell',  posY)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velX)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velY)
+         velX => velocityZonal
+         velY => velocityMeridional
       else
          call mpas_pool_get_array(meshPool, 'xCell', posX)
          call mpas_pool_get_array(meshPool, 'yCell', posY)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velX)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velY)
+         velX => velocityX
+         velY => velocityY
       end if
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', velZ)
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
 
       call mpas_timer_start("stats per proc")
 
@@ -1453,14 +1448,12 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
       integer, pointer :: nVertLevels, nCells, nEdges
       integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
       real (kind=RKIND), dimension(:,:), pointer :: edgeTangentVectors
 
       real (kind=RKIND), dimension(:,:), pointer :: om, OW
@@ -1490,7 +1483,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'okuboWeissScratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'okuboWeissAM', okuboWeissAMPool)
 
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
@@ -1502,7 +1494,6 @@ contains
          call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
 
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
 
          call mpas_pool_get_array(okuboWeissAMPool, 'okuboWeiss', OW)
          call mpas_pool_get_array(okuboWeissAMPool, 'eddyID', OW_cc_id)

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -28,6 +28,7 @@ module ocn_surface_area_weighted_averages
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -160,7 +161,6 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: tracersSurfaceFluxPool
 
@@ -198,7 +198,6 @@ contains
       real (kind=RKIND), dimension(:), pointer :: windStressMeridional
       real (kind=RKIND), dimension(:), pointer :: atmosphericPressure
       real (kind=RKIND), dimension(:), pointer :: ssh
-      real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       ! pointers to data in mesh pool
@@ -294,7 +293,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
 
@@ -342,7 +340,6 @@ contains
          call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth',boundaryLayerDepth)
 
          ! compute mask
          call compute_mask(nCells, nCellsSolve, iRegion, lonCell, latCell, workMask)

--- a/src/core_ocean/analysis_members/mpas_ocn_test_compute_interval.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_test_compute_interval.F
@@ -28,6 +28,7 @@ module ocn_test_compute_interval
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -171,7 +172,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: testComputeIntervalAMPool
       character (len=StrKIND), pointer :: xtime
 
@@ -192,8 +192,6 @@ contains
          call mpas_pool_get_array(testComputeIntervalAMPool, 'testComputeIntervalCounter',testComputeIntervalCounter)
 
          testComputeIntervalCounter = testComputeIntervalCounter + 1
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
          block => block % next
       end do
 

--- a/src/core_ocean/analysis_members/mpas_ocn_time_filters.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_time_filters.F
@@ -245,7 +245,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: timeFiltersAM
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalVelocityLowPass, normalVelocityHighPass, &
                                                     normalVelocityTest
@@ -300,7 +299,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'timeFiltersAM', timeFiltersAMPool)
 
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)

--- a/src/core_ocean/analysis_members/mpas_ocn_transect_transport.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_transect_transport.F
@@ -195,7 +195,6 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: verticalMeshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: transectTransportAM
 
       type (mpas_pool_type), pointer :: transectPool
@@ -260,7 +259,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
          !call mpas_pool_get_subpool(block % structs, 'tracersPool', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'transectTransportAM', transectTransportAMPool)
          call mpas_pool_get_subpool(domain % blocklist % structs, 'transects', transectPool)
 

--- a/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_water_mass_census.F
@@ -29,6 +29,7 @@ module ocn_water_mass_census
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -158,7 +159,6 @@ contains
       type (mpas_pool_type), pointer :: waterMassCensusAMPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: regionPool
 
@@ -177,8 +177,6 @@ contains
 
       ! pointers to data in pools required for T/S water mass census
       real (kind=RKIND), dimension(:,:),   pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:),   pointer :: potentialDensity
-      real (kind=RKIND), dimension(:,:),   pointer :: zMid
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       ! pointers to data in mesh pool
@@ -386,7 +384,6 @@ contains
          ! get pointers to pools
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
          ! get indices for T and S
@@ -401,8 +398,6 @@ contains
 
          ! get pointers to data needed for analysis
          call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
 
          if (additionalRegion == '') then

--- a/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_zonal_mean.F
@@ -28,6 +28,7 @@ module ocn_zonal_mean
 
    use ocn_constants
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -240,7 +241,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
 
       integer :: iTracer, k, iCell, kMax
@@ -249,7 +249,6 @@ contains
       integer, dimension(:), pointer :: maxLevelCell
 
       real (kind=RKIND), dimension(:), pointer ::  areaCell, binVariable, binBoundaryZonalMean
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:), pointer :: velocityZonalZonalMean, velocityMeridionalZonalMean
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       real (kind=RKIND), dimension(:,:,:), allocatable :: sumZonalMean, totalSumZonalMean, normZonalMean
@@ -285,7 +284,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
 
@@ -303,8 +301,6 @@ contains
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
 
          ! Bin by latitude on a sphere, by yCell otherwise.
          if (on_a_sphere) then

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -268,7 +268,7 @@ module ocn_analysis_mode
          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 1)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 1)
          block_ptr => block_ptr % next
       end do
 

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -268,7 +268,7 @@ module ocn_analysis_mode
          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 1)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 1)
          block_ptr => block_ptr % next
       end do
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -38,6 +38,7 @@ module ocn_forward_mode
    use ocn_time_integration_split
    use ocn_tendency
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_test
    use ocn_mesh
 
@@ -119,10 +120,7 @@ module ocn_forward_mode
       real (kind=RKIND) :: maxDensity, maxDensity_global
       real (kind=RKIND), dimension(:), pointer :: meshDensity
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
-      character (len=StrKIND), pointer :: xtime, simulationStartTime
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_Time_Type) :: startTime, alarmTime
       type (MPAS_TimeInterval_type) :: timeStep
@@ -259,7 +257,7 @@ module ocn_forward_mode
 
       call ocn_tendency_init(err_tmp)
       ierr = ior(ierr,err_tmp)
-      call ocn_diagnostics_init(err_tmp)
+      call ocn_diagnostics_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
 
       call ocn_forcing_init(err_tmp)
@@ -338,12 +336,9 @@ module ocn_forward_mode
              call mpas_log_write('An error was encountered in ocn_init_routines_block', MPAS_LOG_CRIT)
          endif
 
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
          xtime = startTimeStamp
 
          ! Set simulationStartTime only if that variable is not read from the restart file.
-         call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
          if (trim(simulationStartTime)=="no_date_available") then
             simulationStartTime = startTimeStamp
          end if
@@ -354,11 +349,7 @@ module ocn_forward_mode
       !$omp master
       block => domain % blocklist
       do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-
          ! compute time since start of simulation, in days
-         call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
          call mpas_set_time(xtime_timeType, dateTimeString=xtime)
          call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
          call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
@@ -504,7 +495,6 @@ module ocn_forward_mode
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: forcingPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: scratchPool
 
       type (MPAS_timeInterval_type) :: timeStep
@@ -605,20 +595,19 @@ module ocn_forward_mode
            call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
            call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-           call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
            call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-           call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, ierr, 1)
+           call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, ierr, 1)
            call mpas_timer_start("land_ice_build_arrays")
-           call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+           call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
                                                          forcingPool, scratchPool, statePool, dt, err)
            call mpas_timer_stop("land_ice_build_arrays")
 
-           call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)
-           call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)
+           call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, err)
+           call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)
 
            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
            if (config_use_Redi.or.config_use_GM) then
-               call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, meshPool, scratchPool, timeLevelIn=1)
+               call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)
            end if
 
            block_ptr => block_ptr % next

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -31,6 +31,7 @@ module ocn_time_integration
    use mpas_log
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_time_integration_rk4
    use ocn_time_integration_split
 
@@ -96,11 +97,8 @@ module ocn_time_integration
       type (dm_info) :: dminfo
       type (block_type), pointer :: block
 
-      type (mpas_pool_type), pointer :: diagnosticsPool, statePool, meshPool
+      type (mpas_pool_type), pointer :: statePool, meshPool
 
-      character (len=StrKIND), pointer :: xtime
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
-      character (len=StrKIND), pointer :: simulationStartTime
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
 
 
@@ -114,16 +112,11 @@ module ocn_time_integration
      block => domain % blocklist
      do while (associated(block))
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-
-        call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
 
         xtime = timeStamp
 
         ! compute time since start of simulation, in days
-        call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', simulationStartTime)
-        call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim',daysSinceStartOfSim)
         call mpas_set_time(xtime_timeType, dateTimeString=xtime)
         call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
         call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -31,6 +31,7 @@ module ocn_time_integration_rk4
    use ocn_constants
    use ocn_tendency
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
 
    use ocn_equation_of_state
@@ -98,7 +99,6 @@ module ocn_time_integration_rk4
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: provisStatePool
       type (mpas_pool_type), pointer :: provisTracersPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: verticalMeshPool
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: scratchPool
@@ -138,10 +138,6 @@ module ocn_time_integration_rk4
       integer, pointer :: indexTemperature
       integer, pointer :: indexSalinity
 
-      ! Diagnostics Indices
-      integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
-      integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
-
       ! Mesh array pointers
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
       real (kind=RKIND), dimension(:), pointer :: bottomDepth
@@ -160,13 +156,6 @@ module ocn_time_integration_rk4
       ! Diagnostics Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge
       real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
-      real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity, normalGMBolusVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
-      real (kind=RKIND), dimension(:), pointer :: gradSSH
-      real (kind=RKIND), dimension(:), pointer :: gradSSHX, gradSSHY, gradSSHZ
-      real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
-      real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, sshGradient
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocityCur, normalVelocityNew
@@ -183,7 +172,6 @@ module ocn_time_integration_rk4
 
       ! State/Tend Field Pointers
       type (field2DReal), pointer :: normalVelocityField, layerThicknessField
-      type (field2DReal), pointer :: wettingVelocityField
       type (field3DReal), pointer :: tracersGroupField
 
       ! Tracer Group Iteartion
@@ -384,8 +372,6 @@ module ocn_time_integration_rk4
           exit ! don't compute in loop meant to update velocity, thickness, and tracers
         end if
 
-        call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
-
         ! Update halos for diagnostic variables.
         if (config_use_cvmix_kpp) then
            call mpas_timer_start("RK4-boundary layer depth halo update")
@@ -416,13 +402,12 @@ module ocn_time_integration_rk4
            block => domain % blocklist
            do while (associated(block))
               call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
-              call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
               call mpas_pool_get_subpool(block % structs, 'state', statePool)
               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
               call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
-              call ocn_tend_freq_filtered_thickness(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+              call ocn_tend_freq_filtered_thickness(tendPool, provisStatePool, meshPool, 1)
               call mpas_threading_barrier()
               block => block % next
            end do
@@ -478,7 +463,6 @@ module ocn_time_integration_rk4
                ! exchange fields for parallelization
                call mpas_pool_get_field(statePool, 'normalVelocity', normalVelocityField, 1)
                call mpas_dmpar_exch_halo_field(normalVelocityField)
-               call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', wettingVelocityField)
                call mpas_dmpar_exch_halo_field(wettingVelocityField)
              end if
 
@@ -636,7 +620,6 @@ module ocn_time_integration_rk4
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
 
@@ -649,26 +632,6 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
 
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
-
-         call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
          call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
          call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
          call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
@@ -710,7 +673,7 @@ module ocn_time_integration_rk4
            end do
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 2)
          call mpas_threading_barrier()
 
          ! Update the effective desnity in land ice if we're coupling to land ice
@@ -727,7 +690,7 @@ module ocn_time_integration_rk4
 
          ! Compute normalGMBolusVelocity and the tracer transport velocity
          if (config_use_GM) then
-             call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+             call ocn_gm_compute_Bolus_velocity(statePool, &
                 meshPool, scratchPool, timeLevelIn=2)
          end if
          call mpas_threading_barrier()
@@ -764,10 +727,10 @@ module ocn_time_integration_rk4
          end do
          !$omp end do
 
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
+         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
          if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
+            call ocn_reconstruct_gm_vectors(meshPool)
          end if
          call mpas_threading_barrier()
 
@@ -808,14 +771,12 @@ module ocn_time_integration_rk4
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
-      type (mpas_pool_type), pointer :: statePool, diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
       type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
       type (mpas_pool_type), pointer :: tracersPool
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge, vertAleTransportTop
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -827,7 +788,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
@@ -838,10 +798,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -860,7 +816,7 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, scratchPool, 1, dt)
       call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
@@ -872,14 +828,12 @@ module ocn_time_integration_rk4
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
-      type (mpas_pool_type), pointer :: statePool, diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
       type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
       type (mpas_pool_type), pointer :: tracersPool
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge, vertAleTransportTop
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -891,7 +845,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
@@ -902,10 +855,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -924,7 +873,7 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+      call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
       call mpas_threading_barrier()
 
@@ -937,14 +886,12 @@ module ocn_time_integration_rk4
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
-      type (mpas_pool_type), pointer :: statePool, diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
       type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
       type (mpas_pool_type), pointer :: swForcingPool, tracersPool
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge, vertAleTransportTop
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -956,7 +903,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
@@ -968,10 +914,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -991,11 +933,11 @@ module ocn_time_integration_rk4
       call mpas_threading_barrier()
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, 1)
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
+      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
                            scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
       call mpas_threading_barrier()
 
@@ -1008,14 +950,12 @@ module ocn_time_integration_rk4
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
-      type (mpas_pool_type), pointer :: statePool, diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
       type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
       type (mpas_pool_type), pointer :: swForcingPool, tracersPool
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge, vertAleTransportTop
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -1027,7 +967,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
@@ -1039,10 +978,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -1061,7 +996,7 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, scratchPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, scratchPool, 1, dt)
       call mpas_threading_barrier()
 
       if (associated(highFreqThicknessProvis)) then
@@ -1077,14 +1012,14 @@ module ocn_time_integration_rk4
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+      call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, 1)
       endif
       call mpas_threading_barrier()
 
-      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
+      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
                            scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
       call mpas_threading_barrier()
 
@@ -1102,14 +1037,12 @@ module ocn_time_integration_rk4
       integer :: iCell, iEdge, k
 
       type (mpas_pool_type), pointer :: statePool, tendPool, meshPool, scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool, provisStatePool, forcingPool
+      type (mpas_pool_type), pointer :: provisStatePool, forcingPool
       type (mpas_pool_type), pointer :: tracersPool, tracersTendPool, provisTracersPool
 
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocityCur, normalVelocityProvis, normalVelocityTend
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, layerThicknessProvis, layerThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: lowFreqDivergenceCur, lowFreqDivergenceProvis, lowFreqDivergenceTend
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity, normalGMBolusVelocity
-      real (kind=RKIND), dimension(:, :), pointer :: wettingVelocity
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupCur, tracersGroupProvis, tracersGroupTend
 
@@ -1133,7 +1066,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
@@ -1157,10 +1089,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
       call mpas_threading_barrier()
 
       !$omp do schedule(runtime) private(k)
@@ -1237,7 +1165,7 @@ module ocn_time_integration_rk4
       end if
       call mpas_threading_barrier()
 
-      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 1)
+      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, scratchPool, tracersPool, 1)
       call mpas_threading_barrier()
 
       ! ------------------------------------------------------------------
@@ -1251,7 +1179,7 @@ module ocn_time_integration_rk4
 
       ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
       if (config_use_GM) then
-         call ocn_gm_compute_Bolus_velocity(provisStatePool, diagnosticsPool, &
+         call ocn_gm_compute_Bolus_velocity(provisStatePool, &
             meshPool, scratchPool, timeLevelIn=1)
       end if
       call mpas_threading_barrier()
@@ -1277,7 +1205,7 @@ module ocn_time_integration_rk4
       integer, pointer :: nCells, nEdges
       integer :: iCell, iEdge, k
 
-      type (mpas_pool_type), pointer :: statePool, tendPool, meshPool, diagnosticsPool
+      type (mpas_pool_type), pointer :: statePool, tendPool, meshPool
       type (mpas_pool_type), pointer :: tracersPool, tracersTendPool
 
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocityNew, normalVelocityTend
@@ -1303,7 +1231,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
       call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
@@ -1323,7 +1250,6 @@ module ocn_time_integration_rk4
 
       call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
-     call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
@@ -1394,11 +1320,10 @@ module ocn_time_integration_rk4
       integer :: iCell, iEdge, k
 
       type (mpas_pool_type), pointer :: statePool, meshPool, forcingPool
-      type (mpas_pool_type), pointer :: diagnosticsPool, scratchPool
+      type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: tracersPool
 
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessNew, normalVelocityNew
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity, normalGMBolusVelocity
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew
 
       integer, dimension(:), pointer :: maxLevelCell
@@ -1420,16 +1345,12 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
 
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
@@ -1452,10 +1373,10 @@ module ocn_time_integration_rk4
          end if
       end do
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 2)
       call mpas_threading_barrier()
 
-      call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
+      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
       call mpas_threading_barrier()
 
    end subroutine ocn_time_integrator_rk4_cleanup!}}}

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -710,7 +710,7 @@ module ocn_time_integration_rk4
            end do
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
          call mpas_threading_barrier()
 
          ! Update the effective desnity in land ice if we're coupling to land ice
@@ -848,12 +848,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -912,12 +912,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -978,12 +978,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -991,7 +991,7 @@ module ocn_time_integration_rk4
       call mpas_threading_barrier()
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, 1)
       endif
       call mpas_threading_barrier()
 
@@ -1049,12 +1049,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur,layerThicknessEdge, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
@@ -1065,12 +1065,12 @@ module ocn_time_integration_rk4
       call mpas_threading_barrier()
 
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
             layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
@@ -1080,7 +1080,7 @@ module ocn_time_integration_rk4
       call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, 1)
       endif
       call mpas_threading_barrier()
 
@@ -1237,7 +1237,7 @@ module ocn_time_integration_rk4
       end if
       call mpas_threading_barrier()
 
-      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 1)
+      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 1)
       call mpas_threading_barrier()
 
       ! ------------------------------------------------------------------
@@ -1452,7 +1452,7 @@ module ocn_time_integration_rk4
          end if
       end do
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
       call mpas_threading_barrier()
 
       call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -565,7 +565,7 @@ module ocn_time_integration_split
                nEdges = nEdgesArray( 1 )
 
                ! Put f*normalBaroclinicVelocity^{perp} in normalVelocityNew as a work variable
-               call ocn_fuperp(statePool, meshPool, 2)
+               call ocn_fuperp(statePool, 2)
 
                allocate(uTemp(nVertLevels))
 
@@ -1467,11 +1467,11 @@ module ocn_time_integration_split
             ! layerThickness has not yet been computed for time level 2.
             call mpas_timer_start('thick vert trans vel top')
             if (associated(highFreqThicknessNew)) then
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+               call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
                  layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, err, highFreqThicknessNew)
             else
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+               call ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, &
                  layerThicknessCur, layerThicknessEdge, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, err)
             endif
@@ -1648,7 +1648,7 @@ module ocn_time_integration_split
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+               call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !
@@ -1871,7 +1871,7 @@ module ocn_time_integration_split
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+        call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
         block => block % next
       end do
@@ -1981,7 +1981,7 @@ module ocn_time_integration_split
             !$omp end do
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, scratchPool, err)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -34,6 +34,7 @@ module ocn_time_integration_split
 
    use ocn_tendency
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
 
    use ocn_equation_of_state
@@ -99,7 +100,6 @@ module ocn_time_integration_split
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: verticalMeshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tendPool
       type (mpas_pool_type), pointer :: tracersTendPool
       type (mpas_pool_type), pointer :: forcingPool
@@ -155,8 +155,6 @@ module ocn_time_integration_split
       integer :: nCells, nEdges
       integer, pointer :: nCellsPtr, nEdgesPtr, nVertLevels, num_tracersGroup, startIndex, endIndex
       integer, pointer :: indexTemperature, indexSalinity
-      integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
-      integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       ! Mesh array pointers
@@ -190,31 +188,12 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupTend, activeTracersTend
 
       ! Diagnostics Array Pointers
-      real (kind=RKIND), dimension(:), pointer :: barotropicForcing, barotropicThicknessFlux
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalTransportVelocity, normalGMBolusVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
-      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
-      real (kind=RKIND), dimension(:), pointer :: gradSSH
-      real (kind=RKIND), dimension(:), pointer :: gradSSHX, gradSSHY, gradSSHZ
-      real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
-      real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, SSHGradient
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 
       ! Diagnostics Field Pointers
       type (field2DReal), pointer :: normalizedRelativeVorticityEdgeField, divergenceField, relativeVorticityField
       type (field1DReal), pointer :: barotropicThicknessFluxField, boundaryLayerDepthField, effectiveDensityField
-      ! tracer tendencies brought in here to normalize by new layer thickness
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-        activeTracerHorizontalAdvectionTendency,      &
-        activeTracerVerticalAdvectionTendency,        &
-        activeTracerSurfaceFluxTendency,              &
-        activeTracerNonLocalTendency,                 &
-        activeTracerHorMixTendency,                   &
-        activeTracerHorizontalAdvectionEdgeFlux
 
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        temperatureShortWaveTendency
       ! State/Tend Field Pointers
       type (field1DReal), pointer :: normalBarotropicVelocitySubcycleField, sshSubcycleField
       type (field2DReal), pointer :: highFreqThicknessField, lowFreqDivergenceField
@@ -290,7 +269,6 @@ module ocn_time_integration_split
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
          call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityCur, 1)
          call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityCur, 1)
@@ -311,8 +289,6 @@ module ocn_time_integration_split
 
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceCur, 1)
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceNew, 2)
-
-         call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
@@ -408,8 +384,6 @@ module ocn_time_integration_split
 
          stage1_tend_time = min(split_explicit_step,2)
 
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
-
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
             call mpas_timer_start("se halo diag obd")
@@ -442,10 +416,9 @@ module ocn_time_integration_split
                call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
                call mpas_pool_get_subpool(block % structs, 'state', statepool)
                call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
-               call ocn_tend_freq_filtered_thickness(tendPool, statePool, diagnosticsPool, meshPool, stage1_tend_time)
+               call ocn_tend_freq_filtered_thickness(tendPool, statePool, meshPool, stage1_tend_time)
                block => block % next
             end do
             call mpas_timer_stop("se freq-filtered-thick computations")
@@ -503,7 +476,6 @@ module ocn_time_integration_split
            call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
            call mpas_pool_get_subpool(block % structs, 'state', statePool)
            call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-           call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
            call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
@@ -513,9 +485,7 @@ module ocn_time_integration_split
 
            call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
 
-           call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-
-           call ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, stage1_tend_time, dt)
+           call ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, scratchPool, stage1_tend_time, dt)
 
            block => block % next
          end do
@@ -545,7 +515,6 @@ module ocn_time_integration_split
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
                call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
                call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
                call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
                call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
@@ -557,9 +526,6 @@ module ocn_time_integration_split
                call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
 
                call mpas_pool_get_array(tendPool, 'normalVelocity', normalVelocityTend)
-
-               call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-               call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
 
                ! Only need to loop over the 1 halo, since there is a halo exchange immediately after this computation.
                nEdges = nEdgesArray( 1 )
@@ -598,7 +564,6 @@ module ocn_time_integration_split
                      thicknessSum  =  thicknessSum + layerThicknessEdge(k,iEdge)
                   enddo
                   barotropicForcing(iEdge) = split * normalThicknessFluxSum / thicknessSum / dt
-
 
                   do k = 1, maxLevelEdgeTop(iEdge)
                      ! These two steps are together here:
@@ -657,15 +622,11 @@ module ocn_time_integration_split
 
                call mpas_pool_get_subpool(block % structs, 'state', statePool)
                call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
                call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
                call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
                call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
-
-               call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-               call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
 
                call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
 
@@ -705,12 +666,8 @@ module ocn_time_integration_split
                call mpas_pool_get_dimension(block % dimensions, 'nCellsArray', nCellsArray)
                call mpas_pool_get_dimension(block % dimensions, 'nEdgesArray', nEdgesArray)
 
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'state', statePool)
                call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-               call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
-               call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
 
                call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
                call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, oldBtrSubcycleTime)
@@ -794,7 +751,6 @@ module ocn_time_integration_split
                      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
                      call mpas_pool_get_subpool(block % structs, 'state', statePool)
                      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-                     call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                      call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
                      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -810,8 +766,6 @@ module ocn_time_integration_split
                      call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleNew, &
                                               newBtrSubcycleTime)
                      call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleCur, oldBtrSubcycleTime)
-
-                     call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
 
                      ! Subtract tidal potential from ssh, if needed
                      !   Subtract the tidal potential from the current subcycle ssh and store and a work array.
@@ -882,7 +836,6 @@ module ocn_time_integration_split
                 call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
                 call mpas_pool_get_subpool(block % structs, 'state', statePool)
                 call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-                call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
                 call mpas_pool_get_array(tendPool, 'ssh', sshTend)
 
@@ -902,8 +855,6 @@ module ocn_time_integration_split
                                             oldBtrSubcycleTime)
                 call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleNew, &
                                             newBtrSubcycleTime)
-
-                call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
 
                 nCells = nCellsPtr
                 nEdges = nEdgesPtr
@@ -1011,7 +962,6 @@ module ocn_time_integration_split
                    call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
                    call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
                    call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-                   call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                    call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
                    call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleCur, &
@@ -1028,8 +978,6 @@ module ocn_time_integration_split
                    call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
                    call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
                    call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-
-                   call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
 
                    call mpas_pool_get_field(scratchPool, 'btrvel_temp', btrvel_tempField)
                    btrvel_temp => btrvel_tempField % array
@@ -1131,7 +1079,6 @@ module ocn_time_integration_split
                    call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
                    call mpas_pool_get_subpool(block % structs, 'state', statePool)
                    call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-                   call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
                    call mpas_pool_get_array(tendPool, 'ssh', sshTend)
 
@@ -1150,8 +1097,6 @@ module ocn_time_integration_split
                                             oldBtrSubcycleTime)
                    call mpas_pool_get_array(statePool, 'normalBarotropicVelocitySubcycle', normalBarotropicVelocitySubcycleNew, &
                                             newBtrSubcycleTime)
-
-                   call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
 
                    nCells = nCellsPtr
                    nEdges = nEdgesPtr
@@ -1295,11 +1240,8 @@ module ocn_time_integration_split
 
                call mpas_pool_get_subpool(block % structs, 'state', statePool)
                call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
                call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
-
-               call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
 
                nEdges = nEdgesPtr
 
@@ -1346,16 +1288,10 @@ module ocn_time_integration_split
 
                call mpas_pool_get_subpool(block % structs, 'state', statePool)
                call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-               call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
                call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
                call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
-
-               call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-               call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-               call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-               call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
 
                call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
                call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
@@ -1448,7 +1384,6 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
             call mpas_pool_get_subpool(block % structs, 'state', statePool)
             call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-            call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
             call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
             call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
@@ -1457,10 +1392,6 @@ module ocn_time_integration_split
             call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
             call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
             call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
-
-            call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-            call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-            call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 
             ! compute vertAleTransportTop.  Use normalTransportVelocity for advection of layerThickness and tracers.
             ! Use time level 1 values of layerThickness and layerThicknessEdge because
@@ -1477,7 +1408,7 @@ module ocn_time_integration_split
             endif
             call mpas_timer_stop('thick vert trans vel top')
 
-            call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+            call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
             block => block % next
          end do
@@ -1498,11 +1429,10 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(block % structs, 'state', statePool)
             call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-            call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
             call mpas_pool_get_subpool(block % structs, 'shortwave', swForcingPool)
-            call ocn_tend_tracer(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, scratchPool, &
+            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, scratchPool, &
                     dt, activeTracersOnly, 2)
 
             block => block % next
@@ -1541,7 +1471,6 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
 
             call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
             call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
@@ -1648,7 +1577,7 @@ module ocn_time_integration_split
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
+               call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 2)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !
@@ -1667,18 +1596,6 @@ module ocn_time_integration_split
                !$omp end do
 
                if (config_compute_active_tracer_budgets) then
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionTendency', &
-                          activeTracerHorizontalAdvectionTendency)
-                  call mpas_pool_get_array(diagnosticspool,'activeTracerVerticalAdvectionTendency', &
-                          activeTracerVerticalAdvectionTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
-                  call mpas_pool_get_array(diagnosticsPool,'activeTracerHorizontalAdvectionEdgeFlux', &
-                          activeTracerHorizontalAdvectionEdgeFlux)
-                  call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-
                   !$omp do schedule(runtime) private(k)
                   do iEdge = 1, nEdges
                      do k= 1, maxLevelEdgeTop(iEdge)
@@ -1862,7 +1779,6 @@ module ocn_time_integration_split
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
         ! Call ocean diagnostic solve in preparation for vertical mixing.  Note
@@ -1871,7 +1787,7 @@ module ocn_time_integration_split
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
+        call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 2)
 
         block => block % next
       end do
@@ -1885,14 +1801,13 @@ module ocn_time_integration_split
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
         ! Compute normalGMBolusVelocity; it will be added to the baroclinic modes in Stage 2 above.
  !       if (config_use_GM.or.config_use_Redi) then
- !          call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+ !          call ocn_gm_compute_Bolus_velocity(statePool, &
  !             meshPool, scratchPool, timeLevelIn=2)
  !       end if
-        call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
+        call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 
         block => block % next
       end do
@@ -1927,7 +1842,6 @@ module ocn_time_integration_split
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
          call mpas_pool_get_dimension(block % dimensions, 'nCells', nCellsPtr)
@@ -1939,28 +1853,6 @@ module ocn_time_integration_split
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
-
-         call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
-
-         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
-         call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
-
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
-         call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
 
          nCells = nCellsPtr
          nEdges = nEdgesPtr
@@ -1981,14 +1873,14 @@ module ocn_time_integration_split
             !$omp end do
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, scratchPool, err)
 
 !         ! Compute normalGMBolusVelocity; it will be added to normalVelocity in Stage 2 of the next cycle.
 !         if (config_use_GM.or.config_use_Redi) then
-!            call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+!            call ocn_gm_compute_Bolus_velocity(statePool, &
 !               meshPool, scratchPool, timeLevelIn=2)
 !         end if
 
@@ -2016,10 +1908,10 @@ module ocn_time_integration_split
          end do
          !$omp end do
 
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
+         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
          if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
+            call ocn_reconstruct_gm_vectors(meshPool)
          end if
 
          block => block % next

--- a/src/core_ocean/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
@@ -83,7 +83,7 @@ contains
       type (block_type), pointer :: block_ptr
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool, statePool
-      type (mpas_pool_type), pointer :: diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: forcingPool
 
       type (mpas_pool_type), pointer :: tracersPool, &
                                         tracersSurfaceRestoringFieldsPool, &
@@ -200,7 +200,6 @@ contains
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
 
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)

--- a/src/core_ocean/mode_init/mpas_ocn_init_ecosys_column.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ecosys_column.F
@@ -85,7 +85,7 @@ contains
       type (block_type), pointer :: block_ptr
 
       type (mpas_pool_type), pointer :: meshPool, verticalMeshPool, statePool
-      type (mpas_pool_type), pointer :: diagnosticsPool, forcingPool
+      type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: ecosysAuxiliary  ! additional forcing fields
 
       type (mpas_pool_type), pointer :: tracersPool
@@ -148,7 +148,6 @@ contains
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
 
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -32,6 +32,7 @@ module ocn_init_global_ocean
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_equation_of_state
    use ocn_init_cell_markers
    use ocn_init_vertical_grids
@@ -1140,7 +1141,7 @@ contains
 
        type (block_type), pointer :: block_ptr
 
-       type (mpas_pool_type), pointer :: meshPool, forcingPool, landIceInitPool, diagnosticsPool, &
+       type (mpas_pool_type), pointer :: meshPool, forcingPool, landIceInitPool, &
                                          statePool
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
@@ -1262,7 +1263,6 @@ contains
 
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -1273,7 +1273,6 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
           call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
@@ -2265,7 +2264,7 @@ contains
       character (len=StrKIND), intent(in) :: interpTracerName
 
       type (block_type), pointer :: block_ptr
-      type (mpas_pool_type), pointer :: meshPool, scratchPool, diagnosticsPool
+      type (mpas_pool_type), pointer :: meshPool, scratchPool
 
       real (kind=RKIND) :: counter
       integer :: iSmooth, j, coc, iCell, k, nDepth
@@ -2281,7 +2280,6 @@ contains
       integer, pointer ::  config_global_ocean_smooth_TS_iterations
 
       real (kind=RKIND), dimension(:), pointer :: outTracerColumn
-      real (kind=RKIND), dimension(:,:), pointer :: zMid
       integer :: inKMax, outKMax
 
       type (field2DReal), pointer :: interpTracerField
@@ -2390,14 +2388,12 @@ contains
       block_ptr => domain % blocklist
       do while(associated(block_ptr))
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
          call mpas_pool_get_array(scratchPool, trim(interpTracerName), interpTracer)
 
          allocate(outTracerColumn(nVertLevels))
@@ -2602,7 +2598,7 @@ subroutine ocn_init_setup_global_ocean_interpolate_swData(domain, iErr)!{{{
 
    type (block_type), pointer :: block_ptr
    type (MPAS_Stream_type) :: zenithStream, chlorophyllStream, clearSkyStream
-   type (mpas_pool_type), pointer :: meshPool, statePool, shortwavePool, diagnosticsPool
+   type (mpas_pool_type), pointer :: meshPool, statePool, shortwavePool
 
    type(MPAS_TimeInterval_type) :: timeStep ! time step interval
    type(MPAS_Time_Type) :: currentTime
@@ -2695,12 +2691,10 @@ subroutine ocn_init_setup_global_ocean_interpolate_swData(domain, iErr)!{{{
       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
       call mpas_pool_get_subpool(block_ptr % structs, 'shortwave', shortwavePool)
-      call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
-      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
       call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)

--- a/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_hurricane.F
@@ -27,6 +27,7 @@ module ocn_init_hurricane
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_init_vertical_grids
    use ocn_init_cell_markers
 
@@ -85,7 +86,6 @@ contains
     type (mpas_pool_type), pointer :: statePool
     type (mpas_pool_type), pointer :: tracersPool
     type (mpas_pool_type), pointer :: verticalMeshPool
-    type (mpas_pool_type), pointer :: diagnosticsPool
 
     ! local variables
     integer :: iCell, k, idx, iEdge, iVertex
@@ -213,7 +213,6 @@ contains
        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
        call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
        call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
@@ -28,6 +28,7 @@ module ocn_init_isomip
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_init_vertical_grids
    use ocn_init_cell_markers
 
@@ -115,7 +116,6 @@ contains
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: verticalMeshPool
       type (mpas_pool_type), pointer :: forcingPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: tracersPool
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool
@@ -127,7 +127,7 @@ contains
       integer, pointer :: index_temperature, index_salinity, index_tracer1
 
       ! Define variable pointers
-      integer, dimension(:), pointer :: maxLevelCell, modifySSHMask, landIceMask
+      integer, dimension(:), pointer :: maxLevelCell, landIceMask
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell,refBottomDepth, &
                                                   vertCoordMovementWeights, bottomDepth, &
                                                   fCell, fEdge, fVertex, dcEdge, &
@@ -135,7 +135,7 @@ contains
                                                   refLayerThickness, refZMid, &
                                                   ssh
       !real (kind=RKIND), dimension(:), pointer :: temperatureRestore, salinityRestore, maskRestore
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness, zMid
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers, debugTracers
       real (kind=RKIND), dimension(:, :), pointer ::    activeTracersPistonVelocity, activeTracersSurfaceRestoringValue
 
@@ -250,7 +250,6 @@ contains
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
@@ -277,9 +276,6 @@ contains
         call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
         call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-        call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
 
         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
         call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
@@ -417,7 +413,6 @@ contains
       block_ptr => domain % blocklist
       do while(associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
         call ocn_compute_Haney_number(domain, iErr)
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
@@ -30,6 +30,7 @@ module ocn_init_isomip_plus
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    use ocn_init_cell_markers
 
@@ -88,7 +89,7 @@ contains
    !--------------------------------------------------------------------
 
       type (domain_type), intent(inout) :: domain
-      type (mpas_pool_type), pointer :: meshPool, statePool, diagnosticsPool, &
+      type (mpas_pool_type), pointer :: meshPool, statePool, &
                                         verticalMeshPool, forcingPool, &
                                         tracersPool
       type (mpas_pool_type), pointer :: tracersInteriorRestoringFieldsPool
@@ -221,12 +222,10 @@ contains
       do while (associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
@@ -261,7 +260,6 @@ contains
       do while (associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
@@ -272,8 +270,6 @@ contains
         call mpas_pool_get_array(meshPool, 'fCell', fCell)
         call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
         call mpas_pool_get_array(meshPool, 'fVertex', fVertex)
-
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
@@ -524,7 +520,7 @@ contains
        type (block_type), pointer :: block_ptr
 
        type (mpas_pool_type), pointer :: meshPool, verticalMeshPool, &
-                                         forcingPool, diagnosticsPool, &
+                                         forcingPool, &
                                          statePool
 
        integer, dimension(:), pointer :: landIceMask
@@ -559,7 +555,6 @@ contains
        do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -574,7 +569,6 @@ contains
           call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
 
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_mode.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_mode.F
@@ -37,6 +37,8 @@ module ocn_init_mode
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics
+   use ocn_diagnostics_variables
 
    use ocn_init_spherical_utils
 
@@ -95,9 +97,7 @@ module ocn_init_mode
       real (kind=RKIND) :: maxDensity, maxDensity_global
       real (kind=RKIND), dimension(:), pointer :: meshDensity
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
 
-      character (len=StrKIND), pointer :: xtime
       type (MPAS_Time_Type) :: startTime
       type (MPAS_TimeInterval_type) :: timeStep
 
@@ -156,10 +156,10 @@ module ocn_init_mode
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
       call mpas_get_timeInterval(timeStep, dt=dt)
 
+      call ocn_diagnostics_init(domain, ierr)
+
       block => domain % blocklist
       do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
-         call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
          xtime = startTimeStamp
          block => block % next
       end do

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -30,6 +30,7 @@ module ocn_init_ssh_and_landIcePressure
    use ocn_constants
    use ocn_init_interpolation
    use ocn_init_vertical_grids
+   use ocn_diagnostics_variables
 
    use ocn_equation_of_state
 
@@ -136,7 +137,7 @@ contains
 
      type (block_type), pointer :: block_ptr
 
-     type (mpas_pool_type), pointer :: meshPool, forcingPool, statePool, diagnosticsPool, &
+     type (mpas_pool_type), pointer :: meshPool, forcingPool, statePool, &
                                        verticalMeshPool, scratchPool
 
      type (mpas_pool_type), pointer :: tracersPool
@@ -145,15 +146,14 @@ contains
      real (kind=RKIND), dimension(:), pointer :: ssh
 
      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, zMid
+     real (kind=RKIND), dimension(:,:), pointer :: layerThickness
 
-     real (kind=RKIND), dimension(:,:), pointer :: density
      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceDraft, &
                                                  effectiveDensityInLandIce
 
 
      real(kind=RKIND), dimension(:,:), pointer :: origZMid
-     integer, dimension(:), pointer :: origMaxLevelCell, modifySSHMask
+     integer, dimension(:), pointer :: origMaxLevelCell
      type (field2DReal), pointer :: origZMidField
      type (field1DInteger), pointer :: origMaxLevelCellField
      integer, pointer :: nCells, nVertLevels
@@ -173,13 +173,10 @@ contains
        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-       call mpas_pool_get_array(diagnosticsPool, 'density', density)
-
-       call ocn_equation_of_state_density(statePool, diagnosticsPool,  &
+       call ocn_equation_of_state_density(statePool, tracersSurfaceValue,  &
            scratchPool, nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 
@@ -202,7 +199,6 @@ contains
          call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -216,10 +212,8 @@ contains
 
          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
          call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
-         call mpas_pool_get_array(diagnosticsPool, 'density', density)
-         call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
 
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, &
+         call ocn_equation_of_state_density(statePool, tracersSurfaceValue, &
              scratchPool, nCells, 0, 'relative', density, iErr, &
              timeLevelIn=1)
 
@@ -271,7 +265,6 @@ contains
        call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
        call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
@@ -286,15 +279,12 @@ contains
 
        call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
        call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
-       call mpas_pool_get_array(diagnosticsPool, 'density', density)
-       call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
 
-       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
        call mpas_pool_get_array(scratchPool, 'scratchZMid', origZMid)
        call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
 
 
-       call ocn_equation_of_state_density(statePool, diagnosticsPool, &
+       call ocn_equation_of_state_density(statePool, tracersSurfaceValue, &
            scratchPool, nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 
@@ -358,15 +348,12 @@ contains
        call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
        call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
        call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-
-       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
        call mpas_pool_get_array(scratchPool, 'scratchZMid', origZMid)
        call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
@@ -426,7 +413,7 @@ contains
 
      type (block_type), pointer :: block_ptr
 
-     type (mpas_pool_type), pointer :: meshPool, statePool, diagnosticsPool, verticalMeshPool
+     type (mpas_pool_type), pointer :: meshPool, statePool, verticalMeshPool
 
      logical, pointer :: config_use_rx1_constraint
 
@@ -438,7 +425,7 @@ contains
      ! Define variable pointers
      integer, dimension(:), pointer :: maxLevelCell
      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
-     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness, zMid
+     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
 
      integer :: iCell
 
@@ -471,7 +458,6 @@ contains
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
 
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -507,7 +493,6 @@ contains
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
          call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
@@ -522,8 +507,6 @@ contains
          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
          call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
-
-         call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
          do iCell = 1, nCells
            if(initWithSSH) then

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -179,7 +179,7 @@ contains
 
        call mpas_pool_get_array(diagnosticsPool, 'density', density)
 
-       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+       call ocn_equation_of_state_density(statePool, diagnosticsPool,  &
            scratchPool, nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 
@@ -219,7 +219,7 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'density', density)
          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
 
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+         call ocn_equation_of_state_density(statePool, diagnosticsPool, &
              scratchPool, nCells, 0, 'relative', density, iErr, &
              timeLevelIn=1)
 
@@ -294,7 +294,7 @@ contains
        call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
 
 
-       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+       call ocn_equation_of_state_density(statePool, diagnosticsPool, &
            scratchPool, nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
@@ -25,6 +25,7 @@ module ocn_init_sub_ice_shelf_2D
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_init_vertical_grids
    use ocn_init_cell_markers
 
@@ -102,7 +103,7 @@ module ocn_init_sub_ice_shelf_2D
      integer, pointer :: index_temperature, index_salinity
 
      ! Define variable pointers
-     integer, dimension(:), pointer :: maxLevelCell, modifySSHMask, landIceMask
+     integer, dimension(:), pointer :: maxLevelCell, landIceMask
      real (kind=RKIND), dimension(:), pointer :: xCell, yCell,refBottomDepth, refZMid, &
           vertCoordMovementWeights, bottomDepth, &
           fCell, fEdge, fVertex, dcEdge, refLayerThickness
@@ -113,9 +114,7 @@ module ocn_init_sub_ice_shelf_2D
 
      logical, pointer :: on_a_sphere
 
-     type (mpas_pool_type), pointer :: diagnosticsPool
      real(kind=RKIND), dimension(:), pointer :: landIceFraction, ssh
-     real (kind=RKIND), dimension(:,:), pointer :: zMid
 
      iErr = 0
 
@@ -199,7 +198,6 @@ module ocn_init_sub_ice_shelf_2D
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
@@ -217,7 +215,6 @@ module ocn_init_sub_ice_shelf_2D
         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
         call ocn_mark_north_boundary(meshPool, yMaxGlobal, dcEdgeMinGlobal, iErr)
         call ocn_mark_south_boundary(meshPool, yMinGlobal, dcEdgeMinGlobal, iErr)
 
@@ -291,7 +288,6 @@ module ocn_init_sub_ice_shelf_2D
      do while(associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -300,8 +296,6 @@ module ocn_init_sub_ice_shelf_2D
         call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
 
         call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
         ! compute active tracer fields
         ! If we are constructing an initial guess (rather than reading ssh in from a stream), these are reference activeTracers

--- a/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
@@ -27,6 +27,7 @@ module ocn_init_tidal_boundary
    use mpas_dmpar
 
    use ocn_constants
+   use ocn_diagnostics
    use ocn_init_vertical_grids
    use ocn_init_cell_markers
 
@@ -88,7 +89,6 @@ contains
     type (mpas_pool_type), pointer :: meshPool
     type (mpas_pool_type), pointer :: forcingPool
     type (mpas_pool_type), pointer :: statePool
-    type (mpas_pool_type), pointer :: diagnosticsPool
     type (mpas_pool_type), pointer :: verticalMeshPool
     type (mpas_pool_type), pointer :: tracersPool
 
@@ -199,7 +199,6 @@ contains
 
       call mpas_pool_get_array(meshPool, 'yCell', yCell)
       call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-      call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
@@ -218,7 +217,6 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(tracersPool, 'debugTracers', debugTracers, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
       call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -26,6 +26,7 @@ module ocn_init_vertical_grids
    use mpas_timer
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -652,11 +653,8 @@ contains
 
       type (block_type), pointer :: block_ptr
 
-      type (mpas_pool_type), pointer :: meshPool, diagnosticsPool, statePool
-      real (kind=RKIND), dimension(:,:), pointer :: zMid
-      real (kind=RKIND), dimension(:,:), pointer :: rx1Edge, rx1Cell
-      real (kind=RKIND), dimension(:), pointer :: rx1MaxEdge, rx1MaxCell, ssh, rx1MaxLevel
-      real (kind=RKIND), pointer :: globalRx1Max
+      type (mpas_pool_type), pointer :: meshPool, statePool
+      real (kind=RKIND), dimension(:), pointer :: ssh, rx1MaxLevel
 
       integer, pointer :: nCells, nVertLevels, nEdges
       integer, dimension(:), pointer :: maxLevelCell
@@ -676,11 +674,9 @@ contains
       allocate(rx1MaxLevel(nVertLevels))
       rx1MaxLevel(:) = 0.0_RKIND
 
-
       block_ptr => domain % blocklist
       do while(associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -690,13 +686,7 @@ contains
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid, 1)
         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-
-        call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', rx1MaxCell, 1)
 
         rx1Edge(:,:) = 0.0_RKIND
         rx1Cell(:,:) = 0.0_RKIND
@@ -737,8 +727,7 @@ contains
 
         block_ptr => block_ptr % next
       end do
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
-      call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max, 1)
+
       do k = 1,nVertLevels
          call mpas_dmpar_max_real(domain % dminfo, rx1MaxLevel(k), globalRx1Max)
          call mpas_log_write ('  max of rx1 in level $i :  $r', intArgs=(/ k /),  realArgs=(/ globalRx1Max /))
@@ -774,7 +763,7 @@ contains
 
       type (block_type), pointer :: block_ptr
 
-      type (mpas_pool_type), pointer :: meshPool, statePool, diagnosticsPool, verticalMeshPool, scratchPool, forcingPool
+      type (mpas_pool_type), pointer :: meshPool, statePool, verticalMeshPool, scratchPool, forcingPool
 
       integer, pointer :: config_rx1_outer_iter_count, config_rx1_inner_iter_count, &
                           config_rx1_horiz_smooth_open_ocean_cells, config_rx1_min_levels
@@ -783,22 +772,19 @@ contains
                            config_rx1_zstar_weight, config_rx1_init_inner_weight, &
                            config_rx1_min_layer_thickness
 
-      type (field2DReal), pointer :: zInterfaceField, goalStretchField, goalWeightField, &
-                                     verticalStretchField
+      type (field2DReal), pointer :: zInterfaceField, goalStretchField, goalWeightField
       type (field1DReal), pointer :: zTopField, zBotField, zBotNewField
       type (field1DInteger), pointer :: maxLevelCellField
-      type (field1DInteger), pointer :: smoothingMaskField, smoothingMaskNewField
+      type (field1DInteger), pointer :: smoothingMaskNewField
 
-      real (kind=RKIND), dimension(:,:), pointer :: zMid, layerThickness, restingThickness, zInterface, &
-                                                    verticalStretch, goalStretch, goalWeight, rx1Edge
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness, zInterface, &
+                                                    goalStretch, goalWeight
       integer, dimension(:), pointer :: landIceMask
       real (kind=RKIND), dimension(:), pointer :: ssh, bottomDepth, refBottomDepth, zTop, zBot, zBotNew, &
                                         refLayerThickness
 
-      real (kind=RKIND), pointer :: globalRx1Max, globalVerticalStretchMax, globalVerticalStretchMin
-
       integer, pointer :: nCells, nVertLevels, nEdges, nCellsSolve
-      integer, dimension(:), pointer :: maxLevelCell, cullCell, nEdgesOnCell, smoothingMask, smoothingMaskNew
+      integer, dimension(:), pointer :: maxLevelCell, cullCell, nEdgesOnCell, smoothingMaskNew
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
 
       integer :: iCell, iEdge, coc, c1, c2, k, maxLevelEdge, iSmooth, iterIndex, maxLevelNeighbors
@@ -828,13 +814,6 @@ contains
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
-      call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMaskField, 1)
-      call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', verticalStretchField, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMax', globalVerticalStretchMax, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMin', globalVerticalStretchMin, 1)
-
       ! allocate scratch variables that persist across blocks
       call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
       call mpas_pool_get_field(scratchPool, 'zInterfaceScratch', zInterfaceField)
@@ -848,7 +827,6 @@ contains
       do while(associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
@@ -856,7 +834,6 @@ contains
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-        call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
 
         maxLevelCell(nCells+1) = -1
         do iCell = 1, nCells
@@ -883,14 +860,12 @@ contains
         do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
           call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
           call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-          call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
 
           call mpas_pool_get_field(scratchPool, 'smoothingMaskNewScratch', smoothingMaskNewField)
           call mpas_allocate_scratch_field(smoothingMaskNewField, .true.)
@@ -928,7 +903,6 @@ contains
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -940,7 +914,6 @@ contains
         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
         call mpas_pool_get_array(scratchPool, 'zInterfaceScratch', zInterface)
 
-        call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
         call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
 
         do iCell = 1, nCells
@@ -980,7 +953,6 @@ contains
           do while(associated(block_ptr))
             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
             call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
             call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
@@ -995,10 +967,6 @@ contains
             call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
             call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-
-            call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
-            call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
-            call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
 
             call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
 
@@ -1081,12 +1049,10 @@ contains
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
           call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
           call mpas_pool_get_array(scratchPool, 'zTopScratch', zTop)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
 
           zTop(:) = ssh(:)
           where(smoothingMask == 1)
@@ -1102,7 +1068,6 @@ contains
           do while(associated(block_ptr))
             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
             call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -1112,8 +1077,6 @@ contains
 
             call mpas_pool_get_array(scratchPool, 'zInterfaceScratch', zInterface)
             call mpas_pool_get_array(scratchPool, 'zBotScratch', zBot)
-            call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
-            call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
             call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
 
             zInterface(k+1,:) = zInterface(k,:) - verticalStretch(k,:)*refLayerThickness(k)
@@ -1174,15 +1137,11 @@ contains
           block_ptr => domain % blocklist
           do while(associated(block_ptr))
             call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-            call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
             call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
             call mpas_pool_get_array(scratchPool, 'zInterfaceScratch', zInterface)
             call mpas_pool_get_array(scratchPool, 'zTopScratch', zTop)
             call mpas_pool_get_array(scratchPool, 'zBotScratch', zBot)
-            call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
-            call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid, 1)
-            call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
             call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
 
             where (smoothingMask(:) == 1)
@@ -1201,11 +1160,9 @@ contains
         block_ptr => domain % blocklist
         do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
           call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-          call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
           call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
           call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
           call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1249,7 +1206,6 @@ contains
         do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -1259,9 +1215,6 @@ contains
           call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
-          call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
-          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid, 1)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
           ! compute rx1Edge so we can determine which cells need to be thickened
@@ -1312,7 +1265,6 @@ contains
       do while(associated(block_ptr))
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
@@ -1326,10 +1278,7 @@ contains
         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid, 1)
         call mpas_pool_get_array(scratchPool, 'zInterfaceScratch', zInterface)
-        call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
-        call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
         call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
 
         ! compute zMid, layerThickness and restingThickness
@@ -1404,14 +1353,14 @@ contains
 
       type (block_type), pointer :: block_ptr
 
-      type (mpas_pool_type), pointer :: meshPool, diagnosticsPool, scratchPool
+      type (mpas_pool_type), pointer :: meshPool, scratchPool
 
       type (field1DReal), pointer :: zBotField, zBotNewField
 
       real (kind=RKIND), dimension(:), pointer :: zTop, zBot, zBotNew, bottomDepth
 
       integer, pointer :: nCells, nVertLevels, nEdges
-      integer, dimension(:), pointer :: maxLevelCell, smoothingMask
+      integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       integer :: iCell, iEdge, c1, c2, iterIndex
@@ -1438,7 +1387,6 @@ contains
         do while(associated(block_ptr))
           call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
           call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
 
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
           call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
@@ -1450,7 +1398,6 @@ contains
 
           call mpas_pool_get_array(scratchPool, 'zTopScratch', zTop)
           call mpas_pool_get_array(scratchPool, 'zBotScratch', zBot)
-          call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
 
           call mpas_pool_get_field(scratchPool, 'zBotNewScratch', zBotNewField)
           call mpas_allocate_scratch_field(zBotNewField, .true.)

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -66,7 +66,8 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_framework_forcing.o \
 	   mpas_ocn_time_varying_forcing.o \
 	   mpas_ocn_wetting_drying.o \
-	   mpas_ocn_tidal_potential_forcing.o
+	   mpas_ocn_tidal_potential_forcing.o \
+	   mpas_ocn_diagnostics_variables.o
 
 all: $(OBJS)
 
@@ -76,13 +77,13 @@ mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_su
 
 mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_mesh.o: 
 
 mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_thick_hadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -90,7 +91,7 @@ mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -108,7 +109,7 @@ mpas_ocn_vel_forcing.o: mpas_ocn_vel_forcing_surface_stress.o mpas_ocn_vel_forci
 
 mpas_ocn_vel_forcing_surface_stress.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing.o
 
 mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -120,11 +121,11 @@ mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o
 
-mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_hmix_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_high_freq_thickness_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -140,9 +141,9 @@ mpas_ocn_tracer_short_wave_absorption_jerlov.o: mpas_ocn_constants.o mpas_ocn_co
 
 mpas_ocn_vmix.o: mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -150,19 +151,19 @@ mpas_ocn_equation_of_state_jm.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_equation_of_state_linear.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_test.o:  mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_test.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_constants.o mpas_ocn_config.o:
 
-mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_restoring.o
+mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_restoring.o mpas_ocn_diagnostics.o
 
 mpas_ocn_surface_bulk_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
+mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
+mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o mpas_ocn_diagnostics.o
 
-mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
+mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -170,7 +171,7 @@ mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_sea_ice.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o
+mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_interior_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -186,17 +187,19 @@ mpas_ocn_tracer_DMS.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_MacroMolecules.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_tracer_surface_flux_to_tend.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_surface_flux_to_tend.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing.o
 
-mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_MacroMolecules.o
 
 mpas_ocn_framework_forcing.o:
 
-mpas_ocn_time_varying_forcing.o:
+mpas_ocn_time_varying_forcing.o: mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o
+mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics.o
 
-mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
+
+mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -152,13 +152,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
+   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
                                    timeLevelIn)
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
       type (mpas_pool_type), intent(inout) :: diagnosticsPool  !< Input: diagnostic fields derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
@@ -328,7 +327,7 @@ contains
       !$omp end master
       call mpas_threading_barrier()
 
-      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
+      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsOwned
@@ -615,20 +614,20 @@ contains
       nCells = nCellsAll
 
       ! compute in-place density
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
                                          nCells, 0, 'relative', density, err, &
                                          inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
                                          timeLevelIn=timeLevel)
       call mpas_threading_barrier()
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
                                          nCells, 1, 'absolute', potentialDensity, &
                                          err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
       ! That is, layer k has been displaced to the depth of layer k+1.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
       call mpas_threading_barrier()
@@ -855,7 +854,7 @@ contains
 
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
-      call ocn_compute_land_ice_flux_input_fields(meshPool, statePool, forcingPool, scratchPool, &
+      call ocn_compute_land_ice_flux_input_fields(statePool, forcingPool, scratchPool, &
                                          diagnosticsPool, timeLevel)
 
       nCells = nCellsHalo( 1 )
@@ -902,7 +901,7 @@ contains
 !>  cell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, oldLayerThickness, layerThicknessEdge, &
+   subroutine ocn_vert_transport_velocity_top(verticalMeshPool, scratchPool, oldLayerThickness, layerThicknessEdge, &
      normalVelocity, oldSSH, dt, vertAleTransportTop, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
@@ -910,9 +909,6 @@ contains
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: horizonal mesh information
 
       type (mpas_pool_type), intent(in) :: &
          verticalMeshPool   !< Input: vertical mesh information
@@ -1003,9 +999,9 @@ contains
       ! Compute desired thickness at new time
       !
       if (present(newHighFreqThickness)) then
-        call ocn_ALE_thickness(meshPool, verticalMeshPool, projectedSSH, ALE_thickness, err, newHighFreqThickness)
+        call ocn_ALE_thickness(verticalMeshPool, projectedSSH, ALE_thickness, err, newHighFreqThickness)
       else
-        call ocn_ALE_thickness(meshPool, verticalMeshPool, projectedSSH, ALE_thickness, err)
+        call ocn_ALE_thickness(verticalMeshPool, projectedSSH, ALE_thickness, err)
       endif
 
       call mpas_threading_barrier()
@@ -1049,10 +1045,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_fuperp(statePool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_fuperp(statePool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: State information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Input time level for state pool
 
       integer :: iEdge, cell1, cell2, eoe, i, j, k
@@ -1109,11 +1104,10 @@ contains
 !>  This routine filters barotropic mode out of the velocity variable.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_vel(statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_filter_btr_mode_vel(statePool, diagnosticsPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: State information
       type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
@@ -1170,12 +1164,11 @@ contains
 !>  This routine filters barotropic mode out of the velocity tendency.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, diagnosticsPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
@@ -1284,11 +1277,10 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, timeLevelIn)!{{{
+    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, diagnosticsPool, scratchPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(in) :: statePool !< Input/Output: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       type (mpas_pool_type), intent(inout) :: diagnosticsPool !< Diagnostics information derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       integer, intent(in), optional :: timeLevelIn
@@ -1383,7 +1375,7 @@ contains
       nCells = nCellsHalo( 2 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, nCells, 0, 'surfaceDisplaced', &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, nCells, 0, 'surfaceDisplaced', &
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
@@ -1471,10 +1463,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_compute_land_ice_flux_input_fields(meshPool, statePool, &
+   subroutine ocn_compute_land_ice_flux_input_fields(statePool, &
       forcingPool, scratchPool, diagnosticsPool, timeLevel)!{{{
 
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: scratch variables

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -36,6 +36,7 @@ module ocn_diagnostics
    use ocn_equation_of_state
    use ocn_thick_ale
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -79,7 +80,7 @@ module ocn_diagnostics
    !--------------------------------------------------------------------
    !
    ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
-   ! These variables were moved from the subroutines, but will be moved back once the 
+   ! These variables were moved from the subroutines, but will be moved back once the
    ! threading implementation is changed to more localized threading
    !
    !--------------------------------------------------------------------
@@ -152,13 +153,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
+   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, scratchPool, tracersPool, &!{{{
                                    timeLevelIn)
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool  !< Input: diagnostic fields derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
@@ -174,32 +174,19 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: &
         ssh,  seaIcePressure, atmosphericPressure, frazilSurfacePressure, &
-        pressureAdjustedSSH, gradSSH, landIcePressure, landIceDraft
+        landIcePressure, landIceDraft
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
-        normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
-        vertAleTransportTop, zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
-        normalizedPlanetaryVorticityEdge, normalizedPlanetaryVorticityVertex, normalizedRelativeVorticityEdge, &
-        normalizedRelativeVorticityVertex, normalizedRelativeVorticityCell, density, displacedDensity, potentialDensity, &
-        temperature, salinity, kineticEnergyVertex, kineticEnergyVertexOnCells, vertVelocityTop, vertTransportVelocityTop, &
-        vertGMBolusVelocityTop, BruntVaisalaFreqTop, vorticityGradientNormalComponent, vorticityGradientTangentialComponent, &
-        RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff, edgeAreaFractionOfCell
+        layerThickness, normalVelocity, &
+        vertAleTransportTop, &
+        temperature, salinity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       character :: c1*6
 
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
-      real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
-      real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
-
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
 
-
-      real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
-      real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
       real (kind=RKIND) :: areaTri1, layerThicknessVertexInv, tempRiVal, dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
       real (kind=RKIND), dimension(:), allocatable:: layerThicknessVertexVec
       integer :: edgeSignOnCell_temp
@@ -220,50 +207,12 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
-      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
-
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
-      !
       ! Compute height on cell edges at velocity locations
       !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
       !
@@ -614,20 +563,20 @@ contains
       nCells = nCellsAll
 
       ! compute in-place density
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, tracersSurfaceValue, scratchPool, &
                                          nCells, 0, 'relative', density, err, &
                                          inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
                                          timeLevelIn=timeLevel)
       call mpas_threading_barrier()
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, tracersSurfaceValue, scratchPool, &
                                          nCells, 1, 'absolute', potentialDensity, &
                                          err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
       ! That is, layer k has been displaced to the depth of layer k+1.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, tracersSurfaceValue, scratchPool, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
       call mpas_threading_barrier()
@@ -731,7 +680,7 @@ contains
       !
 
       nCells = nCellsHalo(2)
-      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, factor, delU2, shearMean)
+      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
          do k=2,maxLevelCell(iCell)
@@ -855,7 +804,7 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       call ocn_compute_land_ice_flux_input_fields(statePool, forcingPool, scratchPool, &
-                                         diagnosticsPool, timeLevel)
+                                         timeLevel)
 
       nCells = nCellsHalo( 1 )
       !$omp do schedule(runtime)
@@ -1104,15 +1053,14 @@ contains
 !>  This routine filters barotropic mode out of the velocity variable.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_vel(statePool, diagnosticsPool, timeLevelIn)!{{{
+   subroutine ocn_filter_btr_mode_vel(statePool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
       integer :: timeLevel
 
@@ -1125,8 +1073,6 @@ contains
       end if
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdgesAll
@@ -1164,16 +1110,15 @@ contains
 !>  This routine filters barotropic mode out of the velocity tendency.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, diagnosticsPool, timeLevelIn)!{{{
+   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, tend_normalVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: tend_normalVelocity
 
       integer :: timeLevel
 
@@ -1186,8 +1131,6 @@ contains
       end if
 
       call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdgesAll
@@ -1226,7 +1169,9 @@ contains
 !>  other diagnostics routines.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostics_init(err)!{{{
+   subroutine ocn_diagnostics_init(domain, err)!{{{
+      type (domain_type), intent(in) :: domain
+
       integer, intent(out) :: err !< Output: Error flag
 
       err = 0
@@ -1257,6 +1202,8 @@ contains
           fCoef = 0
       end if
 
+      call ocn_diagnostics_variables_init(domain, jenkinsOn, hollandJenkinsOn, err)
+
     end subroutine ocn_diagnostics_init!}}}
 
 !***********************************************************************
@@ -1277,11 +1224,10 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, diagnosticsPool, scratchPool, timeLevelIn)!{{{
+    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, scratchPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(in) :: statePool !< Input/Output: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool !< Diagnostics information derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       integer, intent(in), optional :: timeLevelIn
 
@@ -1294,23 +1240,16 @@ contains
 
       ! real pointers
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
-           surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
-           normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux
+           surfaceThicknessFluxRunoff, rainFlux, evaporationFlux
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
-           layerThickness, zMid, zTop, densitySurfaceDisplaced, density, &
-           normalVelocity, activeTracersSurfaceFlux, thermalExpansionCoeff, salineContractionCoeff, &
-           activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux, edgeAreaFractionOfCell
-
-      real (kind=RKIND), dimension(:), pointer :: &
-           indexSurfaceLayerDepth
+           layerThickness, &
+           normalVelocity, activeTracersSurfaceFlux, &
+           activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
            activeTracers
-
-      real (kind=RKIND), dimension(:,:), pointer ::  &
-           bulkRichardsonNumberBuoy, bulkRichardsonNumberShear
 
       ! local
       integer :: iCell, iEdge, i, k, err, timeLevel
@@ -1339,15 +1278,6 @@ contains
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
-      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'nonLocalSurfaceTracerFlux', nonLocalSurfaceTracerFlux)
 
       call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
@@ -1375,7 +1305,7 @@ contains
       nCells = nCellsHalo( 2 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, scratchPool, nCells, 0, 'surfaceDisplaced', &
+      call ocn_equation_of_state_density(statePool, tracersSurfaceValue, scratchPool, nCells, 0, 'surfaceDisplaced', &
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
@@ -1464,12 +1394,11 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(statePool, &
-      forcingPool, scratchPool, diagnosticsPool, timeLevel)!{{{
+      forcingPool, scratchPool, timeLevel)!{{{
 
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: scratch variables
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool !< Input/Output: Diagnostics information
 
       integer, intent(in) :: timeLevel
 
@@ -1483,20 +1412,15 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
 
-      integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
+      integer, pointer :: indexT, indexS
 
       real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
-      real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
-                                                  landIceFrictionVelocity, &
-                                                  topDrag, &
-                                                  topDragMagnitude, &
-                                                  surfaceFluxAttenuationCoefficient
+      real (kind=RKIND), dimension(:), pointer :: landIceFraction
 
       integer, dimension(:), pointer :: landIceMask
 
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity, &
-                                                    landIceBoundaryLayerTracers, landIceTracerTransferVelocities
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
@@ -1546,23 +1470,6 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
-      end if
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
       !$omp master
       allocate(blTempScratch(nCellsAll), &
@@ -1704,39 +1611,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool) !{{{
+   subroutine ocn_reconstruct_gm_vectors(meshPool) !{{{
 
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         normalTransportVelocity, transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
-         transportVelocityMeridional, normalGMBolusVelocity, GMBolusVelocityX, GMBolusVelocityY, GMBolusVelocityZ, &
-         GMBolusVelocityZonal, GMBolusVelocityMeridional, &
-         gmStreamFuncTopOfEdge, GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional
 
       call mpas_timer_start('reconstruct gm vecs')
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
 
       call mpas_reconstruct(meshPool, normalTransportVelocity,          &
                        transportVelocityX,            &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -31,6 +31,7 @@ module ocn_diagnostics
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
    use ocn_gm
    use ocn_equation_of_state
    use ocn_thick_ale
@@ -165,15 +166,6 @@ contains
 
       integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j
       integer :: boundaryMask, velMask, err, nCells, nEdges, nVertices
-      integer, pointer  :: nVertLevels, vertexDegree
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray, nVerticesArray
-
-      integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge, &
-        maxLevelCell, maxLevelEdgeTop, maxLevelEdgeBot, &
-        maxLevelVertexBot
-      integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnVertex, &
-        verticesOnEdge, edgesOnEdge, edgesOnVertex,boundaryCell, kiteIndexOnCell, &
-        verticesOnCell, edgeSignOnVertex, edgeSignOnCell, edgesOnCell, edgeMask
 
       real (kind=RKIND) :: d2fdx2_cell1, d2fdx2_cell2, coef_3rd_order, r_tmp, &
         invAreaCell1, invAreaCell2, invAreaTri1, invAreaTri2, invLength, layerThicknessVertex, coef, &
@@ -182,10 +174,11 @@ contains
       real (kind=RKIND), dimension(:), allocatable:: pTop, div_hu,div_huTransport,div_huGMBolus
 
       real (kind=RKIND), dimension(:), pointer :: &
-        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh,  seaIcePressure, atmosphericPressure, frazilSurfacePressure, &
+        ssh,  seaIcePressure, atmosphericPressure, frazilSurfacePressure, &
         pressureAdjustedSSH, gradSSH, landIcePressure, landIceDraft
+
       real (kind=RKIND), dimension(:,:), pointer :: &
-        weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
+        layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
         vertAleTransportTop, zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
         normalizedPlanetaryVorticityEdge, normalizedPlanetaryVorticityVertex, normalizedRelativeVorticityEdge, &
@@ -194,7 +187,7 @@ contains
         vertGMBolusVelocityTop, BruntVaisalaFreqTop, vorticityGradientNormalComponent, vorticityGradientTangentialComponent, &
         RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff, edgeAreaFractionOfCell
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers, derivTwo
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       character :: c1*6
 
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
@@ -258,45 +251,11 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
       call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
 
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', kiteAreasOnVertex)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-      call mpas_pool_get_array(meshPool, 'fVertex', fVertex)
-      call mpas_pool_get_array(meshPool, 'derivTwo', derivTwo)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', kiteIndexOnCell)
-      call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVerticesArray', nVerticesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
 
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
@@ -310,9 +269,9 @@ contains
       !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
       !
 
-      nEdges = nEdgesArray( size(nEdgesArray) )
-      nCells = nCellsArray( size(nCellsArray) )
-      nVertices = nVerticesArray( size(nVerticesArray) )
+      nEdges = nEdgesAll
+      nCells = nCellsAll
+      nVertices = nVerticesAll
 
       if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
         !$omp do schedule(runtime) private(cell1, cell2, k)
@@ -372,7 +331,7 @@ contains
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
       ! Need owned cells for relativeVorticityCell
-      nCells = nCellsArray( 1 )
+      nCells = nCellsOwned
 
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
       do iCell = 1, nCells
@@ -391,7 +350,7 @@ contains
       !$omp end do
 
       ! Need 0,1,2 halo cells
-      nCells = nCellsArray( 3 )
+      nCells = nCellsHalo( 2 )
       !
       ! Compute divergence, kinetic energy, and vertical velocity
       !
@@ -439,7 +398,7 @@ contains
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
-      nEdges = nEdgesArray( 2 )
+      nEdges = nEdgesHalo( 1 )
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
@@ -457,7 +416,7 @@ contains
       !$omp end do
 
       ! Need 0,1,2 halo cells
-      nCells = nCellsArray( 3 )
+      nCells = nCellsHalo( 2 )
       !
       ! Compute kinetic energy
       !
@@ -525,7 +484,7 @@ contains
       !$omp end master
       !$omp barrier
 
-      nVertices = nVerticesArray( 3 )
+      nVertices = nVerticesHalo( 2 )
 
       !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
       do iVertex = 1, nVertices
@@ -544,7 +503,7 @@ contains
       end do
       !$omp end do
 
-      nEdges = nEdgesArray( 3 )
+      nEdges = nEdgesHalo( 2 )
 
       !$omp do schedule(runtime) private(vertex1, vertex2, k)
       do iEdge = 1, nEdges
@@ -561,7 +520,7 @@ contains
       end do
       !$omp end do
 
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
 
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
       do iCell = 1, nCells
@@ -579,9 +538,9 @@ contains
       end do
       !$omp end do
 
-      nCells = nCellsArray( size(nCellsArray) )
-      nVertices = nVerticesArray( size(nVerticesArray) )
-      nEdges = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
+      nVertices = nVerticesAll
+      nEdges = nCellsAll
 
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
       if (config_apvm_scale_factor>1e-10) then
@@ -592,7 +551,7 @@ contains
          !$omp end master
          !$omp barrier
 
-         nEdges = nEdgesArray( 2 )
+         nEdges = nEdgesHalo( 1 )
 
          !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
          do iEdge = 1,nEdges
@@ -653,7 +612,7 @@ contains
       !
 
       ! Only need densities on 0, 1, and 2 halo cells
-      nCells = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
 
       ! compute in-place density
       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
@@ -663,13 +622,13 @@ contains
       call mpas_threading_barrier()
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
                                          nCells, 1, 'absolute', potentialDensity, &
                                          err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
       ! That is, layer k has been displaced to the depth of layer k+1.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
       call mpas_threading_barrier()
@@ -678,7 +637,7 @@ contains
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
-      nCells = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
       if (config_pressure_gradient_type.eq.'MontgomeryPotential') then
 
         ! use Montgomery Potential when layers are isopycnal.
@@ -752,7 +711,7 @@ contains
 
       endif
 
-      nCells = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
 
       !
       ! Brunt-Vaisala frequency (this has units of s^{-2})
@@ -772,8 +731,8 @@ contains
       ! Gradient Richardson number
       !
 
-      nCells = nCellsArray(3)
-      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
+      nCells = nCellsHalo(2)
+      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, factor, delU2, shearMean)
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
          do k=2,maxLevelCell(iCell)
@@ -816,7 +775,7 @@ contains
       ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
       if(config_use_cvmix_kpp) then
 
-        nCells = nCellsArray( 1 )
+        nCells = nCellsOwned
 
         !$omp do schedule(runtime)
         do iCell=1,nCells
@@ -845,7 +804,7 @@ contains
         enddo
         !$omp end do
 
-        nEdges = nEdgesArray( 1 )
+        nEdges = nEdgesOwned
 
         !
         ! average normal velocity values over the ocean surface layer
@@ -884,7 +843,7 @@ contains
 
       endif
 
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
 
       ! compute the attenuation coefficient for surface fluxes
       !$omp do schedule(runtime)
@@ -899,7 +858,7 @@ contains
       call ocn_compute_land_ice_flux_input_fields(meshPool, statePool, forcingPool, scratchPool, &
                                          diagnosticsPool, timeLevel)
 
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
@@ -916,7 +875,7 @@ contains
          !$omp end do
       end if
 
-      nEdges = nEdgesArray( 2 )
+      nEdges = nEdgesHalo( 1 )
 
       !$omp do schedule(runtime) private(cell1, cell2)
       do iEdge = 1, nEdges
@@ -996,33 +955,16 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iEdge, iCell, k, i, nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge, &
-        maxLevelCell, maxLevelEdgeBot
-      integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
-      real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
       err = 0
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       if (config_vert_coord_movement.eq.'impermeable_interfaces') then
         vertAleTransportTop=0.0_RKIND
         return
       end if
 
-      ncells = nCellsArray(size(nCellsArray))
+      ncells = nCellsAll
 
       !$omp master
       allocate(div_hu(nVertLevels, nCells), &
@@ -1032,7 +974,7 @@ contains
       !$omp barrier
 
       ! Only need to compute over 0 and 1 halos
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
 
       !
       ! thickness-weighted divergence and barotropic divergence
@@ -1114,13 +1056,8 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Input time level for state pool
 
       integer :: iEdge, cell1, cell2, eoe, i, j, k
-      integer, pointer :: nEdgesSolve
-      real (kind=RKIND), dimension(:), pointer :: fEdge
-      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, normalVelocity, normalBaroclinicVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalBaroclinicVelocity
       type (dm_info) :: dminfo
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnEdge
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnEdge
 
       integer :: timeLevel
 
@@ -1135,24 +1072,13 @@ contains
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, timeLevel)
 
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-
-      call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
-
       !DWJ: ADD OMP (Only needed for split explicit)
 
       !
       ! Put f*normalBaroclinicVelocity^{perp} in u as a work variable
       !
       !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
-      do iEdge = 1, nEdgesSolve
+      do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
@@ -1191,10 +1117,8 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
-      integer, pointer :: nEdges
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalVelocity
-      integer, dimension(:), pointer :: maxLevelEdgeTop
 
       integer :: timeLevel
 
@@ -1210,12 +1134,8 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
 
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
@@ -1259,11 +1179,8 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
-      integer, pointer :: nEdges
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, tend_normalVelocity
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop
 
       integer :: timeLevel
 
@@ -1279,12 +1196,8 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
 
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
@@ -1386,15 +1299,8 @@ contains
 
       ! scalars
       integer :: nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-
-      ! integer pointers
-      integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
-      integer, dimension(:,:), pointer :: edgesOnCell
 
       ! real pointers
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
            surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
            normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux
@@ -1434,21 +1340,12 @@ contains
       turbulentVelocitySquared = 0.001_RKIND
 
       ! set scalar values
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', indexTempFlux)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', indexSaltFlux)
 
       ! set pointers into state, mesh, diagnostics and scratch
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
 
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
       call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
@@ -1474,7 +1371,7 @@ contains
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
 
       ! allocate scratch space displaced density computation
-      ncells = nCellsArray(size(nCellsArray))
+      ncells = nCellsAll
       !$omp master
       allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
                thermalExpansionCoeff(nVertLevels, nCells), &
@@ -1483,10 +1380,10 @@ contains
       !$omp barrier
 
       ! Only need to compute over the 0 and 1 halos
-      nCells = nCellsArray( 3 )
+      nCells = nCellsHalo( 2 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, nCells, 0, 'surfaceDisplaced', &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, nCells, 0, 'surfaceDisplaced', &
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
@@ -1594,11 +1491,6 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
 
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
-      integer, pointer :: nCells, nEdges
-
-      integer, dimension(:,:), pointer :: cellsOnCell, cellsOnEdge, cellMask
-
-      integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
 
       integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
@@ -1608,7 +1500,6 @@ contains
                                                   landIceFrictionVelocity, &
                                                   topDrag, &
                                                   topDragMagnitude, &
-                                                  fCell, &
                                                   surfaceFluxAttenuationCoefficient
 
       integer, dimension(:), pointer :: landIceMask
@@ -1634,10 +1525,9 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
          call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          ! compute landIceMask from landIceFraction
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             if (landIceFraction(iCell) >= 0.5_RKIND) then
                landIceMask(iCell) = 1
             else
@@ -1655,15 +1545,6 @@ contains
       end if
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
-
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -1693,18 +1574,14 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
       !$omp master
-      allocate(blTempScratch(nCells), &
-               blSaltScratch(nCells))
+      allocate(blTempScratch(nCellsAll), &
+               blSaltScratch(nCellsAll))
       !$omp end master
       !$omp barrier
 
-      if(hollandJenkinsOn) then
-         call mpas_pool_get_array(meshPool, 'fCell', fCell)
-      end if
-
       ! Compute top drag
       !$omp do schedule(runtime) private(cell1, cell2, velocityMagnitude, landIceEdgeFraction)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
 
@@ -1720,7 +1597,7 @@ contains
 
       ! compute top drag magnitude and friction velocity at cell centers
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMagnitude(iCell) = rho_sw * landIceFraction(iCell) &
                                    * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(1,iCell)
@@ -1732,11 +1609,9 @@ contains
       end do
       !$omp end do
 
-
-
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND
          blSaltScratch(iCell) = 0.0_RKIND
@@ -1755,7 +1630,7 @@ contains
       !$omp end do
 
       !$omp do schedule(runtime) private(weightSum, i, cell2)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
          landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
          if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
@@ -1776,7 +1651,7 @@ contains
 
       if(jenkinsOn) then
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             ! transfer coefficients from namelist
             landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell) &
                                              * config_land_ice_flux_jenkins_heat_transfer_coefficient
@@ -1786,7 +1661,7 @@ contains
          !$omp end do
       else if(hollandJenkinsOn) then
          !$omp do schedule(runtime) private(h_nu, Gamma_turb)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             ! friction-velocity dependent non-dimensional transfer coefficients from
             ! Holland and Jenkins 1999, (14)-(16) with eta_* = 1
             h_nu = 5.0_RKIND*nuSaltWater/landIceFrictionVelocity(iCell) ! uStar should never be zero because of tidal term
@@ -1813,7 +1688,7 @@ contains
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          if(landIceMask(iCell) == 1) then
             surfaceFluxAttenuationCoefficient(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
@@ -1925,15 +1800,11 @@ contains
 
       type (block_type), pointer :: block
 
-      integer, pointer :: nCellsSolve, nEdgesSolve, nVerticesSolve
-
       type (mpas_pool_type), pointer :: meshPool, statePool, tracersPool
       type (mpas_pool_type), pointer :: forcingPool
 
       real (kind=RKIND), dimension(:, :), pointer :: layerThickness, normalVelocity
       real (kind=RKIND), dimension(:, :, :), pointer :: activeTracers
-
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeBot, maxLevelVertexBot
 
       real (kind=RKIND), dimension(:), pointer :: real1DArr
       real (kind=RKIND), dimension(:, :), pointer :: real2DArr
@@ -1979,20 +1850,12 @@ contains
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
-         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
-         call mpas_pool_get_dimension(meshPool, 'nVerticesSolve', nVerticesSolve)
-
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-         call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-         call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-
          call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel=timeLevelLocal)
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel=timeLevelLocal)
          call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel=timeLevelLocal)
 
          ! Check for errors in the state fields
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCellsOwned
             do k = 1, maxLevelCell(iCell)
                thickNanFound = thickNanFound .or. ( .not. layerThickness(k, iCell) == layerThickness(k, iCell) )
                do iTracer = 1, size(activeTracers, dim=1)
@@ -2002,7 +1865,7 @@ contains
             end do
          end do
 
-         do iEdge = 1, nEdgesSolve
+         do iEdge = 1, nEdgesOwned
             do k = 1, maxLevelEdgeBot(iEdge)
                velNanFound = velNanFound .or. ( .not. normalVelocity(k, iEdge) == normalVelocity(k, iEdge) )
             end do
@@ -2027,7 +1890,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2038,7 +1901,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2049,7 +1912,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2060,7 +1923,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2071,7 +1934,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2082,7 +1945,7 @@ contains
             minValue = HUGE(minValue)
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
-            do iCell = 1, nCellsSolve
+            do iCell = 1, nCellsOwned
                minValue = min( minValue, real1DArr(iCell) )
                maxValue = max( maxValue, real1DArr(iCell) )
             end do
@@ -2102,7 +1965,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2115,7 +1978,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2128,7 +1991,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2141,7 +2004,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2154,7 +2017,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2167,7 +2030,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2180,7 +2043,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2193,7 +2056,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2214,7 +2077,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2227,7 +2090,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2240,7 +2103,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2253,7 +2116,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2266,7 +2129,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2279,7 +2142,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iEdge = 1, nEdgesSolve
+               do iEdge = 1, nEdgesOwned
                   minValue = min( minValue, real1DArr(iEdge) )
                   maxValue = max( maxValue, real1DArr(iEdge) )
                end do
@@ -2292,7 +2155,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(meshPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iEdge = 1, nEdgesSolve
+               do iEdge = 1, nEdgesOwned
                   minValue = min( minValue, real1DArr(iEdge) )
                   maxValue = max( maxValue, real1DArr(iEdge) )
                end do
@@ -2313,7 +2176,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2326,7 +2189,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2339,7 +2202,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2352,7 +2215,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2365,7 +2228,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2378,7 +2241,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2391,7 +2254,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2404,7 +2267,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2417,7 +2280,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2430,7 +2293,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2443,7 +2306,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2456,7 +2319,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2469,7 +2332,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do
@@ -2482,7 +2345,7 @@ contains
             maxValue = -HUGE(maxValue)
             call mpas_pool_get_array(forcingPool, fieldName, real1DArr)
             if ( associated(real1DArr) ) then
-               do iCell = 1, nCellsSolve
+               do iCell = 1, nCellsOwned
                   minValue = min( minValue, real1DArr(iCell) )
                   maxValue = max( maxValue, real1DArr(iCell) )
                end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -30,6 +30,7 @@ module ocn_diagnostics
    use mpas_io_units
 
    use ocn_constants
+   use ocn_config
    use ocn_gm
    use ocn_equation_of_state
    use ocn_thick_ale
@@ -71,6 +72,68 @@ module ocn_diagnostics
    integer :: ke_cell_flag, ke_vertex_flag
    real (kind=RKIND) ::  fCoef
    real (kind=RKIND), pointer ::  coef_3rd_order
+
+   logical :: jenkinsOn, hollandJenkinsOn
+
+   !--------------------------------------------------------------------
+   !
+   ! Replace calls to mpas_allocate_scratch_Field with straight allocates.
+   ! These variables were moved from the subroutines, but will be moved back once the 
+   ! threading implementation is changed to more localized threading
+   !
+   !--------------------------------------------------------------------
+
+   ! Subroutine ocn_diagnostic_solve
+   ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
+   !               units: m^2 s^{-2}
+   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
+   ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
+   !                      units: m^2 s^{-2}
+   real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
+   ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
+   !                                     divided by layer thickness, defined at vertices
+   !                              units: s^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
+   ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
+   !                                    defined at vertices
+   !                             units: s^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
+   ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
+   !                                   (positive points from cell1 to cell2)
+   !                            units: s^{-1} m^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
+   ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
+   !                                       (positive points from vertex1 to vertex2)
+   !                                units: s^{-1} m^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
+
+   ! Subroutine ocn_vert_transport_velocity_top
+   ! projectedSSH: projected SSH at a new time
+   !        units: none
+   real (kind=RKIND), dimension(:), allocatable ::  projectedSSH
+   ! div_hu: divergence of (thickness*velocity)
+   !  units: none
+   real (kind=RKIND), dimension(:,:), allocatable :: div_hu
+   ! ALE_Thickness: ALE thickness at new time
+   !         units: none
+   real (kind=RKIND), dimension(:,:), allocatable :: ALE_Thickness
+
+   ! subroutine ocn_compute_KPP_input_fields
+   ! densitySurfaceDisplaced: Density computed by displacing SST and SSS to every vertical
+   !                          layer within the column
+   !                   units: kg m^{-3}
+   real (kind=RKIND), dimension(:,:), allocatable :: densitySurfaceDisplaced
+   ! thermalExpansionCoeff: Thermal expansion coefficient (alpha), defined as $-1/\rho
+   !                        d\rho/dT$ (note negative sign)
+   !                 units: C^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: thermalExpansionCoeff
+   ! salineContractionCoeff: Saline contraction coefficient (beta), defined as $1/\rho
+   !                         d\rho/dS$.  This is also called the haline contraction coefficient.
+   !                  units: PSU^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: salineContractionCoeff
+
+   ! subroutine ocn_compute_land_ice_flux_input_fields
+   real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
 
 !***********************************************************************
 
@@ -139,20 +202,10 @@ contains
       real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
       real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
 
-      type (field2DReal), pointer :: kineticEnergyVertexField, kineticEnergyVertexOnCellsField
-      type (field2DReal), pointer :: normalizedRelativeVorticityVertexField, normalizedPlanetaryVorticityVertexField
-      type (field2DReal), pointer :: vorticityGradientNormalComponentField, vorticityGradientTangentialComponentField
-
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
-      logical, pointer :: config_use_cvmix_kpp
-      logical, pointer :: config_use_wetting_drying
-      real (kind=RKIND), pointer :: config_apvm_scale_factor,  config_coef_3rd_order, config_cvmix_kpp_surface_layer_averaging
-      character (len=StrKIND), pointer :: config_pressure_gradient_type
-      character (len=StrKIND), pointer :: config_thickness_flux_type
 
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient_runoff
+
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
       real (kind=RKIND) :: areaTri1, layerThicknessVertexInv, tempRiVal, dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
@@ -166,17 +219,6 @@ contains
       else
          timeLevel = 1
       end if
-
-      call mpas_pool_get_config(ocnConfigs, 'config_apvm_scale_factor', config_apvm_scale_factor)
-      call mpas_pool_get_config(ocnConfigs, 'config_pressure_gradient_type', config_pressure_gradient_type)
-      call mpas_pool_get_config(ocnConfigs, 'config_coef_3rd_order', config_coef_3rd_order)
-      call mpas_pool_get_config(ocnConfigs, 'config_cvmix_kpp_surface_layer_averaging', config_cvmix_kpp_surface_layer_averaging)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_cvmix_kpp', config_use_cvmix_kpp)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient_runoff',  &
-                                             config_flux_attenuation_coefficient_runoff)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_wetting_drying', config_use_wetting_drying)
-      call mpas_pool_get_config(ocnConfigs, 'config_thickness_flux_type', config_thickness_flux_type)
 
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
@@ -420,13 +462,12 @@ contains
       ! Compute kinetic energy
       !
       if ( ke_vertex_flag == 1 ) then
-         call mpas_pool_get_field(scratchPool, 'kineticEnergyVertex', kineticEnergyVertexField)
-         call mpas_pool_get_field(scratchPool, 'kineticEnergyVertexOnCells', kineticEnergyVertexOnCellsField)
-         call mpas_allocate_scratch_field(kineticEnergyVertexField, .true.)
-         call mpas_allocate_scratch_field(kineticEnergyVertexOnCellsField, .true.)
 
-         kineticEnergyVertex         => kineticEnergyVertexField % array
-         kineticEnergyVertexOnCells  => kineticEnergyVertexOnCellsField % array
+         !$omp master
+         allocate(kineticEnergyVertex(nVertLevels, nVertices), &
+                  kineticEnergyVertexOnCells(nVertLevels, nCells))
+         !$omp end master
+         !$omp barrier
 
          !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
          do iVertex = 1, nVertices
@@ -468,20 +509,21 @@ contains
          end do
          !$omp end do
 
-         call mpas_deallocate_scratch_field(kineticEnergyVertexField, .true.)
-         call mpas_deallocate_scratch_field(kineticEnergyVertexOnCellsField, .true.)
+         !$omp barrier
+         !$omp master
+         deallocate(kineticEnergyVertex, &
+                    kineticEnergyVertexOnCells)
+         !$omp end master
       end if
 
       !
       ! Compute normalized relative and planetary vorticity
       !
-      call mpas_pool_get_field(scratchPool, 'normalizedRelativeVorticityVertex', normalizedRelativeVorticityVertexField)
-      call mpas_pool_get_field(scratchPool, 'normalizedPlanetaryVorticityVertex', normalizedPlanetaryVorticityVertexField)
-      call mpas_allocate_scratch_field(normalizedRelativeVorticityVertexField, .true., .false.)
-      call mpas_allocate_scratch_field(normalizedPlanetaryVorticityVertexField, .true., .false.)
-
-      normalizedPlanetaryVorticityVertex  => normalizedPlanetaryVorticityVertexField % array
-      normalizedRelativeVorticityVertex  => normalizedRelativeVorticityVertexField % array
+      !$omp master
+      allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVertices), &
+               normalizedRelativeVorticityVertex(nVertLevels, nVertices))
+      !$omp end master
+      !$omp barrier
 
       nVertices = nVerticesArray( 3 )
 
@@ -544,13 +586,11 @@ contains
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
       if (config_apvm_scale_factor>1e-10) then
 
-         call mpas_pool_get_field(scratchPool, 'vorticityGradientNormalComponent', vorticityGradientNormalComponentField)
-         call mpas_pool_get_field(scratchPool, 'vorticityGradientTangentialComponent', vorticityGradientTangentialComponentField)
-         call mpas_allocate_scratch_field(vorticityGradientNormalComponentField, .true.)
-         call mpas_allocate_scratch_field(vorticityGradientTangentialComponentField, .true.)
-
-         vorticityGradientNormalComponent => vorticityGradientNormalComponentField % array
-         vorticityGradientTangentialComponent => vorticityGradientTangentialComponentField % array
+         !$omp master
+         allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
+                  vorticityGradientTangentialComponent(nVertLevels, nEdges))
+         !$omp end master
+         !$omp barrier
 
          nEdges = nEdgesArray( 2 )
 
@@ -594,13 +634,19 @@ contains
          enddo
          !$omp end do
 
-         call mpas_deallocate_scratch_field(vorticityGradientNormalComponentField, .true.)
-         call mpas_deallocate_scratch_field(vorticityGradientTangentialComponentField, .true.)
+         !$omp barrier
+         !$omp master
+         deallocate(vorticityGradientNormalComponent, &
+                    vorticityGradientTangentialComponent)
+         !$omp end master
 
       endif
 
-      call mpas_deallocate_scratch_field(normalizedRelativeVorticityVertexField, .true.)
-      call mpas_deallocate_scratch_field(normalizedPlanetaryVorticityVertexField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(normalizedPlanetaryVorticityVertex, &
+                 normalizedRelativeVorticityVertex)
+      !$omp end master
 
       !
       ! equation of state
@@ -617,13 +663,13 @@ contains
       call mpas_threading_barrier()
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
                                          nCells, 1, 'absolute', potentialDensity, &
                                          err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
       ! That is, layer k has been displaced to the depth of layer k+1.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
       call mpas_threading_barrier()
@@ -958,19 +1004,7 @@ contains
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:), pointer :: &
-         projectedSSH       !> projected SSH at new time
-      type (field1DReal), pointer :: projectedSSHField
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         ALE_Thickness, & !> ALE thickness at new time
-         div_hu           !> divergence of (thickness*velocity)
-      type (field2DReal), pointer :: ALE_ThicknessField, div_huField
-
-      character (len=StrKIND), pointer :: config_vert_coord_movement
-
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_vert_coord_movement', config_vert_coord_movement)
 
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -988,19 +1022,17 @@ contains
         return
       end if
 
+      ncells = nCellsArray(size(nCellsArray))
+
+      !$omp master
+      allocate(div_hu(nVertLevels, nCells), &
+               projectedSSH(nCells), &
+               ALE_Thickness(nVertLevels, nCells))
+      !$omp end master
+      !$omp barrier
+
       ! Only need to compute over 0 and 1 halos
       nCells = nCellsArray( 2 )
-
-      call mpas_pool_get_field(scratchPool, 'div_hu', div_huField)
-      call mpas_pool_get_field(scratchPool, 'projectedSSH', projectedSSHField)
-      call mpas_pool_get_field(scratchPool, 'ALE_Thickness', ALE_ThicknessField)
-      call mpas_allocate_scratch_field(div_huField, .true.)
-      call mpas_allocate_scratch_field(projectedSSHField, .true.)
-      call mpas_allocate_scratch_field(ALE_ThicknessField, .true.)
-
-      div_hu => div_huField % array
-      projectedSSH => projectedSSHField % array
-      ALE_Thickness => ALE_ThicknessField % array
 
       !
       ! thickness-weighted divergence and barotropic divergence
@@ -1054,9 +1086,12 @@ contains
       end do
       !$omp end do
 
-      call mpas_deallocate_scratch_field(div_huField, .true.)
-      call mpas_deallocate_scratch_field(projectedSSHField, .true.)
-      call mpas_deallocate_scratch_field(ALE_ThicknessField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(div_hu, &
+                 projectedSSH, &
+                 ALE_Thickness)
+      !$omp end master
 
    end subroutine ocn_vert_transport_velocity_top!}}}
 
@@ -1288,13 +1323,15 @@ contains
    subroutine ocn_diagnostics_init(err)!{{{
       integer, intent(out) :: err !< Output: Error flag
 
-      logical, pointer :: config_include_KE_vertex
-      character (len=StrKIND), pointer :: config_time_integrator
-
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_include_KE_vertex', config_include_KE_vertex)
-      call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
+      jenkinsOn = .false.
+      hollandJenkinsOn = .false.
+      if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
+         jenkinsOn = .true.
+      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
+         hollandJenkinsOn = .true.
+      end if
 
       if(config_include_KE_vertex) then
          ke_vertex_flag = 1
@@ -1361,7 +1398,6 @@ contains
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
            surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
            normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux
-      real (kind=RKIND), pointer :: config_flux_attenuation_coefficient, config_flux_attenuation_coefficient_runoff
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
@@ -1384,8 +1420,6 @@ contains
       real (kind=RKIND) :: numerator, denominator, turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
       real (kind=RKIND) :: sumSurfaceStressSquared
 
-      type (field2DReal), pointer :: densitySurfaceDisplacedField, thermalExpansionCoeffField, salineContractionCoeffField
-
       call mpas_timer_start('KPP input fields')
 
       if (present(timeLevelIn)) then
@@ -1396,9 +1430,6 @@ contains
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient', config_flux_attenuation_coefficient)
-      call mpas_pool_get_config(ocnConfigs, 'config_flux_attenuation_coefficient_runoff',   &
-              config_flux_attenuation_coefficient_runoff)
       ! set the parameter turbulentVelocitySquared
       turbulentVelocitySquared = 0.001_RKIND
 
@@ -1441,23 +1472,21 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
-      ! allocate scratch space displaced density computation
-      call mpas_pool_get_field(scratchPool, 'densitySurfaceDisplaced', densitySurfaceDisplacedField)
-      call mpas_pool_get_field(scratchPool, 'thermalExpansionCoeff', thermalExpansionCoeffField)
-      call mpas_pool_get_field(scratchPool, 'salineContractionCoeff', salineContractionCoeffField)
-      call mpas_allocate_scratch_field(densitySurfaceDisplacedField, .true., .false.)
-      call mpas_allocate_scratch_field(thermalExpansionCoeffField, .true., .false.)
-      call mpas_allocate_scratch_field(salineContractionCoeffField, .true., .false.)
 
-      densitySurfaceDisplaced => densitySurfaceDisplacedField % array
-      thermalExpansionCoeff => thermalExpansionCoeffField % array
-      salineContractionCoeff => salineContractionCoeffField % array
+      ! allocate scratch space displaced density computation
+      ncells = nCellsArray(size(nCellsArray))
+      !$omp master
+      allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
+               thermalExpansionCoeff(nVertLevels, nCells), &
+               salineContractionCoeff(nVertLevels, nCells))
+      !$omp end master
+      !$omp barrier
 
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsArray( 3 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, scratchPool, nCells, 0, 'surfaceDisplaced', &
+      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, nCells, 0, 'surfaceDisplaced', &
                                          densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
@@ -1521,9 +1550,12 @@ contains
       !$omp end do
 
       ! deallocate scratch space
-      call mpas_deallocate_scratch_field(thermalExpansionCoeffField, .true.)
-      call mpas_deallocate_scratch_field(salineContractionCoeffField, .true.)
-      call mpas_deallocate_scratch_field(densitySurfaceDisplacedField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(thermalExpansionCoeff, &
+                 salineContractionCoeff, &
+                 densitySurfaceDisplaced)
+      !$omp end master
 
       call mpas_timer_stop('KPP input fields')
 
@@ -1570,16 +1602,6 @@ contains
 
       integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
-      character (len=StrKIND), pointer :: config_land_ice_flux_formulation, config_land_ice_flux_mode
-
-      real (kind=RKIND), pointer :: config_land_ice_flux_boundaryLayerThickness, &
-                                    config_land_ice_flux_boundaryLayerNeighborWeight, &
-                                    config_land_ice_flux_topDragCoeff, &
-                                    config_land_ice_flux_rms_tidal_velocity, &
-                                    config_land_ice_flux_jenkins_heat_transfer_coefficient, &
-                                    config_land_ice_flux_jenkins_salt_transfer_coefficient, &
-                                    config_land_ice_flux_attenuation_coefficient
-
       real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
       real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
@@ -1587,7 +1609,6 @@ contains
                                                   topDrag, &
                                                   topDragMagnitude, &
                                                   fCell, &
-                                                  blTempScratch, blSaltScratch, &
                                                   surfaceFluxAttenuationCoefficient
 
       integer, dimension(:), pointer :: landIceMask
@@ -1595,9 +1616,6 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity, &
                                                     landIceBoundaryLayerTracers, landIceTracerTransferVelocities
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      type (field1DReal), pointer :: boundaryLayerTemperatureField, boundaryLayerSalinityField
-
-      logical :: jenkinsOn, hollandJenkinsOn
 
       ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
       real (kind=RKIND), parameter :: &
@@ -1607,38 +1625,36 @@ contains
          kVonKarman = 0.4_RKIND, &      ! the von Karman constant
          xiN = 0.052_RKIND              ! dimensionless planetary boundary layer constant
 
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+
+      if ( trim(config_land_ice_flux_mode) .ne. 'off' ) then
+
+         ! we need to compute the landiceMask regardless of which mode we're in so it can be
+         ! added to the restart file
+
+         call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         ! compute landIceMask from landIceFraction
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            if (landIceFraction(iCell) >= 0.5_RKIND) then
+               landIceMask(iCell) = 1
+            else
+               landIceMask(iCell) = 0
+               ! don't allow land-ice fluxes if land ice is masked out
+               landIceFraction(iCell) = 0.0_RKIND
+            end if
+         end do
+         !$omp end do
+
+      end if
 
       if ( trim(config_land_ice_flux_mode) .ne. 'standalone' .and. trim(config_land_ice_flux_mode) .ne. 'coupled' ) then
          return
       end if
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
-
-      jenkinsOn = .false.
-      hollandJenkinsOn = .false.
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_formulation', config_land_ice_flux_formulation)
-      if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
-         jenkinsOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
-         hollandJenkinsOn = .true.
-      end if
-
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_topDragCoeff', config_land_ice_flux_topDragCoeff)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerThickness', &
-                                config_land_ice_flux_boundaryLayerThickness)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_boundaryLayerNeighborWeight', &
-                                config_land_ice_flux_boundaryLayerNeighborWeight)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_rms_tidal_velocity', config_land_ice_flux_rms_tidal_velocity)
-      call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_attenuation_coefficient', &
-                                config_land_ice_flux_attenuation_coefficient)
-
-      if(jenkinsOn) then
-         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_heat_transfer_coefficient', &
-                                   config_land_ice_flux_jenkins_heat_transfer_coefficient)
-         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_jenkins_salt_transfer_coefficient', &
-                                   config_land_ice_flux_jenkins_salt_transfer_coefficient)
-      end if
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -1676,13 +1692,11 @@ contains
       end if
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
-      call mpas_pool_get_field(scratchPool, 'boundaryLayerTemperatureScratch', boundaryLayerTemperatureField)
-      call mpas_pool_get_field(scratchPool, 'boundaryLayerSalinityScratch', boundaryLayerSalinityField)
-      call mpas_allocate_scratch_field(boundaryLayerTemperatureField, .true.)
-      call mpas_allocate_scratch_field(boundaryLayerSalinityField, .true.)
-
-      blTempScratch => boundaryLayerTemperatureField % array
-      blSaltScratch => boundaryLayerSalinityField % array
+      !$omp master
+      allocate(blTempScratch(nCells), &
+               blSaltScratch(nCells))
+      !$omp end master
+      !$omp barrier
 
       if(hollandJenkinsOn) then
          call mpas_pool_get_array(meshPool, 'fCell', fCell)
@@ -1791,8 +1805,11 @@ contains
          !$omp end do
       end if
 
-      call mpas_deallocate_scratch_field(boundaryLayerTemperatureField, .true.)
-      call mpas_deallocate_scratch_field(boundaryLayerSalinityField, .true.)
+      !$omp barrier
+      !$omp master
+      deallocate(blTempScratch, &
+                 blSaltScratch)
+      !$omp end master
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
       !$omp do schedule(runtime)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_routines.F
@@ -24,6 +24,8 @@ module ocn_diagnostics_routines
    use mpas_constants
    use mpas_timer
 
+   use ocn_mesh
+
    implicit none
    private
    save
@@ -64,16 +66,13 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)!{{{
+   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity
@@ -99,29 +98,13 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iVertex, iEdge, i, k
-      integer, pointer :: nEdges, nVertices, vertexDegree
-      integer, dimension(:), pointer :: maxLevelVertexBot
-      integer, dimension(:,:), pointer :: edgesOnVertex, edgeSignOnVertex
 
       real (kind=RKIND) :: invAreaTri1, r_tmp
-      real (kind=RKIND), dimension(:), pointer :: &
-              dcEdge, areaTriangle
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
       err = 0
 
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
-      do iVertex = 1, nVertices
+      do iVertex = 1, nVerticesAll
          circulation(:, iVertex) = 0.0_RKIND
          relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -1,0 +1,422 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_diagnostics
+!
+!> \brief MPAS ocean diagnostics variable definitions
+!> \author Matt Turner
+!> \date   13 May 2020
+!> \details
+!>  This module contains the definitions of all variables contianed in the
+!>  diagnosticsPool, and also gets the variables from the Pool in init.
+!
+!-----------------------------------------------------------------------
+
+module ocn_diagnostics_variables
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_constants
+   use mpas_stream_manager
+   use mpas_io_units
+
+   use ocn_config
+
+   implicit none
+   public
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   real (kind=RKIND), dimension(:,:), pointer :: zMid
+   real (kind=RKIND), dimension(:,:), pointer :: zTop
+   real (kind=RKIND), dimension(:,:), pointer :: divergence
+   real (kind=RKIND), dimension(:,:), pointer :: circulation
+   real (kind=RKIND), dimension(:,:), pointer :: relativeVorticity
+   real (kind=RKIND), dimension(:,:), pointer :: relativeVorticityCell
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedPlanetaryVorticityEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityCell
+   real (kind=RKIND), dimension(:,:), pointer :: density
+   real (kind=RKIND), dimension(:,:), pointer :: displaceddensity
+   real (kind=RKIND), dimension(:,:), pointer :: potentialdensity
+   real (kind=RKIND), dimension(:,:), pointer :: montgomeryPotential
+   real (kind=RKIND), dimension(:,:), pointer :: pressure
+   real (kind=RKIND), dimension(:,:), pointer :: inSituThermalExpansionCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: inSituSalineContractionCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
+   real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge
+   real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
+   real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: vertGMBolusVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: normalGMBolusVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: RiTopOfCell
+   real (kind=RKIND), dimension(:,:), pointer :: RiTopOfEdge
+
+   real (kind=RKIND), dimension(:), pointer :: gradSSH
+   real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
+
+   real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
+   real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
+   real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
+   real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
+
+   real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
+   real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
+
+   real (kind=RKIND), dimension(:), pointer :: landIceFrictionVelocity
+   real (kind=RKIND), dimension(:), pointer :: topDrag
+   real (kind=RKIND), dimension(:), pointer :: topDragMagnitude
+   real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
+   real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
+
+   integer, pointer :: indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
+
+   real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFluxOBL
+
+   real (kind=RKIND), dimension(:), pointer :: surfaceBuoyancyForcing
+   real (kind=RKIND), dimension(:), pointer :: surfaceFrictionVelocity
+
+   real (kind=RKIND), dimension(:,:), pointer :: &
+      transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
+      transportVelocityMeridional, GMBolusVelocityX, GMBolusVelocityY, &
+      GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
+      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional, &
+      gmStreamFuncTopOfCell
+
+   real (kind=RKIND), dimension(:,:), pointer :: rx1Edge
+   real (kind=RKIND), dimension(:,:), pointer :: rx1Cell
+   real (kind=RKIND), dimension(:), pointer :: rx1MaxEdge
+   real (kind=RKIND), dimension(:), pointer :: rx1MaxCell
+   real (kind=RKIND), pointer :: globalRx1Max
+
+   integer, dimension(:), pointer :: smoothingMask
+   real (kind=RKIND), dimension(:,:), pointer :: verticalStretch
+
+   integer, dimension(:), pointer :: modifySSHMask
+
+   real (kind=RKIND), dimension(:,:), pointer :: velocityMeridional
+   real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
+
+   real(kind=RKIND), dimension(:, :), pointer :: kappaGMCell
+   real(kind=RKIND), dimension(:, :), pointer :: kappaRediSfcTaper
+   real(kind=RKIND), dimension(:, :), pointer :: kappaRediCell
+   real(kind=RKIND), dimension(:, :), pointer :: k33
+   real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
+   real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
+   real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
+
+   integer, dimension(:), pointer :: indMLD
+   real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+
+   real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
+
+   real (kind=RKIND), dimension(:,:), pointer :: viscosity
+   real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfEdge
+   real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfCell
+   real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
+   type (field2DReal), pointer :: wettingVelocityField
+
+   real (kind=RKIND), dimension(:,:), pointer :: vertDiffTopOfCell
+   real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
+   integer, dimension(:,:), pointer :: rediLimiterCount
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerSurfaceFluxTendency
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerNonLocalTendency
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerHorMixTendency
+   real (kind=RKIND), dimension(:,:), pointer :: temperatureShortWaveTendency
+   real (kind=RKIND), dimension(:), pointer :: RediKappa
+
+   ! pointers for tendencies used in diagnostic budget computation
+   real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+      activeTracerHorizontalAdvectionTendency, &
+      activeTracerVerticalAdvectionTendency,   &
+      activeTracerHorizontalAdvectionEdgeFlux, &
+      activeTracerVerticalAdvectionTopFlux,    &
+      activeTracerVertMixTendency
+
+   real (kind=RKIND), pointer :: daysSinceStartOfSim
+   character (len=StrKIND), pointer :: xtime, simulationStartTime
+
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumber
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumberBuoy
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumberShear
+
+   real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
+   real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepthSmooth
+   real (kind=RKIND), dimension(:), pointer :: indexBoundaryLayerDepth
+   integer, pointer :: index_vertNonLocalFluxTemp
+
+   real (kind=RKIND), dimension(:), pointer :: salinitySurfaceRestoringTendency
+
+   real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
+   real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
+   real (kind=RKIND), dimension(:), pointer :: gradSSHX
+   real (kind=RKIND), dimension(:), pointer :: gradSSHY
+   real (kind=RKIND), dimension(:), pointer :: gradSSHZ
+
+   real (kind=RKIND), dimension(:), pointer :: barotropicForcing
+   real (kind=RKIND), dimension(:), pointer :: barotropicThicknessFlux
+
+   real (kind=RKIND), dimension(:, :), pointer :: edgeAreaFractionOfCell
+   real (kind=RKIND), dimension(:, :), pointer :: SSHGradient
+   integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+   integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
+
+   type (field1DInteger), pointer :: smoothingMaskField
+   type (field2DReal), pointer :: verticalStretchField
+
+   real (kind=RKIND), pointer :: globalVerticalStretchMax, globalVerticalStretchMin
+   real (kind=RKIND), dimension(:), pointer :: betaEdge
+   real (kind=RKIND), dimension(:), pointer :: eddyLength
+   real (kind=RKIND), dimension(:), pointer :: eddyTime
+   real (kind=RKIND), dimension(:), pointer :: c_visbeck
+   real (kind=RKIND), dimension(:), pointer :: gmResolutionTaper
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_diagnostics_variables_init
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_diagnostics_variables_init
+!
+!> \brief   Initializes variables in the diagnosticsPool
+!> \author  Matt Turner
+!> \date    13 May 2020
+!> \details
+!>  This routine initializes all of the pointers associated with
+!>  variables contained in the diagnosticsPool.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostics_variables_init(domain, jenkinsOn, hollandJenkinsOn, err)!{{{
+      type (domain_type), intent(in) :: domain
+
+      logical, intent(in) :: jenkinsOn
+      logical, intent(in) :: hollandjenkinsOn
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      type (mpas_pool_type), pointer :: diagnosticsPool
+
+      err = 0
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
+
+      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
+      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
+      call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
+      call mpas_pool_get_array(diagnosticsPool, 'density', density)
+      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
+      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
+      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
+      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
+      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
+
+      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
+      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
+      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
+
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
+
+      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
+      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
+      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
+      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
+
+      !
+      ! set pointers for fields related forcing at ocean surface
+      !
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
+
+      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
+
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
+
+      if(jenkinsOn .or. hollandJenkinsOn) then
+        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
+      end if
+
+      call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', rx1MaxCell, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMax', globalVerticalStretchMax, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMin', globalVerticalStretchMin, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
+      call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMaskField, 1)
+      call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', verticalStretchField, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+
+      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+
+      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
+
+      call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
+      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
+      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
+
+      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
+      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
+      call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', wettingVelocityField)
+
+      !
+      ! set pointers for viscosity/diffusivity and initialize to zero
+      !
+      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', bulkRichardsonNumber)
+      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
+      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepthSmooth', boundaryLayerDepthSmooth)
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',bulkRichardsonNumberBuoy)
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',bulkRichardsonNumberShear)
+      call mpas_pool_get_array(diagnosticsPool, 'indexBoundaryLayerDepth',indexBoundaryLayerDepth)
+      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_vertNonLocalFluxTemp', index_vertNonLocalFluxTemp)
+
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
+      call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
+      if (config_compute_active_tracer_budgets) then
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
+         call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
+      endif
+
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerVerticalAdvectionTopFlux',    &
+              activeTracerVerticalAdvectionTopFlux)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerHorizontalAdvectionEdgeFlux', &
+              activeTracerHorizontalAdvectionEdgeFlux)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerHorizontalAdvectionTendency', &
+              activeTracerHorizontalAdvectionTendency)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerVerticalAdvectionTendency',   &
+              activeTracerVerticalAdvectionTendency)
+      call mpas_pool_get_array(diagnosticsPool, &
+         'activeTracerVertMixTendency',activeTracerVertMixTendency)
+
+      call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
+      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+      call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime',simulationStartTime)
+
+      call mpas_pool_get_array(diagnosticsPool,'salinitySurfaceRestoringTendency',salinitySurfaceRestoringTendency)
+
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
+      call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
+
+      call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
+
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)                                    
+      call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)                                        
+      call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
+      call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
+
+    end subroutine ocn_diagnostics_variables_init!}}}
+
+!***********************************************************************
+
+end module ocn_diagnostics_variables
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -27,6 +27,7 @@ module ocn_equation_of_state
    use ocn_equation_of_state_linear
    use ocn_equation_of_state_jm
    use ocn_constants
+   use ocn_mesh
    use mpas_log
 
    implicit none
@@ -88,7 +89,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_equation_of_state_density(statePool, diagnosticsPool,&
-                           meshPool, scratchPool, nCells, kDisplaced,  &
+                           scratchPool, nCells, kDisplaced,  &
                            displacement_type, density, err,            &
                            thermalExpansionCoeff,                      &
                            salineContractionCoeff, timeLevelIn)
@@ -110,7 +111,6 @@ contains
       type (mpas_pool_type), intent(in) :: &
          statePool,           &! pool containing state variables
          diagnosticsPool,     &! pool containing some forcing fields
-         meshPool,            &! pool containing mesh quantities
          scratchPool           ! pool containing some scratch space
 
       !-----------------------------------------------------------------
@@ -138,8 +138,8 @@ contains
 
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-      integer :: iCell, k, nVertLevels, indexT, indexS
-      integer, pointer :: indexTptr, indexSptr, nVertLevelsPtr
+      integer :: iCell, k, indexT, indexS
+      integer, pointer :: indexTptr, indexSptr
       integer :: timeLevel
 
       !-----------------------------------------------------------------
@@ -167,11 +167,8 @@ contains
                                                  indexTptr)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
                                                  indexSptr)
-      call mpas_pool_get_dimension(meshPool,    'nVertLevels', &
-                                                 nVertLevelsPtr)
       indexT      = indexTptr
       indexS      = indexSptr
-      nVertLevels = nVertLevelsPtr
 
       !*** call specific equation of state based on user choice
 

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -88,7 +88,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_density(statePool, diagnosticsPool,&
+   subroutine ocn_equation_of_state_density(statePool, tracersSurfaceValue, &
                            scratchPool, nCells, kDisplaced,  &
                            displacement_type, density, err,            &
                            thermalExpansionCoeff,                      &
@@ -110,8 +110,9 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          statePool,           &! pool containing state variables
-         diagnosticsPool,     &! pool containing some forcing fields
          scratchPool           ! pool containing some scratch space
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: tracersSurfaceValue
 
       !-----------------------------------------------------------------
       ! Output variables
@@ -136,7 +137,6 @@ contains
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer :: iCell, k, indexT, indexS
       integer, pointer :: indexTptr, indexSptr
@@ -157,8 +157,6 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', &
-                                                 tracersSurfaceValue)
       call mpas_pool_get_subpool  (statePool,   'tracers', &
                                                  tracersPool)
       call mpas_pool_get_array    (tracersPool, 'activeTracers', &

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -26,6 +26,7 @@ module ocn_forcing
    use mpas_log
    use mpas_dmpar
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -95,10 +96,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err, timeLevelIn)!{{{
+    subroutine ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
         type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
         type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-        type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
         type (mpas_pool_type), intent(inout) :: forcingPool !< Input/Output: Forcing information
         integer, intent(out) :: err !< Output: Error code
         integer, intent(in), optional :: timeLevelIn
@@ -111,8 +111,6 @@ contains
 
         real (kind=RKIND) :: zTop, zBot, transmissionCoeffTop, transmissionCoeffBot
 
-        real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
-        real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
         real (kind=RKIND), dimension(:,:), pointer :: layerThickness, fractionAbsorbed, fractionAbsorbedRunoff
 
         integer :: iCell, k, timeLevel, nCells
@@ -132,10 +130,6 @@ contains
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff',  &
-                                                   surfaceFluxAttenuationCoefficientRunoff)
 
         call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
         call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -27,7 +27,7 @@ module ocn_frazil_forcing
    use mpas_timer
    use ocn_constants
    use ocn_equation_of_state
-   use ocn_diagnostics
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -370,10 +370,7 @@ contains
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassNew
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassOld
       real (kind=RKIND), pointer, dimension(:)     :: ssh
-      real (kind=RKIND), pointer, dimension(:,:)   :: zMid
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
-      real (kind=RKIND), pointer, dimension(:,:)   :: density
-      real (kind=RKIND), pointer, dimension(:,:)   :: pressure
       real (kind=RKIND), pointer, dimension(:,:,:) :: activeTracers
 
       integer, dimension(:), pointer :: maxLevelCell

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -27,6 +27,7 @@ module ocn_frazil_forcing
    use mpas_timer
    use ocn_constants
    use ocn_equation_of_state
+   use ocn_diagnostics
 
    implicit none
    private
@@ -300,7 +301,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)!{{{
+   subroutine ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -309,7 +310,6 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool !< Input: Diagnostic information
 
       !-----------------------------------------------------------------
       !
@@ -415,9 +415,6 @@ contains
       call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
       call mpas_pool_get_array(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -15,6 +15,7 @@ module ocn_gm
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -68,7 +69,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_GM_compute_Bolus_velocity(statePool, diagnosticsPool, &
+   subroutine ocn_GM_compute_Bolus_velocity(statePool, &
                                             meshPool, scratchPool, timeLevelIn)
       !{{{
 
@@ -92,7 +93,6 @@ contains
       !-----------------------------------------------------------------
 
       type(mpas_pool_type), intent(inout) :: &
-         diagnosticsPool, &! pool containing some diagnostics
          scratchPool           ! pool containing some scratch space
 
       !-----------------------------------------------------------------
@@ -101,18 +101,12 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real(kind=RKIND), dimension(:, :), pointer :: density, displacedDensity, zMid, normalGMBolusVelocity, &
-                                                    layerThicknessEdge, gradDensityEdge, &
-                                                    k33, gmStreamFuncTopOfEdge, BruntVaisalaFreqTop, gmStreamFuncTopOfCell, &
-                                                    layerThickness, inSituThermalExpansionCoeff, &
-                                                    inSituSalineContractionCoeff, kappaRediCell, kappaGMCell, kappaRediSfcTaper, &
-                                                    zTop, RiTopOfCell
+      real(kind=RKIND), dimension(:, :), pointer :: gradDensityEdge, &
+                                                    layerThickness
 
-      real(kind=RKIND), dimension(:), pointer   :: c_visbeck, gmBolusKappa, cGMphaseSpeed, &
-                ssh, eddyLength, eddyTime, betaEdge, fEdge, gmResolutionTaper, RediKappa
-      real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
-      real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
-      integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell, indMLD
+      real(kind=RKIND), dimension(:), pointer   :: ssh
+      real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide, fEdge, latEdge
+      integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iter, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp
@@ -147,30 +141,6 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
-
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff', inSituThermalExpansionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-
-      call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
-     call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -483,13 +453,7 @@ contains
          end if
 
          if (local_config_GM_compute_visbeck) then
-           call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-           call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)
-           call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)
-           call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-           call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-           call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
            !$omp do schedule(runtime) private(cell1, cell2, sumN2, ltSum, sumRi, countN2, zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge) 
            do iEdge = 1, nEdges
               k=1
@@ -755,8 +719,7 @@ contains
       integer, pointer :: nEdges
       integer, pointer :: nVertLevels
       real(kind=RKIND), pointer :: sphere_radius
-      real(kind=RKIND), dimension(:), pointer   :: latEdge, betaEdge, fEdge, &
-            gmResolutionTaper, gmBolusKappa
+      real(kind=RKIND), dimension(:), pointer   :: fEdge, latEdge
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOncell
 
       err = 0
@@ -770,9 +733,9 @@ contains
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
          call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
          if (config_Redi_use_slope_taper) then
             slopeTaperFactor = 1.0_RKIND
@@ -820,7 +783,6 @@ contains
             local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_visbeck = .true.
 
-            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
             !$omp do schedule(runtime)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -711,7 +711,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          end do
       end if
 
-      call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool)
+      call ocn_diagnostic_solve(dt,  statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool)
 
       ! initialize velocities and active tracers on land to be zero.
       areaCell(nCells+1) = -1.0e34_RKIND

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -34,6 +34,7 @@ module ocn_init_routines
    use mpas_tracer_advection_helpers
 
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
    use ocn_constants
 
@@ -615,20 +616,17 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       integer, intent(out) :: err
 
       type (mpas_pool_type), pointer :: meshPool, statePool, tracersPool
-      type (mpas_pool_type), pointer :: forcingPool, diagnosticsPool, scratchPool
+      type (mpas_pool_type), pointer :: forcingPool, scratchPool
       integer :: i, iEdge, iCell, k
       integer :: err1
 
-      integer, dimension(:), pointer :: nAdvCellsForEdge, maxLevelCell, indMLD
+      integer, dimension(:), pointer :: nAdvCellsForEdge, maxLevelCell
       integer, dimension(:), pointer :: maxLevelEdgeBot, maxLevelEdgeTop
       integer, dimension(:,:), pointer :: advCellsForEdge, highOrderAdvectionMask, boundaryCell
-      real (kind=RKIND), dimension(:), pointer :: areaCell, boundaryLayerDepth
-      real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd, normalTransportVelocity
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalGMBolusVelocity, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
-      real (kind=RKIND), dimension(:,:), pointer :: edgeAreaFractionOfCell
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, edgeTangentVectors
       real (kind=RKIND), dimension(:,:,:), pointer :: derivTwo
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
@@ -652,7 +650,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
@@ -670,17 +667,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -711,7 +697,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          end do
       end if
 
-      call ocn_diagnostic_solve(dt,  statePool, forcingPool, diagnosticsPool, scratchPool, tracersPool)
+      call ocn_diagnostic_solve(dt,  statePool, forcingPool, scratchPool, tracersPool)
 
       ! initialize velocities and active tracers on land to be zero.
       areaCell(nCells+1) = -1.0e34_RKIND
@@ -767,13 +753,12 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_initialize_time_levels(statePool)
 
       ! compute land-ice fluxes for potential output at startup
-      call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err1, 1)
+      call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err1, 1)
       err = ior(err, err1)
-      call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
-                                                    forcingPool, scratchPool, statePool, dt, err1)
+      call ocn_surface_land_ice_fluxes_build_arrays(meshPool, forcingPool, scratchPool, &
+                                                    statePool, dt, err1)
+                                                    
       err = ior(err, err1)
-
-
 
    end subroutine ocn_init_routines_block!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -37,6 +37,7 @@ module ocn_init_routines
    use ocn_diagnostics_variables
    use ocn_gm
    use ocn_constants
+   use ocn_mesh
 
    use ocn_surface_land_ice_fluxes
    use ocn_forcing
@@ -243,38 +244,15 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 !>   kiteIndexOnCell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_init_routines_setup_sign_and_index_fields(meshPool)!{{{
+   subroutine ocn_init_routines_setup_sign_and_index_fields()!{{{
 
-       type (mpas_pool_type), intent(inout) :: meshPool
-
-       integer, dimension(:), pointer :: nEdgesOnCell
-       integer, dimension(:,:), pointer :: edgesOnCell, edgesOnVertex, cellsOnVertex, cellsOnEdge, verticesOnCell, verticesOnEdge
-       integer, dimension(:,:), pointer :: edgeSignOnCell, edgeSignOnVertex, kiteIndexOnCell
-
-       integer, pointer :: nCells, nEdges, nVertices, vertexDegree
        integer :: iCell, iEdge, iVertex, i, j, k
-
-       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-       call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-       call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-       call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-       call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
-       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-       call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
-       call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-       call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', kiteIndexOnCell)
 
        edgeSignOnCell = 0.0_RKIND
        edgeSignOnVertex = 0.0_RKIND
        kiteIndexOnCell = 0.0_RKIND
 
-       do iCell = 1, nCells
+       do iCell = 1, nCellsAll
          do i = 1, nEdgesOnCell(iCell)
            iEdge = edgesOnCell(i, iCell)
            iVertex = verticesOnCell(i, iCell)
@@ -294,7 +272,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          end do
        end do
 
-       do iVertex = 1, nVertices
+       do iVertex = 1, nVerticesAll
          do i = 1, vertexDegree
            iEdge = edgesOnVertex(i, iVertex)
 
@@ -325,23 +303,9 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       type (mpas_pool_type), intent(in) :: meshPool
       real (kind=RKIND), dimension(:,:), intent(inout) :: edgeAreaFractionOfCell
 
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:,:), pointer :: edgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
-
-      integer, pointer :: nCells, nEdges
       integer :: iCell, iEdge, i, j, k
 
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             ! edgeAreaFractionOfCell is the fractional area of cell iCell
@@ -620,14 +584,10 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       integer :: i, iEdge, iCell, k
       integer :: err1
 
-      integer, dimension(:), pointer :: nAdvCellsForEdge, maxLevelCell
-      integer, dimension(:), pointer :: maxLevelEdgeBot, maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: advCellsForEdge, highOrderAdvectionMask, boundaryCell
-      real (kind=RKIND), dimension(:), pointer :: areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd
+      integer, dimension(:,:), pointer :: highOrderAdvectionMaskTmp, boundaryCellTmp
+      integer, dimension(:,:), pointer :: edgeSignOnCellTmp, edgeSignOnVertexTmp
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, edgeTangentVectors
-      real (kind=RKIND), dimension(:,:,:), pointer :: derivTwo
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
 
@@ -654,19 +614,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(meshPool, 'derivTwo', derivTwo)
-      call mpas_pool_get_array(meshPool, 'advCoefs', advCoefs)
-      call mpas_pool_get_array(meshPool, 'advCoefs3rd', advCoefs3rd)
-      call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge', nAdvCellsForEdge)
-      call mpas_pool_get_array(meshPool, 'advCellsForEdge', advCellsForEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMask)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMaskTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCellTmp)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -680,15 +629,27 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_config(block % configs, 'config_use_Redi', config_use_Redi)
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
 
-      call ocn_init_routines_setup_sign_and_index_fields(meshPool)
+      call ocn_init_routines_setup_sign_and_index_fields()
+      ! Update edgeSignOnCell and edgeSignOnVertex pionters in ocn_mesh.  The ocn_mesh allocatables
+      ! are updated in ocn_init_routines_setup_sign_and_index_fields.  This updates the pointers to 
+      ! Registry to match the allocatable arrays
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCellTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertexTmp)
+      edgeSignOnCellTmp = int(edgeSignOnCell)
+      edgeSignOnVertexTmp = int(edgeSignOnVertex)
+
       call ocn_init_routines_area_weights(meshPool, edgeAreaFractionOfCell)
       call mpas_initialize_deriv_two(meshPool, derivTwo, err)
       call mpas_tracer_advection_coefficients(meshPool, &
           config_horiz_tracer_adv_order, derivTwo, advCoefs, &
           advCoefs3rd, nAdvCellsForEdge, advCellsForEdge, &
-          err1, maxLevelCell, highOrderAdvectionMask, &
-          boundaryCell)
+          err1, maxLevelCell, highOrderAdvectionMaskTmp, &
+          boundaryCellTmp)
       err = ior(err, err1)
+
+      ! Update ocn_mesh variables for highOrderAdvectionMask and boundaryCell
+      highOrderAdvectionMask = real(highOrderAdvectionMaskTmp, kind=RKIND)
+      boundaryCell = real(boundaryCellTmp, kind=RKIND)
 
       if (.not. config_do_restart) then
          do iCell=1,nCells

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -1044,9 +1044,11 @@ contains
       end do
       end do
 
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the 
+      ! pointer needs to be udpated.
       do n = 1, nCellsAll+1
       do k = 1, maxEdges
-         edgeSignOnCell(k, n) = real(edgeSignOnCellTmp(k, n), RKIND)
+         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
       end do
       end do
 
@@ -1066,10 +1068,12 @@ contains
       end do
       end do
 
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the 
+      ! pointer needs to be udpated.
       do n = 1, nVerticesAll+1
       do k = 1, vertexDegree
-         edgeSignOnVertex(k, n) = &
-            real(edgeSignOnVertexTmp(k, n), RKIND)
+         edgeSignOnVertexTmp(k, n) = &
+            int(edgeSignOnVertex(k, n))
       end do
       end do
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -27,6 +27,7 @@ module ocn_surface_land_ice_fluxes
 
    use ocn_constants
    use ocn_equation_of_state
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -137,7 +138,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)!{{{
+   subroutine ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -145,7 +146,6 @@ contains
       !
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
 
       !-----------------------------------------------------------------
       !
@@ -181,9 +181,6 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
@@ -354,7 +351,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+   subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
       forcingPool, scratchPool, statePool, dt, err) !{{{
 
       !-----------------------------------------------------------------
@@ -364,8 +361,7 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: &
-         meshPool, &     !< Input: mesh information
-         diagnosticsPool !< Input: diagnostics information
+         meshPool        !< Input: mesh information
       real(kind=RKIND), intent(in) :: dt ! the time step over which to accumulate fluxes
 
       !-----------------------------------------------------------------
@@ -440,18 +436,7 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
-      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
-      end if
 
       call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -26,6 +26,7 @@ module ocn_tendency
    use mpas_timer
    use mpas_threading
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_constants
 
    use ocn_surface_bulk_forcing
@@ -107,18 +108,17 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)!{{{
+   subroutine ocn_tend_thick(tendPool, forcingPool, meshPool)!{{{
       implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFluxRunoff
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, &
-         vertAleTransportTop, tend_layerThickness, normalTransportVelocity, fractionAbsorbed, fractionAbsorbedRunoff
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         tend_layerThickness, fractionAbsorbed, fractionAbsorbedRunoff
 
       integer, pointer :: nCells
       integer :: err, iCell
@@ -128,10 +128,6 @@ contains
       call mpas_pool_get_config(ocnConfigs, 'config_disable_thick_all_tend', config_disable_thick_all_tend)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 
       call mpas_pool_get_array(tendPool, 'layerThickness', tend_layerThickness)
 
@@ -209,13 +205,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, timeLevelIn, dt)!{{{
+   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, scratchPool, timeLevelIn, dt)!{{{
       implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       real (kind=RKIND), intent(in) :: dt
       type (mpas_pool_type), intent(inout) :: scratchPool !< Input: Scratch structure
@@ -223,17 +218,12 @@ contains
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh
+      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, ssh
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta 
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThicknessEdge, normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
-        layerThickness, &
-        tend_normalVelocity, circulation, relativeVorticity, viscosity, kineticEnergyCell, &
-        normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-        montgomeryPotential, vertAleTransportTop, divergence, vertViscTopOfEdge, &
-        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, &
+        layerThickness, tend_normalVelocity, circulation
+        
       real (kind=RKIND), dimension(:,:), pointer :: tidalPotentialZMid
-      real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       integer :: timeLevel
@@ -276,29 +266,11 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
-
       call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
 
       call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
 
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
       !
       ! velocity tendency: start accumulating tendency terms
       !
@@ -323,7 +295,7 @@ contains
       call ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)
 
       ! Add top drag to surface stress
-      call ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)
+      call ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)
 
       !
       ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
@@ -343,7 +315,7 @@ contains
       !   zMid is pointed back to the typical value afterward, so the work array is not used in place of zMid elsewhere.
       !
       if (config_use_tidal_potential_forcing) then
-        call ocn_compute_tidal_potential_forcing(meshPool, forcingPool, diagnosticsPool, err)
+        call ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)
       end if
 
       if (config_use_tidal_potential_forcing .and. config_time_integrator == 'RK4') then
@@ -366,8 +338,6 @@ contains
       !
       if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
          ! only pass EOS derivatives if needed.
-         call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-         call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
          call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
               indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
               inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
@@ -376,11 +346,6 @@ contains
               indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
               inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
       endif
-
-      if (config_use_tidal_potential_forcing .and. config_time_integrator == 'RK4') then
-        ! point zMid back to usual array, to be safe
-        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      end if
 
       !
       ! velocity tendency: del2 dissipation, \nu_2 \nabla^2 u
@@ -424,7 +389,7 @@ contains
 !>  This routine computes tracer tendencies for the ocean
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, scratchPool, & !{{{
+   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, scratchPool, & !{{{
                               dt, activeTracersOnlyIn, timeLevelIn )
       implicit none
 
@@ -434,7 +399,6 @@ contains
       type (mpas_pool_type), intent(inout) :: tendPool        !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(in)    :: statePool       !< Input: State information
       type (mpas_pool_type), intent(inout) :: forcingPool     !< Input: Forcing information
-      type (mpas_pool_type), intent(inout)    :: diagnosticsPool !< Input: Diagnostic information
       type (mpas_pool_type), intent(inout)    :: meshPool     !< Input: Mesh information
       type (mpas_pool_type), intent(in)    :: swForcingPool   !< Input: sw data input info
       type (mpas_pool_type), intent(in)    :: scratchPool     !< Input: Scratch information
@@ -465,7 +429,6 @@ contains
       logical, pointer :: config_compute_active_tracer_budgets, &
                           config_cvmix_kpp_nonlocal_with_implicit_mix
       real (kind=RKIND), pointer :: salinity_restoring_constant_piston_velocity
-      integer, dimension(:,:), pointer :: rediLimiterCount
 
       ! iterator for tracer categories
       type (mpas_pool_iterator_type) :: groupItr
@@ -474,9 +437,8 @@ contains
       !
       ! one dimensional pointers
       !
-      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL
+      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: tracerGroupExponentialDecayRate, latCell
-      real (kind=RKIND), dimension(:), pointer :: RediKappa 
       integer, dimension(:), pointer :: maxLevelCell
 
       !
@@ -486,32 +448,21 @@ contains
                                                     tracerGroupIdealAgeMask, tracerGroupTTDMask
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
-        normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed, zMid, &
+        layerThickness, normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed,  &
         fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
-        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux, kappaRediCell, kappaRediSfcTaper
+        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux
 
       !
       ! three dimensional pointers
       !
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-        tracerGroup, tracerGroupTend, vertNonLocalFlux
+        tracerGroup, tracerGroupTend
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
         activeTracers, &  !  need T, S for ecosys
         ecosysTracers     !  need ecosys for DMS and MacroMolecules
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracerGroupInteriorRestoringRate, tracerGroupInteriorRestoringValue
-
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-        slopeTriadUp, slopeTriadDown,                 &
-        activeTracerSurfaceFluxTendency,              &
-        activeTracerNonLocalTendency,                 &
-        activeTracerHorMixTendency,                   &
-        kappaRediEdge
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        temperatureShortWaveTendency
 
       !
       ! Field pointers
@@ -568,20 +519,7 @@ contains
       ! get arrays
       !
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
-      call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -589,16 +527,6 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      !
-      ! get diagnostic arrays for temperature/salinity budget
-      !
-      if (config_compute_active_tracer_budgets) then
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
-         call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
-      endif
 
       if(config_disable_tr_all_tend) return
 
@@ -867,7 +795,7 @@ contains
                ! Tendency for tracer budget is stored within the tracer adv
                ! routine
                call ocn_tracer_advection_tend(tracerGroup, normalThicknessFlux, vertAleTransportTop, layerThickness, &
-                                              dt, meshPool, scratchPool, diagnosticsPool, tracerGroupTend, &
+                                              dt, meshPool, scratchPool, tracerGroupTend, &
                                               trim(groupItr % memberName))
 
                !
@@ -952,7 +880,7 @@ contains
                !
                if (config_use_cvmix_kpp) then
                   call mpas_timer_start("non-local flux from KPP")
-                  call ocn_compute_KPP_input_fields(statePool, forcingPool, diagnosticsPool, scratchPool, timeLevel)
+                  call ocn_compute_KPP_input_fields(statePool, forcingPool, scratchPool, timeLevel)
                   if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
                      if( trim(groupItr % memberName) == 'activeTracers' ) then
                         if (config_compute_active_tracer_budgets) then
@@ -1005,11 +933,10 @@ contains
 !>  config_freq_filtered_thickness is true (z-tilde)
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tend_freq_filtered_thickness(tendPool, statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_tend_freq_filtered_thickness(tendPool, statePool, meshPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
 
@@ -1022,7 +949,7 @@ contains
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr, thickness_filter_timescale_sec, highFreqThick_restore_time_sec, &
          totalThickness
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThicknessEdge, &
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, &
          layerThickness, &
          lowFreqDivergence, highFreqThickness, &
          tend_lowFreqDivergence, tend_highFreqThickness
@@ -1058,8 +985,6 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergence, timeLevel)
       call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThickness, timeLevel)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', tend_lowFreqDivergence)
       call mpas_pool_get_array(tendPool, 'highFreqThickness', tend_highFreqThickness)

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -952,7 +952,7 @@ contains
                !
                if (config_use_cvmix_kpp) then
                   call mpas_timer_start("non-local flux from KPP")
-                  call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, timeLevel)
+                  call ocn_compute_KPP_input_fields(statePool, forcingPool, diagnosticsPool, scratchPool, timeLevel)
                   if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
                      if( trim(groupItr % memberName) == 'activeTracers' ) then
                         if (config_compute_active_tracer_budgets) then

--- a/src/core_ocean/shared/mpas_ocn_test.F
+++ b/src/core_ocean/shared/mpas_ocn_test.F
@@ -30,6 +30,7 @@ module ocn_test
    use mpas_tensor_operations
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -251,7 +252,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_init_gm_test_functions(diagnosticsPool, meshPool, scratchPool)!{{{
+   subroutine ocn_init_gm_test_functions(meshPool, scratchPool)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -268,7 +269,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool  !< Input: diagnostic fields derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
 
       !-----------------------------------------------------------------
@@ -300,8 +300,6 @@ contains
       call mpas_pool_get_array(meshPool, 'yCell',yCell)
       call mpas_pool_get_array(meshPool, 'yEdge',yEdge)
       call mpas_pool_get_array(meshPool, 'bottomDepth',bottomDepth)
-
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
       ! move solution variables to diagnostics pool to include them in output.
       call mpas_pool_get_field(scratchPool, 'yRelativeSlopeSolution',yRelativeSlopeSolutionField)

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -25,6 +25,8 @@ module ocn_thick_ale
    use mpas_timer
 
    use ocn_constants
+   use ocn_mesh
+   use ocn_config
 
    implicit none
    private
@@ -71,16 +73,13 @@ contains
 !>  (z-tilde), and imposes a minimum layer thickness.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_ALE_thickness(meshPool, verticalMeshPool, SSH, ALE_thickness, err, newHighFreqThickness)!{{{
+   subroutine ocn_ALE_thickness(verticalMeshPool, SSH, ALE_thickness, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: horizonal mesh information
 
       type (mpas_pool_type), intent(in) :: &
          verticalMeshPool   !< Input: vertical mesh information
@@ -109,11 +108,8 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k, i, kMax
-      integer, pointer :: nCells, nVertLevels
-      integer, dimension(:), pointer :: maxLevelCell
 
       real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness, thicknessWithRemainder
-      real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
       real (kind=RKIND), dimension(:), allocatable :: &
          SSH_ALE_thickness,      & !> ALE thickness alteration due to SSH (z-star)
          prelim_ALE_Thickness,   & !> ALE thickness at new time
@@ -123,25 +119,12 @@ contains
          restingThickness   !>  Layer thickness when the ocean is at rest, i.e. without SSH or internal perturbations.
 
       logical, pointer :: thicknessFilterActive
-      logical, pointer :: config_use_min_max_thickness
-      real (kind=RKIND), pointer :: config_max_thickness_factor
-      real (kind=RKIND), pointer :: config_min_thickness
 
       err = 0
 
       call mpas_pool_get_package(ocnPackages, 'thicknessFilterActive', thicknessFilterActive)
 
-      call mpas_pool_get_config(ocnConfigs, 'config_use_min_max_thickness', config_use_min_max_thickness)
-      call mpas_pool_get_config(ocnConfigs, 'config_max_thickness_factor', config_max_thickness_factor)
-      call mpas_pool_get_config(ocnConfigs, 'config_min_thickness', config_min_thickness)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
-
       call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
-
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       allocate(SSH_ALE_thickness(nVertLevels), prelim_ALE_thickness(nVertLevels), &
          min_ALE_thickness_down(nVertLevels), min_ALE_thickness_up(nVertLevels))
@@ -152,7 +135,7 @@ contains
       if (configALEthicknessProportionality==1) then ! restingThickness_times_weights
 
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             kMax = maxLevelCell(iCell)
    
             thicknessSum = 1e-14_RKIND
@@ -172,7 +155,7 @@ contains
    
          elseif (configALEthicknessProportionality==2) then ! weights_only
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             kMax = maxLevelCell(iCell)
    
             weightSum = 1e-14_RKIND
@@ -195,7 +178,7 @@ contains
 
       if (thicknessFilterActive) then
          !$omp do schedule(runtime) private(kMax)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             kMax = maxLevelCell(iCell)
 
             ALE_Thickness(1:kMax, iCell) = &
@@ -211,7 +194,7 @@ contains
       if (config_use_min_max_thickness) then
 
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             kMax = maxLevelCell(iCell)
 
             ! go down the column:
@@ -263,9 +246,6 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_thick_ale_init(err)!{{{
       integer, intent(out) :: err !< Output: Error flag
-      character (len=StrKIND), pointer :: config_ALE_thickness_proportionality
-
-      call mpas_pool_get_config(ocnConfigs,'config_ALE_thickness_proportionality',config_ALE_thickness_proportionality)
 
       if (config_ALE_thickness_proportionality=='restingThickness_times_weights') then
           configALEthicknessProportionality = 1

--- a/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
@@ -26,6 +26,7 @@ module ocn_tidal_forcing
    use mpas_timekeeping
    use mpas_timer
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_equation_of_state
 
    implicit none
@@ -157,7 +158,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)!{{{
+   subroutine ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -166,7 +167,6 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool !< Input: Diagnostic information
 
       !-----------------------------------------------------------------
       !
@@ -229,9 +229,6 @@ contains
                                              tidalLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
       call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
-
-      ! compute time since start of simulation, in days
-      call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim', daysSinceStartOfSim)
 
       call mpas_pool_get_config(ocnConfigs, 'config_tidal_forcing_type', config_tidal_forcing_type)
       call mpas_pool_get_config(ocnConfigs, 'config_tidal_forcing_model', config_tidal_forcing_model)

--- a/src/core_ocean/shared/mpas_ocn_tidal_potential_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_potential_forcing.F
@@ -28,6 +28,7 @@ module ocn_tidal_potential_forcing
    use mpas_timekeeping
    use mpas_timer
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -78,7 +79,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_compute_tidal_potential_forcing(meshPool, forcingPool, diagnosticsPool, err)!{{{
+   subroutine ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -86,7 +87,6 @@ contains
       !
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool 
 
       !-----------------------------------------------------------------
       !
@@ -120,8 +120,6 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: latitudeFunction
       integer, dimension(:), pointer :: constituentType
       real (kind=RKIND), dimension(:), pointer :: eta
-      real (kind=RKIND), dimension(:,:), pointer :: zMid, tidalPotentialZMid
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
       
       integer :: iCell
       integer :: jCon, conType
@@ -145,7 +143,6 @@ contains
       call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentType', constituentType)
       call mpas_pool_get_array(forcingPool, 'tidalPotentialLatitudeFunction', latitudeFunction)
       call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', eta)
-      call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
 
       ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotentialRamp)
       t = daysSinceStartOfSim*86400.0_RKIND
@@ -206,7 +203,6 @@ contains
       type (block_type), pointer :: block_ptr 
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool 
       integer, pointer :: nTidalConstituents
       integer, pointer :: nCells 
       real (kind=RKIND), dimension(:), pointer :: tidalConstituentAmplitude
@@ -264,7 +260,6 @@ contains
 
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
         call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', tidalConstituentAmplitude)
         call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', tidalConstituentFreqency)

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -24,6 +24,7 @@ module ocn_time_average_coupled
     use mpas_derived_types
     use mpas_pool_routines
     use ocn_constants
+    use ocn_diagnostics_variables
     use ocn_tracer_ecosys
     use ocn_tracer_DMS
     use ocn_tracer_MacroMolecules
@@ -198,16 +199,14 @@ module ocn_time_average_coupled
 !>  This routine accumulated the coupled time averaging fields
 !
 !-----------------------------------------------------------------------
-    subroutine ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, timeLevel)!{{{
-        type (mpas_pool_type), intent(in) :: diagnosticsPool
+    subroutine ocn_time_average_coupled_accumulate(statePool, forcingPool, timeLevel)!{{{
         type (mpas_pool_type), intent(in) :: statePool
         type (mpas_pool_type), intent(inout) :: forcingPool
         integer, intent(in) :: timeLevel
 
-        real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
-        real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue, avgTracersSurfaceValue
+        real (kind=RKIND), dimension(:,:), pointer :: avgSurfaceVelocity
+        real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue
         real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
-        real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
         integer :: iCell
         integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled, nCells
         real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, landIceTracerTransferVelocities, &
@@ -247,11 +246,6 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgOceanSurfacePhytoC, &
                                                       avgOceanSurfaceDOC
 
-        call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
-        call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
-
         call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
         call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
@@ -281,8 +275,6 @@ module ocn_time_average_coupled
 
         call mpas_pool_get_config(ocnConfigs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
         if(trim(config_land_ice_flux_mode) == 'coupled') then
-           call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-           call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
            call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, timeLevel)
 
            call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)

--- a/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
@@ -21,6 +21,7 @@ module ocn_time_varying_forcing
   use mpas_stream_manager
   use ocn_framework_forcing
   use ocn_constants
+  use ocn_diagnostics_variables
   use mpas_log, only: mpas_log_write
 
   implicit none
@@ -386,8 +387,7 @@ contains
     type (mpas_pool_type), pointer :: &
          mesh, &
          forcingPool, &
-         timeVaryingForcingPool, &
-         diagnosticsPool
+         timeVaryingForcingPool
 
     real(kind=RKIND), dimension(:), pointer :: &
          windSpeedU, &
@@ -406,8 +406,7 @@ contains
          windStressCoefficientLimit
 
     real(kind=RKIND), pointer:: &
-        config_forcing_ramp, &
-        daysSinceStartOfSim
+        config_forcing_ramp
 
     integer, pointer :: &
          nCells
@@ -420,11 +419,9 @@ contains
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
     call MPAS_pool_get_subpool(block % structs, "forcing", forcingPool)
     call MPAS_pool_get_subpool(block % structs, "timeVaryingForcing", timeVaryingForcingPool)
-    call MPAS_pool_get_subpool(block % structs, "diagnostics", diagnosticsPool)
 
     call MPAS_pool_get_dimension(mesh, "nCells", nCells)
 
-    call MPAS_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedU", windSpeedU)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedV", windSpeedV)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedMagnitude", windSpeedMagnitude)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -67,7 +67,7 @@ module ocn_tracer_advection
 
    subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, w,       &
                                         layerThickness, dt, meshPool,          &
-                                        scratchPool, diagnosticsPool, tend,    &
+                                        scratchPool, tend,    &
                                         tracerGroupName)!{{{
 
       !*** Input/Output parameters
@@ -91,8 +91,6 @@ module ocn_tracer_advection
          meshPool            !< [in] Mesh information
       type (mpas_pool_type), intent(in) :: &
          scratchPool         !< [in] Scratch fields
-      type (mpas_pool_type), intent(in) :: &
-         diagnosticsPool     !< [in] Diagnostic fields
       character (len=*), intent(in) :: &
          tracerGroupName     !< [in] Tracer name to check if active tracers
 
@@ -145,7 +143,7 @@ module ocn_tracer_advection
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             diagnosticsPool, computeBudgets)
+                                             computeBudgets)
 
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -33,6 +33,7 @@ module ocn_tracer_advection_mono
    use mpas_tracer_advection_helpers
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -96,7 +97,7 @@ module ocn_tracer_advection_mono
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             diagnosticsPool, computeBudgets)!{{{
+                                             computeBudgets)!{{{
 
       !*** Input/Output parameters
 
@@ -133,8 +134,6 @@ module ocn_tracer_advection_mono
          edgeSignOnCell         !< [in] Sign for flux from edge on each cell
       type (mpas_pool_type), intent(in) :: &
          meshPool               !< [in] Mesh information
-      type (mpas_pool_type), intent(in) :: &
-         diagnosticsPool        !< [in] pool for traceradvection budget term
       logical, intent(in) :: &
          computeBudgets         !< [in] Flag to compute active tracer budgets
 
@@ -181,13 +180,6 @@ module ocn_tracer_advection_mono
          wgtTmp,            &! vertical temporaries for
          flxTmp, sgnTmp      !   high-order flux computation
 
-      ! pointers for tendencies used in diagnostic budget computation
-      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
-         activeTracerHorizontalAdvectionTendency, &
-         activeTracerVerticalAdvectionTendency,   &
-         activeTracerHorizontalAdvectionEdgeFlux, &
-         activeTracerVerticalAdvectionTopFlux
-
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
 
@@ -207,21 +199,6 @@ module ocn_tracer_advection_mono
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-
-      if (computeBudgets) then
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerVerticalAdvectionTopFlux',    &
-                 activeTracerVerticalAdvectionTopFlux)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerHorizontalAdvectionEdgeFlux', &
-                 activeTracerHorizontalAdvectionEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerHorizontalAdvectionTendency', &
-                 activeTracerHorizontalAdvectionTendency)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerVerticalAdvectionTendency',   &
-                 activeTracerVerticalAdvectionTendency)
-      end if
 
       ! Get dimensions
       nVertLevels = size(tracers,dim=2)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -28,6 +28,7 @@ module ocn_tracer_hmix_Redi
 
    use ocn_config
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -446,12 +447,13 @@ contains
 
       type(block_type), pointer :: block
       type(mpas_pool_type), pointer :: meshPool
-      type(mpas_pool_type), pointer :: diagnosticsPool
       type(mpas_pool_type), pointer :: forcingPool
+      type(mpas_pool_type), pointer :: diagnosticsPool
 
-      real(kind=RKIND), dimension(:), pointer :: RediKappa, RediKappaData
+      real(kind=RKIND), dimension(:), pointer :: RediKappaData
+      real(kind=RKIND), dimension(:), pointer :: areaCell
+      integer, dimension(:,:), pointer, contiguous :: cellsOnEdge     ! indices of cells on edges
       real(kind=RKIND), dimension(:), pointer :: dcEdge
-      integer, dimension(:,:), pointer :: cellsOnEdge
 
       integer :: k, iEdge
       integer, pointer :: nVertLevels, nEdges
@@ -469,8 +471,8 @@ contains
       block => domain%blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
+         call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
@@ -28,6 +28,7 @@ module ocn_tracer_surface_restoring
    use mpas_stream_manager
    use ocn_constants
    use ocn_framework_forcing
+   use ocn_diagnostics_variables
 
    implicit none
 
@@ -218,7 +219,6 @@ contains
 
         type (dm_info) :: dminfo
 
-        type (mpas_pool_type), pointer :: diagnosticsPool
         type (mpas_pool_type), pointer :: forcingPool
         type (mpas_pool_type), pointer :: meshPool
         type (mpas_pool_type), pointer :: statePool
@@ -229,7 +229,7 @@ contains
         real (kind=RKIND), pointer :: salinity_restoring_max_difference, salinity_restoring_constant_piston_velocity
 
         real (kind=RKIND), dimension(:), pointer :: &
-           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell, salinitySurfaceRestoringTendency
+           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell
 
         real (kind=RKIND), dimension(:,:), pointer :: &
            activeTracersSurfaceRestoringValue
@@ -321,7 +321,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields',tracersSurfaceRestoringFieldsPool)
         ! Use time level 1, which is always the new time level
@@ -451,7 +450,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields',tracersSurfaceRestoringFieldsPool)
-        call mpas_pool_get_array(diagnosticsPool,'salinitySurfaceRestoringTendency',salinitySurfaceRestoringTendency)
         call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersSurfaceRestoringValue', &
            activeTracersSurfaceRestoringValue)
         call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, 'index_salinitySurfaceRestoringValue',  &

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -27,6 +27,7 @@ module ocn_vmix
    use mpas_timer
 
    use ocn_constants
+   use ocn_diagnostics_variables
    use ocn_vmix_cvmix
    use ocn_vmix_coefs_redi
 
@@ -84,7 +85,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, diagnosticsPool, scratchPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -111,9 +112,6 @@ contains
       type (mpas_pool_type), intent(inout) :: &
          forcingPool             !< Input/Output: forcing information
 
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool             !< Input/Output: diagnostic information
-
       !-----------------------------------------------------------------
       !
       ! output variables
@@ -134,8 +132,6 @@ contains
       integer :: iEdge, iCell, nEdges, nCells
       integer, dimension(:), pointer :: nEdgesArray, nCellsArray
 
-      real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfEdge, vertDiffTopOfCell
-
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing coefficients
@@ -153,9 +149,6 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
 
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-
       nEdges = nEdgesArray( 2 )
 
       !$omp do schedule(runtime)
@@ -172,8 +165,8 @@ contains
       end do
       !$omp end do
 
-      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, diagnosticsPool, err1, timeLevel)
-      call ocn_vmix_coefs_redi_build(meshPool, statePool, diagnosticsPool, err2, timeLevel)
+      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err1, timeLevel)
+      call ocn_vmix_coefs_redi_build(meshPool, statePool, err2, timeLevel)
 
       err = ior(err1, err2)
 
@@ -624,10 +617,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
       real (kind=RKIND), intent(in) :: dt
       type (mpas_pool_type), intent(in) :: meshPool
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool
       type (mpas_pool_type), intent(inout) :: statePool
       type (mpas_pool_type), intent(inout) :: forcingPool
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
@@ -638,12 +630,10 @@ contains
 
       integer :: iCell, timeLevel, k, cell1, cell2, iEdge, nCells, nEdges
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness, layerThicknessEdge, vertViscTopOfEdge, &
-                                                    vertDiffTopOfCell, kineticEnergyCell
-      real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfCell, nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup, vertNonLocalFlux
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
+      real (kind=RKIND), dimension(:,:), pointer :: nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
+      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerVertMixTendency
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
       integer, dimension(:,:), pointer :: cellsOnEdge
       logical, pointer :: config_use_cvmix,config_compute_active_tracer_budgets
@@ -682,14 +672,6 @@ contains
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, &
-         'activeTracerVertMixTendency',activeTracerVertMixTendency)
-
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -699,11 +681,10 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
 
       call mpas_timer_start('vmix coefs', .false.)
-      call ocn_vmix_coefs(meshPool, statePool, forcingPool, diagnosticsPool, scratchPool, err, timeLevel)
+      call ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevel)
       call mpas_timer_stop('vmix coefs')
 
       nCells = nCellsArray(1)
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
       ! if using CVMix, then viscosity has to be averaged from cell centers to cell edges
       if ( config_use_cvmix ) then
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -19,6 +19,7 @@ module ocn_vmix_coefs_redi
    use mpas_timer
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -68,7 +69,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs_redi_build(meshPool, statePool, diagnosticsPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs_redi_build(meshPool, statePool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -90,9 +91,6 @@ contains
       type (mpas_pool_type), intent(inout) :: &
          statePool             !< Input/Output: state information
 
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool             !< Input/Output: diagnostic information
-
       !-----------------------------------------------------------------
       !
       ! output variables
@@ -107,11 +105,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        vertDiffTopOfCell, k33
-      real (kind=RKIND), dimension(:), pointer :: &
-        RediKappa
-
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing tendencies
@@ -121,10 +114,6 @@ contains
       !-----------------------------------------------------------------
 
       err = 0
-
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
 
       if (config_use_Redi) then
           call ocn_tracer_vmix_coefs_redi(meshPool, vertDiffTopOfCell, k33, RediKappa, err)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -20,6 +20,7 @@ module ocn_vmix_cvmix
    use mpas_log
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    use cvmix_kinds_and_types
    use cvmix_put_get
@@ -81,7 +82,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, diagnosticsPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -103,8 +104,6 @@ contains
       type (mpas_pool_type), intent(inout) :: &
          statePool         !< Input/Output: state information
 
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool   !< Input/Output: diagnostic information
 
       type (mpas_pool_type), intent(inout) :: &
          forcingPool   !< Input/Output: forcing information
@@ -129,18 +128,14 @@ contains
         maxLevelCell, nEdgesOnCell
 
       real (kind=RKIND), dimension(:), pointer :: &
-        latCell, lonCell, bottomDepth, surfaceBuoyancyForcing, surfaceFrictionVelocity, fCell, &
-        boundaryLayerDepth, ssh, indexBoundaryLayerDepth, dcEdge, dvEdge, areaCell, iceFraction, &
-        boundaryLayerDepthSmooth, windSpeed10m
+        latCell, lonCell, bottomDepth, fCell, &
+        ssh, dcEdge, dvEdge, areaCell, iceFraction, &
+        windSpeed10m
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        vertViscTopOfCell, vertDiffTopOfCell, layerThickness, &
-        zMid, zTop, density, displacedDensity, potentialDensity, &
-        bulkRichardsonNumber, RiTopOfCell, BruntVaisalaFreqTop, &
-        bulkRichardsonNumberBuoy, bulkRichardsonNumberShear, unresolvedShear, normalVelocity, edgeAreaFractionOfCell
+        layerThickness, normalVelocity
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
-      integer, pointer :: index_vertNonLocalFluxTemp, config_cvmix_num_ri_smooth_loops
+      integer, pointer :: config_cvmix_num_ri_smooth_loops
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnCell, cellMask
 
       logical, pointer :: config_use_cvmix_shear, config_use_cvmix_convection, config_use_cvmix_kpp
@@ -242,50 +237,11 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-
-      !
-      ! set pointers for fields related ocean state
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', bulkRichardsonNumber)
-      call mpas_pool_get_array(diagnosticsPool, 'unresolvedShear', unresolvedShear)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepthSmooth', boundaryLayerDepthSmooth)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop',BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',bulkRichardsonNumberBuoy)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',bulkRichardsonNumberShear)
-      call mpas_pool_get_array(diagnosticsPool, 'indexBoundaryLayerDepth',indexBoundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-
       !
       ! set pointers for fields related to ocean forcing state
       !
       call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
       call mpas_pool_get_array(forcingPool, 'windSpeed10m', windSpeed10m)
-
-      !
-      ! set pointers for fields related forcing at ocean surface
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
-
-      !
-      ! set pointers for viscosity/diffusivity and initialize to zero
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-
-
-      !
-      ! set pointers for nonlocal flux and initialize to zero
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_vertNonLocalFluxTemp', index_vertNonLocalFluxTemp)
 
       nCells = nCellsArray( size(nCellsArray) )
 

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -29,6 +29,7 @@ module ocn_wetting_drying
 
    use ocn_constants
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
 
    implicit none
@@ -239,7 +240,6 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: provisStatePool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessProvis
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge
@@ -255,16 +255,12 @@ contains
 
       err = 0
 
-     call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
      call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
      call mpas_pool_get_subpool(block % structs, 'state', statePool)
      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
-     call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
-     call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-     call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
      ! use thickness at n because constraint is h_n + dt*T_h > h_min
      call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
      call mpas_pool_get_array(provisStatePool, 'layerThickness', layerThicknessProvis, 1)


### PR DESCRIPTION
This PR creates a new file `mpas_ocn_diagnostics_variables.F` that houses all variables in the `diagnosticsPool`.  During `init`, there is a call to `mpas_pool_get_array` for each of the variables in the diagnosticsPool, and then other files use those variables via a `use ocn_diagnostics_variables` statement.  This change makes it easier for these arrays to be copied to the GPUs.  Note, though, that there is no code in this PR to copy arrays to the GPU.

This PR also changes the diagnostics code to use the `ocn_mesh` module instead of the `meshPool`, based on #496.