### PR TITLE
New Mesh: WC14to60kmL60E3SMv2r04

### DIFF
--- a/testing_and_setup/compass/README_ocean.md
+++ b/testing_and_setup/compass/README_ocean.md
@@ -6,11 +6,11 @@ To set up and run ocean test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_0.1.8 -c conda-forge -c e3sm python=3.7 compass=0.1.8
+conda create -n compass_0.1.9 -c conda-forge -c e3sm python=3.7 compass=0.1.9
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_0.1.8
+conda activate compass_0.1.9
 ```
 
 An appropriate conda environment is already available on Los Alamos National

--- a/testing_and_setup/compass/load_compass_env.sh
+++ b/testing_and_setup/compass/load_compass_env.sh
@@ -1,4 +1,4 @@
-version=0.1.8
+version=0.1.9
 
 # The rest of the script should not need to be modified
 if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then

--- a/testing_and_setup/compass/ocean/global_ocean/WC14/init/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/WC14/init/config_E3SM_coupling_files.ini
@@ -14,7 +14,7 @@ prefix = WC
 description = MPAS North America and Arctic Focused Water Cycle mesh for E3SM version
               ${e3sm_version}, with a focused ${min_res}-km resolution
               around North America and ${levels} vertical levels as documented at
-              https://github.com/MPAS-Dev/MPAS-Model/pull/628
+              https://github.com/MPAS-Dev/MPAS-Model/pull/650
 e3sm_version = 2
 mesh_version = 04
 creation_date = autodetect

--- a/testing_and_setup/compass/ocean/global_ocean/WC14/init/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/WC14/init/config_E3SM_coupling_files.ini
@@ -16,7 +16,7 @@ description = MPAS North America and Arctic Focused Water Cycle mesh for E3SM ve
               around North America and ${levels} vertical levels as documented at
               https://github.com/MPAS-Dev/MPAS-Model/pull/628
 e3sm_version = 2
-mesh_version = 03
+mesh_version = 04
 creation_date = autodetect
 min_res = 14
 max_res = 60


### PR DESCRIPTION
Design discussion Water Cycle mesh, 14 km high resolution region:
> MPAS North America and Arctic Focused Water Cycle mesh for E3SM version 2, with a focused 14-km resolution around North America and 60 vertical levels

This iteration of the `WC14` mesh has geometric features changes from MPAS-Dev/geometric_features#147 that improve the representation of England, Scotland, Italy and Hawaii.