### PR TITLE
Correct scaling of thermal thickness limit

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -120,7 +120,7 @@ void velocity_solver_set_parameters(double const* gravity_F, double const* ice_d
   // This function sets parameter values used by MPAS on the C/C++ side
   rho_ice = *ice_density_F;
   rho_ocean = *ocean_density_F;
-  thermal_thickness_limit = *thermal_thickness_limit_F;
+  thermal_thickness_limit = *thermal_thickness_limit_F / unit_length; // Import with Albany scaling
   dynamic_ice_bit_value = *li_mask_ValueDynamicIce;
   ice_present_bit_value = *li_mask_ValueIce;
   velocity_solver_set_physical_parameters__(*gravity_F, rho_ice, *ocean_density_F, *sea_level_F/unit_length, *flowParamA_F*std::pow(unit_length,4)*secondsInAYear, 


### PR DESCRIPTION
This fixed a bug in bcc59078ca4a5034febd38fb6f637f763a78e6bd
