### PR TITLE
Reset pointer to mpas_log_info at the start of each call to mpas_{run,finalize}

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -341,11 +341,15 @@ module mpas_subdriver
 
    subroutine mpas_run(domain_ptr)
 
+      use mpas_log, only: mpas_log_info
+
       implicit none
 
       type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
+
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
 
       iErr = domain_ptr % core % core_run(domain_ptr)
       if ( iErr /= 0 ) then
@@ -389,6 +393,8 @@ module mpas_subdriver
       ! Print out log stats and close log file
       !   (Do this after timer stats are printed and stream mgr finalized,
       !    but before framework is finalized because domain is destroyed there.)
+      if ( associated(domain_ptr % logInfo) ) mpas_log_info => domain_ptr % logInfo
+
       call mpas_log_finalize(iErr)
       if ( iErr /= 0 ) then
          call mpas_dmpar_global_abort('ERROR: Log finalize failed for core ' // trim(domain_ptr % core % coreName))


### PR DESCRIPTION
This merge resets the pointer to` mpas_log_info` at the start of each call to `mpas_run`
and `mpas_finalize`.

Because the `mpas_log` module maintains a pointer to the currently active logging
info as a module variable, this pointer must be set to the logging info for
the currently active domain at the beginning of each call to `mpas_run` and
`mpas_finalize`.
    
There is no need to perform similar logic in `mpas_init`, since the call to
the `core % setup_log()` function call invokes `mpas_log_init()`, which internally
sets the logging info pointer.
