### PR TITLE
Fix distribute calving method

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -133,7 +133,7 @@
 		            description="Defines the topographic height below which ice calves (for topographic_threshold option)."
 		            possible_values="Any non-positive real value"
 		/>
-		<nml_option name="config_calving_thickness" type="real" default_value="100.0" units="m of ice"
+		<nml_option name="config_calving_thickness" type="real" default_value="0.0" units="m of ice"
 		            description="Defines the ice thickness below which ice calves (for thickness_threshold option)."
 		            possible_values="Any positive real value"
 		/>

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -979,11 +979,8 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingMask" type="integer" dimensions="nCells Time" units="m" time_levs="1"
                         description="mask of grid cells that should be calved.  0=no calving, 1=should be calved"
                 />
-                <var name="calvingFrontMaskCell" type="integer" dimensions="nCells Time" units="none" time_levs="1"
+                <var name="calvingFrontMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
                         description="mask of the calving front position on cells"
-                />
-                <var name="calvingFrontMaskEdge" type="integer" dimensions="nEdges Time" units="none" time_levs="1"
-                        description="mask of the calving front position on edges"
                 />
                 <var name="calvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep (less than or equal to ice thickness)"
@@ -993,9 +990,6 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingVelocity" type="real" dimensions="nEdges Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
-                />
-                <var name="requiredCalvingVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
-                     description="total volume of ice that needs to be removed based on calving rate for the given time step"
                 />
                 <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left uncalved from required calving flux at non-dynamic cells"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -997,6 +997,24 @@ is the value of that variable from the *previous* time level!
                 <var name="uncalvedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left uncalved from required calving flux at dynamic cells"
                 />
+                <var name="calvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was calved from non-dynamic cells"
+                />
+                <var name="calvedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was calved from dynamic cells"
+                />
+                <var name="requiredCalvingVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="bookkeeping field for how much volume should be removed from a non-dynamic cell"
+                />
+                <var name="requiredCalvingVolumeNonDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                     description="bookkeeping field for how much volume should be removed from a non-dynamic edge"
+                />
+                <var name="requiredCalvingVolumeDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                     description="bookkeeping field for how much volume should be removed from a dynamic edge"
+                />
+                <var name="requiredCalvingVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="bookkeeping field for how much volume should be removed from a dynamic edge"
+                />
                 <var name="basalWaterThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="thickness of basal water"
                 />

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -979,20 +979,26 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingMask" type="integer" dimensions="nCells Time" units="m" time_levs="1"
                         description="mask of grid cells that should be calved.  0=no calving, 1=should be calved"
                 />
+                <var name="calvingFrontMaskCell" type="integer" dimensions="nCells Time" units="none" time_levs="1"
+                        description="mask of the calving front position on cells"
+                />
+                <var name="calvingFrontMaskEdge" type="integer" dimensions="nEdges Time" units="none" time_levs="1"
+                        description="mask of the calving front position on edges"
+                />
                 <var name="calvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep (less than or equal to ice thickness)"
                 />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
                 />
-                <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-                     description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane).  This retreat rate is converted from a flux to a rate in the code requiredCalvingVolumeRate."
+                <var name="calvingVelocity" type="real" dimensions="nEdges Time" units="m s^{-1}" time_levs="1"
+                     description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
                 />
-                <var name="requiredCalvingVolumeRate" type="real" dimensions="nCells Time" units="m^3 s^{-1}" time_levs="1"
-                     description="total volume of ice that needs to be removed based on eigencalving rate at this margin cell"
+                <var name="requiredCalvingVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                     description="total volume of ice that needs to be removed based on calving rate for the given time step"
                 />
-               <var name="uncalvedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was left uncalved from required calving flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
+               <var name="uncalvedVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved from required calving flux due to only applying flux over immediate neighbors (bookkeeping field)"
                 />
                 <var name="basalWaterThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="thickness of basal water"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -988,7 +988,7 @@ is the value of that variable from the *previous* time level!
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
                 />
-                <var name="calvingVelocity" type="real" dimensions="nEdges Time" units="m s^{-1}" time_levs="1"
+                <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
                 />
                 <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -997,8 +997,11 @@ is the value of that variable from the *previous* time level!
                 <var name="requiredCalvingVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
                      description="total volume of ice that needs to be removed based on calving rate for the given time step"
                 />
-               <var name="uncalvedVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
-                     description="volume of ice that was left uncalved from required calving flux due to only applying flux over immediate neighbors (bookkeeping field)"
+                <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved from required calving flux at non-dynamic cells"
+                />
+                <var name="uncalvedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved from required calving flux at dynamic cells"
                 />
                 <var name="basalWaterThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="thickness of basal water"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1055,7 +1055,10 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="ismip6shelfMelt_offset" type="real" dimensions="nCells" units="kg m^{-2} s^{-1}" packages="ismip6Melt" default_value="0.0"
                      description="Optional field of offset that should be applied to the melt field calculated by the ISMIP6 melt method.  Can be used to run in anomaly mode, but this is not the anomaly.  See Registry.xml for details."
-                        />
+                />
+                <var name="groundedMarineMarginMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
+                     description="mask of grid cells that are grounded and adjacent to the ocean. 0=interior, 1=grounded ice margin"
+                />
                 <!--  description="Optional field of offset that should be appliped to the melt field calculated by the ISMIP6 melt method.  This field is added directly to the melt field calculated by the method and can be used to use the method in anomaly mode.  Note this field is NOT the anomaly.  Let m be the final melt field generated, m_t be the ISMIP6 melt calculation at any time, m_t0 the ISMIP6 melt at time 0, and m_0 a reference melt field (e.g. observed melt field used for initialization).  The melt anomaly would be defined as (delta m)=m_t-m_t0. Then, m=(delta m) + m_0.  Rearranging, m=m_t+(m_0-m_t0).  ismip6shelfMelt_offset is the term in parentheses.  Note that the general usage requires that the first time step be run with ismip6shelfMelt_offset=0 in order to determine m_t0, and then NCO or similar tool used to generate the (m_0-m_t0) field to be input as ismip6shelfMelt_offset in the forward run." -->
                <!-- Scratch variables related to geometry -->
 	       <var name="cellMaskTemporary" type="integer" dimensions="nCells" units="none"

--- a/src/core_landice/Registry_subglacial_hydro.xml
+++ b/src/core_landice/Registry_subglacial_hydro.xml
@@ -41,9 +41,9 @@
 		            description="conductivity coefficient for subglacial water flux"
 		            possible_values="positive real number"
 		/>
-		<nml_option name="config_SGH_till_drainage" type="real" default_value="3.1709792e-11" units="m s^{-1}"
+		<nml_option name="config_SGH_till_drainage" type="real" default_value="0.0" units="m s^{-1}"
 		            description="background subglacial till drainage rate"
-                            possible_values="positive real number.  Default value is 0.001 m/yr in SI units."
+                            possible_values="positive real number.  Disabled by default.  A typical value would be 3.1709792e-11 m/s (0.001 m/yr)."
 		/>
 		<nml_option name="config_SGH_advection" type="character" default_value="fo" units="none"
 		            description="Advection method for SGH. 'fo'=first-order upwind; 'fct'=flux-corrected transport. FCT currently not enabled."

--- a/src/core_landice/Registry_subglacial_hydro.xml
+++ b/src/core_landice/Registry_subglacial_hydro.xml
@@ -43,7 +43,11 @@
 		/>
 		<nml_option name="config_SGH_till_drainage" type="real" default_value="0.0" units="m s^{-1}"
 		            description="background subglacial till drainage rate"
-                            possible_values="positive real number.  Disabled by default.  A typical value would be 3.1709792e-11 m/s (0.001 m/yr)."
+                            possible_values="positive real number.  Disabled by default.  Bueler and van Pelt use 3.1709792e-11 m/s (0.001 m/yr)."
+		/>
+		<nml_option name="config_SGH_till_max" type="real" default_value="0.0" units="m"
+		            description="maximum water thickness in subglacial till. Bueler and van Pelt use 2.0 m"
+		            possible_values="positive real number"
 		/>
 		<nml_option name="config_SGH_advection" type="character" default_value="fo" units="none"
 		            description="Advection method for SGH. 'fo'=first-order upwind; 'fct'=flux-corrected transport. FCT currently not enabled."
@@ -63,10 +67,6 @@
 		/>
 		<nml_option name="config_SGH_englacial_porosity" type="real" default_value="0.01" units="none"
 		            description="notional englacial porosity"
-		            possible_values="positive real number"
-		/>
-		<nml_option name="config_SGH_till_max" type="real" default_value="2.0" units="m"
-		            description="maximum water thickness in subglacial till"
 		            possible_values="positive real number"
 		/>
                 <!-- channel options -->

--- a/src/core_landice/mode_forward/mpas_li_advection.F
+++ b/src/core_landice/mode_forward/mpas_li_advection.F
@@ -1518,6 +1518,7 @@ module li_advection
     subroutine li_layer_normal_velocity(&
          meshPool,               &
          normalVelocity,         &
+         edgeMask,               &
          layerNormalVelocity,    &
          minOfMaxAllowableDt,    &
          err)
@@ -1533,6 +1534,9 @@ module li_advection
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
            normalVelocity        !< Input: normal velocity on cell edges
+
+      integer, dimension(:), intent(in) :: &
+           edgeMask  !< Input: normal velocity on cell edges
 
       !-----------------------------------------------------------------
       !
@@ -1595,6 +1599,8 @@ module li_advection
       ! loop over local edges
       do iEdge = 1, nEdgesSolve
 
+         if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
+
          ! loop over layers
          do k = 1, nVertLevels
 
@@ -1611,6 +1617,10 @@ module li_advection
             minOfMaxAllowableDt = min(minOfMaxAllowableDt, maxAllowableDt)
 
          enddo     ! k
+
+         else
+            layerNormalVelocity(:,iEdge) = 0.0_RKIND
+         endif
 
       enddo   ! iEdge
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1101,27 +1101,14 @@ module li_calving
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
-      real (kind=RKIND), pointer :: config_sea_level
-      real(kind=RKIND), pointer :: config_calving_thickness
-      real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
       integer, dimension(:), pointer :: cellMask
       type (field1dInteger), pointer :: calvingFrontMaskField
-      integer, dimension(:), pointer :: calvingFrontMask
       real (kind=RKIND), pointer :: deltat  !< time step (s)
-      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
-      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: edgesOnCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge
-      integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor
-      real(kind=RKIND) :: cellCalvingFrontLength, cellCalvingFrontHeight
-      logical :: dynamicNeighbor
       integer :: err_tmp
 
       err = 0
@@ -1131,8 +1118,6 @@ module li_calving
                config_calving_eigencalving_parameter_scalar_value)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', &
               config_calving_eigencalving_parameter_source)
-      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
-      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
 
       ! block loop
       block => domain % blocklist
@@ -1145,25 +1130,13 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
          ! get fields
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
-         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
-         call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(velocityPool, 'eMax', eMax)
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
 
-         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
-         call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
-         calvingFrontMask => calvingFrontMaskField % array
 
          ! get parameter value
          if (trim(config_calving_eigencalving_parameter_source) == 'scalar') then
@@ -1181,97 +1154,180 @@ module li_calving
                     realArgs=(/minval(eigencalvingParameter), maxval(eigencalvingParameter)/))
          endif
 
-         ! make mask for effective calving front.
-         ! This is last dynamic cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
-         call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
          calvingVelocity(:) = 0.0_RKIND
-         requiredCalvingVolumeRate(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
                * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
-         do iCell = 1, nCells
-            if (calvingFrontMask(iCell) == 1) then
 
-               ! convert to a volume flux per cell masking some assumptions
-               ! get front length from edge lengths abutting ocean or thin ice
-               ! get front height from max thickness of neighbors (since thickness near the edge could be screwy)
-               cellCalvingFrontLength = 0.0_RKIND
-               cellCalvingFrontHeight = 0.0_RKIND
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if ( (li_mask_is_floating_ice(cellMask(jCell)) .and. &
-                        .not. li_mask_is_dynamic_ice(cellMask(jCell))) .or. &  ! thin ice
-                       (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) ) then  ! open ocean
-                       cellCalvingFrontLength = cellCalvingFrontLength + dvEdge(edgesOnCell(iNeighbor, iCell))
-                  endif
-                  cellCalvingFrontHeight = max(cellCalvingFrontHeight, thickness(jCell))
-               enddo
-
-               requiredCalvingVolumeRate(iCell) = calvingVelocity(iCell) * cellCalvingFrontLength * cellCalvingFrontHeight ! m^3/s
-            endif
-         enddo
-
-         call distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMask, err_tmp)
-         err = ior(err, err_tmp)
-
-         ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
-
-         ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         err = ior(err, err_tmp)
-         call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
-
-
-         ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
-
-         !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
-         ! thickness<config_calving_thickness))
-         ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
-         ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
-         ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
-
-         ! This criteria below only remove too-thin ice at the new calving front,
-         ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
-         ! removing ice backward until all connected too-thin ice has been removed.
-         ! Tests of the current implementation show reasonable behavior.
-         where (calvingFrontMask == 1 .and. thickness<config_calving_thickness)
-             calvingThickness = calvingThickness + thickness
-             thickness = 0.0_RKIND
-         end where
-
-         ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         err = ior(err, err_tmp)
-
-         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-         do iCell = 1, nCells
-            if (li_mask_is_floating_ice(cellMask(iCell))) then
-               ! check neighbors for dynamic ice (floating or grounded)
-               dynamicNeighbor = .false.
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-               enddo
-               if (.not. dynamicNeighbor) then  ! calve this ice
-                  calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-                  thickness(iCell) = 0.0_RKIND
-               endif
-            endif
-         enddo
-
-         call remove_small_islands(meshPool, geometryPool)
-
-         call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
-
+         call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
+         
          block => block % next
+
       enddo
 
    end subroutine eigencalving
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine remove_calving_ice
+!
+!> \brief remove the calving ice volume based on calving velocity or damage threshold value
+!> \author Matthew Hoffman, Tong Zhang
+!> \date   March 2020
+!> \details this subroutine is splitted from the original eigencalving subroutine, and 
+!> is now used by both eigencalving and damagecalving. The damagecalving contains two 
+!> different calving methods: 1) using a calvingVelocity like eigencalving, and
+!> 2) remove the whole ice column if the damage value > a threshold, both are 
+!> incorporated together in the same distribute_calving_flux subroutine
+!-----------------------------------------------------------------------
+
+   subroutine remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
+      type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
+      type (mpas_pool_type), pointer, intent(in) :: velocityPool !< Input: velocity pool
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      integer, pointer :: nCells
+      integer :: iCell, jCell, iNeighbor
+      integer, dimension(:), pointer :: calvingFrontMask
+      real (kind=RKIND) :: cellCalvingFrontLength, cellCalvingFrontHeight
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:), pointer :: cellMask
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), pointer :: config_sea_level
+      real (kind=RKIND), pointer :: config_calving_thickness
+      logical :: dynamicNeighbor
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      type (field1dInteger), pointer :: calvingFrontMaskField
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer :: err_tmp
+
+      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+
+      call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
+      call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
+      calvingFrontMask => calvingFrontMaskField % array
+
+      ! make mask for effective calving front.
+      ! This is last dynamic cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
+      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+
+      requiredCalvingVolumeRate(:) = 0.0_RKIND
+
+      do iCell = 1, nCells
+          if (calvingFrontMask(iCell) == 1) then
+
+            ! convert to a volume flux per cell masking some assumptions
+            ! get front length from edge lengths abutting ocean or thin ice
+            ! get front height from max thickness of neighbors (since thickness near the edge could be screwy)
+             cellCalvingFrontLength = 0.0
+             cellCalvingFrontHeight = 0.0
+             do iNeighbor = 1, nEdgesOnCell(iCell)
+                jCell = cellsOnCell(iNeighbor, iCell)
+                if ( (li_mask_is_floating_ice(cellMask(jCell)) .and. &
+                      .not. li_mask_is_dynamic_ice(cellMask(jCell))) .or. &  ! thin ice
+                     (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) ) then  ! open ocean
+                     cellCalvingFrontLength = cellCalvingFrontLength + dvEdge(edgesOnCell(iNeighbor, iCell))
+                endif
+                cellCalvingFrontHeight = max(cellCalvingFrontHeight, thickness(jCell))
+            enddo
+
+            requiredCalvingVolumeRate(iCell) = calvingVelocity(iCell) * cellCalvingFrontLength * cellCalvingFrontHeight ! m^3/s
+
+          endif
+      enddo
+
+      call distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMask, err_tmp)
+      err = ior(err, err_tmp)
+
+      ! === apply calving ===
+      thickness(:) = thickness(:) - calvingThickness(:)
+
+      ! update mask
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      err = ior(err, err_tmp)
+
+      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+
+      ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
+
+      !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
+      ! thickness<config_calving_thickness))
+      ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
+      ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
+      ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
+
+      ! This criteria below only remove too-thin ice at the new calving front,
+      ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
+      ! removing ice backward until all connected too-thin ice has been removed.
+      ! Tests of the current implementation show reasonable behavior.
+      where (calvingFrontMask == 1 .and. thickness<config_calving_thickness)
+         calvingThickness = calvingThickness + thickness
+         thickness = 0.0_RKIND
+      end where
+
+      ! update mask
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      err = ior(err, err_tmp)
+
+      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+      do iCell = 1, nCells
+        if (li_mask_is_floating_ice(cellMask(iCell))) then
+           ! check neighbors for dynamic ice (floating or grounded)
+           dynamicNeighbor = .false.
+           do iNeighbor = 1, nEdgesOnCell(iCell)
+              jCell = cellsOnCell(iNeighbor, iCell)
+              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+           enddo
+           if (.not. dynamicNeighbor) then  ! calve this ice
+              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+              thickness(iCell) = 0.0_RKIND
+           endif
+        endif
+      enddo
+
+      call remove_small_islands(meshPool, geometryPool)
+
+      call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
+
+    end subroutine remove_calving_ice
+
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1270,7 +1270,8 @@ module li_calving
                    edgeCalvingFrontHeight = thickness(jCell)
                 endif
             enddo
