### PR TITLE
Breakup the diagnostic_solve routine

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1706,7 +1706,8 @@ module ocn_time_integration_split
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, &
+                          scratchPool, tracersPool, 2, full=.false.)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             !

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -76,7 +76,7 @@ mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_su
 
 mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_mesh.o: 
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -516,6 +516,7 @@ contains
       ! Gradient Richardson number
       !
 
+      if ( full_compute ) then
       nCells = nCellsArray(3)
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
@@ -536,6 +537,9 @@ contains
           RiTopOfCell(1,iCell) = RiTopOfCell(2,iCell)
       end do
       !$omp end do
+      !$omp end parallel
+
+      end if    ! full_compute
 
       !
       ! extrapolate tracer values to ocean surface
@@ -544,6 +548,7 @@ contains
       ! field will be updated below is better approximations are available
 
 !TDR need to consider how to handle tracersSurfaceValues
+      !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
          tracersSurfaceValue(:, iCell) = activeTracers(:,1, iCell)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -92,7 +92,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
-                                   timeLevelIn)
+                                   timeLevelIn, full)
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
@@ -102,6 +102,7 @@ contains
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
+      logical, intent(in), optional :: full
 
       integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j
       integer :: boundaryMask, velMask, err, nCells, nEdges, nVertices
@@ -168,6 +169,14 @@ contains
       real (kind=RKIND) :: areaTri1, layerThicknessVertexInv, tempRiVal, dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
       real (kind=RKIND), dimension(:), allocatable:: layerThicknessVertexVec
       integer :: edgeSignOnCell_temp
+
+      logical :: full_compute = .true.
+
+      if ( present(full) ) then
+         full_compute = full
+      else
+         full_compute = .true.
+      end if
 
       call mpas_timer_start('diagnostic solve')
 
@@ -285,6 +294,8 @@ contains
 
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsArray( 1 )
+
+      if ( full_compute ) then
 
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
@@ -511,6 +522,8 @@ contains
 
       deallocate(normalizedPlanetaryVorticityVertex, &
                  normalizedRelativeVorticityVertex)
+
+      end if    ! full_compute
 
       !
       ! equation of state

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -91,10 +91,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
-                                   timeLevelIn, full)
-
-      use ocn_mesh, only: nCellsHalo, nEdgesHalo
+   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &
+                                   timeLevelIn, full)!{{{
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
@@ -106,7 +104,7 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
       logical, intent(in), optional :: full   !< Input: Run all computations?
 
-      integer :: iEdge, iCell, iVertex, k, cell1, cell2, eoe, i, j
+      integer :: iEdge, iCell
       integer :: err, nCells, nEdges, nVertices
       integer, pointer  :: nVertLevels, vertexDegree
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray, nVerticesArray
@@ -118,14 +116,11 @@ contains
         verticesOnEdge, edgesOnEdge, edgesOnVertex,boundaryCell, kiteIndexOnCell, &
         verticesOnCell, edgeSignOnVertex, edgeSignOnCell, edgesOnCell, edgeMask
 
-      real (kind=RKIND) :: coef_3rd_order, r_tmp, &
-        invAreaCell1
-
-      real (kind=RKIND), dimension(:), allocatable:: pTop
+      real (kind=RKIND) :: coef_3rd_order
 
       real (kind=RKIND), dimension(:), pointer :: &
-        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh,  seaIcePressure, atmosphericPressure, frazilSurfacePressure, &
-        pressureAdjustedSSH, gradSSH, landIcePressure, landIceDraft
+        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh,  seaIcePressure, atmosphericPressure, &
+        pressureAdjustedSSH, gradSSH
       real (kind=RKIND), dimension(:,:), pointer :: &
         weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
@@ -149,8 +144,6 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
-      real (kind=RKIND) :: dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
-      integer :: edgeSignOnCell_temp
 
       logical :: full_compute = .true.
 
@@ -236,9 +229,6 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-      call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
@@ -323,83 +313,9 @@ contains
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
-      nCells = nCellsArray( size(nCellsArray) )
-      if (config_pressure_gradient_type.eq.'MontgomeryPotential') then
-
-        ! use Montgomery Potential when layers are isopycnal.
-        ! However, one may use 'pressure_and_zmid' when layers are isopycnal as well.
-        ! Compute pressure at top of each layer, and then Montgomery Potential.
-
-        allocate(pTop(nVertLevels))
-
-        !$omp parallel
-        !$omp do schedule(runtime) private(pTop, k)
-        do iCell = 1, nCells
-
-           ! assume atmospheric pressure at the surface is zero for now.
-           pTop(1) = 0.0_RKIND
-           ! At top layer it is g*SSH, where SSH may be off by a
-           ! constant (ie, bottomDepth can be relative to top or bottom)
-           montgomeryPotential(1,iCell) = gravity &
-              * (bottomDepth(iCell) + sum(layerThickness(1:nVertLevels,iCell)))
-
-           do k = 2, nVertLevels
-              pTop(k) = pTop(k-1) + density(k-1,iCell)*gravity* layerThickness(k-1,iCell)
-
-              ! from delta M = p delta / density
-              montgomeryPotential(k,iCell) = montgomeryPotential(k-1,iCell) &
-                 + pTop(k)*(1.0_RKIND/density(k,iCell) - 1.0_RKIND/density(k-1,iCell))
-           end do
-
-        end do
-        !$omp end do
-        !$omp end parallel
-
-        deallocate(pTop)
-
-      else
-
-        !$omp parallel
-        !$omp do schedule(runtime) private(k)
-        do iCell = 1, nCells
-           ! Pressure for generalized coordinates.
-           ! Pressure at top surface may be due to atmospheric pressure
-           ! or an ice-shelf depression.
-           pressure(1,iCell) = atmosphericPressure(iCell) + seaIcePressure(iCell)
-           if ( associated(frazilSurfacePressure) ) pressure(1,iCell) = pressure(1,iCell) + frazilSurfacePressure(iCell)
-           if ( associated(landIcePressure) ) pressure(1,iCell) = pressure(1,iCell) + landIcePressure(iCell)
-           pressure(1,iCell) = pressure(1,iCell) + density(1,iCell)*gravity*0.5_RKIND*layerThickness(1,iCell)
-
-           do k = 2, maxLevelCell(iCell)
-              pressure(k,iCell) = pressure(k-1,iCell)  &
-                + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
-                               + density(k  ,iCell)*layerThickness(k  ,iCell))
-           end do
-
-           ! Compute zMid, the z-coordinate of the middle of the layer.
-           ! Compute zTop, the z-coordinate of the top of the layer.
-           ! Note the negative sign, since bottomDepth is positive
-           ! and z-coordinates are negative below the surface.
-           k = maxLevelCell(iCell)
-           zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
-           zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) +     layerThickness(k,iCell)
-
-           do k = maxLevelCell(iCell)-1, 1, -1
-              zMid(k,iCell) = zMid(k+1,iCell)  &
-                + 0.5_RKIND*(  layerThickness(k+1,iCell) &
-                       + layerThickness(k  ,iCell))
-              zTop(k,iCell) = zTop(k+1,iCell)  &
-                       + layerThickness(k  ,iCell)
-           end do
-
-           ! copy zTop(1,iCell) into sea-surface height array
-           ssh(iCell) = zTop(1,iCell)
-
-        end do
-        !$omp end do
-        !$omp end parallel
-
-      endif
+      call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
+                atmosphericPressure, seaIcePressure, montgomeryPotential, pressure, &
+                zMid, zTop, ssh)
 
       nCells = nCellsArray( size(nCellsArray) )
 
@@ -442,7 +358,7 @@ contains
          call ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
                 layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
-                surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)!{{{
+                surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)
 
       end if ! full_compute
 
@@ -453,40 +369,8 @@ contains
 
       if ( full_compute ) then
 
-      nCells = nCellsArray( 2 )
-      !$omp parallel
-      !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
-      end do
-      !$omp end do
-      !$omp end parallel
-
-
-      if(associated(landIceDraft)) then
-         !$omp parallel
-         !$omp do schedule(runtime)
-         do iCell = 1, nCells
-            ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
-            ! toward land ice
-            pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
-         end do
-         !$omp end do
-         !$omp end parallel
-      end if
-
-      nEdges = nEdgesArray( 2 )
-
-      !$omp parallel
-      !$omp do schedule(runtime) private(cell1, cell2)
-      do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-
-         gradSSH(iEdge) = edgeMask(1, iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
-      end do
-      !$omp end do
-      !$omp end parallel
+         call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, pressureAdjustedSSH, &
+                gradSSH)
 
       end if ! full_compute
 
@@ -591,7 +475,7 @@ contains
         end if
       end if
 
-   end subroutine ocn_diagnostic_solve_layerThicknessEdge
+   end subroutine ocn_diagnostic_solve_layerThicknessEdge!}}}
 
 !***********************************************************************
 !
