### PR TITLE
Fix OMP Directives and Loop Bounds in Ocean

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -482,7 +482,6 @@ contains
          !--------------------------------------------------
          ! allocate scratch field variables
          !--------------------------------------------------
-         !$omp master
          allocate(firstLayerBuoyCoor(ncells), &
                   lastLayerBuoyCoor(ncells), &
                   heightMidBuoyCoor(nBuoyancyLayers, nCells), &
@@ -520,8 +519,6 @@ contains
                   uPVMidBuoyCoorEA(nBuoyancyLayers, nCells), &
                   vPVMidBuoyCoorEA(nBuoyancyLayers, nCells), &
                   PVFluxTest(2,nBuoyancyLayers, nCells))
-         !$omp end master
-         !$omp barrier
 
          !--------------------------------------------------
          ! assign pointers for ensemble average (EA) and thickness-weighted averaged state
@@ -1063,7 +1060,6 @@ contains
          !-------------------------------------------------------------
          ! deallocate scratch space and test space variables
          !-------------------------------------------------------------
-         !$omp master
          deallocate(firstLayerBuoyCoor, &
                     lastLayerBuoyCoor, &
                     heightMidBuoyCoor, &
@@ -1101,8 +1097,6 @@ contains
                     uPVMidBuoyCoorEA, &
                     vPVMidBuoyCoorEA, &
                     PVFluxTest)
-         !$omp end master
-         !$omp barrier
 
          !-------------------------------------------------------------
          ! update test variables

--- a/src/core_ocean/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_high_frequency_output.F
@@ -240,11 +240,8 @@ contains
          call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
          call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
 
-         !$omp master
          allocate(normalThicknessFluxSum(nEdges))
          allocate(layerThicknessSumEdge(nEdges))
-         !$omp end master
-         !$omp barrier
 
          ! get pointers to pools
          call mpas_pool_get_subpool(block % structs, 'state', statePool)
@@ -693,11 +690,8 @@ contains
          end do
 
          ! scratch arrays
-         !$omp master
          deallocate(normalThicknessFluxSum)
          deallocate(layerThicknessSumEdge)
-         !$omp end master
-         !$omp barrier
 
          block => block % next
       end do

--- a/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -283,14 +283,11 @@ contains
                 "    increase size of ocn_layer_volume_weighted_averages scratch space", MPAS_LOG_CRIT )
          endif
 
-         !$omp master
          allocate(workArray(nDefinedDataFields, size(areaCell)), &
                   workMask(size(areaCell)), &
                   workMin(nDefinedDataFields), &
                   workMax(nDefinedDataFields), &
                   workSum(nDefinedDataFields))
-         !$omp end master
-         !$omp barrier
 
          ! get pointers to data that will be analyzed
          ! listed in the order in which the fields appear in {avg,min,max}ValueWithinOceanLayerRegion
@@ -389,14 +386,11 @@ contains
          kBuffer = 0
 
          ! deallocate scratch fields
-         !$omp barrier
-         !$omp master
          deallocate(workArray, &
                     workMask, &
                     workMin, &
                     workMax, &
                     workSum)
-         !$omp end master
 
          block => block % next
       end do

--- a/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -227,15 +227,13 @@ contains
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
          nCells = nCellsArray( size(nCellsArray) )
-         !$omp master
          allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
-         !$omp end master
-         !$omp barrier
 
          pressureAdjustedForLandIce(:,:) = pressure(:,:)
          !If landice cavity remove land ice pressure to search for ML depth
          if ( associated(landIcePressure) ) then
-           !$omp do schedule(runtime)
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
            do iCell = 1,nCells
              do k = 1,maxLevelCell(iCell)
                 pressureAdjustedForLandIce(k,iCell) = pressureAdjustedForLandIce(k,iCell)   &
@@ -243,11 +241,14 @@ contains
              end do
            end do
            !$omp end do
+           !$omp end parallel
          end if
 
          if(config_AM_mixedLayerDepths_Tthreshold) then
             call mpas_pool_get_array(mixedLayerDepthsAMPool, 'tThreshMLD',tThreshMLD)
-            !$omp do schedule(runtime) private( k, refIndex, found_temp_mld, localVals, interp_local, temp_ref_lev)
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(refIndex, found_temp_mld, k, localvals, temp_ref_lev, dVp1, dV, mldTemp)
             do iCell = 1,nCells
 
                !Initialize RefIndex for cases of very shallow columns
@@ -288,13 +289,16 @@ contains
                    if(.not. found_temp_mld) tThreshMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
                end do !iCell
                !$omp end do
+               !$omp end parallel
 
                if (associated(landIceMask) ) then
+                  !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
                      tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                   end do
                   !$omp end do
+                  !$omp end parallel
                end if
 
           end if !end tThresh MLD search
@@ -303,7 +307,9 @@ contains
             call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD',dThreshMLD)
             call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
 
-            !$omp do schedule(runtime) private( k, refIndex, found_den_mld, localVals, interp_local, den_ref_lev, dV, dVp1, mldTemp)
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(refIndex, found_den_mld, k, localvals, den_ref_lev, dVp1, dV, mldTemp)
             do iCell = 1,nCells
 
                !Initialize RefIndex for cases of very shallow columns
