### PR TITLE
Clone submodules over HTTPS, not SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/core_ocean/cvmix"]
 	path = src/core_ocean/cvmix
-	url = git@github.com:CVMix/CVMix-src.git
+	url = https://github.com/CVMix/CVMix-src.git
 [submodule "src/core_ocean/BGC"]
 	path = src/core_ocean/BGC
-	url = git@github.com:E3SM-Project/Ocean-BGC.git
+	url = https://github.com/E3SM-Project/Ocean-BGC.git


### PR DESCRIPTION
This PR updates the `.gitmodules` settings so that Git will clone the [CVMix](https://github.com/CVMix/CVMix-src) and [BGC](https://github.com/E3SM-Project/Ocean-BGC.git) repositories over HTTPS instead of SSH.

This is important for systems (e.g., build servers) that don't have an SSH key associated with GitHub. These systems need to clone public repositories using anonymous HTTPS.

Prior to this change, attempts to build this repository would emit the following error: `Missing core_ocean/cvmix/.git, did you forget to 'git submodule update --init --recursive' ?` Due to not having an SSH key registered with GitHub, running the requested `git submodule update --init --recursive` line fails due to insufficient access rights.

After this PR, the update command works correctly on anonymous systems.