### PR TITLE
Use ocn_diagnostics_variables in shared/

### DIFF
--- a/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/src/core_ocean/analysis_members/mpas_ocn_eliassen_palm.F
@@ -31,6 +31,7 @@ module ocn_eliassen_palm
    use ocn_constants
    use ocn_config
    use ocn_equation_of_state
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -578,7 +579,7 @@ contains
 
          ! Compute potentialDensity over the entire block to ensure it's valid for EPFT computation
 
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+         call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                             nCells, 1, 'absolute', potentialDensity, &
                                             err) !, timeLevelIn=1)
 

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -268,7 +268,7 @@ module ocn_analysis_mode
          call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 1)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
          block_ptr => block_ptr % next
       end do
 

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -582,18 +582,18 @@ module ocn_forward_mode
            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
            call mpas_pool_get_subpool(block_ptr % structs, 'diagnostics', diagnosticsPool)
            call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-           call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, ierr, 1)
+           call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, ierr, 1)
            call mpas_timer_start("land_ice_build_arrays")
-           call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+           call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
                                                          forcingPool, scratchPool, statePool, dt, err)
            call mpas_timer_stop("land_ice_build_arrays")
 
-           call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)
+           call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, err)
            call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)
 
            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
            if (config_use_Redi.or.config_use_GM) then
-               call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, meshPool, scratchPool, timeLevelIn=1)
+               call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)
            end if
 
            block_ptr => block_ptr % next

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -589,7 +589,7 @@ module ocn_forward_mode
            call mpas_timer_stop("land_ice_build_arrays")
 
            call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)
-           call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)
+           call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)
 
            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
            if (config_use_Redi.or.config_use_GM) then

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -425,7 +425,7 @@ module ocn_time_integration_rk4
               call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
               call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
-              call ocn_tend_freq_filtered_thickness(tendPool, provisStatePool, diagnosticsPool, meshPool, 1)
+              call ocn_tend_freq_filtered_thickness(tendPool, provisStatePool, meshPool, 1)
               block => block % next
            end do
 
@@ -767,7 +767,7 @@ module ocn_time_integration_rk4
          !$omp end do
          !$omp end parallel
 
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
+         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
          if (config_use_GM) then
             call ocn_reconstruct_gm_vectors(meshPool)
@@ -858,8 +858,7 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, &
-                        diagnosticsPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, 1, dt)
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
@@ -921,7 +920,7 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+      call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
 
    end subroutine ocn_time_integrator_rk4_compute_thick_tends!}}}
@@ -989,8 +988,8 @@ module ocn_time_integration_rk4
           call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, meshPool, 1)
       endif
 
-      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
-                           scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
+      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
+                           dt, activeTracersOnlyIn=.false., timeLevelIn=1)
 
    end subroutine ocn_time_integrator_rk4_compute_tracer_tends!}}}
 
@@ -1053,8 +1052,7 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, &
-                        diagnosticsPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, 1, dt)
 
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
@@ -1068,14 +1066,14 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+      call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
       if (config_filter_btr_mode) then
           call ocn_filter_btr_mode_tend_vel(tendPool, provisStatePool, meshPool, 1)
       endif
 
-      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, &
-                           scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
+      call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
+                           dt, activeTracersOnlyIn=.false., timeLevelIn=1)
 
    end subroutine ocn_time_integrator_rk4_compute_tends!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1462,7 +1462,7 @@ module ocn_time_integration_rk4
 
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
 
-      call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
+      call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 
    end subroutine ocn_time_integrator_rk4_cleanup!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -710,7 +710,7 @@ module ocn_time_integration_rk4
            end do
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
@@ -728,7 +728,7 @@ module ocn_time_integration_rk4
 
          ! Compute normalGMBolusVelocity and the tracer transport velocity
          if (config_use_GM) then
-             call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+             call ocn_gm_compute_Bolus_velocity(statePool, &
                 meshPool, scratchPool, timeLevelIn=2)
          end if
 
@@ -1231,7 +1231,7 @@ module ocn_time_integration_rk4
          !$omp end parallel
       end if
 
-      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 1)
+      call ocn_diagnostic_solve(dt, provisStatePool, forcingPool, meshPool, scratchPool, tracersPool, 1)
 
       ! ------------------------------------------------------------------
       ! Accumulating various parametrizations of the transport velocity
@@ -1246,7 +1246,7 @@ module ocn_time_integration_rk4
 
       ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
       if (config_use_GM) then
-         call ocn_gm_compute_Bolus_velocity(provisStatePool, diagnosticsPool, &
+         call ocn_gm_compute_Bolus_velocity(provisStatePool, &
             meshPool, scratchPool, timeLevelIn=1)
       end if
 
@@ -1458,7 +1458,7 @@ module ocn_time_integration_rk4
          end if
       end do
 
-      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+      call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -858,7 +858,7 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, 1, dt)
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
@@ -989,7 +989,7 @@ module ocn_time_integration_rk4
       endif
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
-                           dt, activeTracersOnlyIn=.false., timeLevelIn=1)
+                           scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
 
    end subroutine ocn_time_integrator_rk4_compute_tracer_tends!}}}
 
@@ -1052,7 +1052,7 @@ module ocn_time_integration_rk4
             vertAleTransportTop, err)
       endif
 
-      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, meshPool, 1, dt)
+      call ocn_tend_vel(tendPool, provisStatePool, forcingPool, 1, dt)
 
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
@@ -1073,7 +1073,7 @@ module ocn_time_integration_rk4
       endif
 
       call ocn_tend_tracer(tendPool, provisStatePool, forcingPool, meshPool, swForcingPool, &
-                           dt, activeTracersOnlyIn=.false., timeLevelIn=1)
+                           scratchPool, dt, activeTracersOnlyIn=.false., timeLevelIn=1)
 
    end subroutine ocn_time_integrator_rk4_compute_tends!}}}
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
@@ -437,7 +437,7 @@ module ocn_time_integration_si
                call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
-               call ocn_tend_freq_filtered_thickness(tendPool, statePool, diagnosticsPool, meshPool, stage1_tend_time)
+               call ocn_tend_freq_filtered_thickness(tendPool, statePool, meshPool, stage1_tend_time)
                block => block % next
             end do
             call mpas_timer_stop("si freq-filtered-thick computations")
@@ -510,7 +510,7 @@ module ocn_time_integration_si
 
            call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
-           call ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, stage1_tend_time, dt)
+           call ocn_tend_vel(tendPool, statePool, forcingPool, stage1_tend_time, dt)
 
            block => block % next
          end do
@@ -2822,7 +2822,7 @@ module ocn_time_integration_si
             endif
             call mpas_timer_stop('thick vert trans vel top')
 
-            call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+            call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
             block => block % next
          end do
@@ -2847,7 +2847,7 @@ module ocn_time_integration_si
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
             call mpas_pool_get_subpool(block % structs, 'shortwave', swForcingPool)
-            call ocn_tend_tracer(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, scratchPool, &
+            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, scratchPool, &
                     dt, activeTracersOnly, 2)
 
             block => block % next
@@ -2999,7 +2999,7 @@ module ocn_time_integration_si
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -3179,7 +3179,7 @@ module ocn_time_integration_si
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
         block => block % next
       end do
@@ -3200,7 +3200,7 @@ module ocn_time_integration_si
         !if (config_use_GM) then
         !   call ocn_gm_compute_Bolus_velocity(diagnosticsPool, meshPool, scratchPool)
         !end if
-        call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
+        call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 
         block => block % next
       end do
@@ -3293,7 +3293,7 @@ module ocn_time_integration_si
             !$omp end parallel
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
@@ -3330,7 +3330,7 @@ module ocn_time_integration_si
          !$omp end do
          !$omp end parallel
 
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
+         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
          if (config_use_GM) then
             call ocn_reconstruct_gm_vectors(meshPool)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -449,7 +449,7 @@ module ocn_time_integration_split
                call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
                call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
-               call ocn_tend_freq_filtered_thickness(tendPool, statePool, diagnosticsPool, meshPool, stage1_tend_time)
+               call ocn_tend_freq_filtered_thickness(tendPool, statePool, meshPool, stage1_tend_time)
                block => block % next
             end do
             call mpas_timer_stop("se freq-filtered-thick computations")
@@ -534,8 +534,7 @@ module ocn_time_integration_split
                   sshCur, dt, vertAleTransportTop, err)
             endif
 
-           call ocn_tend_vel(tendPool, statePool, forcingPool, &
-                             diagnosticsPool, stage1_tend_time, dt)
+           call ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, stage1_tend_time, dt)
 
            block => block % next
          end do
@@ -1530,7 +1529,7 @@ module ocn_time_integration_split
             endif
             call mpas_timer_stop('thick vert trans vel top')
 
-            call ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)
+            call ocn_tend_thick(tendPool, forcingPool, meshPool)
 
             block => block % next
          end do
@@ -1555,7 +1554,7 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
             call mpas_pool_get_subpool(block % structs, 'shortwave', swForcingPool)
-            call ocn_tend_tracer(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, scratchPool, &
+            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, &
                     dt, activeTracersOnly, 2)
 
             block => block % next
@@ -2095,7 +2094,7 @@ module ocn_time_integration_split
          !$omp end do
          !$omp end parallel
 
-         call ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, 2)
+         call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
          if (config_use_GM) then
             call ocn_reconstruct_gm_vectors(meshPool)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1965,7 +1965,7 @@ module ocn_time_integration_split
  !          call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
  !             meshPool, scratchPool, timeLevelIn=2)
  !       end if
-        call ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, 2)
+        call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
 
         block => block % next
       end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1706,7 +1706,7 @@ module ocn_time_integration_split
 
                ! Efficiency note: We really only need this to compute layerThicknessEdge, density, pressure, and SSH
                ! in this diagnostics solve.
-               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, &
+               call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                           scratchPool, tracersPool, 2, full=.false.)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1944,7 +1944,7 @@ module ocn_time_integration_split
         ! be computed.  For kpp, more variables may be needed.  Either way, this
         ! could be made more efficient by only computing what is needed for the
         ! implicit vmix routine that follows.
-        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+        call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
         block => block % next
       end do
@@ -1961,7 +1961,7 @@ module ocn_time_integration_split
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
         ! Compute normalGMBolusVelocity; it will be added to the baroclinic modes in Stage 2 above.
  !       if (config_use_GM.or.config_use_Redi) then
- !          call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+ !          call ocn_gm_compute_Bolus_velocity(statePool, &
  !             meshPool, scratchPool, timeLevelIn=2)
  !       end if
         call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
@@ -2057,14 +2057,14 @@ module ocn_time_integration_split
             !$omp end parallel
          end if
 
-         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, 2)
+         call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
          call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
 
 !         ! Compute normalGMBolusVelocity; it will be added to normalVelocity in Stage 2 of the next cycle.
 !         if (config_use_GM.or.config_use_Redi) then
-!            call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
+!            call ocn_gm_compute_Bolus_velocity(statePool, &
 !               meshPool, scratchPool, timeLevelIn=2)
 !         end if
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -534,7 +534,8 @@ module ocn_time_integration_split
                   sshCur, dt, vertAleTransportTop, err)
             endif
 
-           call ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, stage1_tend_time, dt)
+           call ocn_tend_vel(tendPool, statePool, forcingPool, &
+                             stage1_tend_time, dt)
 
            block => block % next
          end do
@@ -1554,7 +1555,7 @@ module ocn_time_integration_split
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
             call mpas_pool_get_subpool(block % structs, 'shortwave', swForcingPool)
-            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, &
+            call ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, scratchPool, &
                     dt, activeTracersOnly, 2)
 
             block => block % next
@@ -1961,7 +1962,7 @@ module ocn_time_integration_split
         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
         ! Compute normalGMBolusVelocity; it will be added to the baroclinic modes in Stage 2 above.
  !       if (config_use_GM.or.config_use_Redi) then
- !          call ocn_gm_compute_Bolus_velocity(statePool, &
+ !          call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
  !             meshPool, scratchPool, timeLevelIn=2)
  !       end if
         call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
@@ -2064,7 +2065,7 @@ module ocn_time_integration_split
 
 !         ! Compute normalGMBolusVelocity; it will be added to normalVelocity in Stage 2 of the next cycle.
 !         if (config_use_GM.or.config_use_Redi) then
-!            call ocn_gm_compute_Bolus_velocity(statePool, &
+!            call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool, &
 !               meshPool, scratchPool, timeLevelIn=2)
 !         end if
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -148,10 +148,9 @@ contains
      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, zMid
 
-     real (kind=RKIND), dimension(:,:), pointer :: density
+     real (kind=RKIND), dimension(:,:), pointer :: density, tracersSurfaceValue
      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceDraft, &
                                                  effectiveDensityInLandIce
-
 
      real(kind=RKIND), dimension(:,:), pointer :: origZMid
      integer, dimension(:), pointer :: origMaxLevelCell, modifySSHMask
@@ -174,8 +173,9 @@ contains
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
        call mpas_pool_get_array(diagnosticsPool, 'density', density)
+       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
 
-       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
            nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 
@@ -213,8 +213,9 @@ contains
          call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
          call mpas_pool_get_array(diagnosticsPool, 'density', density)
          call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+         call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
 
-         call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+         call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
              nCells, 0, 'relative', density, iErr, &
              timeLevelIn=1)
 
@@ -283,13 +284,14 @@ contains
        call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
        call mpas_pool_get_array(diagnosticsPool, 'density', density)
        call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
 
        call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
        call mpas_pool_get_array(scratchPool, 'scratchZMid', origZMid)
        call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
 
 
-       call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
            nCells, 0, 'relative', density, iErr, &
            timeLevelIn=1)
 

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -144,7 +144,7 @@ mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnost
 
 mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_equation_of_state_jm.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -138,11 +138,11 @@ mpas_ocn_tracer_short_wave_absorption_variable.o: mpas_ocn_constants.o mpas_ocn_
 
 mpas_ocn_tracer_short_wave_absorption_jerlov.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix.o: mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vmix.o: mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
-mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vmix_coefs_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_equation_of_state.o: mpas_ocn_equation_of_state_jm.o mpas_ocn_equation_of_state_linear.o mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -194,7 +194,7 @@ mpas_ocn_framework_forcing.o:
 
 mpas_ocn_time_varying_forcing.o:  mpas_ocn_framework_forcing.o
 
-mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o
+mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -120,7 +120,7 @@ mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_advection_mono.o mpas_ocn_tracer_advection_std.o
 
-mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_advection_mono.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_advection_std.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -162,7 +162,7 @@ mpas_ocn_surface_land_ice_fluxes.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_
 
 mpas_ocn_frazil_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
+mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -170,7 +170,7 @@ mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_sea_ice.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 
-mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o
+mpas_ocn_tracer_surface_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_interior_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -192,13 +192,15 @@ mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_framework_forcing.o:
 
-mpas_ocn_time_varying_forcing.o:  mpas_ocn_framework_forcing.o
+mpas_ocn_time_varying_forcing.o:  mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o
+
+mpas_ocn_vel_tidal_potential.o: mpas_ocn_diagnostics_variables.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -193,19 +193,19 @@ contains
       nCells = nCellsAll
 
       ! compute in-place density
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+      call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 0, 'relative', density, err, &
                                          inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
                                          timeLevelIn=timeLevel)
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+      call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 1, 'absolute', potentialDensity, &
                                          err, timeLevelIn=timeLevel)
 
       ! compute displacedDensity, density displaced adiabatically to the mid-depth one layer deeper.
       ! That is, layer k has been displaced to the depth of layer k+1.
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, &
+      call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 1, 'relative', displacedDensity, &
                                          err, timeLevelIn=timeLevel)
 
@@ -1756,13 +1756,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, timeLevelIn)!{{{
+    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(in) :: statePool !< Input/Output: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool !< Diagnostics information derived from State
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       integer, intent(in), optional :: timeLevelIn
 
       ! pool pointers
@@ -1853,8 +1851,9 @@ contains
       nCells = nCellsHalo( 2 )
 
       ! compute EOS by displacing SST/SSS to every vertical layer in column
-      call ocn_equation_of_state_density(statePool, diagnosticsPool, meshPool, nCells, 0, 'surfaceDisplaced', &
-                                         densitySurfaceDisplaced, err, thermalExpansionCoeff, salineContractionCoeff, &
+      call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
+                                         nCells, 0, 'surfaceDisplaced', densitySurfaceDisplaced, &
+                                         err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
       !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,7 +150,7 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
-      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThicknessEdge)
+      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
       coef_3rd_order = config_coef_3rd_order
 
@@ -167,7 +167,7 @@ contains
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
-             layerThicknessEdge, normalVelocity, normalTransportVelocity, &
+             layerThickEdge, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
@@ -181,7 +181,7 @@ contains
 
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
-                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+                normRelVortEdge, normPlanetVortEdge, &
                 normalizedRelativeVorticityCell)
 
       !
@@ -194,7 +194,7 @@ contains
       ! compute in-place density
       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 0, 'relative', density, err, &
-                                         inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
+                                         thermExpCoeff, salineContractCoeff, &
                                          timeLevelIn=timeLevel)
 
       ! compute potentialDensity, the density displaced adiabatically to the mid-depth of top layer.
@@ -255,9 +255,9 @@ contains
          ! average tracer values over the ocean surface layer
          ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
          call ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
-                layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
+                layerThickEdge, normalVelocity, tracersSurfaceLayerValue,  &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
-                surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)
+                sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
 
       end if ! full_compute
 
@@ -1719,12 +1719,12 @@ contains
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
         ! nonzero value to avoid a NaN.
-        normalThicknessFluxSum = layerThicknessEdge(1,iEdge) * tend_normalVelocity(1,iEdge)
-        thicknessSum  = layerThicknessEdge(1,iEdge)
+        normalThicknessFluxSum = layerThickEdge(1,iEdge) * tend_normalVelocity(1,iEdge)
+        thicknessSum  = layerThickEdge(1,iEdge)
 
         do k = 2, maxLevelEdgeTop(iEdge)
-          normalThicknessFluxSum = normalThicknessFluxSum + layerThicknessEdge(k,iEdge) * tend_normalVelocity(k,iEdge)
-          thicknessSum  =  thicknessSum + layerThicknessEdge(k,iEdge)
+          normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * tend_normalVelocity(k,iEdge)
+          thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
         enddo
 
         vertSum = normalThicknessFluxSum / thicknessSum
@@ -2026,8 +2026,8 @@ contains
       !$omp do schedule(runtime)
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
-         topDragMagnitude(iCell) = rho_sw * landIceFraction(iCell) &
-                                   * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(1,iCell)
+         topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
+                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(1,iCell)
 
          ! the friction velocity is the square root of the top drag + variance of tidal velocity
          ! (computed regardless of land-ice coverage)
@@ -2120,7 +2120,7 @@ contains
       !$omp do schedule(runtime)
       do iCell = 1, nCellsAll
          if(landIceMask(iCell) == 1) then
-            surfaceFluxAttenuationCoefficient(iCell) = config_land_ice_flux_attenuation_coefficient
+            sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do
       !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -92,14 +92,13 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool, &
+   subroutine ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, &
                                    timeLevelIn, full)!{{{
 
       real (kind=RKIND), intent(in) :: dt !< Input: Time step
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool  !< Input: diagnostic fields derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
       type (mpas_pool_type), intent(in) :: tracersPool !< Input: tracer fields
       integer, intent(in), optional :: timeLevelIn !< Input: Time level in state

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -44,19 +44,19 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: circulation
    real (kind=RKIND), dimension(:,:), pointer :: relativeVorticity
    real (kind=RKIND), dimension(:,:), pointer :: relativeVorticityCell
-   real (kind=RKIND), dimension(:,:), pointer :: normalizedPlanetaryVorticityEdge
-   real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normPlanetVortEdge
+   real (kind=RKIND), dimension(:,:), pointer :: normRelVortEdge
    real (kind=RKIND), dimension(:,:), pointer :: normalizedRelativeVorticityCell
    real (kind=RKIND), dimension(:,:), pointer :: density
    real (kind=RKIND), dimension(:,:), pointer :: displaceddensity
    real (kind=RKIND), dimension(:,:), pointer :: potentialdensity
    real (kind=RKIND), dimension(:,:), pointer :: montgomeryPotential
    real (kind=RKIND), dimension(:,:), pointer :: pressure
-   real (kind=RKIND), dimension(:,:), pointer :: inSituThermalExpansionCoeff
-   real (kind=RKIND), dimension(:,:), pointer :: inSituSalineContractionCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: thermExpCoeff
+   real (kind=RKIND), dimension(:,:), pointer :: salineContractCoeff
    real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
    real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
-   real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge
+   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdge
    real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
    real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
@@ -74,12 +74,12 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:),   pointer :: normalVelocitySurfaceLayer
    real (kind=RKIND), dimension(:),   pointer :: indexSurfaceLayerDepth
 
-   real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
+   real (kind=RKIND), dimension(:), pointer :: sfcFlxAttCoeff
    real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
 
    real (kind=RKIND), dimension(:), pointer :: landIceFrictionVelocity
    real (kind=RKIND), dimension(:), pointer :: topDrag
-   real (kind=RKIND), dimension(:), pointer :: topDragMagnitude
+   real (kind=RKIND), dimension(:), pointer :: topDragMag
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
    real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
 
@@ -231,19 +231,19 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
       call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
       call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normPlanetVortEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normRelVortEdge)
       call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
       call mpas_pool_get_array(diagnosticsPool, 'density', density)
       call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
       call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
       call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
       call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',thermExpCoeff)
+      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', salineContractCoeff)
       call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
       call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThickEdge)
       call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
       call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
       call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
