### PR TITLE
Add missing initialization of some scalars field members in atm_allocate_scalars (atmosphere/cam)

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -446,6 +446,11 @@ module atm_core_interface
          scalarsField(i) % isActive = .true.
          scalarsField(i) % isVarArray = .true.
          scalarsField(i) % isPersistent = .true.
+         nullify(scalarsField(i) % prev)
+         nullify(scalarsField(i) % next)
+         nullify(scalarsField(i) % sendList)
+         nullify(scalarsField(i) % recvList)
+         nullify(scalarsField(i) % copyList)
 
          allocate(scalarsField(i) % constituentNames(num_scalars))
 
@@ -491,6 +496,11 @@ module atm_core_interface
          scalarsField(i) % isActive = .true.
          scalarsField(i) % isVarArray = .true.
          scalarsField(i) % isPersistent = .true.
+         nullify(scalarsField(i) % prev)
+         nullify(scalarsField(i) % next)
+         nullify(scalarsField(i) % sendList)
+         nullify(scalarsField(i) % recvList)
+         nullify(scalarsField(i) % copyList)
 
          allocate(scalarsField(i) % constituentNames(num_scalars))
 


### PR DESCRIPTION
This merge adds missing initialization for some of the members of scalars fields
that are allocated by the atm_allocate_scalars routine.

Specifically, this merge adds initialization of the prev, next, sendList, 
recvList, and copyList members of these instances to avoid potential problems
later on in the model start-up with the use of uninitialized pointers.