### PR TITLE
Fix cmake for tool exes

### DIFF
--- a/src/build_core.cmake
+++ b/src/build_core.cmake
@@ -48,7 +48,7 @@ function(build_core CORE)
   add_custom_command(
     OUTPUT ${INC_DIR}/core_variables.inc
     COMMAND ${CMAKE_BINARY_DIR}/mpas-source/src/tools/parse < ${CORE_BLDDIR}/Registry_processed.xml
-    DEPENDS ${CORE_BLDDIR}/Registry_processed.xml
+    DEPENDS parse ${CORE_BLDDIR}/Registry_processed.xml
     WORKING_DIRECTORY ${INC_DIR}
   )
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,9 +1,18 @@
 
 if (DEFINED ENV{MPAS_TOOL_DIR})
   message(STATUS "*** Using MPAS tools from $ENV{MPAS_TOOL_DIR} ***")
-  file(COPY $ENV{MPAS_TOOL_DIR}/input_gen/namelist_gen DESTINATION .)
-  file(COPY $ENV{MPAS_TOOL_DIR}/input_gen/streams_gen  DESTINATION .)
-  file(COPY $ENV{MPAS_TOOL_DIR}/registry/parse         DESTINATION .)
+  add_custom_target(namelist_gen)
+  add_custom_command(
+    TARGET namelist_gen PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/namelist_gen ${CMAKE_CURRENT_BINARY_DIR}/namelist_gen)
+  add_custom_target(streams_gen)
+  add_custom_command(
+    TARGET streams_gen PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/streams_gen ${CMAKE_CURRENT_BINARY_DIR}/streams_gen)
+  add_custom_target(parse)
+  add_custom_command(
+    TARGET parse PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/parse ${CMAKE_CURRENT_BINARY_DIR}/parse)
 else()
   message(STATUS "*** Building MPAS tools from source ***")
   # Make build tools, need to be compiled with serial compiler.


### PR DESCRIPTION
Regardless of MPAS_TOOL_DIR, the tool exes need to be targets
and targets that depend of these exes need to always depend on the
needed exe. This will ensure the exes get built regardless of which
targets the user is building.

I tested this change with the E3SM case ne4pg2_r05_oQU480 A_WCYCL1850. I tested both `case.build` and `case.build --separate-builds` with both MPAS_TOOL_DIR enabled and disabled.

