### PR TITLE
Bottom roughness (z_0) based drag term implementation 

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -917,6 +917,10 @@
 					description="If true, implicit bottom drag is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false." units="unitless"
+                                        description="If true, depends on bottom roughness z0"
+                                        possible_values=".true. or .false."
+                />
 		<nml_option name="config_implicit_bottom_drag_coeff" type="real" default_value="1.0e-3" units="unitless"
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"

--- a/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
@@ -223,7 +223,7 @@ contains
          ramp,&
          t, &
          nCycles,&
-         period
+         period,lat
 
       ! End preamble
       !-----------------------------------------------------------------
@@ -250,6 +250,11 @@ contains
          conType = tidalConstituentType(jCon)
          do iCell = 1, nCellsAll
            lon = lonCell(iCell)
+            lat = latCell(iCell)
+            latitudeFunction(iCell,1) = 3.0_RKIND*sin(lat)**2 -1.0_RKIND
+            latitudeFunction(iCell,2) = sin(2.0_RKIND*lat)
+            latitudeFunction(iCell,3) = cos(lat)**2
+
            tidalPotEta(iCell) = tidalPotEta(iCell) + &
                          ramp * tidalConstituentAmplitude(jCon) &
                               * tidalConstituentNodalAmplitude(jCon) &

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -719,7 +719,7 @@ contains
 
       integer :: iEdge, k, cell1, cell2, N, nEdges
       integer, pointer :: nVertLevels
-      real (kind=RKIND) :: implicitCd
+      real (kind=RKIND) :: implicitCd, varmin
       integer, dimension(:), pointer :: nEdgesArray
 
       integer, dimension(:), pointer :: maxLevelEdgeTop
@@ -809,7 +809,10 @@ contains
          end do
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
-         if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
+        if (config_use_implicit_bottom_roughness) then
+           varmin=min(0.16_RKIND/(log(0.5_RKIND*0.5_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))/0.001))**2.0,0.1)
+           implicitCd =max(0.0025_RKIND,varmin)
+         elseif (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
            implicitCd = gravity*(0.5_RKIND*(vegetationManning(cell1) + vegetationManning(cell2)))**2.0 * &
             (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
          else
@@ -1100,7 +1103,9 @@ contains
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(meshPool, bottomDrag, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
-      else if (config_use_implicit_bottom_drag_variable_mannings) then
+          !!vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+      else if (config_use_implicit_bottom_drag_variable_mannings.or. &
+        config_use_implicit_bottom_roughness) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &


### PR DESCRIPTION
Calculation of bottom drag coefficient "implicitCd" using NCOM'S formula :
cb(i,j) = max(cbmin, (vonk/(log(0.5*depth(i,j)/z0)))**2 )).

This bottom drag following the formulation is also used in HYCOM