### PR TITLE
Fix a bug in linking a python script for the vegetation idealized_tra…

### DIFF
--- a/testing_and_setup/compass/ocean/drying_slope/marsh_flooding/idealized_transect/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/drying_slope/marsh_flooding/idealized_transect/config_analysis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config case="analysis">
-	<add_link path_base="script_test_dir" source="comparison.py" dest="comparison.py"/>
+	<add_link source_path="script_test_dir" source="comparison.py" dest="comparison.py"/>
 	<add_link source="../forward1/output.nc" dest="NoVegetation.nc"/>
 	<add_link source="../forward2/output.nc" dest="ConstantVegManning.nc"/>
 	<add_link source="../forward3/output.nc" dest="VegManningEquation.nc"/>


### PR DESCRIPTION
This bug appeared in linking the python script `comparison.py` to the `script_test_dir` directory. It intended to provide the path of the python script by using **`path_base`**, which generated to a invalid hyperlink of the script and failed to run the analysis. Changing it to **`source_path`** fixed this issue.

