### PR TITLE
Fixes decomposition error in k33

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2488,16 +2488,16 @@
 		<var name="eddyTime" type="real" dimensions="nEdges Time" units="s^{-1}"
 			description="inverse eddy time scale in visbeck 1997 closure"
 		/>
-		<var name="kappaGMCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
+		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
 			description="spatially and depth varying GM kappa"
 			packages="gm"
 		/>
-		<var name="kappaRediCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
-			description="spatially and depth varying GM kappa"
+		<var name="RediKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
+			description="Scaling coefficient for GM kappa. Varies from 0 to 1."
 			packages="gm"
 		/>
-		<var name="kappaRediSfcTaper" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
-			description="spatially and depth varying Redi kappa"
+		<var name="RediKappaSfcTaper" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
+			description="Scaling coefficient for Redi kappa. Varies from 0 to 1."
 			packages="gm"
 		/>
 		<var name="rediLimiterCount" type="integer" dimensions="nVertLevels nCells Time" units="NA"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2489,11 +2489,11 @@
 			description="inverse eddy time scale in visbeck 1997 closure"
 		/>
 		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
-			description="spatially and depth varying GM kappa"
+			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
 			packages="gm"
 		/>
 		<var name="RediKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
-			description="Scaling coefficient for GM kappa. Varies from 0 to 1."
+			description="Scaling coefficient for GM kappa. Varies from 0 to 1.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_Redi_use_N2_based_taper = .false. the scaling is set to 1 everywhere."
 			packages="gm"
 		/>
 		<var name="RediKappaSfcTaper" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
@@ -225,7 +225,7 @@ contains
                                   temperatureShortWaveTendency)
          call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
 
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness)
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'activeTracerForcingMLTend', &
                                   activeTracerForcingMLTend)

--- a/src/core_ocean/analysis_members/mpas_ocn_ocean_heat_content.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_ocean_heat_content.F
@@ -203,7 +203,7 @@ contains
 
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness)
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
          call mpas_pool_get_array(oceanHeatContentAMPool, 'oceanHeatContentSfcToBot', oceanHeatContentSfcToBot)
          call mpas_pool_get_array(oceanHeatContentAMPool, 'oceanHeatContentSfcTo700m', oceanHeatContentSfcTo700m)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -105,7 +105,7 @@ contains
                                                     layerThicknessEdge, gradDensityEdge, &
                                                     k33, gmStreamFuncTopOfEdge, BruntVaisalaFreqTop, gmStreamFuncTopOfCell, &
                                                     layerThickness, inSituThermalExpansionCoeff, &
-                                                    inSituSalineContractionCoeff, kappaRediCell, kappaGMCell, kappaRediSfcTaper, &
+                                                    inSituSalineContractionCoeff, RediKappaScaling, gmKappaScaling, RediKappaSfcTaper, &
                                                     zTop, RiTopOfCell
 
       real(kind=RKIND), dimension(:), pointer   :: c_visbeck, gmBolusKappa, cGMphaseSpeed, &
@@ -156,9 +156,9 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
 
       call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
-     call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
+     call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', gmKappaScaling)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
       call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
@@ -230,9 +230,9 @@ contains
 
       !$omp do schedule(runtime)
       do iCell = 1, nCells
-         kappaRediCell(:, iCell) = 1.0_RKIND
-         kappaGMCell(:, iCell) = 1.0_RKIND
-         kappaRediSfcTaper(:, iCell) = 1.0_RKIND
+         RediKappaScaling(:, iCell) = 1.0_RKIND
+         gmKappaScaling(:, iCell) = 1.0_RKIND
+         RediKappaSfcTaper(:, iCell) = 1.0_RKIND
       end do
       !$omp end do
 
@@ -252,7 +252,7 @@ contains
             do k = maxLocation, maxLevelCell(iCell)
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
 
