### PR TITLE
Add formulae to compute vegetation-induced bottom Manning roughness coefficient

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -936,6 +936,10 @@
 					description="Controls if vegetation_drag is used."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_use_vegetation_manning_equation" type="logical" default_value=".false." units="unitless"
+					description="Compute vegetation drag force using vegetation-induced Manning roughness coefficient."
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_vegetation_drag_coefficient" type="real" default_value="1.09" units="unitless"
 					description="Vegetation drag coefficient"
 					possible_values="O(1)"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -931,6 +931,16 @@
 					possible_values="0.0 to turn off, 0.09 is typical value to use for scalar approximation"
 		/>
 	</nml_record>
+	<nml_record name="vegetation_drag" mode="init;forward">
+		<nml_option name="config_use_vegetation_drag" type="logical" default_value=".false." units="unitless"
+					description="Controls if vegetation_drag is used."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_vegetation_drag_coefficient" type="real" default_value="1.09" units="unitless"
+					description="Vegetation drag coefficient"
+					possible_values="O(1)"
+		/>
+	</nml_record>
 	<nml_record name="frazil_ice" mode="forward">
 		<nml_option name="config_use_frazil_ice_formation" type="logical" default_value=".false." units="unitless"
 					description="Controls if fluxes related to frazil ice process are computed."
@@ -1453,6 +1463,7 @@
 		<package name="landIceCouplingPKG" description="This package includes varibles required for land ice coupling but not land ice fluxes in standalone mode."/>
 		<package name="frazilIce" description="This package includes variables required for frazil ice formation."/>
 		<package name="tidalForcing" description="This package includes variables required for tidal forcing on a boundary."/>
+		<package name="vegetationDragPKG" description="This package includes vegetation properties used for computing vegetation drag"/>
 		<package name="inSituEOS" description="This package includes variables required for to compute in situ equation of state derivatives, like thermal expansion and haline contraction."/>
 		<package name="forwardMode" description="This package controls variables that are intended to be used within the forward run mode of the ocean model."/>
 		<package name="analysisMode" description="This package controls variables that are intended to be used within the analysis run mode of the ocean model."/>
@@ -3232,6 +3243,23 @@
 			 packages="tidalForcing"
 		/>
 
+		<!-- Input fields for vegetation properties -->
+		<var name="vegetationHeight" type="real" dimensions="nCells" units="m"
+			 description="Stem height of the vegetation"
+			 packages="vegetationDragPKG"
+		/>
+		<var name="vegetationDiameter" type="real" dimensions="nCells" units="m"
+			 description="Stem diameter of the vegetation"
+			 packages="vegetationDragPKG"
+		/>
+		<var name="vegetationDensity" type="real" dimensions="nCells" units="m^{-2}"
+			 description="Stem density of the vegetation per unit area"
+			 packages="vegetationDragPKG"
+		/>
+		<var name="vegetationMask" type="integer" dimensions="nCells" units="unitless"
+			 description="Mask value 1 as vegetated cell, and 0 as non-vegetated cell"
+			 packages="vegetationDragPKG"
+		/>
 		<!-- Output fields for forcing due to tides -->
 		<var name="tidalLayerThicknessTendency" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="layer thickness tendency due to tidal forcing"

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -122,6 +122,7 @@ module ocn_core_interface
       logical, pointer :: frazilIceActive
       logical, pointer :: tidalForcingActive
       logical, pointer :: tidalPotentialForcingPKGActive
+      logical, pointer :: vegetationDragPKGActive
       logical, pointer :: inSituEOSActive
       logical, pointer :: variableShortwaveActive
       logical, pointer :: gmActive
@@ -151,6 +152,7 @@ module ocn_core_interface
       logical, pointer :: config_use_frazil_ice_formation
       logical, pointer :: config_use_tidal_forcing
       logical, pointer :: config_use_tidal_potential_forcing
+      logical, pointer :: config_use_vegetation_drag
       logical, pointer :: config_use_standardGM
       logical, pointer :: config_use_time_varying_atmospheric_forcing
       logical, pointer :: config_use_time_varying_land_ice_forcing
@@ -306,6 +308,14 @@ module ocn_core_interface
          tidalPotentialForcingPKGActive = .true.
       end if
 
+      !
+      ! test for use of vegetation drag, vegetationDragPKGActive
+      !
+      call mpas_pool_get_package(packagePool, 'vegetationDragPKGActive', vegetationDragPKGActive)
+      call mpas_pool_get_config(configPool, 'config_use_vegetation_drag', config_use_vegetation_drag)
+      if (config_use_vegetation_drag) then
+         vegetationDragPKGActive = .true.
+      end if
       !
       ! test for form of pressure gradient computation
       !

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -728,6 +728,7 @@ contains
 
       ! vegetation_drag
       logical, pointer :: config_use_vegetation_drag
