### PR TITLE
Remove scaling from read_geogrid

### DIFF
--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -498,7 +498,7 @@ module mpas_geotile_manager
 
         interface
            subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
-                                   scalefactor, wordsize, status) bind(C)
+                                   wordsize, status) bind(C)
               use iso_c_binding, only : c_char, c_int, c_float, c_ptr
               character (c_char), dimension(*), intent(in) :: fname
               type (c_ptr), value :: rarray
@@ -507,7 +507,6 @@ module mpas_geotile_manager
               integer (c_int), intent(in), value :: nz
               integer (c_int), intent(in), value :: isigned
               integer (c_int), intent(in), value :: endian
-              real (c_float), intent(in), value :: scalefactor
               integer (c_int), intent(in), value :: wordsize
               integer (c_int), intent(inout) :: status
            end subroutine read_geogrid
@@ -527,7 +526,6 @@ module mpas_geotile_manager
         integer :: start_x, start_y
         integer, pointer :: signed
         character (len=StrKIND), pointer :: endian
-        real (kind=RKIND), pointer :: scalefactor
         logical :: res
 
         character (len=StrKIND) :: fname
@@ -536,7 +534,6 @@ module mpas_geotile_manager
         integer (c_int) :: c_endian
         integer (c_int) :: c_wordsize
         integer (c_int) :: c_signed
-        real (c_float) :: c_scalefactor
         integer (c_int) :: status
         type (c_ptr) :: c_tile_ptr
 
@@ -544,7 +541,6 @@ module mpas_geotile_manager
 
         tile => null()
         endian => null()
-        scalefactor => null()
         signed => null()
 
         call mpas_pool_get_config(mgr % pool, 'tile_x', tile_nx)
@@ -554,13 +550,11 @@ module mpas_geotile_manager
         call mpas_pool_get_config(mgr % pool, 'wordsize', wordsize)
         call mpas_pool_get_config(mgr % pool, 'signed', signed)
         call mpas_pool_get_config(mgr % pool, 'endian', endian)
-        call mpas_pool_get_config(mgr % pool, 'scale_factor', scalefactor)
 
         c_tile_nx = tile_nx + 2 * tile_bdr ! The number of pixels in the x direction, including halo cells
         c_tile_ny = tile_ny + 2 * tile_bdr ! The number of pixels in the y direction, including halo cells
         c_tile_nz = tile_nz ! The number of pixels in the z direction
         c_wordsize = wordsize
-        c_scalefactor = real(scalefactor, c_float)
         c_signed = signed
 
         if (endian == "big") then
@@ -598,8 +592,7 @@ module mpas_geotile_manager
         allocate(tile)
         allocate(tile % tile(tile_nx + (tile_bdr * 2), tile_ny + (tile_bdr * 2), tile_nz))
         c_tile_ptr = c_loc(tile % tile)
-        call read_geogrid(c_fname, c_tile_ptr, c_tile_nx, c_tile_ny, c_tile_nz, c_signed, c_endian, &
-                            c_scalefactor, c_wordsize, status)
+        call read_geogrid(c_fname, c_tile_ptr, c_tile_nx, c_tile_ny, c_tile_nz, c_signed, c_endian, c_wordsize, status)
         if (status /= 0) then
             call mpas_log_write("Error reading this geogrid file: "//trim(fname), messageType=MPAS_LOG_ERR)
             ierr = 1

--- a/src/core_init_atmosphere/mpas_init_atm_gwd.F
+++ b/src/core_init_atmosphere/mpas_init_atm_gwd.F
@@ -21,7 +21,7 @@ module mpas_init_atm_gwd
 
    interface
       subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
-                              scalefactor, wordsize, status) bind(C)
+                              wordsize, status) bind(C)
          use iso_c_binding, only : c_char, c_int, c_float, c_ptr
          character (c_char), dimension(*), intent(in) :: fname
          type (c_ptr), value :: rarray
@@ -30,7 +30,6 @@ module mpas_init_atm_gwd
          integer (c_int), intent(in), value :: nz
          integer (c_int), intent(in), value :: isigned
          integer (c_int), intent(in), value :: endian
-         real (c_float), intent(in), value :: scalefactor
          integer (c_int), intent(in), value :: wordsize
          integer (c_int), intent(inout) :: status
       end subroutine read_geogrid
