### PR TITLE
fixed bad continuation character in ocn init tidal boundary

### DIFF
--- a/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
@@ -202,7 +202,7 @@ contains
       else
         ! assumes we just need to build vertical mesh to deepest point (e.g., no "on land' vertical mesh)
         do k = 1, nVertLevels
-          refBottomDepth(k) = \
+          refBottomDepth(k) = &
           max(config_tidal_boundary_left_bottom_depth, config_tidal_boundary_right_bottom_depth) * interfaceLocations(k+1)
         end do
       end if


### PR DESCRIPTION
In the ocn_init_tidal_boundary.F routine, there was a line with a bad continuation character (backslash instead of "&"). This is a single character replacement with the proper continuation character. 

Fixes #674 


