### PR TITLE
Switch ocean freezing temperature to variable in MPAS-SI

### DIFF
--- a/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
@@ -38,11 +38,12 @@
          dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
 #endif
 
-         albocn    = 0.06_dbl_kind    ,&! ocean albedo
+         albocn    = 0.06_dbl_kind   ,&! ocean albedo
          gravit    = SHR_CONST_G     ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz= -34.0_dbl_kind*depressT,&! freezing temp of seawater (C),
-                                           ! used as Tsfcn for open water
+         Tocnfrz   = -1.8_dbl_kind   ,&! freezing temp of seawater (C), used 
+                                       ! as Tsfcn for open water only when 
+                                       ! tfrz_option is 'minus1p8' or null
          rhofresh  = SHR_CONST_RHOFW ,&! density of fresh water (kg/m^3)
          zvir      = SHR_CONST_ZVIR  ,&! rh2o/rair - 1.0
          vonkar    = SHR_CONST_KARMAN,&! von Karman constant

--- a/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
@@ -41,6 +41,8 @@
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = SHR_CONST_G     ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
+         Tocnfrz= -34.0_dbl_kind*depressT,&! freezing temp of seawater (C),
+                                           ! used as Tsfcn for open water
          rhofresh  = SHR_CONST_RHOFW ,&! density of fresh water (kg/m^3)
          zvir      = SHR_CONST_ZVIR  ,&! rh2o/rair - 1.0
          vonkar    = SHR_CONST_KARMAN,&! von Karman constant

--- a/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
@@ -41,8 +41,6 @@
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = SHR_CONST_G     ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz= -34.0_dbl_kind*depressT,&! freezing temp of seawater (C),
-                                           ! used as Tsfcn for open water
          rhofresh  = SHR_CONST_RHOFW ,&! density of fresh water (kg/m^3)
          zvir      = SHR_CONST_ZVIR  ,&! rh2o/rair - 1.0
          vonkar    = SHR_CONST_KARMAN,&! von Karman constant

--- a/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
@@ -35,8 +35,6 @@
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = 9.80616_dbl_kind ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),
-                                        ! used as Tsfcn for open water
          rhofresh  = 1000.0_dbl_kind  ,&! density of fresh water (kg/m^3)
          zvir      = 0.606_dbl_kind   ,&! rh2o/rair - 1.0
          vonkar    = 0.4_dbl_kind     ,&! von Karman constant

--- a/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
@@ -35,8 +35,9 @@
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = 9.80616_dbl_kind ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),
-                                        ! used as Tsfcn for open water
+         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C), used 
+                                        ! as Tsfcn for open water only when 
+                                        ! tfrz_option is 'minus1p8' or null
          rhofresh  = 1000.0_dbl_kind  ,&! density of fresh water (kg/m^3)
          zvir      = 0.606_dbl_kind   ,&! rh2o/rair - 1.0
          vonkar    = 0.4_dbl_kind     ,&! von Karman constant

--- a/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cice/ice_constants_colpkg.F90
@@ -35,6 +35,8 @@
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = 9.80616_dbl_kind ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
+         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),
+                                        ! used as Tsfcn for open water
          rhofresh  = 1000.0_dbl_kind  ,&! density of fresh water (kg/m^3)
          zvir      = 0.606_dbl_kind   ,&! rh2o/rair - 1.0
          vonkar    = 0.4_dbl_kind     ,&! von Karman constant

--- a/src/core_seaice/column/ice_algae.F90
+++ b/src/core_seaice/column/ice_algae.F90
@@ -385,8 +385,8 @@
 
 !=======================================================================
 
-      subroutine sklbio       (dt,       ntrcr,      &
-                               nilyr,                &
+      subroutine sklbio       (dt,       Tf,         &
+                               ntrcr,    nilyr,      &
                                nbtrcr,   n_algae,    &
                                n_zaero,  n_doc,      &
                                n_dic,    n_don,      &
@@ -419,6 +419,7 @@
 
       real (kind=dbl_kind), intent(in) :: &
          dt,       &  ! time step
+         Tf,       &  ! basal freezing temperature (C)
          hmix,     &  ! mixed layer depth (m)
          aicen,    &  ! ice area fraction
          meltb,    &  ! bottom melt (m)
@@ -472,8 +473,8 @@
                                       fswthru,   first_ice, &
                                       trcrn,     upNOn,     &
                                       upNHn,     grow_alg,  &
-                                      hin,       l_stop,    &
-                                      stop_label)
+                                      hin,       Tf,        &
+                                      l_stop,    stop_label)
 
      if (l_stop) return
 
@@ -503,8 +504,8 @@
                                       fswthru,    first_ice,    &
                                       trcrn,      upNOn,        &
                                       upNHn,      grow_alg_skl, &
-                                      hin,        l_stop,       &
-                                      stop_label)
+                                      hin,        Tf,           &
+                                      l_stop,     stop_label)
 
       use ice_constants_colpkg, only: p5, p05, p1, c1, c0, puny, c10, sk_l
       use ice_colpkg_tracers, only: nt_bgc_N,  ntrcr, bio_index 
@@ -522,6 +523,7 @@
          aicen  , & ! ice area 
          meltb  , & ! bottom ice melt
          congel , & ! bottom ice growth 
