### PR TITLE
Clean up config flag calls

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration.F
@@ -31,6 +31,7 @@ module ocn_time_integration
    use mpas_log
 
    use ocn_constants
+   use ocn_config
    use ocn_time_integration_rk4
    use ocn_time_integration_split
 
@@ -138,11 +139,7 @@ module ocn_time_integration
 
       integer, intent(out) :: err
 
-      character (len=StrKIND), pointer :: config_time_integrator
-
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
 
       rk4On = .false.
       splitOn = .false.

--- a/src/core_ocean/mode_init/mpas_ocn_init_TEMPLATE.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_TEMPLATE.F
@@ -44,6 +44,7 @@ module ocn_init_TEMPLATE
    use mpas_constants
 
    use ocn_constants
+   use ocn_config
    use ocn_init_vertical_grids
    use ocn_init_cell_markers
 
@@ -108,11 +109,6 @@ contains
     real (kind=RKIND) :: localVar1, localVar2
     real (kind=RKIND), dimension(:), pointer :: interfaceLocations
 
-    ! Define config variable pointers
-    character (len=StrKIND), pointer :: config_init_configuration, config_vertical_grid
-    logical, pointer :: config_TEMPLATE_example_flag1
-    real (kind=RKIND), pointer :: config_TEMPLATE_example_flag2
-
     ! Define dimension pointers
     integer, pointer :: nCellsSolve, nEdgesSolve, nVertLevels, nVertLevelsP1
     integer, pointer :: index_temperature, index_salinity
@@ -128,16 +124,7 @@ contains
 
     iErr = 0
 
-    call mpas_pool_get_config(ocnConfigs, 'config_init_configuration', config_init_configuration)
-
     if(config_init_configuration .ne. trim('TEMPLATE')) return
-
-    ! Get config flag settings
-
-    call mpas_pool_get_config(ocnConfigs, 'config_vertical_grid', config_vertical_grid)
-
-    call mpas_pool_get_config(ocnConfigs, 'config_TEMPLATE_example_flag1', config_TEMPLATE_example_flag1)
-    call mpas_pool_get_config(ocnConfigs, 'config_TEMPLATE_example_flag2', config_TEMPLATE_example_flag2)
 
     ! Determine vertical grid for configuration
     call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)

--- a/src/core_ocean/ocean.cmake
+++ b/src/core_ocean/ocean.cmake
@@ -106,7 +106,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_framework_forcing.F
   core_ocean/shared/mpas_ocn_time_varying_forcing.F
   core_ocean/shared/mpas_ocn_wetting_drying.F
-  core_ocean/shared/mpas_ocn_tidal_potential_forcing.F
+  core_ocean/shared/mpas_ocn_vel_tidal_potential.F
 )
 
 set(OCEAN_DRIVER
@@ -179,6 +179,9 @@ list(APPEND RAW_SOURCES
   core_ocean/analysis_members/mpas_ocn_moc_streamfunction.F
   core_ocean/analysis_members/mpas_ocn_ocean_heat_content.F
   core_ocean/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+  core_ocean/analysis_members/mpas_ocn_sediment_flux_index.F
+  core_ocean/analysis_members/mpas_ocn_sediment_transport.F
+  core_ocean/analysis_members/mpas_ocn_harmonic_analysis.F
   core_ocean/analysis_members/mpas_ocn_analysis_driver.F
 )
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -731,9 +731,6 @@ contains
       real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
 
       ! vegetation_drag
-      logical, pointer :: config_use_vegetation_drag
-      logical, pointer :: config_use_vegetation_manning_equation
-      real (kind=RKIND), pointer :: config_vegetation_drag_coefficient
       real (kind=RKIND), dimension(:), pointer :: vegetationHeight
       real (kind=RKIND), dimension(:), pointer :: vegetationDiameter
       real (kind=RKIND), dimension(:), pointer ::vegetationDensity
@@ -755,10 +752,6 @@ contains
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-
-      call mpas_pool_get_config(ocnConfigs, 'config_use_vegetation_drag', config_use_vegetation_drag)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_vegetation_manning_equation', config_use_vegetation_manning_equation)
-      call mpas_pool_get_config(ocnConfigs, 'config_vegetation_drag_coefficient', config_vegetation_drag_coefficient)
 
       call mpas_pool_get_array(forcingPool, 'vegetationMask', vegetationMask)
       call mpas_pool_get_array(forcingPool, 'vegetationHeight', vegetationHeight)

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -262,8 +262,6 @@ contains
 
       err = 0
 
-      call mpas_pool_get_config(ocnConfigs, 'config_use_Redi',config_use_Redi)
-
       if (config_use_Redi) then
          rediDiffOn = .True.
       else


### PR DESCRIPTION
With the addition of
`use ocn_config`
we no longer need to declare config flags or call mpas_pool_get_config. This PR cleans up some oversights or changes from recent merges.