@@ -1349,6 +1233,252 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_diagnostic_solve_pressure
+!
+!> \brief   Computes diagnostic variables for pressure, montgomery potential, and ssh
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for pressure, montgomery potential,
+!>    and ssh
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
+                atmosphericPressure, seaIcePressure, montgomeryPotential, pressure, &
+                zMid, zTop, ssh)!{{{
+
+      use ocn_mesh     ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         density
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         atmosphericPressure
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         seaIcePressure
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         montgomeryPotential
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         pressure
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zMid
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zTop
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         ssh
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells
+      integer :: iCell
+      integer :: k
+
+      real (kind=RKIND), dimension(:), allocatable:: pTop
+
+      real (kind=RKIND), dimension(:), pointer :: &
+        frazilSurfacePressure, landIcePressure
+
+      !
+      ! Pressure
+      ! This section must be placed in the code after computing the density.
+      !
+      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+
+      nCells = nCellsAll
+      if (config_pressure_gradient_type.eq.'MontgomeryPotential') then
+
+        ! use Montgomery Potential when layers are isopycnal.
+        ! However, one may use 'pressure_and_zmid' when layers are isopycnal as well.
+        ! Compute pressure at top of each layer, and then Montgomery Potential.
+
+        allocate(pTop(nVertLevels))
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(pTop, k)
+        do iCell = 1, nCells
+
+           ! assume atmospheric pressure at the surface is zero for now.
+           pTop(1) = 0.0_RKIND
+           ! At top layer it is g*SSH, where SSH may be off by a
+           ! constant (ie, bottomDepth can be relative to top or bottom)
+           montgomeryPotential(1,iCell) = gravity &
+              * (bottomDepth(iCell) + sum(layerThickness(1:nVertLevels,iCell)))
+
+           do k = 2, nVertLevels
+              pTop(k) = pTop(k-1) + density(k-1,iCell)*gravity* layerThickness(k-1,iCell)
+
+              ! from delta M = p delta / density
+              montgomeryPotential(k,iCell) = montgomeryPotential(k-1,iCell) &
+                 + pTop(k)*(1.0_RKIND/density(k,iCell) - 1.0_RKIND/density(k-1,iCell))
+           end do
+
+        end do
+        !$omp end do
+        !$omp end parallel
+
+        deallocate(pTop)
+
+      else
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1, nCells
+           ! Pressure for generalized coordinates.
+           ! Pressure at top surface may be due to atmospheric pressure
+           ! or an ice-shelf depression.
+           pressure(1,iCell) = atmosphericPressure(iCell) + seaIcePressure(iCell)
+           if ( associated(frazilSurfacePressure) ) pressure(1,iCell) = pressure(1,iCell) + frazilSurfacePressure(iCell)
+           if ( associated(landIcePressure) ) pressure(1,iCell) = pressure(1,iCell) + landIcePressure(iCell)
+           pressure(1,iCell) = pressure(1,iCell) + density(1,iCell)*gravity*0.5_RKIND*layerThickness(1,iCell)
+
+           do k = 2, maxLevelCell(iCell)
+              pressure(k,iCell) = pressure(k-1,iCell)  &
+                + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
+                               + density(k  ,iCell)*layerThickness(k  ,iCell))
+           end do
+
+           ! Compute zMid, the z-coordinate of the middle of the layer.
+           ! Compute zTop, the z-coordinate of the top of the layer.
+           ! Note the negative sign, since bottomDepth is positive
+           ! and z-coordinates are negative below the surface.
+           k = maxLevelCell(iCell)
+           zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
+           zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) +     layerThickness(k,iCell)
+
+           do k = maxLevelCell(iCell)-1, 1, -1
+              zMid(k,iCell) = zMid(k+1,iCell)  &
+                + 0.5_RKIND*(  layerThickness(k+1,iCell) &
+                       + layerThickness(k  ,iCell))
+              zTop(k,iCell) = zTop(k+1,iCell)  &
+                       + layerThickness(k  ,iCell)
+           end do
+
+           ! copy zTop(1,iCell) into sea-surface height array
+           ssh(iCell) = zTop(1,iCell)
+
+        end do
+        !$omp end do
+        !$omp end parallel
+
+      endif
+
+   end subroutine ocn_diagnostic_solve_pressure!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_ssh
+!
+!> \brief   Computes diagnostic variables for pressure adjusted ssh and gradSSH
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for pressureAdjustedSSH and gradSSH
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, pressureAdjustedSSH, &
+                gradSSH)!{{{
+
+      use ocn_mesh     ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         ssh
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         seaIcePressure
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         pressureAdjustedSSH
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         gradSSH
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iEdge
+      integer :: cell1, cell2
+
+      real (kind=RKIND), dimension(:), pointer :: landIceDraft
+
+      call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+
+      nCells = nCellsHalo( 1 )
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      if(associated(landIceDraft)) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
+            ! toward land ice
+            pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
+
+      nEdges = nEdgesHalo( 1 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2)
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         gradSSH(iEdge) = edgeMask(1, iEdge) * ( pressureAdjustedSSH(cell2) - pressureAdjustedSSH(cell1) ) / dcEdge(iEdge)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_ssh!}}}
+
+!***********************************************************************
+!
 !  routine ocn_vert_transport_velocity_top
 !
 !> \brief   Computes vertical transport
@@ -1964,7 +2094,7 @@ contains
                  - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell)* min(activeTracers(indexTempFlux,1,iCell),0.0_RKIND)/rho_sw &
                  - fracAbsorbed * (seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell)) * &
                  ocn_freezing_temperature( activeTracers(indexSaltFlux, 1, iCell), pressure=0.0_RKIND, inLandIceCavity=.false.)&
-                  / rho_sw 
+                  / rho_sw
 
          nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = activeTracersSurfaceFlux(indexSaltFlux,iCell) &
                  - fracAbsorbed * surfaceThicknessFlux(iCell) * activeTracers(indexSaltFlux,1,iCell) &
@@ -2953,7 +3083,7 @@ contains
 
    end function ocn_build_log_filename!}}}
 
-   subroutine ocn_write_field_statistics(unitNumber, fieldName, minValue, maxValue)!{{{
+   subroutine ocn_write_field_statistics(unitNumber, fieldName, minValue, maxValue)
       integer, intent(in) :: unitNumber
       character (len=*), intent(in) :: fieldName
       real (kind=RKIND), intent(in) :: minValue, maxValue
@@ -2962,7 +3092,7 @@ contains
       write(unitNumber, *) '        Min: ', minValue
       write(unitNumber, *) '        Max: ', maxValue
 
-   end subroutine ocn_write_field_statistics!}}}
+   end subroutine ocn_write_field_statistics
 
 !***********************************************************************
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -35,6 +35,7 @@ module ocn_diagnostics
    use ocn_equation_of_state
    use ocn_thick_ale
    use ocn_diagnostics_routines
+   use ocn_mesh
 
    implicit none
    private
@@ -106,10 +107,6 @@ contains
 
       integer :: iEdge, iCell
       integer :: err, nCells, nEdges, nVertices
-      integer, pointer  :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray, nEdgesArray, nVerticesArray
-
-      integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND) :: coef_3rd_order
 
@@ -193,15 +190,8 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
       call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
 
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVerticesArray', nVerticesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
@@ -211,9 +201,9 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
 
-      nEdges = nEdgesArray( size(nEdgesArray) )
-      nCells = nCellsArray( size(nCellsArray) )
-      nVertices = nVerticesArray( size(nVerticesArray) )
+      nEdges = nEdgesAll
+      nCells = nCellsAll
+      nVertices = nVerticesAll
 
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThicknessEdge)
 
@@ -257,7 +247,7 @@ contains
       !
 
       ! Only need densities on 0, 1, and 2 halo cells
-      nCells = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
 
       ! compute in-place density
       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
@@ -284,7 +274,7 @@ contains
                 atmosphericPressure, seaIcePressure, montgomeryPotential, pressure, &
                 zMid, zTop, ssh)
 
-      nCells = nCellsArray( size(nCellsArray) )
+      nCells = nCellsAll
 
       if ( full_compute ) then
 
@@ -1053,7 +1043,7 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          relativeVorticity
-      integer, dimension(:,:), intent(in) :: &
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
          edgeSignOnCell   ! debug, mdt :: This array is in ocn_mesh, but results are non-bfb
                           !               if I use the ocn_mesh array
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -1507,14 +1497,8 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iEdge, iCell, k, i, nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: nEdgesOnCell, &
-        maxLevelCell, maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
-      real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
 
       ! Scratch Arrays
       ! projectedSSH: projected SSH at a new time
@@ -1529,30 +1513,19 @@ contains
 
       err = 0
 
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
       if (config_vert_coord_movement.eq.'impermeable_interfaces') then
         vertAleTransportTop=0.0_RKIND
         return
       end if
 
-      ncells = nCellsArray(size(nCellsArray))
+      ncells = nCellsAll
 
       allocate(div_hu(nVertLevels, nCells), &
                projectedSSH(nCells), &
                ALE_Thickness(nVertLevels, nCells))
 
       ! Only need to compute over 0 and 1 halos
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo( 1 )
 
       !
       ! thickness-weighted divergence and barotropic divergence
@@ -1633,12 +1606,7 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Input time level for state pool
 
       integer :: iEdge, cell1, cell2, eoe, j, k
-      integer, pointer :: nEdgesSolve
-      real (kind=RKIND), dimension(:), pointer :: fEdge
-      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, normalVelocity, normalBaroclinicVelocity
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnEdge
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnEdge
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalBaroclinicVelocity
 
       integer :: timeLevel
 
@@ -1653,17 +1621,6 @@ contains
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, timeLevel)
 
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-
-      call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
-
       !DWJ: ADD OMP (Only needed for split explicit)
 
       !
@@ -1671,7 +1628,7 @@ contains
       !
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
-      do iEdge = 1, nEdgesSolve
+      do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
@@ -1711,10 +1668,8 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
-      integer, pointer :: nEdges
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalVelocity
-      integer, dimension(:), pointer :: maxLevelEdgeTop
 
       integer :: timeLevel
 
@@ -1730,13 +1685,9 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
       !$omp parallel
       !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
 
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
@@ -1781,11 +1732,8 @@ contains
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
-      integer, pointer :: nEdges
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, tend_normalVelocity
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop
 
       integer :: timeLevel
 
@@ -1801,13 +1749,9 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
       !$omp parallel
       !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
 
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
@@ -1908,15 +1852,8 @@ contains
 
       ! scalars
       integer :: nCells
-      integer, pointer :: nVertLevels
-      integer, dimension(:), pointer :: nCellsArray
-
-      ! integer pointers
-      integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
-      integer, dimension(:,:), pointer :: edgesOnCell
 
       ! real pointers
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
            surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
            normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux, &
@@ -1968,21 +1905,12 @@ contains
       turbulentVelocitySquared = 0.001_RKIND
 
       ! set scalar values
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', indexTempFlux)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', indexSaltFlux)
 
       ! set pointers into state, mesh, diagnostics and scratch
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
 
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
       call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
@@ -2009,14 +1937,14 @@ contains
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
 
       ! allocate scratch space displaced density computation
-      ncells = nCellsArray(size(nCellsArray))
+      ncells = nCellsAll
 
       allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
                thermalExpansionCoeff(nVertLevels, nCells), &
                salineContractionCoeff(nVertLevels, nCells))
 
       ! Only need to compute over the 0 and 1 halos
-      nCells = nCellsArray( 3 )
+      nCells = nCellsHalo( 2 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, nCells, 0, 'surfaceDisplaced', &
@@ -2129,11 +2057,6 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
 
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
-      integer, pointer :: nCells, nEdges
-
-      integer, dimension(:,:), pointer :: cellsOnCell, cellsOnEdge, cellMask
-
-      integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
 
       integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
@@ -2143,7 +2066,6 @@ contains
                                                   landIceFrictionVelocity, &
                                                   topDrag, &
                                                   topDragMagnitude, &
-                                                  fCell, &
                                                   surfaceFluxAttenuationCoefficient
 
       integer, dimension(:), pointer :: landIceMask
@@ -2170,15 +2092,6 @@ contains
       end if
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
-
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -2207,17 +2120,13 @@ contains
       end if
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
-      allocate(blTempScratch(nCells), &
-               blSaltScratch(nCells))
-
-      if(hollandJenkinsOn) then
-         call mpas_pool_get_array(meshPool, 'fCell', fCell)
-      end if
+      allocate(blTempScratch(nCellsAll), &
+               blSaltScratch(nCellsAll))
 
       ! Compute top drag
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, velocityMagnitude, landIceEdgeFraction)
-      do iEdge = 1, nEdges
+      do iEdge = 1, nEdgesAll
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
 
