### PR TITLE
fix config flag call for ISC init case

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -1057,9 +1057,6 @@ contains
        integer, pointer :: nCells
        integer, dimension(:), pointer :: maxLevelCell, landIceMask, modifySSHMask
 
-       real (kind=RKIND), pointer :: config_global_ocean_topography_smooth_weight
-       integer, pointer :: config_global_ocean_topography_smooth_iterations
-
        integer :: iCell
 
        iErr = 0


### PR DESCRIPTION
With the addition of 
`use ocn_config`
we no longer need to declare config flags or call `mpas_pool_get_config`. These lines should have been deleted, and cause an error when initializing Ice Shelf Cavity cases.

fixes #658