### PR TITLE
Protect OpenMP-offload pragmas in CPU-only threading runs in Seaice

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_mesh_pool.F
+++ b/src/core_seaice/shared/mpas_seaice_mesh_pool.F
@@ -138,6 +138,7 @@ contains
        call MPAS_pool_get_array(velocityVariationalPool, "stress22",             stress22)
        call MPAS_pool_get_array(velocityVariationalPool, "stress12",             stress12)
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
 !$GPU ENTER_DATA COPY_IN_LP             &
 !$GPUC   nCells,                        &
 !$GPUC   nVerticesSolve,                &
@@ -163,6 +164,7 @@ contains
 !$GPUC   stress12,                      &
 !$GPUC   stress22                       &
 !$GPUF
+#endif
 
        block => block % next
     end do
@@ -186,6 +188,7 @@ contains
 
     err = 0
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
     ! first delete on device
 !$GPU EXIT_DATA COPY_DEL_LP             &
 !$GPUC   nCells,                        &
@@ -212,6 +215,7 @@ contains
 !$GPUC   stress12,                      &
 !$GPUC   stress22                       &
 !$GPUF
+#endif
 
     ! then nullify on host
     nullify(nEdgesOnCell,      &
@@ -254,6 +258,7 @@ contains
     type(domain_type) :: &
          domain
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
     ! update arrays on device
 !$GPU UPDATE_D_LP       &
 !$GPUC   solveStress,   &
@@ -265,6 +270,7 @@ contains
 !$GPUC   stress12,      &
 !$GPUC   stress22       &
 !$GPUF
+#endif
 
   end subroutine seaice_mesh_pool_update!}}}
 !-----------------------------------------------------------------------

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver.F
@@ -2377,7 +2377,9 @@ contains
 
     enddo
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
 !$GPU DATA_END
+#endif
 
   end subroutine subcycle_velocity_solver!}}}
 
@@ -2452,7 +2454,9 @@ contains
 
     endif
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
 !$GPU UPDATE_H((stressDivergenceU, stressDivergenceV))
+#endif
 
     ! ocean stress coefficient
     call mpas_timer_start("ocn stress coef")
@@ -2519,7 +2523,9 @@ contains
 
     call seaice_load_balance_timers(domain, "vel after")
 
+#if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
 !$GPU UPDATE_D((uVelocity, vVelocity))
+#endif
 
   end subroutine single_subcycle_velocity_solver!}}}
 


### PR DESCRIPTION
With Intel v19 (on PNL Compy), compiler issues a build-time link error regarding OpenMP-offload pragmas. In presence of OpenMP compiler flags for CPU-only multi-threading (e.g. `-qopenmp`), this protects OpenMP-offload pragmas (`!$omp target ...`) with GPU macros. Checked with `SMS_P80x2.T62_oEC60to30v3.DTESTM.compy_intel`.

[BFB]
