### PR TITLE
New module for ocean diagnostics variables

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -242,7 +242,7 @@ module ocn_forward_mode
 
       call ocn_tendency_init(err_tmp)
       ierr = ior(ierr,err_tmp)
-      call ocn_diagnostics_init(err_tmp)
+      call ocn_diagnostics_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
 
       call ocn_forcing_init(err_tmp)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -770,7 +770,7 @@ module ocn_time_integration_rk4
          call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 
          if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
+            call ocn_reconstruct_gm_vectors(meshPool)
          end if
 
          block => block % next
@@ -985,7 +985,7 @@ module ocn_time_integration_rk4
       endif
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, meshPool, 1)
       endif
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
@@ -1069,7 +1069,7 @@ module ocn_time_integration_rk4
       call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
 
       if (config_filter_btr_mode) then
-          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+          call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, meshPool, 1)
       endif
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -2097,7 +2097,7 @@ module ocn_time_integration_split
          call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
 
          if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool)
+            call ocn_reconstruct_gm_vectors(meshPool)
          end if
 
          block => block % next

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -8,6 +8,7 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_gm.o \
 	   mpas_ocn_diagnostics.o \
 	   mpas_ocn_diagnostics_routines.o \
+	   mpas_ocn_diagnostics_variables.o \
 	   mpas_ocn_thick_ale.o \
 	   mpas_ocn_equation_of_state.o \
 	   mpas_ocn_equation_of_state_jm.o \
@@ -76,7 +77,9 @@ mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_su
 
 mpas_ocn_diagnostics_routines.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_diagnostics_routines.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
+
+mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
 mpas_ocn_mesh.o: 
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -35,6 +35,7 @@ module ocn_diagnostics
    use ocn_equation_of_state
    use ocn_thick_ale
    use ocn_diagnostics_routines
+   use ocn_diagnostics_variables
    use ocn_mesh
 
    implicit none
@@ -56,7 +57,6 @@ module ocn_diagnostics
    public :: ocn_diagnostic_solve, &
              ocn_vert_transport_velocity_top, &
              ocn_fuperp, &
-             ocn_filter_btr_mode_vel, &
              ocn_filter_btr_mode_tend_vel, &
              ocn_reconstruct_gm_vectors, &
              ocn_diagnostics_init, &
@@ -111,30 +111,14 @@ contains
       real (kind=RKIND) :: coef_3rd_order
 
       real (kind=RKIND), dimension(:), pointer :: &
-        ssh,  seaIcePressure, atmosphericPressure, &
-        pressureAdjustedSSH, gradSSH
+        ssh,  seaIcePressure, atmosphericPressure
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThicknessEdge, layerThickness, normalVelocity, normalTransportVelocity, &
-        normalGMBolusVelocity, tangentialVelocity, pressure, circulation, kineticEnergyCell, montgomeryPotential, &
-        zMid, zTop, divergence, relativeVorticity, relativeVorticityCell, &
-        normalizedPlanetaryVorticityEdge, normalizedRelativeVorticityEdge, &
-        normalizedRelativeVorticityCell, density, displacedDensity, potentialDensity, &
-        vertVelocityTop, vertTransportVelocityTop, &
-        vertGMBolusVelocityTop, BruntVaisalaFreqTop, &
-        RiTopOfCell, inSituThermalExpansionCoeff, inSituSalineContractionCoeff, edgeAreaFractionOfCell
+        layerThickness, normalVelocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
-      real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
-      real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
-
       integer :: timeLevel
       integer, pointer :: indexTemperature, indexSalinity
-
-      real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
-      real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
 
       logical :: full_compute = .true.
 
@@ -160,46 +144,8 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
       call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
-      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
-
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
 
       nEdges = nEdgesAll
       nCells = nCellsAll
@@ -319,7 +265,7 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       call ocn_compute_land_ice_flux_input_fields(meshPool, statePool, forcingPool, scratchPool, &
-                                         diagnosticsPool, timeLevel)
+                                         timeLevel)
 
       if ( full_compute ) then
 