+         Tf     , & ! bottom freezing temperature
          fswthru    ! shortwave passing through ice to ocean
 
       logical (kind=log_kind), intent(in) :: &
@@ -579,7 +581,6 @@
          PV_scale_growth = p5           , & ! scale factor in Jin code PV during ice growth
          PV_scale_melt = p05            , & ! scale factor in Jin code PV during ice melt
          growth_max = 1.85e-10_dbl_kind , & ! PVt function reaches maximum here.  (m/s)
-         Tin_bot = -1.8_dbl_kind        , & ! temperature of the ice bottom (oC)
          MJ1 = 9.667e-9_dbl_kind        , & ! (m/s) coefficients in Jin2008
          MJ2 = 38.8_dbl_kind            , & ! (1) from:4.49e-4_dbl_kind*secday   
          MJ3 = 1.04e7_dbl_kind          , & ! 1/(m/s) from: 1.39e-3_dbl_kind*secday^2  
@@ -599,7 +600,7 @@
       Zoo_skl    = c0
       rphi_sk    = c1/phi_sk
       PVt        = c0
-      iTin       = Tin_bot
+      iTin       = Tf
 
       do nn = 1, nbtrcr 
          cinit     (nn) = c0

--- a/src/core_seaice/column/ice_colpkg.F90
+++ b/src/core_seaice/column/ice_colpkg.F90
@@ -57,7 +57,9 @@
            colpkg_snow_temperature, &
            colpkg_liquidus_temperature, &
            colpkg_sea_freezing_temperature, &
-           colpkg_enthalpy_snow
+           colpkg_enthalpy_ice, &
+           colpkg_enthalpy_snow, &
+           colpkg_salinity_profile
 
       ! warning messages
       public :: &
@@ -384,7 +386,31 @@
       end subroutine colpkg_init_thermo
 
 !=======================================================================
+! Initial salinity profile
+!
+! authors: C. M. Bitz, UW
+!          William H. Lipscomb, LANL
 
+      function colpkg_salinity_profile(zn) result(salinity)
+
+        use ice_colpkg_shared, only: saltmax
+        use ice_constants_colpkg, only: c1, c2, pi
+
+        real(kind=dbl_kind), intent(in) :: &
+             zn ! depth
+
+        real(kind=dbl_kind) :: &
+             salinity ! initial salinity profile
+
+        real (kind=dbl_kind), parameter :: &
+             nsal    = 0.407_dbl_kind, &
+             msal    = 0.573_dbl_kind
+
+        salinity = (saltmax/c2)*(c1-cos(pi*zn**(nsal/(msal+zn))))
+
+      end function colpkg_salinity_profile
+
+!=======================================================================
 ! Compute orbital parameters for the specified date.
 !
 ! author:  Bruce P. Briegleb, NCAR 
@@ -1709,6 +1735,33 @@
         endif
 
       end function colpkg_snow_temperature
+
+!=======================================================================
+
+      function colpkg_enthalpy_ice(zTin, zSin) result(qin)
+
+        use ice_colpkg_shared, only: ktherm
+        use ice_mushy_physics, only: enthalpy_mush
+        use ice_constants_colpkg, only: depressT, rhoi, cp_ice, Lfresh, cp_ocn, c1
+
+        real(kind=dbl_kind), intent(in) :: zTin
+        real(kind=dbl_kind), intent(in) :: zSin
+        real(kind=dbl_kind) :: qin
+
+        real(kind=dbl_kind) :: Tmlt
+
+        if (ktherm == 2) then
+
+           qin = enthalpy_mush(zTin, zSin)
+
+        else
+
+           Tmlt = -zSin*depressT
+           qin = -(rhoi * (cp_ice*(Tmlt-zTin) + Lfresh*(c1-Tmlt/zTin) - cp_ocn*Tmlt))
+
+        endif
+
+      end function colpkg_enthalpy_ice
 
 !=======================================================================
 

--- a/src/core_seaice/column/ice_colpkg.F90
+++ b/src/core_seaice/column/ice_colpkg.F90
@@ -2560,21 +2560,21 @@
 
          if (aice > puny) then
 
-            call linear_itd (ncat,     hin_max,        &
-                             nilyr,    nslyr,          &
-                             ntrcr,    trcr_depend,    &
-                             trcr_base,        & 
-                             n_trcr_strata,   &
-                             nt_strata,                &
+            call linear_itd (ncat,     hin_max,     &
+                             nilyr,    nslyr,       &
+                             ntrcr,    trcr_depend, &
+                             trcr_base,             & 
+                             n_trcr_strata,         &
+                             nt_strata,   Tf,       &
                              aicen_init,            &
                              vicen_init,            &
                              aicen,                 &
-                             trcrn,           & 
+                             trcrn,                 & 
                              vicen,                 &
                              vsnon,                 &
-                             aice      ,         &
-                             aice0     ,         &
-                             fpond,       l_stop,      &
+                             aice,                  &
+                             aice0,                 &
+                             fpond,       l_stop,   &
                              stop_label)
 
             if (l_stop) return
@@ -3175,6 +3175,7 @@
                                     nblyr,                       &
                                     ncat,         hin_max,       &
                                     rdg_conv,     rdg_shear,     &
+                                    Tf,                          &
                                     aicen,                       &
                                     trcrn,                       &
                                     vicen,        vsnon,         &
@@ -3202,7 +3203,8 @@
       use ice_colpkg_tracers, only: tr_pond_topo, tr_aero, tr_brine, ntrcr, nbtrcr
 
       real (kind=dbl_kind), intent(in) :: &
-         dt           ! time step
+         dt    , & ! time step
+         Tf        ! ocean freezing temperature
 
       integer (kind=int_kind), intent(in) :: &
          ncat  , & ! number of thickness categories
@@ -3317,7 +3319,8 @@
                          aredistn,     vredistn,       &
                          dardg1ndt,    dardg2ndt,      &
                          dvirdgndt,                    &
-                         araftn,       vraftn)        
+                         araftn,       vraftn,         &
+                         Tf)        
 
          if (l_stop) return
 
