### PR TITLE
Adds EC60to30 decomposition test to nightly

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_128pes_run.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_128pes_run.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<config case="128pes_run">
+	<add_link source="../../init/initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../../init/initial_state/graph.info" dest="graph.info"/>
+	<add_link source="../../init/initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">128</argument>
+		</step>
+
+		<model_run procs="128" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_64pes_run.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_64pes_run.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<config case="64pes_run">
+	<add_link source="../../init/initial_state/initial_state.nc" dest="init.nc"/>
+	<add_link source="../../init/initial_state/graph.info" dest="graph.info"/>
+	<add_link source="../../init/initial_state/init_mode_forcing_data.nc" dest="forcing_data.nc"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="template_forward.xml" path_base="script_resolution_dir"/>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<template file="template_forward.xml" path_base="script_configuration_dir"/>
+		<template file="minimal_output.xml" path_base="script_core_dir" path="templates/streams"/>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="gpmetis">
+			<argument flag="graph.info">64</argument>
+		</step>
+
+		<model_run procs="64" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_driver.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/decomposition_test/config_driver.xml
@@ -1,0 +1,13 @@
+<driver_script name="run.py">
+	<case name="64pes_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running 64pes_run" post_message="  - Complete"/>
+	</case>
+	<case name="128pes_run">
+		<step executable="./run.py" quiet="true" pre_message=" * Running 128pes_run" post_message="  - Complete"/>
+	</case>
+	<validation>
+		<compare_fields file1="64pes_run/output.nc" file2="128pes_run/output.nc">
+			<template file="prognostic_comparison.xml" path_base="script_core_dir" path="templates/validations"/>
+		</compare_fields>
+	</validation>
+</driver_script>

--- a/testing_and_setup/compass/ocean/regression_suites/nightly.xml
+++ b/testing_and_setup/compass/ocean/regression_suites/nightly.xml
@@ -2,7 +2,13 @@
 	<test name="Baroclinic Channel 10km - Default Test" core="ocean" configuration="baroclinic_channel" resolution="10km" test="default">
 		<script name="run_test.py"/>
 	</test>
-	<test name="Global Ocean 240km - Init Test" core="ocean" configuration="global_ocean" resolution="QU240" test="init">
+	<test name="Global Ocean EC60to30 - Init Test" core="ocean" configuration="global_ocean" resolution="EC60to30" test="init">
+		<script name="run.py"/>
+  </test>
+  <test name="Global Ocean EC60to30 - PE Decomposition Test" core="ocean" configuration="global_ocean" resolution="EC60to30" test="decomposition_test">
+    <script name="run.py"/>
+  </test>
+  <test name="Global Ocean 240km - Init Test" core="ocean" configuration="global_ocean" resolution="QU240" test="init">
 		<script name="run.py"/>
 	</test>
 	<test name="Global Ocean 240km - Performance Test" core="ocean" configuration="global_ocean" resolution="QU240" test="performance_test">


### PR DESCRIPTION
This adds a new processor decomposition test to nightly regression suite

The EC60to30 mesh is used with 64 and 128 processors to help test cases similar to E3SM testing/simulations

