### PR TITLE
Assign each domain instance a unique ID, and include the domain ID in log files

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -81,6 +81,7 @@ module mpas_subdriver
       character(len=StrKIND) :: iotype
       logical :: streamsExists
       integer :: mesh_iotype
+      integer, save :: domainID = 0
 
       interface
          subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
@@ -150,6 +151,9 @@ module mpas_subdriver
       domain_ptr % core => corelist
 
       call mpas_allocate_domain(domain_ptr)
+
+      domain_ptr % domainID = domainID
+      domainID = domainID + 1
 
       !
       ! Initialize infrastructure

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -26,6 +26,9 @@
       character (len=StrKIND) :: mesh_spec = '' !< mesh_spec attribute, read in from input file.
       character (len=StrKIND) :: parent_id = '' !< parent_id attribute, read in from input file.
 
+      ! Unique global ID number for this domain
+      integer :: domainID
+
       ! Pointer to timer root
       type (mpas_timer_root), pointer :: timer_root => null()
 

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -120,6 +120,7 @@ module mpas_log
       ! local variables
       !-----------------------------------------------------------------
       character(len=16) :: taskString  !< variable to build the task number as a string with appropriate zero padding
+      character(len=4) :: domainString  !< variable to store the domain number as a string with appropriate zero padding
       integer :: unitNumber !< local variable used to get a unit number
       character(len=strKind) :: proposedLogFileName, proposedErrFileName
       logical :: isOpen
@@ -176,6 +177,10 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
+      ! Store the domain number
+      !   This will be used to number the log files
+      mpas_log_info % domainID = domain % domainID
+
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
       !   * Debug build: All tasks active
@@ -207,8 +212,17 @@ module mpas_log
       else
          write(taskString, '(i9.9)') mpas_log_info % taskID
       end if
-      write(proposedLogFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".out"
-      write(proposedErrFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".err"
+
+      if ( mpas_log_info % domainID > 0 ) then
+         write(domainString, '(i4.4)') mpas_log_info % domainID
+         write(proposedLogFileName, fmt='(a, a, a, a, a, a, a)') &
+                                    "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".d", trim(domainString), ".out"
+         write(proposedErrFileName, fmt='(a, a, a, a, a, a, a)') &
+                                    "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".d", trim(domainString), ".err"
+      else
+         write(proposedLogFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".out"
+         write(proposedErrFileName, fmt='(a, a, a, a, a)') "log.", trim(mpas_log_info % coreName), ".", trim(taskString), ".err"
+      end if
 
       ! Set the log and err file names and unit numbers
       if (present(unitNumbers)) then
@@ -420,6 +434,9 @@ module mpas_log
          write(unitNumber, '(a)') '----------------------------------------------------------------------'
          write(unitNumber, '(a,a,a,a,a,i7.1,a,i7.1)') 'Beginning MPAS-', trim(mpas_log_info % coreName), ' ', &
             trim(logTypeString), ' Log File for task ', mpas_log_info % taskID, ' of ', mpas_log_info % nTasks
+         if ( mpas_log_info % domainID > 0 ) then
+            write(unitNumber, '(a,i7.1)') '    for domain ID ',  mpas_log_info % domainID
+         end if
          call date_and_time(date,time)
          write(unitNumber, '(a)') '    Opened at ' // date(1:4)//'/'//date(5:6)//'/'//date(7:8) // &
             ' ' // time(1:2)//':'//time(3:4)//':'//time(5:6)

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -27,6 +27,7 @@
       integer :: nTasks !<  number of total tasks associated with this instance
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
+      integer :: domainID !< domain number for this instance of the log manager
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run


### PR DESCRIPTION
This merge assigns each domain instance a unique ID and includes the domain
ID in log files.

When there exist multiple instances of domains, the domainID member of
the domain_type may be used to distinguish among instances. The domainID
values for instances begin at 0 and are automatically incremented and assigned
by the mpas_init routine.

The log module also includes '.dXXXX' in the log filenames for any domain
instances beyond instance zero so that log files from different instances do
not overwrite each other.