### PR TITLE
Add missing 'recursive' attribute to MPAS_log_write(...) routine (atmosphere/cam)

### DIFF
--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -461,7 +461,7 @@ module mpas_log
 !
 !-----------------------------------------------------------------------
 
-   subroutine mpas_log_write(message, messageType, masterOnly, flushNow, &
+   recursive subroutine mpas_log_write(message, messageType, masterOnly, flushNow, &
                  intArgs, realArgs, logicArgs, err)
 
       use mpas_threading


### PR DESCRIPTION
This merge adds the 'recursive' attribute to the MPAS_log_write routine.

The MPAS_log_write routine can generate indirectly recursive calls to itself,
for example, when MPAS_log_write calls log_abort, which calls
MPAS_log_finalize, which then calls MPAS_log_write. Without the recursive
attribute, several compilers will halt execution when MPAS is compiled with
DEBUG=true if a recursive call is detected in a routine not marked as recursive.