@@ -2233,7 +2142,7 @@ contains
 
       ! compute top drag magnitude and friction velocity at cell centers
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMagnitude(iCell) = rho_sw * landIceFraction(iCell) &
                                    * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(1,iCell)
@@ -2247,7 +2156,7 @@ contains
 
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
       !$omp do schedule(runtime) private(blThickness, iLevel, dz)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND
          blSaltScratch(iCell) = 0.0_RKIND
@@ -2266,7 +2175,7 @@ contains
       !$omp end do
 
       !$omp do schedule(runtime) private(weightSum, i, cell2)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
          landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
          if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
@@ -2289,7 +2198,7 @@ contains
       if(jenkinsOn) then
          !$omp parallel
          !$omp do schedule(runtime)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             ! transfer coefficients from namelist
             landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell) &
                                              * config_land_ice_flux_jenkins_heat_transfer_coefficient
@@ -2301,7 +2210,7 @@ contains
       else if(hollandJenkinsOn) then
          !$omp parallel
          !$omp do schedule(runtime) private(h_nu, Gamma_turb)
-         do iCell = 1, nCells
+         do iCell = 1, nCellsAll
             ! friction-velocity dependent non-dimensional transfer coefficients from
             ! Holland and Jenkins 1999, (14)-(16) with eta_* = 1
             h_nu = 5.0_RKIND*nuSaltWater/landIceFrictionVelocity(iCell) ! uStar should never be zero because of tidal term
@@ -2327,7 +2236,7 @@ contains
       ! modify the spatially-varying attenuation coefficient where there is land ice
       !$omp parallel
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          if(landIceMask(iCell) == 1) then
             surfaceFluxAttenuationCoefficient(iCell) = config_land_ice_flux_attenuation_coefficient
          end if

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -633,6 +633,8 @@ contains
 
       nCells = nCellsArray( size(nCellsArray) )
 
+      if ( full_compute ) then
+
       !
       ! Brunt-Vaisala frequency (this has units of s^{-2})
       !
@@ -648,6 +650,8 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
+      end if ! full_compute
 
       !
       ! Gradient Richardson number
@@ -693,6 +697,8 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
+      if ( full_compute ) then
 
       !
       ! average tracer values over the ocean surface layer
@@ -821,6 +827,8 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
+      end if ! full_compute
 
       call mpas_timer_stop('diagnostic solve')
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -269,58 +269,12 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
-      !
-      ! Compute height on cell edges at velocity locations
-      !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
-      !
 
       nEdges = nEdgesArray( size(nEdgesArray) )
       nCells = nCellsArray( size(nCellsArray) )
       nVertices = nVerticesArray( size(nVerticesArray) )
 
-      if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
-        !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k)
-        do iEdge = 1, nEdges
-          ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
-          layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
-          cell1 = cellsOnEdge(1,iEdge)
-          cell2 = cellsOnEdge(2,iEdge)
-          do k = 1, maxLevelEdgeTop(iEdge)
-            ! central differenced
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
-          end do
-        end do
-        !$omp end do
-        !$omp end parallel
-      else
-        if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
-          if ( trim(config_thickness_flux_type) .eq. 'upwind') then
-            !$omp parallel
-            !$omp do schedule(runtime) private(cell1, cell2, k)
-            do iEdge = 1, nEdges
-              ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
-              layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
-              cell1 = cellsOnEdge(1,iEdge)
-              cell2 = cellsOnEdge(2,iEdge)
-              do k = 1, maxLevelEdgeTop(iEdge)
-                ! upwind
-                if (normalVelocity(k, iEdge) > 0.0_RKIND) then
-                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell1)
-                elseif (normalVelocity(k, iEdge) < 0.0_RKIND) then
-                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell2)
-                else
-                  layerThicknessEdge(k,iEdge) = max(layerThickness(k,cell1), layerThickness(k,cell2))
-                end if
-              end do
-            end do
-            !$omp end do
-            !$omp end parallel
-          end if
-        else
-          call mpas_log_write('Thickness flux option of ' // trim(config_thickness_flux_type) // 'is not known', MPAS_LOG_CRIT)
-        end if
-      end if
+      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThicknessEdge)
 
       coef_3rd_order = config_coef_3rd_order
 
@@ -912,6 +866,105 @@ contains
       call mpas_timer_stop('diagnostic solve')
 
    end subroutine ocn_diagnostic_solve!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_layerThicknessEdge