-
+            edgeCalvingFrontHeight = 300.0
+!  call mpas_log_write("edge=$i   Ht=$r", intArgs=(/iEdge/), realArgs=(/edgeCalvingFrontHeight/))
             ! TODO: dot product of velocity with edge orientation
             requiredCalvingVolume(iEdge) = calvingVelocity(iEdge) * edgeCalvingFrontLength * edgeCalvingFrontHeight * deltat !m^3
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1324,6 +1324,7 @@ module li_calving
       real(kind=RKIND), dimension(5) :: localInfo, globalInfo
       logical :: openOceanNeighbor
       real(kind=RKIND) :: edgeLengthScaling
+      real(kind=RKIND), parameter :: calvingSmallThk = 1.0e-8 ! in meters, a small thickness threshold
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
@@ -1381,7 +1382,8 @@ module li_calving
                endif
             enddo
             if (thkCount == 0) then
-               !call mpas_log_write("Found a stranded non-dynamic floating cell!", MPAS_LOG_WARN)
+               call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
+                  intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
                ! TODO: Make an error? Print a warning?  Suppress?)
             else
                thicknessForCalving(iCell) = thkSum / real(thkCount, kind=RKIND)
@@ -1500,6 +1502,13 @@ module li_calving
       enddo
       call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
 
+
+      ! Clean up to account for roundoff level errors that can occur
+      do iCell = 1, nCells
+         if (abs(calvingThickness(iCell) - thickness(iCell)) < calvingSmallThk) then
+            calvingThickness(iCell) = thickness(iCell)
+         endif
+      enddo
 
 
       ! End of routine accounting/reporting

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1176,8 +1176,6 @@ module li_calving
 
          calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK
 
-!         calvingVelocity(:) = abs(calvingVelocity(:) * cos(angleEdge(:)))
-
 
          ! Convert calvingVelocity to calvingThickness
          call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
@@ -1309,6 +1307,8 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: areaCell
+      real (kind=RKIND), dimension(:,:), pointer :: uReconstructX
+      real (kind=RKIND), dimension(:,:), pointer :: uReconstructY
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), allocatable :: thicknessForCalving
@@ -1323,6 +1323,7 @@ module li_calving
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       real(kind=RKIND), dimension(5) :: localInfo, globalInfo
       logical :: openOceanNeighbor
+      real(kind=RKIND) :: edgeLengthScaling
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
@@ -1332,6 +1333,8 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
+      call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -1391,9 +1394,9 @@ module li_calving
                if (li_mask_is_floating_ice(edgeMask(iEdge)) .and. li_mask_is_margin(edgeMask(iEdge)) .and. &
                    .not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level & ! ensure margin is w/ocn
                    ) then
-                  requiredCalvingVolumeNonDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
-                          * thicknessForCalving(iCell) * deltat
-                  ! TODO: Change cos to use flow velo!
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  requiredCalvingVolumeNonDynEdge(iEdge) = calvingVelocity(iCell) * &
+                          edgeLengthScaling * dvEdge(iEdge) * thicknessForCalving(iCell) * deltat
                   requiredCalvingVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) + &
                           requiredCalvingVolumeNonDynEdge(iEdge) ! Keep running total
                endif
@@ -1429,8 +1432,9 @@ module li_calving
                do iNeighbor = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(iNeighbor, iCell)
                   if (li_mask_is_margin(edgeMask(iEdge))) then
-                     requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
-                             * thickness(iCell) * deltat
+                     edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                     requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * &
+                          edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
                   endif
                enddo
             endif
@@ -1454,7 +1458,8 @@ module li_calving
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
-                  calvLengthEdge = abs(cos(angleEdge(iEdge))) * dvEdge(iEdge)
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  calvLengthEdge = edgeLengthScaling * dvEdge(iEdge)
                   calvLengthCell = calvLengthCell + calvLengthEdge
                endif
             enddo
@@ -1464,7 +1469,8 @@ module li_calving
                iEdge = edgesOnCell(iNeighbor, iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
-                  calvLengthEdge = abs(cos(angleEdge(iEdge))) * dvEdge(iEdge)
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  calvLengthEdge = edgeLengthScaling * dvEdge(iEdge)
                   requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * volumeAvailableToPass
                   uncalvedVolumeNonDynCell(iCell) = uncalvedVolumeNonDynCell(iCell) - requiredCalvingVolumeDynEdge(iEdge)
                   !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
@@ -1530,6 +1536,23 @@ module li_calving
       deallocate(thicknessForCalving)
 
     end subroutine apply_calving_velocity
+
+    ! Helper function for subroutine apply_calving_velocity
+    ! Calculates the amount to scale an edge length based on the orientation of the edge with the surface velocity
+    function scale_edge_length(angleEdgeHere, u, v)
+       real(kind=RKIND), intent(in) :: angleEdgeHere
+       real(kind=RKIND), intent(in) :: u
+       real(kind=RKIND), intent(in) :: v
+       real(kind=RKIND) :: scale_edge_length
+
+       real(kind=RKIND) :: mag
+
+       mag = sqrt(u**2 + v**2)
+       if (mag == 0.0_RKIND) mag = 1.0_RKIND
+       !scale_edge_length =  abs(u/mag * cos(-1.0*angleEdgeHere) + v/mag * sin(-1.0*angleEdgeHere))  ! dot product of unit vectors
+       scale_edge_length = abs(cos(angleEdgeHere - atan2(v, u)))
+    end function scale_edge_length
+
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1322,13 +1322,14 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: areaCell
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeDynEdge
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynCell, requiredCalvingVolumeDynCell
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructX
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructY
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), allocatable :: thicknessForCalving
-      real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeNonDynCell
-      real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeDynEdge, requiredCalvingVolumeDynCell
+      real (kind=RKIND), dimension(:), pointer :: calvedVolumeNonDynCell, calvedVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
       real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2, calvingSubtotal3
@@ -1364,7 +1365,13 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolumeNonDynCell', uncalvedVolumeNonDynCell)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolumeDynCell', uncalvedVolumeDynCell)
+      call mpas_pool_get_array(geometryPool, 'calvedVolumeNonDynCell', calvedVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'calvedVolumeDynCell', calvedVolumeDynCell)
       call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeNonDynEdge', requiredCalvingVolumeNonDynEdge)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeDynEdge', requiredCalvingVolumeDynEdge)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeNonDynCell', requiredCalvingVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeDynCell', requiredCalvingVolumeDynCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
@@ -1403,14 +1410,12 @@ module li_calving
 
       ! Init fields for accounting
       calvingThickness(:) = 0.0_RKIND
+      calvedVolumeNonDynCell(:) = 0.0_RKIND
+      calvedVolumeDynCell(:) = 0.0_RKIND
       uncalvedVolumeNonDynCell(:) = 0.0_RKIND
       uncalvedVolumeDynCell(:) = 0.0_RKIND
       allocate(cellVolume(nCells+1))
       cellVolume(:) = areaCell(:) * thickness(:)
-      allocate(requiredCalvingVolumeNonDynEdge(nEdges+1))
-      allocate(requiredCalvingVolumeNonDynCell(nCells+1))
-      allocate(requiredCalvingVolumeDynEdge(nEdges+1))
-      allocate(requiredCalvingVolumeDynCell(nCells+1))
       requiredCalvingVolumeNonDynEdge(:) = 0.0_RKIND
       requiredCalvingVolumeNonDynCell(:) = 0.0_RKIND
       requiredCalvingVolumeDynEdge(:) = 0.0_RKIND
@@ -1459,11 +1464,15 @@ module li_calving
             ! c. Apply calving here
             removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeNonDynCell(iCell))  ! Don't use more than available
             calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            calvedVolumeNonDynCell(iCell) = removeVolumeHere
             uncalvedVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             calvingSubtotal1 = calvingSubtotal1 + removeVolumeHere
          endif
       enddo
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'uncalvedVolumeNonDynCell')
+      call mpas_timer_stop("halo updates")
       !call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
 
@@ -1490,7 +1499,7 @@ module li_calving
 
       ! b. copy calving remaining in non-dynamic cells to dynamic edges
       ! Assume height and velocity are uniform, but edge length is not.
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if ( (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
                  uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
             ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
@@ -1532,11 +1541,14 @@ module li_calving
             enddo
          endif
       enddo
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'requiredCalvingVolumeDynEdge')
+      call mpas_timer_stop("halo updates")
 
       ! c. Now apply calving to each cell
       do iCell = 1, nCellsSolve
-         if ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
-                 li_mask_is_dynamic_margin(cellMask(iCell)) ) .or. (groundedMarineMarginMask(iCell) == 1) ) then
+         if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
+            ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                ! No need to check what type of edge this is - only required edges are nonzero
@@ -1546,6 +1558,7 @@ module li_calving
             ! c. Apply calving here
             removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeDynCell(iCell))  ! Don't use more than available
             calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            calvedVolumeDynCell(iCell) = removeVolumeHere
             uncalvedVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             calvingSubtotal2 = calvingSubtotal2 + removeVolumeHere
@@ -1632,10 +1645,6 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       deallocate(cellVolume)
-      deallocate(requiredCalvingVolumeNonDynEdge)
-      deallocate(requiredCalvingVolumeNonDynCell)
-      deallocate(requiredCalvingVolumeDynEdge)
-      deallocate(requiredCalvingVolumeDynCell)
       deallocate(thicknessForCalving)
 
     end subroutine apply_calving_velocity

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1260,6 +1260,7 @@ module li_calving
       real(kind=RKIND) :: thkSum, thkCount
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
+      logical :: openOceanNeighbor
       integer :: err_tmp
 
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
@@ -1360,13 +1361,23 @@ module li_calving
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
                  li_mask_is_margin(cellMask(iCell)) ) then
+            ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
+            openOceanNeighbor = .false.
             do iNeighbor = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(iNeighbor, iCell)
-               if (li_mask_is_margin(edgeMask(iEdge))) then
-                  requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
-                          * thickness(iCell) * deltat
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
+                  openOceanNeighbor = .true.
                endif
             enddo
+            if (openOceanNeighbor) then
+               do iNeighbor = 1, nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(iNeighbor, iCell)
+                  if (li_mask_is_margin(edgeMask(iEdge))) then
+                     requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
+                             * thickness(iCell) * deltat
+                  endif
+               enddo
+            endif
          endif
       enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1206,80 +1206,75 @@ module li_calving
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
 
-      integer, pointer :: nCells
-      integer :: iCell, jCell, iNeighbor
-      integer, dimension(:), pointer :: calvingFrontMask
-      real (kind=RKIND) :: cellCalvingFrontLength, cellCalvingFrontHeight
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
+      integer, pointer :: nEdges, nCells
+      integer :: iEdge, iCell, jCell, iNeighbor
+      integer, dimension(:), pointer :: calvingFrontMaskCell, calvingFrontMaskEdge
+      real (kind=RKIND) :: edgeCalvingFrontLength, edgeCalvingFrontHeight
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolume
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: config_calving_thickness
       logical :: dynamicNeighbor
       real (kind=RKIND), dimension(:), pointer :: dvEdge
-      type (field1dInteger), pointer :: calvingFrontMaskField
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      real (kind=RKIND), pointer :: deltat  !< time step (s)
       integer :: err_tmp
 
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolume', requiredCalvingVolume)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingFrontMaskCell', calvingFrontMaskCell)
+      call mpas_pool_get_array(geometryPool, 'calvingFrontMaskEdge', calvingFrontMaskEdge)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
-      call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
-      calvingFrontMask => calvingFrontMaskField % array
+      call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
       ! make mask for effective calving front.
       ! This is last dynamic cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
-      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
-      requiredCalvingVolumeRate(:) = 0.0_RKIND
+      requiredCalvingVolume(:) = 0.0_RKIND
 
-      do iCell = 1, nCells
-          if (calvingFrontMask(iCell) == 1) then
+      do iEdge = 1, nEdges
+          if (calvingFrontMaskEdge(iEdge) == 1) then
 
-            ! convert to a volume flux per cell masking some assumptions
-            ! get front length from edge lengths abutting ocean or thin ice
-            ! get front height from max thickness of neighbors (since thickness near the edge could be screwy)
-             cellCalvingFrontLength = 0.0
-             cellCalvingFrontHeight = 0.0
-             do iNeighbor = 1, nEdgesOnCell(iCell)
-                jCell = cellsOnCell(iNeighbor, iCell)
-                if ( (li_mask_is_floating_ice(cellMask(jCell)) .and. &
-                      .not. li_mask_is_dynamic_ice(cellMask(jCell))) .or. &  ! thin ice
-                     (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) ) then  ! open ocean
-                     cellCalvingFrontLength = cellCalvingFrontLength + dvEdge(edgesOnCell(iNeighbor, iCell))
+             ! convert to a volume flux per cell masking some assumptions
+             ! get front length from edge lengths abutting ocean or thin ice
+             edgeCalvingFrontLength = dvEdge(iEdge)
+             ! get front height from thickness of upstream (dynamic) neighbor
+             do iNeighbor = 1, 2
+                jCell = cellsOnEdge(iNeighbor, iEdge)
+                if ( li_mask_is_dynamic_ice(cellMask(jCell))) then
+                   edgeCalvingFrontHeight = thickness(jCell)
                 endif
-                cellCalvingFrontHeight = max(cellCalvingFrontHeight, thickness(jCell))
             enddo
 
-!            cellCalvingFrontLength = sqrt(2.0/(3.0*sqrt(3.0))*areaCell(iCell))*2.0 !MJH Step 1
-            cellCalvingFrontLength = sqrt(1.0/2.0*sqrt(3.0)/6.0*areaCell(iCell))*2.0
-
-            requiredCalvingVolumeRate(iCell) = calvingVelocity(iCell) * cellCalvingFrontLength * cellCalvingFrontHeight ! m^3/s
+            ! TODO: dot product of velocity with edge orientation
+            requiredCalvingVolume(iEdge) = calvingVelocity(iEdge) * edgeCalvingFrontLength * edgeCalvingFrontHeight * deltat !m^3
 
           endif
       enddo
 
-      call distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMask, err_tmp)
+      call distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMaskCell, calvingFrontMaskEdge, err_tmp)
+
       err = ior(err, err_tmp)
 
       ! === apply calving ===
@@ -1289,7 +1284,7 @@ module li_calving
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
       err = ior(err, err_tmp)
 
-      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
       ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
 
@@ -1303,7 +1298,7 @@ module li_calving
       ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
       ! removing ice backward until all connected too-thin ice has been removed.
       ! Tests of the current implementation show reasonable behavior.
-      where (calvingFrontMask == 1 .and. thickness<config_calving_thickness)
+      where (calvingFrontMaskCell == 1 .and. thickness<config_calving_thickness)
          calvingThickness = calvingThickness + thickness
          thickness = 0.0_RKIND
       end where
@@ -1332,8 +1327,6 @@ module li_calving
 
       call remove_small_islands(meshPool, geometryPool)
 
-      call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
-
     end subroutine remove_calving_ice
 
 
