### PR TITLE
Add option for LAPACK library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,6 +563,12 @@ endif
 	LIBS += -L$(PNETCDF)/$(PNETCDFLIBLOC) -lpnetcdf
 endif
 
+ifneq "$(LAPACK)" ""
+        LIBS += -L$(LAPACK)
+        LIBS += -llapack
+        LIBS += -lblas
+endif
+
 RM = rm -f
 CPP = cpp -P -traditional
 RANLIB = ranlib


### PR DESCRIPTION
The ocean core is adding an implicit time stepping method that uses Lapack. Linking to Lapack is optional, so this addition should not affect the other cores.