### PR TITLE
New Mesh: EC30to60kmL60E3SMv2r02 and change to 60 layers as default

### DIFF
--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_E3SM_coupling_files.ini
@@ -14,7 +14,8 @@ prefix = EC
 description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
               enhanced resolution around the equator (${min_res} km) and poles
               (35 km), ${max_res}-km resolution at mid latitudes, and ${levels}
-              vertical levels
+              vertical levels as documented at
+              https://github.com/MPAS-Dev/MPAS-Model/pull/668
 e3sm_version = 2
 mesh_version = 02
 creation_date = autodetect

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_E3SM_coupling_files.ini
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_E3SM_coupling_files.ini
@@ -16,7 +16,7 @@ description = MPAS Eddy Closure mesh for E3SM version ${e3sm_version} with
               (35 km), ${max_res}-km resolution at mid latitudes, and ${levels}
               vertical levels
 e3sm_version = 2
-mesh_version = 01
+mesh_version = 02
 creation_date = autodetect
 min_res = 30
 max_res = 60

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state.xml
@@ -1,1 +1,1 @@
-../../config_files/config_initial_state.xml
+../../config_files/config_initial_state_60_layers.xml

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_60_layers.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_60_layers.xml
@@ -1,1 +1,0 @@
-../../config_files/config_initial_state_60_layers.xml

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layer.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layer.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0"?>
-<config case="initial_state">
-	<get_file dest_path="initial_condition_database" file_name="Salinity.01.filled.60levels.PHC.151106.nc">
+<config case="initial_state_64_layer">
+	<get_file dest_path="initial_condition_database" file_name="layer_depth.80Layer.180619.nc">
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
-	<get_file dest_path="initial_condition_database" file_name="PotentialTemperature.01.filled.60levels.PHC.151106.nc">
+	<get_file dest_path="initial_condition_database" file_name="PTemp.Jan_p3.filled.mpas100levs.160127.nc">
+		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
+	</get_file>
+
+	<get_file dest_path="initial_condition_database" file_name="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc">
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
@@ -20,13 +24,15 @@
 		<mirror protocol="wget" url="https://web.lcrc.anl.gov/public/e3sm/mpas_standalonedata/mpas-ocean/initial_condition_database/"/>
 	</get_file>
 
+
 	<add_link source="../culled_mesh/culled_mesh.nc" dest="mesh.nc"/>
 	<add_link source="../culled_mesh/culled_graph.info" dest="graph.info"/>
 	<add_link source="../culled_mesh/critical_passages_mask_final.nc" dest="critical_passages.nc"/>
+	<copy_file source_path="script_test_dir" source="define_vertical_grid.py" dest="define_vertical_grid.py"/>
+	<add_link source_path="script_core_dir" source="scripts/vertical_grid/make_vertical_grid.py" dest="make_vertical_grid.py"/>
 	<add_link source_path="script_core_dir" source="scripts/plots/plot_initial_state.py" dest="plot_initial_state.py"/>
-	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="layer_depth.nc"/>
-	<add_link source_path="initial_condition_database" source="PotentialTemperature.01.filled.60levels.PHC.151106.nc" dest="temperature.nc"/>
-	<add_link source_path="initial_condition_database" source="Salinity.01.filled.60levels.PHC.151106.nc" dest="salinity.nc"/>
+	<add_link source_path="initial_condition_database" source="PTemp.Jan_p3.filled.mpas100levs.160127.nc" dest="temperature.nc"/>
+	<add_link source_path="initial_condition_database" source="Salt.Jan_p3.noBlackCaspian.filled.mpas100levs.160127.nc" dest="salinity.nc"/>
 	<add_link source_path="initial_condition_database" source="windStress.ncep_1958-2000avg.interp3600x2431.151106.nc" dest="wind_stress.nc"/>
 	<add_link source_path="initial_condition_database" source="ETOPO2v2c_f4_151106.nc" dest="topography.nc"/>
 	<add_link source_path="initial_condition_database" source="chlorophyllA_monthly_averages_1deg.151201.nc" dest="swData.nc"/>
@@ -34,9 +40,9 @@
 	<namelist name="namelist.ocean" mode="init">
 		<template file="template_initial_state.xml" path_base="script_configuration_dir"/>
 		<template file="template_critical_passages.xml" path_base="script_core_dir" path="global_ocean"/>
-		<option name="config_global_ocean_depth_file">'layer_depth.nc'</option>
-		<option name="config_global_ocean_depth_conversion_factor">0.01</option>
-		<option name="config_global_ocean_tracer_depth_conversion_factor">0.01</option>
+		<option name="config_global_ocean_depth_file">'vertical_grid.nc'</option>
+		<option name="config_global_ocean_depth_dimname">'nVertLevels'</option>
+		<option name="config_global_ocean_depth_varname">'refMidDepth'</option>
 		<option name="config_global_ocean_minimum_depth">10</option>
 		<option name="config_global_ocean_deepen_critical_passages">.false.</option>
 	</namelist>
@@ -48,10 +54,13 @@
 
 	<run_script name="run.py">
 		<step executable="gpmetis">
-			<argument flag="graph.info">36</argument>
+			<argument flag="graph.info">4</argument>
 		</step>
-		<model_run procs="36" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+		<step executable="./define_vertical_grid.py">
+		</step>
+		<model_run procs="4" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
 		<step executable="./plot_initial_state.py">
 		</step>
 	</run_script>
+
 </config>

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layers.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layers.xml
@@ -1,0 +1,1 @@
+../../config_files/config_initial_state.xml

--- a/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layers.xml
+++ b/testing_and_setup/compass/ocean/global_ocean/EC60to30/init/config_initial_state_64_layers.xml
@@ -1,1 +1,0 @@
-../../config_files/config_initial_state.xml


### PR DESCRIPTION

This PR bumps the revision number on the new 6030 grid, and includes all improvements to islands, channels, and passages for v2 of the E3SM water cycle campaign.

The default number of vertical layers is also switched to 60.
