### PR TITLE
Fix path to docs in Travis CI

### DIFF
--- a/travis_ci/test_docs.bash
+++ b/travis_ci/test_docs.bash
@@ -13,7 +13,7 @@ fi
 # MPAS-Model tag or release
 echo "Docs version: $DOCS_VERSION"
 
-DOCS_PATH="${DOCS_VERSION//\//_}"
+DOCS_PATH="${DOCS_VERSION// /_}"
 
 PUBLICATION_BRANCH=gh-pages
 # Checkout the branch


### PR DESCRIPTION
Replace space (not backslash) with underscore in the path.

Documentation for "latest coastal" and "lastest ocean" is being
placed in a directory that is not very convenient to reference.