@@ -1352,14 +1345,15 @@ module li_calving
 !> 3. If there is still additional ice to be removed, we have to recursively
 !>    remove ice "inland" of this cell until the total required mass is removed
 !-----------------------------------------------------------------------
-   subroutine distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMask, err)
+   subroutine distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMaskCell, calvingFrontMaskEdge, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
       type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
-      integer, dimension(:), intent(in) :: calvingFrontMask
+      integer, dimension(:), intent(in) :: calvingFrontMaskCell
+      integer, dimension(:), intent(in) :: calvingFrontMaskEdge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -1375,39 +1369,39 @@ module li_calving
       ! local variables
       !-----------------------------------------------------------------
 !      logical, pointer :: config_print_calving_info
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolume
          !< Input: the specified calving flux at calving front margin cells
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell ! list of edges that neighbor each cell
       integer, dimension(:), pointer :: cellMask
-      real (kind=RKIND), pointer :: deltat  !< time step (s)
       integer, pointer :: nCells
-      integer :: iCell, iNeighbor, jCell
+      integer :: iEdge, iNeighbor, iCell
       real(kind=RKIND) :: volumeLeft
       real(kind=RKIND) :: removeVolumeHere
       type (field1dReal), pointer :: cellVolumeField
       real(kind=RKIND), dimension(:), pointer :: cellVolume
       real(kind=RKIND), dimension(:), pointer :: uncalvedVolume
-      integer :: inwardNeighbors
-      integer :: outwardNeighbors
+      integer :: nNeighbors
       integer :: uncalvedCount
+      real(kind=RKIND) :: fracToUse
       real(kind=RKIND) :: uncalvedTotal
-      integer, dimension(1000) :: tmpCellIdArray, neighborCellId, dynamicNeighborCellId
+      real(kind=RKIND) :: calvingVolumeDesired
 
       err = 0
 
       ! get fields
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolume', requiredCalvingVolume)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
@@ -1416,95 +1410,94 @@ module li_calving
       cellVolume => cellVolumeField % array
 
       calvingThickness(:) = 0.0_RKIND
-      uncalvedVolume(:) = 0.0_RKIND
+      uncalvedVolume(:) = requiredCalvingVolume(:) ! units m^3
 
       cellVolume(:) = areaCell(:) * thickness(:)
 
-      ! The calving volume needs to be distributed in three ways:
-      ! 1. We need to first remove any "thin" ice in front of this cell
-      ! 2. Then we remove ice from this cell
+
+      ! The calving volume needs to be distributed in steps:
+      ! 1. We need to first remove any downstream ice (non-dynamic) from the calving front edges
+      !    Remove the maximum amount possible but taking evenly from the neighboring edges.
+      !
+      ! 2. Then we remove ice from the upstream neighboring cells of the calving front edge
+      !    Remove the maximum amount possible but taking evenly from the neighboring edges.
+      !
       ! 3. If there is still additional ice to be removed, we have to recursively
       !    remove ice "inland" of this cell until the total required mass is removed
+      !    TODO: Not sure if this violates a CFL-like condition
+
       do iCell = 1, nCells
-         if (calvingFrontMask(iCell) == 1) then
-            volumeLeft = requiredCalvingVolumeRate(iCell) * deltat  ! units m^3
 
-            ! First remove ice from "thin" neighbors
-            outwardNeighbors = 0
-            neighborCellId(:) = 0
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
-                  outwardNeighbors = outwardNeighbors + 1
-                  neighborCellId(outwardNeighbors) = jCell
-               endif
-            enddo
-            do iNeighbor = 1, outwardNeighbors
-               removeVolumeHere = volumeLeft/real(outwardNeighbors, kind=RKIND)
-               calvingThickness(jCell) = calvingThickness(jCell) + removeVolumeHere / areaCell(jCell)
-                      ! < apply to the field that will be used, in thickness units
-               cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
-               volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
+         ! 1. Loop over downstream (non-dynamic, floating) cells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(iCell))) then
 
-            enddo
+            ! Find number of calving edges and total volume they have to offer
+            nNeighbors = 0
+            calvingVolumeDesired = 0.0_RKIND
             do iNeighbor = 1, nEdgesOnCell(iCell)
-               jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
-                  ! this is a thin neighbor - remove as much ice from here as we can
-                  ! TODO: could distribute this evenly amongst neighbors
-                  removeVolumeHere = min(volumeLeft, cellVolume(jCell)) ! how much we want to remove here
-                  calvingThickness(jCell) = calvingThickness(jCell) + removeVolumeHere / areaCell(jCell)
-                      ! < apply to the field that will be used, in thickness units
-                  cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
-                  volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (calvingFrontMaskEdge(iEdge) == 1) then
+                  nNeighbors = nNeighbors + 1
+                  calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(iEdge)
                endif
             enddo
 
-            if (volumeLeft > 0.0_RKIND) then
-               ! Now remove ice from iCell
-               removeVolumeHere = min(volumeLeft, cellVolume(iCell))
-               calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-                  ! < apply to the field that will be used in thickness units
-               cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere ! update accounting on cell volume
-               volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
-            endif
+            if (calvingVolumeDesired > 0.0_RKIND) then
+               ! Calculate what fraction to take of total available ice to give
+               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
+               !call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
+               !        intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
 
-            if (volumeLeft > 0.0_RKIND) then
-               ! Now remove ice from neighbors inward on shelf
-               ! first count up how many there are
-               inwardNeighbors = 0
+               ! Now actually set the amount to calve
                do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if (li_mask_is_floating_ice(cellMask(jCell)) .and. li_mask_is_dynamic_ice(cellMask(jCell)) &
-                          .and. (.not. li_mask_is_dynamic_margin(jCell))) then
-                     inwardNeighbors = inwardNeighbors + 1
+                  iEdge = edgesOnCell(iNeighbor, iCell)
+                  if (calvingFrontMaskEdge(iEdge) == 1) then
+                     removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
+                     calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
+                     uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
                   endif
                enddo
-               ! Now distribute the flux evenly amongst the neighbors
+            endif
+
+         endif ! if this is a downstream cell
+      enddo
+
+      do iCell = 1, nCells
+
+         ! 2. Loop over upstream (dynamic, bed below sea level) cells
+         if (calvingFrontMaskCell(iCell)==1) then
+            ! Find number of calving edges and total volume they have to offer
+            nNeighbors = 0
+            calvingVolumeDesired = 0.0_RKIND
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (calvingFrontMaskEdge(iEdge) == 1) then
+                  nNeighbors = nNeighbors + 1
+                  calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(iEdge)
+                  !call mpas_log_write("Upstream: cell=$i, edge=$i, uncalvedVol=$r", &
+                  !        intArgs=(/iCell, iEdge/), realArgs=(/uncalvedVolume(iEdge)/))
+               endif
+            enddo
+
+            ! Calculate what fraction to take of total available ice to give
+            if (calvingVolumeDesired > 0.0_RKIND) then
+               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
+
+               !call mpas_log_write("Upstream: cell=$i, num=$i, fracToUse=$r", intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
+
+               ! Now actually set the amount to calve
                do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if (li_mask_is_floating_ice(cellMask(jCell)) .and. li_mask_is_dynamic_ice(cellMask(jCell)) &
-                          .and. (.not. li_mask_is_dynamic_margin(jCell))) then
-                     ! this is thick neighbor that is not itself a margin - remove as much ice from here as we can
-                     removeVolumeHere = min(volumeLeft / real(inwardNeighbors, kind=RKIND), cellVolume(jCell))
-                        ! < how much we want to remove here
-                     calvingThickness(jCell) = calvingThickness(jCell) + removeVolumeHere / areaCell(jCell)
-                        ! < apply to the field that will be used in thickness units
-                     cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
-                     volumeLeft = volumeLeft - removeVolumeHere
-                        ! < update accounting on how much left to distribute from current iCell
+                  iEdge = edgesOnCell(iNeighbor, iCell)
+                  if (calvingFrontMaskEdge(iEdge) == 1) then
+                     removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
+                     calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
+                     uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
                   endif
                enddo
-               !TODO: need to recursively distribute across neighbors until fully depleted :(
             endif
+         endif ! if a calving front cell
 
-            ! If we didn't calve enough ice, record that to allow assessment of how bad that is.
-            if (volumeLeft > 0.0_RKIND) then
-               uncalvedVolume(iCell) = 0.0_RKIND
-            endif
-
-         endif ! if cell is calving margin
-      enddo ! cell loop
+      enddo
 
       if (maxval(uncalvedVolume) > 0.0_RKIND) then
 
@@ -1514,13 +1507,12 @@ module li_calving
          call mpas_log_write("distribute_calving_flux failed to distribute all required ice - " // &
                     " ice was left after depleting all neighbors." // &
                     "  Search needs to be expanded to neighbors' neighbors.")
-         call mpas_log_write("   On this processor: $i cells contain uncalved ice, " // &
+         call mpas_log_write("   On this processor: $i edges contain uncalved ice, " // &
                  "for a total uncalved volume of $r m^3 ($r%).", &
                  MPAS_LOG_WARN, intArgs=(/uncalvedCount/), &
-                 realArgs=(/uncalvedTotal, 100.0_RKIND * uncalvedTotal/(requiredCalvingVolumeRate(iCell) * deltat)/))
+                 realArgs=(/uncalvedTotal, 100.0_RKIND * uncalvedTotal/sum(requiredCalvingVolume(:))/))
+         ! TODO: Global reduce
       endif
-
-      call mpas_deallocate_scratch_field(cellVolumeField, .true.)
 
    end subroutine distribute_calving_flux
 
@@ -1614,7 +1606,7 @@ module li_calving
 !> \details Mmake mask for effective calving front.
 !> This is last dynamic floating cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
 !-----------------------------------------------------------------------
-   subroutine calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+   subroutine calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1629,16 +1621,18 @@ module li_calving
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
-      integer, dimension(:) :: calvingFrontMask !< Output: calving front mask
+      integer, dimension(:), intent(out) :: calvingFrontMaskCell !< Output: calving front mask
+      integer, dimension(:), intent(out) :: calvingFrontMaskEdge !< Output: calving front mask
 
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
       integer, pointer :: nCells
       integer :: iCell, iNeighbor, jCell, jNeighbor, kCell
-      logical :: oceanNeighbor
+      logical :: oceanNeighborCell, oceanNeighborEdge
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell ! list of edges that neighbor each cell
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), pointer :: config_sea_level
@@ -1649,31 +1643,38 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
 
-      calvingFrontMask = 0 !initialize
+      calvingFrontMaskEdge = 0 !initialize
+      calvingFrontMaskCell = 0 !initialize
 
       do iCell = 1, nCells
          if ( (li_mask_is_floating_ice(cellMask(iCell))) .and. (li_mask_is_dynamic_margin(cellMask(iCell))) ) then
-            oceanNeighbor = .false.
+            oceanNeighborCell = .false.
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
+               oceanNeighborEdge = .false.
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! make sure this neighbor is adjacent to open ocean (and not thin floating ice up against the coast)
                   do jNeighbor = 1, nEdgesOnCell(jCell)
                      kCell = cellsOnCell(jNeighbor, jCell)
                      if (.not. li_mask_is_ice(cellMask(kCell)) .and. bedTopography(kCell) < config_sea_level) then
-                        oceanNeighbor = .true. ! iCell neighbors thin ice that in turn neighbors open ocean
+                        oceanNeighborEdge = .true. ! iCell neighbors thin ice that in turn neighbors open ocean
                      endif
                   enddo
                endif
                if (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) then
-                  oceanNeighbor = .true. ! this is an open ocean neighbor
+                  oceanNeighborEdge = .true. ! this is an open ocean neighbor
                endif
+               if (oceanNeighborEdge) then
+                  calvingFrontMaskEdge(edgesOnCell(iNeighbor, iCell)) = 1
+               endif
+               oceanNeighborCell = (oceanNeighborCell .or. oceanNeighborEdge)
             enddo
-            if (oceanNeighbor) then
-               calvingFrontMask(iCell) = 1
+            if (oceanNeighborCell) then
+               calvingFrontMaskCell(iCell) = 1
             endif
          endif
       enddo

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1335,7 +1335,10 @@ module li_calving
             !    to calculate the calving volume on those edges and this cell
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
-               if (li_mask_is_floating_ice(edgeMask(iEdge)) .and. li_mask_is_margin(edgeMask(iEdge))) then
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_floating_ice(edgeMask(iEdge)) .and. li_mask_is_margin(edgeMask(iEdge)) .and. &
+                   .not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level & ! ensure margin is w/ocn
+                   ) then
                   requiredCalvingVolumeNonDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
                           * thicknessForCalving(iCell) * deltat
                   ! TODO: Change cos to use flow velo!

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1108,12 +1108,17 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: calvingFrontMask
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor
+      logical :: dynamicNeighbor
+      real(kind=RKIND) :: calvingSubtotal
       integer :: err_tmp
 
       err = 0
@@ -1149,6 +1154,7 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
 
          ! get parameter value
@@ -1170,11 +1176,9 @@ module li_calving
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
-!         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
-!               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
+               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
-
-         calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK
 
 
          ! Convert calvingVelocity to calvingThickness
@@ -1206,30 +1210,34 @@ module li_calving
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
+         ! TODO: global reduce & reporting on amount of calving generated in this step
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
-!      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-!      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-!      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-!      do iCell = 1, nCells
-!        if (li_mask_is_floating_ice(cellMask(iCell))) then
-!           ! check neighbors for dynamic ice (floating or grounded)
-!           dynamicNeighbor = .false.
-!           do iNeighbor = 1, nEdgesOnCell(iCell)
-!              jCell = cellsOnCell(iNeighbor, iCell)
-!              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-!           enddo
-!           if (.not. dynamicNeighbor) then  ! calve this ice
-!              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-!              thickness(iCell) = 0.0_RKIND
-!           endif
-!        endif
-!      enddo
-!
-!      call remove_small_islands(meshPool, geometryPool)
+         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+         calvingSubtotal = 0.0_RKIND
+         do iCell = 1, nCells
+           if (li_mask_is_floating_ice(cellMask(iCell))) then
+              ! check neighbors for dynamic ice (floating or grounded)
+              dynamicNeighbor = .false.
+              do iNeighbor = 1, nEdgesOnCell(iCell)
+                 jCell = cellsOnCell(iNeighbor, iCell)
+                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+              enddo
+              if (.not. dynamicNeighbor) then  ! calve this ice
+                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+                 thickness(iCell) = 0.0_RKIND
+                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
+              endif
+           endif
+         enddo
+         ! TODO: global reduce & reporting on amount of calving generated in this step
+
+         call remove_small_islands(meshPool, geometryPool)
 
          block => block % next
       enddo

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1392,8 +1392,10 @@ module li_calving
       real(kind=RKIND), dimension(:), pointer :: cellVolume
       real(kind=RKIND), dimension(:), pointer :: uncalvedVolume
       integer :: inwardNeighbors
+      integer :: outwardNeighbors
       integer :: uncalvedCount
       real(kind=RKIND) :: uncalvedTotal
+      integer, dimension(1000) :: tmpCellIdArray, neighborCellId, dynamicNeighborCellId
 
       err = 0
 
@@ -1428,6 +1430,23 @@ module li_calving
             volumeLeft = requiredCalvingVolumeRate(iCell) * deltat  ! units m^3
 
             ! First remove ice from "thin" neighbors
+            outwardNeighbors = 0
+            neighborCellId(:) = 0
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
+                  outwardNeighbors = outwardNeighbors + 1
+                  neighborCellId(outwardNeighbors) = jCell
+               endif
+            enddo
+            do iNeighbor = 1, outwardNeighbors
+               removeVolumeHere = volumeLeft/real(outwardNeighbors, kind=RKIND)
+               calvingThickness(jCell) = calvingThickness(jCell) + removeVolumeHere / areaCell(jCell)
+                      ! < apply to the field that will be used, in thickness units
+               cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
+               volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
+
+            enddo
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1317,7 +1317,8 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
       real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2
-      real(kind=RKIND) :: thkSum, thkCount
+      real(kind=RKIND) :: thkSum
+      integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1101,14 +1101,18 @@ module li_calving
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
+      real(kind=RKIND), pointer :: config_calving_thickness
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
       real (kind=RKIND), dimension(:), pointer :: angleEdge
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness
       integer, dimension(:), pointer :: cellMask
-      type (field1dInteger), pointer :: calvingFrontMaskField
+      integer, dimension(:), pointer :: calvingFrontMask
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), pointer :: dvEdge
+      integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor
       integer :: err_tmp
 
