### PR TITLE
Fix issues with thermal solver

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -636,6 +636,7 @@
 			<var name="temperature"/>
 			<var name="waterFrac" packages="thermal"/>
                         <var name="surfaceAirTemperature" packages="thermal"/>
+                        <var name="basalTemperature" packages="thermal"/>
                         <var name="basalHeatFlux" packages="thermal;hydro"/>
                         <var name="basalFrictionFlux" packages="thermal;hydro"/>
                         <var name="heatDissipation" packages="thermal"/>

--- a/src/core_landice/mode_forward/Interface_velocity_solver.hpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.hpp
@@ -74,6 +74,7 @@ void velocity_solver_set_parameters(double const* gravity_F, double const* ice_d
                         double const* sea_level_F, double const* flowParamA_F,
                         double const* flowLawExponent_F, double const* dynamic_thickness_F,
                         double const* clausius_clapeyron_coeff,
+                        double const* thermal_thickness_limit_F,
                         int const* li_mask_ValueDynamicIce, int const* li_mask_ValueIce,
                         bool const* use_GLP_F);
 

--- a/src/core_landice/mode_forward/mpas_li_velocity_external.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity_external.F
@@ -64,6 +64,7 @@ module li_velocity_external
       subroutine velocity_solver_set_parameters(gravity, config_ice_density, config_ocean_density, config_sea_level, &
          config_default_flowParamA, &
          config_flowLawExponent, config_dynamic_thickness, iceMeltingPointPressureDependence, &
+         config_thermal_thickness, &
          li_mask_ValueDynamicIce, li_mask_ValueIce, config_use_glp) &
          bind(C, name="velocity_solver_set_parameters")
 
@@ -72,7 +73,8 @@ module li_velocity_external
          INTEGER(C_INT) :: li_mask_ValueDynamicIce, li_mask_ValueIce
          REAL(C_DOUBLE) :: config_ice_density, config_ocean_density, config_sea_level, config_default_flowParamA, &
                            config_flowLawExponent, config_dynamic_thickness, gravity, &
-                           iceMeltingPointPressureDependence
+                           iceMeltingPointPressureDependence, &
+                           config_thermal_thickness
          LOGICAL(C_BOOL) :: config_use_glp
       end subroutine velocity_solver_set_parameters
 
@@ -261,7 +263,7 @@ contains
       real (kind=RKIND), pointer :: radius
       type (field1DInteger), pointer :: indexToCellIDField, indexToEdgeIDField, indexToVertexIDField
       real (kind=RKIND), pointer :: config_ice_density, config_ocean_density,  config_sea_level, config_default_flowParamA, &
-                                    config_flowLawExponent, config_dynamic_thickness
+                                    config_thermal_thickness, config_flowLawExponent, config_dynamic_thickness
       logical, pointer :: config_use_glp
 
       ! halo exchange arrays
@@ -352,6 +354,7 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_default_flowParamA', config_default_flowParamA)
       call mpas_pool_get_config(liConfigs, 'config_flowLawExponent', config_flowLawExponent)
+      call mpas_pool_get_config(liConfigs, 'config_thermal_thickness', config_thermal_thickness)
       call mpas_pool_get_config(liConfigs, 'config_dynamic_thickness', config_dynamic_thickness)
       call mpas_pool_get_config(liConfigs, 'config_use_glp', config_use_glp)
 #if defined(USE_EXTERNAL_L1L2) || defined(USE_EXTERNAL_FIRSTORDER) || defined(USE_EXTERNAL_STOKES)
@@ -359,6 +362,7 @@ contains
          config_default_flowParamA, &
          config_flowLawExponent, config_dynamic_thickness, &
          iceMeltingPointPressureDependence, &
+         config_thermal_thickness, &
          li_mask_ValueAlbanyActive, li_mask_ValueIce, &
          logical(config_use_glp, KIND=1) )
 


### PR DESCRIPTION
This merge fixes subtle issues with how temperature is handled:
* Fixes a bug in basalThickness on restarts by adding it as a new restart field.
* Forces the interface to use the same definition of which cells have valid temperatures as MPAS is using.