### PR TITLE
Add GPU compiler flags for OpenACC and OpenMP_offload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ xlf:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-xlf-summit:
+xlf-summit-omp-offload:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \

--- a/src/build_core.cmake
+++ b/src/build_core.cmake
@@ -61,6 +61,23 @@ function(build_core CORE)
     endforeach()
   endif()
 
+  # Additional compiler flags
+  if (${MACH} STREQUAL "summit")
+    if (${COMPILER} STREQUAL "pgigpu")
+      list(APPEND CPPDEFS "-DMPAS_OPENACC")
+      foreach(ACC_FILE IN LISTS ADD_ACC_FLAGS)
+       message(STATUS "Adding '-acc -ta=nvidia,cc70,pinned -Minfo=accel' to compilation of ${CMAKE_BINARY_DIR}/${ACC_FILE}")
+       set_property(SOURCE ${CMAKE_BINARY_DIR}/${ACC_FILE} APPEND_STRING PROPERTY COMPILE_FLAGS "-acc -ta=nvidia,cc70,pinned -Minfo=accel")
+      endforeach()
+    elseif (${COMPILER} STREQUAL "ibmgpu")
+      list(APPEND CPPDEFS "-DMPAS_OPENMP_OFFLOAD")
+      foreach(ACC_FILE IN LISTS ADD_ACC_FLAGS)
+        message(STATUS "Adding '-qsmp -qoffload' to compilation of ${CMAKE_BINARY_DIR}/${ACC_FILE}")
+        set_property(SOURCE ${CMAKE_BINARY_DIR}/${ACC_FILE} APPEND_STRING PROPERTY COMPILE_FLAGS "-qsmp -qoffload")
+      endforeach()
+    endif()
+  endif()
+
   genf90_targets("${RAW_SOURCES}" "${INCLUDES}" "${CPPDEFS}" "${NO_PREPROCESS}" "${INC_DIR}")
   target_sources(${COMPONENT} PRIVATE ${SOURCES} $<TARGET_OBJECTS:common>)
 

--- a/src/core_ocean/ocean.cmake
+++ b/src/core_ocean/ocean.cmake
@@ -182,6 +182,23 @@ list(APPEND RAW_SOURCES
   core_ocean/analysis_members/mpas_ocn_analysis_driver.F
 )
 
+# add accelerator/gpu flags
+list(APPEND ADD_ACC_FLAGS
+  core_ocean/shared/mpas_ocn_equation_of_state_jm.f90
+  core_ocean/shared/mpas_ocn_mesh.f90
+  core_ocean/shared/mpas_ocn_surface_bulk_forcing.f90
+  core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.f90
+  core_ocean/shared/mpas_ocn_tendency.f90
+  core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.f90
+  core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.f90
+  core_ocean/shared/mpas_ocn_vel_hadv_coriolis.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_del2.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_del4.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_leith.f90
+  core_ocean/shared/mpas_ocn_vel_pressure_grad.f90
+  core_ocean/shared/mpas_ocn_vel_vadv.f90
+)
+
 # Generate core input
 handle_st_nl_gen(
   "namelist.ocean;namelist.ocean.forward mode=forward;namelist.ocean.analysis mode=analysis;namelist.ocean.init mode=init"


### PR DESCRIPTION
This adds a new framework compiler entry `xlf-summit-omp-offload` that has an option to build with OpenMP offloading support. This also enables OpenACC and OpenMP_offload builds in E3SM.

[bit-for-bit]