@@ -1119,6 +1123,7 @@ module li_calving
                config_calving_eigencalving_parameter_scalar_value)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', &
               config_calving_eigencalving_parameter_source)
+      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
 
       ! block loop
       block => domain % blocklist
@@ -1130,14 +1135,20 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
+         ! get dimensions
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
          ! get fields
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(velocityPool, 'eMax', eMax)
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
 
 
          ! get parameter value
@@ -1169,9 +1180,58 @@ module li_calving
 
 
          call apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
-         
-         block => block % next
 
+         ! === apply calving ===
+         thickness(:) = thickness(:) - calvingThickness(:)
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
+
+         !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
+         ! thickness<config_calving_thickness))
+         ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
+         ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
+         ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
+
+         ! This criteria below only remove too-thin ice at the new calving front,
+         ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
+         ! removing ice backward until all connected too-thin ice has been removed.
+         ! Tests of the current implementation show reasonable behavior.
+         do iCell = 1, nCells
+            if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
+               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               thickness(iCell) = 0.0_RKIND
+            endif
+         enddo
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+!      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+!      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+!      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+!      do iCell = 1, nCells
+!        if (li_mask_is_floating_ice(cellMask(iCell))) then
+!           ! check neighbors for dynamic ice (floating or grounded)
+!           dynamicNeighbor = .false.
+!           do iNeighbor = 1, nEdgesOnCell(iCell)
+!              jCell = cellsOnCell(iNeighbor, iCell)
+!              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+!           enddo
+!           if (.not. dynamicNeighbor) then  ! calve this ice
+!              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+!              thickness(iCell) = 0.0_RKIND
+!           endif
+!        endif
+!      enddo
+!
+!      call remove_small_islands(meshPool, geometryPool)
+
+         block => block % next
       enddo
 
    end subroutine eigencalving
@@ -1210,6 +1270,9 @@ module li_calving
 !> has been completely "drained" to any edges between that non-dynamic cell and dynamic cells upstream.
 !> This is done by weighting the flux to be distrbuted by the length of each such edge in the direction
 !> perpendicular to the calving flux.
+!>
+!> The output of this routine is calvingThickness, which then needs to be applied to thickness
+!> by the calling routine.
 !-----------------------------------------------------------------------
 
    subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
@@ -1233,8 +1296,6 @@ module li_calving
 
       integer, pointer :: nEdges, nCells
       integer :: iEdge, iCell, jCell, iNeighbor
-      real (kind=RKIND) :: edgeCalvingFrontLength, edgeCalvingFrontHeight
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolume
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1242,8 +1303,6 @@ module li_calving
       integer, dimension(:), pointer :: cellMask, edgeMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: config_sea_level
-      real (kind=RKIND), pointer :: config_calving_thickness
-      logical :: dynamicNeighbor
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
@@ -1261,9 +1320,7 @@ module li_calving
       real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       logical :: openOceanNeighbor
-      integer :: err_tmp
 
-      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1273,7 +1330,6 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolume', requiredCalvingVolume)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
@@ -1463,336 +1519,8 @@ module li_calving
       deallocate(requiredCalvingVolumeDynCell)
       deallocate(thicknessForCalving)
 
-      ! === apply calving ===
-      thickness(:) = thickness(:) - calvingThickness(:)
-
-      ! update mask
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-      err = ior(err, err_tmp)
-
-
-!      ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
-!
-!      !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
-!      ! thickness<config_calving_thickness))
-!      ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
-!      ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
-!      ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
-!
-!      ! This criteria below only remove too-thin ice at the new calving front,
-!      ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
-!      ! removing ice backward until all connected too-thin ice has been removed.
-!      ! Tests of the current implementation show reasonable behavior.
-!      where (calvingFrontMaskCell == 1 .and. thickness<config_calving_thickness)
-!         calvingThickness = calvingThickness + thickness
-!         thickness = 0.0_RKIND
-!      end where
-!
-!      ! update mask
-!      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-!      err = ior(err, err_tmp)
-!
-!      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-!      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-!      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-!      do iCell = 1, nCells
-!        if (li_mask_is_floating_ice(cellMask(iCell))) then
-!           ! check neighbors for dynamic ice (floating or grounded)
-!           dynamicNeighbor = .false.
-!           do iNeighbor = 1, nEdgesOnCell(iCell)
-!              jCell = cellsOnCell(iNeighbor, iCell)
-!              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-!           enddo
-!           if (.not. dynamicNeighbor) then  ! calve this ice
-!              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-!              thickness(iCell) = 0.0_RKIND
-!           endif
-!        endif
-!      enddo
-!
-!      call remove_small_islands(meshPool, geometryPool)
 
     end subroutine apply_calving_velocity
-
-
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!    routine distribute_calving_flux
-!
-!> \brief Apply a specified calving flux along the calving front
-!> \author Matthew Hoffman
-!> \date   Feb. 2018
-!> \details Applies a specified calving flux along the calving front.
-!> The calving volume needs to be distributed in three ways:
-!> 1. We need to first remove any "thin" ice in front of this cell
-!> 2. Then we remove ice from this cell
-!> 3. If there is still additional ice to be removed, we have to recursively
-!>    remove ice "inland" of this cell until the total required mass is removed
-!-----------------------------------------------------------------------
-   subroutine distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMaskCell, calvingFrontMaskEdge, err)
-
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
-      type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
-      integer, dimension(:), intent(in) :: calvingFrontMaskCell
-      integer, dimension(:), intent(in) :: calvingFrontMaskEdge
-
-      !-----------------------------------------------------------------
-      ! input/output variables
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-!      logical, pointer :: config_print_calving_info
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolume
-         !< Input: the specified calving flux at calving front margin cells
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
-      real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
-      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: edgesOnCell ! list of edges that neighbor each cell
-      integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nCells
-      integer :: iEdge, iNeighbor, iCell
-      real(kind=RKIND) :: volumeLeft
-      real(kind=RKIND) :: removeVolumeHere
-      type (field1dReal), pointer :: cellVolumeField
-      real(kind=RKIND), dimension(:), pointer :: cellVolume
-      real(kind=RKIND), dimension(:), pointer :: uncalvedVolume
-      integer :: nNeighbors
-      integer :: uncalvedCount
-      real(kind=RKIND) :: fracToUse
-      real(kind=RKIND) :: fracToRemove
-      real(kind=RKIND) :: uncalvedTotal
-      real(kind=RKIND) :: calvingVolumeDesired
-      real(kind=RKIND) :: dsVolumeRemaining, calvingAvailable
-      real(kind=RKIND) :: calvingSubtotal
-      logical :: dynamicNeighbor
-      integer :: jCell
-
-      err = 0
-
-      ! get fields
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolume', requiredCalvingVolume)
-      call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
-      call mpas_allocate_scratch_field(cellVolumeField, .true.)
-      cellVolume => cellVolumeField % array
-
-      calvingThickness(:) = 0.0_RKIND
-      uncalvedVolume(:) = requiredCalvingVolume(:) ! units m^3
-
-      cellVolume(:) = areaCell(:) * thickness(:)
-
-      call mpas_log_write("Beginning to distribute calving.  Total to be removed=$r", &
-              realArgs=(/sum(requiredCalvingVolume(:))/))
-
-      ! The calving volume needs to be distributed in steps:
-      ! 1. We need to first remove any downstream ice (non-dynamic) from the calving front edges
-      !    Remove the maximum amount possible but taking evenly from the neighboring edges.
-      !
-      ! 2. Then we remove ice from the upstream neighboring cells of the calving front edge
-      !    Remove the maximum amount possible but taking evenly from the neighboring edges.
-      !
-      ! 3. If there is still additional ice to be removed, we have to recursively
-      !    remove ice "inland" of this cell until the total required mass is removed
-      !    TODO: Not sure if this violates a CFL-like condition
-
-      ! 1. Loop over downstream (non-dynamic, floating) cells
-      calvingSubtotal = 0.0_RKIND
-      do iCell = 1, nCells
-
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
-
-            ! Find number of calving edges and total volume they have to offer
-            nNeighbors = 0
-            calvingVolumeDesired = 0.0_RKIND
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(iNeighbor, iCell)
-               if (calvingFrontMaskEdge(iEdge) == 1) then
-                  nNeighbors = nNeighbors + 1
-                  calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(iEdge)
-               endif
-            enddo
-
-            if (calvingVolumeDesired > 0.0_RKIND) then
-               ! Calculate what fraction to take of total available ice to give
-               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
-               !call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
-               !        intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
-
-               ! Now actually set the amount to calve
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(iNeighbor, iCell)
-                  if (calvingFrontMaskEdge(iEdge) == 1) then
-                     removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
-                     calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-                     uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
-                     cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-                     calvingSubtotal = calvingSubtotal + removeVolumeHere
-                  endif
-               enddo
-            endif
-
-         endif ! if this is a downstream cell
-      enddo
-      call mpas_log_write("Phase 1 complete. Removed $r m^3 from downstream cells.", &
-              realArgs=(/calvingSubtotal/))
-
-
-
-      ! 1a. Try to eliminate any now stranded downstream cells
-      calvingSubtotal = 0.0_RKIND
-      dsVolumeRemaining = 0.0_RKIND
-      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-      do iCell = 1, nCells
-        if (li_mask_is_floating_ice(cellMask(iCell))) then
-           ! check neighbors for dynamic ice (floating or grounded)
-           dynamicNeighbor = .false.
-           do iNeighbor = 1, nEdgesOnCell(iCell)
-              jCell = cellsOnCell(iNeighbor, iCell)
-              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-           enddo
-           if (.not. dynamicNeighbor) then  ! calve this ice
-              dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
-           endif
-        endif
-      enddo
-
-!      do iCell = 1, nCells
-!         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
-!             dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
-!         endif ! if this is a downstream cell
-!      enddo
-      calvingAvailable = sum(uncalvedVolume(:))
-      if ((calvingAvailable == 0.0_RKIND) .or. (dsVolumeRemaining == 0.0_RKIND)) then
-         fracToUse = 0.0_RKIND
-         fracToRemove = 0.0_RKIND
-      else
-         if (calvingAvailable > dsVolumeRemaining) then
-            fracToUse = dsVolumeRemaining / calvingAvailable
-            fracToRemove = 1.0_RKIND
-         else
-            fracToUse = 1.0_RKIND
-            fracToRemove = calvingAvailable / dsVolumeRemaining
-         endif
-      endif
-      call mpas_log_write("Step 1a.  dsVolRemaining=$r, calvingAvail=$r, fracToUse=$r, fracToRemove=$r", &
-              realArgs=(/dsVolumeRemaining, calvingAvailable, fracToUse, fracToRemove/))
-
-      ! Remove the ice
-      do iCell = 1, nCells
-        if (li_mask_is_floating_ice(cellMask(iCell))) then
-           ! check neighbors for dynamic ice (floating or grounded)
-           dynamicNeighbor = .false.
-           do iNeighbor = 1, nEdgesOnCell(iCell)
-              jCell = cellsOnCell(iNeighbor, iCell)
-              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-           enddo
-           if (.not. dynamicNeighbor) then  ! calve this ice
-            removeVolumeHere = fracToRemove * cellVolume(iCell)
-            calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            calvingSubtotal = calvingSubtotal + removeVolumeHere
-           endif
-        endif
-      enddo
-
-!      do iCell = 1, nCells
-!         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
-!            removeVolumeHere = fracToRemove * cellVolume(iCell)
-!            calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-!            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-!            calvingSubtotal = calvingSubtotal + removeVolumeHere
-!         endif
-!      enddo
-      ! Update the volume remaining to be calved
-      uncalvedVolume(:) = (1.0_RKIND - fracToUse) * uncalvedVolume(:)
-      call mpas_log_write("Phase 1a complete. Removed $r m^3 from downstream cells.", &
-              realArgs=(/calvingSubtotal/))
-
-
-
-      ! 2. Loop over upstream (dynamic, bed below sea level) cells
-      calvingSubtotal = 0.0_RKIND
-      do iCell = 1, nCells
-
-         if (calvingFrontMaskCell(iCell)==1) then
-            ! Find number of calving edges and total volume they have to offer
-            nNeighbors = 0
-            calvingVolumeDesired = 0.0_RKIND
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(iNeighbor, iCell)
-               if (calvingFrontMaskEdge(iEdge) == 1) then
-                  nNeighbors = nNeighbors + 1
-                  calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(iEdge)
-                  !call mpas_log_write("Upstream: cell=$i, edge=$i, uncalvedVol=$r", &
-                  !        intArgs=(/iCell, iEdge/), realArgs=(/uncalvedVolume(iEdge)/))
-               endif
-            enddo
-
-            ! Calculate what fraction to take of total available ice to give
-            if (calvingVolumeDesired > 0.0_RKIND) then
-               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
-
-               !call mpas_log_write("Upstream: cell=$i, num=$i, fracToUse=$r", intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
-
-               ! Now actually set the amount to calve
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(iNeighbor, iCell)
-                  if (calvingFrontMaskEdge(iEdge) == 1) then
-                     removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
-                     calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-                     uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
-                     calvingSubtotal = calvingSubtotal + removeVolumeHere
-                  endif
-               enddo
-            endif
-         endif ! if a calving front cell
-
-      enddo
-      call mpas_log_write("Phase 2 complete. Removed $r m^3 from upstream cells.", &
-              realArgs=(/calvingSubtotal/))
-
-      call mpas_log_write("Calving complete. Removed $r m^3.", &
-              realArgs=(/sum(calvingThickness*areaCell)/))
-      if (maxval(uncalvedVolume) > 0.0_RKIND) then
-
-         uncalvedTotal = sum(uncalvedVolume)
-         uncalvedCount = count(uncalvedVolume > 0.0_RKIND)
-
-         call mpas_log_write("distribute_calving_flux failed to distribute all required ice - " // &
-                    " ice was left after depleting all neighbors." // &
-                    "  Search needs to be expanded to neighbors' neighbors.")
-         call mpas_log_write("   On this processor: $i edges contain uncalved ice, " // &
-                 "for a total uncalved volume of $r m^3 ($r%).", &
-                 MPAS_LOG_WARN, intArgs=(/uncalvedCount/), &
-                 realArgs=(/uncalvedTotal, 100.0_RKIND * uncalvedTotal/sum(requiredCalvingVolume(:))/))
-         ! TODO: Global reduce
-      endif
-
-   end subroutine distribute_calving_flux
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -1884,7 +1612,7 @@ module li_calving
 !> \details Mmake mask for effective calving front.
 !> This is last dynamic floating cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
 !-----------------------------------------------------------------------
-   subroutine calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
+   subroutine calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1899,8 +1627,7 @@ module li_calving
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
-      integer, dimension(:), intent(out) :: calvingFrontMaskCell !< Output: calving front mask
-      integer, dimension(:), intent(out) :: calvingFrontMaskEdge !< Output: calving front mask
+      integer, dimension(:), intent(out) :: calvingFrontMask !< Output: calving front mask
 
       !-----------------------------------------------------------------
       ! local variables
@@ -1925,8 +1652,8 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
 
-      calvingFrontMaskEdge = 0 !initialize
-      calvingFrontMaskCell = 0 !initialize
+      !calvingFrontMaskEdge = 0 !initialize
+      calvingFrontMask = 0 !initialize
 
       do iCell = 1, nCells
          if ( (li_mask_is_floating_ice(cellMask(iCell))) .and. (li_mask_is_dynamic_margin(cellMask(iCell))) ) then
@@ -1946,13 +1673,13 @@ module li_calving
                if (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) then
                   oceanNeighborEdge = .true. ! this is an open ocean neighbor
                endif
-               if (oceanNeighborEdge) then
-                  calvingFrontMaskEdge(edgesOnCell(iNeighbor, iCell)) = 1
-               endif
+               !if (oceanNeighborEdge) then
+               !   calvingFrontMaskEdge(edgesOnCell(iNeighbor, iCell)) = 1
+               !endif
                oceanNeighborCell = (oceanNeighborCell .or. oceanNeighborEdge)
             enddo
             if (oceanNeighborCell) then
-               calvingFrontMaskCell(iCell) = 1
+               calvingFrontMask(iCell) = 1
             endif
          endif
       enddo

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1175,6 +1175,9 @@ module li_calving
                     realArgs=(/minval(eigencalvingParameter), maxval(eigencalvingParameter)/))
          endif
 
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1382,8 +1382,6 @@ module li_calving
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell ! list of edges that neighbor each cell
-      integer, dimension(:,:), pointer :: verticesOnEdge
-      integer, dimension(:,:), pointer :: edgesOnVertex
       integer, dimension(:), pointer :: cellMask
       integer, pointer :: nCells
       integer :: iEdge, iNeighbor, iCell
