### PR TITLE
Fix memory corruption and leak issues in gen_inc for parse executable

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -153,16 +153,17 @@ int add_package_to_list(const char * package, const char * package_list){/*{{{*/
 	token = strsep(&string, ";");
 
 	if(strcmp(package, token) == 0){
+		if(tofree) free(tofree);
 		return 0;
 	}
 
 	while( (token = strsep(&string, ";")) != NULL){
 		if(strcmp(package, token) == 0){
-
+			if(tofree) free(tofree);
 			return 0;
 		}
 	}
-
+	if(tofree) free(tofree);
 	return 1;
 }/*}}}*/
 
@@ -225,12 +226,13 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 				if(out_packages[0] == '\0'){
 					sprintf(out_packages, "%s", token);
 				} else if(add_package_to_list(token, out_packages)){
-					sprintf(out_packages, "%s;%s", out_packages, token);
+					strcat(out_packages, ";");
+					strcat(out_packages, token);
 				}
 
 				while( (token = strsep(&string, ";")) != NULL){
 					if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						strcat(out_packages, token-1);
 					}
 				}
 
@@ -249,12 +251,13 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 					if(out_packages[0] == '\0'){
 						sprintf(out_packages, "%s", token);
 					} else if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						strcat(out_packages, ";");
+						strcat(out_packages, token);
 					}
 
 					while( (token = strsep(&string, ";")) != NULL){
 						if(add_package_to_list(token, out_packages)){
-							sprintf(out_packages, "%s;%s", out_packages, token);
+							strcat(out_packages, token-1);
 						}
 					}
 
@@ -275,12 +278,13 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 				if(out_packages[0] == '\0'){
 					sprintf(out_packages, "%s", token);
 				} else if(add_package_to_list(token, out_packages)){
-					sprintf(out_packages, "%s;%s", out_packages, token);
+					strcat(out_packages, ";");
+					strcat(out_packages, token);
 				}
 
 				while( (token = strsep(&string, ";")) != NULL){
 					if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						strcat(out_packages, token-1);
 					}
 				}
 
@@ -387,12 +391,14 @@ int build_dimension_information(ezxml_t registry, ezxml_t var, int *ndims, int *
 				(*decomp) = dim_decomp;
 			} else if ( (*decomp) != -1 && dim_decomp != -1) {
 				fprintf(stderr, "ERROR: Variable %s contains multiple decomposed dimensions in list: %s\n", varname, vardims);
+				if(tofree) free(tofree);
 				return 1;
 			}
         } else if (is_time) {
             (*has_time) = 1;
 		} else if (!dim_exists) {
 			fprintf(stderr, "ERROR: Dimension %s on variable %s doesn't exist.\n", token, varname);
+			if(tofree) free(tofree);
 			return 1;
 		}
 	}
@@ -408,17 +414,19 @@ int build_dimension_information(ezxml_t registry, ezxml_t var, int *ndims, int *
 				(*decomp) = dim_decomp;
 			} else if ( (*decomp) != -1 && dim_decomp != -1) {
 				fprintf(stderr, "ERROR: Variable %s contains multiple decomposed dimensions in list: %s\n", varname, vardims);
+				if(tofree) free(tofree);
 				return 1;
 			}
         } else if (is_time) {
             (*has_time) = 1;
 		} else if (!dim_exists) {
 			fprintf(stderr, "ERROR: Dimension %s on variable %s doesn't exist.\n", token, varname);
+			if(tofree) free(tofree);
 			return 1;
 		}
 	}
 
-	free(tofree);
+	if(tofree) free(tofree);
 
 	return 0;
 }/*}}}*/
@@ -1127,6 +1135,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 
 				fortprintf(fd, ") then\n");
 				snprintf(sub_spacing, 1024, "   ");
+				if(tofree) free(tofree);
 			}
 
 			fortprintf(fd, "      %sindex_counter = index_counter + 1\n", sub_spacing);
@@ -1192,6 +1201,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 
 							fortprintf(fd, ") then\n");
 							snprintf(sub_spacing, 1024, "   ");
+							if(tofree) free(tofree);
 						}
 
 						fortprintf(fd, "      %sindex_counter = index_counter + 1\n", sub_spacing);
