### PR TITLE
adds new GM option -- eden greatbatch

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2536,7 +2536,7 @@
 		<var name="eddyTime" type="real" dimensions="nEdges Time" units="s^{-1}"
 			description="inverse eddy time scale in Visbeck 1997 closure"
 		/>
-		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA"
+		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA" default_value="1.0"
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
 			packages="gm"
 		/>
@@ -2645,11 +2645,11 @@
 		<var name="indMLD" type="integer" dimensions="nCells Time" units="unitless"
 			description="index of model where mixed layer depth occurs (always one past)"
 		/>
-		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional"
+		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional"
+		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -320,28 +320,28 @@
 		<nml_option name="config_GM_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_kappa_function is set to constant."
 		/>
-		<nml_option name="config_GM_closure" type="character" default_value="edenGreatbatch" units="unitless"
-					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. edenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
-					possible_values="'N2_dependent', 'constant', 'visbeck', 'edenGreatbatch'"
+		<nml_option name="config_GM_closure" type="character" default_value="EdenGreatbatch" units="unitless"
+					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'Visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. EdenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
+					possible_values="'N2_dependent', 'constant', 'Visbeck', 'EdenGreatbatch'"
 		/>
 		<nml_option name="config_GM_baroclinic_mode" type="real" default_value="1.0" units="NA"
 					description="baroclinic wave mode chosen for the ferrari et al 2010 calculation"
 					possible_values="small positive numbers"
 		/>
-		<nml_option name="config_GM_visbeck_alpha" type="real" default_value="0.005" units="NA"
-					description="scaling factor on the visbeck diffusivity parameterization"
+		<nml_option name="config_GM_Visbeck_alpha" type="real" default_value="0.005" units="NA"
+					description="scaling factor on the Visbeck diffusivity parameterization"
 					possible_values="small positive numbers"
 		/>
-		<nml_option name="config_GM_visbeck_max_depth" type="real" default_value="1000.0" units="m"
+		<nml_option name="config_GM_Visbeck_max_depth" type="real" default_value="1000.0" units="m"
 					description="minimum depth for calculation of vertical average"
 					possible_values="values between zero and bottom depth"
 		/>
-		<nml_option name="config_GM_visbeck_min_kappa" type="real" default_value="300.0" units="m^2 s^{-1}"
-					description="minimum value of bolus diffusivity for visbeck scheme"
+		<nml_option name="config_GM_Visbeck_min_kappa" type="real" default_value="300.0" units="m^2 s^{-1}"
+					description="minimum value of bolus diffusivity for Visbeck scheme"
 					possible_values="values around 100s"
 		/>
-		<nml_option name="config_GM_visbeck_max_kappa" type="real" default_value="1800.0" units="m^2 s^{-1}"
-					description="minimum value of bolus diffusivity for visbeck scheme"
+		<nml_option name="config_GM_Visbeck_max_kappa" type="real" default_value="1800.0" units="m^2 s^{-1}"
+					description="minimum value of bolus diffusivity for Visbeck scheme"
 					possible_values="values around 100s"
 		/>
 		<nml_option name="config_gm_EG_riMin" type="real" default_value="200.0" units="NA"
@@ -349,7 +349,7 @@
 					possible_values="numbers greater than zero"
 		/>
 		<nml_option name="config_gm_EG_kappa_factor" type="real" default_value="2.0" units="NA"
-					description="factor to scale diffusivity for eden greatbach scheme"
+					description="factor to scale diffusivity for Eden Greatbach scheme"
 					possible_values="small positive reals"
 		/>
 		<nml_option name="config_GM_min_stratification_ratio" type="real" default_value="0.1" units="NA"
@@ -2527,14 +2527,14 @@
 		<var name="betaEdge" type="real" dimensions="nEdges Time" units="m^{-1} s^{-1}"
 			description="meridional gradient of the coriolis parameter"
 		/>
-		<var name="c_visbeck" type="real" dimensions="nEdges Time" units="m s^{-1}"
-			description="baroclinic wave speed from visbeck parameterization"
+		<var name="c_Visbeck" type="real" dimensions="nEdges Time" units="m s^{-1}"
+			description="baroclinic wave speed from Visbeck parameterization"
 		/>
 		<var name="eddyLength" type="real" dimensions="nEdges Time" units="m"
-			description="eddy length scale in visbeck 1997 closure"
+			description="eddy length scale in Visbeck 1997 closure"
 		/>
 		<var name="eddyTime" type="real" dimensions="nEdges Time" units="s^{-1}"
-			description="inverse eddy time scale in visbeck 1997 closure"
+			description="inverse eddy time scale in Visbeck 1997 closure"
 		/>
 		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA"
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -320,7 +320,7 @@
 		<nml_option name="config_GM_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_kappa_function is set to constant."
 		/>