@@ -1397,9 +1395,6 @@ module li_calving
       real(kind=RKIND) :: fracToUse
       real(kind=RKIND) :: uncalvedTotal
       real(kind=RKIND) :: calvingVolumeDesired
-      integer :: iVertNeighb, iVert, jEdgeNeighb, jEdge, i
-      integer, dimension(100) :: edgeList
-      logical :: alreadyFound
 
       err = 0
 
@@ -1413,8 +1408,6 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
       call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
@@ -1457,8 +1450,8 @@ module li_calving
             if (calvingVolumeDesired > 0.0_RKIND) then
                ! Calculate what fraction to take of total available ice to give
                fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
-               call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
-                       intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
+               !call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
+               !        intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
 
                ! Now actually set the amount to calve
                do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1475,70 +1468,9 @@ module li_calving
          endif ! if this is a downstream cell
       enddo
 
-      ! Make a second pass through non-dynamic cells. Find any that still have ice and try to
-      ! use up any required calving from their neighbors' neighbors
-      ! before moving on to upstream/dynamic cells.  This is to avoid accidentally stranding non-dynamic cells.
       do iCell = 1, nCells
-         if ((li_mask_is_floating_ice(cellMask(iCell))) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
-                 (cellVolume(iCell) > 0.0_RKIND) ) then
 
-            call mpas_log_write("Second pass for cell $i", intArgs=(/iCell/))
-
-            ! Find calving front edges adjacent to this cell's calving front edges
-            nNeighbors = 0
-            calvingVolumeDesired = 0.0_RKIND
-            edgeList(:) = -99
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(iNeighbor, iCell)
-               if (calvingFrontMaskEdge(iEdge) == 1) then
-                  call mpas_log_write("  Looking for edges on edge $i", intArgs=(/iEdge/))
-                  do iVertNeighb = 1, 2
-                     iVert = verticesOnEdge(iVertNeighb, iEdge)
-                     do jEdgeNeighb = 1, 3 ! ASSUMING VERTEXDEGREE IS 3
-                        jEdge = edgesOnVertex(jEdgeNeighb, iVert)
-                        if ((calvingFrontMaskEdge(jEdge) == 1) .and. (jEdge /= iEdge)) then
-                           ! Check if we already found this edge
-                           alreadyFound = .false.
-                           do i = 1, nNeighbors
-                              if (jEdge == edgeList(i)) then
-                                 alreadyFound= .true.
-                                 continue ! If we found this edge already, skip this.
-                              endif
-                           enddo
-                           if (.not. alreadyFound) then
-                              nNeighbors = nNeighbors + 1
-                              edgeList(nNeighbors) = jEdge
-                              call mpas_log_write("     Found edge on edge $i", intArgs=(/jEdge/))
-                              calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(jEdge)
-                           endif
-                        endif
-                     enddo
-                  enddo
-               endif
-            enddo
-
-            if (calvingVolumeDesired > 0.0_RKIND) then
-               ! Calculate what fraction to take of total available ice to give
-               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
-               call mpas_log_write("  Downstream Pass 2: cell=$i, num=$i, fracToUse=$r", &
-                       intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
-
-               ! Now actually set the amount to calve
-               do i = 1, nNeighbors
-                  jEdge = edgeList(i)
-                  removeVolumeHere = fracToUse * uncalvedVolume(jEdge)
-                  calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-                  uncalvedVolume(jEdge) = uncalvedVolume(jEdge) - removeVolumeHere
-                  cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-               enddo ! edge list
-            endif ! if there is calving to give
-
-         endif ! if this is a non-dynamic floating cell
-      enddo ! outer cell loop
-
-
-      ! 2. Loop over upstream (dynamic, bed below sea level) cells
-      do iCell = 1, nCells
+         ! 2. Loop over upstream (dynamic, bed below sea level) cells
          if (calvingFrontMaskCell(iCell)==1) then
             ! Find number of calving edges and total volume they have to offer
             nNeighbors = 0

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1434,7 +1434,7 @@ module li_calving
       do iCell = 1, nCells
 
          ! 1. Loop over downstream (non-dynamic, floating) cells
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(iCell))) then
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
 
             ! Find number of calving edges and total volume they have to offer
             nNeighbors = 0
@@ -1460,6 +1460,7 @@ module li_calving
                      removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
                      calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
                      uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
+                     cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
                   endif
                enddo
             endif

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1271,7 +1271,8 @@ module li_calving
                 cellCalvingFrontHeight = max(cellCalvingFrontHeight, thickness(jCell))
             enddo
 
-            cellCalvingFrontLength = sqrt(2.0/(3.0*sqrt(3.0))*areaCell(iCell))*2.0 !MJH Step 1
+!            cellCalvingFrontLength = sqrt(2.0/(3.0*sqrt(3.0))*areaCell(iCell))*2.0 !MJH Step 1
+            cellCalvingFrontLength = sqrt(1.0/2.0*sqrt(3.0)/6.0*areaCell(iCell))*2.0
 
             requiredCalvingVolumeRate(iCell) = calvingVelocity(iCell) * cellCalvingFrontLength * cellCalvingFrontHeight ! m^3/s
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1393,8 +1393,11 @@ module li_calving
       integer :: nNeighbors
       integer :: uncalvedCount
       real(kind=RKIND) :: fracToUse
+      real(kind=RKIND) :: fracToRemove
       real(kind=RKIND) :: uncalvedTotal
       real(kind=RKIND) :: calvingVolumeDesired
+      real(kind=RKIND) :: dsVolumeRemaining, calvingAvailable
+      real(kind=RKIND) :: calvingSubtotal
 
       err = 0
 
@@ -1419,6 +1422,8 @@ module li_calving
 
       cellVolume(:) = areaCell(:) * thickness(:)
 
+      call mpas_log_write("Beginning to distribute calving.  Total to be removed=$r", &
+              realArgs=(/sum(requiredCalvingVolume(:))/))
 
       ! The calving volume needs to be distributed in steps:
       ! 1. We need to first remove any downstream ice (non-dynamic) from the calving front edges
@@ -1431,9 +1436,10 @@ module li_calving
       !    remove ice "inland" of this cell until the total required mass is removed
       !    TODO: Not sure if this violates a CFL-like condition
 
+      ! 1. Loop over downstream (non-dynamic, floating) cells
+      calvingSubtotal = 0.0_RKIND
       do iCell = 1, nCells
 
-         ! 1. Loop over downstream (non-dynamic, floating) cells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
 
             ! Find number of calving edges and total volume they have to offer
@@ -1461,16 +1467,62 @@ module li_calving
                      calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
                      uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
                      cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+                     calvingSubtotal = calvingSubtotal + removeVolumeHere
                   endif
                enddo
             endif
 
          endif ! if this is a downstream cell
       enddo
+      call mpas_log_write("Phase 1 complete. Removed $r m^3 from downstream cells.", &
+              realArgs=(/calvingSubtotal/))
 
+
+
+      ! 1a. Try to eliminate any remaining downstream cells
+      calvingSubtotal = 0.0_RKIND
+      dsVolumeRemaining = 0.0_RKIND
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+             dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
+         endif ! if this is a downstream cell
+      enddo
+      calvingAvailable = sum(uncalvedVolume(:))
+      if ((calvingAvailable == 0.0_RKIND) .or. (dsVolumeRemaining == 0.0_RKIND)) then
+         fracToUse = 0.0_RKIND
+         fracToRemove = 0.0_RKIND
+      else
+         if (calvingAvailable > dsVolumeRemaining) then
+            fracToUse = dsVolumeRemaining / calvingAvailable
+            fracToRemove = 1.0_RKIND
+         else
+            fracToUse = 1.0_RKIND
+            fracToRemove = calvingAvailable / dsVolumeRemaining
+         endif
+      endif
+      call mpas_log_write("Step 1a.  dsVolRemaining=$r, calvingAvail=$r, fracToUse=$r, fracToRemove=$r", &
+              realArgs=(/dsVolumeRemaining, calvingAvailable, fracToUse, fracToRemove/))
+
+      ! Remove the ice
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+            removeVolumeHere = fracToRemove * cellVolume(iCell)
+            calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
+            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+            calvingSubtotal = calvingSubtotal + removeVolumeHere
+         endif
+      enddo
+      ! Update the volume remaining to be calved
+      uncalvedVolume(:) = (1.0_RKIND - fracToUse) * uncalvedVolume(:)
+      call mpas_log_write("Phase 1a complete. Removed $r m^3 from downstream cells.", &
+              realArgs=(/calvingSubtotal/))
+
+
+
+      ! 2. Loop over upstream (dynamic, bed below sea level) cells
+      calvingSubtotal = 0.0_RKIND
       do iCell = 1, nCells
 
-         ! 2. Loop over upstream (dynamic, bed below sea level) cells
          if (calvingFrontMaskCell(iCell)==1) then
             ! Find number of calving edges and total volume they have to offer
             nNeighbors = 0
@@ -1498,13 +1550,18 @@ module li_calving
                      removeVolumeHere = fracToUse * uncalvedVolume(iEdge)
                      calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
                      uncalvedVolume(iEdge) = uncalvedVolume(iEdge) - removeVolumeHere
+                     calvingSubtotal = calvingSubtotal + removeVolumeHere
                   endif
                enddo
             endif
          endif ! if a calving front cell
 
       enddo
+      call mpas_log_write("Phase 2 complete. Removed $r m^3 from upstream cells.", &
+              realArgs=(/calvingSubtotal/))
 
+      call mpas_log_write("Calving complete. Removed $r m^3.", &
+              realArgs=(/sum(calvingThickness*areaCell)/))
       if (maxval(uncalvedVolume) > 0.0_RKIND) then
 
          uncalvedTotal = sum(uncalvedVolume)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1290,46 +1290,46 @@ module li_calving
 
       call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
-      ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
-
-      !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
-      ! thickness<config_calving_thickness))
-      ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
-      ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
-      ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
-
-      ! This criteria below only remove too-thin ice at the new calving front,
-      ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
-      ! removing ice backward until all connected too-thin ice has been removed.
-      ! Tests of the current implementation show reasonable behavior.
-      where (calvingFrontMaskCell == 1 .and. thickness<config_calving_thickness)
-         calvingThickness = calvingThickness + thickness
-         thickness = 0.0_RKIND
-      end where
-
-      ! update mask
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-      err = ior(err, err_tmp)
-
-      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-      do iCell = 1, nCells
-        if (li_mask_is_floating_ice(cellMask(iCell))) then
-           ! check neighbors for dynamic ice (floating or grounded)
-           dynamicNeighbor = .false.
-           do iNeighbor = 1, nEdgesOnCell(iCell)
-              jCell = cellsOnCell(iNeighbor, iCell)
-              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-           enddo
-           if (.not. dynamicNeighbor) then  ! calve this ice
-              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-              thickness(iCell) = 0.0_RKIND
-           endif
-        endif
-      enddo
-
-      call remove_small_islands(meshPool, geometryPool)
+!      ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
+!
+!      !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
+!      ! thickness<config_calving_thickness))
+!      ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
+!      ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
+!      ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
+!
+!      ! This criteria below only remove too-thin ice at the new calving front,
+!      ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
+!      ! removing ice backward until all connected too-thin ice has been removed.
+!      ! Tests of the current implementation show reasonable behavior.
+!      where (calvingFrontMaskCell == 1 .and. thickness<config_calving_thickness)
+!         calvingThickness = calvingThickness + thickness
+!         thickness = 0.0_RKIND
+!      end where
+!
+!      ! update mask
+!      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+!      err = ior(err, err_tmp)
+!
+!      ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+!      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+!      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+!      do iCell = 1, nCells
+!        if (li_mask_is_floating_ice(cellMask(iCell))) then
+!           ! check neighbors for dynamic ice (floating or grounded)
+!           dynamicNeighbor = .false.
+!           do iNeighbor = 1, nEdgesOnCell(iCell)
+!              jCell = cellsOnCell(iNeighbor, iCell)
+!              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+!           enddo
+!           if (.not. dynamicNeighbor) then  ! calve this ice
+!              calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+!              thickness(iCell) = 0.0_RKIND
+!           endif
+!        endif
+!      enddo
+!
+!      call remove_small_islands(meshPool, geometryPool)
 
     end subroutine remove_calving_ice
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1285,7 +1285,7 @@ module li_calving
 !> perpendicular to the calving flux.
 !>
 !> The output of this routine is calvingThickness, which then needs to be applied to thickness
-!> by the calling routine.  A halo update on calvingThickness is required before applying it!
+!> by the calling routine.
 !-----------------------------------------------------------------------
 
    subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
@@ -1336,7 +1336,9 @@ module li_calving
       real(kind=RKIND) :: thkSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
-      real(kind=RKIND) :: volumeAvailableToPass
+      real(kind=RKIND) :: volumeAvailableToPass !< a temp. var. for accounting purposes that indicates how much volume
+                          !< to be calved is 'leftover' after trying to calve non-dynamic cells and can be transferred to
+                          !< neighboring dynamic cells
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
@@ -1378,7 +1380,7 @@ module li_calving
 
       groundedMarineMarginMask(:) = 0
       do iCell = 1, nCells
-         ! Define marine m      arginal cells as those that are (1) at the ice
+         ! Define grounded marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
@@ -1461,7 +1463,7 @@ module li_calving
                           requiredCalvingVolumeNonDynEdge(iEdge) ! Keep running total
                endif
             enddo
-            ! c. Apply calving here
+            ! c. Calculate calvingThickness here
             removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeNonDynCell(iCell))  ! Don't use more than available
             calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
             calvedVolumeNonDynCell(iCell) = removeVolumeHere
@@ -1509,7 +1511,7 @@ module li_calving
 
             volumeAvailableToPass = uncalvedVolumeNonDynCell(iCell)
 
-            ! Find total length of interface with dynamic cells at this cell
+            ! Find total length of interface with dynamic cells at this cell (i.e. calculate calvLengthCell)
             calvLengthCell = 0.0_RKIND
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
@@ -1520,7 +1522,7 @@ module li_calving
                endif
             enddo
 
-            ! Now pass along the required calving volume relative to the interface length
+            ! Now that we know calvLengthCell, pass along the required calving volume relative to the interface length
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
@@ -1545,7 +1547,7 @@ module li_calving
       call mpas_dmpar_field_halo_exch(domain, 'requiredCalvingVolumeDynEdge')
       call mpas_timer_stop("halo updates")
 
-      ! c. Now apply calving to each cell
+      ! c. Now calculate calvingThickness for each cell
       do iCell = 1, nCellsSolve
          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
             ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1302,13 +1302,14 @@ module li_calving
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
 
-      integer, pointer :: nEdges, nCells, nCellsSolve
+      integer, pointer :: nEdges, nCells, nCellsSolve, nEmptyNeighbors
       integer :: iEdge, iCell, jCell, iNeighbor
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, edgeMask
+      integer, dimension(:), pointer :: groundedMarineMarginMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: dvEdge
@@ -1358,10 +1359,44 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolumeNonDynCell', uncalvedVolumeNonDynCell)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolumeDynCell', uncalvedVolumeDynCell)
+      call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
+      do iCell = 1, nCellsSolve
+      ! Define marine marginal cells as those that are (1) at the ice
+      ! margin, (2) have at least one neighboring cell without ice, (3)
+      ! contain
+      ! grounded ice, and (4) have bed topography below sea level.
+      ! OR is adjacent to an inactive floating margin cell
+        nEmptyNeighbors = 0
+      ! Check if neighboring cells contain ice and have bed topo below sea
+      ! level
+        do iEdge = 1, nEdgesOnCell(iCell)
+           iNeighbor = cellsOnCell(iEdge, iCell)
+           if ( ((thickness(iNeighbor) == 0.0_RKIND) & 
+              .and. bedTopography(iNeighbor) < config_sea_level) &
+              .or. (li_mask_is_floating_ice(cellMask(iNeighbor)) & 
+              .and. li_mask_is_margin(cellMask(iNeighbor)) &
+              .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor))))) then
+               nEmptyNeighbors = nEmptyNeighbors + 1
+           endif
+        enddo 
+        
+        if ( nEmptyNeighbors > 0 &
+           .and. thickness(iCell) > 0.0_RKIND &
+           .and. li_mask_is_grounded_ice(cellMask(iCell)) &
+           .and. bedTopography(iCell) < config_sea_level &
+           .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
+                
+            groundedMarineMarginMask(iCell) = 1
+        else 
+            groundedMarineMarginMask(iCell) = 0
+        endif
+
+     enddo
+ 
 
       ! Init fields for accounting
       calvingThickness(:) = 0.0_RKIND
@@ -1432,8 +1467,8 @@ module li_calving
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
-                 li_mask_is_margin(cellMask(iCell)) ) then
+         if ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
+                 li_mask_is_margin(cellMask(iCell))) .or.  (groundedMarineMarginMask(iCell) == 1) ) then
             ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
             openOceanNeighbor = .false.
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1458,7 +1493,7 @@ module li_calving
       ! b. copy calving remaining in non-dynamic cells to dynamic edges
       ! Assume height and velocity are uniform, but edge length is not.
       do iCell = 1, nCellsSolve
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
+         if ( (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
                  uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
             ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
 
@@ -1496,8 +1531,8 @@ module li_calving
 
       ! c. Now apply calving to each cell
       do iCell = 1, nCellsSolve
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
-                 li_mask_is_dynamic_margin(cellMask(iCell)) ) then
+         if ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
+                 li_mask_is_dynamic_margin(cellMask(iCell)) ) .or. (groundedMarineMarginMask(iCell) == 1) ) then
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                ! No need to check what type of edge this is - only required edges are nonzero

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1155,6 +1155,8 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
 
 
          ! get parameter value

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1294,7 +1294,7 @@ module li_calving
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
 