@@ -377,7 +376,8 @@ module mpas_init_atm_gwd
                                                                                       iy, '-', (iy+tile_y-1)
          call mpas_f_to_c_string(filename, c_filename)
          call read_geogrid(c_filename, tile_ptr, nx, ny, nz, isigned, endian, &
-                           scalefactor, wordsize, istatus)
+                           wordsize, istatus)
+         tile(:,:,:) = tile(:,:,:) * scalefactor
          if (istatus /= 0) then
             call mpas_log_write('Error reading topography tile '//trim(filename), messageType=MPAS_LOG_ERR)
             iErr = 1
@@ -446,7 +446,8 @@ module mpas_init_atm_gwd
                                                                                       iy, '-', (iy+tile_y-1)
          call mpas_f_to_c_string(filename, c_filename)
          call read_geogrid(c_filename, tile_ptr, nx, ny, nz, isigned, endian, &
-                           scalefactor, wordsize, istatus)
+                           wordsize, istatus)
+         tile(:,:,:) = tile(:,:,:) * scalefactor
          if (istatus /= 0) then
             call mpas_log_write('Error reading landuse tile '//trim(filename))
             iErr = 1

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -34,7 +34,7 @@
 
  interface
     subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
-                            scalefactor, wordsize, status) bind(C)
+                            wordsize, status) bind(C)
        use iso_c_binding, only : c_char, c_int, c_float, c_ptr
        character (c_char), dimension(*), intent(in) :: fname
        type (c_ptr), value :: rarray
@@ -43,7 +43,6 @@
        integer (c_int), intent(in), value :: nz
        integer (c_int), intent(in), value :: isigned
        integer (c_int), intent(in), value :: endian
-       real (c_float), intent(in), value :: scalefactor
        integer (c_int), intent(in), value :: wordsize
        integer (c_int), intent(inout) :: status
     end subroutine read_geogrid
@@ -88,6 +87,7 @@
  integer,dimension(:),allocatable  :: nhs
  integer,dimension(:,:),allocatable:: ncat
       
+ real(kind=RKIND), pointer :: scalefactor_ptr
  real(kind=c_float):: scalefactor
  real(kind=c_float),dimension(:,:,:),pointer,contiguous :: rarray
  type(c_ptr) :: rarray_ptr
@@ -340,6 +340,8 @@
  call mpas_pool_get_config(mgr % pool, 'tile_bdr', tile_bdr)
  call mpas_pool_get_config(mgr % pool, 'tile_x', tile_nx)
  call mpas_pool_get_config(mgr % pool, 'tile_y', tile_ny)
+ call mpas_pool_get_config(mgr % pool, 'scale_factor', scalefactor_ptr)
+ scalefactor = scalefactor_ptr
 
  do iCell = 1, nCells
      !
@@ -429,6 +431,7 @@
 
  do iCell = 1, nCells
     ter(iCell) = real(ter_integer(iCell), kind=R8KIND) / real(nhs(iCell), kind=R8KIND)
+    ter(iCell) = ter(iCell) * scalefactor
  end do
 
  deallocate(ter_integer)
@@ -772,8 +775,9 @@
  call mpas_f_to_c_string(fname, c_fname)
 
  call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned, endian, &
-                   scalefactor,wordsize,istatus)
+                   wordsize,istatus)
  call init_atm_check_read_error(istatus, fname)
+ rarray(:,:,:) = rarray(:,:,:) * scalefactor
  soiltemp_1deg(-2:180,-2:183) = rarray(1:183,1:186,1)
 
  write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
@@ -782,8 +786,9 @@
  call mpas_f_to_c_string(fname, c_fname)
 
  call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                        scalefactor,wordsize,istatus)
+                   wordsize,istatus)
  call init_atm_check_read_error(istatus,fname)
+ rarray(:,:,:) = rarray(:,:,:) * scalefactor
  soiltemp_1deg(181:363,-2:183) = rarray(4:186,1:186,1)
 
  interp_list(1) = FOUR_POINT
@@ -860,8 +865,9 @@
           call mpas_f_to_c_string(fname, c_fname)
 
           call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                            scalefactor,wordsize,istatus)
+                            wordsize,istatus)
           call init_atm_check_read_error(istatus, fname)
+          rarray(:,:,:) = rarray(:,:,:) * scalefactor
 
           iPoint = 1
           do j=supersample_fac * 3 + 1, supersample_fac * (ny-3)
@@ -956,8 +962,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor,wordsize,istatus)
+                      wordsize,istatus)
     call init_atm_check_read_error(istatus,fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     maxsnowalb(-2:180,-2:183) = rarray(1:183,1:186,1)
 
     write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
@@ -966,8 +973,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor,wordsize,istatus)
+                      wordsize,istatus)
     call init_atm_check_read_error(istatus, fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     maxsnowalb(181:363,-2:183) = rarray(4:186,1:186,1)
 
     interp_list(1) = FOUR_POINT
@@ -1054,8 +1062,9 @@
           call mpas_f_to_c_string(fname, c_fname)
 
           call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                            scalefactor,wordsize,istatus)