-		<nml_option name="config_GM_closure" type="character" default_value="N2_dependent" units="unitless"
+		<nml_option name="config_GM_closure" type="character" default_value="edenGreatbatch" units="unitless"
 					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. edenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
 					possible_values="'N2_dependent', 'constant', 'visbeck', 'edenGreatbatch'"
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -321,7 +321,7 @@
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Used when config_GM_kappa_function is set to constant."
 		/>
 		<nml_option name="config_GM_closure" type="character" default_value="N2_dependent" units="unitless"
-					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997"
+					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. edenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
 					possible_values="'N2_dependent', 'constant', 'visbeck'"
 		/>
 		<nml_option name="config_GM_baroclinic_mode" type="real" default_value="1.0" units="NA"
@@ -343,6 +343,14 @@
 		<nml_option name="config_GM_visbeck_max_kappa" type="real" default_value="1800.0" units="m^2 s^{-1}"
 					description="minimum value of bolus diffusivity for visbeck scheme"
 					possible_values="values around 100s"
+		/>
+		<nml_option name="config_gm_EG_riMin" type="real" default_value="200.0" units="NA"
+					description="minimum Richardson number to prevent overly large bolus Kappa values"
+					possible_values="numbers greater than zero"
+		/>
+		<nml_option name="config_gm_EG_kappa_factor" type="real" default_value="2.0" units="NA"
+					description="factor to scale diffusivity for eden greatbach scheme"
+					possible_values="small positive reals"
 		/>
 		<nml_option name="config_GM_min_stratification_ratio" type="real" default_value="0.1" units="NA"
 					description="When using config_GM_closure='N2_dependent', the minimum value for N2/Nmax2 ratio."
@@ -2528,7 +2536,7 @@
 		<var name="eddyTime" type="real" dimensions="nEdges Time" units="s^{-1}"
 			description="inverse eddy time scale in visbeck 1997 closure"
 		/>
-		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="NA"
+		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA"
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
 			packages="gm"
 		/>

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -322,7 +322,7 @@
 		/>
 		<nml_option name="config_GM_closure" type="character" default_value="N2_dependent" units="unitless"
 					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. edenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
-					possible_values="'N2_dependent', 'constant', 'visbeck'"
+					possible_values="'N2_dependent', 'constant', 'visbeck', 'edenGreatbatch'"
 		/>
 		<nml_option name="config_GM_baroclinic_mode" type="real" default_value="1.0" units="NA"
 					description="baroclinic wave mode chosen for the ferrari et al 2010 calculation"

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -410,8 +410,7 @@ contains
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
-      nEdges = nEdgesArray( 2 )
-
+      nEdges = nEdgesArray( 3 )
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
       do iEdge = 1, nEdges

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -236,16 +236,6 @@ contains
       !$omp end do
 
       !$omp do schedule(runtime) private(k)
-      do iEdge = 1, nEdges
-         do k = 1, nVertLevels
-            slopeTriadUp(k, :, iEdge) = 0.0_RKIND
-            slopeTriadDown(k, :, iEdge) = 0.0_RKIND
-            gmKappaScaling(k,iEdge) = 1.0_RKIND
-         end do
-      end do
-      !$omp end do
-
-      !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells + 1
          do k = 1, nVertLevels
             k33(k, iCell) = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -702,7 +702,7 @@ contains
                  !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
                  !be removed below in the computation of the stream function
                  gmKappaScaling(k,iEdge) = max(config_GM_visbeck_min_kappa, min(config_gm_EG_kappa_factor* &
-                         Length**2.0*sigma, config_GM_visbeck_max_kappa)) / gmBolusKappa(iCell)
+                         Length**2.0*sigma, config_GM_visbeck_max_kappa)) / gmBolusKappa(iEdge)
               enddo
            enddo
            !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -678,13 +678,13 @@ contains
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
-              Lr = min(config_GM_baroclinic_mode*cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
-                       sqrt(cGMphaseSpeed(iEdge)*config_GM_baroclinic_mode / (2.0_RKIND*betaEdge(iEdge))))
+              Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
+                       sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
               do k=1,maxLevelEdgeTop(iEdge)
                  RiTopOfEdge = 0.5_RKIND*(max(RiTopOfCell(k,cell1),0.0_RKIND) + &
                                           max(RiTopOfCell(k,cell2),0.0_RKIND))
-                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)*config_GM_baroclinic_mode* &
+                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)* &
                              cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))
                  Length = min(Lr,L_rhines)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -46,10 +46,11 @@ module ocn_gm
    real(kind=RKIND), parameter :: epsGM = 1.0e-12_RKIND
 
    ! The following logical variables are used to configure the three 
-   ! available GM closures (constant, N2_dependent, and visbeck)
+   ! available GM closures (constant, N2_dependent, visbeck, edenGreatbatch)
    logical :: local_config_GM_compute_visbeck
    logical :: local_config_GM_lat_variable_c2
    logical :: local_config_GM_kappa_lat_depth_variable
+   logical :: local_config_GM_compute_edenGreatbatch
    real(kind=RKIND) :: slopeTaperFactor, sfcTaperFactor, rediGMinitValue
 
 !***********************************************************************
