### PR TITLE
add the Bassis & Ma damage scheme and links it to Matt's new calving algorithm

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -152,6 +152,10 @@
 		            description="Value of eigencalving parameter if taken as a scalar by option config_calving_eigencalving_parameter_source. (Default value is 1.0e9 m a converted to units used here.)"
 		            possible_values="any positive real number"
 		/>
+		<nml_option name="config_calving_specified_source" type="character" default_value="const" units="none"
+		            description="method of specified calving velocity"
+		            possible_values="'const' (constant calving velocity), 'data' (calving velocity given by data input)"
+		/>
                     <nml_option name="config_calving_velocity_const" type="real" default_value="0.0" units="m s^{-1}"
 		            description="constant calving velocity specified in the namelist"
 		            possible_values="Any positive real value"
@@ -616,6 +620,7 @@
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
                         <var name="basalFrictionFlux"/>
 			<var name="damage"/>
+			<var name="calvingVelocityData"/>
 			<var name="basalMeltInput" packages="hydro"/>
 			<var name="externalWaterInput" packages="hydro"/>
 			<var name="waterThickness" packages="hydro"/>
@@ -710,6 +715,7 @@
                         <var name="channelArea" packages="hydro"/>  <!-- this is only needed if running with channels - could be package-controlled -->
 			<var name="waterFluxMask" packages="hydro"/>
 			<var name="damage"/>
+			<var name="calvingVelocityData"/>
 			<var name="damageMax"/>
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6Melt"/>

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -205,7 +205,7 @@
 		            possible_values="'calving_rate', 'threshold'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
-                        description="A scalar parameter that links damage and calving"
+                        description="A scalar parameter that links damage and calving when we use the calving_rate method"
 	                possible_values="any positive real value"
 		/>
 	</nml_record>
@@ -755,8 +755,6 @@
 			<var name="upperSurface"/>
 			<var name="temperature"/>
 			<var name="cellMask"/>
-			<!--var name="cellMaskFront"/-->
-			<!--var name="cellVolumeLeft"/-->
 			<var name="edgeMask"/>
 			<var name="normalVelocity"/>
 			<var name="uReconstructX"/>
@@ -1055,7 +1053,7 @@ is the value of that variable from the *previous* time level!
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
                 />
                 <var name="damage" type="real" dimensions="nCells Time" units="none" time_levs="1"
-                     description="damage number, ranging from 0 to 1"
+                     description="Damage is parameterized as the local ice thickness divided by the fracture depth, such that unfractured ice has damage=0 and ice fractured through its full thickness has damage=1"
                 />
                 <var name="ddamagedt" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage change rate"
@@ -1063,14 +1061,14 @@ is the value of that variable from the *previous* time level!
                 <var name="damage_nye" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="Nye zero-stress damage number"
                 />
-                <var name="damage_max" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                <var name="damageMax" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="maximum damage number kept constant"
                 />
                 <var name="s0" type="real" dimensions="nCells Time" units="none" time_levs="1"
-                     description="a ratio between hydrostatic pressure and the largest principal tensile stress within ice shelf"
+                     description="a ratio between hydrostatic pressure and the largest principal tensile stress within ice shelf, rho_i * (rho_w - rho_i) * g * h / ( 2 * Tau_xx * rho_w ), where "h" is the ice thickness."
                 />
                 <var name="nstar" type="real" dimensions="nCells Time" units="none" time_levs="1"
-                     description="adjusted Glen flow law parameter"
+                     description="n∗ denotes the usual parameter n from Glen’s flow law, adjusted by including the ratio of the principal horizontal strain rates:  epsilon Dot_yy / epsilon Dot_xx"
                 />
             <var name="visc" type="real" dimensions="nCells Time" units="Pa s" time_levs="1"
                      description="effective viscosity"
@@ -1083,15 +1081,6 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="damageSource" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage source term"
-                />
-                <var name="requiredCalvingVolumeRate" type="real" dimensions="nCells Time" units="m^3 s^{-1}" time_levs="1"
-                     description="total volume of ice that needs to be removed based on eigencalving rate at this margin cell"
-                />
-               <var name="uncalvedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was left uncalved from required calving flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
-                />
-                <var name="requiredCalvingVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
-                     description="total volume of ice that needs to be removed based on calving rate for the given time step"
                 />
                 <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left uncalved from required calving flux at non-dynamic cells"
@@ -1406,72 +1395,68 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
-	  <var name="meanFlowParamAField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+       <var name="meanFlowParamAField" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
+	       description="depth averaged flow parameter A"
 	       persistence="scratch"
 	       />
-	  <!--var name="viscField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <!--var name="viscField" type="real" dimensions="nCells" units="Pa s"
+	       description="effective viscosity"
 	       persistence="scratch"
 	       /-->
-	  <var name="sigmaxyField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+      <var name="sigmaxyField" type="real" dimensions="nCells" units="Pa"
+	       description="deviatoric stress xy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayxField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="sigmayxField" type="real" dimensions="nCells" units="Pa"
+	       description="deviatoric stress yx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaxxField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="sigmaxxField" type="real" dimensions="nCells" units="Pa"
+	       description="deviatoric stress xx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayyField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="sigmayyField" type="real" dimensions="nCells" units="Pa"
+	       description="deviatoric stress yy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaminField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="sigmaminField" type="real" dimensions="nCells" units="Pa"
+	       description="minimum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="sigmamaxField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="sigmamaxField" type="real" dimensions="nCells" units="Pa"
+	       description="maximum principal deviatoric stress"
 	       persistence="scratch"
 	       />
 	  <var name="alphaField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"
 	       />
-	  <!--var name="epsmaxField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <!--var name="epsmaxField" type="real" dimensions="nCells" units="s^{-1}"
+	       description="strain rate corresponding to sigmamax"
 	       persistence="scratch"
 	       /-->
 	  <!--var name="nstarField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	       description="adjusted flow law parameter n"
 	       persistence="scratch"
 	       /-->
 	  <!--var name="s0Field" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	       description="a ratio between hydeostatic pressure and the largest principal stress"
 	       persistence="scratch"
 	       /-->
-	  <!--var name="sourceField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <!--var name="damageSourceField" type="real" dimensions="nCells" units="s^{-1}"
+	       description="damage source"
 	       persistence="scratch"
 	       /-->
-	  <var name="ddamagedtField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+	  <var name="ddamagedtField" type="real" dimensions="nCells" units="s^{-1}"
+          description="d(damage) / dt"
 	       persistence="scratch"
 	       />
-	  <var name="forceField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
+       <var name="forceField" type="real" dimensions="nCells" units="s^{-1}"
+	       description="environmental forcing for damage production"
 	       persistence="scratch"
 	       />
 	  <var name="thicknessField" type="real" dimensions="nCells" units="none"
 	       description="update halo for thickness (nCells)"
-	       persistence="scratch"
-	       />
-	  <var name="meanTField" type="real" dimensions="nCells" units="none"
-	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
 	  <var name="workTracerCell" type="real" dimensions="maxTracersAdvect nCells" units="none"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -197,7 +197,7 @@
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_calving_threshold" type="real" default_value="1.0" units="unitless"
-                        description="Value of damage above which the cell would be calved away."
+                        description="When config_damage_calving_method==threshold, this is the value of damage above which the cell would be calved away.  When config_damage_calving_method==calving_rate, this is the value above which calving becomes proportional to damage."
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_stiffness_min" type="real" default_value="0.1" units="unitless"
@@ -213,7 +213,7 @@
 		            possible_values="'nye', 'extrapolate'"
 		/>
 		        <nml_option name="config_damage_calving_method" type="character" default_value="threshold" units="unitless"
-		                description="Selection of the method for damage calving. For 'threshold', ice with damage above the value specified by 'config_damage_calving_threshold' will be removed (currently, only if this ice is also AT a marine margin, but eventually this will be expanded to also include any ice at the threshold adjacent to cells at the marine margin). For 'calving_rate', a rate of calving is specified as proportional to the damage value above some threshold, with the constant of proportionality specified by 'config_damagecalvingParameter'."
+		                description="Selection of the method for damage calving. For 'threshold', ice with damage above the value specified by 'config_damage_calving_threshold' will be removed (currently, only if this ice is also AT a marine margin, but eventually this will be expanded to also include any ice at the threshold adjacent to cells at the marine margin). For 'calving_rate', a rate of calving is specified as proportional to the damage value above some threshold, with the constant of proportionality specified by 'config_damagecalvingParameter' and the threshold defined by config_damage_calving_threshold."
 		            possible_values="'calving_rate', 'threshold'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -189,7 +189,7 @@
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the 'calculate_damage' function."
+                        description="If .true., then turn on the 'calculate_damage' subroutine. Note that setting this to .true. will evolve damage even if damage-based calving is not being used, which is why it is .false. by default (and thus it should explicitly be set to .true. to use damage based calving)."
 		            possible_values=".true. or .false."
                 />
                 <nml_option name="config_damage_preserve_threshold" type="real" default_value="0.0" units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -134,7 +134,7 @@
 	<nml_record name="calving" in_defaults="true">
 		<nml_option name="config_calving" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for calving ice (as defined further below)."
-		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'mask'"
+		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'damagecalving', 'mask'"
 		/>
 		<nml_option name="config_calving_topography" type="real" default_value="-500.0" units="m"
 		            description="Defines the topographic height below which ice calves (for topographic_threshold option)."
@@ -171,6 +171,34 @@
                 <nml_option name="config_remove_small_islands" type="logical" default_value=".false." units="unitless"
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
+		/>
+                <nml_option name="config_damage_restore_threshold" type="real" default_value="0.0" units="unitless"
+                        description="It is a value above which the old damage number would be kept from the impact of advection (the damage would not heal). For example, if the damage at some location is 0.83, and we set config_damage_restore_threshold to 0.8, then the damage number there will not fall below 0.83. Otherwise, if the damage is 0.7, then it could be decreased to 0.6 if non-damaged ice is transported from upstream. If we set config_damage_restore_threshold to 0 (default), then it will just not play a role in pratical."
+	                possible_values="real value between 0 and 1"
+		/>
+                <nml_option name="config_damage_calving_threshold" type="real" default_value="1.0" units="unitless"
+                        description="It is a value above which the cell would be calved away."
+	                possible_values="real value between 0 and 1"
+		/>
+                <nml_option name="config_damage_stiffness_min" type="real" default_value="0.1" units="unitless"
+                        description="When coupling damage to rheology, we do not allow it to fall below this value"
+	                possible_values="real value between 0 and 1"
+		/>
+                <nml_option name="config_damage_rheology_coupling" type="logical" default_value=".false." units="unitless"
+                        description="If true, then we change stiffnessFactor to 1-damage during the run."
+	                possible_values=".true. or .false."
+		/>
+                <nml_option name="config_use_constant_A" type="logical" default_value=".false." units="unitless"
+                        description="If true, then we use constant A (i.e., config_default_flowParamA) in the damage calculation."
+	                possible_values=".true. or .false."
+		/>
+                <nml_option name="config_damage_if_calving_rate" type="logical" default_value=".false." units="unitless"
+                        description="If true, then we use a parameterized calving velocity to connect calving and damage."
+	                possible_values=".true. or .false."
+		/>
+    <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
+                        description="A scalar parameter that links damage and calving"
+	                possible_values="any positive real value"
 		/>
 	</nml_record>
 
@@ -575,6 +603,10 @@
                         <var name="uReconstructX" packages="higherOrderVelocity"/>
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
                         <var name="basalFrictionFlux"/>
+			<var name="damage"/>
+			<var name="ddamagedt"/>
+			<var name="szero"/>
+			<var name="source"/>
 			<var name="basalMeltInput" packages="hydro"/>
 			<var name="externalWaterInput" packages="hydro"/>
 			<var name="waterThickness" packages="hydro"/>
@@ -668,6 +700,10 @@
 			<var name="waterPressure" packages="hydro"/>
                         <var name="channelArea" packages="hydro"/>  <!-- this is only needed if running with channels - could be package-controlled -->
 			<var name="waterFluxMask" packages="hydro"/>
+			<var name="damage"/>
+			<var name="ddamagedt"/>
+			<var name="szero"/>
+			<var name="source"/>
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6Melt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6Melt"/>
@@ -703,6 +739,8 @@
 			<var name="upperSurface"/>
 			<var name="temperature"/>
 			<var name="cellMask"/>
+			<var name="cellMaskFront"/>
+			<var name="cellVolumeLeft"/>
 			<var name="edgeMask"/>
 			<var name="normalVelocity"/>
 			<var name="uReconstructX"/>
@@ -999,6 +1037,33 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
+                />
+                <var name="damage" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="damage number"
+		/>
+                <var name="ddamagedt" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="damage change rate"
+		/>
+                <var name="damage_nye" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="Nye zero-stress damage number"
+		/>
+                <var name="damage_max" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="maximum damage number kept constant"
+		/>
+                <var name="szero" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="S0 number"
+		/>
+                <var name="source" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
+		     description="damage source term"
+		/>
+                <var name="requiredCalvingVolumeRate" type="real" dimensions="nCells Time" units="m^3 s^{-1}" time_levs="1"
+                     description="total volume of ice that needs to be removed based on eigencalving rate at this margin cell"
+                />
+               <var name="uncalvedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved from required calving flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
+                />
+                <var name="requiredCalvingVolume" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                     description="total volume of ice that needs to be removed based on calving rate for the given time step"
                 />
                 <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left uncalved from required calving flux at non-dynamic cells"
@@ -1310,6 +1375,74 @@ is the value of that variable from the *previous* time level!
 	       persistence="scratch"
 	       />
 	  <var name="workCell3" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="meanFlowParamAField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="viscField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmaxyField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmayxField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmaxxField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmayyField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmaminField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="sigmamaxField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="alphaField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="epsmaxField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="nstarField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <!--var name="szeroField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       /-->
+	  <!--var name="sourceField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       /-->
+	  <var name="ddamagedtField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="forceField" type="real" dimensions="nCells" units="none"
+	       description="generic work array with dimensions of (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="thicknessField" type="real" dimensions="nCells" units="none"
+	       description="update halo for thickness (nCells)"
+	       persistence="scratch"
+	       />
+	  <var name="meanTField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1062,7 +1062,7 @@ is the value of that variable from the *previous* time level!
                 <var name="ddamagedt" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage change rate"
                 />
-                <var name="damage_nye" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                <var name="damageNye" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="Nye zero-stress (Nye, 1957, Proc. R. Soc. A, 239) damage value"
                 />
                 <var name="damageMax" type="real" dimensions="nCells Time" units="none" time_levs="1"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -181,7 +181,7 @@
 	                possible_values=".true. or .false."
 		/>
 		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".true." units="unitless"
-                        description="If true, then the 'li_finalize_damage_after_advection' subroutine is applied, doing the following: 1) set the value of damage at the grounding line based on the choice of 'config_damage_gl_setting', 2) reset the damage to some threshold value if it exceeds that threshold after advection, based on choice of 'config_preserve_damage', 3) couple the updated damage value to the rheology if 'config_damage_rheology_coupling' is true."
+                        description="If true, then the 'li_finalize_damage_after_advection' subroutine is applied, doing the following: 1) set the value of damage at the grounding line based on the choice of 'config_damage_gl_setting', 2) reset the value of damage to its initial value (to avoid healing), based on choice of 'config_preserve_damage', 3) couple the updated damage value to the rheology if 'config_damage_rheology_coupling' is true."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_preserve_damage" type="logical" default_value=".false." units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -172,6 +172,14 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
+		<nml_option name="config_restore_damage" type="logical" default_value=".false." units="unitless"
+                        description="If true, then turn on the restore_damage function."
+		            possible_values=".true. or .false."
+                />
+		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"
+                        description="If true, then turn on the calculate_damage function."
+		            possible_values=".true. or .false."
+                />
                 <nml_option name="config_damage_restore_threshold" type="real" default_value="0.0" units="unitless"
                         description="It is a value above which the old damage number would be kept from the impact of advection (the damage would not heal). For example, if the damage at some location is 0.83, and we set config_damage_restore_threshold to 0.8, then the damage number there will not fall below 0.83. Otherwise, if the damage is 0.7, then it could be decreased to 0.6 if non-damaged ice is transported from upstream. If we set config_damage_restore_threshold to 0 (default), then it will just not play a role in pratical."
 	                possible_values="real value between 0 and 1"
@@ -188,7 +196,7 @@
                         description="If true, then we change stiffnessFactor to 1-damage during the run."
 	                possible_values=".true. or .false."
 		/>
-                <nml_option name="config_use_constant_A" type="logical" default_value=".false." units="unitless"
+                <nml_option name="config_damage_use_constant_A" type="logical" default_value=".false." units="unitless"
                         description="If true, then we use constant A (i.e., config_default_flowParamA) in the damage calculation."
 	                possible_values=".true. or .false."
 		/>
@@ -606,6 +614,10 @@
 			<var name="damage"/>
 			<var name="ddamagedt"/>
 			<var name="szero"/>
+			<var name="nstar"/>
+			<var name="epsmax"/>
+			<var name="sigmamax"/>
+			<var name="visc"/>
 			<var name="source"/>
 			<var name="basalMeltInput" packages="hydro"/>
 			<var name="externalWaterInput" packages="hydro"/>
@@ -703,6 +715,10 @@
 			<var name="damage"/>
 			<var name="ddamagedt"/>
 			<var name="szero"/>
+			<var name="nstar"/>
+			<var name="epsmax"/>
+			<var name="sigmamax"/>
+			<var name="visc"/>
 			<var name="source"/>
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6Melt"/>
@@ -739,8 +755,8 @@
 			<var name="upperSurface"/>
 			<var name="temperature"/>
 			<var name="cellMask"/>
-			<var name="cellMaskFront"/>
-			<var name="cellVolumeLeft"/>
+			<!--var name="cellMaskFront"/-->
+			<!--var name="cellVolumeLeft"/-->
 			<var name="edgeMask"/>
 			<var name="normalVelocity"/>
 			<var name="uReconstructX"/>
@@ -1051,6 +1067,18 @@ is the value of that variable from the *previous* time level!
 		     description="maximum damage number kept constant"
 		/>
                 <var name="szero" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="S0 number"
+		/>
+                <var name="nstar" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="S0 number"
+		/>
+                <var name="visc" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="S0 number"
+		/>
+                <var name="epsmax" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+		     description="S0 number"
+		/>
+                <var name="sigmamax" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
 		     description="S0 number"
 		/>
                 <var name="source" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
@@ -1382,10 +1410,10 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
-	  <var name="viscField" type="real" dimensions="nCells" units="none"
+	  <!--var name="viscField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
-	       />
+	       /-->
 	  <var name="sigmaxyField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
@@ -1414,14 +1442,14 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
-	  <var name="epsmaxField" type="real" dimensions="nCells" units="none"
+	  <!--var name="epsmaxField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
-	       />
-	  <var name="nstarField" type="real" dimensions="nCells" units="none"
+	       /-->
+	  <!--var name="nstarField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
-	       />
+	       /-->
 	  <!--var name="szeroField" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -181,15 +181,15 @@
 	                possible_values=".true. or .false."
 		/>
 		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the li_finalize_damage_after_advection function."
+                        description="If true, then turn on the 'li_finalize_damage_after_advection' function."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_preserve_damage" type="logical" default_value=".false." units="unitless"
-                        description="If true, then we preserve the damage before advection (no heal)"
+                        description="If true, then preserve the value of damage before advection (i.e., do not allow healing of damage to occur)."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the calculate_damage function."
+                        description="If true, then turn on the 'calculate_damage' function."
 		            possible_values=".true. or .false."
                 />
                 <nml_option name="config_damage_preserve_threshold" type="real" default_value="0.0" units="unitless"
@@ -197,27 +197,27 @@
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_calving_threshold" type="real" default_value="1.0" units="unitless"
-                        description="It is a value above which the cell would be calved away."
+                        description="Value of damage above which the cell would be calved away."
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_stiffness_min" type="real" default_value="0.1" units="unitless"
-                        description="The minimum value the stiffnessFactor can take due to evolving damage when stiffnessFactor is calculated from damage (config_damage_rheology_coupling=.true.). Used to prevent unrealistic and/or numerically challenging stiffness values. For example, if damage = 0.9, then stiffnessFactor is 1 - damage = 0.1. But if we set config_damage_stiffness_min = 0.5, then stiffnessFactor can only be allowd as 0.5"
+                        description="The minimum value the 'stiffnessFactor' can take due to evolving damage when 'stiffnessFactor' is calculated from damage (i.e., when 'config_damage_rheology_coupling'=.true.). This is used to prevent unrealistic and/or numerically challenging stiffness values. For example, if damage = 0.9, then 'stiffnessFactor' becomes 1 - damage = 0.1 (a small value that could be challenging for the solver). But if we set 'config_damage_stiffness_min' = 0.5, then 'stiffnessFactor' can only fall as low as 0.5."
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_rheology_coupling" type="logical" default_value=".false." units="unitless"
-                        description="If true, then we change stiffnessFactor to 1-damage during the run."
+                        description="If true, then the value of 'stiffnessFactor' is coupled to damage evolution, i.e. 'stiffnessFactor' = 1-damage."
 	                possible_values=".true. or .false."
 		/>
 		        <nml_option name="config_damage_gl_setting" type="character" default_value="nye" units="unitless"
-		                description="Selection of the method for initializing damage in the first floating grid cells past the grounding line.  'nye' uses Nye's zero stress criteria for defining the damage value.  'extrapolate' extrapolates values from the floating ice downstream back to the first floating cells."
+		                description="Selection of the method for initializing damage in the first floating grid cells past the grounding line: 'nye' uses Nye's zero stress criteria (Nye, 1957, Proc. R. Soc. A, 239) for defining the damage value, 'extrapolate' extrapolates values from the floating ice downstream back to the first floating cells."
 		            possible_values="'nye', 'extrapolate'"
 		/>
-		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"
-		                description="Selection of the method for damage calving"
+		        <nml_option name="config_damage_calving_method" type="character" default_value="threshold" units="unitless"
+		                description="Selection of the method for damage calving. For 'threshold', ice with damage above the value specified by 'config_damage_calving_threshold' will be removed (currently, only if this ice is also AT a marine margin, but eventually this will be expanded to also include any ice at the threshold adjacent to cells at the marine margin). For 'calving_rate', a rate of calving is specified as proportional to the damage value above some threshold, with the constant of proportionality specified by 'config_damagecalvingParameter'."
 		            possible_values="'calving_rate', 'threshold'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
-                        description="A scalar parameter that specifies a calving rate as proportional to the value of damage above some threshold value when using the calving_rate method for the config_damage_calving_method option (with the threshold damage value specified by config_damage_calving_threshold)"
+                        description="A scalar parameter that specifies a calving rate as proportional to the value of damage above some threshold value when using the 'calving_rate' method for the 'config_damage_calving_method' option (with the threshold damage value specified by 'config_damage_calving_threshold')."
 	                possible_values="any positive real value"
 		/>
 	</nml_record>
@@ -1063,7 +1063,7 @@ is the value of that variable from the *previous* time level!
                      description="damage change rate"
                 />
                 <var name="damage_nye" type="real" dimensions="nCells Time" units="none" time_levs="1"
-                     description="Nye zero-stress damage number"
+                     description="Nye zero-stress (Nye, 1957, Proc. R. Soc. A, 239) damage value"
                 />
                 <var name="damageMax" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="maximum damage number kept constant"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -208,9 +208,9 @@
                         description="If true, then we change stiffnessFactor to 1-damage during the run."
 	                possible_values=".true. or .false."
 		/>
-		        <nml_option name="config_damage_gl_setting" type="character" default_value="none" units="unitless"
+		        <nml_option name="config_damage_gl_setting" type="character" default_value="nye" units="unitless"
 		                description="Selection of the method for damage setting near the grounding line"
-		            possible_values="'nye', 'extra'"
+		            possible_values="'nye', 'extrapolate'"
 		/>
 		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"
 		                description="Selection of the method for damage calving"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1275,14 +1275,14 @@ is the value of that variable from the *previous* time level!
                 <var name="tauxy" type="real" dimensions="nCells Time" units="Pa"
                      description="deviatoric stress xy"
                 />
-                <var name="tauyx" type="real" dimensions="nCells Time" units="Pa"     
+                <var name="tauyx" type="real" dimensions="nCells Time" units="Pa"
                      description="deviatoric stress yx"
                 />
-                <var name="tauMax" type="real" dimensions="nCells Time" units="Pa"    
-                     description="maximum principal stress"
+                <var name="tauMax" type="real" dimensions="nCells Time" units="Pa"
+                     description="maximum deviatoric principal stress"
                 />
-                <var name="tauMin" type="real" dimensions="nCells Time" units="Pa"    
-                     description="minimum principal stress"
+                <var name="tauMin" type="real" dimensions="nCells Time" units="Pa"
+                     description="minimum deviatoric principal stress"
                 />
                 <var name="fluxAcrossGroundingLine" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
                      description="flux across grounding line per unit width.  Positive means flux goes from grounded to floating ice."

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -189,7 +189,7 @@
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_stiffness_min" type="real" default_value="0.1" units="unitless"
-                        description="When coupling damage to rheology, we do not allow it to fall below this value. For example, if damage = 0.9, then stiffnessFactor is 1 - damage = 0.1. But if we set config_damage_stiffness_min = 0.5, then stiffnessFactor can only be allowd as 0.5"
+                        description="The minimum value the stiffnessFactor can take due to evolving damage when stiffnessFactor is calculated from damage (config_damage_rheology_coupling=.true.). Used to prevent unrealistic and/or numerically challenging stiffness values. For example, if damage = 0.9, then stiffnessFactor is 1 - damage = 0.1. But if we set config_damage_stiffness_min = 0.5, then stiffnessFactor can only be allowd as 0.5"
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_rheology_coupling" type="logical" default_value=".false." units="unitless"
@@ -1070,7 +1070,7 @@ is the value of that variable from the *previous* time level!
                 <var name="nstar" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="n∗ denotes the usual parameter n from Glen’s flow law, adjusted by including the ratio of the principal horizontal strain rates:  epsilon Dot_yy / epsilon Dot_xx"
                 />
-            <var name="visc" type="real" dimensions="nCells Time" units="Pa s" time_levs="1"
+            <var name="effectiveViscosity" type="real" dimensions="nCells Time" units="Pa s" time_levs="1"
                      description="effective viscosity"
                 />
                 <var name="epsmax" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
@@ -1395,68 +1395,44 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
-       <var name="meanFlowParamAField" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
+       <var name="meanFlowParamAVar" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
 	       description="depth averaged flow parameter A"
 	       persistence="scratch"
 	       />
-	  <!--var name="viscField" type="real" dimensions="nCells" units="Pa s"
-	       description="effective viscosity"
-	       persistence="scratch"
-	       /-->
-      <var name="sigmaxyField" type="real" dimensions="nCells" units="Pa"
+      <var name="sigmaxyVar" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayxField" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmayxVar" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaxxField" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmaxxVar" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayyField" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmayyVar" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaminField" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmaminVar" type="real" dimensions="nCells" units="Pa"
 	       description="minimum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="sigmamaxField" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmamaxVar" type="real" dimensions="nCells" units="Pa"
 	       description="maximum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="alphaField" type="real" dimensions="nCells" units="none"
+	  <var name="alphaVar" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"
 	       />
-	  <!--var name="epsmaxField" type="real" dimensions="nCells" units="s^{-1}"
-	       description="strain rate corresponding to sigmamax"
-	       persistence="scratch"
-	       /-->
-	  <!--var name="nstarField" type="real" dimensions="nCells" units="none"
-	       description="adjusted flow law parameter n"
-	       persistence="scratch"
-	       /-->
-	  <!--var name="s0Field" type="real" dimensions="nCells" units="none"
-	       description="a ratio between hydeostatic pressure and the largest principal stress"
-	       persistence="scratch"
-	       /-->
-	  <!--var name="damageSourceField" type="real" dimensions="nCells" units="s^{-1}"
-	       description="damage source"
-	       persistence="scratch"
-	       /-->
-	  <var name="ddamagedtField" type="real" dimensions="nCells" units="s^{-1}"
+	  <var name="ddamagedtVar" type="real" dimensions="nCells" units="s^{-1}"
           description="d(damage) / dt"
 	       persistence="scratch"
 	       />
-       <var name="forceField" type="real" dimensions="nCells" units="s^{-1}"
+       <var name="envForceVar" type="real" dimensions="nCells" units="s^{-1}"
 	       description="environmental forcing for damage production"
-	       persistence="scratch"
-	       />
-	  <var name="thicknessField" type="real" dimensions="nCells" units="none"
-	       description="update halo for thickness (nCells)"
 	       persistence="scratch"
 	       />
 	  <var name="workTracerCell" type="real" dimensions="maxTracersAdvect nCells" units="none"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -172,8 +172,8 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
-		<nml_option name="config_restore_damage" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the restore_damage function."
+		<nml_option name="config_maintain_broken_ice" type="logical" default_value=".false." units="unitless"
+                        description="If true, then turn on the li_maintain_broken_ice function."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"
@@ -199,6 +199,10 @@
                 <nml_option name="config_damage_use_constant_A" type="logical" default_value=".false." units="unitless"
                         description="If true, then we use constant A (i.e., config_default_flowParamA) in the damage calculation."
 	                possible_values=".true. or .false."
+		/>
+		        <nml_option name="config_damage_gl_setting" type="character" default_value="none" units="unitless"
+		                description="Selection of the method for damage setting near the grounding line"
+		            possible_values="'nye', 'extra'"
 		/>
 		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"
 		                description="Selection of the method for damage calving"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -760,6 +760,8 @@
 			<var name="normalVelocity"/>
 			<var name="uReconstructX"/>
 			<var name="uReconstructY"/>
+			<var name="sigmamin"/>
+			<var name="sigmamax"/>
 		</stream>
                 <!-- input stream for regions masks files (currently only used by regional stats AM, and 
                      the only field used is the regionCellMasks field -->
@@ -1405,23 +1407,23 @@ is the value of that variable from the *previous* time level!
 	       />
       <var name="sigmaxy" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xy"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
 	  <var name="sigmayx" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yx"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
 	  <var name="sigmaxx" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xx"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
 	  <var name="sigmayy" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yy"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
 	  <var name="sigmamin" type="real" dimensions="nCells" units="Pa"
 	       description="minimum principal deviatoric stress"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
 	  <var name="alpha" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -217,7 +217,7 @@
 		            possible_values="'calving_rate', 'threshold'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
-                        description="A scalar parameter that links damage and calving when we use the calving_rate method"
+                        description="A scalar parameter that specifies a calving rate as proportional to the value of damage above some threshold value when using the calving_rate method for the config_damage_calving_method option (with the threshold damage value specified by config_damage_calving_threshold)"
 	                possible_values="any positive real value"
 		/>
 	</nml_record>

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -134,7 +134,7 @@
 	<nml_record name="calving" in_defaults="true">
 		<nml_option name="config_calving" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for calving ice (as defined further below)."
-		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'damagecalving', 'mask'"
+		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'specified_calving_velocity', 'damagecalving', 'mask'"
 		/>
 		<nml_option name="config_calving_topography" type="real" default_value="-500.0" units="m"
 		            description="Defines the topographic height below which ice calves (for topographic_threshold option)."
@@ -151,6 +151,10 @@
                 <nml_option name="config_calving_eigencalving_parameter_scalar_value" type="real" default_value="3.14e16" units="m s"
 		            description="Value of eigencalving parameter if taken as a scalar by option config_calving_eigencalving_parameter_source. (Default value is 1.0e9 m a converted to units used here.)"
 		            possible_values="any positive real number"
+		/>
+                    <nml_option name="config_calving_velocity_const" type="real" default_value="0.0" units="m s^{-1}"
+		            description="constant calving velocity specified in the namelist"
+		            possible_values="Any positive real value"
 		/>
 		<nml_option name="config_data_calving" type="logical" default_value=".false." units="unitless"
 		            description="Select whether or not to configure calving in a 'data' model mode (calc. calving flux but do not update ice geometry)"
@@ -1038,6 +1042,9 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
+                />
+                <var name="calvingVelocityData" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
+                     description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane), given by the input netCDF file."
                 />
                 <var name="damage" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="Damage is parameterized as the local ice thickness divided by the fracture depth, such that unfractured ice has damage=0 and ice fractured through its full thickness has damage=1"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -760,8 +760,6 @@
 			<var name="normalVelocity"/>
 			<var name="uReconstructX"/>
 			<var name="uReconstructY"/>