@@ -3327,7 +3330,8 @@
       !-----------------------------------------------------------------
 
       dtt = dt * ndtd  ! for proper averaging over thermo timestep
-      call cleanup_itd (dtt,                  ntrcr,            &
+      call cleanup_itd (dtt,                  Tf,               &
+                        ntrcr,                                  &
                         nilyr,                nslyr,            &
                         ncat,                 hin_max,          &
                         aicen,                trcrn,            &

--- a/src/core_seaice/column/ice_colpkg.F90
+++ b/src/core_seaice/column/ice_colpkg.F90
@@ -57,9 +57,7 @@
            colpkg_snow_temperature, &
            colpkg_liquidus_temperature, &
            colpkg_sea_freezing_temperature, &
-           colpkg_enthalpy_ice, &
-           colpkg_enthalpy_snow, &
-           colpkg_salinity_profile
+           colpkg_enthalpy_snow
 
       ! warning messages
       public :: &
@@ -386,31 +384,7 @@
       end subroutine colpkg_init_thermo
 
 !=======================================================================
-! Initial salinity profile
-!
-! authors: C. M. Bitz, UW
-!          William H. Lipscomb, LANL
 
-      function colpkg_salinity_profile(zn) result(salinity)
-
-        use ice_colpkg_shared, only: saltmax
-        use ice_constants_colpkg, only: c1, c2, pi
-
-        real(kind=dbl_kind), intent(in) :: &
-             zn ! depth
-
-        real(kind=dbl_kind) :: &
-             salinity ! initial salinity profile
-
-        real (kind=dbl_kind), parameter :: &
-             nsal    = 0.407_dbl_kind, &
-             msal    = 0.573_dbl_kind
-
-        salinity = (saltmax/c2)*(c1-cos(pi*zn**(nsal/(msal+zn))))
-
-      end function colpkg_salinity_profile
-
-!=======================================================================
 ! Compute orbital parameters for the specified date.
 !
 ! author:  Bruce P. Briegleb, NCAR 
@@ -1738,33 +1712,6 @@
 
 !=======================================================================
 
-      function colpkg_enthalpy_ice(zTin, zSin) result(qin)
-
-        use ice_colpkg_shared, only: ktherm
-        use ice_mushy_physics, only: enthalpy_mush
-        use ice_constants_colpkg, only: depressT, rhoi, cp_ice, Lfresh, cp_ocn, c1
-
-        real(kind=dbl_kind), intent(in) :: zTin
-        real(kind=dbl_kind), intent(in) :: zSin
-        real(kind=dbl_kind) :: qin
-
-        real(kind=dbl_kind) :: Tmlt
-
-        if (ktherm == 2) then
-
-           qin = enthalpy_mush(zTin, zSin)
-
-        else
-
-           Tmlt = -zSin*depressT
-           qin = -(rhoi * (cp_ice*(Tmlt-zTin) + Lfresh*(c1-Tmlt/zTin) - cp_ocn*Tmlt))
-
-        endif
-
-      end function colpkg_enthalpy_ice
-
-!=======================================================================
-
       function colpkg_enthalpy_snow(zTsn) result(qsn)
 
         use ice_mushy_physics, only: enthalpy_snow
@@ -2646,7 +2593,8 @@
       !  categories with very small areas.
       !-----------------------------------------------------------------
 
-      call cleanup_itd (dt,                   ntrcr,            &
+      call cleanup_itd (dt,                   Tf,               &
+                        ntrcr,                                  &
                         nilyr,                nslyr,            &
                         ncat,                 hin_max,          &
                         aicen,                trcrn(1:ntrcr,:), &
@@ -3358,7 +3306,7 @@
 ! authors: C. M. Bitz, UW
 !          W. H. Lipscomb, LANL
 
-      subroutine colpkg_aggregate (ncat,               &
+      subroutine colpkg_aggregate (ncat,     Tf,       &
                                    aicen,    trcrn,    &
                                    vicen,    vsnon,    &
                                    aice,     trcr,     &
@@ -3376,6 +3324,9 @@
       integer (kind=int_kind), intent(in) :: &
          ncat  , & ! number of thickness categories
          ntrcr     ! number of tracers in use
+
+      real (kind=dbl_kind), intent(in) :: &
+         Tf        ! ocean freezing temperature           (Celsius)
 
       real (kind=dbl_kind), dimension (:), intent(in) :: &
          aicen , & ! concentration of ice
@@ -3464,7 +3415,8 @@
                                    atrcr,     aice,          &
                                    vice ,     vsno,          &
                                    trcr_base, n_trcr_strata, &
-                                   nt_strata, trcr)   
+                                   nt_strata, trcr,          &
+                                   Tf)   
 
       deallocate (atrcr)
 

--- a/src/core_seaice/column/ice_colpkg.F90
+++ b/src/core_seaice/column/ice_colpkg.F90
@@ -1639,7 +1639,7 @@
       function colpkg_sea_freezing_temperature(sss) result(Tf)
 
         use ice_colpkg_shared, only: tfrz_option
-        use ice_constants_colpkg, only: depressT
+        use ice_constants_colpkg, only: depressT, Tocnfrz
 
         real(dbl_kind), intent(in) :: sss
         real(dbl_kind) :: Tf
@@ -1654,7 +1654,7 @@
 
         else
 
-           Tf = -1.8_dbl_kind
+           Tf = Tocnfrz 
 
         endif
 
@@ -5327,7 +5327,7 @@
                            nblyr, nilyr, nslyr, n_algae, n_zaero, ncat, &
                            n_doc, n_dic,  n_don, n_fed, n_fep,  &
                            meltbn, melttn, congeln, snoicen, &
-                           sst, sss, fsnow, meltsn, hmix, salinz, &
+                           sst, sss, Tf, fsnow, meltsn, hmix, salinz, &
                            hin_old, flux_bio, flux_bio_atm, &
                            aicen_init, vicen_init, aicen, vicen, vsnon, &
                            aice0, trcrn, vsnon_init, skl_bgc, &
@@ -5433,6 +5433,7 @@
          sss     , & ! sea surface salinity (ppt)
          sst     , & ! sea surface temperature (C)
          hmix    , & ! mixed layer depth (m)
+         Tf      , & ! basal freezing temperature (C)
          fsnow       ! snowfall rate (kg/m^2 s)
 
       logical (kind=log_kind), intent(in) :: &
@@ -5690,13 +5691,13 @@
 
             elseif (skl_bgc) then
 
-               call sklbio (dt,                      ntrcr,               &
-                            nilyr,                                        &
+               call sklbio (dt,                      Tf,                  &
+                            ntrcr,                   nilyr,               &
                             nbtrcr,                  n_algae,             &
                             n_zaero,                 n_doc,               &
                             n_dic,                   n_don,               &
                             n_fed,                   n_fep,               &
-                            flux_bio (1:nbtrcr),     ocean_bio(:), &
+                            flux_bio (1:nbtrcr),     ocean_bio(:),        &
                             hmix,                    aicen    (n),        &
                             meltbn   (n),            congeln  (n),        &
                             fswthrun (n),            first_ice(n),        &

--- a/src/core_seaice/column/ice_colpkg_tracers.F90
+++ b/src/core_seaice/column/ice_colpkg_tracers.F90
@@ -164,9 +164,10 @@
                                          atrcrn,    aicen,          &
                                          vicen,     vsnon,          &
                                          trcr_base, n_trcr_strata,  &
-                                         nt_strata, trcrn)
+                                         nt_strata, trcrn,          &
+                                         Tf)
 
-      use ice_constants_colpkg, only: c0, c1, puny, Tocnfrz
+      use ice_constants_colpkg, only: c0, c1, puny
 
       integer (kind=int_kind), intent(in) :: &
          ntrcr                 ! number of tracers in use
@@ -188,7 +189,8 @@
       real (kind=dbl_kind), intent(in) :: &
          aicen , & ! concentration of ice
          vicen , & ! volume per unit area of ice          (m)
-         vsnon     ! volume per unit area of snow         (m)
+         vsnon , & ! volume per unit area of snow         (m)
+         Tf        ! ocean freezing temperature           (Celsius)
 
       real (kind=dbl_kind), dimension (ntrcr), intent(out) :: &
          trcrn     ! ice tracers
@@ -221,7 +223,7 @@
                trcrn(it) = atrcrn(it) / aicen
             else
                trcrn(it) = c0
-               if (it == nt_Tsfc) trcrn(it) = Tocnfrz  ! surface temperature
+               if (it == nt_Tsfc) trcrn(it) = Tf      ! surface temperature
             endif
 
          else

--- a/src/core_seaice/column/ice_itd.F90
+++ b/src/core_seaice/column/ice_itd.F90
@@ -89,7 +89,7 @@
       subroutine rebin (ntrcr,    trcr_depend,     &
                         trcr_base,                 &
                         n_trcr_strata,             &
-                        nt_strata,                 &
+                        nt_strata,   Tf,           &
                         aicen,    trcrn,           &
                         vicen,    vsnon,           &
                         ncat,     hin_max,         &
@@ -97,7 +97,8 @@
 
       integer (kind=int_kind), intent(in) :: &
          ntrcr , & ! number of tracers in use
-         ncat      ! number of thickness categories
+         ncat  , & ! number of thickness categories
+         Tf        ! ocean freezing temperature (C)
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
          trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
@@ -207,7 +208,7 @@
                             trcr_depend,          &
                             trcr_base,            &
                             n_trcr_strata,        &
-                            nt_strata,            &
+                            nt_strata,   Tf,      &
                             aicen,    trcrn,      &
                             vicen,    vsnon,      &
                             hicen,    donor,      &
@@ -255,7 +256,7 @@
                             trcr_depend,          &
                             trcr_base,            &
                             n_trcr_strata,        &
-                            nt_strata,            &
+                            nt_strata,   Tf,      &
                             aicen,    trcrn,      &
                             vicen,    vsnon,      &
                             hicen,    donor,      &
@@ -345,7 +346,7 @@
                             trcr_depend,           &
                             trcr_base,             &
                             n_trcr_strata,         &
-                            nt_strata,             &
+                            nt_strata,   Tf,       &
                             aicen,    trcrn,       &
                             vicen,    vsnon,       &
                             hicen,    donor,       &
@@ -356,7 +357,8 @@
 
       integer (kind=int_kind), intent(in) :: &
          ncat  , & ! number of thickness categories
-         ntrcr     ! number of tracers in use
+         ntrcr , & ! number of tracers in use
+         Tf        ! ocean freezing temperature (C)
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
          trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
@@ -647,11 +649,12 @@
       ! Compute new tracers
       !-----------------------------------------------------------------
 
-         call colpkg_compute_tracers (ntrcr,       trcr_depend, &
-                                      atrcrn(:,n), aicen(n),    &
-                                      vicen(n),    vsnon(n),    &
+         call colpkg_compute_tracers (ntrcr,       trcr_depend,    &
+                                      atrcrn(:,n), aicen(n),       &
+                                      vicen(n),    vsnon(n),       &
                                       trcr_base,   n_trcr_strata,  &
-                                      nt_strata,   trcrn(:,n))
+                                      nt_strata,   trcrn(:,n),     &
+                                      Tf)
 
       enddo                     ! ncat
 
@@ -918,7 +921,7 @@
          call rebin (ntrcr,      trcr_depend, &
                      trcr_base,               &
                      n_trcr_strata,           &
-                     nt_strata,               &
+                     nt_strata,  Tf,          &
                      aicen,      trcrn,       &
                      vicen,      vsnon,       &
                      ncat,       hin_max,     &

--- a/src/core_seaice/column/ice_itd.F90
+++ b/src/core_seaice/column/ice_itd.F90
@@ -28,7 +28,7 @@
 
       use ice_kinds_mod
       use ice_constants_colpkg, only: c0, c1, c2, p001, puny, p5, &
-          Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, Tocnfrz, rhoi
+          Lfresh, rhos, ice_ref_salinity, hs_min, cp_ice, rhoi
       use ice_warnings, only: &
           add_warning
 
@@ -744,7 +744,8 @@
 !
 ! author: William H. Lipscomb, LANL
 
-      subroutine cleanup_itd (dt,          ntrcr,      &
+      subroutine cleanup_itd (dt,          Tf,         &
+                              ntrcr,                   &
                               nilyr,       nslyr,      &
                               ncat,        hin_max,    &
                               aicen,       trcrn,      &
@@ -774,7 +775,8 @@
          n_aero    ! number of aerosol tracers
  
       real (kind=dbl_kind), intent(in) :: & 
-         dt        ! time step 
+         dt    , & ! time step 
+         Tf        ! ocean freezing temperature           (Celsius)
  
       real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
          hin_max   ! category boundaries (m)
@@ -929,7 +931,8 @@
       !-----------------------------------------------------------------
 
       if (limit_aice) then
-         call zap_small_areas (dt,           ntrcr,         &
+         call zap_small_areas (dt,           Tf,            &
+                               ntrcr,                       &
                                ncat,         n_aero,        &
                                nblyr,                       &
                                nilyr,        nslyr,         &
@@ -1016,7 +1019,8 @@
 !
 ! author: William H. Lipscomb, LANL
 
-      subroutine zap_small_areas (dt,        ntrcr,        &
+      subroutine zap_small_areas (dt,        Tf,           &
+                                  ntrcr,                   &
                                   ncat,      n_aero,       &
                                   nblyr,                   &
                                   nilyr,     nslyr,        &
@@ -1049,7 +1053,8 @@
          nbtrcr       ! number of biology tracers
 
       real (kind=dbl_kind), intent(in) :: &
-         dt           ! time step
+         dt       , & ! time step
+         Tf           ! ocean freezing temperature           (Celsius)
 
       real (kind=dbl_kind), intent(inout) :: &
          aice     , & ! total ice concentration
@@ -1189,7 +1194,7 @@
             aice0 = aice0 + aicen(n)
             aicen(n) = c0
             vicen(n) = c0
-            trcrn(nt_Tsfc,n) = Tocnfrz
+            trcrn(nt_Tsfc,n) = Tf
 
       !-----------------------------------------------------------------
       ! Zap snow

--- a/src/core_seaice/column/ice_itd.F90
+++ b/src/core_seaice/column/ice_itd.F90
@@ -97,12 +97,14 @@
 
       integer (kind=int_kind), intent(in) :: &
          ntrcr , & ! number of tracers in use
-         ncat  , & ! number of thickness categories
-         Tf        ! ocean freezing temperature (C)
+         ncat      ! number of thickness categories
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
          trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
          n_trcr_strata  ! number of underlying tracer layers
+
+      real (kind=dbl_kind), intent(in) :: &
+         Tf        ! ocean freezing temperature (C)
 
       real (kind=dbl_kind), dimension (:,:), intent(in) :: &
          trcr_base      ! = 0 or 1 depending on tracer dependency
@@ -357,12 +359,14 @@
 
       integer (kind=int_kind), intent(in) :: &
          ncat  , & ! number of thickness categories
-         ntrcr , & ! number of tracers in use
-         Tf        ! ocean freezing temperature (C)
+         ntrcr     ! number of tracers in use
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
          trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
          n_trcr_strata  ! number of underlying tracer layers
+
+      real (kind=dbl_kind), intent(in) :: &
+         Tf        ! ocean freezing temperature (C)
 
       real (kind=dbl_kind), dimension (:,:), intent(in) :: &
          trcr_base      ! = 0 or 1 depending on tracer dependency

--- a/src/core_seaice/column/ice_mechred.F90
+++ b/src/core_seaice/column/ice_mechred.F90
@@ -100,7 +100,8 @@
                             aredistn,    vredistn,   &
                             dardg1ndt,   dardg2ndt,  &
                             dvirdgndt,               &
-                            araftn,      vraftn)
+                            araftn,      vraftn,     &
+                            Tf)
 
       use ice_colpkg_tracers, only: nt_qice, nt_qsno, nt_fbri, nt_sice
 
@@ -114,7 +115,8 @@
 
       real (kind=dbl_kind), intent(in) :: &
          mu_rdg , & ! gives e-folding scale of ridged ice (m^.5) 
-         dt             ! time step
+         dt     , & ! time step
+         Tf         ! ocean freezing temperature (C)
 
       real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
          hin_max   ! category limits (m)
@@ -371,7 +373,8 @@
                            msnow_mlt,   esnow_mlt,   &
                            maero,       mpond,       &
                            l_stop,      stop_label,  &
-                           aredistn,    vredistn)    
+                           aredistn,    vredistn,    &
+                           Tf)    
 
          if (l_stop) return
 
@@ -1043,7 +1046,8 @@
                               msnow_mlt,   esnow_mlt,       &
                               maero,       mpond,           &
                               l_stop,      stop_label,      &
-                              aredistn,    vredistn)
+                              aredistn,    vredistn,        &
+                              Tf)
 
       use ice_colpkg_tracers, only: nt_qsno, nt_fbri, &
                              nt_alvl, nt_vlvl, nt_aero, tr_aero, &
@@ -1058,7 +1062,8 @@
          krdg_redist      ! selects redistribution function
 
       real (kind=dbl_kind), intent(in) :: &
-         dt             ! time step (s)
+         dt,     & ! time step (s)
+         Tf        ! ocean freezing temperature (C)
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
          trcr_depend, & ! = 0 for aicen tracers, 1 for vicen, 2 for vsnon
@@ -1529,7 +1534,8 @@
                                          atrcrn(:,n), aicen(n),      &
                                          vicen(n),    vsnon(n),      &
                                          trcr_base,   n_trcr_strata, &
-                                         nt_strata,   trcrn(:,n))
+                                         nt_strata,   trcrn(:,n),    &
+                                         Tf)
       enddo
 
       end subroutine ridge_shift

--- a/src/core_seaice/column/ice_therm_itd.F90
+++ b/src/core_seaice/column/ice_therm_itd.F90
@@ -66,16 +66,16 @@
 ! authors: William H. Lipscomb, LANL
 !          Elizabeth C. Hunke, LANL
 
-      subroutine linear_itd (ncat,        hin_max,     &
-                             nilyr,       nslyr,       &
-                             ntrcr,       trcr_depend, & 
+      subroutine linear_itd (ncat,        hin_max,      &
+                             nilyr,       nslyr,        &
+                             ntrcr,       trcr_depend,  & 
                              trcr_base,   n_trcr_strata,&
-                             nt_strata,                &
-                             aicen_init,  vicen_init,  & 
-                             aicen,       trcrn,       & 
-                             vicen,       vsnon,       & 
-                             aice,        aice0,       & 
-                             fpond,       l_stop,      &
+                             nt_strata,   Tf,           &
+                             aicen_init,  vicen_init,   & 
+                             aicen,       trcrn,        & 
+                             vicen,       vsnon,        & 
+                             aice,        aice0,        & 
+                             fpond,       l_stop,       &
                              stop_label)
 
       use ice_itd, only: aggregate_area, shift_ice, & 
@@ -89,7 +89,8 @@
          ncat    , & ! number of thickness categories
          nilyr   , & ! number of ice layers
          nslyr   , & ! number of snow layers
-         ntrcr       ! number of tracers in use
+         ntrcr   , & ! number of tracers in use
+         Tf          ! ocean freezing temperature (C)
 
       real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
          hin_max      ! category boundaries (m)
@@ -555,7 +556,7 @@
                          trcr_depend,           &
                          trcr_base,             &
                          n_trcr_strata,         &
-                         nt_strata,             &
+                         nt_strata,   Tf,       &
                          aicen,    trcrn,       &
                          vicen,    vsnon,       &
                          hicen,    donor,       &

--- a/src/core_seaice/column/ice_therm_itd.F90
+++ b/src/core_seaice/column/ice_therm_itd.F90
@@ -89,7 +89,9 @@
          ncat    , & ! number of thickness categories
          nilyr   , & ! number of ice layers
          nslyr   , & ! number of snow layers
-         ntrcr   , & ! number of tracers in use
+         ntrcr       ! number of tracers in use
+
+      real (kind=dbl_kind), intent(in) :: &
          Tf          ! ocean freezing temperature (C)
 
       real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -1577,8 +1577,8 @@ contains
 
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
-       call MPAS_pool_get_array(ocean_coupling, "freezingMeltingPotential", freezingMeltingPotential)
        call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
+       call MPAS_pool_get_array(ocean_coupling, "freezingMeltingPotential", freezingMeltingPotential)
 
        call MPAS_pool_get_array(drag, "airOceanDragCoefficientRatio", airOceanDragCoefficientRatio)
        call MPAS_pool_get_array(drag, "oceanDragCoefficient", oceanDragCoefficient)
@@ -3463,6 +3463,7 @@ contains
          verticalGrid, &
          seaSurfaceTemperature, &
          seaSurfaceSalinity, &
+         seaFreezingTemperature, &
          snowfallRate, &
          zSalinityFlux, &
          zSalinityGDFlux, &
@@ -3684,6 +3685,7 @@ contains
 
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
+       call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
        call MPAS_pool_get_array(ocean_coupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
 
        call MPAS_pool_get_array(atmos_coupling, "snowfallRate", snowfallRate)
@@ -3849,6 +3851,7 @@ contains
                snowiceFormationCategory(:,iCell), &
                seaSurfaceTemperature(iCell), &
                seaSurfaceSalinity(iCell), &
+               seaFreezingTemperature(iCell), &
                snowfallRate(iCell), &
                snowMeltCategory(:,iCell), &
                oceanMixedLayerDepth(iCell), &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -3471,6 +3471,7 @@ contains
          verticalGrid, &
          seaSurfaceTemperature, &
          seaSurfaceSalinity, &
+         seaFreezingTemperature, &
          snowfallRate, &
          zSalinityFlux, &
          zSalinityGDFlux, &
@@ -3858,6 +3859,7 @@ contains
                snowiceFormationCategory(:,iCell), &
                seaSurfaceTemperature(iCell), &
                seaSurfaceSalinity(iCell), &
+               seaFreezingTemperature(iCell), &
                snowfallRate(iCell), &
                snowMeltCategory(:,iCell), &
                oceanMixedLayerDepth(iCell), &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -3125,6 +3125,7 @@ contains
          tracers_aggregate, &
          ponds, &
          ocean_fluxes, &
+         ocean_coupling, &
          ridging, &
          aerosols, &
          biogeochemistry, &
@@ -3156,6 +3157,7 @@ contains
          oceanFreshWaterFlux, &
          oceanSaltFlux, &
          oceanHeatFlux, &
+         seaFreezingTemperature, &
          iceAreaCell, &
          ridgeConvergence, &
          ridgeShear, &
@@ -3248,6 +3250,8 @@ contains
        call MPAS_pool_get_array(tracers, "iceVolumeCategory", iceVolumeCategory, 1)
        call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
 
+       call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
+
        call MPAS_pool_get_array(ocean_fluxes, "oceanFreshWaterFlux", oceanFreshWaterFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanSaltFlux", oceanSaltFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanHeatFlux", oceanHeatFlux)
@@ -3310,6 +3314,7 @@ contains
                categoryThicknessLimits, & ! hin_max, dimension(0:ncat), intent(inout)
                ridgeConvergence(iCell), &
                ridgeShear(iCell), &
+               seaFreezingTemperature(iCell), &
                iceAreaCategory(1,:,iCell), &
                tracerArrayCategory, &              ! trcrn, dimension(:,:), intent(inout)
                iceVolumeCategory(1,:,iCell), &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -3227,6 +3227,7 @@ contains
        call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistry)
        call MPAS_pool_get_subpool(block % structs, "initial", initial)
        call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocity_solver)
+       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", ocean_coupling)
 
        call MPAS_pool_get_config(block % configs, "config_dynamics_subcycle_number", config_dynamics_subcycle_number)
        call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
@@ -4263,6 +4264,7 @@ contains
        call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
        call MPAS_pool_get_subpool(block % structs, "icestate", icestate)
        call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracers_aggregate)
+       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", ocean_coupling)
 
        call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -1309,7 +1309,6 @@ contains
 
     logical, pointer :: &
          config_use_aerosols, &
-         config_use_prescribed_ice, &
          config_use_snow_liquid_ponds
 
     ! dimensions
@@ -1503,7 +1502,6 @@ contains
 
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
        call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
-       call MPAS_pool_get_config(block % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
        call MPAS_pool_get_config(block % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
@@ -1850,8 +1848,7 @@ contains
                freezeOnset(iCell), &
                dayOfYear, &
                abortFlag, &
-               abortMessage, &
-               config_use_prescribed_ice)
+               abortMessage)
           call column_write_warnings(abortFlag)
 
           ! cell-specific abort message
@@ -4219,7 +4216,8 @@ contains
          mesh, &
          tracers, &
          tracers_aggregate, &
-         icestate
+         icestate, &
+         ocean_coupling
 
     logical, pointer :: &
          config_use_column_biogeochemistry
@@ -4228,7 +4226,8 @@ contains
          iceAreaCell, &
          iceVolumeCell, &
          snowVolumeCell, &
-         openWaterArea
+         openWaterArea, &
+         seaFreezingTemperature
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          iceAreaCategory, &
@@ -4269,6 +4268,8 @@ contains
 
        call MPAS_pool_get_array(icestate, "openWaterArea", openWaterArea)
 
+       call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
+
        setGetPhysicsTracers = .true.
        setGetBGCTracers     = config_use_column_biogeochemistry
 
@@ -4280,6 +4281,7 @@ contains
 
           call colpkg_aggregate(&
                nCategories, &
+               seaFreezingTemperature(iCell), &
                iceAreaCategory(1,:,iCell), &
                tracerArrayCategory, & ! trcrn
                iceVolumeCategory(1,:,iCell), &

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -1309,6 +1309,7 @@ contains
 
     logical, pointer :: &
          config_use_aerosols, &
+         config_use_prescribed_ice, &
          config_use_snow_liquid_ponds
 
     ! dimensions
@@ -1502,6 +1503,7 @@ contains
 
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
        call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
+       call MPAS_pool_get_config(block % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
        call MPAS_pool_get_config(block % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
@@ -1577,8 +1579,8 @@ contains
 
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
-       call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
        call MPAS_pool_get_array(ocean_coupling, "freezingMeltingPotential", freezingMeltingPotential)
+       call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
 
        call MPAS_pool_get_array(drag, "airOceanDragCoefficientRatio", airOceanDragCoefficientRatio)
        call MPAS_pool_get_array(drag, "oceanDragCoefficient", oceanDragCoefficient)
@@ -1848,7 +1850,8 @@ contains
                freezeOnset(iCell), &
                dayOfYear, &
                abortFlag, &
-               abortMessage)
+               abortMessage, &
+               config_use_prescribed_ice)
           call column_write_warnings(abortFlag)
 
           ! cell-specific abort message
@@ -3463,7 +3466,6 @@ contains
          verticalGrid, &
          seaSurfaceTemperature, &
          seaSurfaceSalinity, &
-         seaFreezingTemperature, &
          snowfallRate, &
          zSalinityFlux, &
          zSalinityGDFlux, &
@@ -3851,7 +3853,6 @@ contains
                snowiceFormationCategory(:,iCell), &
                seaSurfaceTemperature(iCell), &
                seaSurfaceSalinity(iCell), &
-               seaFreezingTemperature(iCell), &
                snowfallRate(iCell), &
                snowMeltCategory(:,iCell), &
                oceanMixedLayerDepth(iCell), &


### PR DESCRIPTION
This PR fixes a problem in the column package that also exists in [Icepack](https://github.com/CICE-Consortium/Icepack), in that the ocean freezing temperature has previously been set to a fixed constant rather than the correct value as determined by the input flag tfrz_option (config_sea_freezing_temperature_type in the MPAS dycore).  It affects the code in three places:

1. https://github.com/MPAS-Dev/MPAS-Model/blob/51d5624709f75182130a2fd94715e1bb13310172/src/core_seaice/column/ice_itd.F90#L1191

2. https://github.com/MPAS-Dev/MPAS-Model/blob/51d5624709f75182130a2fd94715e1bb13310172/src/core_seaice/column/ice_algae.F90#L537

3. https://github.com/MPAS-Dev/MPAS-Model/blob/51d5624709f75182130a2fd94715e1bb13310172/src/core_seaice/column/ice_colpkg_tracers.F90#L218

In addition, the default value of tocnfrz being used in the fully coupled model was being set assuming a salinity of the ocean surface was fixed at 34 PSU, which was incorrect:

https://github.com/MPAS-Dev/MPAS-Model/blob/51d5624709f75182130a2fd94715e1bb13310172/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90#L44

This is instead of using the same fixed value of -1.8C in the default setting.   

**The core problem this PR solves is to ensure consistent coupling throughout the code in both stand-alone and coupled configurations of the sea ice model when config_sea_freezing_temperature_type='mushy' as used in E3SM Versions 1 and 2.**   The code in this branch compiles and runs in G-case simulations in E3SM, and now needs the scrutiny of @akturner  and @njeffery in the stand-alone version.    In the G-case simulation, the mushy freezing temperature was also enacted in the ocean model and coupled model according to https://github.com/E3SM-Project/E3SM/pull/3861 and https://github.com/E3SM-Project/E3SM/pull/3983. Existing results indicate this makes a significant impact on Arctic sea ice thickness. The change implemented here should not affect the coupled model in G- and B-case simulations, but is necessary to ensure that testing the stand-alone MPAS-SI and potentially F-cases corresponds to the fully coupled model and ice-ocean coupled simulations.  

_@eclare108213 is working to implement similar changes to Icepack for the CICE Consortium to keep ColPkg and Icepack aligned._
