### PR TITLE
Openmp pgi compiler bug workaround

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -144,9 +144,11 @@ contains
 
       nCells = nCellsArray( 3 )
 
+#ifndef CPRPGI
       !$omp parallel
       !$omp do schedule(runtime) private(depth, k, depLev) &
       !$omp firstprivate(weights)
+#endif
       do iCell = 1, nCells
          depth = 0.0_RKIND
          do k = 1, maxLevelCell(iCell)
@@ -171,8 +173,10 @@ contains
          penetrativeTemperatureFluxOBL(iCell)=penetrativeTemperatureFlux(iCell)*weights(depLev)
 
       end do
+#ifndef CPRPGI
       !$omp end do
       !$omp end parallel
+#endif
 
       deallocate(weights)
 

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -140,8 +140,12 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
+#ifdef CPRPGI
+      !$omp private(iEdge, cell1, cell2, k, vertAleTransportTopEdge, w_dudzTopEdge)
+#else
       !$omp private(iEdge, cell1, cell2, k, vertAleTransportTopEdge) &
       !$omp firstprivate(w_dudzTopEdge)
+#endif
       do iEdge = 1, nEdges
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -138,11 +138,9 @@ contains
 
       nEdges = nEdgesArray( 1 )
 
+#ifndef CPRPGI
       !$omp parallel
       !$omp do schedule(runtime) &
-#ifdef CPRPGI
-      !$omp private(iEdge, cell1, cell2, k, vertAleTransportTopEdge, w_dudzTopEdge)
-#else
       !$omp private(iEdge, cell1, cell2, k, vertAleTransportTopEdge) &
       !$omp firstprivate(w_dudzTopEdge)
 #endif
@@ -165,8 +163,10 @@ contains
           tend(k,iEdge) = tend(k,iEdge) - edgeMask(k, iEdge) * 0.5 * (w_dudzTopEdge(k) + w_dudzTopEdge(k+1))
         enddo
       enddo
+#ifndef CPRPGI
       !$omp end do
       !$omp end parallel
+#endif
 
       deallocate(w_dudzTopEdge)
 


### PR DESCRIPTION
This PR creates a workaround for a PGI compiler issue that causes a failure when running the model w/ PGI + OpenMP.  The workaround is wrapping the OpenMP directives for a few loops (loops that declare an allocatable array as `firstprivate`) in a preprocessor flag (`CPRPGI`).  This flag is already used in other parts of MPAS.

This resolves issue https://github.com/E3SM-Project/E3SM/issues/3793