-      integer, pointer :: nEdges, nCells
+      integer, pointer :: nEdges, nCells, nCellsSolve
       integer :: iEdge, iCell, jCell, iNeighbor
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
@@ -1316,16 +1316,20 @@ module li_calving
       real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeDynEdge, requiredCalvingVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
-      real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2
+      real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2, calvingSubtotal3
       real(kind=RKIND) :: thkSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
-      real(kind=RKIND), dimension(5) :: localInfo, globalInfo
+      real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       logical :: openOceanNeighbor
       real(kind=RKIND) :: edgeLengthScaling
       real(kind=RKIND), parameter :: calvingSmallThk = 1.0e-8 ! in meters, a small thickness threshold
+      integer :: err_tmp
+
+      err = 0
+      err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
@@ -1335,6 +1339,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
       call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
@@ -1369,7 +1374,7 @@ module li_calving
 
       ! 1. Calculate calving rate for all non-dynamic cells by working with their ocean-going edges
       calvingSubtotal1 = 0.0_RKIND
-      do iCell = 1, nCells
+      do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ! a. Translate the calving front height based on dynamic cells to the non-dynamic locations
             ! find mean (or min?) of thickness in dynamic neighbors
@@ -1383,9 +1388,8 @@ module li_calving
                endif
             enddo
             if (thkCount == 0) then
-               call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
-                  intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
-               ! TODO: Make an error? Print a warning?  Suppress?)
+               !call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
+               !   intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
             else
                thicknessForCalving(iCell) = thkSum / real(thkCount, kind=RKIND)
             endif
@@ -1412,15 +1416,14 @@ module li_calving
             calvingSubtotal1 = calvingSubtotal1 + removeVolumeHere
          endif
       enddo
-      call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
-
+      !call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
 
       ! 2. Calculate calving for dynamic cells
       calvingSubtotal2 = 0.0_RKIND
 
       ! a. Calculate calving on dynamic margin edges
-      do iCell = 1, nCells
+      do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
                  li_mask_is_margin(cellMask(iCell)) ) then
             ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
@@ -1446,7 +1449,7 @@ module li_calving
 
       ! b. copy calving remaining in non-dynamic cells to dynamic edges
       ! Assume height and velocity are uniform, but edge length is not.
-      do iCell = 1, nCells
+      do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
                  uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
             ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
@@ -1484,7 +1487,7 @@ module li_calving
       enddo
 
       ! c. Now apply calving to each cell
-      do iCell = 1, nCells
+      do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
                  li_mask_is_dynamic_margin(cellMask(iCell)) ) then
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1501,33 +1504,76 @@ module li_calving
             calvingSubtotal2 = calvingSubtotal2 + removeVolumeHere
          endif
       enddo
-      call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+      !call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
 
 
       ! Clean up to account for roundoff level errors that can occur
-      do iCell = 1, nCells
+      do iCell = 1, nCellsSolve
          if (abs(calvingThickness(iCell) - thickness(iCell)) < calvingSmallThk) then
             calvingThickness(iCell) = thickness(iCell)
          endif
       enddo
 
+      ! Clean up - zap any stranded ice
+      calvingSubtotal3 = 0.0_RKIND
+      do iCell = 1, nCellsSolve
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+            thkCount = 0
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_dynamic_ice(cellMask(jCell))) then
+                  thkCount = thkCount + 1
+               endif
+            enddo
+            if (thkCount == 0) then
+               calvingThickness(iCell) = thickness(iCell)
+               calvingSubtotal3 = calvingSubtotal3 + calvingThickness(iCell)
+            endif
+         endif
+         if (isnan(areaCell(iCell))) then
+            call mpas_log_write("NaN detected in calvingThickness at cell $i", MPAS_LOG_ERR, intArgs=(/iCell/))
+            err_tmp = 1
+            err = ior(err, err_tmp)
+         endif
+      enddo
+
 
       ! End of routine accounting/reporting
-      localInfo(1) = sum(calvingThickness*areaCell)
-      localInfo(2) = calvingSubtotal1
-      localInfo(3) = calvingSubtotal2
-      localInfo(4) = sum(uncalvedVolumeNonDynCell)
-      localInfo(5) = sum(uncalvedVolumeDynCell)
+      localInfo(1) = calvingSubtotal1
+      localInfo(2) = calvingSubtotal2
+      localInfo(3) = calvingSubtotal3
+      localInfo(4) = sum(calvingThickness(1:nCellsSolve) * areaCell(1:nCellsSolve))
+      localInfo(5) = sum(uncalvedVolumeNonDynCell(1:nCellsSolve))
+      localInfo(6) = sum(uncalvedVolumeDynCell(1:nCellsSolve))
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
-      call mpas_dmpar_sum_real_array(domain % dminfo, 5, localInfo, globalInfo)
-      call mpas_log_write("Calving complete. Total calved=$r; Calved from non-dynamic cells=$r; Calved from dynamic cells=$r", &
-!              realArgs=(/sum(calvingThickness*areaCell), calvingSubtotal1, calvingSubtotal2/))
-              realArgs=(/globalInfo(1), globalInfo(2), globalInfo(3)/))
-      call mpas_log_write("   Uncalved volumes: Non-dynamic cells=$r; Dynamic cells=$r", &
-!              realArgs=(/sum(uncalvedVolumeNonDynCell), sum(uncalvedVolumeDynCell)/))
-              realArgs=(/globalInfo(4), globalInfo(5)/))
-      if (globalInfo(2) + globalInfo(3) > 0.0_RKIND) then
-         call mpas_log_write("Calving scheme failed to calve $r m^3.", MPAS_LOG_WARN, realArgs=(/globalInfo(2) + globalInfo(3)/))
+      call mpas_dmpar_sum_real_array(domain % dminfo, 6, localInfo, globalInfo)
+      call mpas_log_write("== Calving complete. Total calved                    = $r", realArgs = (/globalInfo(4)/))
+      call mpas_log_write("==                   Calved from non-dynamic cells   = $r", realArgs = (/globalInfo(1)/))
+      call mpas_log_write("==                   Calved from dynamic cells       = $r", realArgs = (/globalInfo(2)/))
+      call mpas_log_write("==                   Stranded floating cells deleted = $r", realArgs = (/globalInfo(3)/))
+      call mpas_log_write("== Uncalved volumes: Non-dynamic cells=$r; Dynamic cells=$r", realArgs=(/globalInfo(5),globalInfo(6)/))
+      if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.001_RKIND) .and. &
+          (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
+         call mpas_log_write("Calving scheme failed to calve $r m^3. ($r% of total calved)", MPAS_LOG_WARN, &
+                 realArgs=(/globalInfo(5) + globalInfo(6), &
+                 100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
+      endif
+      if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.1_RKIND) .and. &
+          (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
+         call mpas_log_write("Calving scheme failed to calve an amount greater than 10% of the ice calved.  " // &
+                 "Try reducing time step or apply_calving_velocity may need improvements.", &
+                 MPAS_LOG_ERR, realArgs=(/globalInfo(5) + globalInfo(6), &
+                 100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
+         err_tmp = 1
+         err = ior(err, err_tmp)
+      endif
+      if (globalInfo(3) / (globalInfo(4) + 1.0e-30_RKIND) > 0.01_RKIND) then
+         ! If stranded ice deletion results in more than a small amount of the total calving flux, this routine will not
+         ! be accurate.  If this error gets triggered, either try using a smaller timstep or this routine needs improving.
+         call mpas_log_write("Deleting stranded floating cells accounts for more than 1% of calving loss." // &
+                 "  Try using a smaller timestep or apply_calving_velocity may need improvements for this simulation.")
+         err_tmp = 1
+         err = ior(err, err_tmp)
       endif
 
 
@@ -1546,6 +1592,7 @@ module li_calving
       deallocate(thicknessForCalving)
 
     end subroutine apply_calving_velocity
+
 
     ! Helper function for subroutine apply_calving_velocity
     ! Calculates the amount to scale an edge length based on the orientation of the edge with the surface velocity

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1382,6 +1382,8 @@ module li_calving
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell ! list of edges that neighbor each cell
+      integer, dimension(:,:), pointer :: verticesOnEdge
+      integer, dimension(:,:), pointer :: edgesOnVertex
       integer, dimension(:), pointer :: cellMask
       integer, pointer :: nCells
       integer :: iEdge, iNeighbor, iCell
@@ -1395,6 +1397,9 @@ module li_calving
       real(kind=RKIND) :: fracToUse
       real(kind=RKIND) :: uncalvedTotal
       real(kind=RKIND) :: calvingVolumeDesired
+      integer :: iVertNeighb, iVert, jEdgeNeighb, jEdge, i
+      integer, dimension(100) :: edgeList
+      logical :: alreadyFound
 
       err = 0
 
@@ -1408,6 +1413,8 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
+      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
       call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
@@ -1450,8 +1457,8 @@ module li_calving
             if (calvingVolumeDesired > 0.0_RKIND) then
                ! Calculate what fraction to take of total available ice to give
                fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
-               !call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
-               !        intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
+               call mpas_log_write("Downstream: cell=$i, num=$i, fracToUse=$r", &
+                       intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
 
                ! Now actually set the amount to calve
                do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1468,9 +1475,70 @@ module li_calving
          endif ! if this is a downstream cell
       enddo
 
+      ! Make a second pass through non-dynamic cells. Find any that still have ice and try to
+      ! use up any required calving from their neighbors' neighbors
+      ! before moving on to upstream/dynamic cells.  This is to avoid accidentally stranding non-dynamic cells.
       do iCell = 1, nCells
+         if ((li_mask_is_floating_ice(cellMask(iCell))) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
+                 (cellVolume(iCell) > 0.0_RKIND) ) then
 
-         ! 2. Loop over upstream (dynamic, bed below sea level) cells
+            call mpas_log_write("Second pass for cell $i", intArgs=(/iCell/))
+
+            ! Find calving front edges adjacent to this cell's calving front edges
+            nNeighbors = 0
+            calvingVolumeDesired = 0.0_RKIND
+            edgeList(:) = -99
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (calvingFrontMaskEdge(iEdge) == 1) then
+                  call mpas_log_write("  Looking for edges on edge $i", intArgs=(/iEdge/))
+                  do iVertNeighb = 1, 2
+                     iVert = verticesOnEdge(iVertNeighb, iEdge)
+                     do jEdgeNeighb = 1, 3 ! ASSUMING VERTEXDEGREE IS 3
+                        jEdge = edgesOnVertex(jEdgeNeighb, iVert)
+                        if ((calvingFrontMaskEdge(jEdge) == 1) .and. (jEdge /= iEdge)) then
+                           ! Check if we already found this edge
+                           alreadyFound = .false.
+                           do i = 1, nNeighbors
+                              if (jEdge == edgeList(i)) then
+                                 alreadyFound= .true.
+                                 continue ! If we found this edge already, skip this.
+                              endif
+                           enddo
+                           if (.not. alreadyFound) then
+                              nNeighbors = nNeighbors + 1
+                              edgeList(nNeighbors) = jEdge
+                              call mpas_log_write("     Found edge on edge $i", intArgs=(/jEdge/))
+                              calvingVolumeDesired = calvingVolumeDesired + uncalvedVolume(jEdge)
+                           endif
+                        endif
+                     enddo
+                  enddo
+               endif
+            enddo
+
+            if (calvingVolumeDesired > 0.0_RKIND) then
+               ! Calculate what fraction to take of total available ice to give
+               fracToUse = min(cellVolume(iCell) / calvingVolumeDesired, 1.0_RKIND)
+               call mpas_log_write("  Downstream Pass 2: cell=$i, num=$i, fracToUse=$r", &
+                       intArgs=(/iCell, nNeighbors/), realArgs=(/fracToUse/))
+
+               ! Now actually set the amount to calve
+               do i = 1, nNeighbors
+                  jEdge = edgeList(i)
+                  removeVolumeHere = fracToUse * uncalvedVolume(jEdge)
+                  calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
+                  uncalvedVolume(jEdge) = uncalvedVolume(jEdge) - removeVolumeHere
+                  cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+               enddo ! edge list
+            endif ! if there is calving to give
+
+         endif ! if this is a non-dynamic floating cell
+      enddo ! outer cell loop
+
+
+      ! 2. Loop over upstream (dynamic, bed below sea level) cells
+      do iCell = 1, nCells
          if (calvingFrontMaskCell(iCell)==1) then
             ! Find number of calving edges and total volume they have to offer
             nNeighbors = 0

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1179,7 +1179,9 @@ module li_calving
 !         calvingVelocity(:) = abs(calvingVelocity(:) * cos(angleEdge(:)))
 
 
-         call apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
+         ! Convert calvingVelocity to calvingThickness
+         call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -1272,21 +1274,21 @@ module li_calving
 !> perpendicular to the calving flux.
 !>
 !> The output of this routine is calvingThickness, which then needs to be applied to thickness
-!> by the calling routine.
+!> by the calling routine.  A halo update on calvingThickness is required before applying it!
 !-----------------------------------------------------------------------
 
-   subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
+   subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
-      type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
       type (mpas_pool_type), pointer, intent(in) :: velocityPool !< Input: velocity pool
 
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain          !< Input: domain object
       type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
 
       !-----------------------------------------------------------------
@@ -1319,6 +1321,7 @@ module li_calving
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
+      real(kind=RKIND), dimension(5) :: localInfo, globalInfo
       logical :: openOceanNeighbor
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
@@ -1356,6 +1359,7 @@ module li_calving
       requiredCalvingVolumeDynCell(:) = 0.0_RKIND
       allocate(thicknessForCalving(nCells+1))
       thicknessForCalving = 0.0_RKIND
+
 
 
       ! 1. Calculate calving rate for all non-dynamic cells by working with their ocean-going edges
@@ -1405,7 +1409,8 @@ module li_calving
       call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
 
-      ! 4. Calculate calving for dynamic cells
+
+      ! 2. Calculate calving for dynamic cells
       calvingSubtotal2 = 0.0_RKIND
 
       ! a. Calculate calving on dynamic margin edges
@@ -1492,25 +1497,30 @@ module li_calving
 
 
       ! End of routine accounting/reporting
+      localInfo(1) = sum(calvingThickness*areaCell)
+      localInfo(2) = calvingSubtotal1
+      localInfo(3) = calvingSubtotal2
+      localInfo(4) = sum(uncalvedVolumeNonDynCell)
+      localInfo(5) = sum(uncalvedVolumeDynCell)
+      ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+      call mpas_dmpar_sum_real_array(domain % dminfo, 5, localInfo, globalInfo)
       call mpas_log_write("Calving complete. Total calved=$r; Calved from non-dynamic cells=$r; Calved from dynamic cells=$r", &
-              realArgs=(/sum(calvingThickness*areaCell), calvingSubtotal1, calvingSubtotal2/))
+!              realArgs=(/sum(calvingThickness*areaCell), calvingSubtotal1, calvingSubtotal2/))
+              realArgs=(/globalInfo(1), globalInfo(2), globalInfo(3)/))
       call mpas_log_write("   Uncalved volumes: Non-dynamic cells=$r; Dynamic cells=$r", &
-              realArgs=(/sum(uncalvedVolumeNonDynCell), sum(uncalvedVolumeDynCell)/))
-!      if (maxval(uncalvedVolume) > 0.0_RKIND) then
-!
-!         uncalvedTotal = sum(uncalvedVolume)
-!         uncalvedCount = count(uncalvedVolume > 0.0_RKIND)
-!
-!         call mpas_log_write("distribute_calving_flux failed to distribute all required ice - " // &
-!                    " ice was left after depleting all neighbors." // &
-!                    "  Search needs to be expanded to neighbors' neighbors.")
-!         call mpas_log_write("   On this processor: $i edges contain uncalved ice, " // &
-!                 "for a total uncalved volume of $r m^3 ($r%).", &
-!                 MPAS_LOG_WARN, intArgs=(/uncalvedCount/), &
-!                 realArgs=(/uncalvedTotal, 100.0_RKIND * uncalvedTotal/sum(requiredCalvingVolume(:))/))
-!         ! TODO: Global reduce
-!      endif
+!              realArgs=(/sum(uncalvedVolumeNonDynCell), sum(uncalvedVolumeDynCell)/))
+              realArgs=(/globalInfo(4), globalInfo(5)/))
+      if (globalInfo(2) + globalInfo(3) > 0.0_RKIND) then
+         call mpas_log_write("Calving scheme failed to calve $r m^3.", MPAS_LOG_WARN, realArgs=(/globalInfo(2) + globalInfo(3)/))
+      endif
 
+
+      ! Update halos on calvingThickness before applying it.
+      ! Testing seemed to indicate this is not necessary, but I don't understand why not, so leaving it.
+      ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+      call mpas_timer_stop("halo updates")
 
       deallocate(cellVolume)
       deallocate(requiredCalvingVolumeNonDynEdge)
@@ -1518,7 +1528,6 @@ module li_calving
       deallocate(requiredCalvingVolumeDynEdge)
       deallocate(requiredCalvingVolumeDynCell)
       deallocate(thicknessForCalving)
-
 
     end subroutine apply_calving_velocity
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1165,10 +1165,10 @@ module li_calving
 
          calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK
 
-         calvingVelocity(:) = abs(calvingVelocity(:) * cos(angleEdge(:)))
+!         calvingVelocity(:) = abs(calvingVelocity(:) * cos(angleEdge(:)))
 
 
-         call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
+         call apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
          
          block => block % next
 
@@ -1179,19 +1179,40 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine remove_calving_ice
+!    routine apply_calving_velocity
 !
-!> \brief remove the calving ice volume based on calving velocity or damage threshold value
-!> \author Matthew Hoffman, Tong Zhang
+!> \brief Convert a calving velocity to an ice thickness removal
+!> \author Matthew Hoffman
 !> \date   March 2020
-!> \details this subroutine is splitted from the original eigencalving subroutine, and 
-!> is now used by both eigencalving and damagecalving. The damagecalving contains two 
-!> different calving methods: 1) using a calvingVelocity like eigencalving, and
-!> 2) remove the whole ice column if the damage value > a threshold, both are 
-!> incorporated together in the same distribute_calving_flux subroutine
+!> \details This routine takes a calving velocity and converts it to a
+!> thickness removal.  The basic idea is to multiply the calving velocity
+!> by the edge length and height to get a volume flux.  However, the details
+!> are complicated by the unstructured Voronoi mesh and the use of partially-filled
+!> non-dynamic floating grid cells.
+!> The algorithm calculates the required calving volume flux based on edges, and then
+!> applies the volume removal to grid cells, converting that to a thickness removal using areaCell.
+!> This process occurs in phases.
+!>
+!> The first phase handles non-dynamic floating cells. This is done by calculating the required calving flux
+!> at the edges between those non-dynamic floating cells and the open ocean.
+!> The calving velocity and ice thickness are copied from the upstream dynamic
+!> floating cells, because these quantities do not have valid values on the non-dynamic cells.
+!> After calculating the calving flux determined at each of these edges, the non-dyamic floating cells
+!> are looped over, and volume is marked for removal based on the calving flux on the edges of each cell.
+!>
+!> The final phase handles dynamic floating cells that are eligible for calving.
+!> There are two ways this can happen - either they are adjacent to the open ocean (no buffer of
+!> non-dynamic cells present), or they are adjacent to non-dynamic floating cells that had their
+!> entire volume removed by calving, but there still is calving demand remaining.
+!> The first case is handled easily by calculating calving flux on edges between dynamic floating cells
+!> and open ocean using the calving velocity and ice thickness of the dynamic cell itself.
+!> In the second case, "leftover" required calving flux is distributed from a non-dynamic cell that
+!> has been completely "drained" to any edges between that non-dynamic cell and dynamic cells upstream.
+!> This is done by weighting the flux to be distrbuted by the length of each such edge in the direction
+!> perpendicular to the calving flux.
 !-----------------------------------------------------------------------
 
