### PR TITLE
Switch to blackbody coupling for sea ice in E3SM

### DIFF
--- a/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
+++ b/src/core_seaice/column/constants/cesm/ice_constants_colpkg.F90
@@ -25,8 +25,13 @@
          rhoi      = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
          rhow      = SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
          cp_air    = SHR_CONST_CPDAIR ,&! specific heat of air (J/kg/K)
+
          ! (Briegleb JGR 97 11475-11485  July 1992)
-         emissivity= 0.95_dbl_kind    ,&! emissivity of snow and ice
+         !emissivity= 0.95_dbl_kind    ,&! emissivity of snow and ice
+         ! Emissivity has been changed to unity here so that coupling is
+         ! physically correct - instantaneous radiative coupling in CIME
+         emissivity= 1.0_dbl_kind    ,&! emissivity of snow and ice
+
          cp_ice    = SHR_CONST_CPICE  ,&! specific heat of fresh ice (J/kg/K)
          cp_ocn    = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
                                         ! freshwater value needed for enthalpy


### PR DESCRIPTION
This one-line change to the code ensures physically correct coupling in E3SM in that the cloud feedback occurs on the radiation timestep.  Emissivity is set to unity for sea ice. In reality, it is 0.985 or thereabouts, but we do not have the correct coupling infrastructure at present to institute that properly, and in any case, the sensitivity to it is minimal in the coupled model.