### PR TITLE
Fix GWDO check on all water regional simulations

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -448,6 +448,9 @@
  real (kind=RKIND) :: maxvar2d_local, maxvar2d_global
  real (kind=RKIND), dimension(:), pointer :: var2d
  integer, pointer :: nCellsSolve
+ integer, pointer :: iswater_lu
+ integer, pointer, dimension(:) :: ivgtyp
+ integer :: all_water, iall_water
  character (len=StrKIND), pointer :: gwdo_scheme
  type (block_type), pointer :: block
  type (mpas_pool_type), pointer :: meshPool
@@ -473,7 +476,22 @@
 
      call mpas_dmpar_max_real(dminfo, maxvar2d_local, maxvar2d_global)
 
-     if (maxvar2d_global <= 0.0_RKIND) then
+     !
+     ! The GWDO check below can fail on regional simulations that are completely above
+     ! water. So, check to see if the simulation is completely above water and do not
+     ! throw the error if it is.
+     !
+     call mpas_pool_get_array(sfc_inputPool, 'iswater', iswater_lu)
+     call mpas_pool_get_array(sfc_inputPool, 'ivgtyp', ivgtyp)
+     if (all(ivgtyp(1:nCellsSolve) == iswater_lu)) then
+         all_water = 1 ! All water
+     else
+         all_water = 0 ! Land present
+     end if
+
+     call mpas_dmpar_min_int(dminfo, all_water, iall_water)
+
+     if (maxvar2d_global <= 0.0_RKIND .and. iall_water /= 1) then
          call mpas_log_write('*******************************************************************************', &
                              messageType=MPAS_LOG_ERR)
          call mpas_log_write('The GWDO scheme requires valid var2d, con, oa{1,2,3,4}, and ol{1,2,3,4} fields,', &


### PR DESCRIPTION
This merge corrects the atmosphere_model's GWDO check that would incorrectly be triggered when running a regional simulation entirely over water.