-			<var name="sigmamin"/>
-			<var name="sigmamax"/>
 		</stream>
                 <!-- input stream for regions masks files (currently only used by regional stats AM, and 
                      the only field used is the regionCellMasks field -->
@@ -1078,13 +1076,16 @@ is the value of that variable from the *previous* time level!
                 />
             <var name="effectiveViscosity" type="real" dimensions="nCells Time" units="Pa s" time_levs="1"
                      description="effective viscosity"
+                     persistence="persistent"
                 />
                 <var name="epsmax" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="strain rate along the direction of maximum deviatoric principal stress"
                 />
-                <var name="sigmamax" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
+                <!-- SFP: move to vel mod --> 
+                <!-- var name="sigmamax" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
                      description="maximum deviatoric principal stress"
-                />
+                     persistence="persistent"
+                / -->
                 <var name="damageSource" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage source term"
                 />
@@ -1270,6 +1271,25 @@ is the value of that variable from the *previous* time level!
                 <var name="eMin" type="real" dimensions="nCells Time" units="s^{-1}"
                      description="magnitude of second principal surface strain rate"
                 />
+                <!-- SFP: moved from scratch -->
+                <var name="sigmaxx" type="real" dimensions="nCells Time" units="Pa"
+                     description="deviatoric stress xx"
+                />
+                <var name="sigmayy" type="real" dimensions="nCells Time" units="Pa"
+                     description="deviatoric stress yy"
+                />
+                <var name="sigmaxy" type="real" dimensions="nCells Time" units="Pa"
+                     description="deviatoric stress xy"
+                />
+                <var name="sigmayx" type="real" dimensions="nCells Time" units="Pa"     
+                     description="deviatoric stress yx"
+                />
+                <var name="sigmamax" type="real" dimensions="nCells Time" units="Pa"    
+                     description="maximum principal stress"
+                />
+                <var name="sigmamin" type="real" dimensions="nCells Time" units="Pa"    
+                     description="minimum principal stress"
+                />
                 <var name="fluxAcrossGroundingLine" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
                      description="flux across grounding line per unit width.  Positive means flux goes from grounded to floating ice."
                 />
@@ -1403,9 +1423,10 @@ is the value of that variable from the *previous* time level!
 	       />
       <var name="meanFlowParamA" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
 	       description="depth averaged flow parameter A"
-	       persistence="scratch"
+	       persistence="persistent"
 	       />
-      <var name="sigmaxy" type="real" dimensions="nCells" units="Pa"
+      <!-- SFP: moved all of these into vel mod -->
+      <!-- var name="sigmaxy" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xy"
 	       persistence="persistent"
 	       />
@@ -1424,7 +1445,7 @@ is the value of that variable from the *previous* time level!
 	  <var name="sigmamin" type="real" dimensions="nCells" units="Pa"
 	       description="minimum principal deviatoric stress"
 	       persistence="persistent"
-	       />
+	       / -->
 	  <var name="alpha" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1423,16 +1423,8 @@ is the value of that variable from the *previous* time level!
 	       description="minimum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="sigmamax" type="real" dimensions="nCells" units="Pa"
-	       description="maximum principal deviatoric stress"
-	       persistence="scratch"
-	       />
 	  <var name="alpha" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"
-	       persistence="scratch"
-	       />
-	  <var name="ddamagedt" type="real" dimensions="nCells" units="s^{-1}"
-          description="d(damage) / dt"
 	       persistence="scratch"
 	       />
 	  <var name="workTracerCell" type="real" dimensions="maxTracersAdvect nCells" units="none"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -209,7 +209,7 @@
 	                possible_values=".true. or .false."
 		/>
 		        <nml_option name="config_damage_gl_setting" type="character" default_value="nye" units="unitless"
-		                description="Selection of the method for damage setting near the grounding line"
+		                description="Selection of the method for initializing damage in the first floating grid cells past the grounding line.  'nye' uses Nye's zero stress criteria for defining the damage value.  'extrapolate' extrapolates values from the floating ice downstream back to the first floating cells."
 		            possible_values="'nye', 'extrapolate'"
 		/>
 		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -189,7 +189,7 @@
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_stiffness_min" type="real" default_value="0.1" units="unitless"
-                        description="When coupling damage to rheology, we do not allow it to fall below this value"
+                        description="When coupling damage to rheology, we do not allow it to fall below this value. For example, if damage = 0.9, then stiffnessFactor is 1 - damage = 0.1. But if we set config_damage_stiffness_min = 0.5, then stiffnessFactor can only be allowd as 0.5"
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_rheology_coupling" type="logical" default_value=".false." units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -180,8 +180,12 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
-		<nml_option name="config_preserve_high_damage" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the li_preserve_high_damage function."
+		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".false." units="unitless"
+                        description="If true, then turn on the li_finalize_damage_after_advection function."
+		            possible_values=".true. or .false."
+                />
+		<nml_option name="config_preserve_damage" type="logical" default_value=".false." units="unitless"
+                        description="If true, then we preserve the damage before advection (no heal)"
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -172,16 +172,16 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
-		<nml_option name="config_maintain_broken_ice" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the li_maintain_broken_ice function."
+		<nml_option name="config_preserve_high_damage" type="logical" default_value=".false." units="unitless"
+                        description="If true, then turn on the li_preserve_high_damage function."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_calculate_damage" type="logical" default_value=".false." units="unitless"
                         description="If true, then turn on the calculate_damage function."
 		            possible_values=".true. or .false."
                 />
-                <nml_option name="config_damage_restore_threshold" type="real" default_value="0.0" units="unitless"
-                        description="It is a value above which the old damage number would be kept from the impact of advection (the damage would not heal). For example, if the damage at some location is 0.83, and we set config_damage_restore_threshold to 0.8, then the damage number there will not fall below 0.83. Otherwise, if the damage is 0.7, then it could be decreased to 0.6 if non-damaged ice is transported from upstream. If we set config_damage_restore_threshold to 0 (default), then it will just not play a role in pratical."
+                <nml_option name="config_damage_preserve_threshold" type="real" default_value="0.0" units="unitless"
+                        description="It is a value above which the old damage number would be kept from the impact of advection (the damage would not heal). For example, if the damage at some location is 0.83, and we set config_damage_preserve_threshold to 0.8, then the damage number there will not fall below 0.83. Otherwise, if the damage is 0.7, then it could be decreased to a smaller number if non-damaged ice is transported from upstream. If we set config_damage_preserve_threshold to 0 (default), then it will just not play a role in pratical."
 	                possible_values="real value between 0 and 1"
 		/>
                 <nml_option name="config_damage_calving_threshold" type="real" default_value="1.0" units="unitless"
@@ -194,10 +194,6 @@
 		/>
                 <nml_option name="config_damage_rheology_coupling" type="logical" default_value=".false." units="unitless"
                         description="If true, then we change stiffnessFactor to 1-damage during the run."
-	                possible_values=".true. or .false."
-		/>
-                <nml_option name="config_damage_use_constant_A" type="logical" default_value=".false." units="unitless"
-                        description="If true, then we use constant A (i.e., config_default_flowParamA) in the damage calculation."
 	                possible_values=".true. or .false."
 		/>
 		        <nml_option name="config_damage_gl_setting" type="character" default_value="none" units="unitless"
@@ -616,13 +612,6 @@
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
                         <var name="basalFrictionFlux"/>
 			<var name="damage"/>
-			<var name="ddamagedt"/>
-			<var name="s0"/>
-			<var name="nstar"/>
-			<var name="epsmax"/>
-			<var name="sigmamax"/>
-			<var name="visc"/>
-			<var name="source"/>
 			<var name="basalMeltInput" packages="hydro"/>
 			<var name="externalWaterInput" packages="hydro"/>
 			<var name="waterThickness" packages="hydro"/>
@@ -717,13 +706,7 @@
                         <var name="channelArea" packages="hydro"/>  <!-- this is only needed if running with channels - could be package-controlled -->
 			<var name="waterFluxMask" packages="hydro"/>
 			<var name="damage"/>
-			<var name="ddamagedt"/>
-			<var name="s0"/>
-			<var name="nstar"/>
-			<var name="epsmax"/>
-			<var name="sigmamax"/>
-			<var name="visc"/>
-			<var name="source"/>
+			<var name="damageMax"/>
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6Melt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6Melt"/>
@@ -1399,44 +1382,40 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       />
-       <var name="meanFlowParamAVar" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
+      <var name="meanFlowParamA" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
 	       description="depth averaged flow parameter A"
 	       persistence="scratch"
 	       />
-      <var name="sigmaxyVar" type="real" dimensions="nCells" units="Pa"
+      <var name="sigmaxy" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayxVar" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmayx" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaxxVar" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmaxx" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress xx"
 	       persistence="scratch"
 	       />
-	  <var name="sigmayyVar" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmayy" type="real" dimensions="nCells" units="Pa"
 	       description="deviatoric stress yy"
 	       persistence="scratch"
 	       />
-	  <var name="sigmaminVar" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmamin" type="real" dimensions="nCells" units="Pa"
 	       description="minimum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="sigmamaxVar" type="real" dimensions="nCells" units="Pa"
+	  <var name="sigmamax" type="real" dimensions="nCells" units="Pa"
 	       description="maximum principal deviatoric stress"
 	       persistence="scratch"
 	       />
-	  <var name="alphaVar" type="real" dimensions="nCells" units="none"
+	  <var name="alpha" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"
 	       />
-	  <var name="ddamagedtVar" type="real" dimensions="nCells" units="s^{-1}"
+	  <var name="ddamagedt" type="real" dimensions="nCells" units="s^{-1}"
           description="d(damage) / dt"
-	       persistence="scratch"
-	       />
-       <var name="envForceVar" type="real" dimensions="nCells" units="s^{-1}"
-	       description="environmental forcing for damage production"
 	       persistence="scratch"
 	       />
 	  <var name="workTracerCell" type="real" dimensions="maxTracersAdvect nCells" units="none"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -200,9 +200,9 @@
                         description="If true, then we use constant A (i.e., config_default_flowParamA) in the damage calculation."
 	                possible_values=".true. or .false."
 		/>
-                <nml_option name="config_damage_if_calving_rate" type="logical" default_value=".false." units="unitless"
-                        description="If true, then we use a parameterized calving velocity to connect calving and damage."
-	                possible_values=".true. or .false."
+		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"
+		                description="Selection of the method for damage calving"
+		            possible_values="'calving_rate', 'threshold'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
                         description="A scalar parameter that links damage and calving"
@@ -613,7 +613,7 @@
                         <var name="basalFrictionFlux"/>
 			<var name="damage"/>
 			<var name="ddamagedt"/>
-			<var name="szero"/>
+			<var name="s0"/>
 			<var name="nstar"/>
 			<var name="epsmax"/>
 			<var name="sigmamax"/>
@@ -714,7 +714,7 @@
 			<var name="waterFluxMask" packages="hydro"/>
 			<var name="damage"/>
 			<var name="ddamagedt"/>
-			<var name="szero"/>
+			<var name="s0"/>
 			<var name="nstar"/>
 			<var name="epsmax"/>
 			<var name="sigmamax"/>
@@ -1066,7 +1066,7 @@ is the value of that variable from the *previous* time level!
                 <var name="damage_max" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="maximum damage number kept constant"
                 />
-                <var name="szero" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                <var name="s0" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="a ratio between hydrostatic pressure and the largest principal tensile stress within ice shelf"
                 />
                 <var name="nstar" type="real" dimensions="nCells Time" units="none" time_levs="1"
@@ -1450,7 +1450,7 @@ is the value of that variable from the *previous* time level!
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       /-->
-	  <!--var name="szeroField" type="real" dimensions="nCells" units="none"
+	  <!--var name="s0Field" type="real" dimensions="nCells" units="none"
 	       description="generic work array with dimensions of (nCells)"
 	       persistence="scratch"
 	       /-->

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1284,6 +1284,9 @@ is the value of that variable from the *previous* time level!
                 <var name="tauMin" type="real" dimensions="nCells Time" units="Pa"
                      description="minimum deviatoric principal stress"
                 />
+	        <var name="principalStrainRateRatio" type="real" dimensions="nCells" units="none"
+	             description="the ratio of the minimum and maximum principal horizontal strain rates"
+	        />
                 <var name="fluxAcrossGroundingLine" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
                      description="flux across grounding line per unit width.  Positive means flux goes from grounded to floating ice."
                 />
@@ -1417,10 +1420,6 @@ is the value of that variable from the *previous* time level!
 	       />
       <var name="meanFlowParamA" type="real" dimensions="nCells" units="Pa^{-3} s^{-1}"
 	       description="depth averaged flow parameter A"
-	       persistence="scratch"
-	       />
-	  <var name="alpha" type="real" dimensions="nCells" units="none"
-	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"
 	       />
 	  <var name="workTracerCell" type="real" dimensions="maxTracersAdvect nCells" units="none"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -180,8 +180,8 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
-		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".false." units="unitless"
-                        description="If true, then turn on the 'li_finalize_damage_after_advection' function."
+		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".true." units="unitless"
+                        description="If true, then the 'li_finalize_damage_after_advection' subroutine is applied, doing the following: 1) set the value of damage at the grounding line based on the choice of 'config_damage_gl_setting', 2) reset the damage to some threshold value if it exceeds that threshold after advection, based on choice of 'config_preserve_damage', 3) couple the updated damage value to the rheology if 'config_damage_rheology_coupling' is true."
 		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_preserve_damage" type="logical" default_value=".false." units="unitless"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1081,11 +1081,6 @@ is the value of that variable from the *previous* time level!
                 <var name="epsmax" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="strain rate along the direction of maximum deviatoric principal stress"
                 />
-                <!-- SFP: move to vel mod --> 
-                <!-- var name="sigmamax" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
-                     description="maximum deviatoric principal stress"
-                     persistence="persistent"
-                / -->
                 <var name="damageSource" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage source term"
                 />
@@ -1271,7 +1266,6 @@ is the value of that variable from the *previous* time level!
                 <var name="eMin" type="real" dimensions="nCells Time" units="s^{-1}"
                      description="magnitude of second principal surface strain rate"
                 />
-                <!-- SFP: moved from scratch -->
                 <var name="sigmaxx" type="real" dimensions="nCells Time" units="Pa"
                      description="deviatoric stress xx"
                 />
@@ -1425,27 +1419,6 @@ is the value of that variable from the *previous* time level!
 	       description="depth averaged flow parameter A"
 	       persistence="persistent"
 	       />
-      <!-- SFP: moved all of these into vel mod -->
-      <!-- var name="sigmaxy" type="real" dimensions="nCells" units="Pa"
-	       description="deviatoric stress xy"
-	       persistence="persistent"
-	       />
-	  <var name="sigmayx" type="real" dimensions="nCells" units="Pa"
-	       description="deviatoric stress yx"
-	       persistence="persistent"
-	       />
-	  <var name="sigmaxx" type="real" dimensions="nCells" units="Pa"
-	       description="deviatoric stress xx"
-	       persistence="persistent"
-	       />
-	  <var name="sigmayy" type="real" dimensions="nCells" units="Pa"
-	       description="deviatoric stress yy"
-	       persistence="persistent"
-	       />
-	  <var name="sigmamin" type="real" dimensions="nCells" units="Pa"
-	       description="minimum principal deviatoric stress"
-	       persistence="persistent"
-	       / -->
 	  <var name="alpha" type="real" dimensions="nCells" units="none"
 	       description="the ratio of the principal horizontal strain rate"
 	       persistence="scratch"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1054,36 +1054,36 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
                 />
-                <var name="damage" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="damage number"
-		/>
-                <var name="ddamagedt" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="damage change rate"
-		/>
-                <var name="damage_nye" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="Nye zero-stress damage number"
-		/>
-                <var name="damage_max" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="maximum damage number kept constant"
-		/>
-                <var name="szero" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="S0 number"
-		/>
-                <var name="nstar" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="S0 number"
-		/>
-                <var name="visc" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="S0 number"
-		/>
-                <var name="epsmax" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="S0 number"
-		/>
-                <var name="sigmamax" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
-		     description="S0 number"
-		/>
-                <var name="source" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
-		     description="damage source term"
-		/>
+                <var name="damage" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="damage number, ranging from 0 to 1"
+                />
+                <var name="ddamagedt" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
+                     description="damage change rate"
+                />
+                <var name="damage_nye" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="Nye zero-stress damage number"
+                />
+                <var name="damage_max" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="maximum damage number kept constant"
+                />
+                <var name="szero" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="a ratio between hydrostatic pressure and the largest principal tensile stress within ice shelf"
+                />
+                <var name="nstar" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="adjusted Glen flow law parameter"
+                />
+            <var name="visc" type="real" dimensions="nCells Time" units="Pa s" time_levs="1"
+                     description="effective viscosity"
+                />
+                <var name="epsmax" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
+                     description="strain rate along the direction of maximum deviatoric principal stress"
+                />
+                <var name="sigmamax" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
+                     description="maximum deviatoric principal stress"
+                />
+                <var name="damageSource" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
+                     description="damage source term"
+                />
                 <var name="requiredCalvingVolumeRate" type="real" dimensions="nCells Time" units="m^3 s^{-1}" time_levs="1"
                      description="total volume of ice that needs to be removed based on eigencalving rate at this margin cell"
                 />

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1631,53 +1631,58 @@ module li_calving
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-      type (block_type), pointer :: block
+
+!SFP: note some of these in the next block may be removed 
+!if/when stress calc goes to vel mod
+      type (block_type), pointer :: block           
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: thermalPool 
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: velocityPool
       type (mpas_pool_type), pointer :: scratchPool
+
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
-      real(kind=RKIND), pointer :: config_default_flowParamA 
+      real(kind=RKIND), pointer :: config_default_flowParamA   !SFP: need to leave because meanFlowParamA used at end?
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), pointer :: config_sea_level
-      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: thickness !SFP: may not be needed if stress calcs moved to vel mod
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
-      real (kind=RKIND), dimension(:), pointer :: eMax, eMin, exx, exy, eyx, eyy
-      real (kind=RKIND), dimension(:,:), pointer :: flowParamA
-      real (kind=RKIND), dimension(:,:), pointer :: temperature
+      real (kind=RKIND), dimension(:), pointer :: eMax!, eMin, exx, exy, eyx, eyy !SFP: remove eventually (won't need because sigmas come in directly)
+      real (kind=RKIND), dimension(:), pointer :: sigmamax, sigmamin, sigmaxx, sigmaxy, sigmayx, sigmayy !SFP: added -- these should now come in from vel mod 
+      real (kind=RKIND), dimension(:,:), pointer :: flowParamA !SFP: need to leave because meanFlowParamA used at end?
+      real (kind=RKIND), dimension(:,:), pointer :: temperature !SFP: may not be needed if stress calcs moved to vel mod
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
-      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax, effectiveViscosity, sigmamax
+      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax !effectiveViscosity, sigmamax !SFP: move some of these to vel mod; epsmax redundant w/ eMax?
       real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damageMax
-      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
+!      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor !SFP: not used anymore; moved to vel mod
       real (kind=RKIND), pointer ::  &
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-      type (field1dReal), pointer :: meanFlowParamAVar
-      real, dimension(:), pointer :: meanFlowParamA
-      type (field1dReal), pointer :: sigmayxVar
-      real, dimension(:), pointer :: sigmayx
-      type (field1dReal), pointer :: sigmaxyVar
-      real, dimension(:), pointer :: sigmaxy
-      type (field1dReal), pointer :: sigmaxxVar
-      real, dimension(:), pointer :: sigmaxx
-      type (field1dReal), pointer :: sigmayyVar
-      real, dimension(:), pointer :: sigmayy
-      type (field1dReal), pointer :: sigmaminVar
-      real, dimension(:), pointer :: sigmamin
+      type (field1dReal), pointer :: meanFlowParamAVar !SFP: copied to vel mod but left here because used at end 
+      real, dimension(:), pointer :: meanFlowParamA    !SFP: copied to vel mod but left here because used at end
+!      type (field1dReal), pointer :: sigmayxVar
+!      real, dimension(:), pointer :: sigmayx
+!      type (field1dReal), pointer :: sigmaxyVar
+!      real, dimension(:), pointer :: sigmaxy
+!      type (field1dReal), pointer :: sigmaxxVar
+!      real, dimension(:), pointer :: sigmaxx
+!      type (field1dReal), pointer :: sigmayyVar
+!      real, dimension(:), pointer :: sigmayy
+!      type (field1dReal), pointer :: sigmaminVar
+!      real, dimension(:), pointer :: sigmamin
       type (field1dReal), pointer :: alphaVar
       real, dimension(:), pointer :: alpha
 
@@ -1687,7 +1692,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
-      integer, pointer :: nCells, nVertLevels
+      integer, pointer :: nCells, nVertLevels    !SFP may not need nvert levels if moving stress calcs to vel mod?
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
@@ -1702,7 +1707,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
-      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
+      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) !SFP: still needed here since meanFlowParamA used at end
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -1731,7 +1736,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness) !SFP: moved to vel mod for stress calc ... still needed?
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
@@ -1740,83 +1745,98 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)
          call mpas_pool_get_array(geometryPool, 'nstar', nstar)
-         call mpas_pool_get_array(geometryPool, 'epsmax', epsmax)
-         call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
-         call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax)
+         call mpas_pool_get_array(geometryPool, 'epsmax', epsmax) !SFP: note redundant with eMax from vel mod
+         !call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity) !SFP: no longer needed if use eMax instead of epsmax
+         !call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax) !SFP: now !in vel pool; imported below
          call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
 
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-         call mpas_pool_get_array(velocityPool, 'eMax', eMax)
-         call mpas_pool_get_array(velocityPool, 'eMin', eMin)
-         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
-         call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
+         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA) !SFP: need to leave here as meanFlowParamA used at end
+         !call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor) !SFP: move to vel mod
 
-         call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+         !call mpas_pool_get_array(thermalPool, 'temperature', temperature) !SFP: not needed if moved to vel mod?
 
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar)
+         !SFP: copied to vel mod but left here because used at the end below
+         call mpas_pool_get_field(scratchPool, 'meanFlowParamAVar',  meanFlowParamAVar) 
          call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
          meanFlowParamA => meanFlowParamAVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxy', sigmaxyVar )
-         call mpas_allocate_scratch_field(sigmaxyVar, .true.)
-         sigmaxy => sigmaxyVar % array
+         !SFP: following 5 can be removed later as these will be imported from
+         !vel mod; need to copy these to vel mod?
+         !call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
+!         call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
+!         call mpas_allocate_scratch_field(sigmaxyVar, .true.)
+!         sigmaxy => sigmaxyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayx', sigmayxVar )
-         call mpas_allocate_scratch_field(sigmayxVar, .true.)
-         sigmayx => sigmayxVar % array
+!         call mpas_pool_get_field(scratchPool, 'sigmayxVar', sigmayxVar )
+!         call mpas_allocate_scratch_field(sigmayxVar, .true.)
+!         sigmayx => sigmayxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxx', sigmaxxVar )
-         call mpas_allocate_scratch_field(sigmaxxVar, .true.)
-         sigmaxx => sigmaxxVar % array
+!         call mpas_pool_get_field(scratchPool, 'sigmaxxVar', sigmaxxVar )
+!         call mpas_allocate_scratch_field(sigmaxxVar, .true.)
+!         sigmaxx => sigmaxxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayy', sigmayyVar )
-         call mpas_allocate_scratch_field(sigmayyVar, .true.)
-         sigmayy => sigmayyVar % array
+!         call mpas_pool_get_field(scratchPool, 'sigmayyVar', sigmayyVar )
+!         call mpas_allocate_scratch_field(sigmayyVar, .true.)
+!         sigmayy => sigmayyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmamin', sigmaminVar )
-         call mpas_allocate_scratch_field(sigmaminVar, .true.)
-         sigmamin => sigmaminVar % array
+!         call mpas_pool_get_field(scratchPool, 'sigmaminVar', sigmaminVar )
+!         call mpas_allocate_scratch_field(sigmaminVar, .true.)
+!         sigmamin => sigmaminVar % array
 
-         call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
-         call mpas_allocate_scratch_field(alphaVar, .true.)
-         alpha => alphaVar % array
+!         call mpas_pool_get_field(scratchPool, 'alphaVar', alphaVar )
+!         call mpas_allocate_scratch_field(alphaVar, .true.)
+!         alpha => alphaVar % array
 
+         !SFP: leave this struct here for now but eventually remove
+!         call mpas_pool_get_array(velocityPool, 'exx', exx)
+!         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
+!         call mpas_pool_get_array(velocityPool, 'exy', exy)
+!         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
+         call mpas_pool_get_array(velocityPool, 'eMax', eMax) !SFP: used below (in place of epsmax) 
+!         !call mpas_pool_get_array(velocityPool, 'eMin', eMin) !SFP: not used here as far as I can tell
 
-         call mpas_pool_get_array(velocityPool, 'exx', exx)
-         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
-         call mpas_pool_get_array(velocityPool, 'exy', exy)
-         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
+         call mpas_pool_get_array(velocityPool, 'sigmaxx', sigmaxx)
+         call mpas_pool_get_array(velocityPool, 'sigmayy', sigmayy)
+         call mpas_pool_get_array(velocityPool, 'sigmaxy', sigmaxy)
+         call mpas_pool_get_array(velocityPool, 'sigmayx', sigmayx)
+         call mpas_pool_get_array(velocityPool, 'sigmamax', sigmamax)
+         call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
 
+! SFP: copied to vel module but also needed here because flowParmA is used to calc meanFlowParamA used below
          call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
          err = ior(err, err_tmp)
 
-         !meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
+! SFP: copied to vel module but also needed here becuase used near end of ! subroutine
+         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
          ! calculate the depth-averaged flow parameter A
 
-         where (thickness == 0.0_RKIND)
-             effectiveViscosity = 0.0_RKIND
-         elsewhere
-             effectiveViscosity = &
-             0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
-             exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
-         endwhere
+! SFP: moved to vel module
+!         where (thickness == 0.0_RKIND)
+!             effectiveViscosity = 0.0_RKIND
+!         elsewhere
+!             effectiveViscosity = &
+!             0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
+!             exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
+!         endwhere
          ! recover effective viscosity from vel. and temp. fields
 
-         sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
-         sigmayx(:) = 2.0_RKIND*effectiveViscosity(:)*(eyx(:)+exy(:))/2.0_RKIND
+!SFP: moved all stress calcs to vel mod
+!         sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
+!         sigmayx(:) = 2.0_RKIND*effectiveViscosity(:)*(eyx(:)+exy(:))/2.0_RKIND
 
-         sigmaxx(:) = 2.0_RKIND*effectiveViscosity(:)*exx(:)
-         sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
+!         sigmaxx(:) = 2.0_RKIND*effectiveViscosity(:)*exx(:)
+!         sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
          !deviatoric stress
 
-         sigmamin(:) = &
-         (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
-         sigmamax(:) = &
-         (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
+!         sigmamin(:) = &
+!         (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
+!         sigmamax(:) = &
+!         (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
          !deviatoric principal stress
 
          where (thickness == 0.0_RKIND)
@@ -1824,11 +1844,18 @@ module li_calving
              epsmax = 0.0_RKIND
              s0 = 0.0_RKIND
          elsewhere
-             alpha = sigmamin / sigmamax
-             epsmax = sigmamax / (2.0_RKIND*effectiveViscosity)
+             alpha = sigmamin / sigmamax !SFP: leave here but import sigmas from vel mod
+!             epsmax = sigmamax / (2.0_RKIND*effectiveViscosity) 
+             !SFP: above looks redundant w/ eMax from the vel mod; correct calcs below
+             ! if using 'eMax' instead no longer need to calc. eff. visc. at all in this subroutine
+             epsmax = eMax
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
+
+
+         print *, 'alpha= '
+         print *, alpha
              
          !alpha(:) = sigmamin(:) / (sigmamax(:))
          !epsmax(:) = sigmamax(:) / (2.0d0*effectiveViscosity(:))
@@ -1962,7 +1989,7 @@ module li_calving
         endif
         ! always set the damage at the first floating cells to the Nye value
 
-        if (.false.) then
+        if (.true.) then
 
              call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damageSource), maxval(damageSource)/))
@@ -1977,17 +2004,20 @@ module li_calving
              call mpas_log_write("damage value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damage), maxval(damage)/))
              call mpas_log_write("A value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
+                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/)) !SFP: note meanFlowParamA used here so still needs to be calc above
              call mpas_log_write("alpha value range: Min=$r, Max=$r", &
                         realArgs=(/minval(alpha), maxval(alpha)/))
         end if
         ! temporary message output in the log file
 
+         print *, 'damage= '
+         print *, damage
 
-         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
-         call mpas_deallocate_scratch_field(sigmaxxVar, .true.)
-         call mpas_deallocate_scratch_field(sigmayyVar, .true.)
-         call mpas_deallocate_scratch_field(sigmaminVar, .true.)
+
+         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.) !SFP: still needed here since used immediately above
+         !call mpas_deallocate_scratch_field(sigmaxxVar, .true.)
+         !call mpas_deallocate_scratch_field(sigmayyVar, .true.)
+         !call mpas_deallocate_scratch_field(sigmaminVar, .true.)
          !call mpas_deallocate_scratch_field(sigmamaxVar, .true.)
          call mpas_deallocate_scratch_field(alphaVar, .true.)
          !call mpas_deallocate_scratch_field(epsmaxVar, .true.)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1643,6 +1643,7 @@ module li_calving
       real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA   
+      real(kind=RKIND), pointer :: config_flowLawExponent
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), pointer :: config_sea_level
@@ -1683,6 +1684,7 @@ module li_calving
 
       err = 0
 
+      call mpas_pool_get_config(liConfigs, 'config_flowLawExponent', config_flowLawExponent)
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_scalar_value', &
                config_calving_eigencalving_parameter_scalar_value)
@@ -1750,10 +1752,12 @@ module li_calving
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*tauMax*config_ocean_density)
          endwhere
+         ! Compute the hydrostatic to tensile stress ratio (equation 24 from Bassis and Ma, 2015, EPSL, 409, C)
 
          nstar(:) = &
-         12.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)+6.0_RKIND*alpha(:)**2.0_RKIND) 
-         ! Compute the effective flow law exponent
+         4.0_RKIND*config_flowLawExponent*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND) &
+         +3.0_RKIND*(config_flowLawExponent-1.0_RKIND)*alpha(:)**2.0_RKIND) 
+         ! Compute the effective flow law exponent (equation 11 from Bassis and Ma, 2015, EPSL, 409, C)
 
          do iCell = 1, nCells
          if (thickness(iCell) == 0.0_RKIND) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1186,10 +1186,9 @@ module li_calving
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate
-         !calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
-         !      * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
+               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
-         calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value
 
 
          ! Convert calvingVelocity to calvingThickness

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -2624,8 +2624,7 @@ module li_calving
       ! 1. We need to first remove any "thin" ice in front of this cell
       ! 2. Then we remove ice from this cell if damage > threshold
       do iCell = 1, nCells
-         if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
-                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
+         if ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
               .and. li_mask_is_margin(cellMask(iCell)) &
               .and. (damage(iCell) .ge. config_damage_calving_threshold)) then
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1652,7 +1652,6 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax
       real (kind=RKIND), dimension(:), pointer :: sigmamax, sigmamin, sigmaxx, sigmaxy, sigmayx, sigmayy 
@@ -1721,7 +1720,6 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
-         call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1190,7 +1190,7 @@ module li_calving
          !      * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
          calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value
-        
+
 
          ! Convert calvingVelocity to calvingThickness
          call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
@@ -1823,13 +1823,13 @@ module li_calving
         if (trim(config_damage_gl_setting) == 'extrapolate') then
            do iCell = 1, nCells
               if (li_mask_is_grounding_line(cellMask(iCell))) then