@@ -262,12 +262,12 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
       call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
 
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', sfcFlxAttCoeff)
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
 
       call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
       call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMagnitude)
+      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
       call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
       call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -111,13 +111,14 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: velocityMeridional
    real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
 
-   real(kind=RKIND), dimension(:, :), pointer :: kappaGMCell
-   real(kind=RKIND), dimension(:, :), pointer :: kappaRediSfcTaper
-   real(kind=RKIND), dimension(:, :), pointer :: kappaRediCell
-   real(kind=RKIND), dimension(:, :), pointer :: k33
+   real(kind=RKIND), dimension(:,:), pointer :: kappaGMCell
+   real(kind=RKIND), dimension(:,:), pointer :: RediKappaScaling
+   real(kind=RKIND), dimension(:,:), pointer :: RediKappaSfcTaper
+   real(kind=RKIND), dimension(:,:), pointer :: RediKappaCell
+   real(kind=RKIND), dimension(:,:), pointer :: k33
    real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
    real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
-   real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
+   real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
 
    integer, dimension(:), pointer :: indMLD
    real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
@@ -330,13 +331,14 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
       call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediSfcTaper', kappaRediSfcTaper)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
       call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
       call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
       call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaRediCell', kappaRediCell)
+      call mpas_pool_get_array(diagnosticsPool, 'RediKappaCell', RediKappaCell)
 
       call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -112,6 +112,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
 
    real(kind=RKIND), dimension(:,:), pointer :: kappaGMCell
+   real(kind=RKIND), dimension(:,:), pointer :: gmKappaScaling
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaScaling
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaSfcTaper
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaCell
@@ -331,6 +332,7 @@ contains
 
       call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
       call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
+      call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', gmKappaScaling)
       call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
       call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
       call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state.F
@@ -28,6 +28,7 @@ module ocn_equation_of_state
    use ocn_equation_of_state_jm
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
    use mpas_log
 
    implicit none
@@ -88,11 +89,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_equation_of_state_density(statePool, diagnosticsPool,&
-                           meshPool, nCells, kDisplaced,  &
-                           displacement_type, density, err,            &
-                           thermalExpansionCoeff,                      &
-                           salineContractionCoeff, timeLevelIn)
+   subroutine ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
+                           nCells, kDisplaced, displacement_type, density, err,       &
+                           thermalExpansionCoeff, salineContractionCoeff, timeLevelIn)
       !{{{
       !-----------------------------------------------------------------
       ! Input variables
@@ -102,6 +101,9 @@ contains
          nCells,             &! number of horiz mesh cells
          kDisplaced           ! target vert level for adiab displacement
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tracersSurfaceValue
+
       integer, intent(in), optional :: &
          timeLevelIn          ! time level for state variables
 
@@ -110,7 +112,6 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          statePool,           &! pool containing state variables
-         diagnosticsPool,     &! pool containing some forcing fields
          meshPool              ! pool containing mesh quantities
 
       !-----------------------------------------------------------------
@@ -136,7 +137,6 @@ contains
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer :: iCell, k, nVertLevels, indexT, indexS
       integer, pointer :: indexTptr, indexSptr, nVertLevelsPtr
@@ -157,8 +157,6 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', &
-                                                 tracersSurfaceValue)
       call mpas_pool_get_subpool  (statePool,   'tracers', &
                                                  tracersPool)
       call mpas_pool_get_array    (tracersPool, 'activeTracers', &

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -138,10 +138,10 @@ contains
 
         do iCell = 1, nCells
            zTop = 0.0_RKIND
-           transmissionCoeffTop = ocn_forcing_transmission(zTop, surfaceFluxAttenuationCoefficient(iCell))
+           transmissionCoeffTop = ocn_forcing_transmission(zTop, sfcFlxAttCoeff(iCell))
            do k = 1, maxLevelCell(iCell)
               zBot = zTop - layerThickness(k,iCell)
-              transmissionCoeffBot = ocn_forcing_transmission(zBot, surfaceFluxAttenuationCoefficient(iCell))
+              transmissionCoeffBot = ocn_forcing_transmission(zBot, sfcFlxAttCoeff(iCell))
 
               fractionAbsorbed(k, iCell) = transmissionCoeffTop - transmissionCoeffBot
 

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -26,6 +26,7 @@ module ocn_forcing
    use mpas_log
    use mpas_dmpar
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -95,10 +96,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err, timeLevelIn)!{{{
+    subroutine ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
         type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
         type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-        type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
         type (mpas_pool_type), intent(inout) :: forcingPool !< Input/Output: Forcing information
         integer, intent(out) :: err !< Output: Error code
         integer, intent(in), optional :: timeLevelIn
@@ -111,8 +111,6 @@ contains
 
         real (kind=RKIND) :: zTop, zBot, transmissionCoeffTop, transmissionCoeffBot
 
-        real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficient
-        real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
         real (kind=RKIND), dimension(:,:), pointer :: layerThickness, fractionAbsorbed, fractionAbsorbedRunoff
 
         integer :: iCell, k, timeLevel, nCells
@@ -132,10 +130,6 @@ contains
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff',  &
-                                                   surfaceFluxAttenuationCoefficientRunoff)
 
         call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
         call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -27,6 +27,7 @@ module ocn_frazil_forcing
    use mpas_timer
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
    use ocn_equation_of_state
 
    implicit none
@@ -305,7 +306,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)!{{{
+   subroutine ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -314,7 +315,6 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool !< Input: Diagnostic information
 
       !-----------------------------------------------------------------
       !
@@ -364,10 +364,7 @@ contains
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassNew
       real (kind=RKIND), pointer, dimension(:)     :: accumulatedLandIceFrazilMassOld
       real (kind=RKIND), pointer, dimension(:)     :: ssh
-      real (kind=RKIND), pointer, dimension(:,:)   :: zMid
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
-      real (kind=RKIND), pointer, dimension(:,:)   :: density
-      real (kind=RKIND), pointer, dimension(:,:)   :: pressure
       real (kind=RKIND), pointer, dimension(:,:,:) :: activeTracers
 
       integer, dimension(:), pointer :: maxLevelCell
@@ -409,9 +406,6 @@ contains
       call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
       call mpas_pool_get_array(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -15,6 +15,7 @@ module ocn_gm
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -84,7 +85,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_GM_compute_Bolus_velocity(statePool, diagnosticsPool, &
+   subroutine ocn_GM_compute_Bolus_velocity(statePool, &
                                             meshPool, scratchPool, timeLevelIn)
       !{{{
 
@@ -108,7 +109,6 @@ contains
       !-----------------------------------------------------------------
 
       type(mpas_pool_type), intent(inout) :: &
-         diagnosticsPool, &! pool containing some diagnostics
          scratchPool           ! pool containing some scratch space
 
       !-----------------------------------------------------------------
@@ -117,18 +117,14 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real(kind=RKIND), dimension(:, :), pointer :: density, displacedDensity, zMid, normalGMBolusVelocity, &
-                                                    normalVelocity, tangentialVelocity, layerThicknessEdge, &
-                                                    k33, gmStreamFuncTopOfEdge, BruntVaisalaFreqTop, gmStreamFuncTopOfCell, &
-                                                    layerThickness, inSituThermalExpansionCoeff, &
-                                                    inSituSalineContractionCoeff, RediKappaScaling, gmKappaScaling, RediKappaSfcTaper, &
-                                                    zTop, RiTopOfCell
+      real(kind=RKIND), dimension(:, :), pointer :: &
+                                                    normalVelocity, &
+                                                    layerThickness
 
-      real(kind=RKIND), dimension(:), pointer   :: c_Visbeck, gmBolusKappa, cGMphaseSpeed, &
-                ssh, eddyLength, eddyTime, betaEdge, fEdge, gmResolutionTaper, RediKappa
-      real(kind=RKIND), dimension(:, :, :), pointer :: slopeTriadUp, slopeTriadDown
+      real(kind=RKIND), dimension(:), pointer   :: &
+                ssh, fEdge
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
-      integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell, indMLD
+      integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iter, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp
@@ -170,31 +166,6 @@ contains
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
-
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff', inSituThermalExpansionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-
-      call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
-      call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', gmKappaScaling)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -604,13 +575,7 @@ contains
          ! When config_GM_closure = 'Visbeck' actually modify the value of gmBolusKappa based on
          ! Visbeck et al (1997), JPO as recast by Cessi (2008), JPO
          if (local_config_GM_compute_Visbeck) then
-           call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-           call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)
-           call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)
-           call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-           call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-           call mpas_pool_get_array(diagnosticsPool, 'c_Visbeck', c_Visbeck)
            !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
            !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2)
@@ -661,9 +626,7 @@ contains
          ! When config_GM_closure = 'EdenGreatbatch' actually modify the value of gmBolusKappa based on
          ! Eden and Greatbach (2008), Ocean Model., but assuming quasi-geostrophy to simplify the EKE budget
          if (local_config_GM_compute_EdenGreatbatch) then
-           call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-           call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
 
            !$omp parallel
            !$omp do schedule(runtime) private(cell1, cell2, sigma, RiTopOfEdge, &

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -310,8 +310,8 @@ contains
                areaEdge = dcEdge(iEdge)*dvEdge(iEdge)
    
                do k = 1, maxLevelEdgeTop(iEdge)
-                  drhoDT = -inSituThermalExpansionCoeff(k, iCell)
-                  drhoDS = inSituSalineContractionCoeff(k, iCell)
+                  drhoDT = -thermExpCoeff(k, iCell)
+                  drhoDS = salineContractCoeff(k, iCell)
                   dTdx = (activeTracers(indexTemperature, k, cell2) &
                           - activeTracers(indexTemperature, k, cell1)) &
                          *dcEdgeInv
@@ -470,8 +470,8 @@ contains
             ! The interpolation can only be carried out on non-boundary edges
             if (maxLevelEdgeTop(iEdge) .GE. 1) then
                do k = 2, maxLevelEdgeTop(iEdge)
-                  h1 = layerThicknessEdge(k-1,iEdge)
-                  h2 = layerThicknessEdge(k,iEdge)
+                  h1 = layerThickEdge(k-1,iEdge)
+                  h2 = layerThickEdge(k,iEdge)
                   ! Using second-order interpolation below
                   gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
                                 gradDensityEdge(k,iEdge)) / (h1 + h2)
@@ -589,7 +589,7 @@ contains
               cell2 = cellsOnEdge(2, iEdge)
 
               k = 2
-              zEdge = -layerThicknessEdge(k-1,iEdge)
+              zEdge = -layerThickEdge(k-1,iEdge)
               do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
@@ -601,7 +601,7 @@ contains
                 countN2 = countN2 + 1
 
                 k = k + 1
-                zEdge = zEdge - layerThicknessEdge(k-1,iEdge)
+                zEdge = zEdge - layerThickEdge(k-1,iEdge)
               end do
 
               if (countN2 > 0) then
@@ -640,7 +640,7 @@ contains
               do k=2,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
-                 shearEdgeInv = (0.5_RKIND*(layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)))**2.0 &
+                 shearEdgeInv = (0.5_RKIND*(layerThickEdge(k-1,iEdge) + layerThickEdge(k,iEdge)))**2.0 &
                     / (  (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2.0 &
                        + (tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge))**2.0 &
                        + 1.0e-18_RKIND )
@@ -677,10 +677,10 @@ contains
 
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
-                                                                     *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k, iEdge) &
-                                 /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
+                                                                     *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k, iEdge) &
+                                 /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
 
@@ -688,12 +688,12 @@ contains
                do k = 3, maxLevelEdgeTop(iEdge) - 1
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &
-                                    /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
-                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
-                                                                        *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k, iEdge) &
-                                    /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
+                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k - 1, iEdge) &
+                                    /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
+                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
+                                                                        *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
+                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k, iEdge) &
+                                    /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
                   rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                          *gradDensityConstZTopOfEdge(k,iEdge)
                end do
@@ -702,10 +702,10 @@ contains
                k = maxLevelEdgeTop(iEdge)
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThicknessEdge(k - 1, iEdge) &
-                                 /(layerThicknessEdge(k - 1, iEdge) + layerThicknessEdge(k, iEdge))
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThicknessEdge(k - 1, iEdge) &
-                                                                     *layerThicknessEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k - 1, iEdge) &
+                                 /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
+                                                                     *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
                ! Total number of rows
@@ -725,7 +725,7 @@ contains
          do iEdge = 1, nEdges
             do k = 1, maxLevelEdgeTop(iEdge)
                normalGMBolusVelocity(k, iEdge) = gmResolutionTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
-                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThicknessEdge(k, iEdge)
+                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdge(k, iEdge)
             end do
          end do
          !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -570,7 +570,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool, tracersPool
-      type (mpas_pool_type), pointer :: forcingPool, diagnosticsPool, scratchPool
+      type (mpas_pool_type), pointer :: forcingPool, scratchPool
       integer :: i, iEdge, iCell, k
       integer :: err1
 
@@ -593,7 +593,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
-      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
       call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -34,6 +34,7 @@ module ocn_init_routines
    use mpas_tracer_advection_helpers
 
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
    use ocn_constants
    use ocn_config
@@ -573,12 +574,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       integer :: i, iEdge, iCell, k
       integer :: err1
 
-      integer, dimension(:), pointer :: indMLD
-      real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
-      real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity, normalGMBolusVelocity
-      real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
-      real (kind=RKIND), dimension(:,:), pointer :: velocityZonal, velocityMeridional
-      real (kind=RKIND), dimension(:,:), pointer :: edgeAreaFractionOfCell
       integer, dimension(:,:), pointer :: highOrderAdvectionMaskTmp, boundaryCellTmp
       integer, dimension(:,:), pointer :: edgeSignOnCellTmp, edgeSignOnVertexTmp
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
@@ -605,17 +600,6 @@ end subroutine ocn_init_routines_compute_max_level!}}}
 
       call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', highOrderAdvectionMaskTmp)
       call mpas_pool_get_array(meshPool, 'boundaryCell', boundaryCellTmp)
-
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
 
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -650,7 +634,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          end do
       end if
 
-      call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, tracersPool)
+      call ocn_diagnostic_solve(dt,  statePool, forcingPool, meshPool, scratchPool, tracersPool)
 
       ! initialize velocities and active tracers on land to be zero.
       areaCell(nCells+1) = -1.0e34_RKIND
@@ -706,9 +690,9 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       call mpas_pool_initialize_time_levels(statePool)
 
       ! compute land-ice fluxes for potential output at startup
-      call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, diagnosticsPool, forcingPool, err1, 1)
+      call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err1, 1)
       err = ior(err, err1)
-      call ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+      call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
                                                     forcingPool, scratchPool, statePool, dt, err1)
       err = ior(err, err1)
 

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -27,6 +27,7 @@ module ocn_surface_land_ice_fluxes
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
    use ocn_equation_of_state
    use ocn_diagnostics_variables
 
@@ -58,9 +59,18 @@ module ocn_surface_land_ice_fluxes
    !
    !--------------------------------------------------------------------
 
-   logical :: landIceFluxesOn, standaloneOn, isomipOn, jenkinsOn, hollandJenkinsOn
+   logical :: &
+      landIceFluxesOff, &! on/off switch for land ice fluxes
+      standaloneOff,    &! flag to determine coupled or standalone
+      isomipOn,         &! use ISOMIP flux formulation
+      jenkinsOn,        &! use Jenkins flux formulation
+      hollandJenkinsOn, &! use Holland-Jenkins flux formulation
+      useHollandJenkinsAdvDiff ! use Holland-Jenkins advection-diffusion
 
-   real (kind=RKIND) :: cp_land_ice, rho_land_ice
+   real (kind=RKIND) :: &
+      cpLandIce,        &! specific heat for land ice
+      rhoLandIce,       &! density of land ice
+      ISOMIPgammaT       ! parameter for ISOMIP formulation
 
 !***********************************************************************
 
@@ -113,7 +123,7 @@ contains
 
       err = 0
 