@@ -135,7 +136,8 @@ contains
       real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sshEdge, sfcTaper
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx, BVFcent
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
-      real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz!, gradDensityConstZTopOfEdge
+      real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz
+      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       ! Dimensions
       integer :: nsmooth, nCells, nEdges
@@ -236,6 +238,7 @@ contains
          do k = 1, nVertLevels
             slopeTriadUp(k, :, iEdge) = 0.0_RKIND
             slopeTriadDown(k, :, iEdge) = 0.0_RKIND
+            gmKappaScaling(k,iEdge) = 1.0_RKIND
          end do
       end do
       !$omp end do
@@ -251,7 +254,6 @@ contains
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          RediKappaScaling(:, iCell) = 1.0_RKIND
-         gmKappaScaling(:, iCell) = 1.0_RKIND
          RediKappaSfcTaper(:, iCell) = 1.0_RKIND
       end do
       !$omp end do
@@ -486,86 +488,93 @@ contains
          !$omp end do
          !$omp end parallel
  
-      ! Compute density gradient (gradDensityEdge) and gradient of zMid (gradZMidEdge)
-      ! along the constant coordinate surface.
-      ! The computed variables lives at edge and mid-layer depth
-      !$omp parallel
-      !$omp do schedule(runtime) private(cell1, cell2, k)
-      do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
+         ! Compute density gradient (gradDensityEdge) and gradient of zMid (gradZMidEdge)
+         ! along the constant coordinate surface.
+         ! The computed variables lives at edge and mid-layer depth
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, k)
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
 
-         do k=1,maxLevelEdgeTop(iEdge)
-            gradDensityEdge(k,iEdge) = (density(k,cell2) - density(k,cell1)) / dcEdge(iEdge)
-            gradZMidEdge(k,iEdge) = (zMid(k,cell2) - zMid(k,cell1)) / dcEdge(iEdge)
+            do k=1,maxLevelEdgeTop(iEdge)
+               gradDensityEdge(k,iEdge) = (density(k,cell2) - density(k,cell1)) / dcEdge(iEdge)
+               gradZMidEdge(k,iEdge) = (zMid(k,cell2) - zMid(k,cell1)) / dcEdge(iEdge)
+            end do
          end do
-      end do
-      !$omp end do
+         !$omp end do
 
-      !$omp do schedule(runtime) private(k, h1, h2)
-      do iEdge = 1, nEdges
-         ! The interpolation can only be carried out on non-boundary edges
-         if (maxLevelEdgeTop(iEdge) .GE. 1) then
-            do k = 2, maxLevelEdgeTop(iEdge)
-               h1 = layerThicknessEdge(k-1,iEdge)
-               h2 = layerThicknessEdge(k,iEdge)
-               ! Using second-order interpolation below
-               gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * gradDensityEdge(k,iEdge)) / (h1 + h2)
-               gradZMidTopOfEdge(k,iEdge) = (h2 * gradZMidEdge(k-1,iEdge) + h1 * gradZMidEdge(k,iEdge)) / (h1 + h2)
+         !$omp do schedule(runtime) private(k, h1, h2)
+         do iEdge = 1, nEdges
+            ! The interpolation can only be carried out on non-boundary edges
+            if (maxLevelEdgeTop(iEdge) .GE. 1) then
+               do k = 2, maxLevelEdgeTop(iEdge)
+                  h1 = layerThicknessEdge(k-1,iEdge)
+                  h2 = layerThicknessEdge(k,iEdge)
+                  ! Using second-order interpolation below
+                  gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
+                                gradDensityEdge(k,iEdge)) / (h1 + h2)
+                  gradZMidTopOfEdge(k,iEdge) = (h2 * gradZMidEdge(k-1,iEdge) + h1 * &
+                                gradZMidEdge(k,iEdge)) / (h1 + h2)
+               end do
 
-            end do
+               ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells 
+               ! above the top and below the bottom layers of the same depths and density.
+               gradDensityTopOfEdge(1,iEdge) = gradDensityEdge(1,iEdge)
+               gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
+               gradZMidTopOfEdge(1,iEdge) = gradZMidEdge(1,iEdge)
+               gradZMidTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradZMidEdge(maxLevelEdgeTop(iEdge),iEdge)
+            end if
+         end do
+         !$omp end do
 
-            ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells above
-            ! the top and below the bottom layers of the same depths and density.
-            gradDensityTopOfEdge(1,iEdge) = gradDensityEdge(1,iEdge)
-            gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
-            gradZMidTopOfEdge(1,iEdge) = gradZMidEdge(1,iEdge)
-            gradZMidTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradZMidEdge(maxLevelEdgeTop(iEdge),iEdge)
-         end if
-      end do
-      !$omp end do
-
-      !$omp do schedule(runtime) private(k)
-      do iEdge = 1, nEdges
-         if (maxLevelEdgeTop(iEdge) .GE. 1) then
-            do k = 1, maxLevelEdgeTop(iEdge)+1
-               gradDensityConstZTopOfEdge(k,iEdge) = gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1, nEdges
+            if (maxLevelEdgeTop(iEdge) .GE. 1) then
+               do k = 1, maxLevelEdgeTop(iEdge)+1
+                  gradDensityConstZTopOfEdge(k,iEdge) = gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
                                                    * gradZMidTopOfEdge(k,iEdge)