-                  
+
                   damage_downstream = 0.0_RKIND
                   n_damage_downstream = 0
                   do iNeighbor = 1, nEdgesOnCell(iCell)
                       jCell = cellsOnCell(iNeighbor, iCell)
                       if (li_mask_is_floating_ice(cellMask(jCell))) then
-                         
+
                           damage_downstream = damage_downstream + damage(jCell)
                           n_damage_downstream =  n_damage_downstream + 1
                       end if
@@ -1846,7 +1846,7 @@ module li_calving
            ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
 
         elseif (trim(config_damage_gl_setting) == "nye") then
-                        
+
              do iCell = 1, nCells
                 if (li_mask_is_grounding_line(cellMask(iCell))) then
                     do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1896,10 +1896,10 @@ module li_calving
          call mpas_deallocate_scratch_field(alphaVar, .true.)
 
          block => block % next
-             
+
       enddo
 
-   end subroutine li_calculate_damage 
+   end subroutine li_calculate_damage
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1955,7 +1955,7 @@ module li_calving
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, pointer :: nCells 
+      integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream
 
@@ -2025,7 +2025,7 @@ module li_calving
                     do iNeighbor = 1, nEdgesOnCell(iCell)
                         jCell = cellsOnCell(iNeighbor, iCell)
                         if (li_mask_is_floating_ice(cellMask(jCell))) then
-                            
+
                             damage_downstream = damage_downstream + damage(jCell)
                             n_damage_downstream =  n_damage_downstream + 1
                         end if
@@ -2070,7 +2070,7 @@ module li_calving
 
 
         block => block % next
-             
+
       enddo
 
    end subroutine li_finalize_damage_after_advection

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1295,6 +1295,7 @@ module li_calving
       logical, pointer :: config_print_calving_info
       real(kind=RKIND), pointer :: config_calving_thickness
       real(kind=RKIND), pointer :: config_calving_velocity_const
+      real(kind=RKIND), pointer :: config_calving_specified_source
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: calvingVelocityData
       real (kind=RKIND), dimension(:), pointer :: angleEdge
@@ -1318,6 +1319,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_calving_velocity_const', config_calving_velocity_const)
+      call mpas_pool_get_config(liConfigs, 'config_calving_specified_source', config_calving_specified_source)
 
       ! block loop
       block => domain % blocklist
@@ -1349,7 +1351,7 @@ module li_calving
          ! get parameter value
          if (trim(config_calving_specified_source) == 'const') then
              calvingVelocity = config_calving_velocity_const
-         elseif (trim(config_calving_spefified_source) == 'data') then
+         elseif (trim(config_calving_specified_source) == 'data') then
              calvingVelocity = calvingVelocityData
          else
             err = 1

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1761,7 +1761,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
          !SFP: copied to vel mod but left here because used at the end below
-         call mpas_pool_get_field(scratchPool, 'meanFlowParamAVar',  meanFlowParamAVar) 
+         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar) 
          call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
          meanFlowParamA => meanFlowParamAVar % array
 
@@ -1788,9 +1788,9 @@ module li_calving
 !         call mpas_allocate_scratch_field(sigmaminVar, .true.)
 !         sigmamin => sigmaminVar % array
 
-!         call mpas_pool_get_field(scratchPool, 'alphaVar', alphaVar )
-!         call mpas_allocate_scratch_field(alphaVar, .true.)
-!         alpha => alphaVar % array
+         call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
+         call mpas_allocate_scratch_field(alphaVar, .true.)
+         alpha => alphaVar % array
 
          !SFP: leave this struct here for now but eventually remove
 !         call mpas_pool_get_array(velocityPool, 'exx', exx)
@@ -1853,10 +1853,6 @@ module li_calving
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
 
-
-         print *, 'alpha= '
-         print *, alpha
-             
          !alpha(:) = sigmamin(:) / (sigmamax(:))
          !epsmax(:) = sigmamax(:) / (2.0d0*effectiveViscosity(:))
          !s0(:) =
@@ -2009,9 +2005,6 @@ module li_calving
                         realArgs=(/minval(alpha), maxval(alpha)/))
         end if
         ! temporary message output in the log file
-
-         print *, 'damage= '
-         print *, damage
 
 
          call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.) !SFP: still needed here since used immediately above

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1260,7 +1260,11 @@ module li_calving
 !
 !    routine damagecalving
 !
-!> \brief Calve ice from the calving front based on the Bassis-Ma (2015) damage theory 
+!> \brief Calve ice from the calving front based on the Bassis-Ma (2015) damage theory. 
+!> We can use two options: "calving_rate" or "threshold".
+!> If we use "calving_rate", the calving front retreats by removing ice at a speed of k * damage,
+!> where k is a calving parameter. If we use "threshold", the ice at the calving front will be completely
+!> gone if the damage is above the threshold.
 !> \author Tong Zhang
 !> \date   May. 2019
 !> \details Connect calving with the damage model
@@ -1427,7 +1431,7 @@ module li_calving
 !
 !> \author Tong Zhang
 !> \date   May. 2019
-!> \details calulate the damage tracer 
+!> \details calulate the damage tracer for floating ice shelves (damage at grounded ice is constrained as 0) 
 !> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing." 
 !> Earth and Planetary Science Letters 409 (2015): 203-211.
 
@@ -1479,7 +1483,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
-      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax, visc, sigmamax
+      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax, effectiveViscosity, sigmamax
       real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damageMax
@@ -1488,41 +1492,22 @@ module li_calving
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-      real (kind=RKIND), save :: rhoi    ! ice density (kg m^{-3}), copied from config_ice_density
-      real (kind=RKIND), save :: rhoo    ! ocean density (kg m^{-3}), copied from config_ocean_density
-
-      type (field1dReal), pointer :: meanFlowParamAField
+      type (field1dReal), pointer :: meanFlowParamAVar
       real, dimension(:), pointer :: meanFlowParamA
-      !type (field1dReal), pointer :: viscField
-      !real, dimension(:), pointer :: visc
-      type (field1dReal), pointer :: sigmayxField
+      type (field1dReal), pointer :: sigmayxVar
       real, dimension(:), pointer :: sigmayx
-      type (field1dReal), pointer :: sigmaxyField
+      type (field1dReal), pointer :: sigmaxyVar
       real, dimension(:), pointer :: sigmaxy
-      type (field1dReal), pointer :: sigmaxxField
+      type (field1dReal), pointer :: sigmaxxVar
       real, dimension(:), pointer :: sigmaxx
-      type (field1dReal), pointer :: sigmayyField
+      type (field1dReal), pointer :: sigmayyVar
       real, dimension(:), pointer :: sigmayy
-      type (field1dReal), pointer :: sigmaminField
+      type (field1dReal), pointer :: sigmaminVar
       real, dimension(:), pointer :: sigmamin
-      !type (field1dReal), pointer :: sigmamaxField
-      !real, dimension(:), pointer :: sigmamax
-      type (field1dReal), pointer :: alphaField
+      type (field1dReal), pointer :: alphaVar
       real, dimension(:), pointer :: alpha
-      !type (field1dReal), pointer :: epsmaxField
-      !real, dimension(:), pointer :: epsmax
-      !type (field1dReal), pointer :: nstarField
-      !real, dimension(:), pointer :: nstar
-      !type (field1dReal), pointer :: s0Field
-      !real, dimension(:), pointer :: s0
-      !type (field1dReal), pointer :: damageSourceField
-      !real, dimension(:), pointer :: damageSource
-      !type (field1dReal), pointer :: ddamagedtField
-      !real, dimension(:), pointer :: ddamagedt
-      type (field1dReal), pointer :: forceField
-      real, dimension(:), pointer :: force
-
-      ! TZ: we can comment out the scratch field as above and redefine it in Registry.xml if we want to see it in the output nc file
+      type (field1dReal), pointer :: envForceVar
+      real, dimension(:), pointer :: envForce
 
       integer, dimension(:), pointer :: cellMask
       type (field1dInteger), pointer :: calvingFrontMaskField
@@ -1549,6 +1534,8 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
       call mpas_pool_get_config(liConfigs, 'config_damage_use_constant_A', config_damage_use_constant_A)
+      call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
+      call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
 
       ! block loop
       block => domain % blocklist
@@ -1585,21 +1572,15 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 's0', s0)
          call mpas_pool_get_array(geometryPool, 'nstar', nstar)
          call mpas_pool_get_array(geometryPool, 'epsmax', epsmax)
-         call mpas_pool_get_array(geometryPool, 'visc', visc)
+         call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
          call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax)
          call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
 
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-         call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
-         call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
          call mpas_pool_get_array(velocityPool, 'eMax', eMax)
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
-         call mpas_pool_get_array(velocityPool, 'exx', exx)
-         call mpas_pool_get_array(velocityPool, 'exy', exy)
-         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
-         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
          call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
          call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
@@ -1607,112 +1588,79 @@ module li_calving
 
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
-         call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
-         calvingFrontMask => calvingFrontMaskField % array
+         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskVar)
+         call mpas_allocate_scratch_field(calvingFrontMaskVar, .true.)
+         calvingFrontMask => calvingFrontMaskVar % array
 
-         call mpas_pool_get_field(scratchPool, 'meanFlowParamAField',  meanFlowParamAField)
-         call mpas_allocate_scratch_field(meanFlowParamAField, .true.)
-         meanFlowParamA => meanFlowParamAField % array
+         call mpas_pool_get_field(scratchPool, 'meanFlowParamAVar',  meanFlowParamAVar)
+         call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
+         meanFlowParamA => meanFlowParamAVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxyField', sigmaxyField )
-         call mpas_allocate_scratch_field(sigmaxyField, .true.)
-         sigmaxy => sigmaxyField % array
+         call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
+         call mpas_allocate_scratch_field(sigmaxyVar, .true.)
+         sigmaxy => sigmaxyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayxField', sigmayxField )
-         call mpas_allocate_scratch_field(sigmayxField, .true.)
-         sigmayx => sigmayxField % array
+         call mpas_pool_get_field(scratchPool, 'sigmayxVar', sigmayxVar )
+         call mpas_allocate_scratch_field(sigmayxVar, .true.)
+         sigmayx => sigmayxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxxField', sigmaxxField )
-         call mpas_allocate_scratch_field(sigmaxxField, .true.)
-         sigmaxx => sigmaxxField % array
+         call mpas_pool_get_field(scratchPool, 'sigmaxxVar', sigmaxxVar )
+         call mpas_allocate_scratch_field(sigmaxxVar, .true.)
+         sigmaxx => sigmaxxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayyField', sigmayyField )
-         call mpas_allocate_scratch_field(sigmayyField, .true.)
-         sigmayy => sigmayyField % array
+         call mpas_pool_get_field(scratchPool, 'sigmayyVar', sigmayyVar )
+         call mpas_allocate_scratch_field(sigmayyVar, .true.)
+         sigmayy => sigmayyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaminField', sigmaminField )
-         call mpas_allocate_scratch_field(sigmaminField, .true.)
-         sigmamin => sigmaminField % array
+         call mpas_pool_get_field(scratchPool, 'sigmaminVar', sigmaminVar )
+         call mpas_allocate_scratch_field(sigmaminVar, .true.)
+         sigmamin => sigmaminVar % array
 
-         !call mpas_pool_get_field(scratchPool, 'sigmamaxField', sigmamaxField )
-         !call mpas_allocate_scratch_field(sigmamaxField, .true.)
-         !sigmamax => sigmamaxField % array
+         call mpas_pool_get_field(scratchPool, 'alphaVar', alphaVar )
+         call mpas_allocate_scratch_field(alphaVar, .true.)
+         alpha => alphaVar % array
 
-         call mpas_pool_get_field(scratchPool, 'alphaField', alphaField )
-         call mpas_allocate_scratch_field(alphaField, .true.)
-         alpha => alphaField % array
+         call mpas_pool_get_field(scratchPool, 'envForceVar', envForceVar )
+         call mpas_allocate_scratch_field(envForceVar, .true.)
+         envForce => envForceVar % array
 
-         !call mpas_pool_get_field(scratchPool, 'epsmaxField', epsmaxField )
-         !call mpas_allocate_scratch_field(epsmaxField, .true.)
-         !epsmax => epsmaxField % array
-
-         !call mpas_pool_get_field(scratchPool, 'nstarField', nstarField )
-         !call mpas_allocate_scratch_field(nstarField, .true.)
-         !nstar => nstarField % array
-
-         !call mpas_pool_get_field(scratchPool, 's0Field', s0Field )
-         !call mpas_allocate_scratch_field(s0Field, .true.)
-         !s0 => s0Field % array
-
-         !call mpas_pool_get_field(scratchPool, 'damageSourceField', damageSourceField )
-         !call mpas_allocate_scratch_field(damageSourceField, .true.)
-         !damageSource => damageSourceField % array
-
-         !call mpas_pool_get_field(scratchPool, 'ddamagedtField', ddamagedtField )
-         !call mpas_allocate_scratch_field(ddamagedtField, .true.)
-         !ddamagedt => ddamagedtField % array
-
-         call mpas_pool_get_field(scratchPool, 'forceField', forceField )
-         call mpas_allocate_scratch_field(forceField, .true.)
-         force => forceField % array
-
-
-         call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
-         call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
-         rhoi = config_ice_density
-         rhoo = config_ocean_density
-
-
-         call li_compute_gradient_2d(meshPool, uReconstructX(1,:), exx, exy, err_tmp)
+         call calculate_strain_rates(meshPool, velocityPool, err_tmp)
          err = ior(err, err_tmp)
 
-         call li_compute_gradient_2d(meshPool, uReconstructY(1,:), eyx, eyy, err_tmp)
-         err = ior(err, err_tmp)
+         call mpas_pool_get_array(velocityPool, 'exx', exx)
+         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
+         call mpas_pool_get_array(velocityPool, 'exy', exy)
+         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
 
          call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
          err = ior(err, err_tmp)
 
-
          meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
          ! calculate the depth-averaged flow parameter A
 
-         !call mpas_log_write("meanFlowParamA: Min=$r, Max=$r", &
-         !           realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
-
          if (config_damage_use_constant_A) then
              where (thickness == 0.0_RKIND)
-                 visc = 0.0_RKIND
+                 effectiveViscosity = 0.0_RKIND
              elsewhere
-                 visc =
+                 effectiveViscosity =
                  0.5_RKIND*stiffnessFactor*config_default_flowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
                  exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
              endwhere
          else
              where (thickness == 0.0_RKIND)
-                 visc = 0.0_RKIND
+                 effectiveViscosity = 0.0_RKIND
              elsewhere
-                 visc = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
+                 effectiveViscosity = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
                  exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
              endwhere
          end if
          ! recover effective viscosity from vel. and temp. fields
 
-         sigmaxy(:) = 2.0_RKIND*visc(:)*(exy(:)+eyx(:))/2.0_RKIND
-         sigmayx(:) = 2.0_RKIND*visc(:)*(eyx(:)+exy(:))/2.0_RKIND
+         sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
+         sigmayx(:) = 2.0_RKIND*effectiveViscosity(:)*(eyx(:)+exy(:))/2.0_RKIND
 
-         sigmaxx(:) = 2.0_RKIND*visc(:)*exx(:)
-         sigmayy(:) = 2.0_RKIND*visc(:)*eyy(:)
+         sigmaxx(:) = 2.0_RKIND*effectiveViscosity(:)*exx(:)
+         sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
          !deviatoric stress
 
          sigmamin(:) =
@@ -1727,13 +1675,15 @@ module li_calving
              s0 = 0.0_RKIND
          elsewhere
              alpha = sigmamin / sigmamax
-             epsmax = sigmamax / (2.0_RKIND*visc)
-             s0 = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0_RKIND*sigmamax*rhoo)
+             epsmax = sigmamax / (2.0_RKIND*effectiveViscosity)
+             s0 =
+             config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
              
          !alpha(:) = sigmamin(:) / (sigmamax(:))
-         !epsmax(:) = sigmamax(:) / (2.0d0*visc(:))
-         !s0(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
+         !epsmax(:) = sigmamax(:) / (2.0d0*effectiveViscosity(:))
+         !s0(:) =
+         !config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness(:)/(2.0d0*sigmamax(:)*config_ocean_density)
           ! Compute the hydrostatic to tensile stress ratio
           ! These commented lines are doing the same thing as the above where loop. Which is better?
 
@@ -1741,7 +1691,8 @@ module li_calving
          12.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)+6.0_RKIND*alpha(:)**2.0_RKIND) 
           ! Compute the effective flow law exponent
 
-         !s0(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
+         !s0(:) =
+         !config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness(:)/(2.0d0*sigmamax(:)*config_ocean_density)
           ! Compute the hydrostatic to tensile stress ratio
 
          !do iCell = 1, nCells
@@ -1755,22 +1706,22 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
          endif
          enddo
 
          !seconds = daysSinceStart*24.0*3600.0
 
-         ! below is the force for the manufacured experiments
-         !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         ! below is the envForce for the manufacured experiments
+         !envForce(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
-         !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         !envForce(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
-         ! set force to zero if not manufactured
-         force(:) = 0.0_RKIND
+         ! set envForce to zero if none
+         envForce(:) = 0.0_RKIND
 
-         ddamagedt(:) = damageSource(:) * damage(:) + force(:)
+         ddamagedt(:) = damageSource(:) * damage(:) + envForce(:)
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
@@ -1781,7 +1732,7 @@ module li_calving
              if (thickness(iCell) == 0.0_RKIND) then
                  damage_nye(iCell) = 0.0_RKIND
              else
-                 damage_nye(iCell) = (2.0+alpha(iCell)) * sigmamax(iCell) / (gravity*(rhoo-rhoi)*thickness(iCell))
+                 damage_nye(iCell) = (2.0+alpha(iCell)) * sigmamax(iCell) / (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
              endif
          enddo
          !damage_nye(:) = 0.5
@@ -1805,6 +1756,7 @@ module li_calving
                 damage(iCell) = 1.0_RKIND
             end if
          end do
+         ! damage is always larger than the Nye value for initialization of damage evolution.
 
 
          !do iCell = 1, nCells
@@ -1818,6 +1770,8 @@ module li_calving
                 damage(iCell) = 0.0_RKIND
             end if
          end do
+         ! the damage of grouned ice is kept as 0, 
+         ! as the strain rate calculation is only valid for ice shelf
 
          do iCell = 1, nCells
             if (li_mask_is_grounding_line(cellMask(iCell))) then
@@ -1868,21 +1822,20 @@ module li_calving
         ! temporary message output in the log file
 
 
-         call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
-         call mpas_deallocate_scratch_field(meanFlowParamAField, .true.)
-         !call mpas_deallocate_scratch_field(viscField, .true.)
-         call mpas_deallocate_scratch_field(sigmaxxField, .true.)
-         call mpas_deallocate_scratch_field(sigmayyField, .true.)
-         call mpas_deallocate_scratch_field(sigmaminField, .true.)
-         !call mpas_deallocate_scratch_field(sigmamaxField, .true.)
-         call mpas_deallocate_scratch_field(alphaField, .true.)
-         !call mpas_deallocate_scratch_field(epsmaxField, .true.)
-         !call mpas_deallocate_scratch_field(nstarField, .true.)
-         !call mpas_deallocate_scratch_field(s0Field, .true.)
-         !call mpas_deallocate_scratch_field(damageSourceField, .true.)
-         !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
-         call mpas_deallocate_scratch_field(forceField, .true.)
-         ! call mpas_deallocate_scratch_field(damageField, .true.)
+         call mpas_deallocate_scratch_field(calvingFrontMaskVar, .true.)
+         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
+         call mpas_deallocate_scratch_field(sigmaxxVar, .true.)
+         call mpas_deallocate_scratch_field(sigmayyVar, .true.)
+         call mpas_deallocate_scratch_field(sigmaminVar, .true.)
+         !call mpas_deallocate_scratch_field(sigmamaxVar, .true.)
+         call mpas_deallocate_scratch_field(alphaVar, .true.)
+         !call mpas_deallocate_scratch_field(epsmaxVar, .true.)
+         !call mpas_deallocate_scratch_field(nstarVar, .true.)
+         !call mpas_deallocate_scratch_field(s0Var, .true.)
+         !call mpas_deallocate_scratch_field(damageSourceVar, .true.)
+         !call mpas_deallocate_scratch_field(ddamagedtVar, .true.)
+         call mpas_deallocate_scratch_field(envForceVar, .true.)
+         ! call mpas_deallocate_scratch_field(damageVar, .true.)
 
          block => block % next
              

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1763,7 +1763,10 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*eMax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*eMax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/thickness(iCell)
+             ! RHS of equation 26 from Bassis and Ma (2015, EPSL, 409, C). Note that the last set of terms after the minus sign, 
+             ! mdot / rho_i / H, differs from the mdot/H in the paper because our mdot has units of kg/m^2/s and to convert that back
+             ! to the right units (1/sec) you need to multiply by a factor of m^2/kg (1/rho_i * 1/H gives that factor). 
          endif
          enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1897,7 +1897,9 @@ module li_calving
 !> \author Tong Zhang
 !> \date   Oct. 2019
 !> \details restore the damage to the original value before advection if it exceeds some large number
-!>          if we turn on this function, we do not allow the damage to heal (damage to decrease).
+!>          (config_damage_restore_threshold). For example, if config_damage_restore_threshold = 0.5, 
+!>          then the localtions with damage > 0.5 on the ice shelf will not heal.
+!>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_restore_threshold.
 !-----------------------------------------------------------------------
 
    subroutine li_restore_damage(domain, err)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1319,6 +1319,7 @@ module li_calving
       logical :: dynamicNeighbor
       real(kind=RKIND), pointer :: config_damagecalvingParameter
       real(kind=RKIND) :: calvingSubtotal
+      character (len=StrKIND), pointer :: config_damage_calving_method
 
       err = 0
 
@@ -1326,6 +1327,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_damagecalvingParameter', config_damagecalvingParameter)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
       ! block loop
       block => domain % blocklist
@@ -1365,7 +1367,14 @@ module li_calving
                   ! calculate only for floating ice - map of "potential" calving rate
 
          !call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
-         call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+
+         if (trim(config_damage_calving_method) == 'calving_rate') then
+             call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+         endif
+
+         if (trim(config_damage_calving_method) == 'threshold') then
+             call apply_calving_velocity_damage_threshold(meshPool, geometryPool, scratchPool, err)
+         endif
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -1472,7 +1481,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
-      real (kind=RKIND), dimension(:), pointer :: szero, nstar, epsmax, visc, sigmamax
+      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax, visc, sigmamax
       real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damage_max
@@ -1506,8 +1515,8 @@ module li_calving
       !real, dimension(:), pointer :: epsmax
       !type (field1dReal), pointer :: nstarField
       !real, dimension(:), pointer :: nstar
-      !type (field1dReal), pointer :: szeroField
-      !real, dimension(:), pointer :: szero
+      !type (field1dReal), pointer :: s0Field
+      !real, dimension(:), pointer :: s0
       !type (field1dReal), pointer :: damageSourceField
       !real, dimension(:), pointer :: damageSource
       !type (field1dReal), pointer :: ddamagedtField
@@ -1578,7 +1587,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
-         call mpas_pool_get_array(geometryPool, 'szero', szero)
+         call mpas_pool_get_array(geometryPool, 's0', s0)
          call mpas_pool_get_array(geometryPool, 'nstar', nstar)
          call mpas_pool_get_array(geometryPool, 'epsmax', epsmax)
          call mpas_pool_get_array(geometryPool, 'visc', visc)
@@ -1651,9 +1660,9 @@ module li_calving
          !call mpas_allocate_scratch_field(nstarField, .true.)
          !nstar => nstarField % array
 
-         !call mpas_pool_get_field(scratchPool, 'szeroField', szeroField )
-         !call mpas_allocate_scratch_field(szeroField, .true.)
-         !szero => szeroField % array
+         !call mpas_pool_get_field(scratchPool, 's0Field', s0Field )
+         !call mpas_allocate_scratch_field(s0Field, .true.)
+         !s0 => s0Field % array
 
          !call mpas_pool_get_field(scratchPool, 'damageSourceField', damageSourceField )
          !call mpas_allocate_scratch_field(damageSourceField, .true.)
@@ -1722,23 +1731,23 @@ module li_calving
          where (thickness == 0.0_RKIND)
              alpha = 0.0_RKIND
              epsmax = 0.0_RKIND
-             szero = 0.0_RKIND
+             s0 = 0.0_RKIND
          elsewhere
              alpha = sigmamin / sigmamax
              epsmax = sigmamax / (2.0d0*visc)
-             szero = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0d0*sigmamax*rhoo)
+             s0 = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0d0*sigmamax*rhoo)
          endwhere
              
          !alpha(:) = sigmamin(:) / (sigmamax(:))
          !epsmax(:) = sigmamax(:) / (2.0d0*visc(:))
-         !szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
+         !s0(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
           ! Compute the hydrostatic to tensile stress ratio
           ! These commented lines are doing the same thing as the above where loop. Which is better?
 
          nstar(:) = 12.0d0*(1.0d0+alpha(:)+alpha(:)**2)/(4.0d0*(1.0d0+alpha(:)+alpha(:)**2)+6.0d0*alpha(:)**2) 
           ! Compute the effective flow law exponent
 
-         !szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
+         !s0(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
           ! Compute the hydrostatic to tensile stress ratio
 
          !do iCell = 1, nCells
@@ -1752,7 +1761,7 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-             damageSource(iCell) = nstar(iCell) * (1.0d0-szero(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0d0-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
          endif
          enddo
 
@@ -1847,8 +1856,8 @@ module li_calving
 
              call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damageSource), maxval(damageSource)/))
-             call mpas_log_write("szero  value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(szero), maxval(szero)/))
+             call mpas_log_write("s0 value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(s0), maxval(s0)/))
              call mpas_log_write("nstar value range: Min=$r, Max=$r", &
                         realArgs=(/minval(nstar), maxval(nstar)/))
              call mpas_log_write("deltat value range: Min=$r, Max=$r", &
@@ -1875,7 +1884,7 @@ module li_calving
          call mpas_deallocate_scratch_field(alphaField, .true.)
          !call mpas_deallocate_scratch_field(epsmaxField, .true.)
          !call mpas_deallocate_scratch_field(nstarField, .true.)
-         !call mpas_deallocate_scratch_field(szeroField, .true.)
+         !call mpas_deallocate_scratch_field(s0Field, .true.)
          !call mpas_deallocate_scratch_field(damageSourceField, .true.)
          !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
          call mpas_deallocate_scratch_field(forceField, .true.)
@@ -2463,6 +2472,141 @@ module li_calving
        scale_edge_length = abs(cos(angleEdgeHere - atan2(v, u)))
     end function scale_edge_length
 
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine apply_calving_velocity_damage_threshold
+!
+!> \brief Apply a specified calving flux along the calving front
+!> \author Tong Zhang 
+!> \date   Nov. 2020
+!> \details Applies a specified calving flux along the calving front.
+!> The calving volume needs to be distributed in three ways:
+!> 1. We need to first remove any "thin" ice in front of this cell
+!> 2. Then we remove ice from this cell if the damage is above a threshold value
+!-----------------------------------------------------------------------
+   subroutine apply_calving_velocity_damage_threshold(meshPool, geometryPool, scratchPool, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
+      type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
+      integer, dimension(:), intent(in) :: calvingFrontMask
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+!      logical, pointer :: config_print_calving_info
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
+         !< Input: the specified calving flux at calving front margin cells
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
+      real (kind=RKIND), dimension(:), pointer :: thickness, damage
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      real(kind=RKIND), pointer :: config_damage_calving_threshold
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:), pointer :: cellMask
+      real (kind=RKIND), pointer :: deltat  !< time step (s)
+      integer, pointer :: nCells
+      integer :: iCell, iNeighbor, jCell
+      real(kind=RKIND) :: volumeLeft
+      real(kind=RKIND) :: removeVolumeHere
+      type (field1dReal), pointer :: cellVolumeField
+      real(kind=RKIND), dimension(:), pointer :: cellVolume
+      real(kind=RKIND), dimension(:), pointer :: uncalvedVolume
+      integer :: inwardNeighbors
+      integer :: uncalvedCount
+      real(kind=RKIND) :: uncalvedTotal
+      !logical, pointer :: config_damage_if_calving_rate
+
+      err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
+      !call mpas_pool_get_config(liConfigs, 'config_damage_if_calving_rate', config_damage_if_calving_rate)
+
+      ! get fields
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'deltat', deltat)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
+      call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
+      call mpas_pool_get_array(geometryPool, 'damage', damage)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+
+      call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
+      call mpas_allocate_scratch_field(cellVolumeField, .true.)
+      cellVolume => cellVolumeField % array
+
+      calvingThickness(:) = 0.0_RKIND
+
+      cellVolume(:) = areaCell(:) * thickness(:)
+
+      ! The calving volume needs to be distributed in three ways:
+      ! 1. We need to first remove any "thin" ice in front of this cell
+      ! 2. Then we remove ice from this cell if damage > threshold
+      do iCell = 1, nCells
+         if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
+                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
+              .and. li_mask_is_margin(cellMask(iCell)) &
+              .and. (damage(iCell) .ge. config_damage_calving_threshold)) then
+
+            ! First remove ice from "thin" neighbors
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
+                  ! this is a thin neighbor - remove the whole cell volume
+                  removeVolumeHere = cellVolume(jCell) ! how much we want to remove here
+                  calvingThickness(jCell) = removeVolumeHere / areaCell(jCell)
+                      ! < apply to the field that will be used, in thickness units
+                  cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
+               endif
+            enddo
+
+            ! Now remove ice from iCell
+            removeVolumeHere = cellVolume(iCell)
+            ! remove the whole damaged cell
+            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            ! < apply to the field that will be used in thickness units
+            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere 
+            ! update accounting on cell volume
+
+            ! Now calved away the neighboring cells if the damage is also > the threshold value
+            ! I choose to disable this section (i.e., no recursive calving) -- TZ
+            !do iNeighbor = 1, nEdgesOnCell(iCell)
+            !   jCell = cellsOnCell(iNeighbor, iCell)
+            !   if (li_mask_is_floating_ice(cellMask(jCell)) .and. li_mask_is_dynamic_ice(cellMask(jCell)) &
+            !           .and. (.not. li_mask_is_dynamic_margin(jCell)) .and. (damage(jCell) .gt. config_damage_calving_threshold)) then
+            !      removeVolumeHere = cellVolume(jCell)
+                     ! < how much we want to remove here
+            !      calvingThickness(jCell) = removeVolumeHere / areaCell(jCell)
+                     ! < apply to the field that will be used in thickness units
+            !      cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere 
+                     ! update accounting on cell volume
+            !   endif
+            !enddo
+
+         endif ! if cell is calving margin
+
+      enddo ! cell loop
+
+      call mpas_deallocate_scratch_field(cellVolumeField, .true.)
+
+   end subroutine apply_calving_velocity_damage_threshold
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1542,10 +1542,10 @@ module li_calving
 
          if (trim(config_damage_calving_method) == 'calving_rate') then
              call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
-         endif
-
-         if (trim(config_damage_calving_method) == 'threshold') then
-             call apply_calving_velocity_damage_threshold(meshPool, geometryPool, scratchPool, err)
+         elseif (trim(config_damage_calving_method) == 'threshold') then
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, err)
+         else
+             call mpas_log_write("Unknown value for config_damage_calving_method was specified!", MPAS_LOG_ERR)
          endif
 
          ! === apply calving ===
@@ -1641,7 +1641,7 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
 
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
-      real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
+      real(kind=RKIND), pointer :: config_damage_preserve_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA
       real(kind=RKIND), pointer :: config_flowLawExponent
@@ -1693,7 +1693,6 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', config_calving_eigencalving_parameter_source)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
-      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -2496,17 +2495,16 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine apply_calving_velocity_damage_threshold
+!    routine apply_calving_damage_threshold
 !
-!> \brief Apply a specified calving flux along the calving front
-!> \author Tong Zhang 
-!> \date   Nov. 2020
-!> \details Applies a specified calving flux along the calving front.
-!> The calving volume needs to be distributed in three ways:
-!> 1. We need to first remove any "thin" ice in front of this cell
-!> 2. Then we remove ice from this cell if the damage is above a threshold value
+!> \brief Calve any ice that is damaged beyond a specified threshold
+!> \author Tong Zhang, Matt Hoffman
+!> \date   Nov. 2020, March 2021
+!> \details This routine specified floating ice to be calved wherever the damage
+!> value exceeds a specified threshold, assuming the ice is connected to the calving
+!> front.
 !-----------------------------------------------------------------------
-   subroutine apply_calving_velocity_damage_threshold(meshPool, geometryPool, scratchPool, err)
+   subroutine apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -2550,12 +2548,10 @@ module li_calving
       real(kind=RKIND) :: uncalvedTotal
       integer :: nEmptyNeighbors
       real (kind=RKIND), pointer :: config_sea_level
-      !logical, pointer :: config_damage_if_calving_rate
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
-      !call mpas_pool_get_config(liConfigs, 'config_damage_if_calving_rate', config_damage_if_calving_rate)
 
       ! get fields
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
@@ -2582,7 +2578,7 @@ module li_calving
 
       groundedMarineMarginMask(:) = 0
       do iCell = 1, nCells
-         ! Define marine m      arginal cells as those that are (1) at the ice
+         ! Define marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
@@ -2656,7 +2652,7 @@ module li_calving
 
       call mpas_deallocate_scratch_field(cellVolumeField, .true.)
 
-   end subroutine apply_calving_velocity_damage_threshold
+   end subroutine apply_calving_damage_threshold
 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -47,7 +47,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_restore_damage
+   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_maintain_broken_ice
 
    !--------------------------------------------------------------------
    !
@@ -1466,6 +1466,7 @@ module li_calving
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_restore_threshold, config_damage_calving_threshold
       logical, pointer :: config_damage_use_constant_A
+      character, pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA 
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
@@ -1534,6 +1535,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
       call mpas_pool_get_config(liConfigs, 'config_damage_use_constant_A', config_damage_use_constant_A)
+      call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
 
@@ -1773,32 +1775,47 @@ module li_calving
          ! the damage of grouned ice is kept as 0, 
          ! as the strain rate calculation is only valid for ice shelf
 
-         do iCell = 1, nCells
-            if (li_mask_is_grounding_line(cellMask(iCell))) then
-                
-                damage_downstream = 0.0_RKIND
-                n_damage_downstream = 0
-                do iNeighbor = 1, nEdgesOnCell(iCell)
-                    jCell = cellsOnCell(iNeighbor, iCell)
-                    if (li_mask_is_floating_ice(cellMask(jCell))) then
-                       
-                        damage_downstream = damage_downstream + damage(jCell)
-                        n_damage_downstream =  n_damage_downstream + 1
+         if (trim(config_damage_gl_setting) == 'extra') then
+             do iCell = 1, nCells
+                if (li_mask_is_grounding_line(cellMask(iCell))) then
+                    
+                    damage_downstream = 0.0_RKIND
+                    n_damage_downstream = 0
+                    do iNeighbor = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(iNeighbor, iCell)
+                        if (li_mask_is_floating_ice(cellMask(jCell))) then
+                           
+                            damage_downstream = damage_downstream + damage(jCell)
+                            n_damage_downstream =  n_damage_downstream + 1
+                        end if
+                    end do
+
+                    damage(iCell) = damage_downstream
+
+                    if (n_damage_downstream == 0) then
+                        damage(iCell) = 0.0_RKIND
+                    else
+                        damage(iCell) = damage_downstream / n_damage_downstream
                     end if
-                end do
 
-                damage(iCell) = damage_downstream
-
-                if (n_damage_downstream == 0) then
-                    damage(iCell) = 0.0_RKIND
-                else
-                    damage(iCell) = damage_downstream / n_damage_downstream
                 end if
+            end do
+            ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
 
-            end if
-        end do
-        ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
+        elseif (trim(config_damage_gl_setting) == "nye") then
                         
+             do iCell = 1, nCells
+                if (li_mask_is_grounding_line(cellMask(iCell))) then
+                    do iNeighbor = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(iNeighbor, iCell)
+                        if (li_mask_is_floating_ice(cellMask(jCell))) then
+                            damage(jCell) = damage_nye(jCell)
+                        end if
+                    end do
+                end if
+            end do
+        endif
+        ! always set the damage at the first floating cells to the Nye value
 
         if (.true.) then
 
@@ -1845,7 +1862,7 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine li_restore_damage
+!    routine li_maintain_broken_ice
 !
 !> \author Tong Zhang
 !> \date   Oct. 2019
@@ -1855,7 +1872,7 @@ module li_calving
 !>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_restore_threshold.
 !-----------------------------------------------------------------------
 
-   subroutine li_restore_damage(domain, err)
+   subroutine li_maintain_broken_ice(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1883,8 +1900,10 @@ module li_calving
       real(kind=RKIND), pointer :: config_damage_stiffness_min
       logical, pointer :: config_damage_rheology_coupling
       logical, pointer :: config_print_calving_info
+      character, pointer :: config_damage_gl_setting
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: damageMax
+      real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
 
 
@@ -1900,6 +1919,7 @@ module li_calving
 
       call mpas_pool_get_config(liConfigs, 'config_damage_stiffness_min', config_damage_stiffness_min)
       call mpas_pool_get_config(liConfigs, 'config_damage_rheology_coupling', config_damage_rheology_coupling)
+      call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
 
       ! block loop
       block => domain % blocklist
@@ -1919,6 +1939,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
+         call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
 
@@ -1950,29 +1971,44 @@ module li_calving
             end if
          end do
 
-         do iCell = 1, nCells
-            if (li_mask_is_grounding_line(cellMask(iCell))) then
-                damage_downstream = 0.0_RKIND
-                n_damage_downstream = 0
-                do iNeighbor = 1, nEdgesOnCell(iCell)
-                    jCell = cellsOnCell(iNeighbor, iCell)
-                    if (li_mask_is_floating_ice(cellMask(jCell))) then
-                        
-                        damage_downstream = damage_downstream + damage(jCell)
-                        n_damage_downstream =  n_damage_downstream + 1
+         if (trim(config_damage_gl_setting) == 'extra') then
+             do iCell = 1, nCells
+                if (li_mask_is_grounding_line(cellMask(iCell))) then
+                    damage_downstream = 0.0_RKIND
+                    n_damage_downstream = 0
+                    do iNeighbor = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(iNeighbor, iCell)
+                        if (li_mask_is_floating_ice(cellMask(jCell))) then
+                            
+                            damage_downstream = damage_downstream + damage(jCell)
+                            n_damage_downstream =  n_damage_downstream + 1
+                        end if
+                    end do
+
+                    damage(iCell) = damage_downstream
+
+                    if (n_damage_downstream == 0) then
+                        damage(iCell) = 0.0_RKIND
+                    else
+                        damage(iCell) = damage_downstream / n_damage_downstream
                     end if
-                end do
 
-                damage(iCell) = damage_downstream
-
-                if (n_damage_downstream == 0) then
-                    damage(iCell) = 0.0_RKIND
-                else
-                    damage(iCell) = damage_downstream / n_damage_downstream
                 end if
+            end do
 
-            end if
-        end do
+        elseif (trim(config_damage_gl_setting) == 'nye') then
+             do iCell = 1, nCells
+                if (li_mask_is_grounding_line(cellMask(iCell))) then
+                    do iNeighbor = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(iNeighbor, iCell)
+                        if (li_mask_is_floating_ice(cellMask(jCell))) then
+                            damage(jCell) = damage_nye(jCell)
+                        end if
+                    end do
+                end if
+            end do
+            ! always set the damage at the first floating cells to the Nye value
+        endif
 
         if (config_damage_rheology_coupling) then
             do iCell = 1, nCells
@@ -1990,7 +2026,7 @@ module li_calving
              
       enddo
 
-   end subroutine li_restore_damage 
+   end subroutine li_maintain_broken_ice
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -2537,7 +2537,6 @@ module li_calving
       ! local variables
       !-----------------------------------------------------------------
 !      logical, pointer :: config_print_calving_info
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
          !< Input: the specified calving flux at calving front margin cells
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, bedTopography
@@ -2575,7 +2574,6 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
       call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1794,7 +1794,6 @@ module li_calving
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
 
-
          call calculate_strain_rates(meshPool, velocityPool, err_tmp)
          err = ior(err, err_tmp)
 
@@ -1973,17 +1972,6 @@ module li_calving
         endif
         ! always set the damage at the first floating cells to the Nye value
 
-        if (config_damage_rheology_coupling) then
-            do iCell = 1, nCells
-                if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell))) then
-                    stiffnessFactor(iCell) = 1.0_RKIND - damage(iCell)
-                    if (stiffnessFactor(iCell) < config_damage_stiffness_min) then
-                        stiffnessFactor(iCell) = config_damage_stiffness_min
-                    end if
-                end if
-            end do
-        end if
-
         if (.true.) then
 
              call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
@@ -2028,17 +2016,20 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine li_preserve_high_damage
+!    routine li_finalize_damage_after_advection
 !
 !> \author Tong Zhang
 !> \date   Oct. 2019
-!> \details preserve the damage to the original value before advection if it exceeds some large number
+!> \details This routine finalizes the damage calculation after advection by several ways: 1) set the damage at grounding line using
+!>          an extrapolation method or an Nye method.
+!>          2) preserve the damage to the original value before advection if it exceeds some large number
 !>          (config_damage_preserve_threshold). For example, if config_damage_preserve_threshold = 0.5, 
 !>          then the localtions with damage > 0.5 on the ice shelf will not heal.
 !>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_preserve_threshold.
