### PR TITLE
Update jigsaw_to_netcdf to use version from mpas_tools package

### DIFF
--- a/testing_and_setup/compass/README_landice.md
+++ b/testing_and_setup/compass/README_landice.md
@@ -2,16 +2,28 @@
 
 ## COMPASS conda environment
 
-To set up and run landice test cases from COMPASS, you will need a conda
+To set up and run ocean test cases from COMPASS, you will need a conda
 environment.  First, install Miniconda3 (if miniconda is not already
 installed), then create a new conda environment as follows:
 ``` bash
-conda create -n compass_py3.7 -c conda-forge -c xylar python=3.7 geometric_features mpas_tools jigsaw jigsawpy metis pyflann scikit-image basemap pyamg ffmpeg pyqt
+conda create -n compass_0.1.11 -c conda-forge -c e3sm python=3.8 compass=0.1.11
 ```
 Each time you want to work with COMPASS, you will need to run:
 ```
-conda activate compass_py3.7
+conda activate compass_0.1.11
 ```
+
+An appropriate conda environment is already available on Los Alamos National
+Laboratory's Institutional Computing (LANL IC) machines as well as Anvil, Compy
+and Cori.  In each case, you will run:
+```
+source <base_path>/load_latest_compass.sh
+```
+Values of `<base_path>` are:
+* grizzly and badger - `/usr/projects/climate/SHARED_CLIMATE/anaconda_envs`
+* anvil (blues) - `/lcrc/soft/climate/e3sm-unified/`
+* compy - `/share/apps/E3SM/conda_envs`
+* cori - `/global/cfs/cdirs/acme/software/anaconda_envs`
 
 ## Setting config options
 

--- a/testing_and_setup/compass/landice/Thwaites_variability/1km_varres_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/testing_and_setup/compass/landice/Thwaites_variability/1km_varres_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -2,7 +2,6 @@
 <config case="1km_varres_jigsaw">
 
         <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_to_netcdf.py"/>
         <add_executable source="model" dest="landice_model"/>
         <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/>
         <!--        <add_link source_path="script_configuration_dir" source="ais14to4km.20160713.nc" dest="ais_input_data.nc"/>-->
@@ -30,7 +29,7 @@
 
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_to_netcdf.py" >
+                <step executable="jigsaw_to_netcdf" >
                         <argument flag="-m">thwaites_jigsaw_mesh.msh</argument>
                         <argument flag="-o">thwaites_jigsaw_netcdf.nc</argument>
                 </step>

--- a/testing_and_setup/compass/landice/antarctica/200to40km_AIS_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/testing_and_setup/compass/landice/antarctica/200to40km_AIS_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <config case="200km_varres_jigsaw">
 
-        <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_jigsaw_to_netcdf.py"/>
         <!--        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/> -->
         <add_link source_path="script_test_dir" source="antarctica_8km_2018_04_20.nc" dest="ais_input_data.nc"/>
         <add_link source_path="script_test_dir" source="ais_temp_pattyn_cism_format.5km.filled.nc" dest="ais_temperature_input_data.nc"/>
@@ -24,7 +22,7 @@
         <run_script name="setup_test.py">
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_jigsaw_to_netcdf.py"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
+                <step executable="jigsaw_to_netcdf"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
                         <argument flag="-m">ais200to40km-MESH.msh</argument>
                         <argument flag="-o">ais200to40km_jigsaw_netcdf.nc</argument>
                 </step>

--- a/testing_and_setup/compass/landice/antarctica/2km_ABUMIP_jigsaw/standard_configuration/config_setup_experiments.xml
+++ b/testing_and_setup/compass/landice/antarctica/2km_ABUMIP_jigsaw/standard_configuration/config_setup_experiments.xml
@@ -2,7 +2,6 @@
 <config case="2km_varres_jigsaw">
 
         <!-- Set up needed files and executables -->
-        <add_executable source="jigsaw_converter" dest="triangle_jigsaw_to_netcdf.py"/>
         <!--        <add_link source_path="script_configuration_dir" source="albany_input.yaml" dest="."/> -->
         <add_link source_path="script_test_dir" source="Antarctica-1km.BISICLES.CISM-style.nc" dest="ais_input_data.nc"/>
         <add_link source_path="script_test_dir" source="ais2km-MESH.msh" dest="."/>
@@ -23,7 +22,7 @@
         <run_script name="setup_test.py">
 
                 <!-- convert from jigsaw to basic netcdf format-->
-                <step executable="./triangle_jigsaw_to_netcdf.py"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
+                <step executable="jigsaw_to_netcdf"  pre_message="\n\n### Converting from JIGSAW \n\n" post_message="\n\n### Converting from JIGSAW complete\n\n">
                         <argument flag="-m">ais2km-MESH.msh</argument>
                         <argument flag="-o">ais2km_jigsaw_netcdf.nc</argument>
                 </step>

--- a/testing_and_setup/compass/landice/load_compass_env.sh
+++ b/testing_and_setup/compass/landice/load_compass_env.sh
@@ -1,0 +1,33 @@
+version=0.1.11
+
+# The rest of the script should not need to be modified
+if [[ $HOSTNAME = "cori"* ]] || [[ $HOSTNAME = "dtn"* ]]; then
+  base_path="/global/cfs/cdirs/acme/software/anaconda_envs/base"
+elif [[ $HOSTNAME = "acme1"* ]] || [[ $HOSTNAME = "aims4"* ]]; then
+  base_path="/usr/local/e3sm_unified/envs/base"
+elif [[ $HOSTNAME = "blueslogin"* ]]; then
+  base_path="/lcrc/soft/climate/e3sm-unified/base"
+elif [[ $HOSTNAME = "rhea"* ]]; then
+  base_path="/ccs/proj/cli900/sw/rhea/e3sm-unified/base"
+elif [[ $HOSTNAME = "cooley"* ]]; then
+  base_path="/lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base"
+elif [[ $HOSTNAME = "compy"* ]]; then
+  base_path="/share/apps/E3SM/conda_envs/base"
+elif [[ $HOSTNAME = "gr-fe"* ]] || [[ $HOSTNAME = "ba-fe"* ]] || \
+    [[ $HOSTNAME =~ ^gr[0-9]{4}$ ]] || [[ $HOSTNAME =~ ^ba[0-9]{3}$ ]]; then
+  base_path="/usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base"
+else
+  echo "Unknown host name $HOSTNAME.  Add base_path for this machine to the script."
+fi
+
+env_name=compass_${version}
+if [ -d "$base_path/envs/$env_name" ]; then
+  if [ -x "$(command -v module)" ] ; then
+    module unload python
+  fi
+  source "${base_path}/etc/profile.d/conda.sh"
+  conda activate "$env_name"
+else
+  echo "$env_name not found."
+fi
+


### PR DESCRIPTION
This merge updates calls to jigsaw_to_netcdf to use the version from `mpas_tools` rather than from the outdated `compass/ocean/jigsaw_to_MPAS` location.

This merge also updates `README_landice.md` to describe the latest version of the `compass` environment and associated metapackage (v0.1.11).

This merge also adds `landice/load_compass_env/sh` as a potentially convenient shortcut for users to source on supported machines to get the compatible version of the compass environment.  This script gets symlinked into each test case if you use the `--link_load_compass` flag.