@@ -347,13 +353,16 @@ contains
                     end if
              end do !iCell
              !$omp end do
+             !$omp end parallel
 
              if (associated(landIceMask) ) then
+               !$omp parallel
                !$omp do schedule(runtime)
                do iCell = 1, nCells
                   dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
                end do
                !$omp end do
+               !$omp end parallel
 
 
              end if
@@ -368,7 +377,9 @@ contains
 
            allocate(temperatureGradient(nVertLevels,2))
 
-           !$omp do schedule(runtime) private( k, refLevel, found_temp_mld, localVals, interp_local)
+           !$omp parallel
+           !$omp do schedule(runtime) &
+           !$omp private(temperatureGradient, found_temp_mld, k, dz, mldTemp, refLevel)
            do iCell = 1,nCells
 
             temperatureGradient(:,1) = 0.0_RKIND
@@ -411,14 +422,17 @@ contains
 
          end do !iCell
          !$omp end do
+         !$omp end parallel
 
          !normalize MLD to top of ice cavity
          if (associated(landIceMask) ) then
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
              tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
            end do
            !$omp end do
+           !$omp end parallel
          end if
 
 
@@ -431,7 +445,9 @@ contains
 
              allocate(densityGradient(nVertLevels,2))
 
-           !$omp do schedule(runtime) private( k, refLevel, found_den_mld, interp_local, mldTemp, dz)
+           !$omp parallel
+           !$omp do schedule(runtime) &
+           !$omp private(densityGradient, found_den_mld, k, dz, mldTemp, refLevel)
            do iCell = 1,nCells
 
             densityGradient(:,:)=0.0_RKIND
@@ -472,22 +488,22 @@ contains
 
          end do !iCell
          !$omp end do
+         !$omp end parallel
 
          if (associated(landIceMask) ) then
+           !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
              dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
            end do
            !$omp end do
+           !$omp end parallel
          end if
 
          deallocate(densityGradient)
        end if !if(densitygradientflag)
 
-         !$omp barrier
-         !$omp master
          deallocate(pressureAdjustedForLandIce)
-         !$omp end master
          block => block % next
       end do
 

--- a/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_okubo_weiss.F
@@ -1492,15 +1492,12 @@ contains
          call mpas_pool_get_array(okuboWeissAMPool, 'eddyID', OW_cc_id)
          call mpas_pool_get_array(okuboWeissAMPool, 'vorticity', om)
 
-         !$omp master
          allocate(velocityGradient(3, 3, nVertLevels, nCells), &
                   OW_thresh(nVertLevels, nCells), &
                   S(nVertLevels, nCells + 1), &
                   Lam1(nVertLevels, nCells + 1), &
                   Lam2(nVertLevels, nCells + 1), &
                   Lam2_R3(nVertLevels, nCells + 1))
-         !$omp end master
-         !$omp barrier
 
          ! Compute velocity gradient
          call mpas_velocity_gradient_R3Cell(normalVelocity, tangentialVelocity, &
@@ -1522,15 +1519,12 @@ contains
             call mpas_timer_stop("OW connected components")
          end if
 
-         !$omp barrier
-         !$omp master
          deallocate(velocityGradient, &
                     OW_thresh, &
                     S, &
                     Lam1, &
                     Lam2, &
                     Lam2_R3)
-         !$omp end master
 
          block => block % next
       end do

--- a/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -295,14 +295,11 @@ contains
                    "    increase size of ocn_layer_volume_weighted_averages scratch space", MPAS_LOG_CRIT )
             endif
    
-            !$omp master
             allocate(workArray(nDefinedDataFields, size(areaCell)), &
                      workMask(size(areaCell)), &
                      workMin(nDefinedDataFields), &
                      workMax(nDefinedDataFields), &
                      workSum(nDefinedDataFields))
-            !$omp end master
-            !$omp barrier
    
             ! get pointers to data that will be analyzed
             ! listed in the order in which the fields appear in {avg,min,max}SurfaceStatistics
@@ -441,14 +438,11 @@ contains
             enddo
    
             ! deallocate scratch fields
-            !$omp barrier
-            !$omp master
             deallocate(workArray, &
                        workMask, &
                        workMin, &
                        workMax, &
                        workSum)
-            !$omp end master
 
             block => block % next
          end do

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -110,8 +110,10 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k, i, kMax
-      integer, pointer :: nCells, nVertLevels
+      integer, pointer :: nVertLevels
+      integer :: nCells
       integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: nCellsArray
 
       real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness, thicknessWithRemainder
       real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
@@ -133,11 +135,13 @@ contains
 
       call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       allocate(prelim_ALE_thickness(nVertLevels), &
          min_ALE_thickness_down(nVertLevels), min_ALE_thickness_up(nVertLevels))
+
+      nCells = nCellsArray( 2 )
 
       !
       ! ALE thickness alteration due to SSH (z-star)


### PR DESCRIPTION
This PR is a bugfix that corrects errors in a few OpenMP private clauses, and fixes loop bounds in an ALE thickness routine.  

For additional details of the errors that this PR resolves, see https://github.com/E3SM-Project/E3SM/issues/3826

This also potentially fixes https://github.com/MPAS-Dev/MPAS-Model/issues/685 , but I will need to test to confirm.