@@ -1641,69 +1587,6 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_filter_btr_mode_vel
-!
-!> \brief   filters barotropic mode out of the velocity variable.
-!> \author  Mark Petersen
-!> \date    23 September 2011
-!> \details
-!>  This routine filters barotropic mode out of the velocity variable.
-!
-!-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_vel(statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
-
-      type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
-
-      integer :: iEdge, k
-      real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, normalVelocity
-
-      integer :: timeLevel
-
-      call mpas_timer_start("ocn_filter_btr_mode_vel")
-
-      if (present(timeLevelIn)) then
-         timeLevel = timeLevelIn
-      else
-         timeLevel = 1
-      end if
-
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-
-      !$omp parallel
-      !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
-      do iEdge = 1, nEdgesAll
-
-        ! thicknessSum is initialized outside the loop because on land boundaries
-        ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
-        ! nonzero value to avoid a NaN.
-        normalThicknessFluxSum = layerThicknessEdge(1,iEdge) * normalVelocity(1,iEdge)
-        thicknessSum  = layerThicknessEdge(1,iEdge)
-
-        do k = 2, maxLevelEdgeTop(iEdge)
-          normalThicknessFluxSum = normalThicknessFluxSum + layerThicknessEdge(k,iEdge) * normalVelocity(k,iEdge)
-          thicknessSum  =  thicknessSum + layerThicknessEdge(k,iEdge)
-        enddo
-
-        vertSum = normalThicknessFluxSum/thicknessSum
-        do k = 1, maxLevelEdgeTop(iEdge)
-          normalVelocity(k,iEdge) = normalVelocity(k,iEdge) - vertSum
-        enddo
-      enddo ! iEdge
-      !$omp end do
-      !$omp end parallel
-
-      call mpas_timer_stop("ocn_filter_btr_mode_vel")
-
-   end subroutine ocn_filter_btr_mode_vel!}}}
-
-!***********************************************************************
-!
 !  routine ocn_filter_btr_mode_tend_vel
 !
 !> \brief   ocn_filters barotropic mode out of the velocity tendency