+!>           3) coupling rheology to damage if the option config_damage_rheology_coupling is set to True in namelist
 !-----------------------------------------------------------------------
 
-   subroutine li_preserve_high_damage(domain, err)
+   subroutine li_finalize_damage_after_advection(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -2065,6 +2056,7 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
       real(kind=RKIND), pointer :: config_damage_stiffness_min
       logical, pointer :: config_damage_rheology_coupling
+      logical, pointer :: config_preserve_damage
       logical, pointer :: config_print_calving_info
       character, pointer :: config_damage_gl_setting
       real (kind=RKIND), dimension(:), pointer :: damage
@@ -2086,6 +2078,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_damage_stiffness_min', config_damage_stiffness_min)
       call mpas_pool_get_config(liConfigs, 'config_damage_rheology_coupling', config_damage_rheology_coupling)
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
+      call mpas_pool_get_config(liConfigs, 'config_preserve_damage', config_preserve_damage)
 
       ! block loop
       block => domain % blocklist
@@ -2108,12 +2101,13 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
-
-         do iCell = 1, nCells
-            if (damage(iCell) < damageMax(iCell)) then
-                damage(iCell) = damageMax(iCell)
-            end if
-         end do
+         if (config_preserve_damage) then
+             do iCell = 1, nCells
+                if (damage(iCell) < damageMax(iCell)) then
+                    damage(iCell) = damageMax(iCell)
+                end if
+             end do
+         endif
          ! put the damageMax value back to preserve the damage value (no heal)
 
          where (damage < 0.0_RKIND)
@@ -2161,6 +2155,7 @@ module li_calving
 
                 end if
             end do
+            !set the damage at GL to the mean damage value for its neighboring floating cells
 
         elseif (trim(config_damage_gl_setting) == 'nye') then
              do iCell = 1, nCells
@@ -2192,7 +2187,7 @@ module li_calving
              
       enddo
 
-   end subroutine li_preserve_high_damage
+   end subroutine li_finalize_damage_after_advection
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1841,7 +1841,7 @@ module li_calving
          ! the damage of grouned ice is kept as 0, 
          ! as the strain rate calculation is only valid for ice shelf
 
-         if (trim(config_damage_gl_setting) == 'extra') then
+         if (trim(config_damage_gl_setting) == 'extrapolate') then
              do iCell = 1, nCells
                 if (li_mask_is_grounding_line(cellMask(iCell))) then
                     
@@ -2026,7 +2026,7 @@ module li_calving
             end if
          end do
 
-         if (trim(config_damage_gl_setting) == 'extra') then
+         if (trim(config_damage_gl_setting) == 'extrapolate') then
              do iCell = 1, nCells
                 if (li_mask_is_grounding_line(cellMask(iCell))) then
                     damage_downstream = 0.0_RKIND

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1258,6 +1258,179 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!    routine specified_calving_velocity
+!
+!> \brief use a specified calving velocity given by input data
+!> \author Matthew Hoffman
+!> \date   Feb. 2018
+!> \details we can specify the calving velocity by i) a constant value 
+!> given by config_calving_velocity_const in namelist and ii) source data
+!> speficied by input netCDF data (e.g., landice_grid.nc)
+!-----------------------------------------------------------------------
+   subroutine specified_calving_velocity(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: &
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: scratchPool
+      logical, pointer :: config_print_calving_info
+      real(kind=RKIND), pointer :: config_calving_thickness
+      real(kind=RKIND), pointer :: config_calving_velocity_const
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocityData
+      real (kind=RKIND), dimension(:), pointer :: angleEdge
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: calvingFrontMask
+      real (kind=RKIND), pointer :: deltat  !< time step (s)
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      integer, pointer :: nCells
+      integer :: iCell, jCell, iNeighbor
+      logical :: dynamicNeighbor
+      real(kind=RKIND) :: calvingSubtotal
+      integer :: err_tmp
+
+      err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
+      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
+      call mpas_pool_get_config(liConfigs, 'config_calving_velocity_const', config_calving_velocity_const)
+
+      ! block loop
+      block => domain % blocklist
+      do while (associated(block))
+
+         ! get pools
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+
+         ! get dimensions
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+         ! get fields
+         call mpas_pool_get_array(meshPool, 'deltat', deltat)
+         call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
+         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+         call mpas_pool_get_array(geometryPool, 'calvingVelocityData', calvingVelocityData)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+
+
+         ! get parameter value
+         if (trim(config_calving_specified_source) == 'const') then
+             calvingVelocity = config_calving_velocity_const
+         elseif (trim(config_calving_spefified_source) == 'data') then
+             calvingVelocity = calvingVelocityData
+         else
+            err = 1
+            call mpas_log_write("Invalid value specified for option config_calving_specified_source" // &
+                  config_calving_specified_source, MPAS_LOG_ERR)
+         endif
+
+         if (config_print_calving_info) then
+            call mpas_log_write("calvingVelocity(m s) value range: Min=$r, Max=$r", &
+                    realArgs=(/minval(calvingVelocity), maxval(calvingVelocity)/))
+         endif
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! Convert calvingVelocity to calvingThickness
+         call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+
+         ! === apply calving ===
+         thickness(:) = thickness(:) - calvingThickness(:)
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
+
+         !where ((li_mask_is_floating_ice(cellMask) .and. li_mask_is_dynamic_ice(cellMask) .and. &
+         ! thickness<config_calving_thickness))
+         ! The above commented version removed thin ice anywhere on the shelf.  In theory this seemed preferable,
+         ! but in practice it has the tendency to create 'holes' in relatively stagnant areas of ice shelves along
+         ! the grounding line.  Once these holes developed they would grow and eventually collapse the shelf from behind.
+
+         ! This criteria below only remove too-thin ice at the new calving front,
+         ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
+         ! removing ice backward until all connected too-thin ice has been removed.
+         ! Tests of the current implementation show reasonable behavior.
+         do iCell = 1, nCells
+            if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
+               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               thickness(iCell) = 0.0_RKIND
+            endif
+         enddo
+         ! TODO: global reduce & reporting on amount of calving generated in this step
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+         calvingSubtotal = 0.0_RKIND
+         do iCell = 1, nCells
+           if (li_mask_is_floating_ice(cellMask(iCell))) then
+              ! check neighbors for dynamic ice (floating or grounded)
+              dynamicNeighbor = .false.
+              do iNeighbor = 1, nEdgesOnCell(iCell)
+                 jCell = cellsOnCell(iNeighbor, iCell)
+                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+              enddo
+              if (.not. dynamicNeighbor) then  ! calve this ice
+                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+                 thickness(iCell) = 0.0_RKIND
+                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
+              endif
+           endif
+         enddo
+         ! TODO: global reduce & reporting on amount of calving generated in this step
+
+         call remove_small_islands(meshPool, geometryPool)
+
+         block => block % next
+      enddo
+
+   end subroutine specified_calving_velocity
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !    routine damagecalving
 !
 !> \brief Calve ice from the calving front based on the Bassis-Ma (2015) damage theory. 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1757,33 +1757,34 @@ module li_calving
 
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         call mpas_pool_get_field(scratchPool, 'meanFlowParamAVar',  meanFlowParamAVar)
+         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar)
          call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
          meanFlowParamA => meanFlowParamAVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
+         call mpas_pool_get_field(scratchPool, 'sigmaxy', sigmaxyVar )
          call mpas_allocate_scratch_field(sigmaxyVar, .true.)
          sigmaxy => sigmaxyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayxVar', sigmayxVar )
+         call mpas_pool_get_field(scratchPool, 'sigmayx', sigmayxVar )
          call mpas_allocate_scratch_field(sigmayxVar, .true.)
          sigmayx => sigmayxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaxxVar', sigmaxxVar )
+         call mpas_pool_get_field(scratchPool, 'sigmaxx', sigmaxxVar )
          call mpas_allocate_scratch_field(sigmaxxVar, .true.)
          sigmaxx => sigmaxxVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmayyVar', sigmayyVar )
+         call mpas_pool_get_field(scratchPool, 'sigmayy', sigmayyVar )
          call mpas_allocate_scratch_field(sigmayyVar, .true.)
          sigmayy => sigmayyVar % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmaminVar', sigmaminVar )
+         call mpas_pool_get_field(scratchPool, 'sigmamin', sigmaminVar )
          call mpas_allocate_scratch_field(sigmaminVar, .true.)
          sigmamin => sigmaminVar % array
 
-         call mpas_pool_get_field(scratchPool, 'alphaVar', alphaVar )
+         call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
+
 
          call mpas_pool_get_array(velocityPool, 'exx', exx)
          call mpas_pool_get_array(velocityPool, 'eyy', eyy)
@@ -1793,7 +1794,7 @@ module li_calving
          call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
          err = ior(err, err_tmp)
 
-         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
+         !meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
          ! calculate the depth-averaged flow parameter A
 
          where (thickness == 0.0_RKIND)
@@ -1961,7 +1962,7 @@ module li_calving
         endif
         ! always set the damage at the first floating cells to the Nye value
 
-        if (.true.) then
+        if (.false.) then
 
              call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damageSource), maxval(damageSource)/))

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1495,6 +1495,7 @@ module li_calving
       real(kind=RKIND), pointer :: config_damagecalvingParameter
       real(kind=RKIND) :: calvingSubtotal
       character (len=StrKIND), pointer :: config_damage_calving_method
+      real(kind=RKIND), pointer :: config_damage_calving_threshold
 
       err = 0
 
@@ -1503,6 +1504,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
       call mpas_pool_get_config(liConfigs, 'config_damagecalvingParameter', config_damagecalvingParameter)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
 
       ! block loop
       block => domain % blocklist
@@ -1534,13 +1536,20 @@ module li_calving
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
          if (trim(config_damage_calving_method) == 'calving_rate') then
-             ! First calculate the front retreat rate
-             calvingVelocity(:) = config_damagecalvingParameter * damage(:) & ! m/s
-               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
-                  ! calculate only for floating ice
-             call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+             if (config_damage_calving_threshold >= 1.0_RKIND .or. config_damage_calving_threshold < 0.0_RKIND) then
+                call mpas_log_write("Invalid value of config_damage_calving_threshold specified for 'calving_rate' option.  " // &
+                        "Valid values are in the range [0,1).", MPAS_LOG_ERR)
+                err = ior(err, err_tmp)
+             endif
+             ! First calculate the front retreat rate (m/s)
+             calvingVelocity(:) = config_damagecalvingParameter * &
+                max(0.0_RKIND, (damage(:) - config_damage_calving_threshold) / (1.0_RKIND - config_damage_calving_threshold)) &
+                * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND) ! calculate only for floating ice
+             call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err_tmp)
+             err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
-             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, err)
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, err_tmp)
+             err = ior(err, err_tmp)
          else
              call mpas_log_write("Unknown value for config_damage_calving_method was specified!", MPAS_LOG_ERR)
          endif

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -2068,7 +2068,7 @@ module li_calving
 
         if (config_damage_rheology_coupling) then
             do iCell = 1, nCells
-                if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell))) then
+                if (li_mask_is_floating_ice(cellMask(iCell))) then
                     stiffnessFactor(iCell) = 1.0_RKIND - damage(iCell)
                     if (stiffnessFactor(iCell) < config_damage_stiffness_min) then
                         stiffnessFactor(iCell) = config_damage_stiffness_min

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -29,6 +29,7 @@ module li_calving
    use li_setup
    use li_mask
    use li_constants
+   use li_diagnostic_vars
 
 
    implicit none
@@ -1453,7 +1454,7 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_restore_threshold, config_damage_calving_threshold
-      logical, pointer :: config_use_constant_A
+      logical, pointer :: config_damage_use_constant_A
       real(kind=RKIND), pointer :: config_default_flowParamA 
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
@@ -1471,7 +1472,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
-      real (kind=RKIND), dimension(:), pointer :: szero
+      real (kind=RKIND), dimension(:), pointer :: szero, nstar, epsmax, visc, sigmamax
       real (kind=RKIND), dimension(:), pointer :: source
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damage_max
@@ -1485,8 +1486,8 @@ module li_calving
 
       type (field1dReal), pointer :: meanFlowParamAField
       real, dimension(:), pointer :: meanFlowParamA
-      type (field1dReal), pointer :: viscField
-      real, dimension(:), pointer :: visc
+      !type (field1dReal), pointer :: viscField
+      !real, dimension(:), pointer :: visc
       type (field1dReal), pointer :: sigmayxField
       real, dimension(:), pointer :: sigmayx
       type (field1dReal), pointer :: sigmaxyField
@@ -1497,14 +1498,14 @@ module li_calving
       real, dimension(:), pointer :: sigmayy
       type (field1dReal), pointer :: sigmaminField
       real, dimension(:), pointer :: sigmamin
-      type (field1dReal), pointer :: sigmamaxField
-      real, dimension(:), pointer :: sigmamax
+      !type (field1dReal), pointer :: sigmamaxField
+      !real, dimension(:), pointer :: sigmamax
       type (field1dReal), pointer :: alphaField
       real, dimension(:), pointer :: alpha
-      type (field1dReal), pointer :: epsmaxField
-      real, dimension(:), pointer :: epsmax
-      type (field1dReal), pointer :: nstarField
-      real, dimension(:), pointer :: nstar
+      !type (field1dReal), pointer :: epsmaxField
+      !real, dimension(:), pointer :: epsmax
+      !type (field1dReal), pointer :: nstarField
+      !real, dimension(:), pointer :: nstar
       !type (field1dReal), pointer :: szeroField
       !real, dimension(:), pointer :: szero
       !type (field1dReal), pointer :: sourceField
@@ -1515,6 +1516,8 @@ module li_calving
       real, dimension(:), pointer :: force
       type (field1dReal), pointer :: meanTField
       real, dimension(:), pointer :: meanT
+
+      ! TZ: we can comment out the scratch field as above and redefine it in Registry.xml if we want to see it in the output nc file
 
       integer, dimension(:), pointer :: cellMask
       type (field1dInteger), pointer :: calvingFrontMaskField
@@ -1541,7 +1544,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_damage_restore_threshold', config_damage_restore_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
-      call mpas_pool_get_config(liConfigs, 'config_use_constant_A', config_use_constant_A)
+      call mpas_pool_get_config(liConfigs, 'config_damage_use_constant_A', config_damage_use_constant_A)
 
       ! block loop
       block => domain % blocklist
@@ -1576,6 +1579,10 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 'szero', szero)
+         call mpas_pool_get_array(geometryPool, 'nstar', nstar)
+         call mpas_pool_get_array(geometryPool, 'epsmax', epsmax)
+         call mpas_pool_get_array(geometryPool, 'visc', visc)
+         call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax)
          call mpas_pool_get_array(geometryPool, 'source', source)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
@@ -1604,9 +1611,9 @@ module li_calving
          call mpas_allocate_scratch_field(meanFlowParamAField, .true.)
          meanFlowParamA => meanFlowParamAField % array
 
-         call mpas_pool_get_field(scratchPool, 'viscField',  viscField)
-         call mpas_allocate_scratch_field(viscField, .true.)
-         visc => viscField % array
+         !call mpas_pool_get_field(scratchPool, 'viscField',  viscField)
+         !call mpas_allocate_scratch_field(viscField, .true.)
+         !visc => viscField % array
 
          call mpas_pool_get_field(scratchPool, 'sigmaxyField', sigmaxyField )
          call mpas_allocate_scratch_field(sigmaxyField, .true.)
@@ -1628,21 +1635,21 @@ module li_calving
          call mpas_allocate_scratch_field(sigmaminField, .true.)
          sigmamin => sigmaminField % array
 
-         call mpas_pool_get_field(scratchPool, 'sigmamaxField', sigmamaxField )
-         call mpas_allocate_scratch_field(sigmamaxField, .true.)
-         sigmamax => sigmamaxField % array
+         !call mpas_pool_get_field(scratchPool, 'sigmamaxField', sigmamaxField )
+         !call mpas_allocate_scratch_field(sigmamaxField, .true.)
+         !sigmamax => sigmamaxField % array
 
          call mpas_pool_get_field(scratchPool, 'alphaField', alphaField )
          call mpas_allocate_scratch_field(alphaField, .true.)
          alpha => alphaField % array
 
-         call mpas_pool_get_field(scratchPool, 'epsmaxField', epsmaxField )
-         call mpas_allocate_scratch_field(epsmaxField, .true.)
-         epsmax => epsmaxField % array
+         !call mpas_pool_get_field(scratchPool, 'epsmaxField', epsmaxField )
+         !call mpas_allocate_scratch_field(epsmaxField, .true.)
+         !epsmax => epsmaxField % array
 
-         call mpas_pool_get_field(scratchPool, 'nstarField', nstarField )
-         call mpas_allocate_scratch_field(nstarField, .true.)
-         nstar => nstarField % array
+         !call mpas_pool_get_field(scratchPool, 'nstarField', nstarField )
+         !call mpas_allocate_scratch_field(nstarField, .true.)
+         !nstar => nstarField % array
 
          !call mpas_pool_get_field(scratchPool, 'szeroField', szeroField )
          !call mpas_allocate_scratch_field(szeroField, .true.)
@@ -1682,12 +1689,22 @@ module li_calving
 
 
          meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/nVertLevels
+         ! calculate the depth-averaged flow parameter A
+
          call mpas_log_write("meanFlowParamA: Min=$r, Max=$r", &
                     realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
-         if (config_use_constant_A) then
-             visc(:) = 0.5*stiffnessFactor(:)*config_default_flowParamA**(-1.0/3.0)*(sqrt(exx(:)**2+eyy(:)**2 + exx(:)*eyy(:) + 0.25*(exy(:)+eyx(:))**2+1.0e-30))**((1.0-3.0)/3.0)
+         if (config_damage_use_constant_A) then
+             where (thickness == 0.0_RKIND)
+                 visc = 0.0_RKIND
+             elsewhere
+                 visc = 0.5*stiffnessFactor*config_default_flowParamA**(-1.0/3.0)*(sqrt(exx**2+eyy**2 + exx*eyy + 0.25*(exy+eyx)**2))**((1.0-3.0)/3.0)
+             endwhere
          else
-             visc(:) = 0.5*stiffnessFactor(:)*meanFlowParamA(:)**(-1.0/3.0)*(sqrt(exx(:)**2+eyy(:)**2 + exx(:)*eyy(:) + 0.25*(exy(:)+eyx(:))**2))**((1.0-3.0)/3.0)
+             where (thickness == 0.0_RKIND)
+                 visc = 0.0_RKIND
+             elsewhere
+                 visc = 0.5*stiffnessFactor*meanFlowParamA**(-1.0/3.0)*(sqrt(exx**2+eyy**2 + exx*eyy + 0.25*(exy+eyx)**2))**((1.0-3.0)/3.0)
+             endwhere
          end if
          ! recover effective viscosity from vel. and temp. fields
 
@@ -1698,17 +1715,30 @@ module li_calving
          sigmayy(:) = 2*visc(:)*eyy(:)
          !deviatoric stress
 
-         sigmamin(:) = (sigmaxx(:)+sigmayy(:))/2.0-sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2 + 1.0e-30)
-         sigmamax(:) = (sigmaxx(:)+sigmayy(:))/2.0+sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2 + 1.0e-30)
+         sigmamin(:) = (sigmaxx(:)+sigmayy(:))/2.0-sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2)
+         sigmamax(:) = (sigmaxx(:)+sigmayy(:))/2.0+sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2)
          !deviatoric principal stress
 
-         alpha(:) = sigmamin(:) / (sigmamax(:)+1.0e-30)
-         epsmax(:) = sigmamax(:) / (2.0d0*visc(:)+1.0e-30)
+         where (thickness == 0.0_RKIND)
+             alpha = 0.0_RKIND
+             epsmax = 0.0_RKIND
+             szero = 0.0_RKIND
+         elsewhere
+             alpha = sigmamin / sigmamax
+             epsmax = sigmamax / (2.0d0*visc)
+             szero = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0d0*sigmamax*rhoo)
+         endwhere
+             
+         !alpha(:) = sigmamin(:) / (sigmamax(:))
+         !epsmax(:) = sigmamax(:) / (2.0d0*visc(:))
+         !szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
+          ! Compute the hydrostatic to tensile stress ratio
+          ! These commented lines are doing the same thing as the above where loop. Which is better?
 
-         nstar(:) = 12.0d0*(1.0d0+alpha(:)+alpha(:)**2)/(4.0d0*(1.0d0+alpha(:)+alpha(:)**2)+6.0d0*alpha(:)**2+1.0e-30) 
+         nstar(:) = 12.0d0*(1.0d0+alpha(:)+alpha(:)**2)/(4.0d0*(1.0d0+alpha(:)+alpha(:)**2)+6.0d0*alpha(:)**2) 
           ! Compute the effective flow law exponent
 
-         szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo+1.0e-30)
+         !szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
           ! Compute the hydrostatic to tensile stress ratio
 
          !do iCell = 1, nCells
@@ -1716,9 +1746,15 @@ module li_calving
          !        floatingBasalMassBal(iCell) = 0.2/31536000.0*tanh((lowerSurface(iCell)-bedTopography(iCell))/75.0) * max(-100-lowerSurface(iCell),0.0)
          !    end if
          !end do
-         ! Temporary change of BMB for MISMIP+ Ice1r
+         ! Temporary change of BMB for the MISMIP+ Ice1r experiment
 
