### PR TITLE
Adds modifications to the E&G length scale

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -348,9 +348,17 @@
 					description="minimum Richardson number to prevent overly large bolus Kappa values"
 					possible_values="numbers greater than zero"
 		/>
-		<nml_option name="config_gm_EG_kappa_factor" type="real" default_value="2.0" units="NA"
+		<nml_option name="config_gm_EG_kappa_factor" type="real" default_value="3.0" units="NA"
 					description="factor to scale diffusivity for Eden Greatbach scheme"
 					possible_values="small positive reals"
+		/>
+		<nml_option name="config_gm_EG_rossby_factor" type="real" default_value="2.0" units="NA"
+					description="factor multiplying the rossby length in the E&G scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
+					possible_values="small values greater than or equal to one"
+		/>
+		<nml_option name="config_gm_EG_rhines_factor" type="real" default_value="0.3" units="NA"
+					description="factor multiplying the rhines length in the E&G scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
+					possible_values="small positive values less than equal to one"
 		/>
 		<nml_option name="config_GM_min_stratification_ratio" type="real" default_value="0.1" units="NA"
 					description="When using config_GM_closure='N2_dependent', the minimum value for N2/Nmax2 ratio."

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -352,12 +352,12 @@
 					description="factor to scale diffusivity for Eden Greatbach scheme"
 					possible_values="small positive reals"
 		/>
-		<nml_option name="config_gm_EG_rossby_factor" type="real" default_value="2.0" units="NA"
-					description="factor multiplying the rossby length in the E&G scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
+		<nml_option name="config_gm_EG_Rossby_factor" type="real" default_value="2.0" units="NA"
+					description="factor multiplying the Rossby length in the scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
 					possible_values="small values greater than or equal to one"
 		/>
-		<nml_option name="config_gm_EG_rhines_factor" type="real" default_value="0.3" units="NA"
-					description="factor multiplying the rhines length in the E&G scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
+		<nml_option name="config_gm_EG_Rhines_factor" type="real" default_value="0.3" units="NA"
+					description="factor multiplying the Rhines length in the scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
 					possible_values="small positive values less than equal to one"
 		/>
 		<nml_option name="config_GM_min_stratification_ratio" type="real" default_value="0.1" units="NA"

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -683,7 +683,7 @@ contains
                  sigma = max(abs(fEdge(iEdge)),sqrt(2.0_RKIND*betaEdge(iEdge)* &
                              cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))
-                 Length = min(Lr,L_rhines)
+                 Length = min(config_gm_EG_rossby_factor*Lr,config_gm_EG_rhines_factor*L_rhines)
                  !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
                  !be removed below in the computation of the stream function
                  gmKappaScaling(k,iEdge) = max(config_GM_Visbeck_min_kappa, min(config_gm_EG_kappa_factor* &

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -683,7 +683,7 @@ contains
                  sigma = max(abs(fEdge(iEdge)),sqrt(2.0_RKIND*betaEdge(iEdge)* &
                              cGMphaseSpeed(iEdge))) / sqrt(RiTopOfEdge + config_gm_EG_riMin)
                  L_rhines = sigma / (1.0E-18_RKIND + betaEdge(iEdge))
-                 Length = min(config_gm_EG_rossby_factor*Lr,config_gm_EG_rhines_factor*L_rhines)
+                 Length = min(config_gm_EG_Rossby_factor*Lr,config_gm_EG_Rhines_factor*L_rhines)
                  !For compatibility with other schemes, we normalize by the 2-D kappa field, which will
                  !be removed below in the computation of the stream function
                  gmKappaScaling(k,iEdge) = max(config_GM_Visbeck_min_kappa, min(config_gm_EG_kappa_factor* &


### PR DESCRIPTION
equation (28) of eden and greatbatch (2008) shows that implementation
requires a constant factor on the Rossby and Rhines length.  This is
implemented in this PR.

