### PR TITLE
Added vertexDegree back into variational velocity solver.

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_mesh_pool.F
+++ b/src/core_seaice/shared/mpas_seaice_mesh_pool.F
@@ -22,7 +22,8 @@ module seaice_mesh_pool
 
    integer, public :: &
       nCells,         &
-      nVerticesSolve
+      nVerticesSolve, &
+      vertexDegree
 
    integer, public, dimension(:), pointer :: & 
       nEdgesOnCell,   &
@@ -90,8 +91,9 @@ contains
          velocityVariationalPool
 
     integer, pointer ::   &
-         nCellsTmp,       &
-         nVerticesSolveTmp
+         nCellsTmp,         &
+         nVerticesSolveTmp, &
+         vertexDegreeTmp
 
     blockCount = 0
     block => domain % blocklist
@@ -109,9 +111,11 @@ contains
        ! convert mesh dimensions from pointers to scalars
        call mpas_pool_get_dimension(meshPool, 'nCells', nCellsTmp)
        call MPAS_pool_get_dimension(meshPool, "nVerticesSolve", nVerticesSolveTmp)
+       call MPAS_pool_get_dimension(meshPool, "vertexDegree", vertexDegreeTmp)
 
        nCells         = nCellsTmp
        nVerticesSolve = nVerticesSolveTmp
+       vertexDegree   = vertexDegreeTmp
 
        ! point to existing arrays
        call mpas_pool_get_array(meshPool, 'nEdgesOnCell',   nEdgesOnCell)
@@ -142,6 +146,7 @@ contains
 !$GPU ENTER_DATA COPY_IN_LP             &
 !$GPUC   nCells,                        &
 !$GPUC   nVerticesSolve,                &
+!$GPUC   vertexDegree,                  &
 !$GPUC   nEdgesOnCell,                  &
 !$GPUC   verticesOnCell,                &
 !$GPUC   cellsOnVertex,                 &
@@ -193,6 +198,7 @@ contains
 !$GPU EXIT_DATA COPY_DEL_LP             &
 !$GPUC   nCells,                        &
 !$GPUC   nVerticesSolve,                &
+!$GPUC   vertexDegree,                  &
 !$GPUC   nEdgesOnCell,                  &
 !$GPUC   verticesOnCell,                &
 !$GPUC   cellsOnVertex,                 &

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_variational.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_variational.F
@@ -751,7 +751,8 @@ contains
          nVerticesSolve, &
          cellsOnVertex, &
          nEdgesOnCell, &
-         areaTriangle
+         areaTriangle, &
+         vertexDegree
 
     type(MPAS_pool_type), pointer, intent(in) :: &
          mesh !< Input:
@@ -809,7 +810,7 @@ contains
           stressDivergenceVVertex = 0.0_RKIND
 
           ! loop over surrounding cells
-          do iSurroundingCell = 1, 3 !vertexDegree
+          do iSurroundingCell = 1, vertexDegree
 
              ! get the cell number of this cell
              iCell = cellsOnVertex(iSurroundingCell, iVertex)


### PR DESCRIPTION
A previous performance PR changed vertexDegree in the variational velocity solver for the hardwired value of "3". This prevents the code from working correctly for quadrilateral meshes, that are used in idealized test cases and comparisons with structured models such as CICE.

