### PR TITLE
Correct order of argument declarations in atm_time_integration module

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -2737,8 +2737,9 @@ module atm_time_integration
 
       implicit none
 
+      integer, intent(in) :: nEdges            ! for allocating stack variables
       integer, intent(in) :: num_scalars_dummy ! for allocating stack variables
-      integer, intent(in) :: nCells           ! for allocating stack variables
+      integer, intent(in) :: nCells            ! for allocating stack variables
       integer, intent(in) :: nVertLevels_dummy ! for allocating stack variables
       real (kind=RKIND), intent(in) :: dt
       integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
@@ -2761,7 +2762,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1), intent(inout), optional :: scalar_tend
       real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout), optional :: rho_zz_int
       real (kind=RKIND), dimension(:), intent(in) :: invAreaCell
-      integer, intent(in) :: nCellsSolve, nEdges
+      integer, intent(in) :: nCellsSolve
 
       integer :: i, j, iCell, iAdvCell, iEdge, k, iScalar, cell1, cell2
       real (kind=RKIND) :: rho_zz_new_inv
@@ -3008,8 +3009,9 @@ module atm_time_integration
 
       implicit none
 
+      integer, intent(in) :: nEdges            ! for allocating stack variables
       integer, intent(in) :: num_scalars_dummy ! for allocating stack variables
-      integer, intent(in) :: nCells           ! for allocating stack variables
+      integer, intent(in) :: nCells            ! for allocating stack variables
       integer, intent(in) :: nVertLevels_dummy ! for allocating stack variables
       real (kind=RKIND), intent(in) :: dt
       integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
@@ -3033,7 +3035,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1), intent(inout), optional :: scalar_tend
       real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout), optional :: rho_zz_int
       real (kind=RKIND), dimension(:), intent(in) :: invAreaCell
-      integer, intent(in) :: nCellsSolve, nEdges
+      integer, intent(in) :: nCellsSolve
 
       integer :: i, j, iCell, iAdvCell, iEdge, k, iScalar, cell1, cell2
       real (kind=RKIND) :: rho_zz_new_inv


### PR DESCRIPTION
This merge corrects the order of dummy argument declarations in
the atm_time_integration module. The NAG compiler generates the following
errors when compiling the atm_time_integration module:
```
  Error: mpas_atm_time_integration.F, line 2760: Implicit type for NEDGES
         detected at NEDGES@+
  Error: mpas_atm_time_integration.F, line 2764: Symbol NEDGES has already been implicitly typed
         detected at NEDGES@<end-of-statement>

  Error: mpas_atm_time_integration.F, line 3032: Implicit type for NEDGES
         detected at NEDGES@+
  Error: mpas_atm_time_integration.F, line 3036: Symbol NEDGES has already been implicitly typed
         detected at NEDGES@<end-of-statement>
```
These errors are eliminated by moving the declaration of the nEdges dummy
argument above the declarations of the other dummy arguments that are
dimensioned by nEdges.