### PR TITLE
Correct sign in FCT 3rd order advection coefficients

### DIFF
--- a/src/operators/mpas_tracer_advection_helpers.F
+++ b/src/operators/mpas_tracer_advection_helpers.F
@@ -229,14 +229,14 @@ module mpas_tracer_advection_helpers
            k = mpas_binary_search(sorted_cell_indices, 2, 1, nAdvCellsForEdge(iEdge), indexToCellID(cell2))
            if(k <= nAdvCellsForEdge(iEdge)) then
              adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(1,2,iEdge)
-             adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) + deriv_two(1,2,iEdge)
+             adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) - deriv_two(1,2,iEdge)
            end if
 
            do iCell = 1, nEdgesOnCell(cell2)
              k = mpas_binary_search(sorted_cell_indices, 2, 1, nAdvCellsForEdge(iEdge), indexToCellID(cellsOnCell(iCell,cell2)))
              if(k <= nAdvCellsForEdge(iEdge)) then
                adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(iCell+1, 2, iEdge)
-               adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) + deriv_two(iCell+1, 2, iEdge)
+               adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) - deriv_two(iCell+1, 2, iEdge)
              end if
            end do ! loop over iCell
 

--- a/src/operators/mpas_tracer_advection_helpers.F
+++ b/src/operators/mpas_tracer_advection_helpers.F
@@ -209,6 +209,21 @@ module mpas_tracer_advection_helpers
              advCellsForEdge(iCell, iEdge) = sorted_cell_indices(2, iCell)
            end do
 
+           ! equation 7 in Skamarock, W. C., & Gassmann, A. (2011):
+           ! F(u,psi)_{i+1/2} = u_{i+1/2} *
+           !  [   1/2 (psi_{i+1} + psi_i)                       term 1
+           !    - 1/12(dx^2psi_{i+1} + dx^2psi_i)               term 2
+           !    + sign(u) beta/12 (dx^2psi_{i+1} - dx^2psi_i)]  term 3 (note minus sign)
+           !
+           ! adv_coefs accounts for terms 1 and 2 in SG11 equation 7. Term 1 is
+           ! the 2nd-order flux-function term. adv_coefs accounts for this with
+           ! the "+ 0.5" lines below. In the advection routines that use these
+           ! coefficients, the 2nd-order flux loop is then skipped. Term 2 is
+           ! the 4th-order flux-function term. adv_coefs_3rd accounts for term
+           ! 3, the beta term. beta > 0 corresponds to the third-order flux
+           ! function. The - sign in the deriv_two accumulation is for the i+1
+           ! part of term 3, while the + sign is for the i part.
+
            adv_coefs(:,iEdge) = 0.
            adv_coefs_3rd(:,iEdge) = 0.
 

--- a/src/operators/mpas_tracer_advection_helpers.F
+++ b/src/operators/mpas_tracer_advection_helpers.F
@@ -188,7 +188,7 @@ module mpas_tracer_advection_helpers
                sorted_cell_indices(2, n) = cellsOnCell(i, cell1)
                call mpas_hash_insert(cell_hash, cellsOnCell(i, cell1))
              end if
-           end do ! loop over i
+           end do
 
            do i = 1, nEdgesOnCell(cell2)
              if(.not. mpas_hash_search(cell_hash, cellsOnCell(i, cell2))) then
@@ -198,7 +198,7 @@ module mpas_tracer_advection_helpers
                sorted_cell_indices(2, n) = cellsOnCell(i, cell2)
                call mpas_hash_insert(cell_hash, cellsOnCell(i, cell2))
              end if
-           end do ! loop over i
+           end do
 
            call mpas_hash_destroy(cell_hash)
 
@@ -207,11 +207,13 @@ module mpas_tracer_advection_helpers
            nAdvCellsForEdge(iEdge) = n
            do iCell = 1, nAdvCellsForEdge(iEdge)
              advCellsForEdge(iCell, iEdge) = sorted_cell_indices(2, iCell)
-           end do ! loop over iCell
+           end do
 
            adv_coefs(:,iEdge) = 0.
            adv_coefs_3rd(:,iEdge) = 0.
 
+           ! pull together third and fourth order contributions to the flux
+           ! first from cell1
            k = mpas_binary_search(sorted_cell_indices, 2, 1, nAdvCellsForEdge(iEdge), indexToCellID(cell1))
            if(k <= nAdvCellsForEdge(iEdge)) then
              adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(1,1,iEdge)
@@ -224,8 +226,10 @@ module mpas_tracer_advection_helpers
                adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(iCell+1, 1, iEdge)
                adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) + deriv_two(iCell+1, 1, iEdge)
              end if
-           end do ! loop over iCell
+           end do
 
+           ! pull together third and fourth order contributions to the flux
+           ! now from cell2
            k = mpas_binary_search(sorted_cell_indices, 2, 1, nAdvCellsForEdge(iEdge), indexToCellID(cell2))
            if(k <= nAdvCellsForEdge(iEdge)) then
              adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(1,2,iEdge)
@@ -238,13 +242,14 @@ module mpas_tracer_advection_helpers
                adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + deriv_two(iCell+1, 2, iEdge)
                adv_coefs_3rd(k, iEdge) = adv_coefs_3rd(k, iEdge) - deriv_two(iCell+1, 2, iEdge)
              end if
-           end do ! loop over iCell
+           end do
 
            do iCell = 1,nAdvCellsForEdge(iEdge)
              adv_coefs    (iCell,iEdge) = - (dcEdge(iEdge) **2) * adv_coefs    (iCell,iEdge) / 12.
              adv_coefs_3rd(iCell,iEdge) = - (dcEdge(iEdge) **2) * adv_coefs_3rd(iCell,iEdge) / 12.
-           end do ! loop over iCell
+           end do
 
+           ! 2nd order centered contribution - place this in the main flux weights
            k = mpas_binary_search(sorted_cell_indices, 2, 1, nAdvCellsForEdge(iEdge), indexToCellID(cell1))
            if(k <= nAdvCellsForEdge(iEdge)) then
              adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + 0.5
@@ -255,11 +260,12 @@ module mpas_tracer_advection_helpers
              adv_coefs(k, iEdge) = adv_coefs(k, iEdge) + 0.5
            end if
 
+           !  multiply by edge length - thus the flux is just dt*ru times the results of the vector-vector multiply
            do iCell=1,nAdvCellsForEdge(iEdge)
              adv_coefs    (iCell,iEdge) = dvEdge(iEdge) * adv_coefs    (iCell,iEdge)
              adv_coefs_3rd(iCell,iEdge) = dvEdge(iEdge) * adv_coefs_3rd(iCell,iEdge)
-           end do ! loop over iCell
-        end if
+           end do
+        end if  ! only do for edges of owned-cells
       end do ! end loop over edges
 
       deallocate(cell_indices)


### PR DESCRIPTION
Two third-order advection coefficients incorrectly have a plus sign, should be minus. Thanks to @ambrad for his work on this. See discussion at this issue: https://github.com/MPAS-Dev/MPAS-Model/pull/583#issuecomment-675274063

Note that this is a framework merge, but the ocean is the only core that calls the subroutine, `mpas_tracer_advection_coefficients`, that initializes the FCT cell weights. The atmosphere has nearly identical lines in `src/core_atmosphere/mpas_atm_core.F`, subroutine `atm_adv_coef_compression`, which is clearly where this code was originally copied from in 2013.

Also copied comments from the atmospheric core to better explain each term, and cleaned up other comments.