-   subroutine remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
+   subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, scratchPool, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1218,25 +1239,36 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: cellsOnEdge
-      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:), pointer :: cellMask, edgeMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: config_calving_thickness
       logical :: dynamicNeighbor
       real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
+      real (kind=RKIND), dimension(:), allocatable :: thicknessForCalving
+      real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeNonDynCell
+      real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeDynEdge, requiredCalvingVolumeDynCell
+      real (kind=RKIND), dimension(:), allocatable :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
+      real (kind=RKIND), dimension(:), allocatable :: cellVolume
+      real(kind=RKIND) :: calvingSubtotal
+      real(kind=RKIND) :: thkSum, thkCount
+      real(kind=RKIND) :: removeVolumeHere
+      real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       integer :: err_tmp
 
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
@@ -1244,6 +1276,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingFrontMaskCell', calvingFrontMaskCell)
       call mpas_pool_get_array(geometryPool, 'calvingFrontMaskEdge', calvingFrontMaskEdge)
@@ -1255,31 +1288,146 @@ module li_calving
       ! This is last dynamic cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
       call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
-      requiredCalvingVolume(:) = 0.0_RKIND
 
-      do iEdge = 1, nEdges
-          if (calvingFrontMaskEdge(iEdge) == 1) then
+      ! Init fields for accounting
+      calvingThickness(:) = 0.0_RKIND
+      allocate(cellVolume(nCells+1))
+      cellVolume(:) = areaCell(:) * thickness(:)
+      allocate(requiredCalvingVolumeNonDynEdge(nEdges+1))
+      allocate(requiredCalvingVolumeNonDynCell(nCells+1))
+      allocate(requiredCalvingVolumeDynEdge(nEdges+1))
+      allocate(requiredCalvingVolumeDynCell(nCells+1))
+      requiredCalvingVolumeNonDynEdge(:) = 0.0_RKIND
+      requiredCalvingVolumeNonDynCell(:) = 0.0_RKIND
+      requiredCalvingVolumeDynEdge(:) = 0.0_RKIND
+      requiredCalvingVolumeDynCell(:) = 0.0_RKIND
+      allocate(uncalvedVolumeNonDynCell(nCells+1))
+      allocate(uncalvedVolumeDynCell(nCells+1))
+      uncalvedVolumeNonDynCell(:) = 0.0_RKIND
+      uncalvedVolumeDynCell(:) = 0.0_RKIND
+      allocate(thicknessForCalving(nCells+1))
+      thicknessForCalving = 0.0_RKIND
 
-             ! convert to a volume flux per cell masking some assumptions
-             ! get front length from edge lengths abutting ocean or thin ice
-             edgeCalvingFrontLength = dvEdge(iEdge)
-             ! get front height from thickness of upstream (dynamic) neighbor
-             do iNeighbor = 1, 2
-                jCell = cellsOnEdge(iNeighbor, iEdge)
-                if ( li_mask_is_dynamic_ice(cellMask(jCell))) then
-                   edgeCalvingFrontHeight = thickness(jCell)
-                endif
+
+      ! 1. Calculate calving rate for all non-dynamic cells by working with their ocean-going edges
+      calvingSubtotal = 0.0_RKIND
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+            ! a. Translate the calving front height based on dynamic cells to the non-dynamic locations
+            ! find mean (or min?) of thickness in dynamic neighbors
+            thkSum = 0.0_RKIND
+            thkCount = 0
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_dynamic_ice(cellMask(jCell))) then
+                  thkSum = thkSum + thickness(jCell)
+                  thkCount = thkCount + 1
+               endif
             enddo
+            if (thkCount == 0) then
+               call mpas_log_write("Found a stranded non-dynamic floating cell!", MPAS_LOG_WARN)
+               ! TODO: Make an error? Print a warning?  Suppress?)
+            else
+               thicknessForCalving(iCell) = thkSum / real(thkCount, kind=RKIND)
+            endif
+            ! b. Translate the calvingVelocity and thickness from non-dynamic cells to their ocean-going edges
+            !    to calculate the calving volume on those edges and this cell
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (li_mask_is_floating_ice(edgeMask(iEdge)) .and. li_mask_is_margin(edgeMask(iEdge))) then
+                  requiredCalvingVolumeNonDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
+                          * thicknessForCalving(iCell) * deltat
+                  ! TODO: Change cos to use flow velo!
+                  requiredCalvingVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) + &
+                          requiredCalvingVolumeNonDynEdge(iEdge) ! Keep running total
+               endif
+            enddo
+            ! c. Apply calving here
+            removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeNonDynCell(iCell))  ! Don't use more than available
+            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            uncalvedVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) - removeVolumeHere
+            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+            calvingSubtotal = calvingSubtotal + removeVolumeHere
+         endif
+      enddo
+      call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal/))
 
-            ! TODO: dot product of velocity with edge orientation
-            requiredCalvingVolume(iEdge) = calvingVelocity(iEdge) * edgeCalvingFrontLength * edgeCalvingFrontHeight * deltat !m^3
 
-          endif
+      ! 4. Calculate calving for dynamic cells
+      calvingSubtotal = 0.0_RKIND
+
+      ! a. Calculate calving on dynamic margin edges
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
+                 li_mask_is_margin(cellMask(iCell)) ) then
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (li_mask_is_margin(edgeMask(iEdge))) then
+                  requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * abs(cos(angleEdge(iEdge))) * dvEdge(iEdge) &
+                          * thickness(iCell) * deltat
+               endif
+            enddo
+         endif
       enddo
 
-      call distribute_calving_flux(meshPool, geometryPool, scratchPool, calvingFrontMaskCell, calvingFrontMaskEdge, err_tmp)
+      ! b. copy calving remaining in non-dynamic cells to dynamic edges
+      ! Assume height and velocity are uniform, but edge length is not.
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
+                 uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
+            ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagateda
 
-      err = ior(err, err_tmp)
+            ! Find total length of interface with dynamic cells at this cell
+            calvLengthCell = 0.0_RKIND
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
+                  calvLengthEdge = abs(cos(angleEdge(iEdge))) * dvEdge(iEdge)
+                  calvLengthCell = calvLengthCell + calvLengthEdge
+               endif
+            enddo
+
+            ! Now pass along the required calving volume relative to the interface length
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
+                  calvLengthEdge = abs(cos(angleEdge(iEdge))) * dvEdge(iEdge)
+                  requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * uncalvedVolumeNonDynCell(iCell)
+               endif
+            enddo
+         endif
+      enddo
+
+      ! Now apply calving to each cell
+      do iCell = 1, nCells
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
+                 li_mask_is_dynamic_margin(cellMask(iCell)) ) then
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               ! No need to check what type of edge this is - only required edges are nonzero
+               requiredCalvingVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) + &
+                          requiredCalvingVolumeDynEdge(iEdge) ! Keep running total
+            enddo
+            ! c. Apply calving here
+            removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeDynCell(iCell))  ! Don't use more than available
+            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            uncalvedVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) - removeVolumeHere
+            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+            calvingSubtotal = calvingSubtotal + removeVolumeHere
+         endif
+      enddo
+      call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal/))
+
+
+      deallocate(cellVolume)
+      deallocate(requiredCalvingVolumeNonDynEdge)
+      deallocate(requiredCalvingVolumeNonDynCell)
+      deallocate(requiredCalvingVolumeDynEdge)
+      deallocate(requiredCalvingVolumeDynCell)
+      deallocate(thicknessForCalving)
+      deallocate(uncalvedVolumeNonDynCell)
+      deallocate(uncalvedVolumeDynCell)
 
       ! === apply calving ===
       thickness(:) = thickness(:) - calvingThickness(:)
@@ -1331,7 +1479,7 @@ module li_calving
 !
 !      call remove_small_islands(meshPool, geometryPool)
 
-    end subroutine remove_calving_ice
+    end subroutine apply_calving_velocity
 
 
 
@@ -1397,6 +1545,8 @@ module li_calving
       real(kind=RKIND) :: calvingVolumeDesired
       real(kind=RKIND) :: dsVolumeRemaining, calvingAvailable
       real(kind=RKIND) :: calvingSubtotal
+      logical :: dynamicNeighbor
+      integer :: jCell
 
       err = 0
 
@@ -1478,14 +1628,30 @@ module li_calving
 
 
 
-      ! 1a. Try to eliminate any remaining downstream cells
+      ! 1a. Try to eliminate any now stranded downstream cells
       calvingSubtotal = 0.0_RKIND
       dsVolumeRemaining = 0.0_RKIND
+      ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+      ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
       do iCell = 1, nCells
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
-             dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
-         endif ! if this is a downstream cell
+        if (li_mask_is_floating_ice(cellMask(iCell))) then
+           ! check neighbors for dynamic ice (floating or grounded)
+           dynamicNeighbor = .false.
+           do iNeighbor = 1, nEdgesOnCell(iCell)
+              jCell = cellsOnCell(iNeighbor, iCell)
+              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+           enddo
+           if (.not. dynamicNeighbor) then  ! calve this ice
+              dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
+           endif
+        endif
       enddo
+
+!      do iCell = 1, nCells
+!         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+!             dsVolumeRemaining = dsVolumeRemaining + cellVolume(iCell)
+!         endif ! if this is a downstream cell
+!      enddo
       calvingAvailable = sum(uncalvedVolume(:))
       if ((calvingAvailable == 0.0_RKIND) .or. (dsVolumeRemaining == 0.0_RKIND)) then
          fracToUse = 0.0_RKIND
@@ -1504,13 +1670,30 @@ module li_calving
 
       ! Remove the ice
       do iCell = 1, nCells
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+        if (li_mask_is_floating_ice(cellMask(iCell))) then
+           ! check neighbors for dynamic ice (floating or grounded)
+           dynamicNeighbor = .false.
+           do iNeighbor = 1, nEdgesOnCell(iCell)
+              jCell = cellsOnCell(iNeighbor, iCell)
+              if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+           enddo
+           if (.not. dynamicNeighbor) then  ! calve this ice
             removeVolumeHere = fracToRemove * cellVolume(iCell)
             calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             calvingSubtotal = calvingSubtotal + removeVolumeHere
-         endif
+           endif
+        endif
       enddo