+                            wordsize,istatus)
           call init_atm_check_read_error(istatus, fname)
+          rarray(:,:,:) = rarray(:,:,:) *  scalefactor
 
           iPoint = 1
           do j=1,ny
@@ -1152,8 +1161,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor,wordsize,istatus)
+                      wordsize,istatus)
     call init_atm_check_read_error(istatus,fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     vegfra(-2:1250,-2:1253,1:12) = rarray(1:1253,1:1256,1:12)
 
     write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
@@ -1162,8 +1172,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor,wordsize,istatus)
+                      wordsize,istatus)
     call init_atm_check_read_error(istatus,fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     vegfra(1251:2503,-2:1253,1:12) = rarray(4:1256,1:1256,1:12)
 
     do iCell = 1,nCells
@@ -1250,8 +1261,9 @@
           call mpas_f_to_c_string(fname, c_fname)
 
           call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                            scalefactor,wordsize,istatus)
+                            wordsize,istatus)
           call init_atm_check_read_error(istatus, fname)
+          rarray(:,:,:) = rarray(:,:,:) * scalefactor
 
           iPoint = 1
           do j=supersample_fac * 3 + 1, supersample_fac * (ny-3)
@@ -1352,8 +1364,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor, wordsize, istatus)
+                      wordsize, istatus)
     call init_atm_check_read_error(istatus,fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     vegfra(-2:1250,-2:1253,1:12) = rarray(1:1253,1:1256,1:12)
 
     write(fname,'(a,i5.5,a1,i5.5,a1,i5.5,a1,i5.5)') trim(geog_data_path)// &
@@ -1362,8 +1375,9 @@
     call mpas_f_to_c_string(fname, c_fname)
 
     call read_geogrid(c_fname,rarray_ptr,nx,ny,nz,isigned,endian, &
-                      scalefactor,wordsize,istatus)
+                      wordsize,istatus)
     call init_atm_check_read_error(istatus,fname)
+    rarray(:,:,:) = rarray(:,:,:) * scalefactor
     vegfra(1251:2503,-2:1253,1:12) = rarray(4:1256,1:1256,1:12)
 
     do iCell = 1,nCells

--- a/src/core_init_atmosphere/read_geogrid.c
+++ b/src/core_init_atmosphere/read_geogrid.c
@@ -26,7 +26,7 @@
 
  interface
     subroutine read_geogrid(fname, rarray, nx, ny, nz, isigned, endian, &
-                            scalefactor, wordsize, status) bind(C)
+                            wordsize, status) bind(C)
        use iso_c_binding, only : c_char, c_int, c_float, c_ptr
        character (c_char), dimension(*), intent(in) :: fname
        type (c_ptr), value :: rarray
@@ -35,7 +35,6 @@
        integer (c_int), intent(in), value :: nz
        integer (c_int), intent(in), value :: isigned
        integer (c_int), intent(in), value :: endian
-       real (c_float), intent(in), value :: scalefactor
        integer (c_int), intent(in), value :: wordsize
        integer (c_int), intent(inout) :: status
     end subroutine read_geogrid
@@ -51,7 +50,6 @@ int read_geogrid(
       int nz,                /* z-dimension of the array */
       int isigned,           /* 0=unsigned data, 1=signed data */
       int endian,            /* 0=big endian, 1=little endian */
-      float scalefactor,     /* value to multiply array elements by before truncation to integers */
       int wordsize,          /* number of bytes to use for each array element */
       int * status)
 {
@@ -141,13 +139,6 @@ int read_geogrid(
    }
 
    free(c);
-
-   /* Scale real-valued array by scalefactor */
-   if (scalefactor != 1.0)
-   {
-      for (i=0; i<narray; i++)
-         rarray[i] = rarray[i] * (scalefactor);
-   }
 
    return 0;
 }


### PR DESCRIPTION
In preparation for a new parallel interpolation method, this merge removes
the scaling done within the read_geogrid C function and moves it into the
init_atm_static function.

For continuous datatypes, such as terrain height or snow albedo, the new
parallel interpolation method will accumulate values as integers and then
convert them to reals once all accumulation is complete. This method ensures
correctness across processes.

After this commit any new interpolation interpolation of a dataset will need to
scale any read tiles *after* calling read_geogrid.