-         source(:) = nstar(:) * (1.0d0-szero(:))*epsmax(:)-floatingBasalMassBal(:)/rhoi/(thickness(:)+1.0e-30)
+         do iCell = 1, nCells
+         if (thickness(iCell) == 0.0_RKIND) then
+             source(iCell) = 0.0_RKIND
+         else
+             source(iCell) = nstar(iCell) * (1.0d0-szero(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
+         endif
+         enddo
 
          seconds = daysSinceStart*24.0*3600.0
 
@@ -1736,9 +1772,15 @@ module li_calving
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
          !damage(:) =  0.5
-         ! temporarily set damage to a constant value, 0.8
+         ! temporarily set damage to a constant value
 
-         damage_nye(:) = (2.0+alpha(:)) * sigmamax(:) / (gravity*(rhoo-rhoi)*thickness(:)+1e-30)
+         do iCell = 1, nCells
+         if (thickness(iCell) == 0.0_RKIND) then
+             damage_nye(iCell) = 0.0_RKIND
+         else
+             damage_nye(iCell) = (2.0+alpha(iCell)) * sigmamax(iCell) / (gravity*(rhoo-rhoi)*thickness(iCell))
+         endif
+         enddo
          !damage_nye(:) = 0.5
          ! temporarily set damage_nye to a constant value, 0.8
 
@@ -1747,6 +1789,7 @@ module li_calving
                 damage_max(iCell) = damage(iCell)
             end if
          end do
+         ! save the damage_max value for restoring (no heal) later if we want
 
          do iCell = 1, nCells
             if (damage(iCell) < 0.0_RKIND) then
@@ -1768,7 +1811,7 @@ module li_calving
          !end do
 
          do iCell = 1, nCells
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then
+            if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (thickness(iCell) .eq. 0.0_RKIND)) then
                 damage(iCell) = 0.0_RKIND
             end if
          end do
@@ -1824,14 +1867,14 @@ module li_calving
 
          call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
          call mpas_deallocate_scratch_field(meanFlowParamAField, .true.)
-         call mpas_deallocate_scratch_field(viscField, .true.)
+         !call mpas_deallocate_scratch_field(viscField, .true.)
          call mpas_deallocate_scratch_field(sigmaxxField, .true.)
          call mpas_deallocate_scratch_field(sigmayyField, .true.)
          call mpas_deallocate_scratch_field(sigmaminField, .true.)
-         call mpas_deallocate_scratch_field(sigmamaxField, .true.)
+         !call mpas_deallocate_scratch_field(sigmamaxField, .true.)
          call mpas_deallocate_scratch_field(alphaField, .true.)
-         call mpas_deallocate_scratch_field(epsmaxField, .true.)
-         call mpas_deallocate_scratch_field(nstarField, .true.)
+         !call mpas_deallocate_scratch_field(epsmaxField, .true.)
+         !call mpas_deallocate_scratch_field(nstarField, .true.)
          !call mpas_deallocate_scratch_field(szeroField, .true.)
          !call mpas_deallocate_scratch_field(sourceField, .true.)
          !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
@@ -1937,7 +1980,7 @@ module li_calving
                 damage(iCell) = damage_max(iCell)
             end if
          end do
-         ! put the damage_max value back to restore the damage value
+         ! put the damage_max value back to restore the damage value (no heal)
 
          where (damage < 0.0_RKIND)
              damage = 0.0_RKIND

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1647,9 +1647,7 @@ module li_calving
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), pointer :: config_sea_level
 
-!SFP: may not be needed if stress calcs moved to vel mod
       real (kind=RKIND), dimension(:), pointer :: thickness 
-
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
@@ -1658,12 +1656,6 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax
       real (kind=RKIND), dimension(:), pointer :: sigmamax, sigmamin, sigmaxx, sigmaxy, sigmayx, sigmayy 
-
-!SFP: need to leave because meanFlowParamA used at end?
-!      real (kind=RKIND), dimension(:,:), pointer :: flowParamA 
-!SFP: may not be needed if stress calcs moved to vel mod
-!      real (kind=RKIND), dimension(:,:), pointer :: temperature 
-
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
@@ -1675,10 +1667,6 @@ module li_calving
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-!SFP: copied to vel mod but left here because used at end
-!      type (field1dReal), pointer :: meanFlowParamAVar 
-!      real, dimension(:), pointer :: meanFlowParamA    
-
       type (field1dReal), pointer :: alphaVar
       real, dimension(:), pointer :: alpha
 
@@ -1688,7 +1676,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
-      integer, pointer :: nCells, nVertLevels    !SFP may not need nvert levels if moving stress calcs to vel mod?
+      integer, pointer :: nCells    
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
@@ -1703,10 +1691,6 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
-
-!SFP: still needed here since meanFlowParamA used at end
-!      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) 
-
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -1724,8 +1708,6 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
          call mpas_pool_get_array(meshPool, 'xCell', xCell)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'daysSinceStart', daysSinceStart)
@@ -1748,16 +1730,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-
-!SFP: need to leave here as meanFlowParamA used at end
-!         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA) 
-
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
-
-!SFP: copied to vel mod but left here because used at the end below
-!         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar) 
-!         call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
-!         meanFlowParamA => meanFlowParamAVar % array
 
          call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
          call mpas_allocate_scratch_field(alphaVar, .true.)
@@ -1771,19 +1744,11 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'sigmamax', sigmamax)
          call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
 
-! SFP: copied to vel module but also needed here because flowParmA is used to calc meanFlowParamA used below
-!         call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
-!         err = ior(err, err_tmp)
-
-! SFP: copied to vel module but also needed here becuase used near end of subroutine
-         ! calculate the depth-averaged flow parameter A
-!         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
-
          where (thickness == 0.0_RKIND)
              alpha = 0.0_RKIND
              s0 = 0.0_RKIND
          elsewhere
-             alpha = sigmamin / sigmamax !SFP: leave here but import sigmas from vel mod
+             alpha = sigmamin / sigmamax 
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
@@ -1816,8 +1781,6 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-!SFP: substituted 'eMax' for internal var 'epsmax' here (allows us to remove / not calc epsmax)
-             !damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
              damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*eMax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
          endif
          enddo
@@ -1938,17 +1901,11 @@ module li_calving
                         realArgs=(/minval(sigmamax), maxval(sigmamax)/))
              call mpas_log_write("damage value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damage), maxval(damage)/))
-!SFP: if not needed here than we can remove 'meanFlowParamA' calcs and use from this entire subroutine
-!             call mpas_log_write("A value range: Min=$r, Max=$r", &
-!                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/)) 
              call mpas_log_write("alpha value range: Min=$r, Max=$r", &
                         realArgs=(/minval(alpha), maxval(alpha)/))
         end if
         ! temporary message output in the log file
 
-
-!SFP: below line still needed since 'meanFlowParamAVar' is used immediately above
-!         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.) 
          call mpas_deallocate_scratch_field(alphaVar, .true.)
 
          block => block % next

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1632,8 +1632,6 @@ module li_calving
       ! local variables
       !-----------------------------------------------------------------
 
-!SFP: note some of these in the next block may be removed 
-!if/when stress calc goes to vel mod
       type (block_type), pointer :: block           
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: thermalPool 
@@ -1644,45 +1642,43 @@ module li_calving
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
-      real(kind=RKIND), pointer :: config_default_flowParamA   !SFP: need to leave because meanFlowParamA used at end?
+      real(kind=RKIND), pointer :: config_default_flowParamA   
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), pointer :: config_sea_level
-      real (kind=RKIND), dimension(:), pointer :: thickness !SFP: may not be needed if stress calcs moved to vel mod
+
+!SFP: may not be needed if stress calcs moved to vel mod
+      real (kind=RKIND), dimension(:), pointer :: thickness 
+
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
-      real (kind=RKIND), dimension(:), pointer :: eMax!, eMin, exx, exy, eyx, eyy !SFP: remove eventually (won't need because sigmas come in directly)
-      real (kind=RKIND), dimension(:), pointer :: sigmamax, sigmamin, sigmaxx, sigmaxy, sigmayx, sigmayy !SFP: added -- these should now come in from vel mod 
-      real (kind=RKIND), dimension(:,:), pointer :: flowParamA !SFP: need to leave because meanFlowParamA used at end?
-      real (kind=RKIND), dimension(:,:), pointer :: temperature !SFP: may not be needed if stress calcs moved to vel mod
+      real (kind=RKIND), dimension(:), pointer :: eMax
+      real (kind=RKIND), dimension(:), pointer :: sigmamax, sigmamin, sigmaxx, sigmaxy, sigmayx, sigmayy 
+
+!SFP: need to leave because meanFlowParamA used at end?
+!      real (kind=RKIND), dimension(:,:), pointer :: flowParamA 
+!SFP: may not be needed if stress calcs moved to vel mod
+!      real (kind=RKIND), dimension(:,:), pointer :: temperature 
+
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
-      real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax !effectiveViscosity, sigmamax !SFP: move some of these to vel mod; epsmax redundant w/ eMax?
+      real (kind=RKIND), dimension(:), pointer :: s0, nstar
       real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damageMax
-!      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor !SFP: not used anymore; moved to vel mod
       real (kind=RKIND), pointer ::  &
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-      type (field1dReal), pointer :: meanFlowParamAVar !SFP: copied to vel mod but left here because used at end 
-      real, dimension(:), pointer :: meanFlowParamA    !SFP: copied to vel mod but left here because used at end
-!      type (field1dReal), pointer :: sigmayxVar
-!      real, dimension(:), pointer :: sigmayx
-!      type (field1dReal), pointer :: sigmaxyVar
-!      real, dimension(:), pointer :: sigmaxy
-!      type (field1dReal), pointer :: sigmaxxVar
-!      real, dimension(:), pointer :: sigmaxx
-!      type (field1dReal), pointer :: sigmayyVar
-!      real, dimension(:), pointer :: sigmayy
-!      type (field1dReal), pointer :: sigmaminVar
-!      real, dimension(:), pointer :: sigmamin
+!SFP: copied to vel mod but left here because used at end
+!      type (field1dReal), pointer :: meanFlowParamAVar 
+!      real, dimension(:), pointer :: meanFlowParamA    
+
       type (field1dReal), pointer :: alphaVar
       real, dimension(:), pointer :: alpha
 
@@ -1707,7 +1703,10 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
-      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) !SFP: still needed here since meanFlowParamA used at end
+
+!SFP: still needed here since meanFlowParamA used at end
+!      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) 
+
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -1736,7 +1735,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness) !SFP: moved to vel mod for stress calc ... still needed?
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness) 
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
@@ -1745,61 +1744,26 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)
          call mpas_pool_get_array(geometryPool, 'nstar', nstar)
-         call mpas_pool_get_array(geometryPool, 'epsmax', epsmax) !SFP: note redundant with eMax from vel mod
-         !call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity) !SFP: no longer needed if use eMax instead of epsmax
-         !call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax) !SFP: now !in vel pool; imported below
          call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
-
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
-         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA) !SFP: need to leave here as meanFlowParamA used at end
-         !call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor) !SFP: move to vel mod
 
-         !call mpas_pool_get_array(thermalPool, 'temperature', temperature) !SFP: not needed if moved to vel mod?
+!SFP: need to leave here as meanFlowParamA used at end
+!         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA) 
 
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         !SFP: copied to vel mod but left here because used at the end below
-         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar) 
-         call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
-         meanFlowParamA => meanFlowParamAVar % array
-
-         !SFP: following 5 can be removed later as these will be imported from
-         !vel mod; need to copy these to vel mod?
-         !call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
-!         call mpas_pool_get_field(scratchPool, 'sigmaxyVar', sigmaxyVar )
-!         call mpas_allocate_scratch_field(sigmaxyVar, .true.)
-!         sigmaxy => sigmaxyVar % array
-
-!         call mpas_pool_get_field(scratchPool, 'sigmayxVar', sigmayxVar )
-!         call mpas_allocate_scratch_field(sigmayxVar, .true.)
-!         sigmayx => sigmayxVar % array
-
-!         call mpas_pool_get_field(scratchPool, 'sigmaxxVar', sigmaxxVar )
-!         call mpas_allocate_scratch_field(sigmaxxVar, .true.)
-!         sigmaxx => sigmaxxVar % array
-
-!         call mpas_pool_get_field(scratchPool, 'sigmayyVar', sigmayyVar )
-!         call mpas_allocate_scratch_field(sigmayyVar, .true.)
-!         sigmayy => sigmayyVar % array
-
-!         call mpas_pool_get_field(scratchPool, 'sigmaminVar', sigmaminVar )
-!         call mpas_allocate_scratch_field(sigmaminVar, .true.)
-!         sigmamin => sigmaminVar % array
+!SFP: copied to vel mod but left here because used at the end below
+!         call mpas_pool_get_field(scratchPool, 'meanFlowParamA',  meanFlowParamAVar) 
+!         call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
+!         meanFlowParamA => meanFlowParamAVar % array
 
          call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
 
-         !SFP: leave this struct here for now but eventually remove
-!         call mpas_pool_get_array(velocityPool, 'exx', exx)
-!         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
-!         call mpas_pool_get_array(velocityPool, 'exy', exy)
-!         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
-         call mpas_pool_get_array(velocityPool, 'eMax', eMax) !SFP: used below (in place of epsmax) 
-!         !call mpas_pool_get_array(velocityPool, 'eMin', eMin) !SFP: not used here as far as I can tell
-
+         call mpas_pool_get_array(velocityPool, 'eMax', eMax) 
          call mpas_pool_get_array(velocityPool, 'sigmaxx', sigmaxx)
          call mpas_pool_get_array(velocityPool, 'sigmayy', sigmayy)
          call mpas_pool_get_array(velocityPool, 'sigmaxy', sigmaxy)
@@ -1808,50 +1772,23 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
 
 ! SFP: copied to vel module but also needed here because flowParmA is used to calc meanFlowParamA used below
-         call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
-         err = ior(err, err_tmp)
+!         call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
+!         err = ior(err, err_tmp)
 
-! SFP: copied to vel module but also needed here becuase used near end of ! subroutine
-         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
+! SFP: copied to vel module but also needed here becuase used near end of subroutine
          ! calculate the depth-averaged flow parameter A
-
-! SFP: moved to vel module
-!         where (thickness == 0.0_RKIND)
-!             effectiveViscosity = 0.0_RKIND
-!         elsewhere
-!             effectiveViscosity = &
-!             0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
-!             exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
-!         endwhere
-         ! recover effective viscosity from vel. and temp. fields
-
-!SFP: moved all stress calcs to vel mod
-!         sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
-!         sigmayx(:) = 2.0_RKIND*effectiveViscosity(:)*(eyx(:)+exy(:))/2.0_RKIND
-
-!         sigmaxx(:) = 2.0_RKIND*effectiveViscosity(:)*exx(:)
-!         sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
-         !deviatoric stress
-
-!         sigmamin(:) = &
-!         (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
-!         sigmamax(:) = &
-!         (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
-         !deviatoric principal stress
+!         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
 
          where (thickness == 0.0_RKIND)
              alpha = 0.0_RKIND
-             epsmax = 0.0_RKIND
              s0 = 0.0_RKIND
          elsewhere
              alpha = sigmamin / sigmamax !SFP: leave here but import sigmas from vel mod
-!             epsmax = sigmamax / (2.0_RKIND*effectiveViscosity) 
-             !SFP: above looks redundant w/ eMax from the vel mod; correct calcs below
-             ! if using 'eMax' instead no longer need to calc. eff. visc. at all in this subroutine
-             epsmax = eMax
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
+
+!SFP: Below here is a lot of commented out code from Tong. Needs cleaning up still?
 
          !alpha(:) = sigmamin(:) / (sigmamax(:))
          !epsmax(:) = sigmamax(:) / (2.0d0*effectiveViscosity(:))
@@ -1879,7 +1816,9 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
+!SFP: substituted 'eMax' for internal var 'epsmax' here (allows us to remove / not calc epsmax)
+             !damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*eMax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/(thickness(iCell))
          endif
          enddo
 
@@ -1999,26 +1938,18 @@ module li_calving
                         realArgs=(/minval(sigmamax), maxval(sigmamax)/))
              call mpas_log_write("damage value range: Min=$r, Max=$r", &
                         realArgs=(/minval(damage), maxval(damage)/))
-             call mpas_log_write("A value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/)) !SFP: note meanFlowParamA used here so still needs to be calc above
+!SFP: if not needed here than we can remove 'meanFlowParamA' calcs and use from this entire subroutine
+!             call mpas_log_write("A value range: Min=$r, Max=$r", &
+!                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/)) 
              call mpas_log_write("alpha value range: Min=$r, Max=$r", &
                         realArgs=(/minval(alpha), maxval(alpha)/))
         end if
         ! temporary message output in the log file
 
 
-         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.) !SFP: still needed here since used immediately above
-         !call mpas_deallocate_scratch_field(sigmaxxVar, .true.)
-         !call mpas_deallocate_scratch_field(sigmayyVar, .true.)
-         !call mpas_deallocate_scratch_field(sigmaminVar, .true.)
-         !call mpas_deallocate_scratch_field(sigmamaxVar, .true.)
+!SFP: below line still needed since 'meanFlowParamAVar' is used immediately above
+!         call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.) 
          call mpas_deallocate_scratch_field(alphaVar, .true.)
-         !call mpas_deallocate_scratch_field(epsmaxVar, .true.)
-         !call mpas_deallocate_scratch_field(nstarVar, .true.)
-         !call mpas_deallocate_scratch_field(s0Var, .true.)
-         !call mpas_deallocate_scratch_field(damageSourceVar, .true.)
-         !call mpas_deallocate_scratch_field(ddamagedtVar, .true.)
-         ! call mpas_deallocate_scratch_field(damageVar, .true.)
 
          block => block % next
              

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -46,7 +46,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front
+   public :: li_calve_ice, li_restore_calving_front, calculate_damage, restore_damage
 
    !--------------------------------------------------------------------
    !
@@ -211,6 +211,11 @@ module li_calving
       elseif (trim(config_calving) == 'eigencalving') then
 
          call eigencalving(domain, err_tmp)
+         err = ior(err, err_tmp)
+
+      elseif (trim(config_calving) == 'damagecalving') then
+
+         call damage_calving(domain, err_tmp)
          err = ior(err, err_tmp)
 
       elseif (trim(config_calving) == 'mask') then
@@ -1181,10 +1186,11 @@ module li_calving
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
-         calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
-               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+         !calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
+         !      * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
-
+         calvingVelocity(:) = config_calving_eigencalving_parameter_scalar_value
+        
 
          ! Convert calvingVelocity to calvingThickness
          call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
