### PR TITLE
Fix typos in Registry descriptions of rthratenlw and rthratensw

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2955,10 +2955,10 @@
                 <!--  rthratenlw:uncoupled theta tendency due to longwave radiation                             [K s-1] -->
 
                 <var name="rthratensw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="tendency of potential temperature due to short wave radiation"/>
+                     description="tendency of potential temperature due to shortwave radiation"/>
 
                 <var name="rthratenlw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="tendency of potential temperature due to long wave radiation"/>
+                     description="tendency of potential temperature due to longwave radiation"/>
         </var_struct>
 
 


### PR DESCRIPTION
This commit fixes the description of rthratenlw which previously stated that it
was due to 'short wave' radiation instead of 'long wave' radiation.

The descriptions for rthratenlw and rthratensw reference 'long wave' and
'short wave', respectfully, as two words. Other descriptions in the registry
reference these as 'longwave' and 'shortwave', i.e. as a single word, so this
commit changes 'long wave' and 'short wave' to a single word to match the rest
of the registry. This helps when finding fields that are related to shortwave
and longwave radiation.