-      if ( .not. landIceFluxesOn ) return
+      if (landIceFluxesOff) return
 
       call mpas_timer_start("land_ice_" // trim(groupName))
 
@@ -133,63 +143,88 @@ contains
 !> \author  Xylar Asay-Davis
 !> \date    9 September 2015
 !> \details
-!>  This routine computes the top-drag tendency for momentum
-!>  based on current state.
+!>  This routine computes the top-drag tendency under land ice for
+!>  momentum based on current state.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)!{{{
+   subroutine ocn_surface_land_ice_fluxes_vel(&
+                                      sfcStress, sfcStressMag, err)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
       !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
       !-----------------------------------------------------------------
-      real (kind=RKIND), dimension(:), intent(inout) :: surfaceStress, & !< Input/Output: Array for total surface stress
-                                                  surfaceStressMagnitude !< Input/Output: Array for magnitude of surface stress
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         sfcStress,  &!< [inout] accumulated surface stress
+         sfcStressMag !< [inout] accumulated surface stress magnitude
 
       !-----------------------------------------------------------------
-      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: Error flag
+      integer, intent(out) :: err !< [out] Error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
       !-----------------------------------------------------------------
-      integer :: iEdge, iCell
-      integer, pointer :: nCells, nEdges
+
+      integer :: &
+         iEdge, iCell  ! loop indices for edge, cell loops
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** set error flag and return early if land ice fluxes not on
+      !*** otherwise, start timer
 
       err = 0
-
-      if ( .not. landIceFluxesOn ) return
+      if (landIceFluxesOff) return
 
       call mpas_timer_start("top_drag", .false.)
 
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      !*** Transfer data to device
+      !$acc enter data &
+      !$acc    copyin(topDrag, topDragMag)
 
+      !*** simply add input values to accumulated stresses
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(sfcStress, topDrag)
+#else
       !$omp parallel
       !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-        surfaceStress(iEdge) = surfaceStress(iEdge) + topDrag(iEdge)
+#endif
+      do iEdge = 1, nEdgesAll
+        sfcStress(iEdge) = sfcStress(iEdge) + topDrag(iEdge)
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
-      ! Build surface stress magnitude at cell centers
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(sfcStressMag, topDragMag)
+#else
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
-        surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + topDragMagnitude(iCell)
+#endif
+      do iCell = 1, nCellsAll
+        sfcStressMag(iCell) = sfcStressMag(iCell) + topDragMag(iCell)
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
+
+      !*** Transfer any needed data back to host and delete inputs
+      !$acc exit data &
+      !$acc    delete(topDrag, topDragMag)
 
       call mpas_timer_stop("top_drag")
 
@@ -248,7 +283,7 @@ contains
 
       err = 0
 
-      if ( .not. landIceFluxesOn ) return
+      if (landIceFluxesOff) return
 
       call mpas_timer_start("land_ice_thick")
 
@@ -320,7 +355,7 @@ contains
 
       err = 0
 
-      if ( .not. landIceFluxesOn ) return
+      if (landIceFluxesOff) return
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
@@ -408,6 +443,7 @@ contains
 
       real (kind=RKIND), dimension(:,:), pointer :: &
                                                     landIceInterfaceTracers
+
       integer, pointer :: indexIT, indexIS
 
       ! Scratch Arrays
@@ -424,7 +460,7 @@ contains
 
       err = 0
 
-      if ( .not. standaloneOn ) return
+      if (standaloneOff) return
 
       call mpas_timer_start("land_ice_build_arrays")
 
@@ -447,7 +483,7 @@ contains
       call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)
       call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatOld, 1)
 
-      if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
+      if (useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
 
          allocate(freezeInterfaceSalinity(nCells), &
@@ -459,7 +495,8 @@ contains
 
       nCells = nCellsArray( size(nCellsArray) )
 
-      if(isomipOn) then
+      if (isomipOn) then !*** ISOMIP formulation
+
          !$omp parallel
          !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
@@ -475,7 +512,7 @@ contains
             ! or (7) from Jenkins et al. (2001) if gamma constant
             ! and no heat flux into ice
             ! freshwater flux = density * melt rate is in kg/m^2/s
-            freshwaterFlux = -rho_sw * config_land_ice_flux_ISOMIP_gammaT * (cp_sw/latent_heat_fusion_mks) &
+            freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
             landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
@@ -483,7 +520,7 @@ contains
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
             heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
-                              + rho_sw*config_land_ice_flux_ISOMIP_gammaT &
+                              + rho_sw*ISOMIPgammaT &
                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
             landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
 
@@ -492,10 +529,10 @@ contains
          end do
          !$omp end do
          !$omp end parallel
-      end if
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-         if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
+      endif ! isomipOn
+      
+      if (jenkinsOn .or. hollandJenkinsOn) then
+         if(useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
                landIceMask, &
@@ -579,9 +616,9 @@ contains
             heatFluxToLandIce(iCell) = landIceFraction(iCell)*heatFluxToLandIce(iCell)
          end do
 
-      end if
+      endif ! jenkinsOn or hollandJenkinsOn
 
-      if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
+      if(useHollandJenkinsAdvDiff) then
          deallocate(freezeInterfaceSalinity, &
                     freezeInterfaceTemperature, &
                     freezeFreshwaterFlux, &
@@ -616,35 +653,70 @@ contains
 
    subroutine ocn_surface_land_ice_fluxes_init(err)!{{{
 
-      integer, intent(out) :: err !< Output: error flag
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set error code and default values for module variables
 
       err = 0
-      isomipOn = .false.
-      jenkinsOn = .false.
+
+      landIceFluxesOff = .true.
+      standaloneOff    = .true.
+      isomipOn         = .false.
+      jenkinsOn        = .false.
       hollandJenkinsOn = .false.
+      cpLandIce        = 0.0_RKIND
+      rhoLandIce       = 0.0_RKIND
+      ISOMIPgammaT     = 0.0_RKIND
 
-      landIceFluxesOn = (trim(config_land_ice_flux_mode) == 'standalone')  &
-           .or. (trim(config_land_ice_flux_mode) == 'coupled')
-      if(.not. landIceFluxesOn) return
+      !*** Determine whether land ice fluxes are on
 
-      standaloneOn = trim(config_land_ice_flux_mode) == 'standalone'
+      select case (trim(config_land_ice_flux_mode))
+      case ('standalone','Standalone','STANDALONE')
+         landIceFluxesOff = .false.
+         standaloneOff    = .false.
+      case ('coupled','Coupled','COUPLED')
+         landIceFluxesOff = .false.
+         standaloneOff    = .true.
+      case default
+         landIceFluxesOff = .true.
+         standaloneOff    = .true.
+         return
+      end select
 
-      if ( trim(config_land_ice_flux_formulation) == 'ISOMIP' ) then
+      !*** Determine which flux formulation to use
+
+      select case (trim(config_land_ice_flux_formulation))
+
+      case ('isomip','Isomip','ISOMIP')
          isomipOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
+      case ('jenkins', 'Jenkins','JENKINS')
          jenkinsOn = .true.
-      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
+      case ('hollandjenkins','HollandJenkins','HOLLANDJENKINS')
          hollandJenkinsOn = .true.
-      else
+      case default
          call mpas_log_write( &
             "config_land_ice_flux_formulation not one of 'ISOMIP', 'Jenkins', " &
                // "or 'HollandJenkins'.", &
                MPAS_LOG_CRIT)
          err = 1
-      end if
+      end select
 
-      cp_land_ice = config_land_ice_flux_cp_ice
-      rho_land_ice = config_land_ice_flux_rho_ice
+      useHollandJenkinsAdvDiff = &
+                       config_land_ice_flux_useHollandJenkinsAdvDiff
+
+      !*** Set physical values
+
+      cpLandIce    = config_land_ice_flux_cp_ice
+      rhoLandIce   = config_land_ice_flux_rho_ice
+      ISOMIPgammaT = config_land_ice_flux_ISOMIP_gammaT
 
    !--------------------------------------------------------------------
 
@@ -784,7 +856,7 @@ contains
       !   2. the diffusion (if any) of heat into the ice, based on temperature difference between
       !      the reference point in the ice (either the surface or the middle of the bottom layer)
       !      and the interface
-      outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*outInterfaceTemperature(iCell)
+      outIceHeatFlux(iCell) = -cpLandIce*outFreshwaterFlux(iCell)*outInterfaceTemperature(iCell)
     end do
     !$omp end do
     !$omp end parallel
@@ -888,7 +960,7 @@ contains
     integer :: iCell
 
     err = 0
-    cpRatio = cp_land_ice/cp_sw
+    cpRatio = cpLandIce/cp_sw
     !$omp parallel
     !$omp do schedule(runtime) &
     !$omp private(T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c, err)
@@ -930,7 +1002,7 @@ contains
       ! Since we're considering only melting and ignoring diffusion,
       ! the ice loses heat simply by the loss of ice mass at the prescribed
       ! (surface?) ice temperature
-      outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*iceTemperature(iCell)
+      outIceHeatFlux(iCell) = -cpLandIce*outFreshwaterFlux(iCell)*iceTemperature(iCell)
     end do
     !$omp end do
     !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -27,8 +27,8 @@ module ocn_surface_land_ice_fluxes
 
    use ocn_constants
    use ocn_config
-   use ocn_mesh
    use ocn_equation_of_state
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -58,18 +58,9 @@ module ocn_surface_land_ice_fluxes
    !
    !--------------------------------------------------------------------
 
-   logical :: &
-      landIceFluxesOff, &! on/off switch for land ice fluxes
-      standaloneOff,    &! flag to determine coupled or standalone
-      isomipOn,         &! use ISOMIP flux formulation
-      jenkinsOn,        &! use Jenkins flux formulation
-      hollandJenkinsOn, &! use Holland-Jenkins flux formulation
-      useHollandJenkinsAdvDiff ! use Holland-Jenkins advection-diffusion
+   logical :: landIceFluxesOn, standaloneOn, isomipOn, jenkinsOn, hollandJenkinsOn
 
-   real (kind=RKIND) :: &
-      cpLandIce,        &! specific heat for land ice
-      rhoLandIce,       &! density of land ice
-      ISOMIPgammaT       ! parameter for ISOMIP formulation
+   real (kind=RKIND) :: cp_land_ice, rho_land_ice
 
 !***********************************************************************
 
@@ -122,7 +113,7 @@ contains
 
       err = 0
 
-      if (landIceFluxesOff) return
+      if ( .not. landIceFluxesOn ) return
 
       call mpas_timer_start("land_ice_" // trim(groupName))
 
@@ -142,97 +133,63 @@ contains
 !> \author  Xylar Asay-Davis
 !> \date    9 September 2015
 !> \details
-!>  This routine computes the top-drag tendency under land ice for
-!>  momentum based on current state.
+!>  This routine computes the top-drag tendency for momentum
+!>  based on current state.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_vel(diagnosticsPool, &
-                                      sfcStress, sfcStressMag, err)!{{{
+   subroutine ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)!{{{
 
       !-----------------------------------------------------------------
+      !
       ! input variables
       !-----------------------------------------------------------------
-
-      type(mpas_pool_type), intent(in) :: diagnosticsPool
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
 
       !-----------------------------------------------------------------
+      !
       ! input/output variables
       !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:), intent(inout) :: &
-         sfcStress,  &!< [inout] accumulated surface stress
-         sfcStressMag !< [inout] accumulated surface stress magnitude
+      real (kind=RKIND), dimension(:), intent(inout) :: surfaceStress, & !< Input/Output: Array for total surface stress
+                                                  surfaceStressMagnitude !< Input/Output: Array for magnitude of surface stress
 
       !-----------------------------------------------------------------
+      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< [out] Error flag
+      integer, intent(out) :: err !< Output: Error flag
 
       !-----------------------------------------------------------------
+      !
       ! local variables
       !-----------------------------------------------------------------
-
-      integer :: &
-         iEdge, iCell  ! loop indices for edge, cell loops
-
-      real (kind=RKIND), dimension(:), pointer :: &
-         topDrag,  &!< [in] drag at top of ocean on edge
-         topDragMag !< [in] magnitude of drag at top of ocean at center
-
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      !*** set error flag and return early if land ice fluxes not on
-      !*** otherwise, start timer
+      integer :: iEdge, iCell
+      integer, pointer :: nCells, nEdges
 
       err = 0
-      if (landIceFluxesOff) return
+
+      if ( .not. landIceFluxesOn ) return
 
       call mpas_timer_start("top_drag", .false.)
 
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
-      !*** Transfer data to device
-      !$acc enter data &
-      !$acc    copyin(topDrag, topDragMag)
-
-      !*** simply add input values to accumulated stresses
-
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(sfcStress, topDrag)
-#else
       !$omp parallel
       !$omp do schedule(runtime)
-#endif
-      do iEdge = 1, nEdgesAll
-        sfcStress(iEdge) = sfcStress(iEdge) + topDrag(iEdge)
+      do iEdge = 1, nEdges
+        surfaceStress(iEdge) = surfaceStress(iEdge) + topDrag(iEdge)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
-#endif
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(sfcStressMag, topDragMag)
-#else
+      ! Build surface stress magnitude at cell centers
       !$omp do schedule(runtime)
-#endif
-      do iCell = 1, nCellsAll
-        sfcStressMag(iCell) = sfcStressMag(iCell) + topDragMag(iCell)
+      do iCell = 1, nCells
+        surfaceStressMagnitude(iCell) = surfaceStressMagnitude(iCell) + topDragMagnitude(iCell)
       end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
-
-      !*** Transfer any needed data back to host and delete inputs
-      !$acc exit data &
-      !$acc    delete(topDrag, topDragMag)
 
       call mpas_timer_stop("top_drag")
 
@@ -291,7 +248,7 @@ contains
 
       err = 0
 
-      if (landIceFluxesOff) return
+      if ( .not. landIceFluxesOn ) return
 
       call mpas_timer_start("land_ice_thick")
 
@@ -363,7 +320,7 @@ contains
 
       err = 0
 
-      if (landIceFluxesOff) return
+      if ( .not. landIceFluxesOn ) return
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
@@ -470,7 +427,7 @@ contains
 
       err = 0
 
-      if (standaloneOff) return
+      if ( .not. standaloneOn ) return
 
       call mpas_timer_start("land_ice_build_arrays")
 
@@ -504,7 +461,7 @@ contains
       call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)
       call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatOld, 1)
 
-      if (useHollandJenkinsAdvDiff) then
+      if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
 
          allocate(freezeInterfaceSalinity(nCells), &
@@ -516,8 +473,7 @@ contains
 
       nCells = nCellsArray( size(nCellsArray) )
 
-      if (isomipOn) then !*** ISOMIP formulation
-
+      if(isomipOn) then
          !$omp parallel
          !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
@@ -533,7 +489,7 @@ contains
             ! or (7) from Jenkins et al. (2001) if gamma constant
             ! and no heat flux into ice
             ! freshwater flux = density * melt rate is in kg/m^2/s
-            freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
+            freshwaterFlux = -rho_sw * config_land_ice_flux_ISOMIP_gammaT * (cp_sw/latent_heat_fusion_mks) &
                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
             landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
@@ -541,7 +497,7 @@ contains
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
             heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
-                              + rho_sw*ISOMIPgammaT &
+                              + rho_sw*config_land_ice_flux_ISOMIP_gammaT &
                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
             landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
 
@@ -550,10 +506,10 @@ contains
          end do
          !$omp end do
          !$omp end parallel
-      endif ! isomipOn
-      
-      if (jenkinsOn .or. hollandJenkinsOn) then
-         if(useHollandJenkinsAdvDiff) then
+      end if
+
+      if(jenkinsOn .or. hollandJenkinsOn) then
+         if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
                landIceMask, &
@@ -637,9 +593,9 @@ contains
             heatFluxToLandIce(iCell) = landIceFraction(iCell)*heatFluxToLandIce(iCell)
          end do
 
-      endif ! jenkinsOn or hollandJenkinsOn
+      end if
 
-      if(useHollandJenkinsAdvDiff) then
+      if(config_land_ice_flux_useHollandJenkinsAdvDiff) then
          deallocate(freezeInterfaceSalinity, &
                     freezeInterfaceTemperature, &
                     freezeFreshwaterFlux, &
@@ -674,70 +630,35 @@ contains
 
    subroutine ocn_surface_land_ice_fluxes_init(err)!{{{
 
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< [out] error flag
-
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      !*** Set error code and default values for module variables
+      integer, intent(out) :: err !< Output: error flag
 
       err = 0
-
-      landIceFluxesOff = .true.
-      standaloneOff    = .true.
-      isomipOn         = .false.
-      jenkinsOn        = .false.
+      isomipOn = .false.
+      jenkinsOn = .false.
       hollandJenkinsOn = .false.
-      cpLandIce        = 0.0_RKIND
-      rhoLandIce       = 0.0_RKIND
-      ISOMIPgammaT     = 0.0_RKIND
 
-      !*** Determine whether land ice fluxes are on
+      landIceFluxesOn = (trim(config_land_ice_flux_mode) == 'standalone')  &
+           .or. (trim(config_land_ice_flux_mode) == 'coupled')
+      if(.not. landIceFluxesOn) return
 
-      select case (trim(config_land_ice_flux_mode))
-      case ('standalone','Standalone','STANDALONE')
-         landIceFluxesOff = .false.
-         standaloneOff    = .false.
-      case ('coupled','Coupled','COUPLED')
-         landIceFluxesOff = .false.
-         standaloneOff    = .true.
-      case default
-         landIceFluxesOff = .true.
-         standaloneOff    = .true.
-         return
-      end select
+      standaloneOn = trim(config_land_ice_flux_mode) == 'standalone'
 
-      !*** Determine which flux formulation to use
-
-      select case (trim(config_land_ice_flux_formulation))
-
-      case ('isomip','Isomip','ISOMIP')
+      if ( trim(config_land_ice_flux_formulation) == 'ISOMIP' ) then
          isomipOn = .true.
-      case ('jenkins', 'Jenkins','JENKINS')
+      else if ( trim(config_land_ice_flux_formulation) == 'Jenkins' ) then
          jenkinsOn = .true.
-      case ('hollandjenkins','HollandJenkins','HOLLANDJENKINS')
+      else if ( trim(config_land_ice_flux_formulation) == 'HollandJenkins' ) then
          hollandJenkinsOn = .true.
-      case default
+      else
          call mpas_log_write( &
             "config_land_ice_flux_formulation not one of 'ISOMIP', 'Jenkins', " &
                // "or 'HollandJenkins'.", &
                MPAS_LOG_CRIT)
          err = 1
-      end select
+      end if
 
-      useHollandJenkinsAdvDiff = &
-                       config_land_ice_flux_useHollandJenkinsAdvDiff
-
-      !*** Set physical values
-
-      cpLandIce    = config_land_ice_flux_cp_ice
-      rhoLandIce   = config_land_ice_flux_rho_ice
-      ISOMIPgammaT = config_land_ice_flux_ISOMIP_gammaT
+      cp_land_ice = config_land_ice_flux_cp_ice
+      rho_land_ice = config_land_ice_flux_rho_ice
 
    !--------------------------------------------------------------------
 
@@ -877,7 +798,7 @@ contains
       !   2. the diffusion (if any) of heat into the ice, based on temperature difference between
       !      the reference point in the ice (either the surface or the middle of the bottom layer)
       !      and the interface
-      outIceHeatFlux(iCell) = -cpLandIce*outFreshwaterFlux(iCell)*outInterfaceTemperature(iCell)
+      outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*outInterfaceTemperature(iCell)
     end do
     !$omp end do
     !$omp end parallel
@@ -981,7 +902,7 @@ contains
     integer :: iCell
 
     err = 0
-    cpRatio = cpLandIce/cp_sw
+    cpRatio = cp_land_ice/cp_sw
     !$omp parallel
     !$omp do schedule(runtime) &
     !$omp private(T0, dTf_dS, transferVelocityRatio, Tlatent, eta, TlatentStar, a, b, c, err)
@@ -1023,7 +944,7 @@ contains
       ! Since we're considering only melting and ignoring diffusion,
       ! the ice loses heat simply by the loss of ice mass at the prescribed
       ! (surface?) ice temperature
-      outIceHeatFlux(iCell) = -cpLandIce*outFreshwaterFlux(iCell)*iceTemperature(iCell)
+      outIceHeatFlux(iCell) = -cp_land_ice*outFreshwaterFlux(iCell)*iceTemperature(iCell)
     end do
     !$omp end do
     !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -351,7 +351,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, diagnosticsPool, &
+   subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
       forcingPool, scratchPool, statePool, dt, err) !{{{
 
       !-----------------------------------------------------------------
@@ -361,8 +361,7 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: &
-         meshPool, &     !< Input: mesh information
-         diagnosticsPool !< Input: diagnostics information
+         meshPool        !< Input: mesh information
       real(kind=RKIND), intent(in) :: dt ! the time step over which to accumulate fluxes
 
       !-----------------------------------------------------------------
@@ -398,7 +397,6 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
                                                   landIceSurfaceTemperature, &
-                                                  landIceFrictionVelocity, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce
       real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMassOld, &
@@ -408,10 +406,9 @@ contains
 
       integer, dimension(:), pointer :: landIceMask
 
-      real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, &
-                                                    landIceInterfaceTracers, &
-                                                    landIceTracerTransferVelocities
-      integer, pointer :: indexBLT, indexBLS, indexIT, indexIS, indexHeatTrans, indexSaltTrans
+      real (kind=RKIND), dimension(:,:), pointer :: &
+                                                    landIceInterfaceTracers
+      integer, pointer :: indexIT, indexIS
 
       ! Scratch Arrays
       !---
@@ -433,18 +430,7 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
-      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
-      end if
 
       call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -29,6 +29,7 @@ module ocn_tendency
    use ocn_diagnostics_variables
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    use ocn_surface_bulk_forcing
    use ocn_surface_land_ice_fluxes
@@ -110,7 +111,6 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tend_thick(tendPool, forcingPool, meshPool)!{{{
-      implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
@@ -164,7 +164,7 @@ contains
       !
       ! QC Comment (3/15/12): need to make sure that uTranport is the right
       ! transport velocity here.
-      call ocn_thick_hadv_tend(meshPool, normalTransportVelocity, layerThicknessEdge, tend_layerThickness, err)
+      call ocn_thick_hadv_tend(meshPool, normalTransportVelocity, layerThickEdge, tend_layerThickness, err)
 
       !
       ! height tendency: vertical advection term -d/dz(hw)
@@ -204,147 +204,233 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, timeLevelIn, dt)!{{{
-      implicit none
+   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, &
+                           timeLevelIn, dt)!{{{
 
-      type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
-      type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      real (kind=RKIND), intent(in) :: dt
-      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
 
+      real (kind=RKIND), intent(in) :: &
+         dt             !< [in] time step
+
+      integer, intent(in), optional :: &
+         timeLevelIn    !< [in] Time level for state fields
+
+      ! Input structures with lots of fields
+      type (mpas_pool_type), intent(in) :: statePool ! replace
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      ! currently updated as pool variables - change to args?
+
+      type (mpas_pool_type), intent(inout) :: &
+         tendPool,          &!< [out] Tendency structure w/ vel tend
+         forcingPool         !< [out] Forcing structure w/ sfc stresses
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         tendVel             !< [out] normal velocity tendency at edges
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         sfcStress,         &!< [out] surface stress at edges
+         sfcStressMag        !< [out] surface stress magnitude (on cell)
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::           &
+         err,              &! local error flag
+         iEdge, iCell, k,  &! loop indices for edge, cell and vertical
+         indxTemp,         &! tracer index for temperature
+         indxSalt,         &! tracer index for salinity
+         timeLevel          ! time level to use for state variables
+
+      ! various pointers for array retrievals
+
+      integer, pointer :: indexTemperature, indexSalinity
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, ssh
-      real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta 
+      real (kind=RKIND), dimension(:), pointer :: &
+         ssh               ! sea surface height
+
       real (kind=RKIND), dimension(:,:), pointer :: &
-        normalVelocity, &
-        layerThickness, &
-        tend_normalVelocity, circulation
-      real (kind=RKIND), dimension(:,:), pointer :: tidalPotentialZMid
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
+         normalVelocity,     &! normal velocity
+         layerThickness, &
+         circulation
 
-      integer :: timeLevel
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+         activeTracers
 
-      integer :: err, iEdge, iCell, k
-      integer, pointer :: indexTemperature, indexSalinity, nEdges, nCells
-      integer, dimension(:), pointer :: maxLevelCell
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
+      !*** Initialize error code and determine time level
+
+      err = 0
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
       else
          timeLevel = 1
       end if
 
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
+      !*** Retrieve pool variables
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-      call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_array(statePool,   'normalVelocity', &
+                                             normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool,   'layerThickness', &
+                                             layerThickness, timeLevel)
+      call mpas_pool_get_array(statePool,   'ssh', ssh, timeLevel)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                             activeTracers, timeLevel)
 
-      call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinity)
+      indxTemp = indexTemperature
+      indxSalt = indexSalinity
 
-      call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
-      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
-      !
-      ! velocity tendency: start accumulating tendency terms
-      !
-      !$omp Parallel
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         tend_normalVelocity(:, iEdge) = 0.0_RKIND
-         surfaceStress(iEdge) = 0.0_RKIND
+      call mpas_pool_get_array(tendPool, 'normalVelocity', tendVel)
+
+      call mpas_pool_get_array(forcingPool, 'surfaceStress', &
+                                             sfcStress)
+      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
+                                             sfcStressMag)
+
+      !*** Transfer data to device
+      !$acc enter data &
+      !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
+      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
+      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
+      !$acc    pressure, layerThickness, circulation, activeTracers, &
+      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
+      !$acc    normPlanetVortEdge, montgomeryPotential, &
+      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
+      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
+
+      !*** Set output variables to zero before accumulating results
+      
+#ifdef MPAS_OPENACC
+      !$acc parallel loop present(sfcStress, tendVel) private(k)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+#endif
+      do iEdge = 1, nEdgesAll
+         sfcStress(iEdge) = 0.0_RKIND
+         do k=1,nVertLevels
+            tendVel(k,iEdge) = 0.0_RKIND
+         end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop present(sfcStressMag)
+#else
       !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         surfaceStressMagnitude(iCell) = 0.0_RKIND
+#endif
+      do iCell = 1, nCellsAll
+         sfcStressMag(iCell) = 0.0_RKIND
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
-      if(config_disable_vel_all_tend) return
+      !*** Return early if all vel tendencies disabled
+      !*** Otherwise, start timer
 
+      if (config_disable_vel_all_tend) return
       call mpas_timer_start("ocn_tend_vel")
 
-      ! Build bulk forcing surface stress
-      call ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)
+      ! Compute bulk forcing surface stress
+      call ocn_surface_bulk_forcing_vel( &
+                                    forcingPool, sfcStress, &
+                                    sfcStressMag, err)
 
       ! Add top drag to surface stress
-      call ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)
+      call ocn_surface_land_ice_fluxes_vel( &
+                                       sfcStress, sfcStressMag, err)
 
-      !
-      ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
-      !
-      call ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, layerThicknessEdge, &
-         normalVelocity, kineticEnergyCell, tend_normalVelocity, err)
+      ! Add nonlinear Coriolis term and horizontal advection of
+      ! momentum, formulated as grad of kinetic energy
+      call ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
+                                      normPlanetVortEdge, &
+                                      layerThickEdge, normalVelocity, &
+                                      kineticEnergyCell, tendVel, err)
 
-      !
-      ! velocity tendency: vertical advection term -w du/dz
-      !
-      call ocn_vel_vadv_tend(meshPool, normalVelocity, layerThicknessEdge, vertAleTransportTop, tend_normalVelocity, err)
+      ! Add vertical advection term -w du/dz
+      call ocn_vel_vadv_tend(normalVelocity, layerThickEdge, &
+                             vertAleTransportTop, tendVel, err)
 
-      !
-      ! velocity tendency: pressure gradient
-      !
-      if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
-         ! only pass EOS derivatives if needed.
-         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
-              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
-              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
-      else
-         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
-              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
-              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
-      endif
+      ! Add pressure gradient
+      call ocn_vel_pressure_grad_tend(ssh, pressure, &
+                               montgomeryPotential, zMid, &
+                               density, potentialDensity, &
+                               indxTemp, indxSalt, activeTracers, &
+                               thermExpCoeff, salineContractCoeff, &
+                               tendVel, err)
 
-      !
-      ! velocity tendency: tidal potential (if needed) 
-      !
-      call ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)
+      ! Add tidal potential (if needed) 
+      call ocn_compute_tidal_potential_forcing(err)
       if (config_time_integrator == 'RK4') then
-        ! for split explicit, tidal forcing is added in barotropic subsycles
-        call ocn_vel_tidal_potential_tend(meshPool, forcingPool, ssh, tend_normalVelocity, err) 
+        ! for split explicit, tidal forcing is added in barotropic subcycles
+        call ocn_vel_tidal_potential_tend(ssh, tendVel, err) 
       endif
 
-      !
-      ! velocity tendency: del2 dissipation, \nu_2 \nabla^2 u
-      !   computed as \nu( \nabla divergence + k \times \nabla relativeVorticity )
-      !   strictly only valid for config_mom_del2 == constant
-      !
-      call ocn_vel_hmix_tend(meshPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, viscosity, &
-         tend_normalVelocity, err)
+      ! Add horizontal mixing
+      call ocn_vel_hmix_tend(divergence, relativeVorticity, tendVel,err)
 
-      !
-      ! velocity tendency: forcing and bottom drag
-      !
-      call ocn_vel_forcing_tend(meshPool, normalVelocity, surfaceFluxAttenuationCoefficient, &
-              surfaceStress, kineticEnergyCell, layerThicknessEdge, &
-                                tend_normalVelocity, err)
+      ! Add forcing and bottom drag
+      call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
+                                sfcStress, kineticEnergyCell, &
+                                layerThickEdge, tendVel, err)
 
-      !
-      ! velocity tendency: zero if drying
-      !
+      ! vertical mixing treated implicitly in a later routine
+      ! adjust total velocity tendency based on wetting/drying
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop collapse(2) &
+      !$acc    present(tendVel, wettingVelocity)
+#else
       !$omp parallel
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         tend_normalVelocity(:, iEdge) = tend_normalVelocity(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
+      !$omp do schedule(runtime) private(k)
+#endif
+      do iEdge = 1, nEdgesAll
+      do k=1,nVertLevels
+         tendVel(k,iEdge) = tendVel(k,iEdge)* &
+                            (1.0_RKIND - wettingVelocity(k,iEdge))
       end do
+      end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
-      !
-      ! velocity tendency: vertical mixing d/dz( nu_v du/dz))
-      !
+      !*** Transfer any needed data back to host and delete inputs
+      !$acc exit data &
+      !$acc    copyout(tendVel, sfcStress, sfcStressMag) &
+      !$acc    delete( &
+      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
+      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
+      !$acc    pressure, layerThickness, circulation, activeTracers, &
+      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
+      !$acc    normPlanetVortEdge, montgomeryPotential, &
+      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
+      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
+
+      ! stop the timer and exit
+
       call mpas_timer_stop("ocn_tend_vel")
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_tend_vel!}}}
 
@@ -359,7 +445,7 @@ contains
 !>  This routine computes tracer tendencies for the ocean
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, & !{{{
+   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, scratchPool, & !{{{
                               dt, activeTracersOnlyIn, timeLevelIn )
       implicit none
 
@@ -371,6 +457,7 @@ contains
       type (mpas_pool_type), intent(inout) :: forcingPool     !< Input: Forcing information
       type (mpas_pool_type), intent(inout)    :: meshPool     !< Input: Mesh information
       type (mpas_pool_type), intent(in)    :: swForcingPool   !< Input: sw data input info
+      type (mpas_pool_type), intent(in)    :: scratchPool     !< Input: Scratch information
       real (kind=RKIND), intent(in) :: dt                     !< Input: Time step
       logical, intent(in), optional :: activeTracersOnlyIn    !< Input: if true, only compute for active tracers
       integer, intent(in), optional :: timeLevelIn            !< Input/Optional: Time Level Indes
@@ -503,7 +590,7 @@ contains
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, nVertLevels
-            normalThicknessFlux(k, iEdge) = normalTransportVelocity(k, iEdge) * layerThicknessEdge(k, iEdge)
+            normalThicknessFlux(k, iEdge) = normalTransportVelocity(k, iEdge) * layerThickEdge(k, iEdge)
          end do
       end do
       !$omp end do
@@ -769,7 +856,7 @@ contains
                     !$omp end parallel
                  endif
                endif
-               call ocn_tracer_hmix_tend(meshPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
+               call ocn_tracer_hmix_tend(meshPool, layerThickEdge, layerThickness, zMid, tracerGroup, &
                                          RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer, &
                                          RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tracerGroupTend, err)
 
@@ -976,7 +1063,7 @@ contains
           iEdge = edgesOnCell(i, iCell)
 
           do k = 1, maxLevelEdgeTop(iEdge)
-            flux = layerThicknessEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) * invAreaCell
+            flux = layerThickEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) * invAreaCell
             div_hu(k) = div_hu(k) - flux
             div_hu_btr = div_hu_btr - flux
           end do

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -26,6 +26,7 @@ module ocn_tendency
    use mpas_timer
    use mpas_threading
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_constants
    use ocn_config
 
@@ -108,27 +109,22 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)!{{{
+   subroutine ocn_tend_thick(tendPool, forcingPool, meshPool)!{{{
       implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFlux
       real (kind=RKIND), dimension(:), pointer :: surfaceThicknessFluxRunoff
-      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, &
-         vertAleTransportTop, tend_layerThickness, normalTransportVelocity, fractionAbsorbed, fractionAbsorbedRunoff
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         tend_layerThickness, fractionAbsorbed, fractionAbsorbedRunoff
 
       integer, pointer :: nCells
       integer :: err, iCell
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 
       call mpas_pool_get_array(tendPool, 'layerThickness', tend_layerThickness)
 
@@ -208,31 +204,25 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, timeLevelIn, dt)!{{{
+   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, meshPool, timeLevelIn, dt)!{{{
       implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       real (kind=RKIND), intent(in) :: dt
-      type (mpas_pool_type), intent(inout) :: scratchPool !< Input: Scratch structure
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
 
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh
+      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, ssh
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThicknessEdge, normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
+        normalVelocity, &
         layerThickness, &
-        tend_normalVelocity, circulation, relativeVorticity, viscosity, kineticEnergyCell, &
-        normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-        montgomeryPotential, vertAleTransportTop, divergence, vertViscTopOfEdge, &
-        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
+        tend_normalVelocity, circulation
       real (kind=RKIND), dimension(:,:), pointer :: tidalPotentialZMid
-      real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
       integer :: timeLevel
@@ -252,47 +242,17 @@ contains
 
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
-      call mpas_pool_get_array(statePool,   'normalVelocity', &
-                                             normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool,   'layerThickness', &
-                                             layerThickness, timeLevel)
-      call mpas_pool_get_array(statePool,   'ssh', ssh, timeLevel)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', &
-                                             activeTracers, timeLevel)
-
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
-                                                 indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
-                                                 indexSalinity)
-      indxTemp = indexTemperature
-      indxSalt = indexSalinity
-
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', &
-                                                 kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', &
-                                                 layerThickEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', &
-                                                 vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
       call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
 
       call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
-
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
       !
       ! velocity tendency: start accumulating tendency terms
       !
@@ -319,7 +279,7 @@ contains
       call ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)
 
       ! Add top drag to surface stress
-      call ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)
+      call ocn_surface_land_ice_fluxes_vel(meshPool, surfaceStress, surfaceStressMagnitude, err)
 
       !
       ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
@@ -337,8 +297,6 @@ contains
       !
       if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
          ! only pass EOS derivatives if needed.
-         call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
-         call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
          call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
               indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
               inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
@@ -362,7 +320,7 @@ contains
       !   computed as \nu( \nabla divergence + k \times \nabla relativeVorticity )
       !   strictly only valid for config_mom_del2 == constant
       !
-      call ocn_vel_hmix_tend(meshPool, scratchPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, viscosity, &
+      call ocn_vel_hmix_tend(meshPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, viscosity, &
          tend_normalVelocity, err)
 
       !
@@ -401,7 +359,7 @@ contains
 !>  This routine computes tracer tendencies for the ocean
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, swForcingPool, scratchPool, & !{{{
+   subroutine ocn_tend_tracer(tendPool, statePool, forcingPool, meshPool, swForcingPool, & !{{{
                               dt, activeTracersOnlyIn, timeLevelIn )
       implicit none
 
@@ -411,10 +369,8 @@ contains
       type (mpas_pool_type), intent(inout) :: tendPool        !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(in)    :: statePool       !< Input: State information
       type (mpas_pool_type), intent(inout) :: forcingPool     !< Input: Forcing information
-      type (mpas_pool_type), intent(inout)    :: diagnosticsPool !< Input: Diagnostic information
       type (mpas_pool_type), intent(inout)    :: meshPool     !< Input: Mesh information
       type (mpas_pool_type), intent(in)    :: swForcingPool   !< Input: sw data input info
-      type (mpas_pool_type), intent(in)    :: scratchPool     !< Input: Scratch information
       real (kind=RKIND), intent(in) :: dt                     !< Input: Time step
       logical, intent(in), optional :: activeTracersOnlyIn    !< Input: if true, only compute for active tracers
       integer, intent(in), optional :: timeLevelIn            !< Input/Optional: Time Level Indes
@@ -439,7 +395,6 @@ contains
                           config_use_tracerGroup_ttd_forcing
 
       real (kind=RKIND), pointer :: salinity_restoring_constant_piston_velocity
-      integer, dimension(:,:), pointer :: rediLimiterCount
 
       ! iterator for tracer categories
       type (mpas_pool_iterator_type) :: groupItr
@@ -448,9 +403,8 @@ contains
       !
       ! one dimensional pointers
       !
-      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL
+      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: tracerGroupExponentialDecayRate, latCell
-      real (kind=RKIND), dimension(:), pointer :: RediKappa 
       integer, dimension(:), pointer :: maxLevelCell
 
       !
@@ -460,16 +414,16 @@ contains
                                                     tracerGroupIdealAgeMask, tracerGroupTTDMask
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        normalTransportVelocity, layerThickness,vertAleTransportTop, layerThicknessEdge, vertDiffTopOfCell, &
-        tracerGroupSurfaceFlux, fractionAbsorbed, zMid, &
+        layerThickness, &
+        tracerGroupSurfaceFlux, fractionAbsorbed, &
         fractionAbsorbedRunoff, tracerGroupSurfaceFluxRunoff, &
-        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux, RediKappaScaling, RediKappaSfcTaper
+        tracerGroupSurfaceFluxRemoved, nonLocalSurfaceTracerFlux
 
       !
       ! three dimensional pointers
       !
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-        tracerGroup, tracerGroupTend, vertNonLocalFlux
+        tracerGroup, tracerGroupTend
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
         activeTracers, &  !  need T, S for ecosys
@@ -478,14 +432,7 @@ contains
       real (kind=RKIND), dimension(:,:,:), pointer :: tracerGroupInteriorRestoringRate, tracerGroupInteriorRestoringValue
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-        slopeTriadUp, slopeTriadDown,                 &
-        activeTracerSurfaceFluxTendency,              &
-        activeTracerNonLocalTendency,                 &
-        activeTracerHorMixTendency,                   &
         kappaRediEdge
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        temperatureShortWaveTendency
 
       !
       ! local integers/reals/logicals
@@ -534,20 +481,7 @@ contains
       ! get arrays
       !
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
-      call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -555,16 +489,6 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-
-      !
-      ! get diagnostic arrays for temperature/salinity budget
-      !
-      if (config_compute_active_tracer_budgets) then
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
-         call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
-      endif
 
       if(config_disable_tr_all_tend) return
 
@@ -825,7 +749,7 @@ contains
                ! Tendency for tracer budget is stored within the tracer adv
                ! routine
                call ocn_tracer_advection_tend(tracerGroup, normalThicknessFlux, vertAleTransportTop, layerThickness, &
-                                              dt, meshPool, scratchPool, diagnosticsPool, tracerGroupTend, &
+                                              dt, meshPool, tracerGroupTend, &
                                               trim(groupItr % memberName))
 
                !
@@ -845,7 +769,7 @@ contains
                     !$omp end parallel
                  endif
                endif
-               call ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
+               call ocn_tracer_hmix_tend(meshPool, layerThicknessEdge, layerThickness, zMid, tracerGroup, &
                                          RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer, &
                                          RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tracerGroupTend, err)
 
@@ -920,7 +844,7 @@ contains
                !
                if (config_use_cvmix_kpp) then
                   call mpas_timer_start("non-local flux from KPP")
-                  call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, diagnosticsPool, scratchPool, timeLevel)
+                  call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, timeLevel)
                   if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
                      if( trim(groupItr % memberName) == 'activeTracers' ) then
                         if (config_compute_active_tracer_budgets) then
@@ -977,11 +901,10 @@ contains
 !>  config_freq_filtered_thickness is true (z-tilde)
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_tend_freq_filtered_thickness(tendPool, statePool, diagnosticsPool, meshPool, timeLevelIn)!{{{
+   subroutine ocn_tend_freq_filtered_thickness(tendPool, statePool, meshPool, timeLevelIn)!{{{
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency information
       type (mpas_pool_type), intent(in) :: statePool !< Input: State information
-      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostics information
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
 
@@ -994,7 +917,7 @@ contains
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr, thickness_filter_timescale_sec, highFreqThick_restore_time_sec, &
          totalThickness
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThicknessEdge, &
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, &
          layerThickness, &
          lowFreqDivergence, highFreqThickness, &
          tend_lowFreqDivergence, tend_highFreqThickness
@@ -1025,8 +948,6 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergence, timeLevel)
       call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThickness, timeLevel)
-
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
 
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', tend_lowFreqDivergence)
       call mpas_pool_get_array(tendPool, 'highFreqThickness', tend_highFreqThickness)

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -28,7 +28,6 @@ module ocn_tendency
    use ocn_diagnostics
    use ocn_constants
    use ocn_config
-   use ocn_mesh
 
    use ocn_surface_bulk_forcing
    use ocn_surface_land_ice_fluxes
@@ -110,6 +109,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tend_thick(tendPool, forcingPool, diagnosticsPool, meshPool)!{{{
+      implicit none
 
       type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
       type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
@@ -208,99 +208,48 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, &
-                           diagnosticsPool, timeLevelIn, dt)!{{{
+   subroutine ocn_tend_vel(tendPool, statePool, forcingPool, diagnosticsPool, meshPool, scratchPool, timeLevelIn, dt)!{{{
+      implicit none
 
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
+      type (mpas_pool_type), intent(in) :: statePool !< Input: State information
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      type (mpas_pool_type), intent(in) :: diagnosticsPool !< Input: Diagnostic information
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+      real (kind=RKIND), intent(in) :: dt
+      type (mpas_pool_type), intent(inout) :: scratchPool !< Input: Scratch structure
+      integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
 
-      real (kind=RKIND), intent(in) :: &
-         dt             !< [in] time step
-
-      integer, intent(in), optional :: &
-         timeLevelIn    !< [in] Time level for state fields
-
-      ! Input structures with lots of fields
-      type (mpas_pool_type), intent(in) :: statePool ! replace
-      type (mpas_pool_type), intent(in) :: diagnosticsPool ! replace
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-
-      ! currently updated as pool variables - change to args?
-
-      type (mpas_pool_type), intent(inout) :: &
-         tendPool,          &!< [out] Tendency structure w/ vel tend
-         forcingPool         !< [out] Forcing structure w/ sfc stresses
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         tendVel             !< [out] normal velocity tendency at edges
-
-      real (kind=RKIND), dimension(:), pointer :: &
-         sfcStress,         &!< [out] surface stress at edges
-         sfcStressMag        !< [out] surface stress magnitude (on cell)
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-
-      integer ::           &
-         err,              &! local error flag
-         iEdge, iCell, k,  &! loop indices for edge, cell and vertical
-         indxTemp,         &! tracer index for temperature
-         indxSalt,         &! tracer index for salinity
-         timeLevel          ! time level to use for state variables
-
-      ! various pointers for array retrievals
-
-      integer, pointer :: indexTemperature, indexSalinity
       type (mpas_pool_type), pointer :: tracersPool
 
-      real (kind=RKIND), dimension(:), pointer :: &
-         sfcFlxAttCoeff,  &! surface flux attenuation coefficient
-         ssh               ! sea surface height
-
+      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude, surfaceFluxAttenuationCoefficient, ssh
+      real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta 
       real (kind=RKIND), dimension(:,:), pointer :: &
-         layerThickEdge,     &! layer thicknesss at edge
-         normalVelocity,     &! normal velocity
-         tangentialVelocity, &! tangential velocity
-         density, &
-         potentialDensity, &
-         zMid, &
-         pressure, &
-         layerThickness, &
-         circulation, &
-         relativeVorticity, &
-         kineticEnergyCell, &
-         normRelVortEdge,     &! normalized relative vorticity on edge
-         normPlanetVortEdge,  &! normalized planetary vorticity on edge
-         montgomeryPotential, &
-         vertAleTransportTop, &
-         divergence, &
-         vertViscTopOfEdge, &
-         thermExpCoeff,       &! in situ thermal expansion coeff
-         salineContractCoeff, &! in situ saline contraction coeff
-         wettingVelocity
+        layerThicknessEdge, normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
+        layerThickness, &
+        tend_normalVelocity, circulation, relativeVorticity, viscosity, kineticEnergyCell, &
+        normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+        montgomeryPotential, vertAleTransportTop, divergence, vertViscTopOfEdge, &
+        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
+      real (kind=RKIND), dimension(:,:), pointer :: tidalPotentialZMid
+      real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-         activeTracers
+      integer :: timeLevel
 
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
+      integer :: err, iEdge, iCell, k
+      integer, pointer :: indexTemperature, indexSalinity, nEdges, nCells
+      integer, dimension(:), pointer :: maxLevelCell
 
-      !*** Initialize error code and determine time level
-
-      err = 0
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
       else
          timeLevel = 1
       end if
 
-      !*** Retrieve pool variables
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
       call mpas_pool_get_array(statePool,   'normalVelocity', &
@@ -325,171 +274,119 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', &
                                                  vertAleTransportTop)
       call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', &
-                                                 relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', &
-                                                 normRelVortEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', &
-                                                 normPlanetVortEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', &
-                                                 divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', &
-                                                 montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', &
-                                                 pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', &
-                                                 vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'density', &
-                                                 density)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
-                                                 potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', &
-                                                 tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', &
-                                                 sfcFlxAttCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff', &
-                                                 thermExpCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff',  &
-                                                 salineContractCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', &
-                                                 wettingVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normalizedRelativeVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normalizedPlanetaryVorticityEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
+      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
+      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
+      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
+      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
+      call mpas_pool_get_array(diagnosticsPool, 'density', density)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', surfaceFluxAttenuationCoefficient)
 
-      call mpas_pool_get_array(tendPool, 'normalVelocity', tendVel)
+      call mpas_pool_get_array(tendPool, 'normalVelocity', tend_normalVelocity)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceStress', &
-                                             sfcStress)
-      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
-                                             sfcStressMag)
+      call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
+      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
 
-      !*** Transfer data to device
-      !$acc enter data &
-      !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
-      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
-      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
-      !$acc    pressure, layerThickness, circulation, activeTracers, &
-      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
-      !$acc    normPlanetVortEdge, montgomeryPotential, &
-      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
-      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
-
-      !*** Set output variables to zero before accumulating results
-      
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(sfcStress, tendVel) private(k)
-#else
-      !$omp parallel
-      !$omp do schedule(runtime) private(k)
-#endif
-      do iEdge = 1, nEdgesAll
-         sfcStress(iEdge) = 0.0_RKIND
-         do k=1,nVertLevels
-            tendVel(k,iEdge) = 0.0_RKIND
-         end do
-      end do
-#ifndef MPAS_OPENACC
-      !$omp end do
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc parallel loop present(sfcStressMag)
-#else
+      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
+      !
+      ! velocity tendency: start accumulating tendency terms
+      !
+      !$omp Parallel
       !$omp do schedule(runtime)
-#endif
-      do iCell = 1, nCellsAll
-         sfcStressMag(iCell) = 0.0_RKIND
+      do iEdge = 1, nEdges
+         tend_normalVelocity(:, iEdge) = 0.0_RKIND
+         surfaceStress(iEdge) = 0.0_RKIND
       end do
-#ifndef MPAS_OPENACC
+      !$omp end do
+
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         surfaceStressMagnitude(iCell) = 0.0_RKIND
+      end do
       !$omp end do
       !$omp end parallel
-#endif
 
-      !*** Return early if all vel tendencies disabled
-      !*** Otherwise, start timer
+      if(config_disable_vel_all_tend) return
 
-      if (config_disable_vel_all_tend) return
       call mpas_timer_start("ocn_tend_vel")
 
-      ! Compute bulk forcing surface stress
-      call ocn_surface_bulk_forcing_vel( &
-                                    forcingPool, sfcStress, &
-                                    sfcStressMag, err)
+      ! Build bulk forcing surface stress
+      call ocn_surface_bulk_forcing_vel(meshPool, forcingPool, surfaceStress, surfaceStressMagnitude, err)
 
       ! Add top drag to surface stress
-      call ocn_surface_land_ice_fluxes_vel(diagnosticsPool, &
-                                       sfcStress, sfcStressMag, err)
+      call ocn_surface_land_ice_fluxes_vel(meshPool, diagnosticsPool, surfaceStress, surfaceStressMagnitude, err)
 
-      ! Add nonlinear Coriolis term and horizontal advection of
-      ! momentum, formulated as grad of kinetic energy
-      call ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
-                                      normPlanetVortEdge, &
-                                      layerThickEdge, normalVelocity, &
-                                      kineticEnergyCell, tendVel, err)
+      !
+      ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
+      !
+      call ocn_vel_hadv_coriolis_tend(meshPool, normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, layerThicknessEdge, &
+         normalVelocity, kineticEnergyCell, tend_normalVelocity, err)
 
-      ! Add vertical advection term -w du/dz
-      call ocn_vel_vadv_tend(normalVelocity, layerThickEdge, &
-                             vertAleTransportTop, tendVel, err)
+      !
+      ! velocity tendency: vertical advection term -w du/dz
+      !
+      call ocn_vel_vadv_tend(meshPool, normalVelocity, layerThicknessEdge, vertAleTransportTop, tend_normalVelocity, err)
 
-      ! Add pressure gradient
-      call ocn_vel_pressure_grad_tend(ssh, pressure, &
-                               montgomeryPotential, zMid, &
-                               density, potentialDensity, &
-                               indxTemp, indxSalt, activeTracers, &
-                               thermExpCoeff, salineContractCoeff, &
-                               tendVel, err)
-
-      ! Add tidal potential (if needed) 
-      call ocn_compute_tidal_potential_forcing(diagnosticsPool, err)
-      if (config_time_integrator == 'RK4') then
-        ! for split explicit, tidal forcing is added in barotropic subcycles
-        call ocn_vel_tidal_potential_tend(ssh, tendVel, err) 
+      !
+      ! velocity tendency: pressure gradient
+      !
+      if (config_pressure_gradient_type.eq.'Jacobian_from_TS') then
+         ! only pass EOS derivatives if needed.
+         call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',inSituThermalExpansionCoeff)
+         call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', inSituSalineContractionCoeff)
+         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
+              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
+              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
+      else
+         call ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
+              indexTemperature, indexSalinity, activeTracers, tend_normalVelocity, err, &
+              inSituThermalExpansionCoeff,inSituSalineContractionCoeff)
       endif
 
-      ! Add horizontal mixing
-      call ocn_vel_hmix_tend(divergence, relativeVorticity, tendVel,err)
+      !
+      ! velocity tendency: tidal potential (if needed) 
+      !
+      call ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)
+      if (config_time_integrator == 'RK4') then
+        ! for split explicit, tidal forcing is added in barotropic subsycles
+        call ocn_vel_tidal_potential_tend(meshPool, forcingPool, ssh, tend_normalVelocity, err) 
+      endif
 
-      ! Add forcing and bottom drag
-      call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
-                                sfcStress, kineticEnergyCell, &
-                                layerThickEdge, tendVel, err)
+      !
+      ! velocity tendency: del2 dissipation, \nu_2 \nabla^2 u
+      !   computed as \nu( \nabla divergence + k \times \nabla relativeVorticity )
+      !   strictly only valid for config_mom_del2 == constant
+      !
+      call ocn_vel_hmix_tend(meshPool, scratchPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, viscosity, &
+         tend_normalVelocity, err)
 
-      ! vertical mixing treated implicitly in a later routine
-      ! adjust total velocity tendency based on wetting/drying
+      !
+      ! velocity tendency: forcing and bottom drag
+      !
+      call ocn_vel_forcing_tend(meshPool, normalVelocity, surfaceFluxAttenuationCoefficient, &
+              surfaceStress, kineticEnergyCell, layerThicknessEdge, &
+                                tend_normalVelocity, err)
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) &
-      !$acc    present(tendVel, wettingVelocity)
-#else
+      !
+      ! velocity tendency: zero if drying
+      !
       !$omp parallel
-      !$omp do schedule(runtime) private(k)
-#endif
-      do iEdge = 1, nEdgesAll
-      do k=1,nVertLevels
-         tendVel(k,iEdge) = tendVel(k,iEdge)* &
-                            (1.0_RKIND - wettingVelocity(k,iEdge))
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+         tend_normalVelocity(:, iEdge) = tend_normalVelocity(:, iEdge) * (1.0_RKIND - wettingVelocity(:, iEdge))
       end do
-      end do
-#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
-#endif
 
-      !*** Transfer any needed data back to host and delete inputs
-      !$acc exit data &
-      !$acc    copyout(tendVel, sfcStress, sfcStressMag) &
-      !$acc    delete( &
-      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
-      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
-      !$acc    pressure, layerThickness, circulation, activeTracers, &
-      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
-      !$acc    normPlanetVortEdge, montgomeryPotential, &
-      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
-      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
-
-      ! stop the timer and exit
-
+      !
+      ! velocity tendency: vertical mixing d/dz( nu_v du/dz))
+      !
       call mpas_timer_stop("ocn_tend_vel")
-
-   !--------------------------------------------------------------------
 
    end subroutine ocn_tend_vel!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_test.F
+++ b/src/core_ocean/shared/mpas_ocn_test.F
@@ -31,6 +31,7 @@ module ocn_test
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -246,7 +247,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_init_gm_test_functions(diagnosticsPool, meshPool, scratchPool)!{{{
+   subroutine ocn_init_gm_test_functions(meshPool, scratchPool)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -263,7 +264,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool  !< Input: diagnostic fields derived from State
       type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
 
       !-----------------------------------------------------------------
@@ -280,7 +280,6 @@ contains
          config_gm_analytic_bottom_depth, L, R, c1, c2, zMax, zBot
 
       real(kind=RKIND), dimension(:), pointer   :: bottomDepth, refBottomDepthTopOfCell, yCell, yEdge
-      real(kind=RKIND), dimension(:,:), pointer :: zMid
 
       ! Scratch Arrays
       ! yGMStreamFuncSolution: GM stream function reconstructured to the cell centers,
@@ -300,8 +299,6 @@ contains
       call mpas_pool_get_array(meshPool, 'yCell',yCell)
       call mpas_pool_get_array(meshPool, 'yEdge',yEdge)
       call mpas_pool_get_array(meshPool, 'bottomDepth',bottomDepth)
-
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
 
       nVertLevels = maxval(maxLevelCell)
 

--- a/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
@@ -28,6 +28,7 @@ module ocn_tidal_forcing
    use ocn_constants
    use ocn_config
    use ocn_equation_of_state
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -160,7 +161,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, diagnosticsPool, statePool, err)!{{{
+   subroutine ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -169,7 +170,6 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), pointer, intent(in) :: diagnosticsPool !< Input: Diagnostic information
 
       !-----------------------------------------------------------------
       !
@@ -213,7 +213,6 @@ contains
       real (kind=RKIND) :: totalDepth, tidalHeight
 
       character (len=StrKIND), pointer :: simulationStartTime, xtime
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
       type (MPAS_Time_type) :: startTime, xtime_timeType, simulationStartTime_timeType
 
       if ( .not. tidalfluxOn ) return
@@ -224,9 +223,6 @@ contains
                                              tidalLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
       call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
-
-      ! compute time since start of simulation, in days
-      call mpas_pool_get_array(diagnosticsPool, 'daysSinceStartOfSim', daysSinceStartOfSim)
 
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -28,6 +28,7 @@ module ocn_time_average_coupled
     use ocn_tracer_ecosys
     use ocn_tracer_DMS
     use ocn_tracer_MacroMolecules
+    use ocn_diagnostics_variables
 
     implicit none
     save
@@ -194,19 +195,17 @@ module ocn_time_average_coupled
 !>  This routine accumulated the coupled time averaging fields
 !
 !-----------------------------------------------------------------------
-    subroutine ocn_time_average_coupled_accumulate(diagnosticsPool, statePool, forcingPool, timeLevel)!{{{
-        type (mpas_pool_type), intent(in) :: diagnosticsPool
+    subroutine ocn_time_average_coupled_accumulate(statePool, forcingPool, timeLevel)!{{{
         type (mpas_pool_type), intent(in) :: statePool
         type (mpas_pool_type), intent(inout) :: forcingPool
         integer, intent(in) :: timeLevel
 
-        real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
-        real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue, avgTracersSurfaceValue
+        real (kind=RKIND), dimension(:,:), pointer :: avgSurfaceVelocity
+        real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue
         real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
-        real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
         integer :: iCell
         integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled, nCells
-        real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers, landIceTracerTransferVelocities, &
+        real (kind=RKIND), dimension(:,:), pointer :: &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce
 
@@ -238,11 +237,6 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgOceanSurfacePhytoC, &
                                                       avgOceanSurfaceDOC
 
-        call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-        call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
-        call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
-        call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
-
         call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
         call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
@@ -273,8 +267,6 @@ module ocn_time_average_coupled
         !$omp end parallel
 
         if(trim(config_land_ice_flux_mode) == 'coupled') then
-           call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-           call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
            call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, timeLevel)
 
            call mpas_pool_get_array(forcingPool, 'avgLandIceBoundaryLayerTracers', avgLandIceBoundaryLayerTracers)

--- a/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_time_varying_forcing.F
@@ -22,6 +22,7 @@ module ocn_time_varying_forcing
   use ocn_framework_forcing
   use ocn_constants
   use ocn_config
+  use ocn_diagnostics_variables
   use mpas_log, only: mpas_log_write
 
   implicit none
@@ -316,8 +317,7 @@ contains
     type (mpas_pool_type), pointer :: &
          mesh, &
          forcingPool, &
-         timeVaryingForcingPool, &
-         diagnosticsPool
+         timeVaryingForcingPool
 
     real(kind=RKIND), dimension(:), pointer :: &
          windSpeedU, &
@@ -335,9 +335,6 @@ contains
          currentTime, &
          windStressCoefficientLimit
 
-    real(kind=RKIND), pointer:: &
-        daysSinceStartOfSim
-
     integer, pointer :: &
          nCells
 
@@ -347,11 +344,9 @@ contains
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
     call MPAS_pool_get_subpool(block % structs, "forcing", forcingPool)
     call MPAS_pool_get_subpool(block % structs, "timeVaryingForcing", timeVaryingForcingPool)
-    call MPAS_pool_get_subpool(block % structs, "diagnostics", diagnosticsPool)
 
     call MPAS_pool_get_dimension(mesh, "nCells", nCells)
 
-    call MPAS_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedU", windSpeedU)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedV", windSpeedV)
     call MPAS_pool_get_array(timeVaryingForcingPool, "windSpeedMagnitude", windSpeedMagnitude)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -68,7 +68,7 @@ module ocn_tracer_advection
 
    subroutine ocn_tracer_advection_tend(tracers, normalThicknessFlux, w,       &
                                         layerThickness, dt, meshPool,          &
-                                        scratchPool, diagnosticsPool, tend,    &
+                                        tend,    &
                                         tracerGroupName)!{{{
 
       !*** Input/Output parameters
@@ -90,10 +90,6 @@ module ocn_tracer_advection
          dt                  !< [in] Time step
       type (mpas_pool_type), intent(in) :: &
          meshPool            !< [in] Mesh information
-      type (mpas_pool_type), intent(in) :: &
-         scratchPool         !< [in] Scratch fields
-      type (mpas_pool_type), intent(in) :: &
-         diagnosticsPool     !< [in] Diagnostic fields
       character (len=*), intent(in) :: &
          tracerGroupName     !< [in] Tracer name to check if active tracers
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -146,7 +146,7 @@ module ocn_tracer_advection
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             diagnosticsPool, computeBudgets)
+                                             computeBudgets)
 
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -33,6 +33,7 @@ module ocn_tracer_advection_mono
    use mpas_tracer_advection_helpers
 
    use ocn_constants
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -96,7 +97,7 @@ module ocn_tracer_advection_mono
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             diagnosticsPool, computeBudgets)!{{{
+                                             computeBudgets)!{{{
 
       !*** Input/Output parameters
 
@@ -133,8 +134,6 @@ module ocn_tracer_advection_mono
          edgeSignOnCell         !< [in] Sign for flux from edge on each cell
       type (mpas_pool_type), intent(in) :: &
          meshPool               !< [in] Mesh information
-      type (mpas_pool_type), intent(in) :: &
-         diagnosticsPool        !< [in] pool for traceradvection budget term
       logical, intent(in) :: &
          computeBudgets         !< [in] Flag to compute active tracer budgets
 
@@ -181,13 +180,6 @@ module ocn_tracer_advection_mono
          wgtTmp,            &! vertical temporaries for
          flxTmp, sgnTmp      !   high-order flux computation
 
-      ! pointers for tendencies used in diagnostic budget computation
-      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
-         activeTracerHorizontalAdvectionTendency, &
-         activeTracerVerticalAdvectionTendency,   &
-         activeTracerHorizontalAdvectionEdgeFlux, &
-         activeTracerVerticalAdvectionTopFlux
-
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
 
@@ -207,21 +199,6 @@ module ocn_tracer_advection_mono
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-
-      if (computeBudgets) then
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerVerticalAdvectionTopFlux',    &
-                 activeTracerVerticalAdvectionTopFlux)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerHorizontalAdvectionEdgeFlux', &
-                 activeTracerHorizontalAdvectionEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerHorizontalAdvectionTendency', &
-                 activeTracerHorizontalAdvectionTendency)
-         call mpas_pool_get_array(diagnosticsPool,         &
-                'activeTracerVerticalAdvectionTendency',   &
-                 activeTracerVerticalAdvectionTendency)
-      end if
 
       ! Get dimensions
       nVertLevels = size(tracers,dim=2)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix.F
@@ -79,7 +79,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_tend(meshPool, scratchPool, layerThicknessEdge, layerThickness, zMid, tracers, &
+   subroutine ocn_tracer_hmix_tend(meshPool, layerThicknessEdge, layerThickness, zMid, tracers, &
                                    RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
                                    RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
@@ -90,7 +90,6 @@ contains
       !
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: Scratch information
 
       real (kind=RKIND), dimension(:), intent(in), optional :: &
          RediKappa

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_restoring.F
@@ -29,6 +29,7 @@ module ocn_tracer_surface_restoring
    use ocn_constants
    use ocn_config
    use ocn_framework_forcing
+   use ocn_diagnostics_variables
 
    implicit none
 
@@ -220,7 +221,6 @@ contains
 
         type (dm_info) :: dminfo
 
-        type (mpas_pool_type), pointer :: diagnosticsPool
         type (mpas_pool_type), pointer :: forcingPool
         type (mpas_pool_type), pointer :: meshPool
         type (mpas_pool_type), pointer :: statePool
@@ -229,7 +229,7 @@ contains
         type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool
 
         real (kind=RKIND), dimension(:), pointer :: &
-           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell, salinitySurfaceRestoringTendency
+           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell
 
         real (kind=RKIND), dimension(:,:), pointer :: &
            activeTracersSurfaceRestoringValue
@@ -308,7 +308,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_subpool(block % structs, 'state', statePool)
-        call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields',tracersSurfaceRestoringFieldsPool)
         ! Use time level 1, which is always the new time level
@@ -438,7 +437,6 @@ contains
         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
         call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields',tracersSurfaceRestoringFieldsPool)
-        call mpas_pool_get_array(diagnosticsPool,'salinitySurfaceRestoringTendency',salinitySurfaceRestoringTendency)
         call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersSurfaceRestoringValue', &
            activeTracersSurfaceRestoringValue)
         call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, 'index_salinitySurfaceRestoringValue',  &

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix.F
@@ -24,7 +24,8 @@ module ocn_vel_hmix
 
    use mpas_timer
    use mpas_derived_types
-   use mpas_log
+   use mpas_pool_routines
+   use mpas_threading
    use ocn_vel_hmix_del2
    use ocn_vel_hmix_leith
    use ocn_vel_hmix_del4
@@ -56,8 +57,7 @@ module ocn_vel_hmix
    !
    !--------------------------------------------------------------------
 
-   logical :: &
-      hmixOff  ! on/off switch for horizontal velocity mixing
+   logical :: hmixOn
 
 !***********************************************************************
 
@@ -80,58 +80,76 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_tend(div, relVort, tend, err)!{{{
+   subroutine ocn_vel_hmix_tend(meshPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, &
+                                viscosity, tend, err)!{{{
 
       !-----------------------------------------------------------------
+      !
       ! input variables
       !-----------------------------------------------------------------
 
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         div,           &!< [in] velocity divergence
-         relVort         !< [in] relative vorticity
+         divergence    !< Input: velocity divergence
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         relativeVorticity     !< Input: relative vorticity
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity     !< Input: velocity normal to an edge
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tangentialVelocity     !< Input: velocity, tangent to an edge
 
       !-----------------------------------------------------------------
+      !
       ! input/output variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend            !< [inout] accumulated velocity tendency
+         viscosity     !< Input: viscosity
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
 
       !-----------------------------------------------------------------
+      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< [out] error flag
+      integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------
+      !
       ! local variables
       !-----------------------------------------------------------------
 
-      integer :: &
-         err1     ! local error flag
+      integer :: err1
 
-      ! End preamble
       !-----------------------------------------------------------------
-      ! Begin code
-
-      !*** Initialize return error code and viscosity
-      !*** exit early if not turned on, otherwise start relevant timer
-
-      err = 0
-      if (hmixOff) return
-      call mpas_timer_start("vel hmix")
-
+      !
       ! call relevant routines for computing tendencies
       ! note that the user can choose multiple options and the
       !   tendencies will be added together
+      !
+      !-----------------------------------------------------------------
 
-      call ocn_vel_hmix_del2_tend(div, relVort, tend, err1)
+      if(.not.hmixOn) return
+
+      call mpas_timer_start("vel hmix")
+
+      viscosity = 0.0_RKIND
+      err = 0
+
+      call ocn_vel_hmix_del2_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_leith_tend(div, relVort, tend, err1)
+      call ocn_vel_hmix_leith_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_del4_tend(div, relVort, tend, err1)
+      call ocn_vel_hmix_del4_tend(meshPool, divergence, relativeVorticity, tend, err1)
       err = ior(err1, err)
 
       call mpas_timer_stop("vel hmix")
@@ -157,43 +175,27 @@ contains
 
    subroutine ocn_vel_hmix_init(err)!{{{
 
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< [out] error flag
+   !--------------------------------------------------------------------
 
       !-----------------------------------------------------------------
-      ! local variables
+      !
+      ! call individual init routines for each parameterization
+      !
       !-----------------------------------------------------------------
 
       integer :: err1, err2, err3 ! local error flags
 
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
+      integer :: err1, err2, err3
 
-      !*** set error code and defaults
-      err = 0
-      hmixOff = .false.
-
-      !*** call individual init routines
+      hmixOn = .true.
 
       call ocn_vel_hmix_del2_init(err1)
-      if (err1 /= 0) call mpas_log_write( &
-         'Error encountered initializing vel_hmix_del2', MPAS_LOG_ERR)
-
       call ocn_vel_hmix_leith_init(err2)
-      if (err2 /= 0) call mpas_log_write( &
-         'Error encountered initializing vel_hmix_leith', MPAS_LOG_ERR)
-
       call ocn_vel_hmix_del4_init(err3)
-      if (err3 /= 0) call mpas_log_write( &
-         'Error encountered initializing vel_hmix_del4', MPAS_LOG_ERR)
 
       err = ior(ior(err1, err2),err3)
 
-      if (config_disable_vel_hmix) hmixOff = .true.
+      if(config_disable_vel_hmix) hmixOn = .false.
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix.F
@@ -24,8 +24,7 @@ module ocn_vel_hmix
 
    use mpas_timer
    use mpas_derived_types
-   use mpas_pool_routines
-   use mpas_threading
+   use mpas_log
    use ocn_vel_hmix_del2
    use ocn_vel_hmix_leith
    use ocn_vel_hmix_del4
@@ -57,7 +56,8 @@ module ocn_vel_hmix
    !
    !--------------------------------------------------------------------
 
-   logical :: hmixOn
+   logical :: &
+      hmixOff  ! on/off switch for horizontal velocity mixing
 
 !***********************************************************************
 
@@ -80,76 +80,58 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_tend(meshPool, divergence, relativeVorticity, normalVelocity, tangentialVelocity, &
-                                viscosity, tend, err)!{{{
+   subroutine ocn_vel_hmix_tend(div, relVort, tend, err)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         divergence    !< Input: velocity divergence
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity     !< Input: relative vorticity
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: velocity normal to an edge
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         tangentialVelocity     !< Input: velocity, tangent to an edge
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         viscosity     !< Input: viscosity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] accumulated velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
       !-----------------------------------------------------------------
 
-      integer :: err1
+      integer :: &
+         err1     ! local error flag
 
+      ! End preamble
       !-----------------------------------------------------------------
-      !
+      ! Begin code
+
+      !*** Initialize return error code and viscosity
+      !*** exit early if not turned on, otherwise start relevant timer
+
+      err = 0
+      if (hmixOff) return
+      call mpas_timer_start("vel hmix")
+
       ! call relevant routines for computing tendencies
       ! note that the user can choose multiple options and the
       !   tendencies will be added together
-      !
-      !-----------------------------------------------------------------
 
-      if(.not.hmixOn) return
-
-      call mpas_timer_start("vel hmix")
-
-      viscosity = 0.0_RKIND
-      err = 0
-
-      call ocn_vel_hmix_del2_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
+      call ocn_vel_hmix_del2_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_leith_tend(meshPool, divergence, relativeVorticity, viscosity, tend, err1)
+      call ocn_vel_hmix_leith_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_del4_tend(meshPool, divergence, relativeVorticity, tend, err1)
+      call ocn_vel_hmix_del4_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
       call mpas_timer_stop("vel hmix")
@@ -175,27 +157,43 @@ contains
 
    subroutine ocn_vel_hmix_init(err)!{{{
 
-   !--------------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
 
       !-----------------------------------------------------------------
-      !
-      ! call individual init routines for each parameterization
-      !
+      ! local variables
       !-----------------------------------------------------------------
 
       integer :: err1, err2, err3 ! local error flags
 
-      integer :: err1, err2, err3
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
-      hmixOn = .true.
+      !*** set error code and defaults
+      err = 0
+      hmixOff = .false.
+
+      !*** call individual init routines
 
       call ocn_vel_hmix_del2_init(err1)
+      if (err1 /= 0) call mpas_log_write( &
+         'Error encountered initializing vel_hmix_del2', MPAS_LOG_ERR)
+
       call ocn_vel_hmix_leith_init(err2)
+      if (err2 /= 0) call mpas_log_write( &
+         'Error encountered initializing vel_hmix_leith', MPAS_LOG_ERR)
+
       call ocn_vel_hmix_del4_init(err3)
+      if (err3 /= 0) call mpas_log_write( &
+         'Error encountered initializing vel_hmix_del4', MPAS_LOG_ERR)
 
       err = ior(ior(err1, err2),err3)
 
-      if(config_disable_vel_hmix) hmixOn = .false.
+      if (config_disable_vel_hmix) hmixOff = .true.
 
    !--------------------------------------------------------------------
 

--- a/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
@@ -28,6 +28,8 @@ module ocn_vel_tidal_potential
    use mpas_timekeeping
    use mpas_timer
    use ocn_constants
+   use ocn_config
+   use ocn_mesh
    use ocn_diagnostics_variables
 
    implicit none
@@ -57,7 +59,34 @@ module ocn_vel_tidal_potential
    !
    !--------------------------------------------------------------------
 
-   logical :: tidalPotentialOn
+   logical :: &
+      tidalPotentialOff   ! on/off switch for tidal potential
+
+   !*** physical constants
+   real (kind=RKIND) ::  &
+      betaSelfAttrLoad,  &! self-attraction and loading beta
+      tidalPotRamp        ! scale for ramping tidal potential
+
+   !*** eventually these will be private module arrays and 
+   !*** not in the forcing pool so retain pointers here as placeholders
+   real (kind=RKIND), dimension(:), pointer :: &
+      tidalPotEta,                    &!
+      tidalConstituentAmplitude,      &!
+      tidalConstituentFrequency,      &!
+      tidalConstituentLoveNumbers,    &!
+      tidalConstituentNodalAmplitude, &!
+      tidalConstituentAstronomical,   &!
+      tidalConstituentNodalPhase       !
+
+   real (kind=RKIND), dimension(:,:), pointer :: &
+      latitudeFunction 
+
+   integer, dimension(:), pointer :: &
+      tidalConstituentType
+
+   integer :: &
+      nTidalConstituents    ! number of tidal constituents
+
    type :: char_array
      character(:), allocatable :: constituent
    end type
@@ -81,80 +110,77 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_tidal_potential_tend(meshPool, forcingPool, ssh, tend, err)!{{{
+   subroutine ocn_vel_tidal_potential_tend(ssh, tend, err)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         ssh !< Input: Sea surface height
-
-      type (mpas_pool_type), intent(in) :: meshPool          !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: forcingPool       !< Input: forcinginformation
+         ssh             !< [in] Sea surface height
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
+         tend            !< [inout] accumulated velocity tendency
 
       !-----------------------------------------------------------------
-      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, nEdges
-      integer, dimension(:), pointer :: nEdgesArray
-      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelCell
-      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask
+      integer ::       &
+         iEdge, k,     &! loop indices for edge, vertical loops
+         cell1, cell2, &! neighbor cell indices across edge
+         kMax           ! deepest active layer on edge
 
-      real (kind=RKIND), dimension(:), pointer :: dcEdge
-      real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
-      real (kind=RKIND), pointer :: config_self_attraction_and_loading_beta
-      real (kind=RKIND) :: invdcEdge
-      real (kind=RKIND) :: potentialGrad
-      logical, pointer :: config_use_tidal_potential_forcing
+      real (kind=RKIND) :: &
+         invdcEdge,    &! 1/dcEdge
+         potentialGrad  ! tmp potential gradient term
 
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Initialize error code and return early if not turned on
       err = 0
+      if (tidalPotentialOff) return
 
-      if (.not. tidalPotentialOn) return
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', tidalPotentialEta)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing', config_use_tidal_potential_forcing)
-      call mpas_pool_get_config(ocnConfigs, 'config_self_attraction_and_loading_beta', config_self_attraction_and_loading_beta)
-
-      nEdges = nEdgesArray( 1 )
-
-      !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, potentialGrad, k)
-      do iEdge=1,nEdges
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
+      !$acc            tidalPotEta, ssh, tend) &
+      !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
+#else
+      !$omp parallel do schedule(runtime) &
+      !$omp    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
+#endif
+      do iEdge=1,nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+         kMax = maxLevelEdgeTop(iEdge)
 
-         potentialGrad = - gravity * invdcEdge * ( tidalPotentialEta(cell2) - tidalPotentialEta(cell1) &
-                                   + config_self_attraction_and_loading_beta*(ssh(cell2) - ssh(cell1)))
+         potentialGrad = - gravity*invdcEdge* &
+                         (tidalPotEta(cell2) - tidalPotEta(cell1) + &
+                          betaSelfAttrLoad* &
+                          (ssh(cell2) - ssh(cell1)))
 
-         do k=1,maxLevelEdgeTop(iEdge)
-            tend(k,iEdge) = tend(k,iEdge) -  edgeMask(k,iEdge) * potentialGrad
+         do k=1,kMax
+            tend(k,iEdge) = tend(k,iEdge) - &
+                            edgeMask(k,iEdge)*potentialGrad
          end do
       end do
-      !$omp end do
+#ifndef MPAS_OPENACC
+      !$omp end parallel do
+#endif
 
    end subroutine ocn_vel_tidal_potential_tend!}}}
 
@@ -171,89 +197,66 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)!{{{
+   subroutine ocn_compute_tidal_potential_forcing(err)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
       !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
 
       !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      !
       ! output variables
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: Error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
       !-----------------------------------------------------------------
 
-      integer, pointer :: nCells
-      real (kind=RKIND), pointer :: tidalPotentialRamp
-      real (kind=RKIND), dimension(:), pointer :: lonCell
-      integer, dimension(:), pointer ::  maxLevelCell
+      integer :: &
+         iCell, jCon,  &! loop indices for cell, constituent loops
+         conType        ! id for constituent type
 
-      integer, pointer :: nTidalConstituents
-      real (kind=RKIND), dimension(:), pointer :: amplitude, frequency, loveNumbers
-      real (kind=RKIND), dimension(:), pointer :: nodalFactorAmplitude, nodalFactorPhase, astronomicalArgument
-      real (kind=RKIND), dimension(:,:), pointer :: latitudeFunction
-      integer, dimension(:), pointer :: constituentType
-      real (kind=RKIND), dimension(:), pointer :: eta
-      real (kind=RKIND), dimension(:,:), pointer :: zMid, tidalPotentialZMid
-      
-      integer :: iCell
-      integer :: jCon, conType
-      real (kind=RKIND) :: lon,tArg,ramp,t
-      real (kind=RKIND) :: nCycles,period
+      real (kind=RKIND) :: &
+         lon,&
+         tArg,&
+         ramp,&
+         t, &
+         nCycles,&
+         period
 
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** Set error flag and return early if not turned on
       err = 0
+      if (tidalPotentialOff) return
 
-      if ( .not. tidalPotentialOn ) return
-
-      call mpas_pool_get_config(ocnConfigs, 'config_tidal_potential_ramp', tidalPotentialRamp)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-      call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', amplitude)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', frequency)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentLoveNumbers', loveNumbers)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalAmplitude', nodalFactorAmplitude)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAstronomical', astronomicalArgument)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalPhase', nodalFactorPhase)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentType', constituentType)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialLatitudeFunction', latitudeFunction)
-      call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', eta)
-
-      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotentialRamp)
+      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotRamp)
       t = daysSinceStartOfSim*86400.0_RKIND
 
-      do iCell = 1, nCells
-        eta(iCell) = 0.0_RKIND
+      do iCell = 1, nCellsAll
+         tidalPotEta(iCell) = 0.0_RKIND
       end do
 
+      !*** Compute eta by summing all constituent contributions
       do jCon = 1, nTidalConstituents
-        period = 2.0_RKIND*pii/frequency(jCon)
-        nCycles = real(int(t/period),RKIND)
-        targ = frequency(jCon)*(t - nCycles*period) + nodalFactorPhase(jCon) + astronomicalArgument(jCon)
-        conType = constituentType(jCon)
-        do iCell = 1, nCells
-          lon = lonCell(iCell)
-          eta(iCell) = eta(iCell) + ramp &
-                                  * amplitude(jCon) &
-                                  * nodalFactorAmplitude(jCon) &
-                                  * loveNumbers(jCon) &
-                                  * latitudeFunction(iCell,conType+1) &
-                                  * cos(tArg  + real(conType,RKIND)*lon)
-        end do
+         period = 2.0_RKIND*pii/tidalConstituentFrequency(jCon)
+         nCycles = real(int(t/period),RKIND)
+         targ = tidalConstituentFrequency(jCon)*(t - nCycles*period) + &
+                tidalConstituentNodalPhase(jCon) + &
+                tidalConstituentAstronomical(jCon)
+         conType = tidalConstituentType(jCon)
+         do iCell = 1, nCellsAll
+           lon = lonCell(iCell)
+           tidalPotEta(iCell) = tidalPotEta(iCell) + &
+                         ramp * tidalConstituentAmplitude(jCon) &
+                              * tidalConstituentNodalAmplitude(jCon) &
+                              * tidalConstituentLoveNumbers(jCon) &
+                              * latitudeFunction(iCell,conType+1) &
+                              * cos(tArg  + real(conType,RKIND)*lon)
+         end do
         
       end do
 
@@ -275,8 +278,11 @@ contains
 
    subroutine ocn_vel_tidal_potential_init(domain,err)!{{{
 
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
       type (domain_type), intent(inout) :: domain
-      integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------
       ! output variables
@@ -301,120 +307,119 @@ contains
       type (block_type), pointer :: block_ptr 
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: meshPool
-      integer, pointer :: nTidalConstituents
-      integer, pointer :: nCells 
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentAmplitude
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentFreqency
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentLoveNumbers
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentNodalAmplitude
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentAstronomical
-      real (kind=RKIND), dimension(:), pointer :: tidalConstituentNodalPhase
-      real (kind=RKIND), dimension(:), pointer :: latCell 
-      real (kind=RKIND), dimension(:), pointer :: eta
-      real (kind=RKIND), dimension(:,:), pointer :: latitudeFunction 
-      integer, dimension(:), pointer :: tidalConstituentType
-      type (MPAS_Time_Type) :: refTime
-      integer :: iCell,iCon
-      real (kind=RKIND) :: lat
+      integer, pointer :: nTidalPotentialConstituents
 
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
+      !*** Set error flags and default values
       err = 0
-
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing', config_use_tidal_potential_forcing)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_M2', config_use_tidal_potential_forcing_M2)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_S2', config_use_tidal_potential_forcing_S2)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_N2', config_use_tidal_potential_forcing_N2)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_K2', config_use_tidal_potential_forcing_K2)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_K1', config_use_tidal_potential_forcing_K1)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_O1', config_use_tidal_potential_forcing_O1)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_Q1', config_use_tidal_potential_forcing_Q1)
-      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_P1', config_use_tidal_potential_forcing_P1)
-      call mpas_pool_get_config(ocnConfigs, 'config_tidal_potential_reference_time', config_tidal_potential_reference_time)
-
-      block_ptr => domain % blocklist
-      do while(associated(block_ptr))
-        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', eta)
-
-        do iCell = 1,nCells
-          eta(iCell) = 0.0_RKIND
-        end do
-
-        block_ptr => block_ptr % next
-      end do      
-
-      tidalPotentialOn = .false.
-      if (config_use_tidal_potential_forcing) then
-        tidalPotentialOn = .true.
-      else
-        return
-      end if
-
-
-      block_ptr => domain % blocklist
-      do while(associated(block_ptr))
-
-        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-        call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', tidalConstituentAmplitude)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', tidalConstituentFreqency)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentLoveNumbers', tidalConstituentLoveNumbers)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalAmplitude', tidalConstituentNodalAmplitude)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAstronomical', tidalConstituentAstronomical)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalPhase', tidalConstituentNodalPhase)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentType', tidalConstituentType)
-        call mpas_pool_get_array(forcingPool, 'tidalPotentialLatitudeFunction', latitudeFunction)
-        call mpas_pool_get_array(meshPool, 'latCell', latCell)
-        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-        call mpas_set_time(refTime, dateTimeString=config_tidal_potential_reference_time)
-
-        nTidalConstituents = 0
-        if (config_use_tidal_potential_forcing_M2) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'M2'
-        end if 
-
-        if (config_use_tidal_potential_forcing_S2) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'S2'
-        end if 
+      tidalPotentialOff = .true.
+      betaSelfAttrLoad  = 0.0_RKIND
+      tidalPotRamp      = 1.0e20_RKIND
  
-        if (config_use_tidal_potential_forcing_N2) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'N2'
-        end if 
+      !*** If tidal potential turned on, set all relevant variables
 
-        if (config_use_tidal_potential_forcing_K2) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'K2'
-        end if 
+      if (config_use_tidal_potential_forcing) then
 
-        if (config_use_tidal_potential_forcing_K1) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'K1'
-        end if 
+         tidalPotentialOff = .false.
 
-        if (config_use_tidal_potential_forcing_O1) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'O1'
-        end if 
+         betaSelfAttrLoad = config_self_attraction_and_loading_beta
+         tidalPotRamp     = config_tidal_potential_ramp
 
-        if (config_use_tidal_potential_forcing_Q1) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'Q1'
-        end if 
+         !*** retrieve variables from pool
+         !*** eventually replace with allocated module private vars
 
-        if (config_use_tidal_potential_forcing_P1) then
-          nTidalConstituents = nTidalConstituents + 1
-          constituentList(nTidalConstituents)%constituent = 'P1'
-        end if 
+         block_ptr => domain % blocklist
+         call mpas_pool_get_subpool(block_ptr%structs, 'forcing', &
+                                                      forcingPool)
 
-        call tidal_constituent_factors(constituentList,nTidalConstituents,refTime, &
-                                       tidalConstituentFreqency, &
+         call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', &
+                                                tidalPotEta)
+
+         call mpas_pool_get_array(forcingPool, &
+                            'nTidalPotentialConstituents', &
+                             nTidalPotentialConstituents)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentAmplitude', & 
+                             tidalConstituentAmplitude)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentFrequency', &
+                            tidalConstituentFrequency)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentLoveNumbers', &
+                            tidalConstituentLoveNumbers)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentNodalAmplitude', &
+                            tidalConstituentNodalAmplitude)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentAstronomical', &
+                            tidalConstituentAstronomical)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentNodalPhase', &
+                            tidalConstituentNodalPhase)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialConstituentType', &
+                            tidalConstituentType)
+         call mpas_pool_get_array(forcingPool, &
+                            'tidalPotentialLatitudeFunction', &
+                            latitudeFunction)
+
+         call mpas_set_time(refTime, &
+               dateTimeString=config_tidal_potential_reference_time)
+
+         do iCell = 1,nCellsAll
+            tidalPotEta(iCell) = 0.0_RKIND
+         end do
+
+         nTidalConstituents = 0
+         if (config_use_tidal_potential_forcing_M2) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'M2'
+         end if 
+
+         if (config_use_tidal_potential_forcing_S2) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'S2'
+         end if 
+ 
+         if (config_use_tidal_potential_forcing_N2) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'N2'
+         end if 
+
+         if (config_use_tidal_potential_forcing_K2) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'K2'
+         end if 
+
+         if (config_use_tidal_potential_forcing_K1) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'K1'
+         end if 
+
+         if (config_use_tidal_potential_forcing_O1) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'O1'
+         end if 
+
+         if (config_use_tidal_potential_forcing_Q1) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'Q1'
+         end if 
+
+         if (config_use_tidal_potential_forcing_P1) then
+            nTidalConstituents = nTidalConstituents + 1
+            constituentList(nTidalConstituents)%constituent = 'P1'
+         end if 
+
+         ! set point value in forcing pool just in case
+         nTidalPotentialConstituents = nTidalConstituents
+
+         call tidal_constituent_factors(constituentList, &
+                                       nTidalConstituents, refTime, &
+                                       tidalConstituentFrequency, &
                                        tidalConstituentAmplitude, &
                                        tidalConstituentLoveNumbers, &
                                        tidalConstituentNodalAmplitude, &
@@ -423,27 +428,34 @@ contains
                                        tidalConstituentType, &
                                        err)
 
-        do iCell = 1,nCells
-          lat = latCell(iCell)
-          latitudeFunction(iCell,1) = 3.0_RKIND*sin(lat)**2 - 1.0_RKIND 
-          latitudeFunction(iCell,2) = sin(2.0_RKIND*lat)
-          latitudeFunction(iCell,3) = cos(lat)**2
-        end do
+         do iCell = 1,nCellsAll
+            lat = latCell(iCell)
+            latitudeFunction(iCell,1) = 3.0_RKIND*sin(lat)**2 -1.0_RKIND 
+            latitudeFunction(iCell,2) = sin(2.0_RKIND*lat)
+            latitudeFunction(iCell,3) = cos(lat)**2
+         end do
         
-        do iCon = 1,nTidalConstituents  
-          call mpas_log_write('Constituent '//constituentList(iCon)%constituent)
-          call mpas_log_write('  Frequency $r', realArgs=(/ tidalConstituentFreqency(iCon) /))
-          call mpas_log_write('  Amplitude $r', realArgs=(/ tidalConstituentAmplitude(iCon) /))
-          call mpas_log_write('  LoveNumbers $r', realArgs=(/ tidalConstituentLoveNumbers(iCon) /))
-          call mpas_log_write('  NodalAmplitude $r', realArgs=(/ tidalConstituentNodalAmplitude(iCon) /))
-          call mpas_log_write('  Astronomical argument $r', realArgs=(/ tidalConstituentAstronomical(iCon) /))
-          call mpas_log_write('  NodalPhase $r', realArgs=(/ tidalConstituentNodalPhase(iCon) /))
-          call mpas_log_write('  Type $i', intArgs=(/ tidalConstituentType(iCon) /))
-          call mpas_log_write(' ')
-        end do
+         do iCon = 1,nTidalConstituents
+            call mpas_log_write( &
+                 'Constituent '//constituentList(iCon)%constituent)
+            call mpas_log_write('  Frequency $r', &
+                 realArgs=(/ tidalConstituentFrequency(iCon) /))
+            call mpas_log_write('  Amplitude $r', &
+                 realArgs=(/ tidalConstituentAmplitude(iCon) /))
+            call mpas_log_write('  LoveNumbers $r', &
+                 realArgs=(/ tidalConstituentLoveNumbers(iCon) /))
+            call mpas_log_write('  NodalAmplitude $r', &
+                 realArgs=(/ tidalConstituentNodalAmplitude(iCon) /))
+            call mpas_log_write('  Astronomical argument $r', &
+                 realArgs=(/ tidalConstituentAstronomical(iCon) /))
+            call mpas_log_write('  NodalPhase $r', &
+                 realArgs=(/ tidalConstituentNodalPhase(iCon) /))
+            call mpas_log_write('  Type $i', &
+                 intArgs=(/ tidalConstituentType(iCon) /))
+            call mpas_log_write(' ')
+         end do
 
-        block_ptr => block_ptr % next
-      end do      
+      end if ! tidal potential on
 
       !-----------------------------------------------------------------
 
@@ -458,7 +470,7 @@ contains
 !> \author  Steven Brus
 !> \date    September 2019
 !> \details
-!>  This routine initializes the ampiltude, frequency, love numbers, 
+!>  This routine initializes the amplitude, frequency, love numbers, 
 !>  astronomical argument and nodal factors for each tidal constituent
 !>  Nodal factor equations are from:
 !>         "Manual of Harmonic Analysis and Prediction of Tides"
@@ -468,7 +480,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine tidal_constituent_factors(constituentList,nTidalConstituents,refTime, &
-                                     tidalConstituentFreqency, &
+                                     tidalConstituentFrequency, &
                                      tidalConstituentAmplitude, &
                                      tidalConstituentLoveNumbers, &
                                      tidalConstituentNodalAmplitude, &
@@ -481,7 +493,7 @@ contains
       integer, intent(in) :: nTidalConstituents
       type (MPAS_Time_Type), intent(in) :: refTime
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentAmplitude
-      real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentFreqency
+      real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentFrequency
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentLoveNumbers
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentNodalAmplitude
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentAstronomical
@@ -550,7 +562,7 @@ contains
       do j = 1,nTidalConstituents
         if (constituentList(j)%constituent == 'M2') then
           tidalConstituentAmplitude(j) = 0.242334_RKIND
-          tidalConstituentFreqency(j) = 1.405189e-4_RKIND
+          tidalConstituentFrequency(j) = 1.405189e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = cos(0.5_RKIND*I*deg2rad)**4/0.91544_RKIND
@@ -559,7 +571,7 @@ contains
 
         else if (constituentList(j)%constituent == 'S2') then
           tidalConstituentAmplitude(j) = 0.112743_RKIND
-          tidalConstituentFreqency(j) = 1.454441e-4_RKIND
+          tidalConstituentFrequency(j) = 1.454441e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 1.0_RKIND
@@ -568,7 +580,7 @@ contains
 
         else if (constituentList(j)%constituent == 'N2') then
           tidalConstituentAmplitude(j) = 0.046397_RKIND
-          tidalConstituentFreqency(j) = 1.378797e-4_RKIND
+          tidalConstituentFrequency(j) = 1.378797e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = cos(0.5_RKIND*I*deg2rad)**4/0.91544_RKIND
@@ -577,7 +589,7 @@ contains
 
         else if (constituentList(j)%constituent == 'K2') then
           tidalConstituentAmplitude(j) = 0.030684_RKIND 
-          tidalConstituentFreqency(j) = 1.458423e-4_RKIND
+          tidalConstituentFrequency(j) = 1.458423e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND 
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 0.001_RKIND+sqrt(19.0444_RKIND*sin(I*deg2rad)**4 + &
@@ -588,7 +600,7 @@ contains
 
         else if (constituentList(j)%constituent == 'K1') then
           tidalConstituentAmplitude(j) = 0.141565_RKIND
-          tidalConstituentFreqency(j) = 0.7292117e-4_RKIND
+          tidalConstituentFrequency(j) = 0.7292117e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.736_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sqrt(0.8965_RKIND*sin(2.0_RKIND*I*deg2rad)**2 + &
@@ -599,7 +611,7 @@ contains
 
         else if (constituentList(j)%constituent == 'O1') then
           tidalConstituentAmplitude(j) = 0.100661_RKIND
-          tidalConstituentFreqency(j) = 0.6759774e-4_RKIND
+          tidalConstituentFrequency(j) = 0.6759774e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.695_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sin(I*deg2rad)*cos(0.5_RKIND*I*deg2rad)**2/0.37988_RKIND
@@ -608,7 +620,7 @@ contains
 
         else if (constituentList(j)%constituent == 'Q1') then
           tidalConstituentAmplitude(j) = 0.019273_RKIND 
-          tidalConstituentFreqency(j) = 0.6495854e-4_RKIND
+          tidalConstituentFrequency(j) = 0.6495854e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.695_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sin(I*deg2rad)*cos(0.5_RKIND*I*deg2rad)**2/0.37988_RKIND
@@ -617,7 +629,7 @@ contains
 
         else if (constituentList(j)%constituent == 'P1') then
           tidalConstituentAmplitude(j) = 0.046848_RKIND
-          tidalConstituentFreqency(j) = 0.7252295e-4_RKIND
+          tidalConstituentFrequency(j) = 0.7252295e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.706_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 1.0_RKIND 

--- a/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_tidal_potential.F
@@ -28,8 +28,7 @@ module ocn_vel_tidal_potential
    use mpas_timekeeping
    use mpas_timer
    use ocn_constants
-   use ocn_config
-   use ocn_mesh
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -58,34 +57,7 @@ module ocn_vel_tidal_potential
    !
    !--------------------------------------------------------------------
 
-   logical :: &
-      tidalPotentialOff   ! on/off switch for tidal potential
-
-   !*** physical constants
-   real (kind=RKIND) ::  &
-      betaSelfAttrLoad,  &! self-attraction and loading beta
-      tidalPotRamp        ! scale for ramping tidal potential
-
-   !*** eventually these will be private module arrays and 
-   !*** not in the forcing pool so retain pointers here as placeholders
-   real (kind=RKIND), dimension(:), pointer :: &
-      tidalPotEta,                    &!
-      tidalConstituentAmplitude,      &!
-      tidalConstituentFrequency,      &!
-      tidalConstituentLoveNumbers,    &!
-      tidalConstituentNodalAmplitude, &!
-      tidalConstituentAstronomical,   &!
-      tidalConstituentNodalPhase       !
-
-   real (kind=RKIND), dimension(:,:), pointer :: &
-      latitudeFunction 
-
-   integer, dimension(:), pointer :: &
-      tidalConstituentType
-
-   integer :: &
-      nTidalConstituents    ! number of tidal constituents
-
+   logical :: tidalPotentialOn
    type :: char_array
      character(:), allocatable :: constituent
    end type
@@ -109,77 +81,80 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_tidal_potential_tend(ssh, tend, err)!{{{
+   subroutine ocn_vel_tidal_potential_tend(meshPool, forcingPool, ssh, tend, err)!{{{
 
       !-----------------------------------------------------------------
+      !
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         ssh             !< [in] Sea surface height
+         ssh !< Input: Sea surface height
+
+      type (mpas_pool_type), intent(in) :: meshPool          !< Input: mesh information
+      type (mpas_pool_type), intent(in) :: forcingPool       !< Input: forcinginformation
 
       !-----------------------------------------------------------------
+      !
       ! input/output variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend            !< [inout] accumulated velocity tendency
+         tend          !< Input/Output: velocity tendency
 
       !-----------------------------------------------------------------
+      !
       ! output variables
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: err !< [out] error flag
+      integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------
+      !
       ! local variables
       !-----------------------------------------------------------------
 
-      integer ::       &
-         iEdge, k,     &! loop indices for edge, vertical loops
-         cell1, cell2, &! neighbor cell indices across edge
-         kMax           ! deepest active layer on edge
+      integer :: iEdge, k, cell1, cell2, nEdges
+      integer, dimension(:), pointer :: nEdgesArray
+      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelCell
+      integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask
 
-      real (kind=RKIND) :: &
-         invdcEdge,    &! 1/dcEdge
-         potentialGrad  ! tmp potential gradient term
+      real (kind=RKIND), dimension(:), pointer :: dcEdge
+      real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
+      real (kind=RKIND), pointer :: config_self_attraction_and_loading_beta
+      real (kind=RKIND) :: invdcEdge
+      real (kind=RKIND) :: potentialGrad
+      logical, pointer :: config_use_tidal_potential_forcing
 
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      !*** Initialize error code and return early if not turned on
       err = 0
-      if (tidalPotentialOff) return
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
-      !$acc            tidalPotEta, ssh, tend) &
-      !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
-#else
-      !$omp parallel do schedule(runtime) &
-      !$omp    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
-#endif
-      do iEdge=1,nEdgesOwned
+      if (.not. tidalPotentialOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+      call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', tidalPotentialEta)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing', config_use_tidal_potential_forcing)
+      call mpas_pool_get_config(ocnConfigs, 'config_self_attraction_and_loading_beta', config_self_attraction_and_loading_beta)
+
+      nEdges = nEdgesArray( 1 )
+
+      !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, potentialGrad, k)
+      do iEdge=1,nEdges
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          invdcEdge = 1.0_RKIND / dcEdge(iEdge)
-         kMax = maxLevelEdgeTop(iEdge)
 
-         potentialGrad = - gravity*invdcEdge* &
-                         (tidalPotEta(cell2) - tidalPotEta(cell1) + &
-                          betaSelfAttrLoad* &
-                          (ssh(cell2) - ssh(cell1)))
+         potentialGrad = - gravity * invdcEdge * ( tidalPotentialEta(cell2) - tidalPotentialEta(cell1) &
+                                   + config_self_attraction_and_loading_beta*(ssh(cell2) - ssh(cell1)))
 
-         do k=1,kMax
-            tend(k,iEdge) = tend(k,iEdge) - &
-                            edgeMask(k,iEdge)*potentialGrad
+         do k=1,maxLevelEdgeTop(iEdge)
+            tend(k,iEdge) = tend(k,iEdge) -  edgeMask(k,iEdge) * potentialGrad
          end do
       end do
-#ifndef MPAS_OPENACC
-      !$omp end parallel do
-#endif
+      !$omp end do
 
    end subroutine ocn_vel_tidal_potential_tend!}}}
 
@@ -196,74 +171,89 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_compute_tidal_potential_forcing(diagnosticsPool, err)!{{{
+   subroutine ocn_compute_tidal_potential_forcing(meshPool, forcingPool, err)!{{{
 
       !-----------------------------------------------------------------
+      !
       ! input variables
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: diagnosticsPool 
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
 
       !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
       ! output variables
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: Error flag
 
       !-----------------------------------------------------------------
+      !
       ! local variables
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), pointer :: daysSinceStartOfSim
+      integer, pointer :: nCells
+      real (kind=RKIND), pointer :: tidalPotentialRamp
+      real (kind=RKIND), dimension(:), pointer :: lonCell
+      integer, dimension(:), pointer ::  maxLevelCell
+
+      integer, pointer :: nTidalConstituents
+      real (kind=RKIND), dimension(:), pointer :: amplitude, frequency, loveNumbers
+      real (kind=RKIND), dimension(:), pointer :: nodalFactorAmplitude, nodalFactorPhase, astronomicalArgument
+      real (kind=RKIND), dimension(:,:), pointer :: latitudeFunction
+      integer, dimension(:), pointer :: constituentType
+      real (kind=RKIND), dimension(:), pointer :: eta
+      real (kind=RKIND), dimension(:,:), pointer :: zMid, tidalPotentialZMid
       
-      integer :: &
-         iCell, jCon,  &! loop indices for cell, constituent loops
-         conType        ! id for constituent type
+      integer :: iCell
+      integer :: jCon, conType
+      real (kind=RKIND) :: lon,tArg,ramp,t
+      real (kind=RKIND) :: nCycles,period
 
-      real (kind=RKIND) :: &
-         lon,&
-         tArg,&
-         ramp,&
-         t, &
-         nCycles,&
-         period
-
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      !*** Set error flag and return early if not turned on
       err = 0
-      if (tidalPotentialOff) return
 
-      !*** Get pool variables (eventually private module variables?)
-      call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", &
-                                                 daysSinceStartOfSim)
+      if ( .not. tidalPotentialOn ) return
 
-      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotRamp)
+      call mpas_pool_get_config(ocnConfigs, 'config_tidal_potential_ramp', tidalPotentialRamp)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+      call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', amplitude)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', frequency)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentLoveNumbers', loveNumbers)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalAmplitude', nodalFactorAmplitude)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAstronomical', astronomicalArgument)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalPhase', nodalFactorPhase)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentType', constituentType)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialLatitudeFunction', latitudeFunction)
+      call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', eta)
+
+      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotentialRamp)
       t = daysSinceStartOfSim*86400.0_RKIND
 
-      do iCell = 1, nCellsAll
-         tidalPotEta(iCell) = 0.0_RKIND
+      do iCell = 1, nCells
+        eta(iCell) = 0.0_RKIND
       end do
 
-      !*** Compute eta by summing all constituent contributions
       do jCon = 1, nTidalConstituents
-         period = 2.0_RKIND*pii/tidalConstituentFrequency(jCon)
-         nCycles = real(int(t/period),RKIND)
-         targ = tidalConstituentFrequency(jCon)*(t - nCycles*period) + &
-                tidalConstituentNodalPhase(jCon) + &
-                tidalConstituentAstronomical(jCon)
-         conType = tidalConstituentType(jCon)
-         do iCell = 1, nCellsAll
-           lon = lonCell(iCell)
-           tidalPotEta(iCell) = tidalPotEta(iCell) + &
-                         ramp * tidalConstituentAmplitude(jCon) &
-                              * tidalConstituentNodalAmplitude(jCon) &
-                              * tidalConstituentLoveNumbers(jCon) &
-                              * latitudeFunction(iCell,conType+1) &
-                              * cos(tArg  + real(conType,RKIND)*lon)
-         end do
+        period = 2.0_RKIND*pii/frequency(jCon)
+        nCycles = real(int(t/period),RKIND)
+        targ = frequency(jCon)*(t - nCycles*period) + nodalFactorPhase(jCon) + astronomicalArgument(jCon)
+        conType = constituentType(jCon)
+        do iCell = 1, nCells
+          lon = lonCell(iCell)
+          eta(iCell) = eta(iCell) + ramp &
+                                  * amplitude(jCon) &
+                                  * nodalFactorAmplitude(jCon) &
+                                  * loveNumbers(jCon) &
+                                  * latitudeFunction(iCell,conType+1) &
+                                  * cos(tArg  + real(conType,RKIND)*lon)
+        end do
         
       end do
 
@@ -285,11 +275,8 @@ contains
 
    subroutine ocn_vel_tidal_potential_init(domain,err)!{{{
 
-      !-----------------------------------------------------------------
-      ! input/output variables
-      !-----------------------------------------------------------------
-
       type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------
       ! output variables
@@ -314,120 +301,120 @@ contains
       type (block_type), pointer :: block_ptr 
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: diagnosticsPool 
-      integer, pointer :: nTidalPotentialConstituents
+      integer, pointer :: nTidalConstituents
+      integer, pointer :: nCells 
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentAmplitude
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentFreqency
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentLoveNumbers
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentNodalAmplitude
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentAstronomical
+      real (kind=RKIND), dimension(:), pointer :: tidalConstituentNodalPhase
+      real (kind=RKIND), dimension(:), pointer :: latCell 
+      real (kind=RKIND), dimension(:), pointer :: eta
+      real (kind=RKIND), dimension(:,:), pointer :: latitudeFunction 
+      integer, dimension(:), pointer :: tidalConstituentType
+      type (MPAS_Time_Type) :: refTime
+      integer :: iCell,iCon
+      real (kind=RKIND) :: lat
 
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
 
-      !*** Set error flags and default values
       err = 0
-      tidalPotentialOff = .true.
-      betaSelfAttrLoad  = 0.0_RKIND
-      tidalPotRamp      = 1.0e20_RKIND
- 
-      !*** If tidal potential turned on, set all relevant variables
 
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing', config_use_tidal_potential_forcing)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_M2', config_use_tidal_potential_forcing_M2)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_S2', config_use_tidal_potential_forcing_S2)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_N2', config_use_tidal_potential_forcing_N2)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_K2', config_use_tidal_potential_forcing_K2)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_K1', config_use_tidal_potential_forcing_K1)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_O1', config_use_tidal_potential_forcing_O1)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_Q1', config_use_tidal_potential_forcing_Q1)
+      call mpas_pool_get_config(ocnConfigs, 'config_use_tidal_potential_forcing_P1', config_use_tidal_potential_forcing_P1)
+      call mpas_pool_get_config(ocnConfigs, 'config_tidal_potential_reference_time', config_tidal_potential_reference_time)
+
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', eta)
+
+        do iCell = 1,nCells
+          eta(iCell) = 0.0_RKIND
+        end do
+
+        block_ptr => block_ptr % next
+      end do      
+
+      tidalPotentialOn = .false.
       if (config_use_tidal_potential_forcing) then
+        tidalPotentialOn = .true.
+      else
+        return
+      end if
 
-         tidalPotentialOff = .false.
 
-         betaSelfAttrLoad = config_self_attraction_and_loading_beta
-         tidalPotRamp     = config_tidal_potential_ramp
+      block_ptr => domain % blocklist
+      do while(associated(block_ptr))
 
-         !*** retrieve variables from pool
-         !*** eventually replace with allocated module private vars
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+        call mpas_pool_get_array(forcingPool, 'nTidalPotentialConstituents', nTidalConstituents)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAmplitude', tidalConstituentAmplitude)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentFrequency', tidalConstituentFreqency)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentLoveNumbers', tidalConstituentLoveNumbers)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalAmplitude', tidalConstituentNodalAmplitude)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentAstronomical', tidalConstituentAstronomical)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentNodalPhase', tidalConstituentNodalPhase)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialConstituentType', tidalConstituentType)
+        call mpas_pool_get_array(forcingPool, 'tidalPotentialLatitudeFunction', latitudeFunction)
+        call mpas_pool_get_array(meshPool, 'latCell', latCell)
+        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-         block_ptr => domain % blocklist
-         call mpas_pool_get_subpool(block_ptr%structs, 'forcing', &
-                                                      forcingPool)
+        call mpas_set_time(refTime, dateTimeString=config_tidal_potential_reference_time)
 
-         call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', &
-                                                tidalPotEta)
+        nTidalConstituents = 0
+        if (config_use_tidal_potential_forcing_M2) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'M2'
+        end if 
 
-         call mpas_pool_get_array(forcingPool, &
-                            'nTidalPotentialConstituents', &
-                             nTidalPotentialConstituents)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentAmplitude', & 
-                             tidalConstituentAmplitude)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentFrequency', &
-                            tidalConstituentFrequency)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentLoveNumbers', &
-                            tidalConstituentLoveNumbers)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentNodalAmplitude', &
-                            tidalConstituentNodalAmplitude)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentAstronomical', &
-                            tidalConstituentAstronomical)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentNodalPhase', &
-                            tidalConstituentNodalPhase)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialConstituentType', &
-                            tidalConstituentType)
-         call mpas_pool_get_array(forcingPool, &
-                            'tidalPotentialLatitudeFunction', &
-                            latitudeFunction)
-
-         call mpas_set_time(refTime, &
-               dateTimeString=config_tidal_potential_reference_time)
-
-         do iCell = 1,nCellsAll
-            tidalPotEta(iCell) = 0.0_RKIND
-         end do
-
-         nTidalConstituents = 0
-         if (config_use_tidal_potential_forcing_M2) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'M2'
-         end if 
-
-         if (config_use_tidal_potential_forcing_S2) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'S2'
-         end if 
+        if (config_use_tidal_potential_forcing_S2) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'S2'
+        end if 
  
-         if (config_use_tidal_potential_forcing_N2) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'N2'
-         end if 
+        if (config_use_tidal_potential_forcing_N2) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'N2'
+        end if 
 
-         if (config_use_tidal_potential_forcing_K2) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'K2'
-         end if 
+        if (config_use_tidal_potential_forcing_K2) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'K2'
+        end if 
 
-         if (config_use_tidal_potential_forcing_K1) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'K1'
-         end if 
+        if (config_use_tidal_potential_forcing_K1) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'K1'
+        end if 
 
-         if (config_use_tidal_potential_forcing_O1) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'O1'
-         end if 
+        if (config_use_tidal_potential_forcing_O1) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'O1'
+        end if 
 
-         if (config_use_tidal_potential_forcing_Q1) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'Q1'
-         end if 
+        if (config_use_tidal_potential_forcing_Q1) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'Q1'
+        end if 
 
-         if (config_use_tidal_potential_forcing_P1) then
-            nTidalConstituents = nTidalConstituents + 1
-            constituentList(nTidalConstituents)%constituent = 'P1'
-         end if 
+        if (config_use_tidal_potential_forcing_P1) then
+          nTidalConstituents = nTidalConstituents + 1
+          constituentList(nTidalConstituents)%constituent = 'P1'
+        end if 
 
-         ! set point value in forcing pool just in case
-         nTidalPotentialConstituents = nTidalConstituents
-
-         call tidal_constituent_factors(constituentList, &
-                                       nTidalConstituents, refTime, &
-                                       tidalConstituentFrequency, &
+        call tidal_constituent_factors(constituentList,nTidalConstituents,refTime, &
+                                       tidalConstituentFreqency, &
                                        tidalConstituentAmplitude, &
                                        tidalConstituentLoveNumbers, &
                                        tidalConstituentNodalAmplitude, &
@@ -436,34 +423,27 @@ contains
                                        tidalConstituentType, &
                                        err)
 
-         do iCell = 1,nCellsAll
-            lat = latCell(iCell)
-            latitudeFunction(iCell,1) = 3.0_RKIND*sin(lat)**2 -1.0_RKIND 
-            latitudeFunction(iCell,2) = sin(2.0_RKIND*lat)
-            latitudeFunction(iCell,3) = cos(lat)**2
-         end do
+        do iCell = 1,nCells
+          lat = latCell(iCell)
+          latitudeFunction(iCell,1) = 3.0_RKIND*sin(lat)**2 - 1.0_RKIND 
+          latitudeFunction(iCell,2) = sin(2.0_RKIND*lat)
+          latitudeFunction(iCell,3) = cos(lat)**2
+        end do
         
-         do iCon = 1,nTidalConstituents
-            call mpas_log_write( &
-                 'Constituent '//constituentList(iCon)%constituent)
-            call mpas_log_write('  Frequency $r', &
-                 realArgs=(/ tidalConstituentFrequency(iCon) /))
-            call mpas_log_write('  Amplitude $r', &
-                 realArgs=(/ tidalConstituentAmplitude(iCon) /))
-            call mpas_log_write('  LoveNumbers $r', &
-                 realArgs=(/ tidalConstituentLoveNumbers(iCon) /))
-            call mpas_log_write('  NodalAmplitude $r', &
-                 realArgs=(/ tidalConstituentNodalAmplitude(iCon) /))
-            call mpas_log_write('  Astronomical argument $r', &
-                 realArgs=(/ tidalConstituentAstronomical(iCon) /))
-            call mpas_log_write('  NodalPhase $r', &
-                 realArgs=(/ tidalConstituentNodalPhase(iCon) /))
-            call mpas_log_write('  Type $i', &
-                 intArgs=(/ tidalConstituentType(iCon) /))
-            call mpas_log_write(' ')
-         end do
+        do iCon = 1,nTidalConstituents  
+          call mpas_log_write('Constituent '//constituentList(iCon)%constituent)
+          call mpas_log_write('  Frequency $r', realArgs=(/ tidalConstituentFreqency(iCon) /))
+          call mpas_log_write('  Amplitude $r', realArgs=(/ tidalConstituentAmplitude(iCon) /))
+          call mpas_log_write('  LoveNumbers $r', realArgs=(/ tidalConstituentLoveNumbers(iCon) /))
+          call mpas_log_write('  NodalAmplitude $r', realArgs=(/ tidalConstituentNodalAmplitude(iCon) /))
+          call mpas_log_write('  Astronomical argument $r', realArgs=(/ tidalConstituentAstronomical(iCon) /))
+          call mpas_log_write('  NodalPhase $r', realArgs=(/ tidalConstituentNodalPhase(iCon) /))
+          call mpas_log_write('  Type $i', intArgs=(/ tidalConstituentType(iCon) /))
+          call mpas_log_write(' ')
+        end do
 
-      end if ! tidal potential on
+        block_ptr => block_ptr % next
+      end do      
 
       !-----------------------------------------------------------------
 
@@ -478,7 +458,7 @@ contains
 !> \author  Steven Brus
 !> \date    September 2019
 !> \details
-!>  This routine initializes the amplitude, frequency, love numbers, 
+!>  This routine initializes the ampiltude, frequency, love numbers, 
 !>  astronomical argument and nodal factors for each tidal constituent
 !>  Nodal factor equations are from:
 !>         "Manual of Harmonic Analysis and Prediction of Tides"
@@ -488,7 +468,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine tidal_constituent_factors(constituentList,nTidalConstituents,refTime, &
-                                     tidalConstituentFrequency, &
+                                     tidalConstituentFreqency, &
                                      tidalConstituentAmplitude, &
                                      tidalConstituentLoveNumbers, &
                                      tidalConstituentNodalAmplitude, &
@@ -501,7 +481,7 @@ contains
       integer, intent(in) :: nTidalConstituents
       type (MPAS_Time_Type), intent(in) :: refTime
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentAmplitude
-      real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentFrequency
+      real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentFreqency
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentLoveNumbers
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentNodalAmplitude
       real (kind=RKIND), dimension(:), intent(out) :: tidalConstituentAstronomical
@@ -570,7 +550,7 @@ contains
       do j = 1,nTidalConstituents
         if (constituentList(j)%constituent == 'M2') then
           tidalConstituentAmplitude(j) = 0.242334_RKIND
-          tidalConstituentFrequency(j) = 1.405189e-4_RKIND
+          tidalConstituentFreqency(j) = 1.405189e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = cos(0.5_RKIND*I*deg2rad)**4/0.91544_RKIND
@@ -579,7 +559,7 @@ contains
 
         else if (constituentList(j)%constituent == 'S2') then
           tidalConstituentAmplitude(j) = 0.112743_RKIND
-          tidalConstituentFrequency(j) = 1.454441e-4_RKIND
+          tidalConstituentFreqency(j) = 1.454441e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 1.0_RKIND
@@ -588,7 +568,7 @@ contains
 
         else if (constituentList(j)%constituent == 'N2') then
           tidalConstituentAmplitude(j) = 0.046397_RKIND
-          tidalConstituentFrequency(j) = 1.378797e-4_RKIND
+          tidalConstituentFreqency(j) = 1.378797e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = cos(0.5_RKIND*I*deg2rad)**4/0.91544_RKIND
@@ -597,7 +577,7 @@ contains
 
         else if (constituentList(j)%constituent == 'K2') then
           tidalConstituentAmplitude(j) = 0.030684_RKIND 
-          tidalConstituentFrequency(j) = 1.458423e-4_RKIND
+          tidalConstituentFreqency(j) = 1.458423e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.693_RKIND 
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 0.001_RKIND+sqrt(19.0444_RKIND*sin(I*deg2rad)**4 + &
@@ -608,7 +588,7 @@ contains
 
         else if (constituentList(j)%constituent == 'K1') then
           tidalConstituentAmplitude(j) = 0.141565_RKIND
-          tidalConstituentFrequency(j) = 0.7292117e-4_RKIND
+          tidalConstituentFreqency(j) = 0.7292117e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.736_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sqrt(0.8965_RKIND*sin(2.0_RKIND*I*deg2rad)**2 + &
@@ -619,7 +599,7 @@ contains
 
         else if (constituentList(j)%constituent == 'O1') then
           tidalConstituentAmplitude(j) = 0.100661_RKIND
-          tidalConstituentFrequency(j) = 0.6759774e-4_RKIND
+          tidalConstituentFreqency(j) = 0.6759774e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.695_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sin(I*deg2rad)*cos(0.5_RKIND*I*deg2rad)**2/0.37988_RKIND
@@ -628,7 +608,7 @@ contains
 
         else if (constituentList(j)%constituent == 'Q1') then
           tidalConstituentAmplitude(j) = 0.019273_RKIND 
-          tidalConstituentFrequency(j) = 0.6495854e-4_RKIND
+          tidalConstituentFreqency(j) = 0.6495854e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.695_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = sin(I*deg2rad)*cos(0.5_RKIND*I*deg2rad)**2/0.37988_RKIND
@@ -637,7 +617,7 @@ contains
 
         else if (constituentList(j)%constituent == 'P1') then
           tidalConstituentAmplitude(j) = 0.046848_RKIND
-          tidalConstituentFrequency(j) = 0.7252295e-4_RKIND
+          tidalConstituentFreqency(j) = 0.7252295e-4_RKIND
           tidalConstituentLoveNumbers(j) = 0.706_RKIND
           tidalConstituentAstronomical(j) = 0.0_RKIND 
           tidalConstituentNodalAmplitude(j) = 1.0_RKIND 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -31,6 +31,7 @@ module ocn_vmix
    use ocn_config
    use ocn_vmix_cvmix
    use ocn_vmix_coefs_redi
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -86,7 +87,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, diagnosticsPool, scratchPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -113,9 +114,6 @@ contains
       type (mpas_pool_type), intent(inout) :: &
          forcingPool             !< Input/Output: forcing information
 
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool             !< Input/Output: diagnostic information
-
       !-----------------------------------------------------------------
       !
       ! output variables
@@ -136,8 +134,6 @@ contains
       integer :: iEdge, iCell, nEdges, nCells
       integer, dimension(:), pointer :: nEdgesArray, nCellsArray
 
-      real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfEdge, vertDiffTopOfCell
-
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing coefficients
@@ -154,9 +150,6 @@ contains
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
 
       nEdges = nEdgesArray( 2 )
 
@@ -178,8 +171,8 @@ contains
       !$omp end do
       !$omp end parallel
 
-      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, diagnosticsPool, err1, timeLevel)
-      call ocn_vmix_coefs_redi_build(meshPool, statePool, diagnosticsPool, err2, timeLevel)
+      call ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err1, timeLevel)
+      call ocn_vmix_coefs_redi_build(meshPool, statePool, err2, timeLevel)
 
       err = ior(err1, err2)
 
@@ -1012,10 +1005,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_implicit(dt, meshPool, diagnosticsPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, timeLevelIn)!{{{
       real (kind=RKIND), intent(in) :: dt
       type (mpas_pool_type), intent(in) :: meshPool
-      type (mpas_pool_type), intent(inout) :: diagnosticsPool
       type (mpas_pool_type), intent(inout) :: statePool
       type (mpas_pool_type), intent(inout) :: forcingPool
       type (mpas_pool_type), intent(in) :: scratchPool !< Input/Output: Scratch structure
@@ -1027,12 +1019,10 @@ contains
       integer :: iCell, timeLevel, k, cell1, cell2, iEdge, nCells, nEdges
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
       real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh, bottomDepth   ! needed for depth-variable computation
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness, layerThicknessEdge, vertViscTopOfEdge, &
-                                                    vertDiffTopOfCell, kineticEnergyCell
-      real (kind=RKIND), dimension(:,:), pointer :: vertViscTopOfCell, nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup, vertNonLocalFlux
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
+      real (kind=RKIND), dimension(:,:), pointer :: nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
+      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerVertMixTendency
       integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -1057,14 +1047,6 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, &
-         'activeTracerVertMixTendency',activeTracerVertMixTendency)
-
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -1077,11 +1059,10 @@ contains
       call mpas_pool_get_array(forcingPool, 'bottomDrag', bottomDrag)
 
       call mpas_timer_start('vmix coefs', .false.)
-      call ocn_vmix_coefs(meshPool, statePool, forcingPool, diagnosticsPool, scratchPool, err, timeLevel)
+      call ocn_vmix_coefs(meshPool, statePool, forcingPool, scratchPool, err, timeLevel)
       call mpas_timer_stop('vmix coefs')
 
       nCells = nCellsArray(1)
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
       ! if using CVMix, then viscosity has to be averaged from cell centers to cell edges
       if ( config_use_cvmix ) then
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -1089,21 +1089,21 @@ contains
       call mpas_timer_start('vmix solve momentum', .false.)
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(meshPool, bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
       else if (config_use_implicit_bottom_drag_variable_mannings) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, &
+          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, &
           ssh, bottomDepth, err)
       else if (config_Rayleigh_friction.or. &
                config_Rayleigh_bottom_friction.or. &
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(meshPool, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
       end if
       call mpas_timer_stop('vmix solve momentum')
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_coefs_redi.F
@@ -20,6 +20,7 @@ module ocn_vmix_coefs_redi
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -68,7 +69,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs_redi_build(meshPool, statePool, diagnosticsPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs_redi_build(meshPool, statePool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -90,9 +91,6 @@ contains
       type (mpas_pool_type), intent(inout) :: &
          statePool             !< Input/Output: state information
 
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool             !< Input/Output: diagnostic information
-
       !-----------------------------------------------------------------
       !
       ! output variables
@@ -107,11 +105,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:), pointer :: &
-        vertDiffTopOfCell, k33
-      real (kind=RKIND), dimension(:), pointer :: &
-        RediKappa
-
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing tendencies
@@ -121,10 +114,6 @@ contains
       !-----------------------------------------------------------------
 
       err = 0
-
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
 
       if (config_use_Redi) then
           call ocn_tracer_vmix_coefs_redi(meshPool, vertDiffTopOfCell, k33, RediKappa, err)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -508,13 +508,13 @@ contains
 
                  deltaVelocitySquared(1) = 0.0_RKIND
 
-                 normalVelocitySum(1) = normalVelocity(1, iEdge)*layerThicknessEdge(1,iEdge)
-                 layerThicknessEdgeSum(1) = layerThicknessEdge(1,iEdge)
+                 normalVelocitySum(1) = normalVelocity(1, iEdge)*layerThickEdge(1,iEdge)
+                 layerThicknessEdgeSum(1) = layerThickEdge(1,iEdge)
 
                  do kIndexOBL = 2, maxLevelCell(iCell)
                     normalVelocitySum(kIndexOBL) = normalVelocitySum(kIndexOBL-1) + &
-                                      layerThicknessEdge(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
-                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThicknessEdge(kIndexOBL, iEdge)
+                                      layerThickEdge(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
+                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdge(kIndexOBL, iEdge)
                  end do
 
                  do kIndexOBL = 1, maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -21,6 +21,7 @@ module ocn_vmix_cvmix
 
    use ocn_constants
    use ocn_config
+   use ocn_diagnostics_variables
 
    use cvmix_kinds_and_types
    use cvmix_put_get
@@ -94,7 +95,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, diagnosticsPool, err, timeLevelIn)!{{{
+   subroutine ocn_vmix_coefs_cvmix_build(meshPool, statePool, forcingPool, err, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -115,9 +116,6 @@ contains
 
       type (mpas_pool_type), intent(inout) :: &
          statePool         !< Input/Output: state information
-
-      type (mpas_pool_type), intent(inout) :: &
-         diagnosticsPool   !< Input/Output: diagnostic information
 
       type (mpas_pool_type), intent(inout) :: &
          forcingPool   !< Input/Output: forcing information
@@ -142,18 +140,14 @@ contains
         maxLevelCell, nEdgesOnCell, maxLevelEdgeTop
 
       real (kind=RKIND), dimension(:), pointer :: &
-        latCell, lonCell, bottomDepth, surfaceBuoyancyForcing, surfaceFrictionVelocity, fCell, &
-        boundaryLayerDepth, ssh, indexBoundaryLayerDepth, dcEdge, dvEdge, areaCell, iceFraction, &
-        boundaryLayerDepthSmooth, windSpeed10m
+        latCell, lonCell, bottomDepth, fCell, &
+        ssh, dcEdge, dvEdge, areaCell, iceFraction, &
+        windSpeed10m
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-        vertViscTopOfCell, vertDiffTopOfCell, layerThickness, &
-        zMid, zTop, density, displacedDensity, potentialDensity, &
-        bulkRichardsonNumber, RiTopOfCell, BruntVaisalaFreqTop, &
-        bulkRichardsonNumberBuoy, bulkRichardsonNumberShear, unresolvedShear, normalVelocity, edgeAreaFractionOfCell
+        layerThickness, &
+        normalVelocity
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
-      integer, pointer :: index_vertNonLocalFluxTemp
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, cellsOnCell, cellMask
 
       integer :: k, i, iCell, jCell, iNeighbor, iter, timeLevel, kIndexOBL, kav, iEdge, nCells
@@ -170,7 +164,6 @@ contains
                                                       potentialDensitySum, RiTemp,              &
                                                       layerThicknessSum, layerThicknessEdgeSum
       real (kind=RKIND), dimension(:), allocatable, target :: RiSmoothed, BVFSmoothed, OBLDepths, interfaceForcings
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge
       logical :: bulkRichardsonFlag
 
       real (kind=RKIND) :: langmuirEnhancementFactor, langmuirNumber
@@ -232,51 +225,11 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-
-      !
-      ! set pointers for fields related ocean state
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', bulkRichardsonNumber)
-      call mpas_pool_get_array(diagnosticsPool, 'unresolvedShear', unresolvedShear)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepthSmooth', boundaryLayerDepthSmooth)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop',BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',bulkRichardsonNumberBuoy)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',bulkRichardsonNumberShear)
-      call mpas_pool_get_array(diagnosticsPool, 'indexBoundaryLayerDepth',indexBoundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
-
       !
       ! set pointers for fields related to ocean forcing state
       !
       call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
       call mpas_pool_get_array(forcingPool, 'windSpeed10m', windSpeed10m)
-
-      !
-      ! set pointers for fields related forcing at ocean surface
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
-
-      !
-      ! set pointers for viscosity/diffusivity and initialize to zero
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
-
-
-      !
-      ! set pointers for nonlocal flux and initialize to zero
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_vertNonLocalFluxTemp', index_vertNonLocalFluxTemp)
 
       nCells = nCellsArray( size(nCellsArray) )
 

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -30,6 +30,7 @@ module ocn_wetting_drying
    use ocn_constants
    use ocn_config
    use ocn_diagnostics
+   use ocn_diagnostics_variables
    use ocn_gm
 
    implicit none
@@ -238,13 +239,9 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool
       type (mpas_pool_type), pointer :: provisStatePool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessProvis
-      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessEdge
-      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
-      real (kind=RKIND), dimension(:, :), pointer :: wettingVelocity
 
       integer, dimension(:), pointer :: maxLevelEdgeTop
       integer, dimension(:), pointer :: maxLevelEdgeBot
@@ -253,16 +250,12 @@ contains
 
       err = 0
 
-     call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
      call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
      call mpas_pool_get_subpool(block % structs, 'state', statePool)
      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
-     call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
-     call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThicknessEdge)
-     call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
      ! use thickness at n because constraint is h_n + dt*T_h > h_min
      call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
      call mpas_pool_get_array(provisStatePool, 'layerThickness', layerThicknessProvis, 1)

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -274,7 +274,7 @@ contains
 
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
-     call ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdge, layerThicknessCur, layerThicknessProvis, &
+     call ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdge, layerThicknessCur, layerThicknessProvis, &
                                              normalTransportVelocity, rkSubstepWeight, wettingVelocity, err)
 
      ! prevent drying from happening with selective wettingVelocity


### PR DESCRIPTION
This PR propagates the use of the new module `ocn_diagnostics_variables` in the `shared/` subdirectory of the ocean model.  This includes the removal of many pointer retrievals related to `diagnosticsPool`.

[BFB]