@@ -1249,6 +1255,752 @@ module li_calving
 
    end subroutine eigencalving
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine damagecalving
+!
+!> \brief Calve ice from the calving front based on the Bassis-Ma (2015) damage theory 
+!> \author Tong Zhang
+!> \date   May. 2019
+!> \details Calving using damage model
+!> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing." 
+!> Earth and Planetary Science Letters 409 (2015): 203-211.
+! TODO need to properly connect damage tracer to calving flux
+
+!-----------------------------------------------------------------------
+   subroutine damage_calving(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: &
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: scratchPool
+      logical, pointer :: config_print_calving_info
+      real (kind=RKIND), pointer :: config_sea_level
+      real(kind=RKIND), pointer :: config_calving_thickness
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), dimension(:), pointer :: eMax, eMin
+      real (kind=RKIND), dimension(:), pointer :: damage
+      integer, dimension(:), pointer :: cellMask
+      type (field1dInteger), pointer :: calvingFrontMaskField
+      integer, dimension(:), pointer :: calvingFrontMask
+      real (kind=RKIND), pointer :: deltat  !< time step (s)
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      integer, pointer :: nCells
+      integer :: iCell, jCell, iNeighbor
+      real(kind=RKIND) :: cellCalvingFrontLength, cellCalvingFrontHeight
+      integer :: err_tmp
+      logical :: dynamicNeighbor
+      real(kind=RKIND), pointer :: config_damagecalvingParameter
+      real(kind=RKIND) :: calvingSubtotal
+
+      err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
+      call mpas_pool_get_config(liConfigs, 'config_damagecalvingParameter', config_damagecalvingParameter)
+
+      ! block loop
+      block => domain % blocklist
+      do while (associated(block))
+
+         ! get pools
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+
+         ! get fields
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_array(meshPool, 'deltat', deltat)
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'damage', damage)
+         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+
+         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
+         call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
+         calvingFrontMask => calvingFrontMaskField % array
+
+         !call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+
+         calvingVelocity(:) = 0.0_RKIND
+         ! First calculate the front retreat rate (Levermann eq. 1)
+         calvingVelocity(:) = config_damagecalvingParameter * damage(:) & ! m/s
+               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+                  ! calculate only for floating ice - map of "potential" calving rate
+
+         !call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
+         call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+
+         ! === apply calving ===
+         thickness(:) = thickness(:) - calvingThickness(:)
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         do iCell = 1, nCells
+            if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
+               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               thickness(iCell) = 0.0_RKIND
+            endif
+         enddo
+
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
+         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
+         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
+         calvingSubtotal = 0.0_RKIND
+         do iCell = 1, nCells
+           if (li_mask_is_floating_ice(cellMask(iCell))) then
+              ! check neighbors for dynamic ice (floating or grounded)
+              dynamicNeighbor = .false.
+              do iNeighbor = 1, nEdgesOnCell(iCell)
+                 jCell = cellsOnCell(iNeighbor, iCell)
+                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
+              enddo
+              if (.not. dynamicNeighbor) then  ! calve this ice
+                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+                 thickness(iCell) = 0.0_RKIND
+                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
+              endif
+           endif
+         enddo
+         ! TODO: global reduce & reporting on amount of calving generated in this step
+
+         call remove_small_islands(meshPool, geometryPool)
+
+         block => block % next
+
+      enddo
+
+   end subroutine damage_calving
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine calculate_damage
+!
+!> \author Tong Zhang
+!> \date   May. 2019
+!> \details calulate the damage tracer 
+!> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing." 
+!> Earth and Planetary Science Letters 409 (2015): 203-211.
+
+!-----------------------------------------------------------------------
+
+   subroutine calculate_damage(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: &
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: thermalPool 
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: scratchPool
+      real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
+      real(kind=RKIND), pointer :: config_damage_restore_threshold, config_damage_calving_threshold
+      logical, pointer :: config_use_constant_A
+      real(kind=RKIND), pointer :: config_default_flowParamA 
+      character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
+      logical, pointer :: config_print_calving_info
+      real (kind=RKIND), pointer :: config_sea_level
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: lowerSurface
+      real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), dimension(:), pointer :: eMax, eMin, exx, exy, eyx, eyy
+      real (kind=RKIND), dimension(:,:), pointer :: flowParamA
+      real (kind=RKIND), dimension(:,:), pointer :: temperature
+      real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
+      real (kind=RKIND), dimension(:), pointer :: damage
+      real (kind=RKIND), dimension(:), pointer :: ddamagedt
+      real (kind=RKIND), dimension(:), pointer :: szero
+      real (kind=RKIND), dimension(:), pointer :: source
+      real (kind=RKIND), dimension(:), pointer :: damage_nye
+      real (kind=RKIND), dimension(:), pointer :: damage_max
+      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
+      real (kind=RKIND), pointer ::  &
+           config_ice_density,            & ! ice density
+           config_ocean_density             ! ocean density
+
+      real (kind=RKIND), save :: rhoi    ! ice density (kg m^{-3}), copied from config_ice_density
+      real (kind=RKIND), save :: rhoo    ! ocean density (kg m^{-3}), copied from config_ocean_density
+
+      type (field1dReal), pointer :: meanFlowParamAField
+      real, dimension(:), pointer :: meanFlowParamA
+      type (field1dReal), pointer :: viscField
+      real, dimension(:), pointer :: visc
+      type (field1dReal), pointer :: sigmayxField
+      real, dimension(:), pointer :: sigmayx
+      type (field1dReal), pointer :: sigmaxyField
+      real, dimension(:), pointer :: sigmaxy
+      type (field1dReal), pointer :: sigmaxxField
+      real, dimension(:), pointer :: sigmaxx
+      type (field1dReal), pointer :: sigmayyField
+      real, dimension(:), pointer :: sigmayy
+      type (field1dReal), pointer :: sigmaminField
+      real, dimension(:), pointer :: sigmamin
+      type (field1dReal), pointer :: sigmamaxField
+      real, dimension(:), pointer :: sigmamax
+      type (field1dReal), pointer :: alphaField
+      real, dimension(:), pointer :: alpha
+      type (field1dReal), pointer :: epsmaxField
+      real, dimension(:), pointer :: epsmax
+      type (field1dReal), pointer :: nstarField
+      real, dimension(:), pointer :: nstar
+      !type (field1dReal), pointer :: szeroField
+      !real, dimension(:), pointer :: szero
+      !type (field1dReal), pointer :: sourceField
+      !real, dimension(:), pointer :: source
+      !type (field1dReal), pointer :: ddamagedtField
+      !real, dimension(:), pointer :: ddamagedt
+      type (field1dReal), pointer :: forceField
+      real, dimension(:), pointer :: force
+      type (field1dReal), pointer :: meanTField
+      real, dimension(:), pointer :: meanT
+
+      integer, dimension(:), pointer :: cellMask
+      type (field1dInteger), pointer :: calvingFrontMaskField
+      integer, dimension(:), pointer :: calvingFrontMask
+      real (kind=RKIND), pointer :: deltat, daysSinceStart !< time step (s)
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell
+      real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
+      integer, pointer :: nCells, nVertLevels
+      integer :: iCell, jCell, iNeighbor, n_damage_downstream
+      real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
+      real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
+      character (len=StrKIND), pointer :: xtime
+      integer :: err_tmp, loc
+
+      err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
+      call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_scalar_value', &
+               config_calving_eigencalving_parameter_scalar_value)
+      call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', config_calving_eigencalving_parameter_source)
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_damage_restore_threshold', config_damage_restore_threshold)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
+      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
+      call mpas_pool_get_config(liConfigs, 'config_use_constant_A', config_use_constant_A)
+
+      ! block loop
+      block => domain % blocklist
+      do while (associated(block))
+
+         ! get pools
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+
+         ! get fields
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+         call mpas_pool_get_array(meshPool, 'xCell', xCell)
+         call mpas_pool_get_array(meshPool, 'deltat', deltat)
+         call mpas_pool_get_array(meshPool, 'daysSinceStart', daysSinceStart)
+         call mpas_pool_get_array(meshPool, 'xtime', xtime)
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
+         call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
+         call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
+         call mpas_pool_get_array(geometryPool, 'damage', damage)
+         call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
+         call mpas_pool_get_array(geometryPool, 'szero', szero)
+         call mpas_pool_get_array(geometryPool, 'source', source)
+         call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
+         call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
+
+         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+         call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
+         call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
+         call mpas_pool_get_array(velocityPool, 'eMax', eMax)
+         call mpas_pool_get_array(velocityPool, 'eMin', eMin)
+         call mpas_pool_get_array(velocityPool, 'exx', exx)
+         call mpas_pool_get_array(velocityPool, 'exy', exy)
+         call mpas_pool_get_array(velocityPool, 'eyx', eyx)
+         call mpas_pool_get_array(velocityPool, 'eyy', eyy)
+         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
+         call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
+
+         call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+
+         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+
+         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
+         call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
+         calvingFrontMask => calvingFrontMaskField % array
+
+         call mpas_pool_get_field(scratchPool, 'meanFlowParamAField',  meanFlowParamAField)
+         call mpas_allocate_scratch_field(meanFlowParamAField, .true.)
+         meanFlowParamA => meanFlowParamAField % array
+
+         call mpas_pool_get_field(scratchPool, 'viscField',  viscField)
+         call mpas_allocate_scratch_field(viscField, .true.)
+         visc => viscField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmaxyField', sigmaxyField )
+         call mpas_allocate_scratch_field(sigmaxyField, .true.)
+         sigmaxy => sigmaxyField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmayxField', sigmayxField )
+         call mpas_allocate_scratch_field(sigmayxField, .true.)
+         sigmayx => sigmayxField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmaxxField', sigmaxxField )
+         call mpas_allocate_scratch_field(sigmaxxField, .true.)
+         sigmaxx => sigmaxxField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmayyField', sigmayyField )
+         call mpas_allocate_scratch_field(sigmayyField, .true.)
+         sigmayy => sigmayyField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmaminField', sigmaminField )
+         call mpas_allocate_scratch_field(sigmaminField, .true.)
+         sigmamin => sigmaminField % array
+
+         call mpas_pool_get_field(scratchPool, 'sigmamaxField', sigmamaxField )
+         call mpas_allocate_scratch_field(sigmamaxField, .true.)
+         sigmamax => sigmamaxField % array
+
+         call mpas_pool_get_field(scratchPool, 'alphaField', alphaField )
+         call mpas_allocate_scratch_field(alphaField, .true.)
+         alpha => alphaField % array
+
+         call mpas_pool_get_field(scratchPool, 'epsmaxField', epsmaxField )
+         call mpas_allocate_scratch_field(epsmaxField, .true.)
+         epsmax => epsmaxField % array
+
+         call mpas_pool_get_field(scratchPool, 'nstarField', nstarField )
+         call mpas_allocate_scratch_field(nstarField, .true.)
+         nstar => nstarField % array
+
+         !call mpas_pool_get_field(scratchPool, 'szeroField', szeroField )
+         !call mpas_allocate_scratch_field(szeroField, .true.)
+         !szero => szeroField % array
+
+         !call mpas_pool_get_field(scratchPool, 'sourceField', sourceField )
+         !call mpas_allocate_scratch_field(sourceField, .true.)
+         !source => sourceField % array
+
+         !call mpas_pool_get_field(scratchPool, 'ddamagedtField', ddamagedtField )
+         !call mpas_allocate_scratch_field(ddamagedtField, .true.)
+         !ddamagedt => ddamagedtField % array
+
+         call mpas_pool_get_field(scratchPool, 'forceField', forceField )
+         call mpas_allocate_scratch_field(forceField, .true.)
+         force => forceField % array
+
+         call mpas_pool_get_field(scratchPool, 'meanTField', meanTField )
+         call mpas_allocate_scratch_field(meanTField, .true.)
+         meanT => meanTField % array
+
+         call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
+         call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
+         rhoi = config_ice_density
+         rhoo = config_ocean_density
+
+         meanT(:) = sum(temperature(:,:), dim=1)/nVertLevels
+
+         call li_compute_gradient_2d(meshPool, uReconstructX(1,:), exx, exy, err_tmp)
+         err = ior(err, err_tmp)
+
+         call li_compute_gradient_2d(meshPool, uReconstructY(1,:), eyx, eyy, err_tmp)
+         err = ior(err, err_tmp)
+
+         call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
+         err = ior(err, err_tmp)
+
+
+         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/nVertLevels
+         call mpas_log_write("meanFlowParamA: Min=$r, Max=$r", &
+                    realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
+         if (config_use_constant_A) then
+             visc(:) = 0.5*stiffnessFactor(:)*config_default_flowParamA**(-1.0/3.0)*(sqrt(exx(:)**2+eyy(:)**2 + exx(:)*eyy(:) + 0.25*(exy(:)+eyx(:))**2+1.0e-30))**((1.0-3.0)/3.0)
+         else
+             visc(:) = 0.5*stiffnessFactor(:)*meanFlowParamA(:)**(-1.0/3.0)*(sqrt(exx(:)**2+eyy(:)**2 + exx(:)*eyy(:) + 0.25*(exy(:)+eyx(:))**2))**((1.0-3.0)/3.0)
+         end if
+         ! recover effective viscosity from vel. and temp. fields
+
+         sigmaxy(:) = 2*visc(:)*(exy(:)+eyx(:))/2.0
+         sigmayx(:) = 2*visc(:)*(eyx(:)+exy(:))/2.0
+
+         sigmaxx(:) = 2*visc(:)*exx(:)
+         sigmayy(:) = 2*visc(:)*eyy(:)
+         !deviatoric stress
+
+         sigmamin(:) = (sigmaxx(:)+sigmayy(:))/2.0-sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2 + 1.0e-30)
+         sigmamax(:) = (sigmaxx(:)+sigmayy(:))/2.0+sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2 + 1.0e-30)
+         !deviatoric principal stress
+
+         alpha(:) = sigmamin(:) / (sigmamax(:)+1.0e-30)
+         epsmax(:) = sigmamax(:) / (2.0d0*visc(:)+1.0e-30)
+
+         nstar(:) = 12.0d0*(1.0d0+alpha(:)+alpha(:)**2)/(4.0d0*(1.0d0+alpha(:)+alpha(:)**2)+6.0d0*alpha(:)**2+1.0e-30) 
+          ! Compute the effective flow law exponent
+
+         szero(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo+1.0e-30)
+          ! Compute the hydrostatic to tensile stress ratio
+
+         !do iCell = 1, nCells
+         !    if (li_mask_is_floating_ice(cellMask(iCell))) then
+         !        floatingBasalMassBal(iCell) = 0.2/31536000.0*tanh((lowerSurface(iCell)-bedTopography(iCell))/75.0) * max(-100-lowerSurface(iCell),0.0)
+         !    end if
+         !end do
+         ! Temporary change of BMB for MISMIP+ Ice1r
+
+         source(:) = nstar(:) * (1.0d0-szero(:))*epsmax(:)-floatingBasalMassBal(:)/rhoi/(thickness(:)+1.0e-30)
+
+         seconds = daysSinceStart*24.0*3600.0
+
+         ! below is the force for the manufacured experiments
+         !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         !    source(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
+         !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         !    source(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
+
+         ! set force to zero if not manufactured
+         force(:) = 0.0
+
+         ddamagedt(:) = source(:) * damage(:) + force(:)
+
+         damage(:) = damage(:) + ddamagedt(:) * deltat
+
+         !damage(:) =  0.5
+         ! temporarily set damage to a constant value, 0.8
+
+         damage_nye(:) = (2.0+alpha(:)) * sigmamax(:) / (gravity*(rhoo-rhoi)*thickness(:)+1e-30)
+         !damage_nye(:) = 0.5
+         ! temporarily set damage_nye to a constant value, 0.8
+
+         do iCell = 1, nCells
+            if (damage(iCell) > config_damage_restore_threshold) then
+                damage_max(iCell) = damage(iCell)
+            end if
+         end do
+
+         do iCell = 1, nCells
+            if (damage(iCell) < 0.0_RKIND) then
+                damage(iCell) = 0.0_RKIND
+            end if
+            if (damage(iCell) < damage_nye(iCell)) then
+                damage(iCell) = damage_nye(iCell)
+            end if
+            if (damage(iCell) > 1.0_RKIND) then
+                damage(iCell) = 1.0_RKIND
+            end if
+         end do
+
+
+         !do iCell = 1, nCells
+         !   if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (.not.(li_mask_is_dynamic_ice(cellMask(iCell))))) then
+         !       damage(iCell) = 0.0_RKIND
+         !   end if
+         !end do
+
+         do iCell = 1, nCells
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                damage(iCell) = 0.0_RKIND
+            end if
+         end do
+
+         do iCell = 1, nCells
+            if (li_mask_is_grounding_line(cellMask(iCell))) then
+                
+                damage_downstream = 0.0_RKIND
+                n_damage_downstream = 0
+                do iNeighbor = 1, nEdgesOnCell(iCell)
+                    jCell = cellsOnCell(iNeighbor, iCell)
+                    if (li_mask_is_floating_ice(cellMask(jCell))) then
+                       
+                        damage_downstream = damage_downstream + damage(jCell)
+                        n_damage_downstream =  n_damage_downstream + 1
+                    end if
+                end do
+
+                damage(iCell) = damage_downstream
+
+                if (n_damage_downstream == 0) then
+                    damage(iCell) = 0.0_RKIND
+                else
+                    damage(iCell) = damage_downstream / n_damage_downstream
+                end if
+
+            end if
+        end do
+        ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
+                        
+
+        if (.true.) then
+
+             call mpas_log_write("source value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(source), maxval(source)/))
+             call mpas_log_write("szero  value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(szero), maxval(szero)/))
+             call mpas_log_write("nstar value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(nstar), maxval(nstar)/))
+             call mpas_log_write("deltat value range: Min=$r, Max=$r", &
+                        realArgs=(/deltat, deltat/))
+             call mpas_log_write("sigmamax value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(sigmamax), maxval(sigmamax)/))
+             call mpas_log_write("damage value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(damage), maxval(damage)/))
+             call mpas_log_write("A value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
+             call mpas_log_write("alpha value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(alpha), maxval(alpha)/))
+        end if
+        ! temporary message output in the log file
+
+
+         call mpas_deallocate_scratch_field(calvingFrontMaskField, .true.)
+         call mpas_deallocate_scratch_field(meanFlowParamAField, .true.)
+         call mpas_deallocate_scratch_field(viscField, .true.)
+         call mpas_deallocate_scratch_field(sigmaxxField, .true.)
+         call mpas_deallocate_scratch_field(sigmayyField, .true.)
+         call mpas_deallocate_scratch_field(sigmaminField, .true.)
+         call mpas_deallocate_scratch_field(sigmamaxField, .true.)
+         call mpas_deallocate_scratch_field(alphaField, .true.)
+         call mpas_deallocate_scratch_field(epsmaxField, .true.)
+         call mpas_deallocate_scratch_field(nstarField, .true.)
+         !call mpas_deallocate_scratch_field(szeroField, .true.)
+         !call mpas_deallocate_scratch_field(sourceField, .true.)
+         !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
+         call mpas_deallocate_scratch_field(forceField, .true.)
+         call mpas_deallocate_scratch_field(meanTField, .true.)
+         ! call mpas_deallocate_scratch_field(damageField, .true.)
+
+         block => block % next
+             
+      enddo
+
+   end subroutine calculate_damage 
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine restore_damage
+!
+!> \author Tong Zhang
+!> \date   Oct. 2019
+!> \details restore the damage to the original value before advection if it exceeds some large number
+!-----------------------------------------------------------------------
+
+   subroutine restore_damage(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: &
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: scratchPool
+      real(kind=RKIND), pointer :: config_damage_stiffness_min
+      logical, pointer :: config_damage_rheology_coupling
+      logical, pointer :: config_print_calving_info
+      real (kind=RKIND), dimension(:), pointer :: damage
+      real (kind=RKIND), dimension(:), pointer :: damage_max
+      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
+      real (kind=RKIND), pointer ::  &
+           config_ice_density,            & ! ice density
+           config_ocean_density             ! ocean density
+
+      real (kind=RKIND), save :: rhoi    ! ice density (kg m^{-3}), copied from config_ice_density
+      real (kind=RKIND), save :: rhoo    ! ocean density (kg m^{-3}), copied from config_ocean_density
+
+      integer, dimension(:), pointer :: cellMask
+      type (field1dInteger), pointer :: calvingFrontMaskField
+      integer, dimension(:), pointer :: calvingFrontMask
+      integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
+      integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
+      integer, dimension(:,:), pointer :: edgesOnCell
+      real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
+      integer, pointer :: nCells, nVertLevels
+      integer :: iCell, jCell, iNeighbor, n_damage_downstream
+      real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds
+      integer :: err_tmp, loc
+
+      err = 0
+
+
+      call mpas_pool_get_config(liConfigs, 'config_damage_stiffness_min', config_damage_stiffness_min)
+      call mpas_pool_get_config(liConfigs, 'config_damage_rheology_coupling', config_damage_rheology_coupling)
+
+      ! block loop
+      block => domain % blocklist
+      do while (associated(block))
+
+         ! get pools
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+
+         ! get fields
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'damage', damage)
+         call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
+         call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
+
+
+         do iCell = 1, nCells
+            if (damage(iCell) < damage_max(iCell)) then
+                damage(iCell) = damage_max(iCell)
+            end if
+         end do
+         ! put the damage_max value back to restore the damage value
+
+         where (damage < 0.0_RKIND)
+             damage = 0.0_RKIND
+         end where
+
+         where (damage > 1.0_RKIND)
+             damage = 1.0_RKIND
+         end where
+
+
+         !do iCell = 1, nCells
+         !   if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (.not.(li_mask_is_dynamic_ice(cellMask(iCell))))) then
+         !       damage(iCell) = 0.0_RKIND
+         !   end if
+         !end do
+
+         do iCell = 1, nCells
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                damage(iCell) = 0.0_RKIND
+            end if
+         end do
+
+         do iCell = 1, nCells
+            if (li_mask_is_grounding_line(cellMask(iCell))) then
+                damage_downstream = 0.0_RKIND
+                n_damage_downstream = 0
+                do iNeighbor = 1, nEdgesOnCell(iCell)
+                    jCell = cellsOnCell(iNeighbor, iCell)
+                    if (li_mask_is_floating_ice(cellMask(jCell))) then
+                        
+                        damage_downstream = damage_downstream + damage(jCell)
+                        n_damage_downstream =  n_damage_downstream + 1
+                    end if
+                end do
+
+                damage(iCell) = damage_downstream
+
+                if (n_damage_downstream == 0) then
+                    damage(iCell) = 0.0_RKIND
+                else
+                    damage(iCell) = damage_downstream / n_damage_downstream
+                end if
+
+            end if
+        end do
+
+        if (config_damage_rheology_coupling) then
+            do iCell = 1, nCells
+                if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell))) then
+                    stiffnessFactor(iCell) = 1.0_RKIND - damage(iCell)
+                    if (stiffnessFactor(iCell) < config_damage_stiffness_min) then
+                        stiffnessFactor(iCell) = config_damage_stiffness_min
+                    end if
+                end if
+            end do
+        end if
+
+
+         block => block % next
+             
+      enddo
+
+   end subroutine restore_damage 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1657,8 +1657,7 @@ module li_calving
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-      type (field1dReal), pointer :: alphaVar
-      real, dimension(:), pointer :: alpha
+      real, dimension(:), pointer :: principalStrainRateRatio
 
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltat !< time step (s)
@@ -1706,29 +1705,29 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
-         call mpas_allocate_scratch_field(alphaVar, .true.)
-         alpha => alphaVar % array
-
          call mpas_pool_get_array(velocityPool, 'eMax', eMax)
          call mpas_pool_get_array(velocityPool, 'tauMax', tauMax)
          call mpas_pool_get_array(velocityPool, 'tauMin', tauMin)
+         call mpas_pool_get_array(velocityPool, 'principalStrainRateRatio', principalStrainRateRatio)
 
          where (thickness == 0.0_RKIND)
-             alpha = 0.0_RKIND
+             principalStrainRateRatio = 0.0_RKIND
              s0 = 0.0_RKIND
              nstar = 0.0_RKIND
          elsewhere
              ! Compute the hydrostatic to tensile stress ratio (equation 24 from Bassis and Ma, 2015, EPSL, 409, C)
-             alpha = tauMin / tauMax
+             ! In Bassis & Ma this is beta, defined as ratio of principal strain rates.  Here we calculate as ratio of
+             ! deviatoric stresses, which is equivalent.
+             principalStrainRateRatio = tauMin / tauMax
 
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*tauMax*config_ocean_density)
 
              ! Compute the effective flow law exponent (equation 11 from Bassis and Ma, 2015, EPSL, 409, C)
-             nstar(:) = 4.0_RKIND * config_flowLawExponent * (1.0_RKIND + alpha(:) + alpha(:)**2) / &
-                     (4.0_RKIND * (1.0_RKIND + alpha(:) + alpha(:)**2) + &
-                      3.0_RKIND * (config_flowLawExponent - 1.0_RKIND )* alpha(:)**2)
+             nstar(:) = 4.0_RKIND * config_flowLawExponent * &
+                     (1.0_RKIND + principalStrainRateRatio(:) + principalStrainRateRatio(:)**2) / &
+                     (4.0_RKIND * (1.0_RKIND + principalStrainRateRatio(:) + principalStrainRateRatio(:)**2) + &
+                      3.0_RKIND * (config_flowLawExponent - 1.0_RKIND )* principalStrainRateRatio(:)**2)
          endwhere
 
 
@@ -1757,7 +1756,8 @@ module li_calving
              if (thickness(iCell) == 0.0_RKIND) then
                  damageNye(iCell) = 0.0_RKIND
              else
-                 damageNye(iCell) = (2.0+alpha(iCell)) * tauMax(iCell) / (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
+                 damageNye(iCell) = (2.0+principalStrainRateRatio(iCell)) * tauMax(iCell) / &
+                         (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
              endif
          enddo
 
@@ -1838,8 +1838,8 @@ module li_calving
            localMaxInfo(2) = maxval(s0)
            localMinInfo(3) = minval(nstar)
            localMaxInfo(3) = maxval(nstar)
-           localMinInfo(4) = minval(alpha)
-           localMaxInfo(4) = maxval(alpha)
+           localMinInfo(4) = minval(principalStrainRateRatio)
+           localMaxInfo(4) = maxval(principalStrainRateRatio)
            localMinInfo(5) = minval(tauMax)
            localMaxInfo(5) = maxval(tauMax)
            localMinInfo(6) = minval(damage)
@@ -1854,7 +1854,7 @@ module li_calving
                         realArgs=(/globalMinInfo(2), globalMaxInfo(2)/))
            call mpas_log_write("nstar value range: Min=$r, Max=$r", &
                         realArgs=(/globalMinInfo(3), globalMaxInfo(3)/))
-           call mpas_log_write("alpha value range: Min=$r, Max=$r", &
+           call mpas_log_write("principalStrainRateRatio value range: Min=$r, Max=$r", &
                         realArgs=(/globalMinInfo(4), globalMaxInfo(4)/))
            call mpas_log_write("tauMax value range: Min=$r, Max=$r", &
                         realArgs=(/globalMinInfo(5), globalMaxInfo(5)/))
@@ -1863,7 +1863,6 @@ module li_calving
         end if
         ! temporary message output in the log file
 
-         call mpas_deallocate_scratch_field(alphaVar, .true.)
 
          block => block % next
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1185,7 +1185,7 @@ module li_calving
          err = ior(err, err_tmp)
 
          calvingVelocity(:) = 0.0_RKIND
-         ! First calculate the front retreat rate (Levermann eq. 1)
+         ! First calculate the front retreat rate
          !calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) & ! m/s
          !      * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
@@ -1751,27 +1751,9 @@ module li_calving
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*tauMax*config_ocean_density)
          endwhere
 
-         !alpha(:) = tauMin(:) / (tauMax(:))
-         !epsmax(:) = tauMax(:) / (2.0d0*effectiveViscosity(:))
-         !s0(:) =
-         !config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness(:)/(2.0d0*tauMax(:)*config_ocean_density)
-          ! Compute the hydrostatic to tensile stress ratio
-          ! These commented lines are doing the same thing as the above where loop. Which is better?
-
          nstar(:) = &
          12.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)+6.0_RKIND*alpha(:)**2.0_RKIND) 
-          ! Compute the effective flow law exponent
-
-         !s0(:) =
-         !config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness(:)/(2.0d0*tauMax(:)*config_ocean_density)
-          ! Compute the hydrostatic to tensile stress ratio
-
-         !do iCell = 1, nCells
-         !    if (li_mask_is_floating_ice(cellMask(iCell))) then
-         !        floatingBasalMassBal(iCell) = 0.2/31536000.0*tanh((lowerSurface(iCell)-bedTopography(iCell))/75.0) * max(-100-lowerSurface(iCell),0.0)
-         !    end if
-         !end do
-         ! Temporary change of BMB for the MISMIP+ Ice1r experiment
+         ! Compute the effective flow law exponent
 
          do iCell = 1, nCells
          if (thickness(iCell) == 0.0_RKIND) then
@@ -1781,9 +1763,7 @@ module li_calving
          endif
          enddo
 
-         !seconds = daysSinceStart*24.0*3600.0
-
-         ! below is the cases for the manufacured experiments
+         !! Commented out lines immediately below here are for use with manufacured experiments
          !ddamagedt(:) = damageSource(:)*damage(:) - 0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
          !ddamagedt(:) = damageSource(:)*damage(:) - 0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
@@ -1793,9 +1773,6 @@ module li_calving
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
-         !damage(:) =  0.5
-         ! temporarily set damage to a constant value
-
          do iCell = 1, nCells
              if (thickness(iCell) == 0.0_RKIND) then
                  damage_nye(iCell) = 0.0_RKIND
@@ -1803,15 +1780,13 @@ module li_calving
                  damage_nye(iCell) = (2.0+alpha(iCell)) * tauMax(iCell) / (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
              endif
          enddo
-         !damage_nye(:) = 0.5
-         ! temporarily set damage_nye to a constant value, 0.8
 
          do iCell = 1, nCells
             if (damage(iCell) > config_damage_preserve_threshold) then
                 damageMax(iCell) = damage(iCell)
             end if
          end do
-         ! save the damageMax value for restoring (no heal) later if we want
+         ! save the damageMax value for restoring later if that option is chosen (i.e., do NOT allowing for healing to occur)
 
          do iCell = 1, nCells
             if (damage(iCell) < 0.0_RKIND) then
@@ -1826,47 +1801,39 @@ module li_calving
          end do
          ! damage is always larger than the Nye value for initialization of damage evolution.
 
-
-         !do iCell = 1, nCells
-         !   if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (.not.(li_mask_is_dynamic_ice(cellMask(iCell))))) then
-         !       damage(iCell) = 0.0_RKIND
-         !   end if
-         !end do
-
          do iCell = 1, nCells
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (thickness(iCell) .eq. 0.0_RKIND)) then
                 damage(iCell) = 0.0_RKIND
             end if
          end do
-         ! the damage of grouned ice is kept as 0, 
-         ! as the strain rate calculation is only valid for ice shelf
+         ! the damage of grouneded ice is kept as 0, as the strain rate calculation is only valid for ice shelf
 
-         if (trim(config_damage_gl_setting) == 'extrapolate') then
-             do iCell = 1, nCells
-                if (li_mask_is_grounding_line(cellMask(iCell))) then
-                    
-                    damage_downstream = 0.0_RKIND
-                    n_damage_downstream = 0
-                    do iNeighbor = 1, nEdgesOnCell(iCell)
-                        jCell = cellsOnCell(iNeighbor, iCell)
-                        if (li_mask_is_floating_ice(cellMask(jCell))) then
-                           
-                            damage_downstream = damage_downstream + damage(jCell)
-                            n_damage_downstream =  n_damage_downstream + 1
-                        end if
-                    end do
+        if (trim(config_damage_gl_setting) == 'extrapolate') then
+           do iCell = 1, nCells
+              if (li_mask_is_grounding_line(cellMask(iCell))) then
+                  
+                  damage_downstream = 0.0_RKIND
+                  n_damage_downstream = 0
+                  do iNeighbor = 1, nEdgesOnCell(iCell)
+                      jCell = cellsOnCell(iNeighbor, iCell)
+                      if (li_mask_is_floating_ice(cellMask(jCell))) then
+                         
+                          damage_downstream = damage_downstream + damage(jCell)
+                          n_damage_downstream =  n_damage_downstream + 1
+                      end if
+                  end do
 
-                    damage(iCell) = damage_downstream
+                  damage(iCell) = damage_downstream
 
-                    if (n_damage_downstream == 0) then
-                        damage(iCell) = 0.0_RKIND
-                    else
-                        damage(iCell) = damage_downstream / n_damage_downstream
-                    end if
+                  if (n_damage_downstream == 0) then
+                      damage(iCell) = 0.0_RKIND
+                  else
+                      damage(iCell) = damage_downstream / n_damage_downstream
+                  end if
 
-                end if
-            end do
-            ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
+              end if
+           end do
+           ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
 
         elseif (trim(config_damage_gl_setting) == "nye") then
                         
@@ -2078,7 +2045,7 @@ module li_calving
         end if
 
 
-         block => block % next
+        block => block % next
              
       enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1681,6 +1681,7 @@ module li_calving
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
+      real(kind=RKIND), dimension(6) :: localMinInfo, localMaxInfo, globalMinInfo, globalMaxInfo
       integer :: err_tmp, loc
 
       err = 0
@@ -1860,21 +1861,35 @@ module li_calving
         ! always set the damage at the first floating cells to the Nye value
 
         if (.true.) then
+           ! End of routine accounting/reporting
+           localMinInfo(1) = minval(damageSource)
+           localMaxInfo(1) = maxval(damageSource)
+           localMinInfo(2) = minval(s0)
+           localMaxInfo(2) = maxval(s0)
+           localMinInfo(3) = minval(nstar)
+           localMaxInfo(3) = maxval(nstar)
+           localMinInfo(4) = minval(alpha)
+           localMaxInfo(4) = maxval(alpha)
+           localMinInfo(5) = minval(tauMax)
+           localMaxInfo(5) = maxval(tauMax)
+           localMinInfo(6) = minval(damage)
+           localMaxInfo(6) = maxval(damage)
+           ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+           call mpas_dmpar_min_real_array(domain % dminfo, 6, localMinInfo, globalMinInfo)
+           call mpas_dmpar_max_real_array(domain % dminfo, 6, localMaxInfo, globalMaxInfo)
 
-             call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(damageSource), maxval(damageSource)/))
-             call mpas_log_write("s0 value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(s0), maxval(s0)/))
-             call mpas_log_write("nstar value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(nstar), maxval(nstar)/))
-             call mpas_log_write("deltat value range: Min=$r, Max=$r", &
-                        realArgs=(/deltat, deltat/))
-             call mpas_log_write("tauMax value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(tauMax), maxval(tauMax)/))
-             call mpas_log_write("damage value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(damage), maxval(damage)/))
-             call mpas_log_write("alpha value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(alpha), maxval(alpha)/))
+           call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(1), globalMaxInfo(1)/))
+           call mpas_log_write("s0 value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(2), globalMaxInfo(2)/))
+           call mpas_log_write("nstar value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(3), globalMaxInfo(3)/))
+           call mpas_log_write("alpha value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(4), globalMaxInfo(4)/))
+           call mpas_log_write("tauMax value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(5), globalMaxInfo(5)/))
+           call mpas_log_write("damage value range: Min=$r, Max=$r", &
+                        realArgs=(/globalMinInfo(6), globalMaxInfo(6)/))
         end if
         ! temporary message output in the log file
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1261,9 +1261,9 @@ module li_calving
 !> \brief use a specified calving velocity given by input data
 !> \author Matthew Hoffman
 !> \date   Feb. 2018
-!> \details we can specify the calving velocity by i) a constant value 
+!> \details we can specify the calving velocity by i) a constant value
 !> given by config_calving_velocity_const in namelist and ii) source data
-!> speficied by input netCDF data (e.g., landice_grid.nc)
+!> specified by calvingVelocityData
 !-----------------------------------------------------------------------
    subroutine specified_calving_velocity(domain, err)
 
@@ -1352,13 +1352,13 @@ module li_calving
          elseif (trim(config_calving_specified_source) == 'data') then
              calvingVelocity = calvingVelocityData
          else
-            err = 1
+            err = ior(err, 1)
             call mpas_log_write("Invalid value specified for option config_calving_specified_source" // &
                   config_calving_specified_source, MPAS_LOG_ERR)
          endif
 
          if (config_print_calving_info) then
-            call mpas_log_write("calvingVelocity(m s) value range: Min=$r, Max=$r", &
+            call mpas_log_write("calvingVelocity(m s) value range on this processor: Min=$r, Max=$r", &
                     realArgs=(/minval(calvingVelocity), maxval(calvingVelocity)/))
          endif
 
@@ -1530,16 +1530,14 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
 
+
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
-         calvingVelocity(:) = 0.0_RKIND
-         ! First calculate the front retreat rate
-         calvingVelocity(:) = config_damagecalvingParameter * damage(:) & ! m/s
-               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
-                  ! calculate only for floating ice - map of "potential" calving rate
-
-
          if (trim(config_damage_calving_method) == 'calving_rate') then
+             ! First calculate the front retreat rate
+             calvingVelocity(:) = config_damagecalvingParameter * damage(:) & ! m/s
+               * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
+                  ! calculate only for floating ice
              call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
          elseif (trim(config_damage_calving_method) == 'threshold') then
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, err)
@@ -1605,8 +1603,8 @@ module li_calving
 !
 !> \author Tong Zhang
 !> \date   May. 2019
-!> \details calulate the damage tracer for floating ice shelves (damage at grounded ice is constrained as 0) 
-!> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing." 
+!> \details calulate the damage tracer for floating ice shelves (damage at grounded ice is constrained as 0)
+!> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing."
 !> Earth and Planetary Science Letters 409 (2015): 203-211.
 
 !-----------------------------------------------------------------------
@@ -1639,29 +1637,21 @@ module li_calving
       type (mpas_pool_type), pointer :: velocityPool
       type (mpas_pool_type), pointer :: scratchPool
 
-      real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_preserve_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA
       real(kind=RKIND), pointer :: config_flowLawExponent
-      character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
-      real (kind=RKIND), pointer :: config_sea_level
 
       real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: lowerSurface
-      real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax
-      real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin, tauxx, tauxy, tauyx, tauyy
+      real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
       real (kind=RKIND), dimension(:), pointer :: s0, nstar
       real (kind=RKIND), dimension(:), pointer :: damageSource
-      real (kind=RKIND), dimension(:), pointer :: damage_nye
+      real (kind=RKIND), dimension(:), pointer :: damageNye
       real (kind=RKIND), dimension(:), pointer :: damageMax
       real (kind=RKIND), pointer ::  &
            config_ice_density,            & ! ice density
@@ -1671,26 +1661,19 @@ module li_calving
       real, dimension(:), pointer :: alpha
 
       integer, dimension(:), pointer :: cellMask
-      real (kind=RKIND), pointer :: deltat, daysSinceStart !< time step (s)
+      real (kind=RKIND), pointer :: deltat !< time step (s)
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: edgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
       integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
-      real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
+      real(kind=RKIND) :: damage_downstream
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       real(kind=RKIND), dimension(6) :: localMinInfo, localMaxInfo, globalMinInfo, globalMaxInfo
-      integer :: err_tmp, loc
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_flowLawExponent', config_flowLawExponent)
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
-      call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_scalar_value', &
-               config_calving_eigencalving_parameter_scalar_value)
-      call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', config_calving_eigencalving_parameter_source)
-      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
@@ -1709,27 +1692,18 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-         call mpas_pool_get_array(meshPool, 'xCell', xCell)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
-         call mpas_pool_get_array(meshPool, 'daysSinceStart', daysSinceStart)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
-         call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)
          call mpas_pool_get_array(geometryPool, 'nstar', nstar)
          call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
-         call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
+         call mpas_pool_get_array(geometryPool, 'damageNye', damageNye)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
-         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
          call mpas_pool_get_field(scratchPool, 'alpha', alphaVar )
@@ -1737,10 +1711,6 @@ module li_calving
          alpha => alphaVar % array
 
          call mpas_pool_get_array(velocityPool, 'eMax', eMax)
-         call mpas_pool_get_array(velocityPool, 'tauxx', tauxx)
-         call mpas_pool_get_array(velocityPool, 'tauyy', tauyy)
-         call mpas_pool_get_array(velocityPool, 'tauxy', tauxy)
-         call mpas_pool_get_array(velocityPool, 'tauyx', tauyx)
          call mpas_pool_get_array(velocityPool, 'tauMax', tauMax)
          call mpas_pool_get_array(velocityPool, 'tauMin', tauMin)
 
@@ -1785,9 +1755,9 @@ module li_calving
 
          do iCell = 1, nCells
              if (thickness(iCell) == 0.0_RKIND) then
-                 damage_nye(iCell) = 0.0_RKIND
+                 damageNye(iCell) = 0.0_RKIND
              else
-                 damage_nye(iCell) = (2.0+alpha(iCell)) * tauMax(iCell) / (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
+                 damageNye(iCell) = (2.0+alpha(iCell)) * tauMax(iCell) / (gravity*(config_ocean_density-config_ice_density)*thickness(iCell))
              endif
          enddo
 
@@ -1802,8 +1772,8 @@ module li_calving
             if (damage(iCell) < 0.0_RKIND) then
                 damage(iCell) = 0.0_RKIND
             end if
-            if (damage(iCell) < damage_nye(iCell)) then
-                damage(iCell) = damage_nye(iCell)
+            if (damage(iCell) < damageNye(iCell)) then
+                damage(iCell) = damageNye(iCell)
             end if
             if (damage(iCell) > 1.0_RKIND) then
                 damage(iCell) = 1.0_RKIND
@@ -1816,9 +1786,11 @@ module li_calving
                 damage(iCell) = 0.0_RKIND
             end if
          end do
-         ! the damage of grouneded ice is kept as 0, as the strain rate calculation is only valid for ice shelf
+         ! the damage of grounded ice is kept as 0, as the strain rate calculation is only valid for ice shelf
 
+        ! Options for initializing damage where ice goes afloat:
         if (trim(config_damage_gl_setting) == 'extrapolate') then
+           ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf
            do iCell = 1, nCells
               if (li_mask_is_grounding_line(cellMask(iCell))) then
 
@@ -1841,24 +1813,24 @@ module li_calving
 
               end if
            end do
-           ! set the damage for a cell at the GL to the average damage value for its neighbor cells downstream on the ice shelf 
-
         elseif (trim(config_damage_gl_setting) == "nye") then
-
-             do iCell = 1, nCells
+            ! set the damage at the first floating cells to the Nye value
+            do iCell = 1, nCells
                 if (li_mask_is_grounding_line(cellMask(iCell))) then
                     do iNeighbor = 1, nEdgesOnCell(iCell)
                         jCell = cellsOnCell(iNeighbor, iCell)
                         if (li_mask_is_floating_ice(cellMask(jCell))) then
-                            damage(jCell) = damage_nye(jCell)
+                            damage(jCell) = damageNye(jCell)
                         end if
                     end do
                 end if
             end do
+        else
+            call mpas_log_write("Unknown value specified for config_damage_gl_setting!", MPAS_LOG_ERR)
+            err = ior(err, 1)
         endif
-        ! always set the damage at the first floating cells to the Nye value
 
-        if (.true.) then
+        if (config_print_calving_info) then
            ! End of routine accounting/reporting
            localMinInfo(1) = minval(damageSource)
            localMaxInfo(1) = maxval(damageSource)
@@ -1908,7 +1880,7 @@ module li_calving
 !> \details This routine finalizes the damage calculation after advection by several ways: 1) set the damage at grounding line using
 !>          an extrapolation method or an Nye method.
 !>          2) preserve the damage to the original value before advection if it exceeds some large number
-!>          (config_damage_preserve_threshold). For example, if config_damage_preserve_threshold = 0.5, 
+!>          (config_damage_preserve_threshold). For example, if config_damage_preserve_threshold = 0.5,
 !>          then the localtions with damage > 0.5 on the ice shelf will not heal.
 !>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_preserve_threshold.
 !>           3) coupling rheology to damage if the option config_damage_rheology_coupling is set to True in namelist
@@ -1946,7 +1918,7 @@ module li_calving
       character (len=StrKIND), pointer :: config_damage_gl_setting
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: damageMax
-      real (kind=RKIND), dimension(:), pointer :: damage_nye
+      real (kind=RKIND), dimension(:), pointer :: damageNye
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
 
 
@@ -1956,6 +1928,7 @@ module li_calving
       integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream
+      integer :: err_tmp
 
       err = 0
 
@@ -1982,8 +1955,12 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
-         call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
+         call mpas_pool_get_array(geometryPool, 'damageNye', damageNye)
          call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
+
+         ! make sure masks are up to date.  May not be necessary, but safer to do anyway.
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
 
          if (config_preserve_damage) then
              do iCell = 1, nCells
@@ -2003,14 +1980,8 @@ module li_calving
          end where
 
 
-         !do iCell = 1, nCells
-         !   if ((li_mask_is_grounded_ice(cellMask(iCell))) .or. (.not.(li_mask_is_dynamic_ice(cellMask(iCell))))) then
-         !       damage(iCell) = 0.0_RKIND
-         !   end if
-         !end do
-
          do iCell = 1, nCells
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then
+            if (li_mask_is_grounded_ice(cellMask(iCell)) .or. .not. li_mask_is_ice(cellMask(iCell))) then
                 damage(iCell) = 0.0_RKIND
             end if
          end do
@@ -2047,7 +2018,7 @@ module li_calving
                     do iNeighbor = 1, nEdgesOnCell(iCell)
                         jCell = cellsOnCell(iNeighbor, iCell)
                         if (li_mask_is_floating_ice(cellMask(jCell))) then
-                            damage(jCell) = damage_nye(jCell)
+                            damage(jCell) = damageNye(jCell)
                         end if
                     end do
                 end if
@@ -2524,27 +2495,15 @@ module li_calving
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-!      logical, pointer :: config_print_calving_info
-         !< Input: the specified calving flux at calving front margin cells
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, bedTopography
-      real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: groundedMarineMarginMask
       real(kind=RKIND), pointer :: config_damage_calving_threshold
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: cellMask
-      real (kind=RKIND), pointer :: deltat  !< time step (s)
       integer, pointer :: nCells
       integer :: iCell, iNeighbor, jCell, iEdge
-      real(kind=RKIND) :: volumeLeft
-      real(kind=RKIND) :: removeVolumeHere
-      type (field1dReal), pointer :: cellVolumeField
-      real(kind=RKIND), dimension(:), pointer :: cellVolume
-      real(kind=RKIND), dimension(:), pointer :: uncalvedVolume
-      integer :: inwardNeighbors
-      integer :: uncalvedCount
-      real(kind=RKIND) :: uncalvedTotal
       integer :: nEmptyNeighbors
       real (kind=RKIND), pointer :: config_sea_level
 
@@ -2555,25 +2514,16 @@ module li_calving
       ! get fields
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
       call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
-      call mpas_allocate_scratch_field(cellVolumeField, .true.)
-      cellVolume => cellVolumeField % array
 
       calvingThickness(:) = 0.0_RKIND