@@ -1713,17 +1596,16 @@ contains
 !>  This routine filters barotropic mode out of the velocity tendency.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_filter_btr_mode_tend_vel(tendPool, statePool, meshPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state pool
 
       integer :: iEdge, k
       real (kind=RKIND) :: vertSum, normalThicknessFluxSum, thicknessSum
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, tend_normalVelocity
+      real (kind=RKIND), dimension(:,:), pointer :: tend_normalVelocity
 
       integer :: timeLevel
 
@@ -1736,8 +1618,6 @@ contains
       end if
 
       call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
       !$omp parallel
       !$omp do schedule(runtime) private(normalThicknessFluxSum, thicknessSum, k, vertSum)
@@ -1778,7 +1658,8 @@ contains
 !>  other diagnostics routines.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostics_init(err)!{{{
+   subroutine ocn_diagnostics_init(domain, err)!{{{
+      type(domain_type), intent(in) :: domain
       integer, intent(out) :: err !< Output: Error flag
 
       err = 0
@@ -1808,6 +1689,8 @@ contains
           ! is added separately to the momentum tendencies.
           fCoef = 0
       end if
+
+      call ocn_diagnostics_variables_init(domain, jenkinsOn, hollandJenkinsOn, err)
 
     end subroutine ocn_diagnostics_init!}}}
 
@@ -1845,18 +1728,14 @@ contains
 
       ! real pointers
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
-           surfaceBuoyancyForcing, surfaceFrictionVelocity, penetrativeTemperatureFluxOBL, &
-           normalVelocitySurfaceLayer, surfaceThicknessFluxRunoff, rainFlux, evaporationFlux, &
+           surfaceThicknessFluxRunoff, rainFlux, evaporationFlux, &
            icebergFreshWaterFlux, seaIceFreshWaterFlux
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
-           layerThickness, zMid, zTop, density, &
+           layerThickness, &
            normalVelocity, activeTracersSurfaceFlux, &
-           activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux, edgeAreaFractionOfCell
-
-      real (kind=RKIND), dimension(:), pointer :: &
-           indexSurfaceLayerDepth
+           activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
            activeTracers
@@ -1902,15 +1781,6 @@ contains
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
-      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'nonLocalSurfaceTracerFlux', nonLocalSurfaceTracerFlux)
 
       call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
@@ -2028,13 +1898,12 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(meshPool, statePool, &
-      forcingPool, scratchPool, diagnosticsPool, timeLevel)!{{{
+      forcingPool, scratchPool, timeLevel)!{{{
 
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: scratch variables
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool !< Input/Output: Diagnostics information
 
       integer, intent(in) :: timeLevel
 
@@ -2048,20 +1917,15 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
 
-      integer, pointer :: indexT, indexS, indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
+      integer, pointer :: indexT, indexS
 
       real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
-      real (kind=RKIND), dimension(:), pointer :: landIceFraction, &
-                                                  landIceFrictionVelocity, &
-                                                  topDrag, &
-                                                  topDragMagnitude, &
-                                                  surfaceFluxAttenuationCoefficient
+      real (kind=RKIND), dimension(:), pointer :: landIceFraction
 
       integer, dimension(:), pointer :: landIceMask
 
-      real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell, layerThickness, normalVelocity, &
-                                                    landIceBoundaryLayerTracers, landIceTracerTransferVelocities
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       ! Scratch Arrays
@@ -2093,22 +1957,6 @@ contains
       call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
-      end if
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
       allocate(blTempScratch(nCellsAll), &
                blSaltScratch(nCellsAll))
@@ -2252,39 +2100,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_reconstruct_gm_vectors(diagnosticsPool, meshPool) !{{{
+   subroutine ocn_reconstruct_gm_vectors(meshPool) !{{{
 
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         normalTransportVelocity, transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
-         transportVelocityMeridional, normalGMBolusVelocity, GMBolusVelocityX, GMBolusVelocityY, GMBolusVelocityZ, &
-         GMBolusVelocityZonal, GMBolusVelocityMeridional, &
-         gmStreamFuncTopOfEdge, GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional
 
       call mpas_timer_start('reconstruct gm vecs')
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
 
       call mpas_reconstruct(meshPool, normalTransportVelocity,          &
                        transportVelocityX,            &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -1,0 +1,422 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_diagnostics
+!
+!> \brief MPAS ocean diagnostics variable definitions
+!> \author Matt Turner
+!> \date   13 May 2020
+!> \details
+!>  This module contains the definitions of all variables contianed in the
+!>  diagnosticsPool, and also gets the variables from the Pool in init.
+!
+!-----------------------------------------------------------------------
+
+module ocn_diagnostics_variables
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_constants
+   use mpas_stream_manager
+   use mpas_io_units
+
+   use ocn_config
+
+   implicit none
+   public
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   real (kind=RKIND), dimension(:,:), pointer :: zMid
+   real (kind=RKIND), dimension(:,:), pointer :: zTop
+   real (kind=RKIND), dimension(:,:), pointer :: divergence
+   real (kind=RKIND), dimension(:,:), pointer :: circulation
+   real (kind=RKIND), dimension(:,:), pointer :: relativeVorticity
+   real (kind=RKIND), dimension(:,:), pointer :: relativeVorticityCell
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedPlanetaryVorticityEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityCell
+   real (kind=RKIND), dimension(:,:), pointer :: density
+   real (kind=RKIND), dimension(:,:), pointer :: displaceddensity
+   real (kind=RKIND), dimension(:,:), pointer :: potentialdensity
+   real (kind=RKIND), dimension(:,:), pointer :: montgomeryPotential
+   real (kind=RKIND), dimension(:,:), pointer :: pressure
+   real (kind=RKIND), dimension(:,:), pointer :: inSituThermalExpansionCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: inSituSalineContractionCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
+   real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge
+   real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
+   real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: vertGMBolusVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: normalGMBolusVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: RiTopOfCell
+   real (kind=RKIND), dimension(:,:), pointer :: RiTopOfEdge
+
+   real (kind=RKIND), dimension(:), pointer :: gradSSH
+   real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
+
+   real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
+   real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
+   real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
+   real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
+
+   real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
+   real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
+
+   real (kind=RKIND), dimension(:), pointer :: landIceFrictionVelocity
+   real (kind=RKIND), dimension(:), pointer :: topDrag
+   real (kind=RKIND), dimension(:), pointer :: topDragMagnitude
+   real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
+   real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
+
+   integer, pointer :: indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
+
+   real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFluxOBL
+
+   real (kind=RKIND), dimension(:), pointer :: surfaceBuoyancyForcing
+   real (kind=RKIND), dimension(:), pointer :: surfaceFrictionVelocity
+
+   real (kind=RKIND), dimension(:,:), pointer :: &
+      transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
+      transportVelocityMeridional, GMBolusVelocityX, GMBolusVelocityY, &
+      GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
+      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional, &
+      gmStreamFuncTopOfCell
+
+   real (kind=RKIND), dimension(:,:), pointer :: rx1Edge
+   real (kind=RKIND), dimension(:,:), pointer :: rx1Cell
+   real (kind=RKIND), dimension(:), pointer :: rx1MaxEdge
+   real (kind=RKIND), dimension(:), pointer :: rx1MaxCell
+   real (kind=RKIND), pointer :: globalRx1Max
+
+   integer, dimension(:), pointer :: smoothingMask
+   real (kind=RKIND), dimension(:,:), pointer :: verticalStretch
+
+   integer, dimension(:), pointer :: modifySSHMask
+
+   real (kind=RKIND), dimension(:,:), pointer :: velocityMeridional
+   real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
+
+   real(kind=RKIND), dimension(:, :), pointer :: kappaGMCell
+   real(kind=RKIND), dimension(:, :), pointer :: kappaRediSfcTaper
+   real(kind=RKIND), dimension(:, :), pointer :: kappaRediCell
+   real(kind=RKIND), dimension(:, :), pointer :: k33
+   real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
+   real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
+   real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
+
+   integer, dimension(:), pointer :: indMLD
+   real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
+
+   real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
+
+   real (kind=RKIND), dimension(:,:), pointer :: viscosity
+   real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfEdge
+   real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfCell
+   real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
+   type (field2DReal), pointer :: wettingVelocityField
+
+   real (kind=RKIND), dimension(:,:), pointer :: vertDiffTopOfCell
+   real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
+   integer, dimension(:,:), pointer :: rediLimiterCount
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerSurfaceFluxTendency
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerNonLocalTendency
+   real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerHorMixTendency
+   real (kind=RKIND), dimension(:,:), pointer :: temperatureShortWaveTendency
+   real (kind=RKIND), dimension(:), pointer :: RediKappa
+
+   ! pointers for tendencies used in diagnostic budget computation
+   real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+      activeTracerHorizontalAdvectionTendency, &
+      activeTracerVerticalAdvectionTendency,   &
+      activeTracerHorizontalAdvectionEdgeFlux, &
+      activeTracerVerticalAdvectionTopFlux,    &
+      activeTracerVertMixTendency
+
+   real (kind=RKIND), pointer :: daysSinceStartOfSim
+   character (len=StrKIND), pointer :: xtime, simulationStartTime
+
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumber
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumberBuoy
+   real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumberShear
+
+   real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
+   real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepthSmooth
+   real (kind=RKIND), dimension(:), pointer :: indexBoundaryLayerDepth
+   integer, pointer :: index_vertNonLocalFluxTemp
+
+   real (kind=RKIND), dimension(:), pointer :: salinitySurfaceRestoringTendency
+
+   real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
+   real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
+   real (kind=RKIND), dimension(:), pointer :: gradSSHX
+   real (kind=RKIND), dimension(:), pointer :: gradSSHY
+   real (kind=RKIND), dimension(:), pointer :: gradSSHZ
+
+   real (kind=RKIND), dimension(:), pointer :: barotropicForcing
+   real (kind=RKIND), dimension(:), pointer :: barotropicThicknessFlux
+
+   real (kind=RKIND), dimension(:, :), pointer :: edgeAreaFractionOfCell
+   real (kind=RKIND), dimension(:, :), pointer :: SSHGradient
+   integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+   integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
+
+   type (field1DInteger), pointer :: smoothingMaskField
+   type (field2DReal), pointer :: verticalStretchField
+
+   real (kind=RKIND), pointer :: globalVerticalStretchMax, globalVerticalStretchMin
+   real (kind=RKIND), dimension(:), pointer :: betaEdge
+   real (kind=RKIND), dimension(:), pointer :: eddyLength
+   real (kind=RKIND), dimension(:), pointer :: eddyTime
+   real (kind=RKIND), dimension(:), pointer :: c_visbeck
+   real (kind=RKIND), dimension(:), pointer :: gmResolutionTaper
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_diagnostics_variables_init
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_diagnostics_variables_init
+!
+!> \brief   Initializes variables in the diagnosticsPool
+!> \author  Matt Turner
+!> \date    13 May 2020
+!> \details
+!>  This routine initializes all of the pointers associated with
+!>  variables contained in the diagnosticsPool.
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostics_variables_init(domain, jenkinsOn, hollandJenkinsOn, err)!{{{
+      type (domain_type), intent(in) :: domain
+
+      logical, intent(in) :: jenkinsOn
+      logical, intent(in) :: hollandjenkinsOn
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      type (mpas_pool_type), pointer :: diagnosticsPool
+
+      err = 0
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
+
+      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
+      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
+      call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
+      call mpas_pool_get_array(diagnosticsPool, 'density', density)
+      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
+      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
+      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
+      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
+      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
+      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
+
+      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
+      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
+      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
+
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
+
+      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
+      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
+      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
+      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
+
+      !
+      ! set pointers for fields related forcing at ocean surface
+      !
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
+
+      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
+
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
+
+      if(jenkinsOn .or. hollandJenkinsOn) then
+        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
+        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
+      end if
+
+      call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', rx1MaxCell, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMax', globalVerticalStretchMax, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMin', globalVerticalStretchMin, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
+      call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
+      call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMaskField, 1)
+      call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', verticalStretchField, 1)
+
+      call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+
+      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+
+      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
+
+      call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
+      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
+      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
+      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
+      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
+
+      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
+      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
+      call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', wettingVelocityField)
+
+      !
+      ! set pointers for viscosity/diffusivity and initialize to zero
+      !
+      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', bulkRichardsonNumber)
+      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
+      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepthSmooth', boundaryLayerDepthSmooth)
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',bulkRichardsonNumberBuoy)
+      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',bulkRichardsonNumberShear)
+      call mpas_pool_get_array(diagnosticsPool, 'indexBoundaryLayerDepth',indexBoundaryLayerDepth)
+      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
+
+      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_vertNonLocalFluxTemp', index_vertNonLocalFluxTemp)
+
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
+      call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
+      if (config_compute_active_tracer_budgets) then
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
+         call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
+         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
+      endif
+
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerVerticalAdvectionTopFlux',    &
+              activeTracerVerticalAdvectionTopFlux)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerHorizontalAdvectionEdgeFlux', &
+              activeTracerHorizontalAdvectionEdgeFlux)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerHorizontalAdvectionTendency', &
+              activeTracerHorizontalAdvectionTendency)
+      call mpas_pool_get_array(diagnosticsPool,         &
+             'activeTracerVerticalAdvectionTendency',   &
+              activeTracerVerticalAdvectionTendency)
+      call mpas_pool_get_array(diagnosticsPool, &
+         'activeTracerVertMixTendency',activeTracerVertMixTendency)
+
+      call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
+      call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
+      call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime',simulationStartTime)
+
+      call mpas_pool_get_array(diagnosticsPool,'salinitySurfaceRestoringTendency',salinitySurfaceRestoringTendency)
+
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
+      call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
+      call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
+
+      call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
+
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
+      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
+
+      call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)                                    
+      call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)                                        
+      call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
+      call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
+
+    end subroutine ocn_diagnostics_variables_init!}}}
+
+!***********************************************************************
+
+end module ocn_diagnostics_variables
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker


### PR DESCRIPTION
This PR add a new module to house the variables contained in `diagnosticsPool` in the ocean model.  This also implements the use of the new module in the `mpas_ocn_diagnostics.F` file.

This is the first of a handful of PRs that will replace #611 by breaking it up into smaller PRs.