### PR TITLE
Add support for building with NAG compilers (atmosphere/cam)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,31 @@ bluegene:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
+nag:
+	( $(MAKE) all \
+	"FC_PARALLEL = mpifort" \
+	"CC_PARALLEL = mpicc" \
+	"CXX_PARALLEL = mpic++" \
+	"FC_SERIAL = nagfor" \
+	"CC_SERIAL = gcc" \
+	"CXX_SERIAL = g++" \
+	"FFLAGS_PROMOTION = -r8" \
+	"FFLAGS_OPT = -free -mismatch -O3 -convert=big_ieee" \
+	"CFLAGS_OPT = -O3" \
+	"CXXFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT = -O3" \
+	"FFLAGS_DEBUG = -free -mismatch -O0 -g -C -convert=big_ieee" \
+	"CFLAGS_DEBUG = -O0 -g -Wall -pedantic" \
+	"CXXFLAGS_DEBUG = -O0 -g -Wall -pedantic" \
+	"LDFLAGS_DEBUG = -O0 -g -C" \
+	"FFLAGS_OMP = -qsmp=omp" \
+	"CFLAGS_OMP = -qsmp=omp" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DUNDERSCORE -DNAG_COMPILER" )
+
 CPPINCLUDES = 
 FCINCLUDES = 
 LIBS = 

--- a/src/external/Makefile
+++ b/src/external/Makefile
@@ -3,7 +3,7 @@
 all: esmf_time ezxml-lib
 
 esmf_time:
-	( cd esmf_time_f90; $(MAKE) FC="$(FC) $(FFLAGS)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS) -DHIDE_MPI" GEN_F90=$(GEN_F90) )
+	( cd esmf_time_f90; $(MAKE) FC="$(FC)" FFLAGS="$(FFLAGS)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS) -DHIDE_MPI" GEN_F90=$(GEN_F90) )
 
 ezxml-lib:
 	( cd ezxml; $(MAKE) )

--- a/src/operators/mpas_spline_interpolation.F
+++ b/src/operators/mpas_spline_interpolation.F
@@ -115,6 +115,10 @@ module mpas_spline_interpolation
 
 ! INPUT PARAMETERS:
 
+  integer, intent(in) :: &
+    n,      &!< Input: number of nodes, input grid
+    nOut       !< Input: number of nodes, output grid
+
   real (kind=RKIND), dimension(n), intent(in) :: &
     x,         &!< Input: node location, input grid
     y,       &!< Input: interpolation variable, input grid
@@ -122,10 +126,6 @@ module mpas_spline_interpolation
 
   real (kind=RKIND), dimension(nOut), intent(in) :: &
     xOut          !< Input: node location, output grid
-
-  integer, intent(in) :: &
-    n,      &!< Input: number of nodes, input grid
-    nOut       !< Input: number of nodes, output grid
 
 ! OUTPUT PARAMETERS:
 
@@ -359,16 +359,16 @@ subroutine mpas_integrate_cubic_spline(x,y,y2ndDer,n,x1,x2,y_integral)  !{{{
 
 ! !INPUT PARAMETERS:
 
+  integer, intent(in) :: &
+    N,      &!< Input: number of nodes, input grid
+    NOut       !< Input: number of nodes, output grid
+
   real (kind=RKIND), dimension(n), intent(in) :: &
     x,         &!< Input: node location, input grid
     y         !< Input: interpolation variable, input grid
 
   real (kind=RKIND), dimension(nOut), intent(in) :: &
     xOut          !< Input: node location, output grid
-
-  integer, intent(in) :: &
-    N,      &!< Input: number of nodes, input grid
-    NOut       !< Input: number of nodes, output grid
 
 ! !OUTPUT PARAMETERS:
 

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -645,7 +645,11 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 		}
 
 		fortprintf(fd, "      if (dminfo %% my_proc_id == IO_NODE) then\n");
+		fortprintf(fd, "! Rewinding before each read leads to errors when the code is built with\n");
+		fortprintf(fd, "! the NAG Fortran compiler. If building with NAG, be kind and don't rewind.\n");
+		fortprintf(fd, "#ifndef NAG_COMPILER\n");
 		fortprintf(fd, "         rewind(unitNumber)\n");
+		fortprintf(fd, "#endif\n");
 		fortprintf(fd, "         read(unitNumber, %s, iostat=ierr)\n", nmlrecname);
 		fortprintf(fd, "      end if\n");
 


### PR DESCRIPTION
This PR adds a build target for the NAG compilers to the top-level Makefile, and
it also fixes several compilation issues with the NAG compilers in shared code.

Although the 'test' core can now be compiled with the NAG compilers, other cores
contain issues in their core-specific code that prevent compilation, and this PR
does not address those issues.