+
+!      do iCell = 1, nCells
+!         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+!            removeVolumeHere = fracToRemove * cellVolume(iCell)
+!            calvingThickness(iCell) = calvingThickness(iCell) + removeVolumeHere / areaCell(iCell)
+!            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+!            calvingSubtotal = calvingSubtotal + removeVolumeHere
+!         endif
+!      enddo
       ! Update the volume remaining to be calved
       uncalvedVolume(:) = (1.0_RKIND - fracToUse) * uncalvedVolume(:)
       call mpas_log_write("Phase 1a complete. Removed $r m^3 from downstream cells.", &

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1233,7 +1233,6 @@ module li_calving
 
       integer, pointer :: nEdges, nCells
       integer :: iEdge, iCell, jCell, iNeighbor
-      integer, dimension(:), pointer :: calvingFrontMaskCell, calvingFrontMaskEdge
       real (kind=RKIND) :: edgeCalvingFrontLength, edgeCalvingFrontHeight
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolume
       real (kind=RKIND), dimension(:), pointer :: thickness
@@ -1254,11 +1253,12 @@ module li_calving
       real (kind=RKIND), dimension(:), allocatable :: thicknessForCalving
       real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeNonDynCell
       real (kind=RKIND), dimension(:), allocatable :: requiredCalvingVolumeDynEdge, requiredCalvingVolumeDynCell
-      real (kind=RKIND), dimension(:), allocatable :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
+      real (kind=RKIND), dimension(:), pointer :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
-      real(kind=RKIND) :: calvingSubtotal
+      real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2
       real(kind=RKIND) :: thkSum, thkCount
       real(kind=RKIND) :: removeVolumeHere
+      real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       logical :: openOceanNeighbor
       integer :: err_tmp
@@ -1279,15 +1279,11 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'calvingFrontMaskCell', calvingFrontMaskCell)
-      call mpas_pool_get_array(geometryPool, 'calvingFrontMaskEdge', calvingFrontMaskEdge)
+      call mpas_pool_get_array(geometryPool, 'uncalvedVolumeNonDynCell', uncalvedVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'uncalvedVolumeDynCell', uncalvedVolumeDynCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
-
-      ! make mask for effective calving front.
-      ! This is last dynamic cell, but also make sure it has a neighbor that is open ocean or thin floating ice.
-      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
 
       ! Init fields for accounting
@@ -1302,16 +1298,12 @@ module li_calving
       requiredCalvingVolumeNonDynCell(:) = 0.0_RKIND
       requiredCalvingVolumeDynEdge(:) = 0.0_RKIND
       requiredCalvingVolumeDynCell(:) = 0.0_RKIND
-      allocate(uncalvedVolumeNonDynCell(nCells+1))
-      allocate(uncalvedVolumeDynCell(nCells+1))
-      uncalvedVolumeNonDynCell(:) = 0.0_RKIND
-      uncalvedVolumeDynCell(:) = 0.0_RKIND
       allocate(thicknessForCalving(nCells+1))
       thicknessForCalving = 0.0_RKIND
 
 
       ! 1. Calculate calving rate for all non-dynamic cells by working with their ocean-going edges
-      calvingSubtotal = 0.0_RKIND
+      calvingSubtotal1 = 0.0_RKIND
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ! a. Translate the calving front height based on dynamic cells to the non-dynamic locations
@@ -1326,7 +1318,7 @@ module li_calving
                endif
             enddo
             if (thkCount == 0) then
-               call mpas_log_write("Found a stranded non-dynamic floating cell!", MPAS_LOG_WARN)
+               !call mpas_log_write("Found a stranded non-dynamic floating cell!", MPAS_LOG_WARN)
                ! TODO: Make an error? Print a warning?  Suppress?)
             else
                thicknessForCalving(iCell) = thkSum / real(thkCount, kind=RKIND)
@@ -1351,14 +1343,14 @@ module li_calving
             calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
             uncalvedVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            calvingSubtotal = calvingSubtotal + removeVolumeHere
+            calvingSubtotal1 = calvingSubtotal1 + removeVolumeHere
          endif
       enddo
-      call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal/))
+      call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
 
       ! 4. Calculate calving for dynamic cells
-      calvingSubtotal = 0.0_RKIND
+      calvingSubtotal2 = 0.0_RKIND
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCells
@@ -1389,7 +1381,12 @@ module li_calving
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
                  uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
-            ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagateda
+            ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
+
+            !call mpas_log_write("Passing calving from non-dynamic cell $i.  $r available to pass", &
+            !        realArgs=(/uncalvedVolumeNonDynCell(iCell)/), intArgs=(/iCell/))
+
+            volumeAvailableToPass = uncalvedVolumeNonDynCell(iCell)
 
             ! Find total length of interface with dynamic cells at this cell
             calvLengthCell = 0.0_RKIND
@@ -1407,13 +1404,16 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
                   calvLengthEdge = abs(cos(angleEdge(iEdge))) * dvEdge(iEdge)
-                  requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * uncalvedVolumeNonDynCell(iCell)
+                  requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * volumeAvailableToPass
+                  uncalvedVolumeNonDynCell(iCell) = uncalvedVolumeNonDynCell(iCell) - requiredCalvingVolumeDynEdge(iEdge)
+                  !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
+                  !        realArgs=(/requiredCalvingVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
                endif
             enddo
          endif
       enddo
 
-      ! Now apply calving to each cell
+      ! c. Now apply calving to each cell
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
                  li_mask_is_dynamic_margin(cellMask(iCell)) ) then
@@ -1428,10 +1428,32 @@ module li_calving
             calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
             uncalvedVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            calvingSubtotal = calvingSubtotal + removeVolumeHere
+            calvingSubtotal2 = calvingSubtotal2 + removeVolumeHere
          endif
       enddo
-      call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal/))
+      call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+
+
+
+      ! End of routine accounting/reporting
+      call mpas_log_write("Calving complete. Total calved=$r; Calved from non-dynamic cells=$r; Calved from dynamic cells=$r", &
+              realArgs=(/sum(calvingThickness*areaCell), calvingSubtotal1, calvingSubtotal2/))
+      call mpas_log_write("   Uncalved volumes: Non-dynamic cells=$r; Dynamic cells=$r", &
+              realArgs=(/sum(uncalvedVolumeNonDynCell), sum(uncalvedVolumeDynCell)/))
+!      if (maxval(uncalvedVolume) > 0.0_RKIND) then
+!
+!         uncalvedTotal = sum(uncalvedVolume)
+!         uncalvedCount = count(uncalvedVolume > 0.0_RKIND)
+!
+!         call mpas_log_write("distribute_calving_flux failed to distribute all required ice - " // &
+!                    " ice was left after depleting all neighbors." // &
+!                    "  Search needs to be expanded to neighbors' neighbors.")
+!         call mpas_log_write("   On this processor: $i edges contain uncalved ice, " // &
+!                 "for a total uncalved volume of $r m^3 ($r%).", &
+!                 MPAS_LOG_WARN, intArgs=(/uncalvedCount/), &
+!                 realArgs=(/uncalvedTotal, 100.0_RKIND * uncalvedTotal/sum(requiredCalvingVolume(:))/))
+!         ! TODO: Global reduce
+!      endif
 
 
       deallocate(cellVolume)
@@ -1440,8 +1462,6 @@ module li_calving
       deallocate(requiredCalvingVolumeDynEdge)
       deallocate(requiredCalvingVolumeDynCell)
       deallocate(thicknessForCalving)
-      deallocate(uncalvedVolumeNonDynCell)
-      deallocate(uncalvedVolumeDynCell)
 
       ! === apply calving ===
       thickness(:) = thickness(:) - calvingThickness(:)
@@ -1450,7 +1470,6 @@ module li_calving
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
       err = ior(err, err_tmp)
 
-      call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMaskCell, calvingFrontMaskEdge)
 
 !      ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1270,8 +1270,7 @@ module li_calving
                    edgeCalvingFrontHeight = thickness(jCell)
                 endif
             enddo
-            edgeCalvingFrontHeight = 300.0
-!  call mpas_log_write("edge=$i   Ht=$r", intArgs=(/iEdge/), realArgs=(/edgeCalvingFrontHeight/))
+
             ! TODO: dot product of velocity with edge orientation
             requiredCalvingVolume(iEdge) = calvingVelocity(iEdge) * edgeCalvingFrontLength * edgeCalvingFrontHeight * deltat !m^3
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1104,6 +1104,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
+      real (kind=RKIND), dimension(:), pointer :: angleEdge
       integer, dimension(:), pointer :: cellMask
       type (field1dInteger), pointer :: calvingFrontMaskField
       real (kind=RKIND), pointer :: deltat  !< time step (s)
@@ -1131,6 +1132,7 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
+         call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
@@ -1162,6 +1164,8 @@ module li_calving
                   ! calculate only for floating ice - map of "potential" calving rate
 
          calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK
+
+         calvingVelocity(:) = abs(calvingVelocity(:) * cos(angleEdge(:)))
 
 
          call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1302,8 +1302,9 @@ module li_calving
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
 
-      integer, pointer :: nEdges, nCells, nCellsSolve, nEmptyNeighbors
+      integer, pointer :: nEdges, nCells, nCellsSolve
       integer :: iEdge, iCell, jCell, iNeighbor
+      integer :: nEmptyNeighbors
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1332,7 +1333,6 @@ module li_calving
       real(kind=RKIND) :: volumeAvailableToPass
       real(kind=RKIND) :: calvLengthCell, calvLengthEdge
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
-      logical :: openOceanNeighbor
       real(kind=RKIND) :: edgeLengthScaling
       real(kind=RKIND), parameter :: calvingSmallThk = 1.0e-8 ! in meters, a small thickness threshold
       integer :: err_tmp
@@ -1364,42 +1364,42 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
-      do iCell = 1, nCellsSolve
-      ! Define marine marginal cells as those that are (1) at the ice
-      ! margin, (2) have at least one neighboring cell without ice, (3)
-      ! contain
-      ! grounded ice, and (4) have bed topography below sea level.
-      ! OR is adjacent to an inactive floating margin cell
-        nEmptyNeighbors = 0
-      ! Check if neighboring cells contain ice and have bed topo below sea
-      ! level
-        do iEdge = 1, nEdgesOnCell(iCell)
+      groundedMarineMarginMask(:) = 0
+      do iCell = 1, nCells
+         ! Define marine m      arginal cells as those that are (1) at the ice
+         ! margin, (2) have at least one neighboring cell without ice, (3) contain
+         ! grounded ice, and (4) have bed topography below sea level.
+         ! OR is adjacent to an inactive floating margin cell
+
+         ! Check if neighboring cells contain ice and have bed topo below sea level
+         nEmptyNeighbors = 0
+         do iEdge = 1, nEdgesOnCell(iCell)
            iNeighbor = cellsOnCell(iEdge, iCell)
-           if ( ((thickness(iNeighbor) == 0.0_RKIND) & 
-              .and. bedTopography(iNeighbor) < config_sea_level) &
-              .or. (li_mask_is_floating_ice(cellMask(iNeighbor)) & 
+           if ( (((thickness(iNeighbor) == 0.0_RKIND) &
+              .and. bedTopography(iNeighbor) < config_sea_level)) &
+              .or. ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
               .and. li_mask_is_margin(cellMask(iNeighbor)) &
-              .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor))))) then
+              .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
                nEmptyNeighbors = nEmptyNeighbors + 1
            endif
-        enddo 
-        
-        if ( nEmptyNeighbors > 0 &
-           .and. thickness(iCell) > 0.0_RKIND &
+         enddo
+
+         if ( nEmptyNeighbors > 0 &
            .and. li_mask_is_grounded_ice(cellMask(iCell)) &
            .and. bedTopography(iCell) < config_sea_level &
            .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
-                
-            groundedMarineMarginMask(iCell) = 1
-        else 
-            groundedMarineMarginMask(iCell) = 0
-        endif
 
-     enddo
- 
+            groundedMarineMarginMask(iCell) = 1
+         else
+            groundedMarineMarginMask(iCell) = 0
+         endif
+      enddo
+
 
       ! Init fields for accounting
       calvingThickness(:) = 0.0_RKIND
+      uncalvedVolumeNonDynCell(:) = 0.0_RKIND
+      uncalvedVolumeDynCell(:) = 0.0_RKIND
       allocate(cellVolume(nCells+1))
       cellVolume(:) = areaCell(:) * thickness(:)
       allocate(requiredCalvingVolumeNonDynEdge(nEdges+1))
@@ -1467,26 +1467,19 @@ module li_calving
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
-         if ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) .and. &
-                 li_mask_is_margin(cellMask(iCell))) .or.  (groundedMarineMarginMask(iCell) == 1) ) then
+         if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
+                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
+              .and. li_mask_is_margin(cellMask(iCell)) ) then
             ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
-            openOceanNeighbor = .false.
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
-                  openOceanNeighbor = .true.
+                  iEdge = edgesOnCell(iNeighbor, iCell)
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * &
+                          edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
                endif
             enddo
-            if (openOceanNeighbor) then
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(iNeighbor, iCell)
-                  if (li_mask_is_margin(edgeMask(iEdge))) then
-                     edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                     requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * &
-                          edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
-                  endif
-               enddo
-            endif
          endif
       enddo
 
@@ -1520,6 +1513,12 @@ module li_calving
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
                   calvLengthEdge = edgeLengthScaling * dvEdge(iEdge)
+                  if (requiredCalvingVolumeDynEdge(iEdge) > 0.0_RKIND) then
+                     call mpas_log_write("Unexpectedly found a dynamic edge that already has calving assigned to it." // &
+                           "  There is a flaw in apply_calving_velocity that needs to be fixed!", MPAS_LOG_ERR)
+                     err_tmp = 1
+                     err = ior(err, err_tmp)
+                  endif
                   requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * volumeAvailableToPass
                   uncalvedVolumeNonDynCell(iCell) = uncalvedVolumeNonDynCell(iCell) - requiredCalvingVolumeDynEdge(iEdge)
                   !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1157,8 +1157,8 @@ module li_calving
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
-         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
-               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+!         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
+!               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
 
          calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1223,6 +1223,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       type (field1dInteger), pointer :: calvingFrontMaskField
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer :: err_tmp
 
@@ -1240,6 +1241,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
 
       call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
       call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
@@ -1268,6 +1270,8 @@ module li_calving
                 endif
                 cellCalvingFrontHeight = max(cellCalvingFrontHeight, thickness(jCell))
             enddo
+
+            cellCalvingFrontLength = sqrt(2.0/(3.0*sqrt(3.0))*areaCell(iCell))*2.0 !MJH Step 1
 
             requiredCalvingVolumeRate(iCell) = calvingVelocity(iCell) * cellCalvingFrontLength * cellCalvingFrontHeight ! m^3/s
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1161,6 +1161,9 @@ module li_calving
                * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
 
+         calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value  !MJH HACK
+
+
          call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
          
          block => block % next

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -247,6 +247,7 @@ module li_time_integration_fe
 
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
+      integer, dimension(:), pointer :: edgeMask
 
       logical, pointer :: config_print_thickness_advection_info
       logical, pointer :: config_adaptive_timestep
@@ -329,6 +330,7 @@ module li_time_integration_fe
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
          call mpas_pool_get_array(velocityPool, 'normalVelocity', normalVelocity)
+         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
          call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
 
          ! compute normal velocities and advective CFL limit for this block
@@ -336,6 +338,7 @@ module li_time_integration_fe
          call li_layer_normal_velocity( &
               meshPool,               &
               normalVelocity,         &
+              edgeMask,               &
               layerNormalVelocity,    &
               allowableAdvecDt,       &
               err_tmp)

--- a/src/core_landice/shared/mpas_li_mask.F
+++ b/src/core_landice/shared/mpas_li_mask.F
@@ -358,7 +358,9 @@ contains
           if (li_mask_is_ice(cellMask(i))) then
               isMargin = .false.
               do j=1,nEdgesOnCell(i) ! Check if any neighbors are non-ice
-                  isMargin = ( isMargin .or. (.not. li_mask_is_ice(cellMask(cellsOnCell(j,i)))) )
+                  if (cellsOnCell(j,i) > 0) then
+                     isMargin = ( isMargin .or. (.not. li_mask_is_ice(cellMask(cellsOnCell(j,i)))) )
+                  endif
               enddo
               if (isMargin) then
                  cellMask(i) = ior(cellMask(i), li_mask_ValueMargin)


### PR DESCRIPTION
This merge rewrites the method for converting a calvingVelocity to a calvingThickness.

This requirement of this part of the code is to take a calving velocity and convert it to a
thickness to be removed.  The basic idea is (and was) to multiply the calving velocity
by the edge length and height to get a volume flux.  However, the details
are complicated by the unstructured Voronoi mesh and the use of partially-filled
non-dynamic floating grid cells.

The new algorithm rewrites this procedure.  It calculates the required calving volume flux based on edges, 
and then applies the volume removal to cells, converting that to a thickness removal using areaCell.
An important detail of the new scheme is that it assumes the direction of calvingVelocity is parallel to 
the ice surface velocity rather than perpendicular to every edge.

This ice removal process occurs in two phases:

The first phase handles non-dynamic floating cells. This is done by calculating the required calving flux
at the edges between those non-dynamic floating cells and the open ocean.
The calving velocity and ice thickness are copied from the upstream dynamic
floating cells, because these quantities do not have valid values on the non-dynamic cells.
After calculating the calving flux determined at each of these edges, the non-dyamic floating cells
are looped over, and volume is marked for removal based on the calving flux on the edges of each cell.

The final phase handles dynamic floating cells that are eligible for calving.
There are two ways this can happen - either they are adjacent to the open ocean (no buffer of
non-dynamic cells present), or they are adjacent to non-dynamic floating cells that had their
entire volume removed by calving, but there still is calving demand remaining.
The first case is handled easily by calculating calving flux on edges between dynamic floating cells
and open ocean using the calving velocity and ice thickness of the dynamic cell itself.
In the second case, "leftover" required calving flux is distributed from a non-dynamic cell that
has been completely "drained" to any edges between that non-dynamic cell and dynamic cells upstream.
This is done by weighting the flux to be distributed by the length of each such edge in the direction
perpendicular to the calving flux.

Further details of the new scheme can be seen in the commit messages.  The commit history contains a number of temporary and outdated commits to retain the history of what didn't work in addition to what did.