-            end do
-         end if
-      end do
-      !$omp end do
-      !$omp end parallel
+               end do
+            end if
+         end do
+         !$omp end do
+         !$omp end parallel
 
+         nEdges = nEdgesArray(3)
          ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
          ! based on stratification relative to the maximum in the column
          if (local_config_GM_kappa_lat_depth_variable) then
             !$omp parallel
             !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN)
-            do iCell=1,nCells
+            do iEdge=1,nEdges
                k=1
-               maxN = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
+                                                    BruntVaisalaFreqTop(k,cell2))
+               maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                do k = 2, maxLevelCell(iCell)
-                 maxN = max(maxN,max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND))
+                 BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
+                                                      BruntVaisalaFreqTop(k,cell2))
+                 maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
                enddo
 
                do k = 1,maxLevelCell(iCell)
-                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
+                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
+                                                       BruntVaisalaFreqTop(k,cell2))
+                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
 
-                  gmKappaScaling(k, iCell) = min(max(config_GM_min_stratification_ratio, &
+                  gmKappaScaling(k, iEdge) = min(max(config_GM_min_stratification_ratio, &
                                                BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
                                                1.0_RKIND)
-                  RediKappaScaling(k, iCell) = gmKappaScaling(k, iCell)
                end do
            enddo
            !$omp end do
            !$omp end parallel
          end if
 
-         nEdges = nEdgesArray(3)
-
-         ! For config_GM_closure = 'N2_dependent' or 'visbeck' compute a spatially variable
-         ! baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
+         ! For config_GM_closure = 'N2_dependent' or 'visbeck' or 'edenGreatbatch' compute a spatially
+         ! variable baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
             !$omp parallel
             !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, &
@@ -666,6 +675,35 @@ contains
            !$omp end parallel
          end if
 
+         ! When config_GM_closure = 'edenGreatbatch' actually modify the value of gmBolusKappa based on
+         ! Eden and Greatbach (2008), Ocean Model., but assuming quasi-geostrophy to simplify the EKE budget
+         if (local_config_GM_compute_edenGreatbatch) then
+           call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
+           call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+           call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+
+           do iEdge=1,nEdges
+              sumRi = 0.0_RKIND
+              cell1 = cellsOnEdge(1, iEdge)
+              cell2 = cellsOnEdge(2, iEdge)
+
+              do k=1,maxLevelEdgeTop(iEdge)
+                 RiTopOfEdge = 0.5_RKIND*(max(RiTopOfCell(k,cell1),0.0_RKIND) + &
+                                          max(RiTopOfCell(k,cell2),0.0_RKIND))
+                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)*cGMphaseSpeed(iEdge))) / &
+                         sqrt(sumRi + config_gm_EG_riMin)
+                 L_rhines = sigma / (1.0E-11_RKIND + betaEdge(iEdge))
+                 Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)), sqrt(cGMphaseSpeed(iEdge) / &
+                         (2.0_RKIND*betaEdge(iEdge))))
+                 Length = min(Lr,L_rhines)
+                 !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
+                 !be removed below in the computation of the stream function
+                 gmKappaScaling(k,iEdge) = max(config_GM_visbeck_min_kappa, min(config_gm_EG_kappa_factor* &
+                         Length**2.0*sigma, config_GM_visbeck_max_kappa)) / gmBolusKappa(iCell)
+              enddo
+            enddo
+         endif
+
          if(config_Redi_set_RediKappa_to_GMKappa) then
             !$omp parallel
             !$omp do schedule(runtime)
@@ -692,19 +730,17 @@ contains
                ! First row
                k = 2
 
-               kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
                                                                      *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
                tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k, iEdge) &
                                  /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*kappaGMEdge*gravity/rho_sw &
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
 
                ! Second to next to the last rows
                do k = 3, maxLevelEdgeTop(iEdge) - 1
-                  kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                   tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &
@@ -713,21 +749,19 @@ contains
                                                                         *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
                   tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k, iEdge) &
                                     /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
-                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*kappaGMEdge*gravity/rho_sw &
+                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                          *gradDensityConstZTopOfEdge(k,iEdge)
                end do
 
                ! Last row
                k = maxLevelEdgeTop(iEdge)
-               kappaGMEdge = 0.5_RKIND*(gmKappaScaling(k, cell1) + gmKappaScaling(k, cell2))
-
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &
                                  /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
                tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
                                                                      *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*kappaGMEdge*gravity/rho_sw &
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
                ! Total number of rows
                N = maxLevelEdgeTop(iEdge) - 1
@@ -740,7 +774,6 @@ contains
          !!$omp end do
          !!$omp end parallel
 