-               kappaRediCell(k, iCell) = min(max(config_GM_min_stratification_ratio, &
+               RediKappaScaling(k, iCell) = min(max(config_GM_min_stratification_ratio, &
                                                BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
                                            1.0_RKIND)
             end do
@@ -263,7 +263,7 @@ contains
       if (local_config_GM_kappa_lat_depth_variable) then
         !$omp do schedule(runtime)
         do iCell=1,nCells
-          kappaGMCell(:, iCell) = kappaRediCell(:,iCell)
+          gmKappaScaling(:, iCell) = RediKappaScaling(:,iCell)
         enddo
         !$omp end do
       end if
@@ -275,7 +275,7 @@ contains
             zMLD = ssh(iCell) - zMid(k, iCell)
 
             do k = 1, indMLD(iCell)
-               kappaRediSfcTaper(k, iCell) = abs((ssh(iCell) - zMid(k, iCell))/(zMLD))
+               RediKappaSfcTaper(k, iCell) = abs((ssh(iCell) - zMid(k, iCell))/(zMLD))
             end do
          end do
          !$omp end do
@@ -364,7 +364,7 @@ contains
                slopeTaperUp = 1.0_RKIND + slopeTaperFactor*(slopeTaperUp - 1.0_RKIND)
                slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
 
-               sfcTaper = min(kappaRediSfcTaper(k, cell1), kappaRediSfcTaper(k, cell2))
+               sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
                sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
                sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
 
@@ -390,8 +390,8 @@ contains
 
          ! Normalize k33
          do k = 2, maxLevelCell(iCell)
-            k33(k, iCell) = k33(k, iCell)/k33Norm(k)*kappaRediSfcTaper(k, iCell)* &
-                            kappaRediCell(k, iCell)
+            k33(k, iCell) = k33(k, iCell)/k33Norm(k)*RediKappaSfcTaper(k, iCell)* &
+                            RediKappaScaling(k, iCell)
          end do
          k33(1, iCell) = 0.0_RKIND
          k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
@@ -563,7 +563,7 @@ contains
                gradDensityTopOfEdge = (layerThicknessEdge(k - 1, iEdge)*gradDensityEdge(k - 1, iEdge) + &
                                        layerThicknessEdge(k, iEdge)*gradDensityEdge(k, iEdge))/(layerThicknessEdge(k - 1, iEdge) + &
                                                                                                 layerThicknessEdge(k, iEdge))
-               kappaGMEdge = 0.5_RKIND*(kappaGMCell(k, cell1) + kappaGMCell(k, cell2))
+               kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
@@ -579,7 +579,7 @@ contains
                                        layerThicknessEdge(k, iEdge)*gradDensityEdge(k, iEdge)) & 
                                        /(layerThicknessEdge(k - 1, iEdge) + &
                                        layerThicknessEdge(k, iEdge))
-                  kappaGMEdge = 0.5_RKIND*(kappaGMCell(k, cell1) + kappaGMCell(k, cell2))
+                  kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                   tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &
@@ -597,7 +597,7 @@ contains
                gradDensityTopOfEdge = (layerThicknessEdge(k - 1, iEdge)*gradDensityEdge(k - 1, iEdge) + &
                                        layerThicknessEdge(k, iEdge)*gradDensityEdge(k, iEdge))/(layerThicknessEdge(k - 1, iEdge) + &
                                                                                                 layerThicknessEdge(k, iEdge))
-               kappaGMEdge = 0.5_RKIND*(kappaGMCell(k, cell1) + kappaGMCell(k, cell2))
+               kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -421,7 +421,7 @@ contains
 
       if (config_use_GM) then
          nEdges = nEdgesArray(3)
-         !$omp do schedule(runtime) private(cell1, cell2, dcEdgeInv, &
+         !$omp do schedule(runtime) private(k, cell1, cell2, dcEdgeInv, &
          !$omp& drhoDT, drhoDS, dTdx, dSdx, drhoDx)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)
@@ -449,7 +449,7 @@ contains
          nEdges = nEdgesArray(3)
 
          if (local_config_GM_lat_variable_c2) then
-            !$omp do schedule(runtime) private(cell1, cell2, sumN2, ltSum, countN2, BruntVaisalaFreqTopEdge)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, BruntVaisalaFreqTopEdge)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
@@ -490,7 +490,8 @@ contains
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
            call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
            call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
-           !$omp do schedule(runtime) private(cell1, cell2, sumN2, ltSum, sumRi, countN2, zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge) 
+           !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
+           !$omp& zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge)
            do iEdge = 1, nEdges
               k=1
               sumN2 = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -489,7 +489,7 @@ contains
         normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
         normalThicknessFlux, tracerGroupSurfaceFlux, fractionAbsorbed, zMid, &
         fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
