### PR TITLE
Fix non-standard BOZ-literal integer constant in module_ra_cam_support

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
@@ -8,7 +8,7 @@ MODULE module_ra_cam_support
   implicit none
       integer, parameter :: r8 = 8
       real(r8), parameter:: inf = 1.e20 ! CAM sets this differently in infnan.F90
-      integer, parameter:: bigint = O'17777777777'           ! largest possible 32-bit integer 
+      integer, parameter:: bigint = int(O'17777777777')      ! largest possible 32-bit integer 
 
       integer :: ixcldliq 
       integer :: ixcldice


### PR DESCRIPTION
This merge corrects a non-standard BOZ-literal constant in module_ra_cam_support.

The GNU 10.1.0 compiler identified a non-standard BOZ-literal constant in
module_ra_cam_support.F, failing to compile this file with the following error:
```
  module_ra_cam_support.F:11:35:

     11 |       integer, parameter:: bigint = O'17777777777'           ! largest possible 32-bit integer
        |                                   1
  Error: BOZ literal constant at (1) is neither a data-stmt-constant nor an actual argument to INT, REAL, DBLE, or CMPLX intrinsic function [see ‘-fno-allow-invalid-boz’]
```
As per the Fortran 2003 standard, this constant should be typed with the INT
intrinsic (or be used in a data statement):
```
  4.4.1 Integer type

  C410 (R411) A boz-literal-constant shall appear only as a data-stmt-constant in
  a DATA statement, as the actual argument associated with the dummy argument A of
  the numeric intrinsic functions DBLE, REAL or INT, or as the actual argument
  associated with the X or Y dummy argument of the intrinsic function CMPLX.
```
This commit uses the INT intrinsic with an argument of O'17777777777' to
initialize the bigint parameter.