### PR TITLE
Added registry file defining namelist parameters used by e3sm driver

### DIFF
--- a/src/core_seaice/Registry.e3sm.xml
+++ b/src/core_seaice/Registry.e3sm.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<registry model="mpas" core="seaice" core_abbrev="seaice" version="7.0">
+	<nml_record name="prescribed_mode" in_defaults="true">
+		<nml_option name="stream_year_first" type="integer" default_value="-999" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_year_last" type="integer" default_value="-999" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="model_year_align" type="integer" default_value="-999" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_fldvarname" type="character" default_value="ice_cov" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_fldfilename" type="character_array::400" default_value="unset" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_domtvarname" type="character" default_value="time" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_domxvarname" type="character" default_value="xc" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_domyvarname" type="character" default_value="yc" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_domareaname" type="character" default_value="area" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_dommaskname" type="character" default_value="mask" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_domfilename" type="character" default_value="unset" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_mapread" type="character" default_value="NOT_SET" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+		<nml_option name="stream_fill" type="logical" default_value="false" units="unitless"
+			description="Prescribed ice stream parameter for e3sm sea ice driver."
+			possible_values="Unknown"
+		/>
+	</nml_record>
+</registry>


### PR DESCRIPTION
Added registry file defining namelist parameters used only by the e3sm driver. These do not appear anywhere in MPAS-Seaice. They include a new character array type since the driver anmelist requires this for e3sm streams.