@@ -1348,7 +1358,8 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				sprintf(temp_str, "%s", token);
 
 				while ( ( token = strsep(&string, "'") ) != NULL ) {
-					sprintf(temp_str, "%s''%s", temp_str, token);
+					strcat(temp_str,"''");
+					strcat(temp_str,token);
 				}
 
 				free(tofree);
@@ -1364,7 +1375,8 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				sprintf(temp_str, "%s", token);
 
 				while ( ( token = strsep(&string, "'") ) != NULL ) {
-					sprintf(temp_str, "%s''%s", temp_str, token);
+					strcat(temp_str,"''");
+					strcat(temp_str,token);
 				}
 
 				free(tofree);
@@ -1401,6 +1413,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 			fortprintf(fd, " .or. %sActive", token);
 		}
 		fortprintf(fd, ") then\n");
+		if(tofree) free(tofree);
 	}
 
 	for(time_lev = 1; time_lev <= time_levs; time_lev++){
@@ -1557,7 +1570,8 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
-				sprintf(temp_str, "%s''%s", temp_str, token);
+				strcat(temp_str,"''");
+				strcat(temp_str,token);
 			}
 
 			free(tofree);
@@ -1573,7 +1587,8 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
-				sprintf(temp_str, "%s''%s", temp_str, token);
+				strcat(temp_str,"''");
+				strcat(temp_str,token);
 			}
 
 			free(tofree);
@@ -1608,6 +1623,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		}
 
 		fortprintf(fd, ") then\n");
+		if(tofree) free(tofree);
 	}
 
 	for(time_lev = 1; time_lev <= time_levs; time_lev++){
@@ -1658,7 +1674,7 @@ int parse_struct(FILE *fd, ezxml_t registry, ezxml_t superStruct, int subpool, c
 
 	structname = ezxml_attr(superStruct, "name");
 	structnameincode = ezxml_attr(superStruct, "name_in_code");
-	
+
 	if(!structnameincode){
 		structnameincode = ezxml_attr(superStruct, "name");
 	}
@@ -2109,7 +2125,6 @@ int generate_immutable_streams(ezxml_t registry){/*{{{*/
 											fortprintf(fd, "   call MPAS_stream_mgr_add_field(manager, \'%s\', \'%s\', packages=packages, ierr=ierr)\n", optname, optvarname);
 										else
 											fortprintf(fd, "   call MPAS_stream_mgr_add_field(manager, \'%s\', \'%s\', ierr=ierr)\n", optname, optvarname);
-										
 									}
 
 									/* Loop over arrays of fields listed within the stream */
@@ -2557,5 +2572,3 @@ int parse_structs_from_registry(ezxml_t registry)/*{{{*/
 
 	return 0;
 }/*}}}*/
-
-


### PR DESCRIPTION
The `parse` executable exhibits memory corruption under certain compiler/libc combinations.   The source of the problems are `sprintf()` calls with overlapping pointers which is not permitted by the C standard.   In particular, the memory corruption leads to malformed `.inc` files on MacOS when linking to Apple `libc` and on Linux linking to `glibc` under various compilers whenever any C-compiler optimizations are enabled.

From [`man sprintf`](https://linux.die.net/man/3/sprintf):
> **Notes**
> Some programs imprudently rely on code such as the following
> `sprintf(buf, "%s some further text", buf);`
> to append text to buf. However, the standards explicitly note that the results are undefined if source and destination buffers overlap when calling sprintf(), snprintf(), vsprintf(), and vsnprintf(). Depending on the version of gcc(1) used, and the compiler options employed, calls such as the above will not produce the expected results. 

This PR fixes those problematic locations in the source, relying on `strcat()` instead.

Additionally, in multiple locations variables named `tofree` are never `free()`'d.  While these memory leaks are arguably not a major correctness problem for this very simple short-running executable, they do present a myriad of false-positives for memory-checking and static-analysis tools, making it difficult to find any actual memory corruption errors.

With these changes, the parser executable corruption bugs appear to be fixed.

Tested with platforms/compilers:
* Linux
  * `GCC-10.2.0`
  * `Clang-10.0.1`
  * `Intel-20`
* MacOS
  * `GCC-10.2.0`
  * `Clang-11.0.3`

I am submitting this PR against `master` on advice from @mgduda to merge to the oldest branch exhibiting the bug, but I think the same patch will also apply cleanly to `develop` or `v7.0`.