-         nEdges = nEdgesArray(3)
          ! Compute normalGMBolusVelocity from the stream function and apply resolution taper of GM here
          !$omp parallel
          !$omp do schedule(runtime) private(k)
@@ -931,6 +964,7 @@ contains
             local_config_GM_lat_variable_c2 = .false.
             local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_visbeck = .false.
+            local_config_GM_compute_edenGreatbatch = .false.
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
@@ -943,6 +977,8 @@ contains
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .true.
             local_config_GM_compute_visbeck = .false.
+            local_config_GM_compute_edenGreatbatch = .false.
+
             RediGMinitValue = 0.0_RKIND
             ! for N2 dependence, we still assign Kappa as a constant.
             !$omp parallel
@@ -956,6 +992,24 @@ contains
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_visbeck = .true.
+            local_config_GM_compute_edenGreatbatch = .false.
+
+            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
+            call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+            call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge=1,nEdges
+              betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
+              gmBolusKappa(iEdge) = config_GM_visbeck_max_kappa
+            end do
+            !$omp end do
+            !$omp end parallel
+         else if (config_GM_closure == 'edenGreatbatch') then
+            local_config_GM_lat_variable_c2 = .true.
+            local_config_GM_kappa_lat_depth_variable = .false.
+            local_config_GM_compute_visbeck = .false.
+            local_config_GM_compute_edenGreatbatch = .true.
 
             call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -577,33 +577,23 @@ contains
          ! variable baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, countN2, &
-            !$omp             BruntVaisalaFreqTopEdge, lt1, lt2)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
                sumN2 = 0.0
-               ltSum = 0.0
-               countN2 = 0
-
-               cGMphaseSpeed(iEdge) = config_GM_constant_gravWaveSpeed
 
                do k = 2, maxLevelEdgeTop(iEdge)-1
 
-                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
-                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                   lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                   lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
-                  sumN2 = sumN2 + 0.5_RKIND*(lt1*max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
-                                lt2*max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
-
-                  ltSum = ltSum + 0.5_RKIND*(lt1+lt2)
-                  countN2 = countN2 + 1
+                  sumN2 = sumN2 + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
+                                lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
 
                end do
 
-               if (countN2 > 0) cGMphaseSpeed(iEdge) = max(config_GM_constant_gravWaveSpeed, sqrt(sumN2/ltSum)* &
-                            ltSum/(config_GM_baroclinic_mode*3.141592_RKIND))
+               cGMphaseSpeed(iEdge) = max(config_GM_constant_gravWaveSpeed,                          &
+                                          sumN2/(config_GM_baroclinic_mode*3.141592_RKIND))
 
             end do
             !$omp end do
@@ -683,20 +673,20 @@ contains
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
 
            !$omp parallel
-           !$omp do schedule(runtime) private(cell1, cell2, sumRi, sigma, RiTopOfEdge, &
+           !$omp do schedule(runtime) private(cell1, cell2, sigma, RiTopOfEdge, &
            !$omp             L_rhines, Lr, Length)
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
+              Lr = min(config_GM_baroclinic_mode*cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
+                       sqrt(cGMphaseSpeed(iEdge)*config_GM_baroclinic_mode / (2.0_RKIND*betaEdge(iEdge))))
 
               do k=1,maxLevelEdgeTop(iEdge)
                  RiTopOfEdge = 0.5_RKIND*(max(RiTopOfCell(k,cell1),0.0_RKIND) + &
                                           max(RiTopOfCell(k,cell2),0.0_RKIND))
-                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)*cGMphaseSpeed(iEdge))) / &
-                         sqrt(RiTopOfEdge + config_gm_EG_riMin)
-                 L_rhines = sigma / (1.0E-11_RKIND + betaEdge(iEdge))
-                 Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)), sqrt(cGMphaseSpeed(iEdge) / &
-                         (2.0_RKIND*betaEdge(iEdge))))
+                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)*config_GM_baroclinic_mode* &
+                             cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
+                 L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))
                  Length = min(Lr,L_rhines)
                  !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
                  !be removed below in the computation of the stream function

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -545,7 +545,7 @@ contains
          ! based on stratification relative to the maximum in the column
          if (local_config_GM_kappa_lat_depth_variable) then
             !$omp parallel
-            !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN)
+            !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
             do iEdge=1,nEdges
                k=1
                cell1 = cellsOnEdge(1,iEdge)
@@ -553,13 +553,13 @@ contains
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                     BruntVaisalaFreqTop(k,cell2))
                maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               do k = 2, maxLevelCell(iCell)
+               do k = 2, maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                       BruntVaisalaFreqTop(k,cell2))
                  maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
                enddo
 
-               do k = 1,maxLevelCell(iCell)
+               do k = 1, maxLevelEdgeTop(iEdge)
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                        BruntVaisalaFreqTop(k,cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -686,7 +686,6 @@ contains
            !$omp do schedule(runtime) private(cell1, cell2, sumRi, sigma, RiTopOfEdge, &
            !$omp             L_rhines, Lr, Length)
            do iEdge=1,nEdges
-              sumRi = 0.0_RKIND
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
 
@@ -694,7 +693,7 @@ contains
                  RiTopOfEdge = 0.5_RKIND*(max(RiTopOfCell(k,cell1),0.0_RKIND) + &
                                           max(RiTopOfCell(k,cell2),0.0_RKIND))
                  sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)*cGMphaseSpeed(iEdge))) / &
