### PR TITLE
Ensures windSpeed(U,V) fields are defined

### DIFF
--- a/testing_and_setup/compass/ocean/hurricane/hurricane_wind_pressure/winds_io/output_data.py
+++ b/testing_and_setup/compass/ocean/hurricane/hurricane_wind_pressure/winds_io/output_data.py
@@ -26,7 +26,7 @@ def write_netcdf(filename: str, curr_hurricane: Hurricane, grid: Geogrid, winds:
     # Format time
     ref_date = curr_hurricane[0].ref_time 
     xtime = []
-    for it in range(0,len(curr_hurricane)):
+    for it in range(0,len(curr_hurricane)-1):
       t = curr_hurricane[it].time
       date = ref_date + datetime.timedelta(hours=np.float64(t))
       xtime.append(date.strftime('%Y-%m-%d_%H:%M:%S'+45*' '))


### PR DESCRIPTION
Previously, index error in synthetic hurricane code
would allow undefined fields to be produced, which
are interpreted in MPAS-O as a larger number, which
would cause unrealistic forcing.
