### PR TITLE
Update MPAS framework for E3SM builds with machine- and/or compiler-specific flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,16 @@
 
 # Source CIME-generated Macros
 include(${CASEROOT}/Macros.cmake)
+# Load machine/compiler specific settings
+set(COMPILER_SPECIFIC_DEPENDS ${CASEROOT}/Depends.${COMPILER}.cmake)
+set(MACHINE_SPECIFIC_DEPENDS ${CASEROOT}/Depends.${MACH}.cmake)
+set(PLATFORM_SPECIFIC_DEPENDS ${CASEROOT}/Depends.${MACH}.${COMPILER}.cmake)
+set(TRY_TO_LOAD ${COMPILER_SPECIFIC_DEPENDS} ${MACHINE_SPECIFIC_DEPENDS} ${PLATFORM_SPECIFIC_DEPENDS})
+foreach(ITEM IN LISTS TRY_TO_LOAD)
+  if (EXISTS ${ITEM})
+    include(${ITEM})
+  endif()
+endforeach()
 
 #
 # General setup

--- a/src/Makefile.in.E3SM
+++ b/src/Makefile.in.E3SM
@@ -14,6 +14,10 @@ endif
 # End duplicated logic
 
 include $(CASEROOT)/Macros.make
+# Load machine/compiler specific settings
+-include $(CASEROOT)/Depends.$(COMPILER)
+-include $(CASEROOT)/Depends.$(MACH)
+-include $(CASEROOT)/Depends.$(MACH).$(COMPILER)
 
 ifneq ($(wildcard core_$(CORE)/build_options.mk), ) # Check for build_options.mk
     include core_$(CORE)/build_options.mk

--- a/src/build_core.cmake
+++ b/src/build_core.cmake
@@ -61,23 +61,6 @@ function(build_core CORE)
     endforeach()
   endif()
 
-  # Additional compiler flags
-  if (${MACH} STREQUAL "summit")
-    if (${COMPILER} STREQUAL "pgigpu")
-      list(APPEND CPPDEFS "-DMPAS_OPENACC")
-      foreach(ACC_FILE IN LISTS ADD_ACC_FLAGS)
-       message(STATUS "Adding '-acc -ta=nvidia,cc70,pinned -Minfo=accel' to compilation of ${CMAKE_BINARY_DIR}/${ACC_FILE}")
-       set_property(SOURCE ${CMAKE_BINARY_DIR}/${ACC_FILE} APPEND_STRING PROPERTY COMPILE_FLAGS "-acc -ta=nvidia,cc70,pinned -Minfo=accel")
-      endforeach()
-    elseif (${COMPILER} STREQUAL "ibmgpu")
-      list(APPEND CPPDEFS "-DMPAS_OPENMP_OFFLOAD")
-      foreach(ACC_FILE IN LISTS ADD_ACC_FLAGS)
-        message(STATUS "Adding '-qsmp -qoffload' to compilation of ${CMAKE_BINARY_DIR}/${ACC_FILE}")
-        set_property(SOURCE ${CMAKE_BINARY_DIR}/${ACC_FILE} APPEND_STRING PROPERTY COMPILE_FLAGS "-qsmp -qoffload")
-      endforeach()
-    endif()
-  endif()
-
   genf90_targets("${RAW_SOURCES}" "${INCLUDES}" "${CPPDEFS}" "${NO_PREPROCESS}" "${INC_DIR}")
   target_sources(${COMPONENT} PRIVATE ${SOURCES} $<TARGET_OBJECTS:common>)
 

--- a/src/core_ocean/ocean.cmake
+++ b/src/core_ocean/ocean.cmake
@@ -182,6 +182,23 @@ list(APPEND RAW_SOURCES
   core_ocean/analysis_members/mpas_ocn_analysis_driver.F
 )
 
+# add accelerator/gpu flags
+list(APPEND ADD_ACC_FLAGS
+  core_ocean/shared/mpas_ocn_equation_of_state_jm.f90
+  core_ocean/shared/mpas_ocn_mesh.f90
+  core_ocean/shared/mpas_ocn_surface_bulk_forcing.f90
+  core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.f90
+  core_ocean/shared/mpas_ocn_tendency.f90
+  core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.f90
+  core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.f90
+  core_ocean/shared/mpas_ocn_vel_hadv_coriolis.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_del2.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_del4.f90
+  core_ocean/shared/mpas_ocn_vel_hmix_leith.f90
+  core_ocean/shared/mpas_ocn_vel_pressure_grad.f90
+  core_ocean/shared/mpas_ocn_vel_vadv.f90
+)
+
 # Generate core input
 handle_st_nl_gen(
   "namelist.ocean;namelist.ocean.forward mode=forward;namelist.ocean.analysis mode=analysis;namelist.ocean.init mode=init"

--- a/src/core_ocean/ocean.cmake
+++ b/src/core_ocean/ocean.cmake
@@ -182,23 +182,6 @@ list(APPEND RAW_SOURCES
   core_ocean/analysis_members/mpas_ocn_analysis_driver.F
 )
 
-# add accelerator/gpu flags
-list(APPEND ADD_ACC_FLAGS
-  core_ocean/shared/mpas_ocn_equation_of_state_jm.f90
-  core_ocean/shared/mpas_ocn_mesh.f90
-  core_ocean/shared/mpas_ocn_surface_bulk_forcing.f90
-  core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.f90
-  core_ocean/shared/mpas_ocn_tendency.f90
-  core_ocean/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.f90
-  core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.f90
-  core_ocean/shared/mpas_ocn_vel_hadv_coriolis.f90
-  core_ocean/shared/mpas_ocn_vel_hmix_del2.f90
-  core_ocean/shared/mpas_ocn_vel_hmix_del4.f90
-  core_ocean/shared/mpas_ocn_vel_hmix_leith.f90
-  core_ocean/shared/mpas_ocn_vel_pressure_grad.f90
-  core_ocean/shared/mpas_ocn_vel_vadv.f90
-)
-
 # Generate core input
 handle_st_nl_gen(
   "namelist.ocean;namelist.ocean.forward mode=forward;namelist.ocean.analysis mode=analysis;namelist.ocean.init mode=init"


### PR DESCRIPTION
Different machines and compilers may require adjusted compiler flags. In E3SM, Depends.$compiler, Depends.$machine and Depends.$machine.$compiler enable this. This PR adds these files by makefile includes and uses them for OpenACC-based GPU builds. Tested with PGI compiler on ORNL Summit and ANL Blues machines.

[bit-for-bit]