+      logical, pointer :: config_use_vegetation_manning_equation
       real (kind=RKIND), pointer :: config_vegetation_drag_coefficient
       real (kind=RKIND), pointer :: config_implicit_bottom_drag_coeff
       real (kind=RKIND), dimension(:), pointer :: vegetationHeight
@@ -752,6 +753,7 @@ contains
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
       call mpas_pool_get_config(ocnConfigs, 'config_use_vegetation_drag', config_use_vegetation_drag)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_vegetation_manning_equation', config_use_vegetation_manning_equation)
       call mpas_pool_get_config(ocnConfigs, 'config_vegetation_drag_coefficient', config_vegetation_drag_coefficient)
       call mpas_pool_get_config(ocnConfigs, 'config_implicit_bottom_drag_coeff', config_implicit_bottom_drag_coeff)
 
@@ -766,8 +768,8 @@ contains
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
       A(1)=0.0_RKIND
 
-      ! Compute bottomDrag induced by vegetation
-      if (config_use_vegetation_drag) then
+      ! Compute bottomDrag (Manning roughness) induced by vegetation
+      if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
         do iCell = 1, nCells
           if (vegetationDensity(iCell) * vegetationHeight(iCell) * vegetationDiameter(iCell) .eq. 0.0_RKIND) then
             vegetationMask(iCell) = 0

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -654,8 +654,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, bottomDrag, dt, kineticEnergyCell, & !{{{
-                                         vertViscTopOfEdge, layerThickness, &
+   subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, forcingPool, bottomDrag, dt, & !{{{
+                                         kineticEnergyCell, vertViscTopOfEdge, layerThickness, &
                                          layerThicknessEdge, normalVelocity, ssh, bottomDepth, err)
 
       !-----------------------------------------------------------------
@@ -666,6 +666,9 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information
+
+      type (mpas_pool_type), intent(inout) :: &
+         forcingPool          !< Input: forcing information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          kineticEnergyCell        !< Input: kinetic energy at cell
@@ -679,7 +682,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness !< Input: thickness at cell center
 
-       real (kind=RKIND), dimension(:), intent(in) :: &
+       real (kind=RKIND), dimension(:), intent(inout) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
 
        real (kind=RKIND), dimension(:), pointer :: ssh
@@ -723,20 +726,69 @@ contains
 
       real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
 
+      ! vegetation_drag
+      logical, pointer :: config_use_vegetation_drag
+      real (kind=RKIND), pointer :: config_vegetation_drag_coefficient
+      real (kind=RKIND), pointer :: config_implicit_bottom_drag_coeff
+      real (kind=RKIND), dimension(:), pointer :: vegetationHeight
+      real (kind=RKIND), dimension(:), pointer :: vegetationDiameter
+      real (kind=RKIND), dimension(:), pointer ::vegetationDensity
+      integer, dimension(:), pointer ::vegetationMask
+      real (kind=RKIND) :: lambda, beta, alpha, total_h
+      real (kind=RKIND) :: inundation_depth, von_karman, cff1, cff2, cff3, cff4
+      integer:: iCell, nCells
+      integer, pointer :: nCellsSolve
+
       err = 0
+      von_karman = 0.4_RKIND
 
       if(.not.velVmixOn) return
 
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
+      call mpas_pool_get_config(ocnConfigs, 'config_use_vegetation_drag', config_use_vegetation_drag)
+      call mpas_pool_get_config(ocnConfigs, 'config_vegetation_drag_coefficient', config_vegetation_drag_coefficient)
+      call mpas_pool_get_config(ocnConfigs, 'config_implicit_bottom_drag_coeff', config_implicit_bottom_drag_coeff)
+
+      call mpas_pool_get_array(forcingPool, 'vegetationMask', vegetationMask)
+      call mpas_pool_get_array(forcingPool, 'vegetationHeight', vegetationHeight)
+      call mpas_pool_get_array(forcingPool, 'vegetationDensity', vegetationDensity)
+      call mpas_pool_get_array(forcingPool, 'vegetationDiameter', vegetationDiameter)
+
       nEdges = nEdgesArray( 1 )
+      nCells = nCellsSolve
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
       A(1)=0.0_RKIND
+
+      ! Compute bottomDrag induced by vegetation
+      if (config_use_vegetation_drag) then
+        do iCell = 1, nCells
+          if (vegetationMask(iCell) .eq. 1) then
+            total_h = bottomDepth(iCell) + ssh(iCell)
+            inundation_depth = MIN(vegetationHeight(iCell), total_h)
+            inundation_depth = MAX(inundation_depth, 1e-6)
+            lambda = vegetationDiameter(iCell) * vegetationDensity(iCell)
+            alpha = (config_vegetation_drag_coefficient*lambda/ &
+                   (4.0_RKIND*von_karman**2.0_RKIND*inundation_depth**2.0_RKIND))**(1.0_RKIND/3.0_RKIND)
+            beta = 0.5_RKIND*alpha*inundation_depth*(1.0_RKIND - EXP(-2.0_RKIND*alpha*inundation_depth)) &
+                  / (1.0_RKIND - EXP(-alpha*inundation_depth))**2.0_RKIND
+            cff1 = total_h**(2.0_RKIND/3.0_RKIND) &
+                  * SQRT((0.5_RKIND*beta*lambda*config_vegetation_drag_coefficient*inundation_depth &
+                  + config_implicit_bottom_drag_coeff)/(gravity*total_h))
+            cff2 = (alpha*inundation_depth)**2.0_RKIND/(1.0_RKIND - EXP(-alpha*inundation_depth))
+            cff3 = (1.0_RKIND - EXP(-alpha*inundation_depth))/(alpha**2.0_RKIND*inundation_depth*total_h)
+            cff4 = LOG(total_h/inundation_depth) - (1.0_RKIND-inundation_depth/total_h) &
+                  * (1.0_RKIND - 1.0_RKIND/(alpha*inundation_depth))
+            bottomDrag(iCell) = cff1/(cff2*(cff3+cff4))
+          endif
+        enddo
+      endif
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
@@ -1074,7 +1126,7 @@ contains
             vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
         else if (config_use_implicit_bottom_drag_variable_mannings) then
           ! update bottomDrag via Cd=g*n^2*h^(-1/3)
-          call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, bottomDrag, &
+          call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, forcingPool, bottomDrag, &
             dt, kineticEnergyCell, &
             vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, &
             ssh, bottomDepth, err)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -734,9 +734,9 @@ contains
       real (kind=RKIND), dimension(:), pointer :: vegetationDiameter
       real (kind=RKIND), dimension(:), pointer ::vegetationDensity
       integer, dimension(:), pointer ::vegetationMask
-      real (kind=RKIND) :: lambda, beta, alpha, total_h
+      real (kind=RKIND) :: old_bottomDrag, lambda, beta, alpha, total_h
       real (kind=RKIND) :: inundation_depth, von_karman, cff1, cff2, cff3, cff4
-      integer:: iCell, nCells
+      integer :: iCell, nCells
       integer, pointer :: nCellsSolve
 
       err = 0
@@ -769,7 +769,11 @@ contains
       ! Compute bottomDrag induced by vegetation
       if (config_use_vegetation_drag) then
         do iCell = 1, nCells
+          if (vegetationDensity(iCell) * vegetationHeight(iCell) * vegetationDiameter(iCell) .eq. 0.0_RKIND) then
+            vegetationMask(iCell) = 0
+          endif
           if (vegetationMask(iCell) .eq. 1) then
+            old_bottomDrag = bottomDrag(iCell)
             total_h = bottomDepth(iCell) + ssh(iCell)
             inundation_depth = MIN(vegetationHeight(iCell), total_h)
             inundation_depth = MAX(inundation_depth, 1e-6)
@@ -786,6 +790,7 @@ contains
             cff4 = LOG(total_h/inundation_depth) - (1.0_RKIND-inundation_depth/total_h) &
                   * (1.0_RKIND - 1.0_RKIND/(alpha*inundation_depth))
             bottomDrag(iCell) = cff1/(cff2*(cff3+cff4))
+            bottomDrag(iCell) = MAX(bottomDrag(iCell), old_bottomDrag)
           endif
         enddo
       endif


### PR DESCRIPTION
This PR implemented a series of formulae to compute the vegetation-induced bottom Manning roughness coefficient (n). The formulae convert the vegetation properties (stem height, diameter and density) to n. The formulae have been verified by an external python code. This implementation is default off and compiles fine. 

The reference paper is 
Moki, H., Taguchi, K., Nakagawa, Y., Montani, S. and Kuwae, T., 2020. Spatial and seasonal impacts of submerged aquatic vegetation (SAV) drag force on hydrodynamics in shallow waters. Journal of Marine Systems, p.103373.

