### PR TITLE
Update CMake builds for pre-built MPAS tools

### DIFF
--- a/src/build_core.cmake
+++ b/src/build_core.cmake
@@ -48,7 +48,7 @@ function(build_core CORE)
   add_custom_command(
     OUTPUT ${INC_DIR}/core_variables.inc
     COMMAND ${CMAKE_BINARY_DIR}/mpas-source/src/tools/parse < ${CORE_BLDDIR}/Registry_processed.xml
-    DEPENDS parse ${CORE_BLDDIR}/Registry_processed.xml
+    DEPENDS ${CORE_BLDDIR}/Registry_processed.xml
     WORKING_DIRECTORY ${INC_DIR}
   )
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,13 +1,21 @@
 
-# Make build tools, need to be compiled with serial compiler.
-set(CMAKE_C_COMPILER ${SCC})
+if (DEFINED ENV{MPAS_TOOL_DIR})
+  message(STATUS "*** Using MPAS tools from $ENV{MPAS_TOOL_DIR} ***")
+  file(COPY $ENV{MPAS_TOOL_DIR}/input_gen/namelist_gen DESTINATION .)
+  file(COPY $ENV{MPAS_TOOL_DIR}/input_gen/streams_gen  DESTINATION .)
+  file(COPY $ENV{MPAS_TOOL_DIR}/registry/parse         DESTINATION .)
+else()
+  message(STATUS "*** Building MPAS tools from source ***")
+  # Make build tools, need to be compiled with serial compiler.
+  set(CMAKE_C_COMPILER ${SCC})
 
-add_executable(streams_gen input_gen/streams_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
-add_executable(namelist_gen input_gen/namelist_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
-add_executable(parse registry/parse.c registry/dictionary.c registry/gen_inc.c registry/fortprintf.c registry/utility.c ../external/ezxml/ezxml.c)
+  add_executable(streams_gen input_gen/streams_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
+  add_executable(namelist_gen input_gen/namelist_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
+  add_executable(parse registry/parse.c registry/dictionary.c registry/gen_inc.c registry/fortprintf.c registry/utility.c ../external/ezxml/ezxml.c)
 
-foreach(EXEITEM streams_gen namelist_gen parse)
-  target_compile_definitions(${EXEITEM} PRIVATE ${CPPDEFS})
-  target_compile_options(${EXEITEM} PRIVATE "-Uvector")
-  target_include_directories(${EXEITEM} PRIVATE ${INCLUDES})
-endforeach()
+  foreach(EXEITEM streams_gen namelist_gen parse)
+    target_compile_definitions(${EXEITEM} PRIVATE ${CPPDEFS})
+    target_compile_options(${EXEITEM} PRIVATE "-Uvector")
+    target_include_directories(${EXEITEM} PRIVATE ${INCLUDES})
+  endforeach()
+endif()


### PR DESCRIPTION
Avoid building `namelist_gen`, `streams_gen` and `parse` tools if
pre-built tools are available in MPAS_TOOL_DIR environment variable.
This helps building MPAS in E3SM with Cray compilers (`cce/9.0.2-classic`) on ALCF Theta.

[BFB]