### PR TITLE
Widen Redi halo in hmix, correct OpenMP private variables

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -132,7 +132,7 @@ contains
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iter, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp
-      real(kind=RKIND)                 :: kappaGMEdge, sumN2, countN2, maxN, kappaSum, ltSum
+      real(kind=RKIND)                 :: sumN2, countN2, maxN, kappaSum, ltSum
       real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sshEdge, sfcTaper
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx, BVFcent
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
@@ -698,8 +698,8 @@ contains
 
          nEdges = nEdgesArray(3)
          !!$omp parallel
-         !!$omp do schedule(runtime) private(cell1, cell2, k, gradDensityTopOfEdge, dzdxTopOfEdge, &
-         !!$omp             gradDensityConstZTopOfEdge, kappaGMEdge, BruntVaisalaFreqTopEdge, N) &
+         !!$omp do schedule(runtime) private(cell1, cell2, k, &
+         !!$omp             BruntVaisalaFreqTopEdge, N) &
          !!$omp firstprivate(tridiagB, tridiagC, rightHandSide, tridiagA)
          do iEdge = 1, nEdges
             cell1 = cellsOnEdge(1, iEdge)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -189,7 +189,7 @@ contains
       !$omp end do
       !$omp end parallel
 
-      nCells = nCellsArray(1)
+      nCells = nCellsArray(2)
       nCellsP1 = nCellsArray(size(nCellsArray)) + 1
 
       ! Term 1: this is the "standard" horizontal del2 term, but with RediKappa coefficient.


### PR DESCRIPTION
This fixes https://github.com/E3SM-Project/E3SM/issues/3958.  A computation in the Redi hmix needed to be widened by one halo ring. Otherwise, partition tests failed - but only in E3SM and only with DIB-IAF-ISMF (data iceberg, ice sheet melt fluxes). 

I also removed incorrect variables in an OpenMP private statement, and removed an unused variable.

This PR is BFB with previous.
