### PR TITLE
Bugfix for PGI failure after diagnostic solve breakup

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1489,6 +1489,7 @@ contains
       integer :: iEdge, iCell, k, i, nCells
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
+      integer, dimension(:, :), pointer :: edgeSignOnCell
 
       ! Scratch Arrays
       ! projectedSSH: projected SSH at a new time
@@ -1507,6 +1508,8 @@ contains
         vertAleTransportTop=0.0_RKIND
         return
       end if
+
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
       ncells = nCellsAll
 


### PR DESCRIPTION
Add back the retrieval of edgeSignOnCell from meshPool to the
ocn_vert_transport_velocity_top subroutine on mpas_ocn_diagnostics.F.  