-                         sqrt(sumRi + config_gm_EG_riMin)
+                         sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-11_RKIND + betaEdge(iEdge))
                  Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)), sqrt(cGMphaseSpeed(iEdge) / &
                          (2.0_RKIND*betaEdge(iEdge))))

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -118,7 +118,7 @@ contains
       !-----------------------------------------------------------------
 
       real(kind=RKIND), dimension(:, :), pointer :: density, displacedDensity, zMid, normalGMBolusVelocity, &
-                                                    layerThicknessEdge, &
+                                                    normalVelocity, tangentialVelocity, layerThicknessEdge, &
                                                     k33, gmStreamFuncTopOfEdge, BruntVaisalaFreqTop, gmStreamFuncTopOfCell, &
                                                     layerThickness, inSituThermalExpansionCoeff, &
                                                     inSituSalineContractionCoeff, RediKappaScaling, gmKappaScaling, RediKappaSfcTaper, &
@@ -137,7 +137,7 @@ contains
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx, BVFcent
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
       real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz
-      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines
+      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines, shearEdge
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       ! Dimensions
       integer :: nsmooth, nCells, nEdges
@@ -163,6 +163,7 @@ contains
 
       call mpas_timer_start('gm bolus velocity')
 
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
@@ -170,6 +171,7 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
+      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'density', density)
       call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
       call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff', inSituThermalExpansionCoeff)
@@ -674,7 +676,7 @@ contains
 
            !$omp parallel
            !$omp do schedule(runtime) private(cell1, cell2, sigma, RiTopOfEdge, &
-           !$omp             L_rhines, Lr, Length)
+           !$omp             L_rhines, Lr, Length, BruntVaisalaFreqTopEdge, shearEdge)
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
@@ -682,8 +684,13 @@ contains
                        sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
               do k=1,maxLevelEdgeTop(iEdge)
-                 RiTopOfEdge = 0.5_RKIND*(max(RiTopOfCell(k,cell1),0.0_RKIND) + &
-                                          max(RiTopOfCell(k,cell2),0.0_RKIND))
+                 BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
+                                          max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
+                 shearEdge = ((normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge)) / (0.5_RKIND*     &
+                   (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge))))**2.0 +             &
+                   ((tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge)) / (0.5_RKIND*       &
+                   (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge))))**2.0
+                 RiTopOfEdge = BruntVaisalaFreqTopEdge / (1.0E-15_RKIND + shearEdge)
                  sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)* &
                              cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -46,11 +46,11 @@ module ocn_gm
    real(kind=RKIND), parameter :: epsGM = 1.0e-12_RKIND
 
    ! The following logical variables are used to configure the three 
-   ! available GM closures (constant, N2_dependent, visbeck, edenGreatbatch)
-   logical :: local_config_GM_compute_visbeck
+   ! available GM closures (constant, N2_dependent, Visbeck, EdenGreatbatch)
+   logical :: local_config_GM_compute_Visbeck
    logical :: local_config_GM_lat_variable_c2
    logical :: local_config_GM_kappa_lat_depth_variable
-   logical :: local_config_GM_compute_edenGreatbatch
+   logical :: local_config_GM_compute_EdenGreatbatch
    real(kind=RKIND) :: slopeTaperFactor, sfcTaperFactor, rediGMinitValue
 
 !***********************************************************************
@@ -124,7 +124,7 @@ contains
                                                     inSituSalineContractionCoeff, RediKappaScaling, gmKappaScaling, RediKappaSfcTaper, &
                                                     zTop, RiTopOfCell
 
-      real(kind=RKIND), dimension(:), pointer   :: c_visbeck, gmBolusKappa, cGMphaseSpeed, &
+      real(kind=RKIND), dimension(:), pointer   :: c_Visbeck, gmBolusKappa, cGMphaseSpeed, &
                 ssh, eddyLength, eddyTime, betaEdge, fEdge, gmResolutionTaper, RediKappa
       real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
@@ -573,7 +573,7 @@ contains
            !$omp end parallel
          end if
 
-         ! For config_GM_closure = 'N2_dependent' or 'visbeck' or 'edenGreatbatch' compute a spatially
+         ! For config_GM_closure = 'N2_dependent' or 'Visbeck' or 'EdenGreatbatch' compute a spatially
          ! variable baroclinic phase speed, the mode can be specified by config_GM_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
             !$omp parallel
@@ -609,16 +609,16 @@ contains
             !$omp end parallel
          end if
 
-         ! When config_GM_closure = 'visbeck' actually modify the value of gmBolusKappa based on
+         ! When config_GM_closure = 'Visbeck' actually modify the value of gmBolusKappa based on
          ! Visbeck et al (1997), JPO as recast by Cessi (2008), JPO