+!
+!> \brief   Computes diagnostic variable layerThicknessEdge
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variable layerThicknessEdge
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, &
+                layerThicknessEdge)!{{{
+
+      use ocn_mesh   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity     !< Input: transport
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThickness      !< Input: layer thickness
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         layerThicknessEdge     !< Output: layer thickness on edge
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k, cell1, cell2, nEdges
+
+      !
+      ! Compute height on cell edges at velocity locations
+      !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
+      !
+
+      nEdges = nEdgesAll
+
+      if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
+        !$omp parallel
+        !$omp do schedule(runtime) private(cell1, cell2, k)
+        do iEdge = 1, nEdges
+          ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
+          layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+          do k = 1, maxLevelEdgeTop(iEdge)
+            ! central differenced
+            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
+          end do
+        end do
+        !$omp end do
+        !$omp end parallel
+      else
+        if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
+          if ( trim(config_thickness_flux_type) .eq. 'upwind') then
+            !$omp parallel
+            !$omp do schedule(runtime) private(cell1, cell2, k)
+            do iEdge = 1, nEdges
+              ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
+              layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              do k = 1, maxLevelEdgeTop(iEdge)
+                ! upwind
+                if (normalVelocity(k, iEdge) > 0.0_RKIND) then
+                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell1)
+                elseif (normalVelocity(k, iEdge) < 0.0_RKIND) then
+                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell2)
+                else
+                  layerThicknessEdge(k,iEdge) = max(layerThickness(k,cell1), layerThickness(k,cell2))
+                end if
+              end do
+            end do
+            !$omp end do
+            !$omp end parallel
+          end if
+        else
+          call mpas_log_write('Thickness flux option of ' // trim(config_thickness_flux_type) // 'is not known', MPAS_LOG_CRIT)
+        end if
+      end if
+
+   end subroutine ocn_diagnostic_solve_layerThicknessEdge
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -525,94 +525,13 @@ contains
 
       if ( full_compute ) then
 
-      !
-      ! average tracer values over the ocean surface layer
-      ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
-      if(config_use_cvmix_kpp) then
-
-        nCells = nCellsArray( 1 )
-
-        !$omp parallel
-        !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
-        do iCell=1,nCells
-          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
-          sumSurfaceLayer=0.0_RKIND
-          tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
-          indexSurfaceLayerDepth(iCell) = -9.e30
-          do k=1,maxLevelCell(iCell)
-           sumSurfaceLayer = sumSurfaceLayer + layerThickness(k,iCell)
-           rSurfaceLayer = maxLevelCell(iCell)
-           if(sumSurfaceLayer.gt.surfaceLayerDepth) then
-             sumSurfaceLayer = sumSurfaceLayer - layerThickness(k,iCell)
-             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThickness(k,iCell)
-             indexSurfaceLayerDepth(iCell) = rSurfaceLayer
-             exit
-           endif
-          end do
-          tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
-          do k=1,int(rSurfaceLayer)
-            tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
-                                              * layerThickness(k,iCell)
-          enddo
-          k=min( int(rSurfaceLayer)+1, maxLevelCell(iCell) )
-          tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
-                                            * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
-        enddo
-        !$omp end do
-        !$omp end parallel
-
-        nEdges = nEdgesArray( 1 )
-
-        !
-        ! average normal velocity values over the ocean surface layer
-        ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
-        !
-
-        !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
-        do iEdge=1,nEdges
-          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
-          cell1=cellsOnEdge(1,iEdge)
-          cell2=cellsOnEdge(2,iEdge)
-          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
-          sumSurfaceLayer=0.0_RKIND
-          rSurfaceLayer = min(1, maxLevelEdgeTop(iEdge))
-          do k=1,maxLevelEdgeTop(iEdge)
-           rSurfaceLayer = k
-           sumSurfaceLayer = sumSurfaceLayer + layerThicknessEdge(k,iEdge)
-           if(sumSurfaceLayer.gt.surfaceLayerDepth) then
-             sumSurfaceLayer = sumSurfaceLayer - layerThicknessEdge(k,iEdge)
-             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThicknessEdge(k,iEdge)
-             exit
-           endif
-          end do
-          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
-          do k=1,int(rSurfaceLayer)
-            normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + normalVelocity(k,iEdge) &
-                                              * layerThicknessEdge(k,iEdge)
-          enddo
-          k=int(rSurfaceLayer)+1
-          if(k.le.maxLevelEdgeTop(iEdge)) then
-            normalVelocitySurfaceLayer(iEdge) = (normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &
-                                              * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
-          end if
-        enddo
-        !$omp end do
-        !$omp end parallel
-
-      endif
-
-      nCells = nCellsArray( 2 )
-
-      ! compute the attenuation coefficient for surface fluxes
-      !$omp parallel
-      !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         surfaceFluxAttenuationCoefficient(iCell) = config_flux_attenuation_coefficient
-         surfaceFluxAttenuationCoefficientRunoff(iCell) = config_flux_attenuation_coefficient_runoff
-      end do
-      !$omp end do
-      !$omp end parallel
+         !
+         ! average tracer values over the ocean surface layer
+         ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
+         call ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
+                layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
+                indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
+                surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)!{{{
 
       end if ! full_compute
 
@@ -1181,6 +1100,164 @@ contains
       !$omp end parallel
 
    end subroutine ocn_diagnostic_solve_richardson!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_surfaceLayer
+!
+!> \brief   Computes diagnostic variables for surface layer
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for averages of tracer
+!>    values at surface layer
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
+                layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
+                indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
+                surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)!{{{
+
+      use ocn_mesh   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThickness      !< Input: layer thickness
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+        activeTracers
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThicknessEdge
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        normalVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         tracersSurfaceLayerValue
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         indexSurfaceLayerDepth
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         normalVelocitySurfaceLayer
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         surfaceFluxAttenuationCoefficient
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         surfaceFluxAttenuationCoefficientRunoff
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iEdge
+      integer :: k
+      real(kind=RKIND) :: rSurfaceLayer
+      integer :: cell1, cell2
+      real(kind=RKIND) :: surfaceLayerDepth
+      real(kind=RKIND) :: sumSurfaceLayer
+
+      !
+      ! average tracer values over the ocean surface layer
+      ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
+      if(config_use_cvmix_kpp) then
+
+        nCells = nCellsOwned
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        do iCell=1,nCells
+          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
+          sumSurfaceLayer=0.0_RKIND
+          tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
+          indexSurfaceLayerDepth(iCell) = -9.e30
+          do k=1,maxLevelCell(iCell)
+           sumSurfaceLayer = sumSurfaceLayer + layerThickness(k,iCell)
+           rSurfaceLayer = maxLevelCell(iCell)
+           if(sumSurfaceLayer.gt.surfaceLayerDepth) then
+             sumSurfaceLayer = sumSurfaceLayer - layerThickness(k,iCell)
+             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThickness(k,iCell)
+             indexSurfaceLayerDepth(iCell) = rSurfaceLayer
+             exit
+           endif
+          end do
+          tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
+          do k=1,int(rSurfaceLayer)
+            tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
+                                              * layerThickness(k,iCell)
+          enddo
+          k=min( int(rSurfaceLayer)+1, maxLevelCell(iCell) )
+          tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
+                                            * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
+        enddo
+        !$omp end do
+        !$omp end parallel
+
+        nEdges = nEdgesOwned
+
+        !
+        ! average normal velocity values over the ocean surface layer
+        ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
+        !
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        do iEdge=1,nEdges
+          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
+          cell1=cellsOnEdge(1,iEdge)
+          cell2=cellsOnEdge(2,iEdge)
+          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
+          sumSurfaceLayer=0.0_RKIND
+          rSurfaceLayer = min(1, maxLevelEdgeTop(iEdge))
+          do k=1,maxLevelEdgeTop(iEdge)
+           rSurfaceLayer = k
+           sumSurfaceLayer = sumSurfaceLayer + layerThicknessEdge(k,iEdge)
+           if(sumSurfaceLayer.gt.surfaceLayerDepth) then
+             sumSurfaceLayer = sumSurfaceLayer - layerThicknessEdge(k,iEdge)
+             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThicknessEdge(k,iEdge)
+             exit
+           endif
+          end do
+          normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
+          do k=1,int(rSurfaceLayer)
+            normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + normalVelocity(k,iEdge) &
+                                              * layerThicknessEdge(k,iEdge)
+          enddo
+          k=int(rSurfaceLayer)+1
+          if(k.le.maxLevelEdgeTop(iEdge)) then
+            normalVelocitySurfaceLayer(iEdge) = (normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &
+                                              * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
+          end if
+        enddo
+        !$omp end do
+        !$omp end parallel
+
+      endif
+
+      nCells = nCellsHalo( 1 )
+
+      ! compute the attenuation coefficient for surface fluxes
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         surfaceFluxAttenuationCoefficient(iCell) = config_flux_attenuation_coefficient
+         surfaceFluxAttenuationCoefficientRunoff(iCell) = config_flux_attenuation_coefficient_runoff
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_surfaceLayer!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -223,7 +223,7 @@ contains
 
       if ( full_compute ) then
 
-         call ocn_diagnostic_solve_vortVel(relativeVorticity, edgeSignOnCell, &
+         call ocn_diagnostic_solve_vortVel(relativeVorticity, &
                 layerThicknessEdge, normalVelocity, normalTransportVelocity, &
                 normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
                 vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
@@ -240,6 +240,7 @@ contains
                    layerThickness, relativeVorticity, &
                    normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
                    normalizedRelativeVorticityCell)
+
       end if    ! full_compute
 
       !
@@ -1021,17 +1022,13 @@ contains
 !>    velocities
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, edgeSignOnCell, &
+   subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
                 layerThicknessEdge, normalVelocity, normalTransportVelocity, &
                 normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
                 vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
                 kineticEnergyCell, tangentialVelocity)!{{{
 
-      use ocn_mesh, only: nCellsHalo, nEdgesHalo, nCellsOwned, areaCell, &
-                          nEdgesOnCell, kiteIndexOnCell, verticesOnCell, &
-                          maxLevelCell, nVertLevels, kiteAreasOnVertex, &
-                          edgesOnCell, dcEdge, dvEdge, weightsOnEdge, &
-                          nEdgesOnEdge, edgesOnEdge, maxLevelEdgeTop   ! debug, mdt :: this should be module-level
+      use ocn_mesh
 
       implicit none
 
@@ -1043,9 +1040,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          relativeVorticity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         edgeSignOnCell   ! debug, mdt :: This array is in ocn_mesh, but results are non-bfb
-                          !               if I use the ocn_mesh array
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThicknessEdge
       real (kind=RKIND), dimension(:,:), intent(in) :: &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -145,13 +145,6 @@ contains
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
 
-      ! Scratch Arrays
-      ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
-      !               units: m^2 s^{-2}
-      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
-      ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
-      !                      units: m^2 s^{-2}
-      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
       ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
       !                                     divided by layer thickness, defined at vertices
       !                              units: s^{-1}
@@ -388,54 +381,7 @@ contains
       ! Compute kinetic energy
       !
       if ( ke_vertex_flag == 1 ) then
-
-         allocate(kineticEnergyVertex(nVertLevels, nVertices), &
-                  kineticEnergyVertexOnCells(nVertLevels, nCells))
-
-         !$omp parallel
-         !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
-         do iVertex = 1, nVertices
-           kineticEnergyVertex(:, iVertex) = 0.0_RKIND
-           do i = 1, vertexDegree
-             iEdge = edgesOnVertex(i, iVertex)
-             r_tmp = dcEdge(iEdge) * dvEdge(iEdge) * 0.25_RKIND / areaTriangle(iVertex)
-             do k = 1, nVertLevels
-               kineticEnergyVertex(k, iVertex) = kineticEnergyVertex(k, iVertex) + r_tmp * normalVelocity(k, iEdge)**2
-             end do
-           end do
-         end do
-         !$omp end do
-
-         !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
-         do iCell = 1, nCells
-           kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
-           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-           do i = 1, nEdgesOnCell(iCell)
-             j = kiteIndexOnCell(i, iCell)
-             iVertex = verticesOnCell(i, iCell)
-             do k = 1, nVertLevels
-               kineticEnergyVertexOnCells(k, iCell) = kineticEnergyVertexOnCells(k, iCell) + kiteAreasOnVertex(j, iVertex) &
-                                                    * kineticEnergyVertex(k, iVertex) * invAreaCell1
-             end do
-           end do
-         end do
-         !$omp end do
-
-         !
-         ! Compute kinetic energy in each cell by blending kineticEnergyCell and kineticEnergyVertexOnCells
-         !
-         !$omp do schedule(runtime) private(k)
-         do iCell = 1, nCells
-            do k = 1, nVertLevels
-               kineticEnergyCell(k,iCell) = 5.0_RKIND / 8.0_RKIND * kineticEnergyCell(k,iCell) + 3.0_RKIND / 8.0_RKIND &
-                                          * kineticEnergyVertexOnCells(k,iCell)
-            end do
-         end do
-         !$omp end do
-         !$omp end parallel
-
-         deallocate(kineticEnergyVertex, &
-                    kineticEnergyVertexOnCells)
+         call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
       !
@@ -965,6 +911,112 @@ contains
       end if
 
    end subroutine ocn_diagnostic_solve_layerThicknessEdge
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_kineticEnergy
+!
+!> \brief   Computes diagnostic variable kineticEnergyCell
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variable kineticEnergyCell
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_kineticEnergy(normalVelocity, &
+                kineticEnergyCell)!{{{
+
+      use ocn_mesh   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity     !< Input: transport
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         kineticEnergyCell
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iVertex, i, iEdge, k, j, nCells, nVertices, iCell
+      real (kind=RKIND) :: r_tmp, invAreaCell1
+
+      ! Scratch Arrays
+      ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
+      !               units: m^2 s^{-2}
+      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
+      ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
+      !                      units: m^2 s^{-2}
+      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
+
+      nCells = nCellsHalo( 2 )
+      nVertices = nVerticesAll
+
+      allocate(kineticEnergyVertex(nVertLevels, nVertices), &
+               kineticEnergyVertexOnCells(nVertLevels, nCells))
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
+      do iVertex = 1, nVertices
+        kineticEnergyVertex(:, iVertex) = 0.0_RKIND
+        do i = 1, vertexDegree
+          iEdge = edgesOnVertex(i, iVertex)
+          r_tmp = dcEdge(iEdge) * dvEdge(iEdge) * 0.25_RKIND / areaTriangle(iVertex)
+          do k = 1, nVertLevels
+            kineticEnergyVertex(k, iVertex) = kineticEnergyVertex(k, iVertex) + r_tmp * normalVelocity(k, iEdge)**2
+          end do
+        end do
+      end do
+      !$omp end do
+
+      !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+      do iCell = 1, nCells
+        kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
+        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          j = kiteIndexOnCell(i, iCell)
+          iVertex = verticesOnCell(i, iCell)
+          do k = 1, nVertLevels
+            kineticEnergyVertexOnCells(k, iCell) = kineticEnergyVertexOnCells(k, iCell) + kiteAreasOnVertex(j, iVertex) &
+                                                 * kineticEnergyVertex(k, iVertex) * invAreaCell1
+          end do
+        end do
+      end do
+      !$omp end do
+
+      !
+      ! Compute kinetic energy in each cell by blending kineticEnergyCell and kineticEnergyVertexOnCells
+      !
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCells
+         do k = 1, nVertLevels
+            kineticEnergyCell(k,iCell) = 5.0_RKIND / 8.0_RKIND * kineticEnergyCell(k,iCell) + 3.0_RKIND / 8.0_RKIND &
+                                       * kineticEnergyVertexOnCells(k,iCell)
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(kineticEnergyVertex, &
+                 kineticEnergyVertexOnCells)
+
+   end subroutine ocn_diagnostic_solve_kineticEnergy
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -789,10 +789,14 @@ contains
       !$omp end do
       !$omp end parallel
 
+      end if ! full_compute
+
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       call ocn_compute_land_ice_flux_input_fields(meshPool, statePool, forcingPool, scratchPool, &
                                          diagnosticsPool, timeLevel)
+
+      if ( full_compute ) then
 
       nCells = nCellsArray( 2 )
       !$omp parallel
@@ -802,6 +806,7 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
 
       if(associated(landIceDraft)) then
          !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -102,10 +102,10 @@ contains
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state
-      logical, intent(in), optional :: full
+      logical, intent(in), optional :: full   !< Input: Run all computations?
 
-      integer :: iEdge, iCell, iVertex, k, cell1, cell2, vertex1, vertex2, eoe, i, j
-      integer :: boundaryMask, velMask, err, nCells, nEdges, nVertices
+      integer :: iEdge, iCell, iVertex, k, cell1, cell2, eoe, i, j
+      integer :: err, nCells, nEdges, nVertices
       integer, pointer  :: nVertLevels, vertexDegree
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray, nVerticesArray
 
@@ -116,9 +116,8 @@ contains
         verticesOnEdge, edgesOnEdge, edgesOnVertex,boundaryCell, kiteIndexOnCell, &
         verticesOnCell, edgeSignOnVertex, edgeSignOnCell, edgesOnCell, edgeMask
 
-      real (kind=RKIND) :: d2fdx2_cell1, d2fdx2_cell2, coef_3rd_order, r_tmp, &
-        invAreaCell1, invAreaCell2, invAreaTri1, invAreaTri2, invLength, layerThicknessVertex, coef, &
-        shearMean, shearSquared, delU2, sumSurfaceLayer, surfaceLayerDepth, rSurfaceLayer
+      real (kind=RKIND) :: coef_3rd_order, r_tmp, &
+        invAreaCell1
 
       real (kind=RKIND), dimension(:), allocatable:: pTop, div_hu,div_huTransport,div_huGMBolus
 
@@ -128,15 +127,14 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: &
         weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
-        vertAleTransportTop, zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
+        zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
         normalizedPlanetaryVorticityEdge, normalizedRelativeVorticityEdge, &
         normalizedRelativeVorticityCell, density, displacedDensity, potentialDensity, &
-        temperature, salinity, vertVelocityTop, vertTransportVelocityTop, &
+        vertVelocityTop, vertTransportVelocityTop, &
         vertGMBolusVelocityTop, BruntVaisalaFreqTop, &
         RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff, edgeAreaFractionOfCell
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers, derivTwo
-      character :: c1*6
 
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
@@ -149,8 +147,7 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
-      real (kind=RKIND) :: areaTri1, layerThicknessVertexInv, tempRiVal, dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
-      real (kind=RKIND), dimension(:), allocatable:: layerThicknessVertexVec
+      real (kind=RKIND) :: dcEdge_temp, dvEdge_temp, weightsOnEdge_temp
       integer :: edgeSignOnCell_temp
 
       logical :: full_compute = .true.
@@ -369,19 +366,17 @@ contains
       !$omp end do
       !$omp end parallel
 
-      ! Need 0,1,2 halo cells
-      nCells = nCellsArray( 3 )
-      !
-      ! Compute kinetic energy
-      !
-      if ( ke_vertex_flag == 1 ) then
-         call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
-      end if
+         !
+         ! Compute kinetic energy
+         !
+         if ( ke_vertex_flag == 1 ) then
+            call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
+         end if
 
-      call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
-                layerThickness, relativeVorticity, &
-                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-                normalizedRelativeVorticityCell)
+         call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
+                   layerThickness, relativeVorticity, &
+                   normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+                   normalizedRelativeVorticityCell)
       end if    ! full_compute
 
       !
@@ -1326,7 +1321,7 @@ contains
       integer :: iEdge, iCell, k, i, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge, &
+      integer, dimension(:), pointer :: nEdgesOnCell, &
         maxLevelCell, maxLevelEdgeTop
       integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
 
@@ -1449,11 +1444,10 @@ contains
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Input time level for state pool
 
-      integer :: iEdge, cell1, cell2, eoe, i, j, k
+      integer :: iEdge, cell1, cell2, eoe, j, k
       integer, pointer :: nEdgesSolve
       real (kind=RKIND), dimension(:), pointer :: fEdge
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, normalVelocity, normalBaroclinicVelocity
-      type (dm_info) :: dminfo
 
       integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnEdge
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnEdge
@@ -1707,8 +1701,6 @@ contains
 !>    CVMix/KPP requires the following fields as intent(in):
 !>       surfaceBuoyancyForcing
 !>       surfaceFrictionVelocity
-!>       bulkRichardsonNumberBuoy
-!>       bulkRichardsonNumberShear
 !>
 !
 !-----------------------------------------------------------------------
@@ -1754,13 +1746,10 @@ contains
       real (kind=RKIND), dimension(:,:,:), pointer :: &
            activeTracers
 
-      real (kind=RKIND), dimension(:,:), pointer ::  &
-           bulkRichardsonNumberBuoy, bulkRichardsonNumberShear
-
       ! local
-      integer :: iCell, iEdge, i, k, err, timeLevel
+      integer :: iCell, iEdge, i, err, timeLevel
       integer, pointer :: indexTempFlux, indexSaltFlux
-      real (kind=RKIND) :: numerator, denominator, turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
+      real (kind=RKIND) :: turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
       real (kind=RKIND) :: sumSurfaceStressSquared
 
       ! Scratch Arrays
@@ -2274,15 +2263,8 @@ contains
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeBot, maxLevelVertexBot
 
       real (kind=RKIND), dimension(:), pointer :: real1DArr
-      real (kind=RKIND), dimension(:, :), pointer :: real2DArr
-      real (kind=RKIND), dimension(:, :, :), pointer :: real3DArr
-      real (kind=RKIND), dimension(:, :, :, :), pointer :: real4DArr
-      real (kind=RKIND), dimension(:, :, :, :, :), pointer :: real5DArr
-      integer, dimension(:), pointer :: int1DArr
-      integer, dimension(:, :), pointer :: int2DArr
-      integer, dimension(:, :, :), pointer :: int3DArr
 
-      integer :: iCell, iEdge, iVertex, iTracer, k
+      integer :: iCell, iEdge, iTracer, k
 
       logical :: fatalErrorDetected
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -146,23 +146,6 @@ contains
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
 
-      ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
-      !                                     divided by layer thickness, defined at vertices
-      !                              units: s^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
-      ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
-      !                                    defined at vertices
-      !                             units: s^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
-      ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
-      !                                   (positive points from cell1 to cell2)
-      !                            units: s^{-1} m^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
-      ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
-      !                                       (positive points from vertex1 to vertex2)
-      !                                units: s^{-1} m^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
-
 
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
@@ -395,134 +378,10 @@ contains
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
-      !
-      ! Compute normalized relative and planetary vorticity
-      !
-      allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVertices), &
-               normalizedRelativeVorticityVertex(nVertLevels, nVertices))
-
-      nVertices = nVerticesArray( 3 )
-
-      !$omp parallel
-      !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
-      do iVertex = 1, nVertices
-         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
-         do k = 1, maxLevelVertexBot(iVertex)
-            layerThicknessVertex = 0.0_RKIND
-            do i = 1, vertexDegree
-               layerThicknessVertex = layerThicknessVertex + layerThickness(k,cellsOnVertex(i,iVertex)) &
-                                    * kiteAreasOnVertex(i,iVertex)
-            end do
-            layerThicknessVertex = layerThicknessVertex * invAreaTri1
-
-            normalizedRelativeVorticityVertex(k,iVertex) = relativeVorticity(k,iVertex) / layerThicknessVertex
-            normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
-         end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      nEdges = nEdgesArray( 3 )
-
-      !$omp parallel
-      !$omp do schedule(runtime) private(vertex1, vertex2, k)
-      do iEdge = 1, nEdges
-        normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
-        normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
-        vertex1 = verticesOnEdge(1, iEdge)
-        vertex2 = verticesOnEdge(2, iEdge)
-        do k = 1, maxLevelEdgeBot(iEdge)
-          normalizedRelativeVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedRelativeVorticityVertex(k, vertex1) &
-                                                    + normalizedRelativeVorticityVertex(k, vertex2))
-          normalizedPlanetaryVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedPlanetaryVorticityVertex(k, vertex1) &
-                                                     + normalizedPlanetaryVorticityVertex(k, vertex2))
-        end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      nCells = nCellsArray( 2 )
-
-      !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
-      do iCell = 1, nCells
-        normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-
-        do i = 1, nEdgesOnCell(iCell)
-          j = kiteIndexOnCell(i, iCell)
-          iVertex = verticesOnCell(i, iCell)
-          do k = 1, maxLevelCell(iCell)
-            normalizedRelativeVorticityCell(k, iCell) = normalizedRelativeVorticityCell(k, iCell) &
-              + kiteAreasOnVertex(j, iVertex) * normalizedRelativeVorticityVertex(k, iVertex) * invAreaCell1
-          end do
-        end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      nCells = nCellsArray( size(nCellsArray) )
-      nVertices = nVerticesArray( size(nVerticesArray) )
-      nEdges = nCellsArray( size(nCellsArray) )
-
-      ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
-      if (config_apvm_scale_factor>1e-10) then
-
-         allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
-                  vorticityGradientTangentialComponent(nVertLevels, nEdges))
-
-         nEdges = nEdgesArray( 2 )
-
-         !$omp parallel
-         !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
-         do iEdge = 1,nEdges
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            vertex1 = verticesOnedge(1, iEdge)
-            vertex2 = verticesOnedge(2, iEdge)
-
-            invLength = 1.0_RKIND / dcEdge(iEdge)
-            ! Compute gradient of PV in normal direction
-            !   ( this computes the gradient for all edges bounding real cells )
-            do k=1,maxLevelEdgeTop(iEdge)
-               vorticityGradientNormalComponent(k,iEdge) = &
-                  (normalizedRelativeVorticityCell(k,cell2) - normalizedRelativeVorticityCell(k,cell1)) * invLength
-            enddo
-
-            invLength = 1.0_RKIND / dvEdge(iEdge)
-            ! Compute gradient of PV in the tangent direction
-            !   ( this computes the gradient at all edges bounding real cells and distance-1 ghost cells )
-            do k = 1,maxLevelEdgeBot(iEdge)
-              vorticityGradientTangentialComponent(k,iEdge) = &
-                 (normalizedRelativeVorticityVertex(k,vertex2) - normalizedRelativeVorticityVertex(k,vertex1)) * invLength
-            enddo
-
-         enddo
-         !$omp end do
-
-         !
-         ! Modify PV edge with upstream bias.
-         !
-         !$omp do schedule(runtime) private(k)
-         do iEdge = 1,nEdges
-            do k = 1,maxLevelEdgeBot(iEdge)
-              normalizedRelativeVorticityEdge(k,iEdge) = normalizedRelativeVorticityEdge(k,iEdge) &
-                - config_apvm_scale_factor * dt * &
-                    (  normalVelocity(k,iEdge)     * vorticityGradientNormalComponent(k,iEdge)      &
-                     + tangentialVelocity(k,iEdge) * vorticityGradientTangentialComponent(k,iEdge) )
-            enddo
-         enddo
-         !$omp end do
-         !$omp end parallel
-
-         deallocate(vorticityGradientNormalComponent, &
-                    vorticityGradientTangentialComponent)
-
-      endif
-
-      deallocate(normalizedPlanetaryVorticityVertex, &
-                 normalizedRelativeVorticityVertex)
-
+      call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
+                layerThickness, relativeVorticity, &
+                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+                normalizedRelativeVorticityCell)
       end if    ! full_compute
 
       !
@@ -1042,7 +901,218 @@ contains
       deallocate(kineticEnergyVertex, &
                  kineticEnergyVertexOnCells)
 
-   end subroutine ocn_diagnostic_solve_kineticEnergy
+   end subroutine ocn_diagnostic_solve_kineticEnergy!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_vorticity
+!
+!> \brief   Computes diagnostic variables for vorticity
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for vorticity
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
+                layerThickness, relativeVorticity, &
+                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+                normalizedRelativeVorticityCell)!{{{
+
+      use ocn_mesh   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), intent(in) :: dt !< Input: Time step
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity     !< Input: transport
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tangentialVelocity !< Input: transport
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        layerThickness      !< Input: layer thickness
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        relativeVorticity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        normalizedRelativeVorticityEdge
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        normalizedPlanetaryVorticityEdge
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        normalizedRelativeVorticityCell
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nVertices, nEdges, nCells
+      integer :: iVertex, k, i, iEdge, iCell, j
+      integer :: vertex1, vertex2, cell1, cell2
+      real(kind=RKIND) :: invAreaTri1, invAreaCell1, invLength
+      real(kind=RKIND) :: layerThicknessVertex
+
+      ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
+      !                                     divided by layer thickness, defined at vertices
+      !                              units: s^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
+      ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
+      !                                    defined at vertices
+      !                             units: s^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
+      ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
+      !                                   (positive points from cell1 to cell2)
+      !                            units: s^{-1} m^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
+      ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
+      !                                       (positive points from vertex1 to vertex2)
+      !                                units: s^{-1} m^{-1}
+      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
+
+
+
+      !
+      ! Compute normalized relative and planetary vorticity
+      !
+      allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVerticesAll), &
+               normalizedRelativeVorticityVertex(nVertLevels, nVerticesAll))
+
+      nVertices = nVerticesHalo( 2 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
+      do iVertex = 1, nVertices
+         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+         do k = 1, maxLevelVertexBot(iVertex)
+            layerThicknessVertex = 0.0_RKIND
+            do i = 1, vertexDegree
+               layerThicknessVertex = layerThicknessVertex + layerThickness(k,cellsOnVertex(i,iVertex)) &
+                                    * kiteAreasOnVertex(i,iVertex)
+            end do
+            layerThicknessVertex = layerThicknessVertex * invAreaTri1
+
+            normalizedRelativeVorticityVertex(k,iVertex) = relativeVorticity(k,iVertex) / layerThicknessVertex
+            normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      nEdges = nEdgesHalo( 2 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(vertex1, vertex2, k)
+      do iEdge = 1, nEdges
+        normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
+        normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
+        vertex1 = verticesOnEdge(1, iEdge)
+        vertex2 = verticesOnEdge(2, iEdge)
+        do k = 1, maxLevelEdgeBot(iEdge)
+          normalizedRelativeVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedRelativeVorticityVertex(k, vertex1) &
+                                                    + normalizedRelativeVorticityVertex(k, vertex2))
+          normalizedPlanetaryVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedPlanetaryVorticityVertex(k, vertex1) &
+                                                     + normalizedPlanetaryVorticityVertex(k, vertex2))
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsHalo ( 1 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+      do iCell = 1, nCells
+        normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
+        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+        do i = 1, nEdgesOnCell(iCell)
+          j = kiteIndexOnCell(i, iCell)
+          iVertex = verticesOnCell(i, iCell)
+          do k = 1, maxLevelCell(iCell)
+            normalizedRelativeVorticityCell(k, iCell) = normalizedRelativeVorticityCell(k, iCell) &
+              + kiteAreasOnVertex(j, iVertex) * normalizedRelativeVorticityVertex(k, iVertex) * invAreaCell1
+          end do
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      nCells = nCellsAll
+      nVertices = nVerticesAll
+      nEdges = nCellsAll
+
+      ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
+      if (config_apvm_scale_factor>1e-10) then
+
+         allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
+                  vorticityGradientTangentialComponent(nVertLevels, nEdges))
+
+         nEdges = nEdgesHalo( 1 )
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
+         do iEdge = 1,nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            vertex1 = verticesOnedge(1, iEdge)
+            vertex2 = verticesOnedge(2, iEdge)
+
+            invLength = 1.0_RKIND / dcEdge(iEdge)
+            ! Compute gradient of PV in normal direction
+            !   ( this computes the gradient for all edges bounding real cells )
+            do k=1,maxLevelEdgeTop(iEdge)
+               vorticityGradientNormalComponent(k,iEdge) = &
+                  (normalizedRelativeVorticityCell(k,cell2) - normalizedRelativeVorticityCell(k,cell1)) * invLength
+            enddo
+
+            invLength = 1.0_RKIND / dvEdge(iEdge)
+            ! Compute gradient of PV in the tangent direction
+            !   ( this computes the gradient at all edges bounding real cells and distance-1 ghost cells )
+            do k = 1,maxLevelEdgeBot(iEdge)
+              vorticityGradientTangentialComponent(k,iEdge) = &
+                 (normalizedRelativeVorticityVertex(k,vertex2) - normalizedRelativeVorticityVertex(k,vertex1)) * invLength
+            enddo
+
+         enddo
+         !$omp end do
+
+         !
+         ! Modify PV edge with upstream bias.
+         !
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1,nEdges
+            do k = 1,maxLevelEdgeBot(iEdge)
+              normalizedRelativeVorticityEdge(k,iEdge) = normalizedRelativeVorticityEdge(k,iEdge) &
+                - config_apvm_scale_factor * dt * &
+                    (  normalVelocity(k,iEdge)     * vorticityGradientNormalComponent(k,iEdge)      &
+                     + tangentialVelocity(k,iEdge) * vorticityGradientTangentialComponent(k,iEdge) )
+            enddo
+         enddo
+         !$omp end do
+         !$omp end parallel
+
+         deallocate(vorticityGradientNormalComponent, &
+                    vorticityGradientTangentialComponent)
+
+      endif
+
+      deallocate(normalizedPlanetaryVorticityVertex, &
+                 normalizedRelativeVorticityVertex)
+
+
+   end subroutine ocn_diagnostic_solve_vorticity!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -106,23 +106,18 @@ contains
 
       integer :: iEdge, iCell
       integer :: err, nCells, nEdges, nVertices
-      integer, pointer  :: nVertLevels, vertexDegree
+      integer, pointer  :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray, nVerticesArray
 
-      integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge, &
-        maxLevelCell, maxLevelEdgeTop, maxLevelEdgeBot, &
-        maxLevelVertexBot
-      integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnVertex, &
-        verticesOnEdge, edgesOnEdge, edgesOnVertex,boundaryCell, kiteIndexOnCell, &
-        verticesOnCell, edgeSignOnVertex, edgeSignOnCell, edgesOnCell, edgeMask
+      integer, dimension(:,:), pointer :: edgeSignOnCell
 
       real (kind=RKIND) :: coef_3rd_order
 
       real (kind=RKIND), dimension(:), pointer :: &
-        bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh,  seaIcePressure, atmosphericPressure, &
+        ssh,  seaIcePressure, atmosphericPressure, &
         pressureAdjustedSSH, gradSSH
       real (kind=RKIND), dimension(:,:), pointer :: &
-        weightsOnEdge, kiteAreasOnVertex, layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
+        layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
         normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
         zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
         normalizedPlanetaryVorticityEdge, normalizedRelativeVorticityEdge, &
@@ -131,7 +126,7 @@ contains
         vertGMBolusVelocityTop, BruntVaisalaFreqTop, &
         RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff, edgeAreaFractionOfCell
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers, derivTwo
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
@@ -141,19 +136,18 @@ contains
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
 
-
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
       real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
 
       logical :: full_compute = .true.
+
+      call mpas_timer_start('diagnostic solve')
 
       if ( present(full) ) then
          full_compute = full
       else
          full_compute = .true.
       end if
-
-      call mpas_timer_start('diagnostic solve')
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -199,33 +193,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
       call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
 
-      call mpas_pool_get_array(meshPool, 'weightsOnEdge', weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', kiteAreasOnVertex)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
-      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', nEdgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnEdge', edgesOnEdge)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-      call mpas_pool_get_array(meshPool, 'fVertex', fVertex)
-      call mpas_pool_get_array(meshPool, 'derivTwo', derivTwo)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', kiteIndexOnCell)
-      call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
 
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
@@ -234,7 +202,6 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
       call mpas_pool_get_dimension(meshPool, 'nVerticesArray', nVerticesArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
 
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
@@ -660,8 +627,6 @@ contains
       !                                       (positive points from vertex1 to vertex2)
       !                                units: s^{-1} m^{-1}
       real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
-
-
 
       !
       ! Compute normalized relative and planetary vorticity

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -221,27 +221,23 @@ contains
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
-      if ( full_compute ) then
+      call ocn_diagnostic_solve_vortVel(relativeVorticity, &
+             layerThicknessEdge, normalVelocity, normalTransportVelocity, &
+             normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
+             vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
+             kineticEnergyCell, tangentialVelocity)
 
-         call ocn_diagnostic_solve_vortVel(relativeVorticity, &
-                layerThicknessEdge, normalVelocity, normalTransportVelocity, &
-                normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
-                vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-                kineticEnergyCell, tangentialVelocity)
+      !
+      ! Compute kinetic energy
+      !
+      if ( ke_vertex_flag == 1 ) then
+         call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
+      end if
 
-         !
-         ! Compute kinetic energy
-         !
-         if ( ke_vertex_flag == 1 ) then
-            call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
-         end if
-
-         call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
-                   layerThickness, relativeVorticity, &
-                   normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-                   normalizedRelativeVorticityCell)
-
-      end if    ! full_compute
+      call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
+                layerThickness, relativeVorticity, &
+                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+                normalizedRelativeVorticityCell)
 
       !
       ! equation of state

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -494,47 +494,11 @@ contains
 
       if ( full_compute ) then
 
-      !
-      ! Brunt-Vaisala frequency (this has units of s^{-2})
-      !
-      coef = -gravity / rho_sw
-      !$omp parallel
-      !$omp do schedule(runtime) private(k)
-      do iCell = 1, nCells
-         BruntVaisalaFreqTop(1,iCell) = 0.0_RKIND
-         do k = 2, maxLevelCell(iCell)
-            BruntVaisalaFreqTop(k,iCell) = coef * (displacedDensity(k-1,iCell) - density(k,iCell)) &
-              / (zMid(k-1,iCell) - zMid(k,iCell))
-          end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      !
-      ! Gradient Richardson number
-      !
-
-      nCells = nCellsArray(3)
-      !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
-      do iCell=1,nCells
-         RiTopOfCell(:,iCell) = 100.0_RKIND
-         do k=2,maxLevelCell(iCell)
-           shearSquared = 0.0_RKIND
-           do i = 1, nEdgesOnCell(iCell)
-             iEdge = edgesOnCell(i, iCell)
-             delU2 = (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2
-             shearSquared = shearSquared + edgeAreaFractionOfCell(i,iCell) * delU2
-           enddo
-           ! Note that the factor of two is from averaging dot product to cell center on a C-grid
-           shearMean = sqrt(2.0_RKIND*shearSquared )
-           shearMean = shearMean / (zMid(k-1,iCell) - zMid(k,iCell))
-           RiTopOfCell(k,iCell) = BruntVaisalaFreqTop(k,iCell) / (shearMean**2 + 1.0e-10_RKIND)
-          end do
-          RiTopOfCell(1,iCell) = RiTopOfCell(2,iCell)
-      end do
-      !$omp end do
-      !$omp end parallel
+         !
+         ! Brunt-Vaisala frequency and gradient Richardson number
+         !
+         call ocn_diagnostic_solve_richardson(displacedDensity, density, zMid, &
+                normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)
 
       end if    ! full_compute
 
@@ -1115,6 +1079,108 @@ contains
 
 
    end subroutine ocn_diagnostic_solve_vorticity!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_richardson
+!
+!> \brief   Computes diagnostic variables for gradient richardson
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for gradient richardson
+!>   number and brunt viasala
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_richardson(displacedDensity, density, zMid, &
+                normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)!{{{
+
+      use ocn_mesh   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        displacedDensity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        density
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        zMid
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        normalVelocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        edgeAreaFractionOfCell
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        BruntVaisalaFreqTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+        RiTopOfCell
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real(kind=RKIND) :: coef, shearSquared, delU2, shearMean
+      integer :: iCell, k, i, iEdge
+      integer :: nCells
+      real(kind=RKIND) :: invAreaCell1
+
+      !
+      ! Brunt-Vaisala frequency (this has units of s^{-2})
+      !
+      coef = -gravity / rho_sw
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCellsAll
+         BruntVaisalaFreqTop(1,iCell) = 0.0_RKIND
+         do k = 2, maxLevelCell(iCell)
+            BruntVaisalaFreqTop(k,iCell) = coef * (displacedDensity(k-1,iCell) - density(k,iCell)) &
+              / (zMid(k-1,iCell) - zMid(k,iCell))
+          end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      !
+      ! Gradient Richardson number
+      !
+
+      nCells = nCellsHalo( 2 )
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
+      do iCell=1,nCells
+         RiTopOfCell(:,iCell) = 100.0_RKIND
+         do k=2,maxLevelCell(iCell)
+           shearSquared = 0.0_RKIND
+           do i = 1, nEdgesOnCell(iCell)
+             iEdge = edgesOnCell(i, iCell)
+             delU2 = (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2
+             shearSquared = shearSquared + edgeAreaFractionOfCell(i,iCell) * delU2
+           enddo
+           ! Note that the factor of two is from averaging dot product to cell center on a C-grid
+           shearMean = sqrt(2.0_RKIND*shearSquared )
+           shearMean = shearMean / (zMid(k-1,iCell) - zMid(k,iCell))
+           RiTopOfCell(k,iCell) = BruntVaisalaFreqTop(k,iCell) / (shearMean**2 + 1.0e-10_RKIND)
+          end do
+          RiTopOfCell(1,iCell) = RiTopOfCell(2,iCell)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_richardson!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -94,6 +94,8 @@ contains
    subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &!{{{
                                    timeLevelIn, full)
 
+      use ocn_mesh, only: nCellsHalo, nEdgesHalo
+
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
@@ -119,7 +121,7 @@ contains
       real (kind=RKIND) :: coef_3rd_order, r_tmp, &
         invAreaCell1
 
-      real (kind=RKIND), dimension(:), allocatable:: pTop, div_hu,div_huTransport,div_huGMBolus
+      real (kind=RKIND), dimension(:), allocatable:: pTop
 
       real (kind=RKIND), dimension(:), pointer :: &
         bottomDepth, fVertex, dvEdge, dcEdge, areaCell, areaTriangle, ssh,  seaIcePressure, atmosphericPressure, frazilSurfacePressure, &
@@ -272,99 +274,13 @@ contains
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
-      ! Need owned cells for relativeVorticityCell
-      nCells = nCellsArray( 1 )
-
       if ( full_compute ) then
 
-      !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
-      do iCell = 1, nCells
-        relativeVorticityCell(:,iCell) = 0.0_RKIND
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-
-        do i = 1, nEdgesOnCell(iCell)
-          j = kiteIndexOnCell(i, iCell)
-          iVertex = verticesOnCell(i, iCell)
-          do k = 1, maxLevelCell(iCell)
-            relativeVorticityCell(k, iCell) = relativeVorticityCell(k, iCell) + kiteAreasOnVertex(j, iVertex) &
-                                            * relativeVorticity(k, iVertex) * invAreaCell1
-          end do
-        end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      ! Need 0,1,2 halo cells
-      nCells = nCellsArray( 3 )
-      !
-      ! Compute divergence, kinetic energy, and vertical velocity
-      !
-      allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
-
-      !$omp parallel
-      !$omp do schedule(runtime) &
-      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-      !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
-      do iCell = 1, nCells
-         divergence(:, iCell) = 0.0_RKIND
-         kineticEnergyCell(:, iCell) = 0.0_RKIND
-         div_hu(:) = 0.0_RKIND
-         div_huTransport(:) = 0.0_RKIND
-         div_huGMBolus(:) = 0.0_RKIND
-         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
-         do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
-            dcEdge_temp = dcEdge(iEdge)
-            dvEdge_temp = dvEdge(iEdge)
-            do k = 1, maxLevelCell(iCell)
-               r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
-
-               divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
-               div_hu(k) = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * r_tmp
-               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
-                                              + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
-               ! Compute vertical velocity from the horizontal total transport
-               div_huTransport(k) = div_huTransport(k) &
-                                    - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp &
-                                    * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
-               ! Compute vertical velocity from the horizontal GM Bolus velocity
-               div_huGMBolus(k) = div_huGMBolus(k) &
-                                  - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
-            end do
-         end do
-         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-         vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-         do k=maxLevelCell(iCell),1,-1
-            vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
-            vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
-            vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
-         end do
-      end do
-      !$omp end do
-      !$omp end parallel
-
-      deallocate(div_hu,div_huTransport,div_huGMBolus)
-
-      nEdges = nEdgesArray( 3 )
-      !$omp parallel
-      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
-      do iEdge = 1, nEdges
-         tangentialVelocity(:, iEdge) = 0.0_RKIND
-         ! Compute v (tangential) velocities
-         do i = 1, nEdgesOnEdge(iEdge)
-            eoe = edgesOnEdge(i,iEdge)
-            weightsOnEdge_temp = weightsOnEdge(i, iEdge)
-            do k = 1, maxLevelEdgeTop(iEdge)
-               tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) &
-                                              + weightsOnEdge_temp * normalVelocity(k, eoe)
-            end do
-         end do
-      end do
-      !$omp end do
-      !$omp end parallel
+         call ocn_diagnostic_solve_vortVel(relativeVorticity, edgeSignOnCell, &
+                layerThicknessEdge, normalVelocity, normalTransportVelocity, &
+                normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
+                vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
+                kineticEnergyCell, tangentialVelocity)
 
          !
          ! Compute kinetic energy
@@ -1253,6 +1169,183 @@ contains
       !$omp end parallel
 
    end subroutine ocn_diagnostic_solve_surfaceLayer!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_vortVel
+!
+!> \brief   Computes diagnostic variables for vorticity and velocity
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables for vorticity and vertical
+!>    velocities
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, edgeSignOnCell, &
+                layerThicknessEdge, normalVelocity, normalTransportVelocity, &
+                normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
+                vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
+                kineticEnergyCell, tangentialVelocity)!{{{
+
+      use ocn_mesh, only: nCellsHalo, nEdgesHalo, nCellsOwned, areaCell, &
+                          nEdgesOnCell, kiteIndexOnCell, verticesOnCell, &
+                          maxLevelCell, nVertLevels, kiteAreasOnVertex, &
+                          edgesOnCell, dcEdge, dvEdge, weightsOnEdge, &
+                          nEdgesOnEdge, edgesOnEdge, maxLevelEdgeTop   ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         relativeVorticity
+      integer, dimension(:,:), intent(in) :: &
+         edgeSignOnCell   ! debug, mdt :: This array is in ocn_mesh, but results are non-bfb
+                          !               if I use the ocn_mesh array
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalTransportVelocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalGMBolusVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         vertVelocityTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertTransportVelocityTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertGMBolusVelocityTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         relativeVorticityCell
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         divergence
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         kineticEnergyCell
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         tangentialVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iVertex, iEdge
+      integer :: i, j, k
+      integer :: edgeSignOnCell_temp, eoe
+      real(kind=RKIND) :: invAreaCell1
+      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+
+      real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport,div_huGMBolus
+
+      ! Need owned cells for relativeVorticityCell
+      nCells = nCellsOwned
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
+      do iCell = 1, nCells
+        relativeVorticityCell(:,iCell) = 0.0_RKIND
+        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+        do i = 1, nEdgesOnCell(iCell)
+          j = kiteIndexOnCell(i, iCell)
+          iVertex = verticesOnCell(i, iCell)
+          do k = 1, maxLevelCell(iCell)
+            relativeVorticityCell(k, iCell) = relativeVorticityCell(k, iCell) + kiteAreasOnVertex(j, iVertex) &
+                                            * relativeVorticity(k, iVertex) * invAreaCell1
+          end do
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! Need 0,1,2 halo cells
+      nCells = nCellsHalo( 2 )
+
+      !
+      ! Compute divergence, kinetic energy, and vertical velocity
+      !
+      allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+      !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
+      do iCell = 1, nCells
+         divergence(:, iCell) = 0.0_RKIND
+         kineticEnergyCell(:, iCell) = 0.0_RKIND
+         div_hu(:) = 0.0_RKIND
+         div_huTransport(:) = 0.0_RKIND
+         div_huGMBolus(:) = 0.0_RKIND
+         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dcEdge_temp = dcEdge(iEdge)
+            dvEdge_temp = dvEdge(iEdge)
+            do k = 1, maxLevelCell(iCell)
+               r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
+
+               divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
+               div_hu(k) = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * r_tmp
+               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
+                                              + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
+               ! Compute vertical velocity from the horizontal total transport
+               div_huTransport(k) = div_huTransport(k) &
+                                    - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp &
+                                    * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
+               ! Compute vertical velocity from the horizontal GM Bolus velocity
+               div_huGMBolus(k) = div_huGMBolus(k) &
+                                  - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+            end do
+         end do
+         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+         vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
+         do k=maxLevelCell(iCell),1,-1
+            vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
+            vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
+            vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(div_hu,div_huTransport,div_huGMBolus)
+
+      nEdges = nEdgesHalo( 2 )
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+      do iEdge = 1, nEdges
+         tangentialVelocity(:, iEdge) = 0.0_RKIND
+         ! Compute v (tangential) velocities
+         do i = 1, nEdgesOnEdge(iEdge)
+            eoe = edgesOnEdge(i,iEdge)
+            weightsOnEdge_temp = weightsOnEdge(i, iEdge)
+            do k = 1, maxLevelEdgeTop(iEdge)
+               tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) &
+                                              + weightsOnEdge_temp * normalVelocity(k, eoe)
+            end do
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_vortVel!}}}
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -510,13 +510,10 @@ contains
       !$omp end do
       !$omp end parallel
 
-      end if ! full_compute
-
       !
       ! Gradient Richardson number
       !
 
-      if ( full_compute ) then
       nCells = nCellsArray(3)
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -37,6 +37,7 @@ module ocn_init_routines
    use ocn_gm
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    use ocn_surface_land_ice_fluxes
    use ocn_forcing
@@ -243,38 +244,15 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 !>   kiteIndexOnCell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_init_routines_setup_sign_and_index_fields(meshPool)!{{{
+   subroutine ocn_init_routines_setup_sign_and_index_fields()!{{{
 
-       type (mpas_pool_type), intent(inout) :: meshPool
-
-       integer, dimension(:), pointer :: nEdgesOnCell
-       integer, dimension(:,:), pointer :: edgesOnCell, edgesOnVertex, cellsOnVertex, cellsOnEdge, verticesOnCell, verticesOnEdge
-       integer, dimension(:,:), pointer :: edgeSignOnCell, edgeSignOnVertex, kiteIndexOnCell
-
-       integer, pointer :: nCells, nEdges, nVertices, vertexDegree
        integer :: iCell, iEdge, iVertex, i, j, k
-
-       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-       call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-       call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-       call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-       call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
-       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-       call mpas_pool_get_array(meshPool, 'verticesOnCell', verticesOnCell)
-       call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-       call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', kiteIndexOnCell)
 
        edgeSignOnCell = 0.0_RKIND
        edgeSignOnVertex = 0.0_RKIND
        kiteIndexOnCell = 0.0_RKIND
 
-       do iCell = 1, nCells
+       do iCell = 1, nCellsAll
          do i = 1, nEdgesOnCell(iCell)
            iEdge = edgesOnCell(i, iCell)
            iVertex = verticesOnCell(i, iCell)
@@ -294,7 +272,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          end do
        end do
 
-       do iVertex = 1, nVertices
+       do iVertex = 1, nVerticesAll
          do i = 1, vertexDegree
            iEdge = edgesOnVertex(i, iVertex)
 
@@ -322,26 +300,12 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 !-----------------------------------------------------------------------
    subroutine ocn_init_routines_area_weights(meshPool, edgeAreaFractionOfCell)!{{{
 
-      type (mpas_pool_type), intent(in) :: meshPool
+      type(mpas_pool_type), intent(inout) :: meshPool
       real (kind=RKIND), dimension(:,:), intent(inout) :: edgeAreaFractionOfCell
 
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:,:), pointer :: edgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell
-
-      integer, pointer :: nCells, nEdges
       integer :: iCell, iEdge, i, j, k
 
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      do iCell = 1, nCells
+      do iCell = 1, nCellsAll
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             ! edgeAreaFractionOfCell is the fractional area of cell iCell
@@ -539,7 +503,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
               do iCell = 1,nCells
                  if (landIceMask(iCell)==0.and.abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
-                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', & 
+                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
                     call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
                        intArgs=(/iCell, maxLevelCell(iCell) /), &
@@ -550,7 +514,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
               do iCell = 1,nCells
                  if (abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
-                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', & 
+                    call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
                     call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
                        intArgs=(/iCell, maxLevelCell(iCell) /), &
@@ -603,22 +567,22 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       real (kind=RKIND), intent(in) :: dt
       integer, intent(out) :: err
 
-      type (mpas_pool_type), pointer :: meshPool, statePool, tracersPool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: statePool, tracersPool
       type (mpas_pool_type), pointer :: forcingPool, diagnosticsPool, scratchPool
       integer :: i, iEdge, iCell, k
       integer :: err1
 
-      integer, dimension(:), pointer :: nAdvCellsForEdge, maxLevelCell, indMLD
-      integer, dimension(:), pointer :: maxLevelEdgeBot, maxLevelEdgeTop
-      integer, dimension(:,:), pointer :: advCellsForEdge, highOrderAdvectionMask, boundaryCell
-      real (kind=RKIND), dimension(:), pointer :: areaCell, boundaryLayerDepth
-      real (kind=RKIND), dimension(:,:), pointer :: advCoefs, advCoefs3rd, normalTransportVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, normalGMBolusVelocity, edgeTangentVectors
+      integer, dimension(:), pointer :: indMLD
+      real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
+      real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity, normalGMBolusVelocity
       real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
       real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
       real (kind=RKIND), dimension(:,:), pointer :: edgeAreaFractionOfCell
-      real (kind=RKIND), dimension(:,:,:), pointer :: derivTwo
+      integer, dimension(:,:), pointer :: highOrderAdvectionMaskTmp, boundaryCellTmp
+      integer, dimension(:,:), pointer :: edgeSignOnCellTmp, edgeSignOnVertexTmp
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
 
@@ -639,19 +603,8 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(meshPool, 'derivTwo', derivTwo)
-      call mpas_pool_get_array(meshPool, 'advCoefs', advCoefs)
-      call mpas_pool_get_array(meshPool, 'advCoefs3rd', advCoefs3rd)
-      call mpas_pool_get_array(meshPool, 'nAdvCellsForEdge', nAdvCellsForEdge)
-      call mpas_pool_get_array(meshPool, 'advCellsForEdge', advCellsForEdge)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMask)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', edgeTangentVectors)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMaskTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCellTmp)
 
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
       call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
@@ -667,15 +620,28 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
 
-      call ocn_init_routines_setup_sign_and_index_fields(meshPool)
+      call ocn_init_routines_setup_sign_and_index_fields()
+
+      ! Update edgeSignOnCell and edgeSignOnVertex pionters in ocn_mesh.  The ocn_mesh allocatables
+      ! are updated in ocn_init_routines_setup_sign_and_index_fields.  This updates the pointers to
+      ! Registry to match the allocatable arrays
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCellTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertexTmp)
+      edgeSignOnCellTmp = int(edgeSignOnCell)
+      edgeSignOnVertexTmp = int(edgeSignOnVertex)
+
       call ocn_init_routines_area_weights(meshPool, edgeAreaFractionOfCell)
       call mpas_initialize_deriv_two(meshPool, derivTwo, err)
       call mpas_tracer_advection_coefficients(meshPool, &
           config_horiz_tracer_adv_order, derivTwo, advCoefs, &
           advCoefs3rd, nAdvCellsForEdge, advCellsForEdge, &
-          err1, maxLevelCell, highOrderAdvectionMask, &
-          boundaryCell)
+          err1, maxLevelCell, highOrderAdvectionMaskTmp, &
+          boundaryCellTmp)
       err = ior(err, err1)
+
+      ! Update ocn_mesh variables for highOrderAdvectionMask and boundaryCell
+      highOrderAdvectionMask = real(highOrderAdvectionMaskTmp, kind=RKIND)
+      boundaryCell = real(boundaryCellTmp, kind=RKIND)
 
       if (.not. config_do_restart) then
          do iCell=1,nCells

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -1032,9 +1032,11 @@ contains
       end do
       end do
 
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+      ! pointer needs to be udpated
       do n = 1, nCellsAll+1
       do k = 1, maxEdges
-         edgeSignOnCell(k, n) = real(edgeSignOnCellTmp(k, n), RKIND)
+         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
       end do
       end do
 
@@ -1054,10 +1056,12 @@ contains
       end do
       end do
 
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+      ! pointer needs to be udpated
       do n = 1, nVerticesAll+1
       do k = 1, vertexDegree
-         edgeSignOnVertex(k, n) = &
-            real(edgeSignOnVertexTmp(k, n), RKIND)
+         edgeSignOnVertexTmp(k, n) = &
+            int(edgeSignOnVertex(k, n))
       end do
       end do
 


### PR DESCRIPTION
This PR breaks up the diagnostic_solve subroutine, and modifies the split-explicit timestepping scheme to have 1 of the calls to diagnostic solve only calculate a few of the variables.



