### PR TITLE
Parallel interpolation of the terrain field

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -272,32 +272,14 @@
 !
 ! Interpolate HGT
 !
-!nx = 126
-!ny = 126
- nx = 1206
- ny = 1206
- nz = 1
- isigned  = 1
- endian   = 0
- wordsize = 2
- scalefactor = 1.0
- allocate(rarray(nx,ny,nz))
- allocate(nhs(nCells))
- nhs(:) = 0
- ter(:) = 0.0
 
- rarray_ptr = c_loc(rarray)
-
- start_lat = -89.99583
  select case(trim(config_topo_data))
     case('GTOPO30')
        call mpas_log_write('Using GTOPO30 terrain dataset')
        geog_sub_path = 'topo_30s/'
-       start_lon = -179.99583
     case('GMTED2010')
        call mpas_log_write('Using GMTED2010 terrain dataset')
        geog_sub_path = 'topo_gmted2010_30s/'
-       start_lon = 0.004166667
     case('default')
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Invalid topography dataset '''//trim(config_topo_data) &
@@ -307,66 +289,7 @@
        call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select
 
- do jTileStart = 1,20401,ny-6
-    jTileEnd = jTileStart + ny - 1 - 6
-
-    do iTileStart=1,42001,nx-6
-       iTileEnd = iTileStart + nx - 1 - 6
-       write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)//trim(geog_sub_path), &
-                    iTileStart,'-',iTileEnd,'.',jTileStart,'-',jTileEnd
-       call mpas_log_write(trim(fname))
-       call mpas_f_to_c_string(fname, c_fname)
-
-       call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                         scalefactor,wordsize,istatus)
-       call init_atm_check_read_error(istatus, fname)
-
-       iPoint = 1
-       do j=4,ny-3
-       do i=4,nx-3
-          lat_pt = start_lat + (jTileStart + j - 5) * 0.0083333333
-          lon_pt = start_lon + (iTileStart + i - 5) * 0.0083333333
-          lat_pt = lat_pt * PI / 180.0
-          lon_pt = lon_pt * PI / 180.0
-
-          iPoint = nearest_cell(lat_pt,lon_pt,iPoint,nCells,maxEdges, &
-                                nEdgesOnCell,cellsOnCell, &
-                                latCell,lonCell)
-
-          !
-          ! For all but the outermost boundary cells, we can safely assume that the nearest
-          ! model grid cell contains the pixel (else, a different cell would be nearest)
-          !
-          if (bdyMaskCell(iPoint) < nBdyLayers) then
-             ter(iPoint) = ter(iPoint) + rarray(i,j,1)
-             nhs(iPoint) = nhs(iPoint) + 1
-
-          ! For outermost boundary cells, additional work is needed to verify that the pixel
-          ! actually lies within the nearest cell
-          else
-             zPixel = sphere_radius * sin(lat_pt)                  ! Model cell coordinates assume a "full" sphere radius
-             xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
-             yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
-
-             if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
-                         nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
-
-                ter(iPoint) = ter(iPoint) + rarray(i,j,1)
-                nhs(iPoint) = nhs(iPoint) + 1
-
-             end if
-          end if
-       end do
-       end do
-
-    end do
- end do
-
- do iCell = 1,nCells
-    ter(iCell) = ter(iCell) / real(nhs(iCell))
- end do
- deallocate(rarray)
- deallocate(nhs)
+ ter(:) = 0.0_RKIND
  call mpas_log_write('--- end interpolate TER')
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -20,8 +20,8 @@
  use mpas_geometry_utils, only : mpas_in_cell
  use mpas_atmphys_utilities
 
- use mpas_kd_tree, only : mpas_kd_type, mpas_kd_construct, mpas_kd_free
- use mpas_geotile_manager, only : mpas_geotile_mgr_type
+ use mpas_kd_tree, only : mpas_kd_type, mpas_kd_construct, mpas_kd_free, mpas_kd_search
+ use mpas_geotile_manager, only : mpas_geotile_mgr_type, mpas_geotile_type, mpas_latlon_to_xyz
 
  use iso_c_binding, only : c_char, c_int, c_float, c_loc, c_ptr
 
@@ -106,7 +106,7 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: vegfra
 
  integer, pointer :: isice_lu, iswater_lu
- integer, pointer :: nCells, nEdges, nVertices, maxEdges
+ integer, pointer :: nCells, nCellsSolve, nEdges, nVertices, maxEdges
  logical, pointer :: on_a_sphere
  real (kind=RKIND), pointer :: sphere_radius
  
@@ -125,6 +125,7 @@
  real (kind=RKIND), dimension(:), pointer :: fEdge, fVertex
 
  real (kind=RKIND), dimension(:), pointer :: ter
+ integer (kind=I8KIND), dimension(:), pointer :: ter_integer
  real (kind=RKIND), dimension(:), pointer :: soiltemp
  real (kind=RKIND), dimension(:), pointer :: snoalb
  real (kind=RKIND), dimension(:), pointer :: shdmin, shdmax
@@ -141,9 +142,17 @@
 
  type (mpas_kd_type), dimension(:), pointer :: kd_points
  type (mpas_kd_type), pointer :: tree
+ type (mpas_kd_type), pointer :: res
 
- integer :: ierr
  type (mpas_geotile_mgr_type) :: mgr
+ type (mpas_geotile_type), pointer :: tile
+
+ real (kind=RKIND) :: tval
+ integer, pointer :: tile_bdr
+ integer, pointer :: tile_nx, tile_ny
+
+ logical :: all_pixels_mapped_to_halo_cells
+ integer :: ierr
 
 !--------------------------------------------------------------------------------------------------
 
@@ -216,6 +225,7 @@
  call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
 
  call mpas_pool_get_dimension(dims, 'nCells', nCells)
+ call mpas_pool_get_dimension(dims, 'nCellsSolve', nCellsSolve)
  call mpas_pool_get_dimension(dims, 'nEdges', nEdges)
  call mpas_pool_get_dimension(dims, 'nVertices', nVertices)
  call mpas_pool_get_dimension(dims, 'maxEdges', maxEdges)
@@ -317,7 +327,116 @@
     call mpas_log_write('Error occured when initalizing the interpolation of terrain height (ter)', messageType=MPAS_LOG_CRIT)
  endif
 
+
+ allocate(ter_integer(nCells))
+ allocate(nhs(nCells))
+
+ !
+ ! Store tile values as a I8KIND integer temporarily to avoid floating
+ ! point round off differences and to have +/- 9.22x10^18 range of representative
+ ! values. For example, a 120 km mesh with a 1 meter data set with 6 decimal of
+ ! precision will allow for values of 180x10^12.
+ !
+ ter_integer(:) = 0_I8KIND
  ter(:) = 0.0_RKIND
+ nhs(:) = 0
+
+ call mpas_pool_get_config(mgr % pool, 'tile_bdr', tile_bdr)
+ call mpas_pool_get_config(mgr % pool, 'tile_x', tile_nx)
+ call mpas_pool_get_config(mgr % pool, 'tile_y', tile_ny)
+
+ do iCell = 1, nCells
+     !
+     ! Load the tile at each cell center. This insures all cells receive values
+     !
+     if (nhs(iCell) == 0) then
+         tile => null()
+         ierr = mgr % get_tile(latCell(iCell), lonCell(iCell), tile)
+         if (ierr /= 0 .or. .not. associated(tile)) then
+             call mpas_log_write('Could not get tile that contained cell $i', intArgs=(/iCell/), messageType=MPAS_LOG_CRIT)
+         end if
+
+         ierr = mgr % push_tile(tile)
+         if (ierr /= 0) then
+             call mpas_log_write("Error pushing this tile onto the stack: "//trim(tile%fname), messageType=MPAS_LOG_CRIT)
+         end if
+     end if
+
+     !
+     ! Process each tile by removing it from the stack. Determine the closest cell center to each tile
+     ! pixel by using a KD search and assign its value to that cell.
+     !
+     do while (.not. mgr % is_stack_empty())
+         tile => mgr % pop_tile()
+
+         if (tile % is_processed) then
+             cycle
+         end if
+
+         call mpas_log_write('Processing tile: '//trim(tile%fname))
+
+         all_pixels_mapped_to_halo_cells = .true.
+
+         do j = 1 + tile_bdr, tile_ny + tile_bdr, 1
+            do i = 1 + tile_bdr, tile_nx + tile_bdr, 1
+
+               tval = tile % tile(i, j, 1)
+
+               call mgr % tile_to_latlon(tile, j, i, lat_pt, lon_pt)
+               call mpas_latlon_to_xyz(xPixel, yPixel, zPixel, sphere_radius, lat_pt, lon_pt)
+               call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res)
+
+               !
+               ! For all but the outermost boundary cells, we can safely assume that the nearest
+               ! model grid cell contains the pixel (else, a different cell would be nearest)
+               !
+               if (bdyMaskCell(res % id) < nBdyLayers) then
+                  ter_integer(res % id) = ter_integer(res % id) + int(tval, kind=I8KIND)
+                  nhs(res % id) = nhs(res % id) + 1
+
+                  if (res % id <= nCellsSolve) then
+                      all_pixels_mapped_to_halo_cells = .false.
+                  end if
+
+               ! For outermost boundary cells, additional work is needed to verify that the pixel
+               ! actually lies within the nearest cell
+               else
+                  if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(res % id), yCell(res % id), zCell(res % id), &
+                                   nEdgesOnCell(res % id), verticesOnCell(:,res % id), xVertex, yVertex, zVertex)) then
+
+                     ter_integer(res % id) = ter_integer(res % id) + int(tval, kind=I8KIND)
+                     nhs(res % id) = nhs(res % id) + 1
+
+                     if (res % id <= nCellsSolve) then
+                         all_pixels_mapped_to_halo_cells = .false.
+                     end if
+                  end if
+               end if
+            end do
+        end do
+
+        tile % is_processed = .true.
+
+        !
+        ! If a single pixel value maps to an owned cell (i.e. <= nCellsSolve) then
+        ! it is possible that the neighboring tiles might contain pixels that map
+        ! to this process' compute cells, so add them to the stack.
+        !
+        if (.not. all_pixels_mapped_to_halo_cells) then
+            ierr = mgr % push_neighbors(tile)
+            if (ierr /= 0) then
+                call mpas_log_write("Error pushing the tile neighbors of: "//trim(tile%fname), messageType=MPAS_LOG_CRIT)
+            end if
+        end if
+     end do
+ end do
+
+ do iCell = 1, nCells
+    ter(iCell) = real(ter_integer(iCell), kind=R8KIND) / real(nhs(iCell), kind=R8KIND)
+ end do
+
+ deallocate(ter_integer)
+ deallocate(nhs)
 
  ierr = mgr % finalize()
  if (ierr /= 0) then

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -20,6 +20,8 @@
  use mpas_geometry_utils, only : mpas_in_cell
  use mpas_atmphys_utilities
 
+ use mpas_kd_tree, only : mpas_kd_type, mpas_kd_construct, mpas_kd_free
+
  use iso_c_binding, only : c_char, c_int, c_float, c_loc, c_ptr
 
  implicit none
@@ -136,6 +138,9 @@
 
  real (kind=RKIND) :: xPixel, yPixel, zPixel
 
+ type (mpas_kd_type), dimension(:), pointer :: kd_points
+ type (mpas_kd_type), pointer :: tree
+
 !--------------------------------------------------------------------------------------------------
 
 
@@ -226,6 +231,21 @@
  areaTriangle = areaTriangle * sphere_radius**2.0
  kiteAreasOnVertex = kiteAreasOnVertex * sphere_radius**2.0
 
+!
+! Initialize the KD-Tree
+!
+ allocate(kd_points(nCells))
+ do i = 1, nCells
+     allocate(kd_points(i) % point(3))
+     kd_points(i) % point = (/xCell(i), yCell(i), zCell(i)/)
+     kd_points(i) % id = i ! Cell ID
+ enddo
+ tree => null()
+ tree => mpas_kd_construct(kd_points, 3)
+ if (.not. associated(tree)) then
+     call mpas_log_write('Error creating the KD-Tree for static interpolation', messageType=MPAS_LOG_CRIT)
+ endif
+
 
 !
 ! Initialize Coriolis parameter field on edges and vertices
@@ -272,7 +292,6 @@
 !
 ! Interpolate HGT
 !
-
  select case(trim(config_topo_data))
     case('GTOPO30')
        call mpas_log_write('Using GTOPO30 terrain dataset')
@@ -1174,6 +1193,12 @@ if (rarray(i,j,1) == 0) cycle
  end if
 
  call mpas_log_write('--- end interpolate ALBEDO12M')
+
+!
+! Deallocate and free the KD Tree
+!
+ call mpas_kd_free(tree)
+ deallocate(kd_points)
 
 
  end subroutine init_atm_static

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -21,6 +21,7 @@
  use mpas_atmphys_utilities
 
  use mpas_kd_tree, only : mpas_kd_type, mpas_kd_construct, mpas_kd_free
+ use mpas_geotile_manager, only : mpas_geotile_mgr_type
 
  use iso_c_binding, only : c_char, c_int, c_float, c_loc, c_ptr
 
@@ -140,6 +141,9 @@
 
  type (mpas_kd_type), dimension(:), pointer :: kd_points
  type (mpas_kd_type), pointer :: tree
+
+ integer :: ierr
+ type (mpas_geotile_mgr_type) :: mgr
 
 !--------------------------------------------------------------------------------------------------
 
@@ -308,7 +312,18 @@
        call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select
 
+ ierr = mgr % init(trim(config_geog_data_path)//trim(geog_sub_path))
+ if (ierr /= 0) then
+    call mpas_log_write('Error occured when initalizing the interpolation of terrain height (ter)', messageType=MPAS_LOG_CRIT)
+ endif
+
  ter(:) = 0.0_RKIND
+
+ ierr = mgr % finalize()
+ if (ierr /= 0) then
+    call mpas_log_write('Error occured when finalizing the interpolation of terrain height (ter)', messageType=MPAS_LOG_CRIT)
+ endif
+
  call mpas_log_write('--- end interpolate TER')
 
 

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -17,6 +17,7 @@
  use init_atm_llxy
  use mpas_c_interfacing, only : mpas_f_to_c_string
 
+ use mpas_geometry_utils, only : mpas_in_cell
  use mpas_atmphys_utilities
 
  use iso_c_binding, only : c_char, c_int, c_float, c_loc, c_ptr
@@ -347,7 +348,7 @@
              xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
              yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+             if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                          nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
 
                 ter(iPoint) = ter(iPoint) + rarray(i,j,1)
@@ -446,7 +447,7 @@ if (rarray(i,j,1) == 0) cycle
              xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
              yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+             if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                          nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
 
                 ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
@@ -529,7 +530,7 @@ if (rarray(i,j,1) == 0) cycle
              xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
              yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-             if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+             if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                          nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
 
                 ncat(int(rarray(i,j,1)),iPoint) = ncat(int(rarray(i,j,1)),iPoint) + 1
@@ -741,7 +742,7 @@ if (rarray(i,j,1) == 0) cycle
                    xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
                    yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-                   if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+                   if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                                nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
                       snoalb(iPoint) = snoalb(iPoint) + rarray(ii,jj,1)
                       nhs(iPoint) = nhs(iPoint) + 1
@@ -936,7 +937,7 @@ if (rarray(i,j,1) == 0) cycle
                 xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
                 yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-                if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+                if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                             nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
                    do k=1,nz
                       if (rarray(i,j,k) == msgval) then
@@ -1135,7 +1136,7 @@ if (rarray(i,j,1) == 0) cycle
                 xPixel = sphere_radius * cos(lon_pt) * cos(lat_pt)    ! at this point, so we need to ues the same radius
                 yPixel = sphere_radius * sin(lon_pt) * cos(lat_pt)    ! for source pixel coordinates
 
-                if (in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
+                if (mpas_in_cell(xPixel, yPixel, zPixel, xCell(iPoint), yCell(iPoint), zCell(iPoint), &
                             nEdgesOnCell(iPoint), verticesOnCell(:,iPoint), xVertex, yVertex, zVertex)) then
                    do k=1,nz
                       if (rarray(ii,jj,k) == msgval) then
@@ -1326,146 +1327,6 @@ if (rarray(i,j,1) == 0) cycle
  sphere_distance = 2.*radius*asin(arg1)
 
  end function sphere_distance
-
-
-!-----------------------------------------------------------------------
-!  routine mirror_point
-!
-!> \brief Finds the "mirror" of a point about a great-circle arc
-!> \author Michael Duda
-!> \date   7 March 2019
-!> \details
-!>  Given the endpoints of a great-circle arc (A,B) and a point, computes
-!>  the location of the point on the opposite side of the arc along a great-
-!>  circle arc that intersects (A,B) at a right angle, and such that the arc
-!>  between the point and its mirror is bisected by (A,B).
-!>
-!>  Assumptions: A, B, and the point to be reflected all lie on the surface
-!>  of the unit sphere.
-!
-!-----------------------------------------------------------------------
-subroutine mirror_point(xPoint, yPoint, zPoint, xA, yA, zA, xB, yB, zB, xMirror, yMirror, zMirror)
-
-   implicit none
-
-   real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
-   real(kind=RKIND), intent(in) :: xA, yA, zA
-   real(kind=RKIND), intent(in) :: xB, yB, zB
-   real(kind=RKIND), intent(out) :: xMirror, yMirror, zMirror
-
-   real(kind=RKIND) :: alpha
-
-   !
-   ! Find the spherical angle between arcs AP and AB (where P is the point to be reflected)
-   !
-   alpha = sphere_angle(xA, yA, zA, xPoint, yPoint, zPoint, xB, yB, zB)
-
-   !
-   ! Rotate the point to be reflected by twice alpha about the vector from the origin to A
-   !
-   call rotate_about_vector(xPoint, yPoint, zPoint, 2.0_RKIND * alpha, 0.0_RKIND, 0.0_RKIND, 0.0_RKIND, &
-                            xA, yA, zA, xMirror, yMirror, zMirror)
-
-end subroutine mirror_point
-
-
-!-----------------------------------------------------------------------
-!  routine rotate_about_vector
-!
-!> \brief Rotates a point about a vector in R3
-!> \author Michael Duda
-!> \date   7 March 2019
-!> \details
-!>  Rotates the point (x,y,z) through an angle theta about the vector
-!>  originating at (a, b, c) and having direction (u, v, w).
-!
-!>  Reference: https://sites.google.com/site/glennmurray/Home/rotation-matrices-and-formulas/rotation-about-an-arbitrary-axis-in-3-dimensions
-!
-!-----------------------------------------------------------------------
-subroutine rotate_about_vector(x, y, z, theta, a, b, c, u, v, w, xp, yp, zp)
-
-   implicit none
-
-   real (kind=RKIND), intent(in) :: x, y, z, theta, a, b, c, u, v, w
-   real (kind=RKIND), intent(out) :: xp, yp, zp
-
-   real (kind=RKIND) :: vw2, uw2, uv2
-   real (kind=RKIND) :: m
-
-   vw2 = v**2.0 + w**2.0
-   uw2 = u**2.0 + w**2.0
-   uv2 = u**2.0 + v**2.0
-   m = sqrt(u**2.0 + v**2.0 + w**2.0)
-
-   xp = (a*vw2 + u*(-b*v-c*w+u*x+v*y+w*z) + ((x-a)*vw2+u*(b*v+c*w-v*y-w*z))*cos(theta) + m*(-c*v+b*w-w*y+v*z)*sin(theta))/m**2.0
-   yp = (b*uw2 + v*(-a*u-c*w+u*x+v*y+w*z) + ((y-b)*uw2+v*(a*u+c*w-u*x-w*z))*cos(theta) + m*( c*u-a*w+w*x-u*z)*sin(theta))/m**2.0
-   zp = (c*uv2 + w*(-a*u-b*v+u*x+v*y+w*z) + ((z-c)*uv2+w*(a*u+b*v-u*x-v*y))*cos(theta) + m*(-b*u+a*v-v*x+u*y)*sin(theta))/m**2.0
-
-end subroutine rotate_about_vector
-
-
-!-----------------------------------------------------------------------
-!  routine in_cell
-!
-!> \brief Determines whether a point is within a Voronoi cell
-!> \author Michael Duda
-!> \date   7 March 2019
-!> \details
-!>  Given a point on the surface of the sphere, the corner points of a Voronoi
-!>  cell, and the generating point for that Voronoi cell, determines whether
-!>  the given point is within the Voronoi cell.
-!
-!-----------------------------------------------------------------------
-logical function in_cell(xPoint, yPoint, zPoint, xCell, yCell, zCell, &
-                         nEdgesOnCell, verticesOnCell, xVertex, yVertex, zVertex)
-
-   use mpas_geometry_utils, only : mpas_arc_length
-
-   implicit none
-
-   real(kind=RKIND), intent(in) :: xPoint, yPoint, zPoint
-   real(kind=RKIND), intent(in) :: xCell, yCell, zCell
-   integer, intent(in) :: nEdgesOnCell
-   integer, dimension(:), intent(in) :: verticesOnCell
-   real(kind=RKIND), dimension(:), intent(in) :: xVertex, yVertex, zVertex
-
-   integer :: i
-   integer :: vtx1, vtx2
-   real(kind=RKIND) :: xNeighbor, yNeighbor, zNeighbor
-   real(kind=RKIND) :: inDist, outDist
-   real(kind=RKIND) :: radius
-   real(kind=RKIND) :: radius_inv
-
-   radius = sqrt(xCell * xCell + yCell * yCell + zCell * zCell)
-   radius_inv = 1.0_RKIND / radius
-
-   inDist = mpas_arc_length(xPoint, yPoint, zPoint, xCell, yCell, zCell)
-
-   in_cell = .true.
-
-   do i=1,nEdgesOnCell
-      vtx1 = verticesOnCell(i)
-      vtx2 = verticesOnCell(mod(i,nEdgesOnCell)+1)
-
-      call mirror_point(xCell*radius_inv, yCell*radius_inv, zCell*radius_inv, &
-                        xVertex(vtx1)*radius_inv, yVertex(vtx1)*radius_inv, zVertex(vtx1)*radius_inv, &
-                        xVertex(vtx2)*radius_inv, yVertex(vtx2)*radius_inv, zVertex(vtx2)*radius_inv, &
-                        xNeighbor, yNeighbor, zNeighbor)
-
-      xNeighbor = xNeighbor * radius
-      yNeighbor = yNeighbor * radius
-      zNeighbor = zNeighbor * radius
-
-      outDist = mpas_arc_length(xPoint, yPoint, zPoint, xNeighbor, yNeighbor, zNeighbor)
-
-      if (outDist < inDist) then
-         in_cell = .false.
-         return
-      end if
-
-   end do
-
-end function in_cell
 
 
 !==================================================================================================


### PR DESCRIPTION
This merge allows the ability the init_atmosphere model to safely interpolate the ter field in parallel. However, because other fields are yet to be updated to run in parallel, the check in init_atm_cases to prevent parallel interpolation is still present.

Before this merge, parallel interpolation of the ter field (or any static field) was possible, but would incorrectly interpolate datatile pixels on interpolating on convex decompositions (when running non-serial interpolations without a convext partition file) as the nearest_cell routine would incorrectly choose the wrong cell for interpolation point for a datatile pixel.

This merge updates the algorithm for the interpolation of the ter field so that it can be interpolated in parallel in the future.