-         if (local_config_GM_compute_visbeck) then
+         if (local_config_GM_compute_Visbeck) then
            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)
            call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
            call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-           call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
+           call mpas_pool_get_array(diagnosticsPool, 'c_Visbeck', c_Visbeck)
            !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
            !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2)
@@ -633,7 +633,7 @@ contains
 
               k = 2
               zEdge = -layerThicknessEdge(k-1,iEdge)
-              do while(zEdge > -config_GM_visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
+              do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
                 sumN2 = sumN2 + 0.5_RKIND*(lt1*max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
@@ -648,26 +648,26 @@ contains
               end do
 
               if (countN2 > 0) then
-                c_visbeck(iEdge) = sqrt(sumN2*ltsum)
+                c_Visbeck(iEdge) = sqrt(sumN2*ltsum)
                 sumRi = sumRi / (ltsum + 1.0E-11_RKIND)
 
-                eddyLength(iEdge) = min(c_visbeck(iEdge)/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
-                                sqrt(c_visbeck(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
-                eddyTime(iEdge) = 1.0_RKIND / (max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_visbeck(iEdge)*betaEdge(iEdge))) /  &
+                eddyLength(iEdge) = min(c_Visbeck(iEdge)/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
+                                sqrt(c_Visbeck(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
+                eddyTime(iEdge) = 1.0_RKIND / (max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_Visbeck(iEdge)*betaEdge(iEdge))) /  &
                                       (1.0E-11_RKIND + sqrt(sumRi)))
-                gmBolusKappa(iEdge) = config_GM_visbeck_alpha * eddyLength(iEdge)**2.0_RKIND / (1.0E-15 + eddyTime(iEdge))
-                gmBolusKappa(iEdge) = max(config_GM_visbeck_min_kappa, min(gmBolusKappa(iEdge), config_GM_visbeck_max_kappa))
+                gmBolusKappa(iEdge) = config_GM_Visbeck_alpha * eddyLength(iEdge)**2.0_RKIND / (1.0E-15 + eddyTime(iEdge))
+                gmBolusKappa(iEdge) = max(config_GM_Visbeck_min_kappa, min(gmBolusKappa(iEdge), config_GM_Visbeck_max_kappa))
              else !for really shallow columns use min bolus kappa
-                gmBolusKappa(iEdge) = config_GM_visbeck_min_kappa
+                gmBolusKappa(iEdge) = config_GM_Visbeck_min_kappa
              end if
            end do
            !$omp end do
            !$omp end parallel
          end if
 
-         ! When config_GM_closure = 'edenGreatbatch' actually modify the value of gmBolusKappa based on
+         ! When config_GM_closure = 'EdenGreatbatch' actually modify the value of gmBolusKappa based on
          ! Eden and Greatbach (2008), Ocean Model., but assuming quasi-geostrophy to simplify the EKE budget
-         if (local_config_GM_compute_edenGreatbatch) then
+         if (local_config_GM_compute_EdenGreatbatch) then
            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
@@ -690,8 +690,8 @@ contains
                  Length = min(Lr,L_rhines)
                  !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
                  !be removed below in the computation of the stream function
-                 gmKappaScaling(k,iEdge) = max(config_GM_visbeck_min_kappa, min(config_gm_EG_kappa_factor* &
-                         Length**2.0*sigma, config_GM_visbeck_max_kappa)) / gmBolusKappa(iEdge)
+                 gmKappaScaling(k,iEdge) = max(config_GM_Visbeck_min_kappa, min(config_gm_EG_kappa_factor* &
+                         Length**2.0*sigma, config_GM_Visbeck_max_kappa)) / gmBolusKappa(iEdge)
               enddo
            enddo
            !$omp end do
@@ -957,8 +957,8 @@ contains
          if (config_GM_closure == 'constant') then
             local_config_GM_lat_variable_c2 = .false.
             local_config_GM_kappa_lat_depth_variable = .false.
-            local_config_GM_compute_visbeck = .false.
-            local_config_GM_compute_edenGreatbatch = .false.
+            local_config_GM_compute_Visbeck = .false.
+            local_config_GM_compute_EdenGreatbatch = .false.
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
@@ -970,8 +970,8 @@ contains
          else if (config_GM_closure == 'N2_dependent') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .true.
-            local_config_GM_compute_visbeck = .false.
-            local_config_GM_compute_edenGreatbatch = .false.
+            local_config_GM_compute_Visbeck = .false.
+            local_config_GM_compute_EdenGreatbatch = .false.
 
             RediGMinitValue = 0.0_RKIND
             ! for N2 dependence, we still assign Kappa as a constant.
@@ -982,11 +982,12 @@ contains
             end do
             !$omp end do
             !$omp end parallel
-         else if (config_GM_closure == 'visbeck') then
+         else if (config_GM_closure == 'Visbeck'.or. &
+                  config_GM_closure == 'visbeck') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .false.
-            local_config_GM_compute_visbeck = .true.
-            local_config_GM_compute_edenGreatbatch = .false.
+            local_config_GM_compute_Visbeck = .true.
+            local_config_GM_compute_EdenGreatbatch = .false.
 
             call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
@@ -995,15 +996,16 @@ contains
             !$omp do schedule(runtime)
             do iEdge=1,nEdges
               betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
-              gmBolusKappa(iEdge) = config_GM_visbeck_max_kappa
+              gmBolusKappa(iEdge) = config_GM_Visbeck_max_kappa
             end do
             !$omp end do
             !$omp end parallel
-         else if (config_GM_closure == 'edenGreatbatch') then
+         else if (config_GM_closure == 'EdenGreatbatch'.or. &
+                  config_GM_closure == 'edenGreatbatch') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .false.
-            local_config_GM_compute_visbeck = .false.
-            local_config_GM_compute_edenGreatbatch = .true.
+            local_config_GM_compute_Visbeck = .false.
+            local_config_GM_compute_EdenGreatbatch = .true.
 
             call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
@@ -1012,7 +1014,7 @@ contains
             !$omp do schedule(runtime)
             do iEdge=1,nEdges
               betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
-              gmBolusKappa(iEdge) = config_GM_visbeck_max_kappa
+              gmBolusKappa(iEdge) = config_GM_Visbeck_max_kappa
             end do
             !$omp end do
             !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -561,7 +561,7 @@ contains
                  maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
                enddo
 
-               do k = 1, maxLevelEdgeTop(iEdge)
+               do k = 2, maxLevelEdgeTop(iEdge)
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                        BruntVaisalaFreqTop(k,cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
@@ -683,7 +683,7 @@ contains
               Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
                        sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
-              do k=1,maxLevelEdgeTop(iEdge)
+              do k=2,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
                  shearEdgeInv = (0.5_RKIND*(layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)))**2.0 &

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -704,10 +704,10 @@ contains
                  gmKappaScaling(k,iEdge) = max(config_GM_visbeck_min_kappa, min(config_gm_EG_kappa_factor* &
                          Length**2.0*sigma, config_GM_visbeck_max_kappa)) / gmBolusKappa(iCell)
               enddo
-            enddo
+           enddo
+           !$omp end do
+           !$omp end parallel
          endif
-         !$omp end do
-         !$omp end parallel
 
          if(config_Redi_set_RediKappa_to_GMKappa) then
             !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -137,7 +137,7 @@ contains
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx, BVFcent
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
       real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz
-      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines, shearEdge
+      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines, shearEdgeInv
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       ! Dimensions
       integer :: nsmooth, nCells, nEdges
@@ -676,7 +676,7 @@ contains
 
            !$omp parallel
            !$omp do schedule(runtime) private(cell1, cell2, sigma, RiTopOfEdge, &
-           !$omp             L_rhines, Lr, Length, BruntVaisalaFreqTopEdge, shearEdge)
+           !$omp             L_rhines, Lr, Length, BruntVaisalaFreqTopEdge, shearEdgeInv)
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
@@ -686,12 +686,12 @@ contains
               do k=1,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
-                 shearEdge = ((normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge)) / (0.5_RKIND*     &
-                   (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge))))**2.0 +             &
-                   ((tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge)) / (0.5_RKIND*       &
-                   (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge))))**2.0
-                 RiTopOfEdge = BruntVaisalaFreqTopEdge / (1.0E-15_RKIND + shearEdge)
-                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0*betaEdge(iEdge)* &
+                 shearEdgeInv = (0.5_RKIND*(layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)))**2.0 &
+                    / (  (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2.0 &
+                       + (tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge))**2.0 &
+                       + 1.0e-18_RKIND )
+                 RiTopOfEdge = BruntVaisalaFreqTopEdge * shearEdgeInv
+                 sigma = max(abs(fEdge(iEdge)),sqrt(2.0_RKIND*betaEdge(iEdge)* &
                              cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))
                  Length = min(Lr,L_rhines)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -682,6 +682,9 @@ contains
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
 
+           !$omp parallel
+           !$omp do schedule(runtime) private(cell1, cell2, sumRi, sigma, RiTopOfEdge, &
+           !$omp             L_rhines, Lr, Length)
            do iEdge=1,nEdges
               sumRi = 0.0_RKIND
               cell1 = cellsOnEdge(1, iEdge)
@@ -703,6 +706,8 @@ contains
               enddo
             enddo
          endif
+         !$omp end do
+         !$omp end parallel
 
          if(config_Redi_set_RediKappa_to_GMKappa) then
             !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -305,8 +305,7 @@ contains
       !$omp do schedule(runtime)  &
       !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
       !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
-      !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper) &
-      !$omp firstprivate(slopeTriadUp, slopeTriadDown)
+      !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND


### PR DESCRIPTION
This adds a simplified version of the Eden and Greatbatch (2008) EKE budget to compute the GM bolus kappa.  It is a steady state budget but is fully three-dimensional.

