### PR TITLE
Use an explicit format when converting dt to a string in mpas_set_timeInterval

### DIFF
--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1334,6 +1334,9 @@ module mpas_timekeeping
       character (len=StrKIND) :: timeSubString
       character (len=StrKIND) :: secDecSubString
       character(len=StrKIND), pointer, dimension(:) :: subStrings
+      character(len=16) :: fmtString
+      integer :: iwidth
+      integer :: idecimals
 
 !      if (present(DD)) then
 !         days = DD
@@ -1403,8 +1406,29 @@ module mpas_timekeeping
       if (present(timeString) .or. present(dt)) then
 
 
-         if(present(dt)) then
-            write (timeString_,*) "00:00:", dt         
+         if (present(dt)) then
+            !
+            ! Before writing dt into a timeString, first construct an appropriate format string
+            !
+
+            ! Number of decimal places of precision (9 = nanosecond precision)
+            idecimals = 9
+
+            ! Scale total width of representation based on max(log10(dt),0.0)
+            ! (+2 for at least a leading zero and a '.')
+            if (dt /= 0.0_RKIND) then
+               iwidth = int(max(log10(abs(dt)),0.0_RKIND)) + idecimals + 2
+            else
+               iwidth = idecimals + 2
+            end if
+
+            ! Add an extra character for a minus sign if needed
+            if (dt < 0.0_RKIND) then
+               iwidth = iwidth + 1
+            end if
+
+            write(fmtString, '(a,i2.2,a,i2.2,a)') '(a,f', iwidth, '.', idecimals, ')'
+            write(timeString_,trim(fmtString)) '00:00:', dt
          else
             timeString_ = timeString
          end if


### PR DESCRIPTION
This merge switches to the use of an explicit format string when converting `dt`
to a string in the `mpas_set_timeInterval` routine.

If the real-valued `dt` optional argument is given to the `mpas_set_timeInterval`
routine, the value of this variable is written into a string using an internal
write statement. Before this commit, list-directed output was used in this write
(i.e., the format was `*`), which permits the compiler to choose either the 'f'
or 'e' edit descriptors. If the 'e' edit descriptor was chosen, the value of `dt`
would be incorrectly converted to a fractional seconds value.

For example, if dt = 600.0, the NAG compiler generates the `timeString_`

00:00:   6.0000000000000000E+02

which lead to an interval of 6 seconds rather than 600 seconds.

The solution adopted in this commit is to use an explicit 'f' edit descriptor
in a format string when writing the `timeString_` string.

Although the Fortran 2003 standard permits an 'f' edit descriptor with a zero
width, e.g., `f0.9`, the use of a zero width leaves the choice of whether to print
a leading zero up to the compiler. In the case of the GNU (and possibly other)
compilers, a `dt` value of, say, 0.1 results in a `timeString_` of

00:00:.100000000

Parsing of the whole seconds part of `timeString_` then leads to errors.

To avoid leaving choices of how to format the `dt` value up to the compiler, this
commit dynamically builds a format string that uses the 'f' edit descriptor.