### PR TITLE
Fix parameters in enthalpy and hydro modules

### DIFF
--- a/src/core_landice/Registry_subglacial_hydro.xml
+++ b/src/core_landice/Registry_subglacial_hydro.xml
@@ -90,7 +90,7 @@
 		            description="power of beta parameter in subglacial water flux formula (in channels)"
 		            possible_values="positive real number"
 		/>
-		<nml_option name="config_SGH_chnl_conduc_coeff" type="real" default_value="0.1" units="m^(2*beta-alpha) s^(2*beta-3) kg^(1-beta)"
+		<nml_option name="config_SGH_chnl_conduc_coeff" type="real" default_value="0.1" units="m^(2*beta-2*alpha+1) s^(2*beta-3) kg^(1-beta)"
 		            description="conductivity coefficient (in channels)"
 		            possible_values="positive real number"
 		/>

--- a/src/core_landice/shared/mpas_li_constants.F
+++ b/src/core_landice/shared/mpas_li_constants.F
@@ -63,8 +63,8 @@ module li_constants
                                                            !< These values are from the Ocean Water Freezing Point Calculator,
                                                            !< http://www.csgnetwork.com/h2ofreezecalc.html (25 Nov. 2014)
 
-   real (kind=RKIND), parameter, public :: &
-        iceMeltingPointPressureDependence = 9.7456e-8_RKIND  ! Dependence of ice melting point on pressure (K Pa^-1)
+   real (kind=RKIND), parameter, public :: iceMeltingPointPressureDependence = 7.9e-8_RKIND
+      !< Clausius-Clapeyron constant: Dependence of ice melting point on pressure (K Pa^-1)
 
    !  conversion factors
    real (kind=RKIND), parameter, public :: kelvin_to_celsius = 273.15_RKIND    !< factor to convert Kelvin to Celsius


### PR DESCRIPTION
This merge fixes two small parameter issues:
* Changing Clausius-Clapeyron parameter to match that used by Albany.
* Updating units of channel hydraulic conductivity in Registry.