-
-      cellVolume(:) = areaCell(:) * thickness(:)
 
       groundedMarineMarginMask(:) = 0
       do iCell = 1, nCells
@@ -2620,14 +2570,11 @@ module li_calving
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! this is a thin neighbor - remove the whole cell volume
                   calvingThickness(jCell) = thickness(jCell)
-                  cellVolume(jCell) = 0.0_RKIND ! update accounting on cell volume
                endif
             enddo
 
             calvingThickness(iCell) = thickness(iCell)
             ! < apply to the field that will be used in thickness units
-            cellVolume(iCell) = 0.0_RKIND
-            ! update accounting on cell volume
 
             ! Now calved away the neighboring cells if the damage is also > the threshold value
             ! I choose to disable this section (i.e., no recursive calving) -- TZ
@@ -2648,8 +2595,6 @@ module li_calving
          endif ! if cell is calving margin
 
       enddo ! cell loop
-
-      call mpas_deallocate_scratch_field(cellVolumeField, .true.)
 
    end subroutine apply_calving_damage_threshold
 
@@ -2731,7 +2676,6 @@ module li_calving
       enddo
 
    end subroutine mask_calving
-
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1753,8 +1753,6 @@ module li_calving
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
 
-!SFP: Below here is a lot of commented out code from Tong. Needs cleaning up still?
-
          !alpha(:) = sigmamin(:) / (sigmamax(:))
          !epsmax(:) = sigmamax(:) / (2.0d0*effectiveViscosity(:))
          !s0(:) =

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1480,9 +1480,8 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
       real (kind=RKIND), dimension(:), pointer :: damage
-      integer, dimension(:), pointer :: cellMask
-      type (field1dInteger), pointer :: calvingFrontMaskField
       integer, dimension(:), pointer :: calvingFrontMask
+      integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1530,12 +1529,9 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+         call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
 
-         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskField)
-         call mpas_allocate_scratch_field(calvingFrontMaskField, .true.)
-         calvingFrontMask => calvingFrontMaskField % array
-
-         !call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
+         call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate
@@ -1559,6 +1555,11 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
+         ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
+         ! This criteria below only remove too-thin ice at the new calving front,
+         ! meaning just one 'row' of cells per timestep.  This could be expanded to continue
+         ! removing ice backward until all connected too-thin ice has been removed.
+         ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1538,7 +1538,7 @@ module li_calving
          !call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
          calvingVelocity(:) = 0.0_RKIND
-         ! First calculate the front retreat rate (Levermann eq. 1)
+         ! First calculate the front retreat rate
          calvingVelocity(:) = config_damagecalvingParameter * damage(:) & ! m/s
                * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
@@ -1632,9 +1632,9 @@ module li_calving
       ! local variables
       !-----------------------------------------------------------------
 
-      type (block_type), pointer :: block           
+      type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool
-      type (mpas_pool_type), pointer :: thermalPool 
+      type (mpas_pool_type), pointer :: thermalPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: velocityPool
       type (mpas_pool_type), pointer :: scratchPool
@@ -1642,20 +1642,20 @@ module li_calving
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
       character (len=StrKIND), pointer :: config_damage_gl_setting
-      real(kind=RKIND), pointer :: config_default_flowParamA   
+      real(kind=RKIND), pointer :: config_default_flowParamA
       real(kind=RKIND), pointer :: config_flowLawExponent
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), pointer :: config_sea_level
 
-      real (kind=RKIND), dimension(:), pointer :: thickness 
+      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: eMax
-      real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin, tauxx, tauxy, tauyx, tauyy 
+      real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin, tauxx, tauxy, tauyx, tauyy
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
@@ -1676,7 +1676,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
-      integer, pointer :: nCells    
+      integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
@@ -1718,7 +1718,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness) 
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'eigencalvingParameter', eigencalvingParameter)
@@ -1736,7 +1736,7 @@ module li_calving
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
 
-         call mpas_pool_get_array(velocityPool, 'eMax', eMax) 
+         call mpas_pool_get_array(velocityPool, 'eMax', eMax)
          call mpas_pool_get_array(velocityPool, 'tauxx', tauxx)
          call mpas_pool_get_array(velocityPool, 'tauyy', tauyy)
          call mpas_pool_get_array(velocityPool, 'tauxy', tauxy)
@@ -1747,26 +1747,29 @@ module li_calving
          where (thickness == 0.0_RKIND)
              alpha = 0.0_RKIND
              s0 = 0.0_RKIND
+             nstar = 0.0_RKIND
          elsewhere
-             alpha = tauMin / tauMax 
+             ! Compute the hydrostatic to tensile stress ratio (equation 24 from Bassis and Ma, 2015, EPSL, 409, C)
+             alpha = tauMin / tauMax
+
              s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*tauMax*config_ocean_density)
-         endwhere
-         ! Compute the hydrostatic to tensile stress ratio (equation 24 from Bassis and Ma, 2015, EPSL, 409, C)
 
-         nstar(:) = &
-         4.0_RKIND*config_flowLawExponent*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND) &
-         +3.0_RKIND*(config_flowLawExponent-1.0_RKIND)*alpha(:)**2.0_RKIND) 
-         ! Compute the effective flow law exponent (equation 11 from Bassis and Ma, 2015, EPSL, 409, C)
+             ! Compute the effective flow law exponent (equation 11 from Bassis and Ma, 2015, EPSL, 409, C)
+             nstar(:) = 4.0_RKIND * config_flowLawExponent * (1.0_RKIND + alpha(:) + alpha(:)**2) / &
+                     (4.0_RKIND * (1.0_RKIND + alpha(:) + alpha(:)**2) + &
+                      3.0_RKIND * (config_flowLawExponent - 1.0_RKIND )* alpha(:)**2)
+         endwhere
+
 
          do iCell = 1, nCells
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
              damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*eMax(iCell)-floatingBasalMassBal(iCell)/config_ice_density/thickness(iCell)
-             ! RHS of equation 26 from Bassis and Ma (2015, EPSL, 409, C). Note that the last set of terms after the minus sign, 
+             ! RHS of equation 26 from Bassis and Ma (2015, EPSL, 409, C). Note that the last set of terms after the minus sign,
              ! mdot / rho_i / H, differs from the mdot/H in the paper because our mdot has units of kg/m^2/s and to convert that back
-             ! to the right units (1/sec) you need to multiply by a factor of m^2/kg (1/rho_i * 1/H gives that factor). 
+             ! to the right units (1/sec) you need to multiply by a factor of m^2/kg (1/rho_i * 1/H gives that factor).
          endif
          enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -47,7 +47,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front, calculate_damage, restore_damage
+   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_restore_damage
 
    !--------------------------------------------------------------------
    !
@@ -1263,10 +1263,9 @@ module li_calving
 !> \brief Calve ice from the calving front based on the Bassis-Ma (2015) damage theory 
 !> \author Tong Zhang
 !> \date   May. 2019
-!> \details Calving using damage model
+!> \details Connect calving with the damage model
 !> Bassis, Jeremy N., and Y. Ma. "Evolution of basal crevasses links ice shelf stability to ocean forcing." 
 !> Earth and Planetary Science Letters 409 (2015): 203-211.
-! TODO need to properly connect damage tracer to calving flux
 
 !-----------------------------------------------------------------------
    subroutine damage_calving(domain, err)
@@ -1366,7 +1365,6 @@ module li_calving
                * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND)
                   ! calculate only for floating ice - map of "potential" calving rate
 
-         !call remove_calving_ice(meshPool, geometryPool, velocityPool, scratchPool, err)
 
          if (trim(config_damage_calving_method) == 'calving_rate') then
              call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
@@ -1425,7 +1423,7 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine calculate_damage
+!    routine li_calculate_damage
 !
 !> \author Tong Zhang
 !> \date   May. 2019
@@ -1435,7 +1433,7 @@ module li_calving
 
 !-----------------------------------------------------------------------
 
-   subroutine calculate_damage(domain, err)
+   subroutine li_calculate_damage(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1484,7 +1482,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: s0, nstar, epsmax, visc, sigmamax
       real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
-      real (kind=RKIND), dimension(:), pointer :: damage_max
+      real (kind=RKIND), dimension(:), pointer :: damageMax
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
       real (kind=RKIND), pointer ::  &
            config_ice_density,            & ! ice density
@@ -1523,8 +1521,6 @@ module li_calving
       !real, dimension(:), pointer :: ddamagedt
       type (field1dReal), pointer :: forceField
       real, dimension(:), pointer :: force
-      type (field1dReal), pointer :: meanTField
-      real, dimension(:), pointer :: meanT
 
       ! TZ: we can comment out the scratch field as above and redefine it in Registry.xml if we want to see it in the output nc file
 
@@ -1540,7 +1536,6 @@ module li_calving
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds, R, A01, A02, Q1, Q2
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
-      character (len=StrKIND), pointer :: xtime
       integer :: err_tmp, loc
 
       err = 0
@@ -1594,7 +1589,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax)
          call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
-         call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
+         call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
 
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
@@ -1619,10 +1614,6 @@ module li_calving
          call mpas_pool_get_field(scratchPool, 'meanFlowParamAField',  meanFlowParamAField)
          call mpas_allocate_scratch_field(meanFlowParamAField, .true.)
          meanFlowParamA => meanFlowParamAField % array
-
-         !call mpas_pool_get_field(scratchPool, 'viscField',  viscField)
-         !call mpas_allocate_scratch_field(viscField, .true.)
-         !visc => viscField % array
 
          call mpas_pool_get_field(scratchPool, 'sigmaxyField', sigmaxyField )
          call mpas_allocate_scratch_field(sigmaxyField, .true.)
@@ -1676,16 +1667,12 @@ module li_calving
          call mpas_allocate_scratch_field(forceField, .true.)
          force => forceField % array
 
-         call mpas_pool_get_field(scratchPool, 'meanTField', meanTField )
-         call mpas_allocate_scratch_field(meanTField, .true.)
-         meanT => meanTField % array
 
          call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
          call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
          rhoi = config_ice_density
          rhoo = config_ocean_density
 
-         meanT(:) = sum(temperature(:,:), dim=1)/nVertLevels
 
          call li_compute_gradient_2d(meshPool, uReconstructX(1,:), exx, exy, err_tmp)
          err = ior(err, err_tmp)
@@ -1697,35 +1684,41 @@ module li_calving
          err = ior(err, err_tmp)
 
 
-         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/nVertLevels
+         meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
          ! calculate the depth-averaged flow parameter A
 
-         call mpas_log_write("meanFlowParamA: Min=$r, Max=$r", &
-                    realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
+         !call mpas_log_write("meanFlowParamA: Min=$r, Max=$r", &
+         !           realArgs=(/minval(meanFlowParamA), maxval(meanFlowParamA)/))
+
          if (config_damage_use_constant_A) then
              where (thickness == 0.0_RKIND)
                  visc = 0.0_RKIND
              elsewhere
-                 visc = 0.5*stiffnessFactor*config_default_flowParamA**(-1.0/3.0)*(sqrt(exx**2+eyy**2 + exx*eyy + 0.25*(exy+eyx)**2))**((1.0-3.0)/3.0)
+                 visc =
+                 0.5_RKIND*stiffnessFactor*config_default_flowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
+                 exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
              endwhere
          else
              where (thickness == 0.0_RKIND)
                  visc = 0.0_RKIND
              elsewhere
-                 visc = 0.5*stiffnessFactor*meanFlowParamA**(-1.0/3.0)*(sqrt(exx**2+eyy**2 + exx*eyy + 0.25*(exy+eyx)**2))**((1.0-3.0)/3.0)
+                 visc = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
+                 exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
              endwhere
          end if
          ! recover effective viscosity from vel. and temp. fields
 
-         sigmaxy(:) = 2*visc(:)*(exy(:)+eyx(:))/2.0
-         sigmayx(:) = 2*visc(:)*(eyx(:)+exy(:))/2.0
+         sigmaxy(:) = 2.0_RKIND*visc(:)*(exy(:)+eyx(:))/2.0_RKIND
+         sigmayx(:) = 2.0_RKIND*visc(:)*(eyx(:)+exy(:))/2.0_RKIND
 
-         sigmaxx(:) = 2*visc(:)*exx(:)
-         sigmayy(:) = 2*visc(:)*eyy(:)
+         sigmaxx(:) = 2.0_RKIND*visc(:)*exx(:)
+         sigmayy(:) = 2.0_RKIND*visc(:)*eyy(:)
          !deviatoric stress
 
-         sigmamin(:) = (sigmaxx(:)+sigmayy(:))/2.0-sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2)
-         sigmamax(:) = (sigmaxx(:)+sigmayy(:))/2.0+sqrt(((sigmaxx(:)-sigmayy(:))/2.0)**2+((sigmaxy(:)+sigmayx(:))/2)**2)
+         sigmamin(:) =
+         (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
+         sigmamax(:) =
+         (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
          !deviatoric principal stress
 
          where (thickness == 0.0_RKIND)
@@ -1734,8 +1727,8 @@ module li_calving
              s0 = 0.0_RKIND
          elsewhere
              alpha = sigmamin / sigmamax
-             epsmax = sigmamax / (2.0d0*visc)
-             s0 = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0d0*sigmamax*rhoo)
+             epsmax = sigmamax / (2.0_RKIND*visc)
+             s0 = rhoi*(rhoo-rhoi)*gravity*thickness/(2.0_RKIND*sigmamax*rhoo)
          endwhere
              
          !alpha(:) = sigmamin(:) / (sigmamax(:))
@@ -1744,7 +1737,8 @@ module li_calving
           ! Compute the hydrostatic to tensile stress ratio
           ! These commented lines are doing the same thing as the above where loop. Which is better?
 
-         nstar(:) = 12.0d0*(1.0d0+alpha(:)+alpha(:)**2)/(4.0d0*(1.0d0+alpha(:)+alpha(:)**2)+6.0d0*alpha(:)**2) 
+         nstar(:) =
+         12.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)+6.0_RKIND*alpha(:)**2.0_RKIND) 
           ! Compute the effective flow law exponent
 
          !s0(:) = rhoi*(rhoo-rhoi)*gravity*thickness(:)/(2.0d0*sigmamax(:)*rhoo)
@@ -1761,11 +1755,11 @@ module li_calving
          if (thickness(iCell) == 0.0_RKIND) then
              damageSource(iCell) = 0.0_RKIND
          else
