### PR TITLE
Move domain_ptr and corelist from module variables to arguments in subdriver

### DIFF
--- a/src/driver/mpas.F
+++ b/src/driver/mpas.F
@@ -8,14 +8,18 @@
 program mpas
 
    use mpas_subdriver
+   use mpas_derived_types, only : core_type, domain_type
 
    implicit none
 
-   call mpas_init()
+   type (core_type), pointer :: corelist => null()
+   type (domain_type), pointer :: domain => null()
 
-   call mpas_run() 
+   call mpas_init(corelist, domain)
 
-   call mpas_finalize()
+   call mpas_run(domain) 
+
+   call mpas_finalize(corelist, domain)
 
    stop
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -35,14 +35,11 @@ module mpas_subdriver
    use test_core_interface
 #endif
 
-   type (core_type), pointer :: corelist => null()
-   type (dm_info), pointer :: dminfo
-   type (domain_type), pointer :: domain_ptr
 
    contains
 
 
-   subroutine mpas_init()
+   subroutine mpas_init(corelist, domain_ptr, mpi_comm)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_init, MPAS_build_stream_filename, MPAS_stream_mgr_validate_streams
       use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
@@ -52,6 +49,10 @@ module mpas_subdriver
       use mpas_log
  
       implicit none
+
+      type (core_type), intent(inout), pointer :: corelist
+      type (domain_type), intent(inout), pointer :: domain_ptr
+      integer, intent(in), optional :: mpi_comm
 
       integer :: iArg, nArgs
       logical :: readNamelistArg, readStreamsArg
@@ -154,7 +155,7 @@ module mpas_subdriver
       !
       ! Initialize infrastructure
       !
-      call mpas_framework_init_phase1(domain_ptr % dminfo)
+      call mpas_framework_init_phase1(domain_ptr % dminfo, mpi_comm=mpi_comm)
 
 
 #ifdef CORE_ATMOSPHERE
@@ -338,9 +339,11 @@ module mpas_subdriver
    end subroutine mpas_init
 
 
-   subroutine mpas_run()
+   subroutine mpas_run(domain_ptr)
 
       implicit none
+
+      type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
 
@@ -352,12 +355,15 @@ module mpas_subdriver
    end subroutine mpas_run
 
 
-   subroutine mpas_finalize()
+   subroutine mpas_finalize(corelist, domain_ptr)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
-      use mpas_log, only : mpas_log_finalize
+      use mpas_log, only : mpas_log_finalize, mpas_log_info
 
       implicit none
+
+      type (core_type), intent(inout), pointer :: corelist
+      type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
 


### PR DESCRIPTION
Towards the goal of supporting multiple instances of domains within a single
simulation, this merge moves domain_ptr and corelist from module variables
in the mpas_subdriver module to arguments to the mpas_init, mpas_run, and
mpas_finalize routines.

The main program (in mpas.F) now passes instances of a core_type and
a domain_type to the subriver's mpas_init, mpas_run, and mpas_finalize routines.