-        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux, kappaRediCell, kappaRediSfcTaper
+        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux, RediKappaScaling, RediKappaSfcTaper
 
       !
       ! three dimensional pointers
@@ -577,8 +577,8 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
       call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
       call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
       call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
       call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
@@ -887,7 +887,7 @@ contains
                endif
                call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
                                          RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer, &
-                                         kappaRediSfcTaper, kappaRediCell, rediLimiterCount, tracerGroupTend, err)
+                                         RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tracerGroupTend, err)
 
                if(trim(groupItr % memberName)=='activeTracers') then
                  isActiveTracer = .true.

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -81,7 +81,7 @@ contains
 
    subroutine ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracers, &
                                    RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
-                                   kappaRediSfcTaper, kappaRediCell, rediLimiterCount, tend, err)!{{{
+                                   RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
 
       !-----------------------------------------------------------------
@@ -100,7 +100,7 @@ contains
          layerThickness,     &!< Input: thickness at centers
          zMid                 !< Input: Z coordinate at the center of a cell
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &
-         kappaRediSfcTaper, kappaRediCell        !< Input: vertical structure of GM/Redi limiter
+         RediKappaSfcTaper, RediKappaScaling        !< Input: vertical structure of GM/Redi limiter
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         slopeTriadUp, slopeTriadDown, &
@@ -154,8 +154,8 @@ contains
       if (config_use_Redi) then
         call ocn_tracer_hmix_Redi_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
                                      RediKappa, dt, isActiveTracer,        &
-                                     slopeTriadUp, slopeTriadDown, kappaRediSfcTaper, &
-                                     kappaRediCell, rediLimiterCount, tend, err1)
+                                     slopeTriadUp, slopeTriadDown, RediKappaSfcTaper, &
+                                     RediKappaScaling, rediLimiterCount, tend, err1)
       endif
       err = ior(err1, err2)
       call mpas_timer_stop("tracer hmix")

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -76,7 +76,7 @@ contains
 
    subroutine ocn_tracer_hmix_Redi_tend(meshPool, scratchPool, layerThickness, layerThicknessEdge, zMid, tracers, &
                                         RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
-                                        kappaRediSfcTaper, kappaRediCell, rediLimiterCount, tend, err)!{{{
+                                        RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -93,8 +93,8 @@ contains
       real(kind=RKIND), dimension(:, :), intent(in) :: &
          layerThicknessEdge, &!< Input: thickness at edge
          zMid, &!< Input: Z coordinate at the center of a cell
-         kappaRediSfcTaper, &!< Input: vertical structure of GM/Redi limiter
-         kappaRediCell, &
+         RediKappaSfcTaper, &!< Input: vertical structure of GM/Redi limiter
+         RediKappaScaling, &
          layerThickness
 
       real(kind=RKIND), dimension(:, :, :), intent(in) :: &
@@ -222,10 +222,10 @@ contains
             coef = dvEdge(iEdge)
 
             k = 1
-            kappaRediEdgeVal = 0.25_RKIND*(kappaRediCell(k, cell1) + kappaRediCell(k, cell2) + &
-                                           kappaRediCell(k + 1, cell1) + kappaRediCell(k + 1, cell2))* &
-                               0.25_RKIND*(kappaRediSfcTaper(k, cell1) + kappaRediSfcTaper(k, cell2) + &
-                                           kappaRediSfcTaper(k + 1, cell1) + kappaRediSfcTaper(k + 1, cell2))
+            kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -246,10 +246,10 @@ contains
 
             do k = 2, maxLevelEdgeTop(iEdge) - 1
 
-               kappaRediEdgeVal = 0.25_RKIND*(kappaRediCell(k, cell1) + kappaRediCell(k, cell2) + &
-                                              kappaRediCell(k + 1, cell1) + kappaRediCell(k + 1, cell2))*0.25_RKIND* &
-                                  (kappaRediSfcTaper(k, cell1) + kappaRediSfcTaper(k, cell2) + &
-                                   kappaRediSfcTaper(k + 1, cell1) + kappaRediSfcTaper(k + 1, cell2))
+               kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))*0.25_RKIND* &
+                                  (RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                   RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
                do iTr = 1, nTracers
                   ! \kappa_2 \nabla \phi on edge
@@ -282,10 +282,10 @@ contains
             end do
 
             k = maxLevelEdgeTop(iEdge)
-            kappaRediEdgeVal = 0.25_RKIND*(kappaRediCell(k, cell1) + kappaRediCell(k, cell2) + &
-                                           kappaRediCell(k + 1, cell1) + kappaRediCell(k + 1, cell2))* &
-                               0.25_RKIND*(kappaRediSfcTaper(k, cell1) + kappaRediSfcTaper(k, cell2) + &
-                                           kappaRediSfcTaper(k + 1, cell1) + kappaRediSfcTaper(k + 1, cell2))
+            kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -336,8 +336,8 @@ contains
                ! 2.0 in next line is because a dot product on a C-grid
                ! requires a factor of 1/2 to average to the cell center.
                flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
-                            (kappaRediSfcTaper(k, iCell)*kappaRediCell(k, iCell)*fluxRediZTop(iTr, k)  &
-                            * invAreaCell - kappaRediSfcTaper(k + 1, iCell)*kappaRediCell(k + 1, iCell) &
+                            (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
+                            * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
                             *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
                redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
@@ -394,9 +394,9 @@ contains
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
-                                     (kappaRediSfcTaper(k, iCell)*kappaRediCell(k, iCell)* &
-                                      redi_term3_topOfCell(iTr, k, iCell) - kappaRediSfcTaper(k + 1, iCell) &
-                                      *kappaRediCell(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+                                     (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
+                                      redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
+                                      *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
             end do
          end do
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -180,7 +180,7 @@ contains
       !$omp barrier
 
       nCells = nCellsArray(2)
-      !$omp do schedule(runtime) private(i,iEdge)
+      !$omp do schedule(runtime) private(i, iEdge)
       do iCell = 1,nCells
         rediKappaCell(iCell) = 0.0_RKIND
         do i = 1, nEdgesOnCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -179,6 +179,7 @@ contains
       !$omp end master
       !$omp barrier
 
+      !$omp do schedule(runtime) private(rediKappaCell, iEdge)
       nCells = nCellsArray(2)
       do iCell = 1,nCells
         rediKappaCell(iCell) = 0.0_RKIND
@@ -188,6 +189,7 @@ contains
         enddo
         rediKappaCell(iCell) = rediKappaCell(iCell) / areaCell(iCell)
       enddo
+      !$omp end do
 
       nCells = nCellsArray(1)
       nCellsP1 = nCellsArray(size(nCellsArray)) + 1

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -179,8 +179,8 @@ contains
       !$omp end master
       !$omp barrier
 
-      !$omp do schedule(runtime) private(rediKappaCell, iEdge)
       nCells = nCellsArray(2)
+      !$omp do schedule(runtime) private(i,iEdge)
       do iCell = 1,nCells
         rediKappaCell(iCell) = 0.0_RKIND
         do i = 1, nEdgesOnCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -55,6 +55,7 @@ module ocn_tracer_hmix_Redi
    !--------------------------------------------------------------------
 
    real(kind=RKIND) :: term1TaperFactor
+   real(kind=RKIND), dimension(:), allocatable :: rediKappaCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term2_edge, redi_term3_topOfCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term1, redi_term2, redi_term3
 
@@ -141,7 +142,7 @@ contains
       real(kind=RKIND) :: flux, flux_term1, flux_term2, flux_term3, dTracerDx, coef
       real(kind=RKIND) :: r_tmp, tracer_turb_flux, kappaRediEdgeVal
       real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
-      real(kind=RKIND), dimension(:), allocatable :: minimumVal, rediKappaCell
+      real(kind=RKIND), dimension(:), allocatable :: minimumVal
       real(kind=RKIND), dimension(:, :), allocatable :: fluxRediZTop
       err = 0
 
@@ -168,9 +169,9 @@ contains
       nEdges = nEdgesArray(size(nEdgesArray))
 
       allocate (minimumVal(nTracers))
-      allocate (rediKappaCell(nCells))
       allocate (fluxRediZTop(nTracers, nVertLevels + 1))
       !$omp master
+      allocate (rediKappaCell(nCells))
       allocate (redi_term1(nTracers, nVertLevels, nCells))
       allocate (redi_term2(nTracers, nVertLevels, nCells))
       allocate (redi_term3(nTracers, nVertLevels, nCells))
@@ -334,7 +335,7 @@ contains
                ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
                ! 2.0 in next line is because a dot product on a C-grid
                ! requires a factor of 1/2 to average to the cell center.
-               flux_term3 = RediKappa(iCell)*2.0_RKIND* &
+               flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
                             (kappaRediSfcTaper(k, iCell)*kappaRediCell(k, iCell)*fluxRediZTop(iTr, k)  &
                             * invAreaCell - kappaRediSfcTaper(k + 1, iCell)*kappaRediCell(k + 1, iCell) &
                             *fluxRediZTop(iTr, k + 1) * invAreaCell)
@@ -413,8 +414,8 @@ contains
 
       deallocate (fluxRediZTop)
       deallocate (minimumVal)
-      deallocate (rediKappaCell)
       !$omp master
+      deallocate (rediKappaCell)
       deallocate (redi_term1)
       deallocate (redi_term2)
       deallocate (redi_term3)
@@ -486,7 +487,7 @@ contains
                RediKappa(iEdge) = config_Redi_kappa
             end do
             !$omp end do
-         else if (config_Redi_closure == 'data') then
+          else if (config_Redi_closure == 'data') then
             ! read RediKappa in from input
             call mpas_log_write("config_Redi_closure = 'data'. "// &
                                 "Make sure that the variable RediKappa is read in from an input file.")

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -217,7 +217,8 @@ contains
             rediKappaCell = rediKappaCell + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
          enddo
 
-         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + RediKappaCell * k33(:, iCell)
+         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + rediKappaCell * k33(:, iCell) &
+                        / areaCell(iCell)
       end do
       !$omp end do
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -209,7 +209,7 @@ contains
 
       nCells = nCellsArray(1)
 
-      !$omp do schedule(runtime) private(rediKappaCell, iEdge)
+      !$omp do schedule(runtime) private(i, rediKappaCell, iEdge)
       do iCell = 1, nCells
          rediKappaCell = 0.0_RKIND
          do i = 1, nEdgesOnCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -178,8 +178,13 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          k33
 
-      integer :: iCell, nCells
-      integer, pointer :: nCellsSolve
+      real (kind=RKIND) :: rediKappaCell
+      real (kind=RKIND),dimension(:),pointer :: dvEdge, dcEdge, areaCell
+
+      integer :: i, iCell, nCells, iEdge
+
+      integer, dimension(:), pointer :: nEdgesOnCell, nCellsArray
+      integer, dimension(:,:), pointer :: edgesOnCell
 
       integer, intent(out) :: err !< Output: error flag
 
@@ -195,13 +200,24 @@ contains
 
       call mpas_timer_start('tracer redi coef')
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
-      nCells = nCellsSolve
+      nCells = nCellsArray(1)
 
-      !$omp do schedule(runtime)
+      !$omp do schedule(runtime) private(rediKappaCell, iEdge)
       do iCell = 1, nCells
-         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + RediKappa(iCell) * k33(:, iCell)
+         rediKappaCell = 0.0_RKIND
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            rediKappaCell = rediKappaCell + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
+         enddo
+
+         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + RediKappaCell * k33(:, iCell)
       end do
       !$omp end do
 

--- a/testing_and_setup/compass/ocean/global_ocean/QU240/daily_output_test/config_test.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/QU240/daily_output_test/config_test.xml
@@ -59,7 +59,8 @@
 				<member name="vertGMBolusVelocityTop" type="var"/>
 				<member name="GMBolusVelocityZonal" type="var"/>
 				<member name="GMBolusVelocityMeridional" type="var"/>
-				<member name="kappaGMCell" type="var"/>
+				<member name="gmKappaScaling" type="var"/>
+				<member name="RediKappaScaling" type="var"/>
 				<member name="cGMphaseSpeed" type="var"/>
 				<member name="velocityZonalTimesTemperature_GM" type="var"/>
 				<member name="velocityMeridionalTimesTemperature_GM" type="var"/>


### PR DESCRIPTION
Currently it is being assumed rediKappa lives at cell centers for the
k33 term in mpas_ocn_vmix_coefs_redi.F, however the rest of the model
assumes rediKappa lives on edges, this is causing a decomposition test
to fail. This PR fixes that bug. Also removes warnings from analysis
members, and improves variable names and descriptions.