-             damageSource(iCell) = nstar(iCell) * (1.0d0-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0_RKIND-s0(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
          endif
          enddo
 
-         seconds = daysSinceStart*24.0*3600.0
+         !seconds = daysSinceStart*24.0*3600.0
 
          ! below is the force for the manufacured experiments
          !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
@@ -1774,7 +1768,7 @@ module li_calving
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
          ! set force to zero if not manufactured
-         force(:) = 0.0
+         force(:) = 0.0_RKIND
 
          ddamagedt(:) = damageSource(:) * damage(:) + force(:)
 
@@ -1784,21 +1778,21 @@ module li_calving
          ! temporarily set damage to a constant value
 
          do iCell = 1, nCells
-         if (thickness(iCell) == 0.0_RKIND) then
-             damage_nye(iCell) = 0.0_RKIND
-         else
-             damage_nye(iCell) = (2.0+alpha(iCell)) * sigmamax(iCell) / (gravity*(rhoo-rhoi)*thickness(iCell))
-         endif
+             if (thickness(iCell) == 0.0_RKIND) then
+                 damage_nye(iCell) = 0.0_RKIND
+             else
+                 damage_nye(iCell) = (2.0+alpha(iCell)) * sigmamax(iCell) / (gravity*(rhoo-rhoi)*thickness(iCell))
+             endif
          enddo
          !damage_nye(:) = 0.5
          ! temporarily set damage_nye to a constant value, 0.8
 
          do iCell = 1, nCells
             if (damage(iCell) > config_damage_restore_threshold) then
-                damage_max(iCell) = damage(iCell)
+                damageMax(iCell) = damage(iCell)
             end if
          end do
-         ! save the damage_max value for restoring (no heal) later if we want
+         ! save the damageMax value for restoring (no heal) later if we want
 
          do iCell = 1, nCells
             if (damage(iCell) < 0.0_RKIND) then
@@ -1888,25 +1882,25 @@ module li_calving
          !call mpas_deallocate_scratch_field(damageSourceField, .true.)
          !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
          call mpas_deallocate_scratch_field(forceField, .true.)
-         call mpas_deallocate_scratch_field(meanTField, .true.)
          ! call mpas_deallocate_scratch_field(damageField, .true.)
 
          block => block % next
              
       enddo
 
-   end subroutine calculate_damage 
+   end subroutine li_calculate_damage 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine restore_damage
+!    routine li_restore_damage
 !
 !> \author Tong Zhang
 !> \date   Oct. 2019
 !> \details restore the damage to the original value before advection if it exceeds some large number
+!>          if we turn on this function, we do not allow the damage to heal (damage to decrease).
 !-----------------------------------------------------------------------
 
-   subroutine restore_damage(domain, err)
+   subroutine li_restore_damage(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1935,26 +1929,16 @@ module li_calving
       logical, pointer :: config_damage_rheology_coupling
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), dimension(:), pointer :: damage
-      real (kind=RKIND), dimension(:), pointer :: damage_max
+      real (kind=RKIND), dimension(:), pointer :: damageMax
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
-      real (kind=RKIND), pointer ::  &
-           config_ice_density,            & ! ice density
-           config_ocean_density             ! ocean density
 
-      real (kind=RKIND), save :: rhoi    ! ice density (kg m^{-3}), copied from config_ice_density
-      real (kind=RKIND), save :: rhoo    ! ocean density (kg m^{-3}), copied from config_ocean_density
 
       integer, dimension(:), pointer :: cellMask
-      type (field1dInteger), pointer :: calvingFrontMaskField
-      integer, dimension(:), pointer :: calvingFrontMask
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, dimension(:,:), pointer :: edgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: xCell, dvEdge
-      integer, pointer :: nCells, nVertLevels
+      integer, pointer :: nCells 
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
-      real(kind=RKIND) :: damage_downstream, damage_tmp, cellCalvingFrontLength, cellCalvingFrontHeight, seconds
-      integer :: err_tmp, loc
+      real(kind=RKIND) :: damage_downstream
 
       err = 0
 
@@ -1975,21 +1959,20 @@ module li_calving
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
-         call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
+         call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
          call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
 
          do iCell = 1, nCells
-            if (damage(iCell) < damage_max(iCell)) then
-                damage(iCell) = damage_max(iCell)
+            if (damage(iCell) < damageMax(iCell)) then
+                damage(iCell) = damageMax(iCell)
             end if
          end do
-         ! put the damage_max value back to restore the damage value (no heal)
+         ! put the damageMax value back to restore the damage value (no heal)
 
          where (damage < 0.0_RKIND)
              damage = 0.0_RKIND
@@ -2052,7 +2035,7 @@ module li_calving
              
       enddo
 
-   end subroutine restore_damage 
+   end subroutine li_restore_damage 
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1833,8 +1833,6 @@ module li_calving
                       end if
                   end do
 
-                  damage(iCell) = damage_downstream
-
                   if (n_damage_downstream == 0) then
                       damage(iCell) = 0.0_RKIND
                   else

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -2633,23 +2633,19 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! this is a thin neighbor - remove the whole cell volume
-                  removeVolumeHere = cellVolume(jCell) ! how much we want to remove here
-                  calvingThickness(jCell) = removeVolumeHere / areaCell(jCell)
-                      ! < apply to the field that will be used, in thickness units
-                  cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
+                  calvingThickness(jCell) = thickness(jCell)
+                  cellVolume(jCell) = 0.0_RKIND ! update accounting on cell volume
                endif
             enddo
 
-            ! Now remove ice from iCell
-            removeVolumeHere = cellVolume(iCell)
-            ! remove the whole damaged cell
-            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            calvingThickness(iCell) = thickness(iCell)
             ! < apply to the field that will be used in thickness units
-            cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere 
+            cellVolume(iCell) = 0.0_RKIND
             ! update accounting on cell volume
 
             ! Now calved away the neighboring cells if the damage is also > the threshold value
             ! I choose to disable this section (i.e., no recursive calving) -- TZ
+            !TODO: a flood fill algorithm might be needed for this threshold method in the future 
             !do iNeighbor = 1, nEdgesOnCell(iCell)
             !   jCell = cellsOnCell(iNeighbor, iCell)
             !   if (li_mask_is_floating_ice(cellMask(jCell)) .and. li_mask_is_dynamic_ice(cellMask(jCell)) &

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -31,7 +31,6 @@ module li_calving
    use li_constants
    use li_diagnostic_vars
 
-
    implicit none
    private
 
@@ -47,7 +46,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_preserve_high_damage
+   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_finalize_damage_after_advection
 
    !--------------------------------------------------------------------
    !
@@ -1295,7 +1294,7 @@ module li_calving
       logical, pointer :: config_print_calving_info
       real(kind=RKIND), pointer :: config_calving_thickness
       real(kind=RKIND), pointer :: config_calving_velocity_const
-      real(kind=RKIND), pointer :: config_calving_specified_source
+      character (len=StrKIND), pointer :: config_calving_specified_source
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: calvingVelocityData
       real (kind=RKIND), dimension(:), pointer :: angleEdge
@@ -1640,7 +1639,7 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
-      character, pointer :: config_damage_gl_setting
+      character (len=StrKIND), pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA 
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
       logical, pointer :: config_print_calving_info
@@ -1683,8 +1682,6 @@ module li_calving
       real, dimension(:), pointer :: alpha
 
       integer, dimension(:), pointer :: cellMask
-      type (field1dInteger), pointer :: calvingFrontMaskField
-      integer, dimension(:), pointer :: calvingFrontMask
       real (kind=RKIND), pointer :: deltat, daysSinceStart !< time step (s)
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1709,7 +1706,6 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
-      call mpas_pool_get_config(liConfigs, 'config_damage_rheology_coupling', config_damage_rheology_coupling)
 
       ! block loop
       block => domain % blocklist
@@ -1729,7 +1725,6 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'xCell', xCell)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'daysSinceStart', daysSinceStart)
-         call mpas_pool_get_array(meshPool, 'xtime', xtime)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1762,10 +1757,6 @@ module li_calving
 
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
 
-         call mpas_pool_get_field(scratchPool, 'iceCellMask2',  calvingFrontMaskVar)
-         call mpas_allocate_scratch_field(calvingFrontMaskVar, .true.)
-         calvingFrontMask => calvingFrontMaskVar % array
-
          call mpas_pool_get_field(scratchPool, 'meanFlowParamAVar',  meanFlowParamAVar)
          call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
          meanFlowParamA => meanFlowParamAVar % array
@@ -1794,9 +1785,6 @@ module li_calving
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
 
-         call calculate_strain_rates(meshPool, velocityPool, err_tmp)
-         err = ior(err, err_tmp)
-
          call mpas_pool_get_array(velocityPool, 'exx', exx)
          call mpas_pool_get_array(velocityPool, 'eyy', eyy)
          call mpas_pool_get_array(velocityPool, 'exy', exy)
@@ -1811,7 +1799,8 @@ module li_calving
          where (thickness == 0.0_RKIND)
              effectiveViscosity = 0.0_RKIND
          elsewhere
-             effectiveViscosity = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
+             effectiveViscosity = &
+             0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
              exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
          endwhere
          ! recover effective viscosity from vel. and temp. fields
@@ -1823,9 +1812,9 @@ module li_calving
          sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
          !deviatoric stress
 
-         sigmamin(:) =
+         sigmamin(:) = &
          (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
-         sigmamax(:) =
+         sigmamax(:) = &
          (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
          !deviatoric principal stress
 
@@ -1836,7 +1825,7 @@ module li_calving
          elsewhere
              alpha = sigmamin / sigmamax
              epsmax = sigmamax / (2.0_RKIND*effectiveViscosity)
-             s0 =
+             s0 = &
              config_ice_density*(config_ocean_density-config_ice_density)*gravity*thickness/(2.0_RKIND*sigmamax*config_ocean_density)
          endwhere
              
@@ -1847,7 +1836,7 @@ module li_calving
           ! Compute the hydrostatic to tensile stress ratio
           ! These commented lines are doing the same thing as the above where loop. Which is better?
 
-         nstar(:) =
+         nstar(:) = &
          12.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)/(4.0_RKIND*(1.0_RKIND+alpha(:)+alpha(:)**2.0_RKIND)+6.0_RKIND*alpha(:)**2.0_RKIND) 
           ! Compute the effective flow law exponent
 
@@ -1994,7 +1983,6 @@ module li_calving
         ! temporary message output in the log file
 
 
-         call mpas_deallocate_scratch_field(calvingFrontMaskVar, .true.)
          call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
          call mpas_deallocate_scratch_field(sigmaxxVar, .true.)
          call mpas_deallocate_scratch_field(sigmayyVar, .true.)
@@ -2058,7 +2046,7 @@ module li_calving
       logical, pointer :: config_damage_rheology_coupling
       logical, pointer :: config_preserve_damage
       logical, pointer :: config_print_calving_info
-      character, pointer :: config_damage_gl_setting
+      character (len=StrKIND), pointer :: config_damage_gl_setting
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: damageMax
       real (kind=RKIND), dimension(:), pointer :: damage_nye
@@ -2094,7 +2082,6 @@ module li_calving
 
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'damageMax', damageMax)
@@ -2627,7 +2614,6 @@ module li_calving
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
       type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
-      integer, dimension(:), intent(in) :: calvingFrontMask
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -2646,15 +2632,16 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeRate
          !< Input: the specified calving flux at calving front margin cells
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
-      real (kind=RKIND), dimension(:), pointer :: thickness, damage
+      real (kind=RKIND), dimension(:), pointer :: thickness, damage, bedTopography
       real (kind=RKIND), dimension(:), pointer :: areaCell
+      integer, dimension(:), pointer :: groundedMarineMarginMask
       real(kind=RKIND), pointer :: config_damage_calving_threshold
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       integer, pointer :: nCells
-      integer :: iCell, iNeighbor, jCell
+      integer :: iCell, iNeighbor, jCell, iEdge
       real(kind=RKIND) :: volumeLeft
       real(kind=RKIND) :: removeVolumeHere
       type (field1dReal), pointer :: cellVolumeField
@@ -2663,6 +2650,8 @@ module li_calving
       integer :: inwardNeighbors
       integer :: uncalvedCount
       real(kind=RKIND) :: uncalvedTotal
+      integer :: nEmptyNeighbors
+      real (kind=RKIND), pointer :: config_sea_level
       !logical, pointer :: config_damage_if_calving_rate
 
       err = 0
@@ -2671,14 +2660,17 @@ module li_calving
       !call mpas_pool_get_config(liConfigs, 'config_damage_if_calving_rate', config_damage_if_calving_rate)
 
       ! get fields
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeRate', requiredCalvingVolumeRate)
       call mpas_pool_get_array(geometryPool, 'uncalvedVolume', uncalvedVolume)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
+      call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -2690,6 +2682,37 @@ module li_calving
       calvingThickness(:) = 0.0_RKIND
 
       cellVolume(:) = areaCell(:) * thickness(:)
+
+      groundedMarineMarginMask(:) = 0
+      do iCell = 1, nCells
+         ! Define marine m      arginal cells as those that are (1) at the ice
+         ! margin, (2) have at least one neighboring cell without ice, (3) contain
+         ! grounded ice, and (4) have bed topography below sea level.
+         ! OR is adjacent to an inactive floating margin cell
+
+         ! Check if neighboring cells contain ice and have bed topo below sea level
+         nEmptyNeighbors = 0
+         do iEdge = 1, nEdgesOnCell(iCell)
+           iNeighbor = cellsOnCell(iEdge, iCell)
+           if ( (((thickness(iNeighbor) == 0.0_RKIND) &
+              .and. bedTopography(iNeighbor) < config_sea_level)) &
+              .or. ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
+              .and. li_mask_is_margin(cellMask(iNeighbor)) &
+              .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
+               nEmptyNeighbors = nEmptyNeighbors + 1
+           endif
+         enddo
+
+         if ( nEmptyNeighbors > 0 &
+           .and. li_mask_is_grounded_ice(cellMask(iCell)) &
+           .and. bedTopography(iCell) < config_sea_level &
+           .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
+
+            groundedMarineMarginMask(iCell) = 1
+         else
+            groundedMarineMarginMask(iCell) = 0
+         endif
+      enddo
 
       ! The calving volume needs to be distributed in three ways:
       ! 1. We need to first remove any "thin" ice in front of this cell

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -47,7 +47,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_maintain_broken_ice
+   public :: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_preserve_high_damage
 
    !--------------------------------------------------------------------
    !
@@ -1464,8 +1464,7 @@ module li_calving
       type (mpas_pool_type), pointer :: velocityPool
       type (mpas_pool_type), pointer :: scratchPool
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
-      real(kind=RKIND), pointer :: config_damage_restore_threshold, config_damage_calving_threshold
-      logical, pointer :: config_damage_use_constant_A
+      real(kind=RKIND), pointer :: config_damage_preserve_threshold, config_damage_calving_threshold
       character, pointer :: config_damage_gl_setting
       real(kind=RKIND), pointer :: config_default_flowParamA 
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
@@ -1507,8 +1506,6 @@ module li_calving
       real, dimension(:), pointer :: sigmamin
       type (field1dReal), pointer :: alphaVar
       real, dimension(:), pointer :: alpha
-      type (field1dReal), pointer :: envForceVar
-      real, dimension(:), pointer :: envForce
 
       integer, dimension(:), pointer :: cellMask
       type (field1dInteger), pointer :: calvingFrontMaskField
@@ -1531,13 +1528,13 @@ module li_calving
                config_calving_eigencalving_parameter_scalar_value)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', config_calving_eigencalving_parameter_source)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
-      call mpas_pool_get_config(liConfigs, 'config_damage_restore_threshold', config_damage_restore_threshold)
+      call mpas_pool_get_config(liConfigs, 'config_damage_preserve_threshold', config_damage_preserve_threshold)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
-      call mpas_pool_get_config(liConfigs, 'config_damage_use_constant_A', config_damage_use_constant_A)
       call mpas_pool_get_config(liConfigs, 'config_damage_gl_setting', config_damage_gl_setting)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
+      call mpas_pool_get_config(liConfigs, 'config_damage_rheology_coupling', config_damage_rheology_coupling)
 
       ! block loop
       block => domain % blocklist
@@ -1622,9 +1619,6 @@ module li_calving
          call mpas_allocate_scratch_field(alphaVar, .true.)
          alpha => alphaVar % array
 
-         call mpas_pool_get_field(scratchPool, 'envForceVar', envForceVar )
-         call mpas_allocate_scratch_field(envForceVar, .true.)
-         envForce => envForceVar % array
 
          call calculate_strain_rates(meshPool, velocityPool, err_tmp)
          err = ior(err, err_tmp)
@@ -1640,22 +1634,12 @@ module li_calving
          meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)
          ! calculate the depth-averaged flow parameter A
 
-         if (config_damage_use_constant_A) then
-             where (thickness == 0.0_RKIND)
-                 effectiveViscosity = 0.0_RKIND
-             elsewhere
-                 effectiveViscosity =
-                 0.5_RKIND*stiffnessFactor*config_default_flowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
-                 exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
-             endwhere
-         else
-             where (thickness == 0.0_RKIND)
-                 effectiveViscosity = 0.0_RKIND
-             elsewhere
-                 effectiveViscosity = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
-                 exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
-             endwhere
-         end if
+         where (thickness == 0.0_RKIND)
+             effectiveViscosity = 0.0_RKIND
+         elsewhere
+             effectiveViscosity = 0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND +
+             exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
+         endwhere
          ! recover effective viscosity from vel. and temp. fields
 
          sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
@@ -1714,16 +1698,13 @@ module li_calving
 
          !seconds = daysSinceStart*24.0*3600.0
 
-         ! below is the envForce for the manufacured experiments
-         !envForce(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         ! below is the cases for the manufacured experiments
+         !ddamagedt(:) = damageSource(:)*damage(:) - 0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
-         !envForce(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
+         !ddamagedt(:) = damageSource(:)*damage(:) - 0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
-         ! set envForce to zero if none
-         envForce(:) = 0.0_RKIND
-
-         ddamagedt(:) = damageSource(:) * damage(:) + envForce(:)
+         ddamagedt(:) = damageSource(:) * damage(:)
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
@@ -1741,7 +1722,7 @@ module li_calving
          ! temporarily set damage_nye to a constant value, 0.8
 
          do iCell = 1, nCells
-            if (damage(iCell) > config_damage_restore_threshold) then
+            if (damage(iCell) > config_damage_preserve_threshold) then
                 damageMax(iCell) = damage(iCell)
             end if
          end do
@@ -1817,6 +1798,17 @@ module li_calving
         endif
         ! always set the damage at the first floating cells to the Nye value
 
+        if (config_damage_rheology_coupling) then
+            do iCell = 1, nCells
+                if (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell))) then
+                    stiffnessFactor(iCell) = 1.0_RKIND - damage(iCell)
+                    if (stiffnessFactor(iCell) < config_damage_stiffness_min) then
+                        stiffnessFactor(iCell) = config_damage_stiffness_min
+                    end if
+                end if
+            end do
+        end if
+
         if (.true.) then
 
              call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
@@ -1851,7 +1843,6 @@ module li_calving
          !call mpas_deallocate_scratch_field(s0Var, .true.)
          !call mpas_deallocate_scratch_field(damageSourceVar, .true.)
          !call mpas_deallocate_scratch_field(ddamagedtVar, .true.)
-         call mpas_deallocate_scratch_field(envForceVar, .true.)
          ! call mpas_deallocate_scratch_field(damageVar, .true.)
 
          block => block % next
@@ -1862,17 +1853,17 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine li_maintain_broken_ice
+!    routine li_preserve_high_damage
 !
 !> \author Tong Zhang
 !> \date   Oct. 2019
-!> \details restore the damage to the original value before advection if it exceeds some large number
-!>          (config_damage_restore_threshold). For example, if config_damage_restore_threshold = 0.5, 
+!> \details preserve the damage to the original value before advection if it exceeds some large number
+!>          (config_damage_preserve_threshold). For example, if config_damage_preserve_threshold = 0.5, 
 !>          then the localtions with damage > 0.5 on the ice shelf will not heal.
-!>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_restore_threshold.
+!>          Thus, if we turn on this function, we do not allow the damage to heal if damage > config_damage_preserve_threshold.
 !-----------------------------------------------------------------------
 
-   subroutine li_maintain_broken_ice(domain, err)
+   subroutine li_preserve_high_damage(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1948,7 +1939,7 @@ module li_calving
                 damage(iCell) = damageMax(iCell)
             end if
          end do
-         ! put the damageMax value back to restore the damage value (no heal)
+         ! put the damageMax value back to preserve the damage value (no heal)
 
          where (damage < 0.0_RKIND)
              damage = 0.0_RKIND
@@ -2026,7 +2017,7 @@ module li_calving
              
       enddo
 
-   end subroutine li_maintain_broken_ice
+   end subroutine li_preserve_high_damage
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1473,7 +1473,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: damage
       real (kind=RKIND), dimension(:), pointer :: ddamagedt
       real (kind=RKIND), dimension(:), pointer :: szero, nstar, epsmax, visc, sigmamax
-      real (kind=RKIND), dimension(:), pointer :: source
+      real (kind=RKIND), dimension(:), pointer :: damageSource
       real (kind=RKIND), dimension(:), pointer :: damage_nye
       real (kind=RKIND), dimension(:), pointer :: damage_max
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
@@ -1508,8 +1508,8 @@ module li_calving
       !real, dimension(:), pointer :: nstar
       !type (field1dReal), pointer :: szeroField
       !real, dimension(:), pointer :: szero
-      !type (field1dReal), pointer :: sourceField
-      !real, dimension(:), pointer :: source
+      !type (field1dReal), pointer :: damageSourceField
+      !real, dimension(:), pointer :: damageSource
       !type (field1dReal), pointer :: ddamagedtField
       !real, dimension(:), pointer :: ddamagedt
       type (field1dReal), pointer :: forceField
@@ -1583,7 +1583,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'epsmax', epsmax)
          call mpas_pool_get_array(geometryPool, 'visc', visc)
          call mpas_pool_get_array(geometryPool, 'sigmamax', sigmamax)
-         call mpas_pool_get_array(geometryPool, 'source', source)
+         call mpas_pool_get_array(geometryPool, 'damageSource', damageSource)
          call mpas_pool_get_array(geometryPool, 'damage_nye', damage_nye)
          call mpas_pool_get_array(geometryPool, 'damage_max', damage_max)
 
@@ -1655,9 +1655,9 @@ module li_calving
          !call mpas_allocate_scratch_field(szeroField, .true.)
          !szero => szeroField % array
 
-         !call mpas_pool_get_field(scratchPool, 'sourceField', sourceField )
-         !call mpas_allocate_scratch_field(sourceField, .true.)
-         !source => sourceField % array
+         !call mpas_pool_get_field(scratchPool, 'damageSourceField', damageSourceField )
+         !call mpas_allocate_scratch_field(damageSourceField, .true.)
+         !damageSource => damageSourceField % array
 
          !call mpas_pool_get_field(scratchPool, 'ddamagedtField', ddamagedtField )
          !call mpas_allocate_scratch_field(ddamagedtField, .true.)
@@ -1750,9 +1750,9 @@ module li_calving
 
          do iCell = 1, nCells
          if (thickness(iCell) == 0.0_RKIND) then
-             source(iCell) = 0.0_RKIND
+             damageSource(iCell) = 0.0_RKIND
          else
-             source(iCell) = nstar(iCell) * (1.0d0-szero(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
+             damageSource(iCell) = nstar(iCell) * (1.0d0-szero(iCell))*epsmax(iCell)-floatingBasalMassBal(iCell)/rhoi/(thickness(iCell))
          endif
          enddo
 
@@ -1760,14 +1760,14 @@ module li_calving
 
          ! below is the force for the manufacured experiments
          !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*(1+epsmax(:)*seconds)*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
-         !    source(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
+         !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
          !force(:) = -0.44/2.0 * (uReconstructX(1,:)/1000.0*exp(-uReconstructX(1,:)*seconds/1000.0) +    &
-         !    source(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
+         !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
          ! set force to zero if not manufactured
          force(:) = 0.0
 
-         ddamagedt(:) = source(:) * damage(:) + force(:)
+         ddamagedt(:) = damageSource(:) * damage(:) + force(:)
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
@@ -1845,8 +1845,8 @@ module li_calving
 
         if (.true.) then
 
-             call mpas_log_write("source value range: Min=$r, Max=$r", &
-                        realArgs=(/minval(source), maxval(source)/))
+             call mpas_log_write("damageSource value range: Min=$r, Max=$r", &
+                        realArgs=(/minval(damageSource), maxval(damageSource)/))
              call mpas_log_write("szero  value range: Min=$r, Max=$r", &
                         realArgs=(/minval(szero), maxval(szero)/))
              call mpas_log_write("nstar value range: Min=$r, Max=$r", &
@@ -1876,7 +1876,7 @@ module li_calving
          !call mpas_deallocate_scratch_field(epsmaxField, .true.)
          !call mpas_deallocate_scratch_field(nstarField, .true.)
          !call mpas_deallocate_scratch_field(szeroField, .true.)
-         !call mpas_deallocate_scratch_field(sourceField, .true.)
+         !call mpas_deallocate_scratch_field(damageSourceField, .true.)
          !call mpas_deallocate_scratch_field(ddamagedtField, .true.)
          call mpas_deallocate_scratch_field(forceField, .true.)
          call mpas_deallocate_scratch_field(meanTField, .true.)

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -29,7 +29,7 @@ module li_time_integration_fe
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_restore_damage
+   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_maintain_broken_ice_
    use li_thermal, only: li_thermal_solver
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -106,13 +106,13 @@ module li_time_integration_fe
 
       logical, pointer :: config_restore_calving_front
       logical, pointer :: config_calculate_damage
-      logical, pointer :: config_restore_damage
+      logical, pointer :: config_maintain_broken_ice
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
-      call mpas_pool_get_config(liConfigs, 'config_restore_damage',config_restore_damage)
+      call mpas_pool_get_config(liConfigs, 'config_maintain_broken_ice',config_maintain_broken_ice)
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -147,12 +147,12 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("advect thickness and tracers")
 
-! === restore damage ===========
-      if (config_restore_damage) then
-          call mpas_timer_start("restore damage")
-          call li_restore_damage(domain, err_tmp)
+! === maintain broken ice ===========
+      if (config_maintain_broken_ice) then
+          call mpas_timer_start("maintain broken ice")
+          call li_maintain_broken_ice(domain, err_tmp)
           err = ior(err, err_tmp)
-          call mpas_timer_stop("restore damage")
+          call mpas_timer_stop("maintain broken ice")
       endif
 
 ! === Update subglacial hydrology  ===========

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -133,6 +133,12 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("vertical therm")
 
+! === Compute new state for prognostic variables ==================================
+      call mpas_timer_start("advect thickness and tracers")
+      call advection_solver(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("advect thickness and tracers")
+
 ! === calculate damage ===========
       if (config_calculate_damage) then
           call mpas_timer_start("damage")
@@ -140,12 +146,6 @@ module li_time_integration_fe
           err = ior(err, err_tmp)
           call mpas_timer_stop("damage")
       endif
-
-! === Compute new state for prognostic variables ==================================
-      call mpas_timer_start("advect thickness and tracers")
-      call advection_solver(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("advect thickness and tracers")
 
 ! === preserve high damage ===========
       if (config_preserve_high_damage) then

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -105,10 +105,14 @@ module li_time_integration_fe
       integer :: err_tmp
 
       logical, pointer :: config_restore_calving_front
+      logical, pointer :: config_calculate_damage
+      logical, pointer :: config_restore_damage
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
+      call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
+      call mpas_pool_get_config(liConfigs, 'config_restore_damage',config_restore_damage)
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -130,10 +134,12 @@ module li_time_integration_fe
       call mpas_timer_stop("vertical therm")
 
 ! === calculate damage ===========
-      call mpas_timer_start("damage")
-      call calculate_damage(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("damage")
+      if (config_calculate_damage) then
+          call mpas_timer_start("damage")
+          call calculate_damage(domain, err_tmp)
+          err = ior(err, err_tmp)
+          call mpas_timer_stop("damage")
+      endif
 
 ! === Compute new state for prognostic variables ==================================
       call mpas_timer_start("advect thickness and tracers")
@@ -142,10 +148,12 @@ module li_time_integration_fe
       call mpas_timer_stop("advect thickness and tracers")
 
 ! === restore damage ===========
-      call mpas_timer_start("restore damage")
-      call restore_damage(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("restore damage")
+      if (config_restore_damage) then
+          call mpas_timer_start("restore damage")
+          call restore_damage(domain, err_tmp)
+          err = ior(err, err_tmp)
+          call mpas_timer_stop("restore damage")
+      endif
 
 ! === Update subglacial hydrology  ===========
 ! It's not clear where the best place to call this should be.

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -29,7 +29,7 @@ module li_time_integration_fe
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front
+   use li_calving, only: li_calve_ice, li_restore_calving_front, calculate_damage, restore_damage
    use li_thermal, only: li_thermal_solver
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -129,11 +129,23 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("vertical therm")
 
+! === calculate damage ===========
+      call mpas_timer_start("damage")
+      call calculate_damage(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("damage")
+
 ! === Compute new state for prognostic variables ==================================
       call mpas_timer_start("advect thickness and tracers")
       call advection_solver(domain, err_tmp)
       err = ior(err, err_tmp)
       call mpas_timer_stop("advect thickness and tracers")
+
+! === restore damage ===========
+      call mpas_timer_start("restore damage")
+      call restore_damage(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("restore damage")
 
 ! === Update subglacial hydrology  ===========
 ! It's not clear where the best place to call this should be.

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -29,7 +29,7 @@ module li_time_integration_fe
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front, calculate_damage, restore_damage
+   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_restore_damage
    use li_thermal, only: li_thermal_solver
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -136,7 +136,7 @@ module li_time_integration_fe
 ! === calculate damage ===========
       if (config_calculate_damage) then
           call mpas_timer_start("damage")
-          call calculate_damage(domain, err_tmp)
+          call li_calculate_damage(domain, err_tmp)
           err = ior(err, err_tmp)
           call mpas_timer_stop("damage")
       endif
@@ -150,7 +150,7 @@ module li_time_integration_fe
 ! === restore damage ===========
       if (config_restore_damage) then
           call mpas_timer_start("restore damage")
-          call restore_damage(domain, err_tmp)
+          call li_restore_damage(domain, err_tmp)
           err = ior(err, err_tmp)
           call mpas_timer_stop("restore damage")
       endif

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -29,7 +29,7 @@ module li_time_integration_fe
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_preserve_high_damage
+   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_finalize_damage_after_advection
    use li_thermal, only: li_thermal_solver
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -106,13 +106,13 @@ module li_time_integration_fe
 
       logical, pointer :: config_restore_calving_front
       logical, pointer :: config_calculate_damage
-      logical, pointer :: config_preserve_high_damage
+      logical, pointer :: config_finalize_damage_after_advection
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
-      call mpas_pool_get_config(liConfigs, 'config_preserve_high_damage',config_preserve_high_damage)
+      call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection',config_finalize_damage_after_advection)
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -133,12 +133,6 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("vertical therm")
 
-! === Compute new state for prognostic variables ==================================
-      call mpas_timer_start("advect thickness and tracers")
-      call advection_solver(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("advect thickness and tracers")
-
 ! === calculate damage ===========
       if (config_calculate_damage) then
           call mpas_timer_start("damage")
@@ -147,12 +141,18 @@ module li_time_integration_fe
           call mpas_timer_stop("damage")
       endif
 
-! === preserve high damage ===========
-      if (config_preserve_high_damage) then
-          call mpas_timer_start("preserve high damage")
-          call li_preserve_high_damage(domain, err_tmp)
+! === Compute new state for prognostic variables ==================================
+      call mpas_timer_start("advect thickness and tracers")
+      call advection_solver(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("advect thickness and tracers")
+
+! === finalize damage after advection ===========
+      if (config_finalize_damage_after_advection) then
+          call mpas_timer_start("finalize damage")
+          call li_finalize_damage_after_advection(domain, err_tmp)
           err = ior(err, err_tmp)
-          call mpas_timer_stop("preserve high damage")
+          call mpas_timer_stop("finalize damage")
       endif
 
 ! === Update subglacial hydrology  ===========

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -29,7 +29,7 @@ module li_time_integration_fe
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_maintain_broken_ice_
+   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_preserve_high_damage
    use li_thermal, only: li_thermal_solver
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -106,13 +106,13 @@ module li_time_integration_fe
 
       logical, pointer :: config_restore_calving_front
       logical, pointer :: config_calculate_damage
-      logical, pointer :: config_maintain_broken_ice
+      logical, pointer :: config_preserve_high_damage
 
       err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
-      call mpas_pool_get_config(liConfigs, 'config_maintain_broken_ice',config_maintain_broken_ice)
+      call mpas_pool_get_config(liConfigs, 'config_preserve_high_damage',config_preserve_high_damage)
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -147,12 +147,12 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("advect thickness and tracers")
 
-! === maintain broken ice ===========
-      if (config_maintain_broken_ice) then
-          call mpas_timer_start("maintain broken ice")
-          call li_maintain_broken_ice(domain, err_tmp)
+! === preserve high damage ===========
+      if (config_preserve_high_damage) then
+          call mpas_timer_start("preserve high damage")
+          call li_preserve_high_damage(domain, err_tmp)
           err = ior(err, err_tmp)
-          call mpas_timer_stop("maintain broken ice")
+          call mpas_timer_stop("preserve high damage")
       endif
 
 ! === Update subglacial hydrology  ===========

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -658,8 +658,6 @@ contains
          ! ---
          ! --- Calculate strain rates on cell centers
          ! ---
-!SFP: altered to stress calcs addd
-!         call calculate_strain_rates(meshPool, velocityPool, err_tmp) 
          call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
          err = ior(err, err_tmp)
 
@@ -870,7 +868,6 @@ contains
 !        call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
 
       use li_setup
-!SFP: should this be added here or at top of module?
       use li_diagnostic_vars 
 
       !-----------------------------------------------------------------
@@ -879,7 +876,6 @@ contains
       type (mpas_pool_type), intent(in) :: &
          meshPool                                     !< Input: mesh object
 
-!SFP: added for stress calcs (from damage mod)
       type (mpas_pool_type), intent(in) :: &
          geometryPool                                 !< Input: geometry object
       type (mpas_pool_type), intent(in) :: &
@@ -903,12 +899,10 @@ contains
       !-----------------------------------------------------------------
 
       real(kind=RKIND), dimension(:), pointer :: exx, eyy, exy, eyx, eTheta, eMax, eMin
-!SFP: added for stress calcs (from damage mod)
       real(kind=RKIND), dimension(:), pointer :: sigmaxx, sigmayy, sigmaxy, sigmayx, sigmamax, sigmamin
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       integer :: err_tmp
 
-!SFP moved these from damage mod 
       real (kind=RKIND), dimension(:), pointer :: thickness 
       real (kind=RKIND), dimension(:,:), pointer :: temperature 
       real(kind=RKIND), pointer :: config_default_flowParamA  
@@ -916,16 +910,13 @@ contains
       real (kind=RKIND), dimension(:), pointer :: effectiveViscosity
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
 
-!SFP moved these from damage mod 
       type (field1dReal), pointer :: meanFlowParamAVar
       real, dimension(:), pointer :: meanFlowParamA
 
-!SFP: moved from damage mod
       integer, pointer :: nVertLevels 
 
       err = 0
 
-!SFP: moved from damage mod
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels) 
 
       call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
@@ -939,7 +930,6 @@ contains
       call mpas_pool_get_array(velocityPool, 'eMax', eMax)
       call mpas_pool_get_array(velocityPool, 'eMin', eMin)
 
-!SFP added to replace related calcs initially done in damage mod
       call mpas_pool_get_array(velocityPool, 'sigmaxx', sigmaxx)
       call mpas_pool_get_array(velocityPool, 'sigmayy', sigmayy)
       call mpas_pool_get_array(velocityPool, 'sigmaxy', sigmaxy)
@@ -947,19 +937,15 @@ contains
       call mpas_pool_get_array(velocityPool, 'sigmamax', sigmamax)
       call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
 
-!SFP moved from damage mod
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) 
 
-!SFP moved from damage mod
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor) 
 
-!SFP moved from damage mod
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
 
-!SFP moved from damage mod
       call mpas_pool_get_field(scratchPool, 'meanFlowParamA', meanFlowParamAVar) 
       call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
       meanFlowParamA => meanFlowParamAVar % array
@@ -980,11 +966,9 @@ contains
       call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
       err = ior(err, err_tmp)
 
-!SFP: moved from damage mod
      ! calculate the depth-averaged flow parameter A
       meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
 
-!SFP: moved from damage mod
       ! calculate effective viscosity from strain rate and flow param.
       where (thickness == 0.0_RKIND)
           effectiveViscosity = 0.0_RKIND
@@ -1006,8 +990,7 @@ contains
       sigmamax(:) = &
       (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
 
-!SFP: moved from damage mod
-    call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
+      call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
 
    !--------------------------------------------------------------------
    end subroutine calculate_strain_rates

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -658,7 +658,8 @@ contains
          ! ---
          ! --- Calculate strain rates on cell centers
          ! ---
-         call calculate_strain_rates(meshPool, velocityPool, err_tmp)
+!         call calculate_strain_rates(meshPool, velocityPool, err_tmp) !SFP: altered to stress calcs addd
+         call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
          err = ior(err, err_tmp)
 
          block => block % next
@@ -864,15 +865,25 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine calculate_strain_rates(meshPool, velocityPool, err)
+   subroutine calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
+!        call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
 
       use li_setup
+      use li_diagnostic_vars !SFP: added ... goes here or at top of module?
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(in) :: &
          meshPool                                     !< Input: mesh object
+
+!SFP: added for stress calcs (from damage mod)
+      type (mpas_pool_type), intent(in) :: &
+         geometryPool                                 !< Input: geometry object
+      type (mpas_pool_type), intent(in) :: &
+         thermalPool                                  !< Input: thermal object
+      type (mpas_pool_type), intent(in) :: &
+         scratchPool                                  !< Input: scratch object
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -888,14 +899,35 @@ contains
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
+
       real(kind=RKIND), dimension(:), pointer :: exx, eyy, exy, eyx, eTheta, eMax, eMin
+      real(kind=RKIND), dimension(:), pointer :: sigmaxx, sigmayy, sigmaxy, sigmayx, sigmamax, sigmamin !SFP: added
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       integer :: err_tmp
 
+      !SFP moved these from damage mod 
+      real (kind=RKIND), dimension(:), pointer :: thickness 
+      real (kind=RKIND), dimension(:,:), pointer :: temperature 
+      real(kind=RKIND), pointer :: config_default_flowParamA  
+      real (kind=RKIND), dimension(:,:), pointer :: flowParamA
+      real (kind=RKIND), dimension(:), pointer :: effectiveViscosity
+      real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
+
+      !SFP moved these from damage mod 
+      type (field1dReal), pointer :: meanFlowParamAVar
+      real, dimension(:), pointer :: meanFlowParamA
+
+      !SFP: moved from damage mod
+      integer, pointer :: nVertLevels 
+
       err = 0
+
+      !SFP: moved from damage mod
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels) 
 
       call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
       call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
+
       call mpas_pool_get_array(velocityPool, 'exx', exx)
       call mpas_pool_get_array(velocityPool, 'eyy', eyy)
       call mpas_pool_get_array(velocityPool, 'exy', exy)
@@ -904,10 +936,34 @@ contains
       call mpas_pool_get_array(velocityPool, 'eMax', eMax)
       call mpas_pool_get_array(velocityPool, 'eMin', eMin)
 
+      !SFP added to replace related calcs initially done in damage mod
+      call mpas_pool_get_array(velocityPool, 'sigmaxx', sigmaxx)
+      call mpas_pool_get_array(velocityPool, 'sigmayy', sigmayy)
+      call mpas_pool_get_array(velocityPool, 'sigmaxy', sigmaxy)
+      call mpas_pool_get_array(velocityPool, 'sigmayx', sigmayx)
+      call mpas_pool_get_array(velocityPool, 'sigmamax', sigmamax)
+      call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
+
+      !SFP moved from damage mod
+      call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) 
+
+      !SFP moved from damage mod
+      call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+      call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
+      call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor) 
+
+      !SFP moved from damage mod
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
+
+      !SFP moved from damage mod
+      call mpas_pool_get_field(scratchPool, 'meanFlowParamA', meanFlowParamAVar) 
+      call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
+      meanFlowParamA => meanFlowParamAVar % array
+
       ! Calculate strain rates
       call li_compute_gradient_2d(meshPool, uReconstructX(1,:), exx, exy, err_tmp)
       err = ior(err, err_tmp)
-
       call li_compute_gradient_2d(meshPool, uReconstructY(1,:), eyx, eyy, err_tmp)
       err = ior(err, err_tmp)
 
@@ -917,6 +973,40 @@ contains
       ! Calculate principal strain rates
       eMax = 0.5_RKIND * (exx + eyy) + sqrt( (0.5_RKIND * (exx - eyy))**2 + (0.25_RKIND*(exy + eyx))**2)
       eMin = 0.5_RKIND * (exx + eyy) - sqrt( (0.5_RKIND * (exx - eyy))**2 + (0.25_RKIND*(exy + eyx))**2)
+
+      call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
+      err = ior(err, err_tmp)
+
+      !SFP: moved from damage mod
+     ! calculate the depth-averaged flow parameter A
+      meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
+
+      !SFP: moved from damage mod
+      ! calculate effective viscosity from strain rate and flow param.
+
+      where (thickness == 0.0_RKIND)
+          effectiveViscosity = 0.0_RKIND
+      !SFP: note that in debug mode, code crashes here due to (I think?) a div. by zero
+      elsewhere
+          effectiveViscosity = &
+          0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
+          exx*eyy + 0.25_RKIND*(exy+eyx)**2.0_RKIND))**((1.0_RKIND-3.0_RKIND)/3.0_RKIND)
+      endwhere
+
+      ! calculate deviatoric stresses
+      sigmaxx(:) = 2.0_RKIND*effectiveViscosity(:)*exx(:)
+      sigmayy(:) = 2.0_RKIND*effectiveViscosity(:)*eyy(:)
+      sigmaxy(:) = 2.0_RKIND*effectiveViscosity(:)*(exy(:)+eyx(:))/2.0_RKIND
+      sigmayx(:) = 2.0_RKIND*effectiveViscosity(:)*(eyx(:)+exy(:))/2.0_RKIND
+
+      ! calculate principal stresses
+      sigmamin(:) = &
+      (sigmaxx(:)+sigmayy(:))/2.0_RKIND-sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
+      sigmamax(:) = &
+      (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
+
+    !SFP: moved from damage mod
+    call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
 
    !--------------------------------------------------------------------
    end subroutine calculate_strain_rates

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -658,7 +658,8 @@ contains
          ! ---
          ! --- Calculate strain rates on cell centers
          ! ---
-!         call calculate_strain_rates(meshPool, velocityPool, err_tmp) !SFP: altered to stress calcs addd
+!SFP: altered to stress calcs addd
+!         call calculate_strain_rates(meshPool, velocityPool, err_tmp) 
          call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
          err = ior(err, err_tmp)
 
@@ -869,7 +870,8 @@ contains
 !        call calculate_strain_rates(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
 
       use li_setup
-      use li_diagnostic_vars !SFP: added ... goes here or at top of module?
+!SFP: should this be added here or at top of module?
+      use li_diagnostic_vars 
 
       !-----------------------------------------------------------------
       ! input variables
@@ -901,11 +903,12 @@ contains
       !-----------------------------------------------------------------
 
       real(kind=RKIND), dimension(:), pointer :: exx, eyy, exy, eyx, eTheta, eMax, eMin
-      real(kind=RKIND), dimension(:), pointer :: sigmaxx, sigmayy, sigmaxy, sigmayx, sigmamax, sigmamin !SFP: added
+!SFP: added for stress calcs (from damage mod)
+      real(kind=RKIND), dimension(:), pointer :: sigmaxx, sigmayy, sigmaxy, sigmayx, sigmamax, sigmamin
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       integer :: err_tmp
 
-      !SFP moved these from damage mod 
+!SFP moved these from damage mod 
       real (kind=RKIND), dimension(:), pointer :: thickness 
       real (kind=RKIND), dimension(:,:), pointer :: temperature 
       real(kind=RKIND), pointer :: config_default_flowParamA  
@@ -913,16 +916,16 @@ contains
       real (kind=RKIND), dimension(:), pointer :: effectiveViscosity
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
 
-      !SFP moved these from damage mod 
+!SFP moved these from damage mod 
       type (field1dReal), pointer :: meanFlowParamAVar
       real, dimension(:), pointer :: meanFlowParamA
 
-      !SFP: moved from damage mod
+!SFP: moved from damage mod
       integer, pointer :: nVertLevels 
 
       err = 0
 
-      !SFP: moved from damage mod
+!SFP: moved from damage mod
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels) 
 
       call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
@@ -936,7 +939,7 @@ contains
       call mpas_pool_get_array(velocityPool, 'eMax', eMax)
       call mpas_pool_get_array(velocityPool, 'eMin', eMin)
 
-      !SFP added to replace related calcs initially done in damage mod
+!SFP added to replace related calcs initially done in damage mod
       call mpas_pool_get_array(velocityPool, 'sigmaxx', sigmaxx)
       call mpas_pool_get_array(velocityPool, 'sigmayy', sigmayy)
       call mpas_pool_get_array(velocityPool, 'sigmaxy', sigmaxy)
@@ -944,19 +947,19 @@ contains
       call mpas_pool_get_array(velocityPool, 'sigmamax', sigmamax)
       call mpas_pool_get_array(velocityPool, 'sigmamin', sigmamin)
 
-      !SFP moved from damage mod
+!SFP moved from damage mod
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA) 
 
-      !SFP moved from damage mod
+!SFP moved from damage mod
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor) 
 
-      !SFP moved from damage mod
+!SFP moved from damage mod
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
 
-      !SFP moved from damage mod
+!SFP moved from damage mod
       call mpas_pool_get_field(scratchPool, 'meanFlowParamA', meanFlowParamAVar) 
       call mpas_allocate_scratch_field(meanFlowParamAVar, .true.)
       meanFlowParamA => meanFlowParamAVar % array
@@ -977,16 +980,14 @@ contains
       call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
       err = ior(err, err_tmp)
 
-      !SFP: moved from damage mod
+!SFP: moved from damage mod
      ! calculate the depth-averaged flow parameter A
       meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels)      
 
-      !SFP: moved from damage mod
+!SFP: moved from damage mod
       ! calculate effective viscosity from strain rate and flow param.
-
       where (thickness == 0.0_RKIND)
           effectiveViscosity = 0.0_RKIND
-      !SFP: note that in debug mode, code crashes here due to (I think?) a div. by zero
       elsewhere
           effectiveViscosity = &
           0.5_RKIND*stiffnessFactor*meanFlowParamA**(-1.0_RKIND/3.0_RKIND)*(sqrt(exx**2.0_RKIND+eyy**2.0_RKIND + &
@@ -1005,7 +1006,7 @@ contains
       sigmamax(:) = &
       (sigmaxx(:)+sigmayy(:))/2.0_RKIND+sqrt(((sigmaxx(:)-sigmayy(:))/2.0_RKIND)**2.0_RKIND+((sigmaxy(:)+sigmayx(:))/2.0_RKIND)**2.0_RKIND)
 
-    !SFP: moved from damage mod
+!SFP: moved from damage mod
     call mpas_deallocate_scratch_field(meanFlowParamAVar, .true.)
 
    !--------------------------------------------------------------------

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -51,7 +51,9 @@ module li_velocity
    public :: li_velocity_init, &
              li_velocity_finalize, &
              li_velocity_block_init, &
-             li_velocity_solve
+             li_velocity_solve, &
+             calculate_strain_rates
+
 
    !--------------------------------------------------------------------
    !


### PR DESCRIPTION
This PR adds new capability for 1) simulating the evolution of ice shelf “damage” and 2) allowing for iceberg calving and calving front retreat to occur as a function of the damage at the calving front.

Damage evolution is implemented based on the approach of Bassis and Ma (EPSL, v.409, 2015). Damage, which can span the range 0 (undamaged ice) to 1 (fully fractured ice), is conceptualized as the depth of sub-grid scale fractures relative to the full ice thickness. In practice, damage must be non-zero to evolve and so is “seeded” (initialized) everywhere on the ice shelf according to the Nye “zero stress” approximation (Nye, Proc. R. Soc. A., 239, 1957). In addition to increasing over time, damage may also “heal” over time (reduce) based on the local stress regime or basal (submarine) mass balance.

Calving as a function of the damage value can occur by one of two mechanisms, 1) all ice at the calving front with damage above a specified threshold value is calved away, 2) ice at the calving front with damage above the specified threshold is calved away at a rate that is proportional the value of damage above the threshold. The first method currently suffers from the limitation that only ice immediately adjacent to the ocean (“at” that calving front) is removed. This will be improved upon in later development that will use a flood fill algorithm to allow for the detection and removal of any and all ice connected to the calving front with damage above the specified threshold value.

Several other configurable options are available to aid in the practical application of the code. These include:

* set a threshold value (0> but <1) above which damage ice calves (damage need not reach 1 in order for calving to occur)

* set the coefficient of proportionality between the calving rate and the damage-above-threshold value when that method of calving is chosen

* turn damage healing on or off

* set a threshold value above which additional healing does not occur (ice is assumed too damage to heal)

* couple the value of the damage to the ice rheology via the ice stiffness factor (stiffness = 1 - damage)

* when coupling damage and ice rheology, set a threshold such that the ice stiffness will not drop below a given value, to aid in solver stability

Currently, damage is advected similar to other tracers (e.g., temperature), via first-order upwinding. Damage evolves in time according to an explicit forward Euler scheme. Both of these may be improved on in the future.
