### PR TITLE
Impulse Response Function addition

### DIFF
--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -118,6 +118,7 @@ module ocn_core_interface
       logical, pointer :: windStressBulkPKGActive
       logical, pointer :: variableBottomDragPKGActive
       logical, pointer :: tracerBudgetActive
+      logical, pointer :: IRFTracerBudgetPKGActive
       logical, pointer :: landIcePressurePKGActive
       logical, pointer :: landIceFluxesPKGActive
       logical, pointer :: landIceCouplingPKGActive
@@ -170,6 +171,7 @@ module ocn_core_interface
       logical, pointer :: config_use_bulk_wind_stress
       logical, pointer :: config_use_bulk_thickness_flux
       logical, pointer :: config_compute_active_tracer_budgets
+      logical, pointer :: config_use_IRFTracers
       character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
        type (mpas_pool_iterator_type) :: groupItr
@@ -259,6 +261,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_compute_active_tracer_budgets', config_compute_active_tracer_budgets)
       if ( config_compute_active_tracer_budgets ) then
          tracerBudgetActive = .true.
+      end if
+
+      !
+      ! test for tracer budget
+      !
+      call mpas_pool_get_package(packagePool, 'IRFTracerBudgetPKGActive', IRFTracerBudgetPKGActive)
+      call mpas_pool_get_config(configPool, 'config_use_IRFTracers', config_use_IRFTracers)
+      if ( config_use_IRFTracers) then
+         IRFTracerBudgetPKGActive = .true.
       end if
 
       !

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -244,9 +244,9 @@ module ocn_time_integration_split
          activeTracersTend       ! active tracer tendencies
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-        IRFTracersHorAdvTend,      &
-        IRFTracersVertAdvTend,        &
-        IRFTracerSurfaceFluxTend,              &
+        IRFTracersHorAdvTend, &
+        IRFTracersVertAdvTend, &
+        IRFTracerSurfaceFluxTend, &
         IRFTracersNonLocalTend
 
       ! Forcing pool
@@ -421,7 +421,6 @@ module ocn_time_integration_split
                end do
                !$omp end do
                !$omp end parallel
-
             end if
          end if
       end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -243,6 +243,12 @@ module ocn_time_integration_split
          tracersGroupTend,      &! tendencies for tracer groups
          activeTracersTend       ! active tracer tendencies
 
+      real (kind=RKIND), dimension(:,:,:), pointer :: &
+        IRFTracersHorAdvTend,      &
+        IRFTracersVertAdvTend,        &
+        IRFTracerSurfaceFluxTend,              &
+        IRFTracersNonLocalTend
+
       ! Forcing pool
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 
@@ -415,6 +421,7 @@ module ocn_time_integration_split
                end do
                !$omp end do
                !$omp end parallel
+
             end if
          end if
       end do
@@ -1685,6 +1692,20 @@ module ocn_time_integration_split
                !$omp end parallel
             endif
 
+            if ( config_use_IRFTracers ) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCells
+                  do k= 1, maxLevelCell(iCell)
+                     IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                     IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                     IRFTracersNonLocalTend(:,k,iCell) = IRFTracersNonLocalTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            endif
+
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &
                                                 groupItr) )
@@ -1923,6 +1944,28 @@ module ocn_time_integration_split
          end do
          !$omp end do
          !$omp end parallel
+      end if
+
+      if ( config_use_IRFTracers ) then
+         call mpas_pool_begin_iteration(tracersPool)
+         do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
+            if ( groupItr % memberType == MPAS_POOL_FIELD ) then
+                  ! Reset Impulse Response Functions to original value
+                  if ( trim(groupItr % memberName) == 'IRFTracers' ) then
+                  call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupCur, 1)
+                  call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
+                     !$omp parallel
+                     !$omp do schedule(runtime) private(k)
+                     do iCell = 1, nCells
+                        do k = 1, maxLevelCell(iCell)
+                           tracersGroupNew(:,k,iCell) = tracersGroupCur(:,k,iCell)
+                        end do
+                     end do
+                     !$omp end do
+                     !$omp end parallel
+                  end if
+            end if
+         end do
       end if
 
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1685,19 +1685,19 @@ module ocn_time_integration_split
                !$omp end parallel
             endif
 
-            if ( config_use_IRFTracers ) then
-               !$omp parallel
-               !$omp do schedule(runtime) private(k)
-               do iCell = 1, nCells
-                  do k= 1, maxLevelCell(iCell)
-                     IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
-                     IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
-                     IRFTracersNonLocalTend(:,k,iCell) = IRFTracersNonLocalTend(:,k,iCell) / layerThicknessNew(k,iCell)
-                  end do
-               end do
-               !$omp end do
-               !$omp end parallel
-            endif
+            !if ( config_use_IRFTracers ) then
+            !   !$omp parallel
+            !   !$omp do schedule(runtime) private(k)
+            !   do iCell = 1, nCells
+            !      do k= 1, maxLevelCell(iCell)
+            !         IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+            !         IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+            !         IRFTracersNonLocalTend(:,k,iCell) = IRFTracersNonLocalTend(:,k,iCell) / layerThicknessNew(k,iCell)
+            !      end do
+            !   end do
+            !   !$omp end do
+            !   !$omp end parallel
+            !endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1685,7 +1685,7 @@ module ocn_time_integration_split
                !$omp end parallel
             endif
 
-            if ( config_use_IRFTracers .and. config_normalize_IRFTracers_by_layerThickness) then
+            if ( config_use_IRFTracers .and. config_IRFTracers_normalize_by_layerThickness) then
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -243,12 +243,6 @@ module ocn_time_integration_split
          tracersGroupTend,      &! tendencies for tracer groups
          activeTracersTend       ! active tracer tendencies
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: &
-        IRFTracersHorAdvTend, &
-        IRFTracersVertAdvTend, &
-        IRFTracerSurfaceFluxTend, &
-        IRFTracersNonLocalTend
-
       ! Forcing pool
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1685,20 +1685,20 @@ module ocn_time_integration_split
                !$omp end parallel
             endif
 
-            !if ( config_use_IRFTracers ) then
-            !   !$omp parallel
-            !   !$omp do schedule(runtime) private(k)
-            !   do iCell = 1, nCells
-            !      do k= 1, maxLevelCell(iCell)
-            !         IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
-            !         IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
-            !         IRFTracersHorMixTend(:,k,iCell) = IRFTracersHorMixTend(:,k,iCell) / layerThicknessNew(k,iCell)
-            !         IRFTracersNonLocalTend(:,k,iCell) = IRFTracersNonLocalTend(:,k,iCell) / layerThicknessNew(k,iCell)
-            !      end do
-            !   end do
-            !   !$omp end do
-            !   !$omp end parallel
-            !endif
+            if ( config_use_IRFTracers .and. config_normalize_IRFTracers_by_layerThickness) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCells
+                  do k= 1, maxLevelCell(iCell)
+                     IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                     IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                     IRFTracersHorMixTend(:,k,iCell) = IRFTracersHorMixTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                     IRFTracersVertMixTend(:,k,iCell) = IRFTracersVertMixTend(:,k,iCell) / layerThicknessNew(k,iCell)
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1692,6 +1692,7 @@ module ocn_time_integration_split
             !      do k= 1, maxLevelCell(iCell)
             !         IRFTracersHorAdvTend(:,k,iCell) = IRFTracersHorAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
             !         IRFTracersVertAdvTend(:,k,iCell)  = IRFTracersVertAdvTend(:,k,iCell) / layerThicknessNew(k,iCell)
+            !         IRFTracersHorMixTend(:,k,iCell) = IRFTracersHorMixTend(:,k,iCell) / layerThicknessNew(k,iCell)
             !         IRFTracersNonLocalTend(:,k,iCell) = IRFTracersNonLocalTend(:,k,iCell) / layerThicknessNew(k,iCell)
             !      end do
             !   end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -149,7 +149,12 @@ module ocn_diagnostics_variables
       activeTracerVerticalAdvectionTendency,   &
       activeTracerHorizontalAdvectionEdgeFlux, &
       activeTracerVerticalAdvectionTopFlux,    &
-      activeTracerVertMixTendency
+      activeTracerVertMixTendency,             &
+      IRFTracersHorAdvTend,    &
+      IRFTracersVertAdvTend, &
+      IRFTracerSurfaceFluxTend, &
+      IRFTracersNonLocalTend
+
 
    real (kind=RKIND), pointer :: daysSinceStartOfSim
    character (len=StrKIND), pointer :: xtime, simulationStartTime
@@ -401,6 +406,13 @@ contains
               activeTracerVerticalAdvectionTendency)
       call mpas_pool_get_array(diagnosticsPool, &
          'activeTracerVertMixTendency',activeTracerVertMixTendency)
+
+      if ( config_use_IRFTracers ) then
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracersHorAdvTend',IRFTracersHorAdvTend)
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracersVertAdvTend',IRFTracersVertAdvTend)
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracerSurfaceFluxTend',IRFTracerSurfaceFluxTend)
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracersNonLocalTend',IRFTracersNonLocalTend)
+      endif
 
       call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
       call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -152,8 +152,8 @@ module ocn_diagnostics_variables
       activeTracerVertMixTendency,             &
       IRFTracersHorAdvTend,    &
       IRFTracersVertAdvTend, &
-      IRFTracerSurfaceFluxTend, &
-      IRFTracersNonLocalTend
+      IRFTracersHorMixTend, &
+      IRFTracersVertMixTend
 
 
    real (kind=RKIND), pointer :: daysSinceStartOfSim
@@ -410,8 +410,8 @@ contains
       if ( config_use_IRFTracers ) then
          call mpas_pool_get_array(diagnosticsPool,'IRFTracersHorAdvTend',IRFTracersHorAdvTend)
          call mpas_pool_get_array(diagnosticsPool,'IRFTracersVertAdvTend',IRFTracersVertAdvTend)
-         call mpas_pool_get_array(diagnosticsPool,'IRFTracerSurfaceFluxTend',IRFTracerSurfaceFluxTend)
-         call mpas_pool_get_array(diagnosticsPool,'IRFTracersNonLocalTend',IRFTracersNonLocalTend)
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracersHorMixTend',IRFTracersHorMixTend)
+         call mpas_pool_get_array(diagnosticsPool,'IRFTracersVertMixTend',IRFTracersVertMixTend)
       endif
 
       call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -579,7 +579,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
+      real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup, tracersGroupNew
 
       integer, pointer :: nCells, nEdges, nVertices, nVertLevels
 
@@ -655,6 +655,19 @@ end subroutine ocn_init_routines_compute_max_level!}}}
                do iCell=1,nCells
                   tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) =  -1.0e34_RKIND
                end do
+               ! Copy Impulse Response Functions from time index 1 to time 2
+               ! That is because we copy it from index 2 to 1 at the beginning
+               ! of each time step to reset the IRFs.
+               if ( trim(groupItr % memberName) == 'IRFTracers' ) then
+                  call mpas_pool_get_array(tracersPool, groupItr % memberName, tracersGroupNew, 2)
+                  !$omp do schedule(runtime) private(k)
+                  do iCell = 1, nCells
+                     do k = 1, nVertLevels
+                        tracersGroupNew(:,k,iCell) = tracersGroup(:,k,iCell)
+                     end do
+                  end do
+                  !$omp end do
+               end if
             end if
          end if
       end do

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -855,7 +855,7 @@ contains
                     !$omp end do
                     !$omp end parallel
                  endif
-               elseif(trim(groupItr % memberName)=='ImpulseResponseFunctions') then
+               elseif(trim(groupItr % memberName)=='IRFTracers') then
                     !$omp parallel
                     !$omp do schedule(runtime)
                     do iCell = 1, nCells
@@ -880,7 +880,7 @@ contains
                     !$omp end do
                     !$omp end parallel
                  endif
-               elseif(trim(groupItr % memberName)=='ImpulseResponseFunctions') then
+               elseif(trim(groupItr % memberName)=='IRFTracers') then
                     !$omp parallel
                     !$omp do schedule(runtime)
                     do iCell = 1, nCells

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -855,6 +855,14 @@ contains
                     !$omp end do
                     !$omp end parallel
                  endif
+               elseif(trim(groupItr % memberName)=='ImpulseResponseFunctions') then
+                    !$omp parallel
+                    !$omp do schedule(runtime)
+                    do iCell = 1, nCells
+                      IRFTracersHorMixTend(:,:,iCell) = tracerGroupTend(:,:,iCell)
+                    enddo
+                    !$omp end do
+                    !$omp end parallel
                endif
                call ocn_tracer_hmix_tend(meshPool, layerThickEdge, layerThickness, zMid, tracerGroup, &
                                          RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer, &
@@ -872,6 +880,14 @@ contains
                     !$omp end do
                     !$omp end parallel
                  endif
+               elseif(trim(groupItr % memberName)=='ImpulseResponseFunctions') then
+                    !$omp parallel
+                    !$omp do schedule(runtime)
+                    do iCell = 1, nCells
+                      IRFTracersHorMixTend(:,:,iCell) = tracerGroupTend(:,:,iCell) - IRFTracersHorMixTend(:,:,iCell)
+                    enddo
+                    !$omp end do
+                    !$omp end parallel
                endif
  
                !

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -96,7 +96,8 @@ module ocn_tracer_advection
       !*** Local variables
 
       logical :: &
-         computeBudgets      ! flag to compute active tracer budget
+         computeBudgets,    &! flag to compute active tracer budget
+         computeIRFs         ! flag to compute IRFs
 
       real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
          advCoefs, advCoefs3rd ! advection coefficients
@@ -132,6 +133,7 @@ module ocn_tracer_advection
 
       ! determine whether active tracer budgets should be computed
       computeBudgets = (budgetDiagsOn .and. tracerGroupName == 'activeTracers')
+      computeIRFs = (tracerGroupName == 'IRFTracers')
 
       ! call specific advection routine based on choice of monotonicity
       if (monotonicOn) then
@@ -142,7 +144,7 @@ module ocn_tracer_advection
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             computeBudgets)
+                                             computeBudgets, computeIRFs)
 
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -97,7 +97,8 @@ module ocn_tracer_advection
 
       logical :: &
          computeBudgets,    &! flag to compute active tracer budget
-         computeIRFs         ! flag to compute IRFs
+         computeIRFs,       &! flag to compute IRFs
+         limiterOn           ! flag to limit tracer group
 
       real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
          advCoefs, advCoefs3rd ! advection coefficients
@@ -134,6 +135,12 @@ module ocn_tracer_advection
       ! determine whether active tracer budgets should be computed
       computeBudgets = (budgetDiagsOn .and. tracerGroupName == 'activeTracers')
       computeIRFs = (tracerGroupName == 'IRFTracers')
+      if (config_IRFTracers_limit_advection.and.computeIRFs.or. &
+          config_debugTracers_limit_advection.and.(tracerGroupName == 'debugTracers')) then
+        limiterOn = .true.
+      else
+        limiterOn = .false.
+      endif
 
       ! call specific advection routine based on choice of monotonicity
       if (monotonicOn) then
@@ -144,7 +151,8 @@ module ocn_tracer_advection
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             computeBudgets, computeIRFs)
+                                             computeBudgets, computeIRFs,      &
+                                             limiterOn)
 
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -143,7 +143,8 @@ module ocn_tracer_advection
       endif
 
       ! call specific advection routine based on choice of monotonicity
-      if (monotonicOn) then
+      if (limiterOn) then
+         call mpas_log_write('Calling mono_tend for tracer group '//tracerGroupName)
          call ocn_tracer_advection_mono_tend(tend, tracers, layerThickness,    &
                                              normalThicknessFlux, w, dt,       &
                                              advCoefs, advCoefs3rd,            &
@@ -155,6 +156,7 @@ module ocn_tracer_advection
                                              limiterOn)
 
       else
+         call mpas_log_write('Calling std_tend for tracer group '//tracerGroupName)
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
             nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
             layerThickness, dt, meshPool, tend, maxLevelCell, maxLevelEdgeTop, &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -139,7 +139,7 @@ module ocn_tracer_advection
           config_debugTracers_limit_advection.and.(tracerGroupName == 'debugTracers')) then
         limiterOn = .true.
       else
-        limiterOn = .false.
+        limiterOn = monotonicOn
       endif
 
       ! call specific advection routine based on choice of monotonicity

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -158,7 +158,7 @@ module ocn_tracer_advection
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
             nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
             layerThickness, dt, meshPool, tend, maxLevelCell, maxLevelEdgeTop, &
-            highOrderAdvectionMask, edgeSignOnCell)
+            highOrderAdvectionMask, edgeSignOnCell, computeIRFs)
       endif
 
       call mpas_timer_stop("tracer adv")

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -182,15 +182,6 @@ module ocn_tracer_advection_mono
          wgtTmp,            &! vertical temporaries for
          flxTmp, sgnTmp      !   high-order flux computation
 
-      ! pointers for tendencies used in diagnostic budget computation
-      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
-         activeTracerHorizontalAdvectionTendency, &
-         activeTracerVerticalAdvectionTendency,   &
-         activeTracerHorizontalAdvectionEdgeFlux, &
-         activeTracerVerticalAdvectionTopFlux,    &
-         IRFTracersHorAdvTend,    &
-         IRFTracersVertAdvTend
-
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -453,11 +453,15 @@ module ocn_tracer_advection_mono
         !$omp end do
         !$omp end parallel
 
+        if (.not.limiterOn) then
+            flxIn(:,:) = 1.0_RKIND
+            flxOut(:,:) = 1.0_RKIND
+        endif
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('scale factor build')
         call mpas_timer_start('rescale horiz fluxes')
 #endif
-        if (limiterOn) then
+        !if (limiterOn) then
           ! Need all of the edges around owned cells
           nEdges = nEdgesArray( 2 )
           !  rescale the high order horizontal fluxes
@@ -475,7 +479,7 @@ module ocn_tracer_advection_mono
           end do ! iEdge loop
           !$omp end do
           !$omp end parallel
-        endif
+        !endif
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
         call mpas_timer_start('flux accumulate')

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -97,7 +97,8 @@ module ocn_tracer_advection_mono
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             computeBudgets, computeIRFs)!{{{
+                                             computeBudgets, computeIRFs,      &
+                                             limiterOn)!{{{
 
       !*** Input/Output parameters
 
@@ -137,7 +138,9 @@ module ocn_tracer_advection_mono
       logical, intent(in) :: &
          computeBudgets         !< [in] Flag to compute active tracer budgets
       logical, intent(in) :: &
-         computeIRFs         ! flag to compute IRFs
+         computeIRFs            !< [in] Flag to compute IRF tracer budgets
+      logical, intent(in) :: &
+         limiterOn              !< [in] Flag to limit this tracer group
 
       !*** Local variables
 
@@ -454,23 +457,25 @@ module ocn_tracer_advection_mono
         call mpas_timer_stop('scale factor build')
         call mpas_timer_start('rescale horiz fluxes')
 #endif
-        ! Need all of the edges around owned cells
-        nEdges = nEdgesArray( 2 )
-        !  rescale the high order horizontal fluxes
-        !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k)
-        do iEdge = 1, nEdges
-          cell1 = cellsOnEdge(1,iEdge)
-          cell2 = cellsOnEdge(2,iEdge)
-          do k = 1, maxLevelEdgeTop(iEdge)
-            highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
-                                    min(flxOut(k,cell1), flxIn (k,cell2)) &
-                                  + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
-                                    min(flxIn (k,cell1), flxOut(k,cell2))
-          end do ! k loop
-        end do ! iEdge loop
-        !$omp end do
-        !$omp end parallel
+        if (limiterOn) then
+          ! Need all of the edges around owned cells
+          nEdges = nEdgesArray( 2 )
+          !  rescale the high order horizontal fluxes
+          !$omp parallel
+          !$omp do schedule(runtime) private(cell1, cell2, k)
+          do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k = 1, maxLevelEdgeTop(iEdge)
+              highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                    + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxIn (k,cell1), flxOut(k,cell2))
+            end do ! k loop
+          end do ! iEdge loop
+          !$omp end do
+          !$omp end parallel
+        endif
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('rescale horiz fluxes')
         call mpas_timer_start('flux accumulate')
@@ -810,33 +815,51 @@ module ocn_tracer_advection_mono
         nCells = nCellsArray( 1 )
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
-        !$omp parallel
-        !$omp do schedule(runtime) private(kmax, k, flux)
-        do iCell = 1, nCells
-          kmax = maxLevelCell(iCell)
-          ! rescale the high order vertical flux
-          do k = 2, kmax
-            flux =  highOrderFlx(k,iCell)
-            highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
-                                    min(flxOut(k  ,iCell), &
-                                        flxIn (k-1,iCell)) &
-                                  + min(0.0_RKIND,flux)*   &
-                                    min(flxOut(k-1,iCell), &
-                                        flxIn (k  ,iCell))
-          end do ! k loop
+        if (limiterOn) then
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k, flux)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            ! rescale the high order vertical flux
+            do k = 2, kmax
+              flux =  highOrderFlx(k,iCell)
+              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                      min(flxOut(k  ,iCell), &
+                                          flxIn (k-1,iCell)) &
+                                    + min(0.0_RKIND,flux)*   &
+                                      min(flxOut(k-1,iCell), &
+                                          flxIn (k  ,iCell))
+            end do ! k loop
 
-          do k = 1,kmax
-            ! workTend on the RHS is the upwind tendency
-            ! workTend on the LHS is the total vertical advection tendency
-            workTend(k, iCell) = workTend(k, iCell)       &
-                               + (highOrderFlx(k+1,iCell) &
-                                - highOrderFlx(k  ,iCell))
-            tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
-          end do ! k loop
+            do k = 1,kmax
+              ! workTend on the RHS is the upwind tendency
+              ! workTend on the LHS is the total vertical advection tendency
+              workTend(k, iCell) = workTend(k, iCell)       &
+                                 + (highOrderFlx(k+1,iCell) &
+                                  - highOrderFlx(k  ,iCell))
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
+            end do ! k loop
 
-        end do ! iCell loop
-        !$omp end do
-        !$omp end parallel
+          end do ! iCell loop
+          !$omp end do
+          !$omp end parallel
+        else ! no limiter
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k, flux)
+          do iCell = 1, nCells
+            do k = 1,kmax
+              ! workTend on the RHS is the upwind tendency
+              ! workTend on the LHS is the total vertical advection tendency
+              workTend(k, iCell) = workTend(k, iCell)       &
+                                 + (highOrderFlx(k+1,iCell) &
+                                  - highOrderFlx(k  ,iCell))
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) + workTend(k,iCell)
+            end do ! k loop
+
+          end do ! iCell loop
+          !$omp end do
+          !$omp end parallel
+        endif
 
         if (computeIRFs) then
            !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -97,7 +97,7 @@ module ocn_tracer_advection_mono
                                              maxLevelCell, maxLevelEdgeTop,    &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
-                                             computeBudgets)!{{{
+                                             computeBudgets, computeIRFs)!{{{
 
       !*** Input/Output parameters
 
@@ -136,6 +136,8 @@ module ocn_tracer_advection_mono
          meshPool               !< [in] Mesh information
       logical, intent(in) :: &
          computeBudgets         !< [in] Flag to compute active tracer budgets
+      logical, intent(in) :: &
+         computeIRFs         ! flag to compute IRFs
 
       !*** Local variables
 
@@ -179,6 +181,15 @@ module ocn_tracer_advection_mono
       real (kind=RKIND), dimension(size(tracers, dim=2)) :: &
          wgtTmp,            &! vertical temporaries for
          flxTmp, sgnTmp      !   high-order flux computation
+
+      ! pointers for tendencies used in diagnostic budget computation
+      real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
+         activeTracerHorizontalAdvectionTendency, &
+         activeTracerVerticalAdvectionTendency,   &
+         activeTracerHorizontalAdvectionEdgeFlux, &
+         activeTracerVerticalAdvectionTopFlux,    &
+         IRFTracersHorAdvTend,    &
+         IRFTracersVertAdvTend
 
       real (kind=RKIND), parameter :: &
          eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
@@ -505,6 +516,18 @@ module ocn_tracer_advection_mono
         !$omp end do
         !$omp end parallel
 
+        if (computeIRFs) then
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCells
+             do k = 1, maxLevelCell(iCell)
+                 IRFTracersHorAdvTend(iTracer,k,iCell) = workTend(k,iCell)
+             end do
+           end do ! iCell loop
+           !$omp end do
+           !$omp end parallel
+        end if
+
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('flux accumulate')
         call mpas_timer_start('advect diags')
@@ -823,6 +846,18 @@ module ocn_tracer_advection_mono
         end do ! iCell loop
         !$omp end do
         !$omp end parallel
+
+        if (computeIRFs) then
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCells
+             do k = 1, maxLevelCell(iCell)
+                 IRFTracersVertAdvTend(iTracer,k,iCell) = workTend(k,iCell)
+             end do
+           end do ! iCell loop
+           !$omp end do
+           !$omp end parallel
+        end if
 
         ! Compute advection diagnostics and monotonicity checks if requested
 #ifdef _ADV_TIMERS

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -847,6 +847,7 @@ module ocn_tracer_advection_mono
           !$omp parallel
           !$omp do schedule(runtime) private(kmax, k, flux)
           do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
             do k = 1,kmax
               ! workTend on the RHS is the upwind tendency
               ! workTend on the LHS is the total vertical advection tendency

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -26,6 +26,7 @@ module ocn_tracer_advection_std
    use mpas_pool_routines
    use mpas_io_units
    use mpas_threading
+   use ocn_diagnostics_variables
 
    use mpas_tracer_advection_helpers
 
@@ -66,11 +67,13 @@ module ocn_tracer_advection_std
    subroutine ocn_tracer_advection_std_tend(tracers, adv_coefs, adv_coefs_3rd, nAdvCellsForEdge, advCellsForEdge, &!{{{
                                              normalThicknessFlux, w, layerThickness, verticalCellSize, dt, meshPool, &
                                              tend, maxLevelCell, maxLevelEdgeTop, &
-                                             highOrderAdvectionMask, edgeSignOnCell)
+                                             highOrderAdvectionMask, edgeSignOnCell, computeIRFs)
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input: current tracer values
       real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs !< Input: Advection coefficients for 2nd order advection
       real (kind=RKIND), dimension(:,:), intent(in) :: adv_coefs_3rd !< Input: Advection coeffs for blending in 3rd/4th order
+      logical, intent(in) :: &
+         computeIRFs            !< [in] Flag to compute IRF tracer budgets
       integer, dimension(:), intent(in) :: nAdvCellsForEdge !< Input: Number of advection cells for each edge
       integer, dimension(:,:), intent(in) :: advCellsForEdge !< Input: List of advection cells for each edge
       real (kind=RKIND), dimension(:,:), intent(in) :: normalThicknessFlux !< Input: Thichness weighted velocitiy
@@ -226,7 +229,38 @@ module ocn_tracer_advection_std
         end do ! iCell loop
         !$omp end do
         !$omp end parallel
+
+        if (computeIRFs) then
+          !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k)
+          do iCell = 1, nCells
+            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+            IRFTracersHorAdvTend(iTracer,:,iCell) = 0.0_RKIND
+            do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              do k = 1, maxLevelEdgeTop(iEdge)
+                IRFTracersHorAdvTend(iTracer,k,iCell) = IRFTracersHorAdvTend(iTracer,k,iCell) &
+                    + edgeSignOnCell(i, iCell) * high_order_horiz_flux(k, iEdge) * invAreaCell1
+              end do
+            end do
+          end do
+          !$omp end do
+
+          ! Accumulate the scaled high order vertical tendencies.
+          !$omp do schedule(runtime) private(k)
+          do iCell = 1, nCellsSolve
+            IRFTracersVertAdvTend(iTracer,:,iCell) = 0.0_RKIND
+            do k = 1,maxLevelCell(iCell)
+              IRFTracersVertAdvTend(iTracer,k,iCell) = IRFTracersVertAdvTend(iTracer,k,iCell) &
+                     + verticalDivergenceFactor(k) * (high_order_vert_flux(k+1, iCell) &
+                     - high_order_vert_flux(k, iCell))
+            end do ! k loop
+          end do ! iCell loop
+          !$omp end do
+          !$omp end parallel
+        end if
+
       end do ! iTracer loop
+
 
       deallocate(tracer_cur, high_order_horiz_flux, high_order_vert_flux)
       deallocate(verticalDivergenceFactor)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -228,7 +228,6 @@ module ocn_tracer_advection_std
           end do ! k loop
         end do ! iCell loop
         !$omp end do
-        !$omp end parallel
 
         if (computeIRFs) then
           !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k)
@@ -256,9 +255,9 @@ module ocn_tracer_advection_std
             end do ! k loop
           end do ! iCell loop
           !$omp end do
-          !$omp end parallel
         end if
 
+        !$omp end parallel
       end do ! iTracer loop
 
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -1128,6 +1128,14 @@ contains
                   !$omp end do
                   !$omp end parallel
                endif
+            elseif (trim(groupItr % memberName) == 'ImpulseResponseFunctions') then
+                  !$omp parallel
+                  !$omp do schedule(runtime)
+                  do iCell = 1, nCells
+                     IRFTracersVertMixTend(:,:,iCell)=tracersGroup(:,:,iCell)
+                  end do
+                  !$omp end do
+                  !$omp end parallel
             endif
 
             if ( associated(tracersGroup) ) then
@@ -1157,6 +1165,15 @@ contains
                   !$omp end do
                   !$omp end parallel
                endif
+            elseif (trim(groupItr % memberName) == 'ImpulseResponseFunctions') then
+                  !$omp parallel
+                  !$omp do schedule(runtime)
+                  do iCell = 1, nCells
+                     IRFTracersVertMixTend(:,:,iCell) = &
+                        (tracersGroup(:,:,iCell) - IRFTracersVertMixTend(:,:,iCell)) / dt
+                  end do
+                  !$omp end do
+                  !$omp end parallel
             endif
 
          end if

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -1128,7 +1128,7 @@ contains
                   !$omp end do
                   !$omp end parallel
                endif
-            elseif (trim(groupItr % memberName) == 'ImpulseResponseFunctions') then
+            elseif (trim(groupItr % memberName) == 'IRFTracers') then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
@@ -1165,7 +1165,7 @@ contains
                   !$omp end do
                   !$omp end parallel
                endif
-            elseif (trim(groupItr % memberName) == 'ImpulseResponseFunctions') then
+            elseif (trim(groupItr % memberName) == 'IRFTracers') then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells

--- a/src/core_ocean/tracer_groups/Registry_IRF.xml
+++ b/src/core_ocean/tracer_groups/Registry_IRF.xml
@@ -1,3 +1,4 @@
+<!-- Registry for Impulse Response Function tracer group -->
 	<nml_record name="tracer_forcing_IRFTracers">
 		<nml_option name="config_use_IRFTracers" type="logical" default_value=".false." units="unitless"
 			description="if true, the 'IRFGRP' category is enabled for the run"

--- a/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
+++ b/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
@@ -687,57 +687,6 @@
 	</var_struct>
 
 	<var_struct name="diagnostics" time_levs="1">
-		<var_array name="IRFTracersNonLocalTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
-			 <var name="IRF_1NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_2NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_3NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_4NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_5NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_6NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_7NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_8NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_9NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_10NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_11NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_12NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_13NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_14NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_15NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_16NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_17NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_18NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_19NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_20NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_21NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_22NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_23NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_24NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_25NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_26NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_27NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_28NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_29NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_30NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_31NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_32NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_33NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_34NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_35NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_36NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_37NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_38NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_39NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_40NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_41NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_42NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_43NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_44NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_45NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_46NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_47NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_48NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_49NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-		</var_array>
 		<var_array name="IRFTracersHorAdvTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
 			 <var name="IRF_1HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			 <var name="IRF_2HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
@@ -840,57 +789,6 @@
 			<var name="IRF_48VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			<var name="IRF_49VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 		</var_array>
-		<var_array name="IRFTracersVertMixTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
-			 <var name="IRF_1VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_2VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_3VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_4VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_5VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_6VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_7VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_8VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			 <var name="IRF_9VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_10VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_11VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_12VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_13VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_14VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_15VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_16VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_17VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_18VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_19VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_20VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_21VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_22VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_23VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_24VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_25VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_26VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_27VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_28VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_29VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_30VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_31VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_32VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_33VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_34VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_35VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_36VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_37VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_38VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_39VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_40VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_41VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_42VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_43VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_44VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_45VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_46VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_47VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_48VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-			<var name="IRF_49VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
-		</var_array>
 		<var_array name="IRFTracersHorMixTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
 			 <var name="IRF_1HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			 <var name="IRF_2HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
@@ -941,5 +839,56 @@
 			<var name="IRF_47HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			<var name="IRF_48HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			<var name="IRF_49HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
+		<var_array name="IRFTracersVertMixTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 		</var_array>
 	</var_struct>

--- a/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
+++ b/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
@@ -1,0 +1,894 @@
+	<nml_record name="tracer_forcing_IRFTracers">
+		<nml_option name="config_use_IRFTracers" type="logical" default_value=".false." units="unitless"
+			description="if true, the 'IRFGRP' category is enabled for the run"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_surface_bulk_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_surface_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, surface restoring source is applied to tracers in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_interior_restoring" type="logical" default_value=".false." units="unitless"
+			description="if true, interior restoring source is applied to tracers in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_exponential_decay" type="logical" default_value=".false." units="unitless"
+			description="if true, exponential decay source is applied to tracers in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_idealAge_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, idealAge forcing source is applied to tracers in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_ttd_forcing" type="logical" default_value=".false." units="unitless"
+			description="if true, transit time distribution forcing source is applied to tracers in 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_surface_value" type="logical" default_value=".false." units="unitless"
+			description="if true, surface value is computed for 'IRFGRP' category"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_use_IRFTracers_sea_ice_coupling" type="logical" default_value=".false." units="unitless"
+			description="if true, couple IRF fields with sea ice"
+			possible_values=".true. or .false."
+		/>
+	</nml_record>
+
+	<packages>
+		<package name="IRFTracersPKG" description="This package includes variables required to include IRFGRP."/>
+		<package name="IRFTracersBulkRestoringPKG" description="This package includes variables required to compute bulk restoring on the IRF tracer group."/>
+		<package name="IRFTracersSurfaceRestoringPKG" description="This package includes variables required to compute surface restoring on the IRF tracer group."/>
+		<package name="IRFTracersInteriorRestoringPKG" description="This package includes variables required to compute interior restoring on the IRF tracer group."/>
+		<package name="IRFTracersExponentialDecayPKG" description="This package includes variables required to compute exponential decay on the IRF tracer group."/>
+		<package name="IRFTracersIdealAgePKG" description="This package includes variables required to compute ideal age forcing on the IRF tracer group."/>
+		<package name="IRFTracersTTDPKG" description="This package includes variables required to compute transit-time distribution forcing on the IRF tracer group."/>
+		<package name="IRFTracerBudgetPKG" description="This package includes variables required to compute IRF tracer budget"/>
+	</packages>
+
+	<var_struct name="state" time_levs="2">
+		<var_struct name="tracers" time_levs="2">
+			<var_array name="IRFTracers" dimensions="nVertLevels nCells Time" type="real" packages="IRFTracersPKG" >
+				 <var name="IRF_1" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="tend" time_levs="1">
+		<var_struct name="tracersTend" time_levs="1">
+			<var_array name="IRFTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracersPKG">
+				 <var name="IRF_1Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_2Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_3Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_4Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_5Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_6Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_7Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_8Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				 <var name="IRF_9Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_10Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_11Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_12Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_13Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_14Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_15Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_16Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_17Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_18Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_19Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_20Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_21Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_22Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_23Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_24Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_25Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_26Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_27Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_28Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_29Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_30Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_31Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_32Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_33Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_34Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_35Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_36Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_37Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_38Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_39Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_40Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_41Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_42Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_43Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_44Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_45Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_46Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_47Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_48Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+				<var name="IRF_49Tend" array_group="IRFGRP" units="IRF unit m^{-3} s^{-1}"/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="forcing" time_levs="1">
+		<var_struct name="tracersSurfaceFlux" time_levs="1">
+			<var_array name="IRFTracersSurfaceFlux" type="real" dimensions="nCells Time" packages="IRFTracersPKG">
+				 <var name="IRF_1SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49SurfaceFlux" array_group="IRFSurfaceFluxGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+			<var_array name="IRFTracersSurfaceFluxRunoff" type="real" dimensions="nCells Time" packages="IRFTracersPKG">
+				 <var name="IRF_1SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49SurfaceFluxRunoff" array_group="IRFSurfaceFluxRunoffGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+			<var_array name="IRFTracersSurfaceFluxRemoved" type="real" dimensions="nCells Time" packages="IRFTracersPKG">
+				 <var name="IRF_1SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49SurfaceFluxRemoved" array_group="IRFSurfaceFluxRemovedGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersSurfaceRestoringFields" time_levs="1">
+			<var_array name="IRFTracersPistonVelocity" type="real" dimensions="nCells Time" packages="IRFTracersSurfaceRestoringPKG">
+				<var name="IRF_1PistonVelocity" array_group="IRFPVGRP" units="m s^{-1}"
+				 <var name="IRF_1PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49PistonVelocity" array_group="IRFPVGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+			<var_array name="IRFTracersSurfaceRestoringValue" type="real" dimensions="nCells Time" packages="IRFTracersSurfaceRestoringPKG">
+				 <var name="IRF_1SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49SurfaceRestoringValue" array_group="IRFSRVGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersInteriorRestoringFields" time_levs="1">
+			<var_array name="IRFTracersInteriorRestoringRate" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracersInteriorRestoringPKG">
+				 <var name="IRF_1InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49InteriorRestoringRate" array_group="IRFIRRGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+			<var_array name="IRFTracersInteriorRestoringValue" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracersInteriorRestoringPKG">
+				 <var name="IRF_1InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49InteriorRestoringValue" array_group="IRFIRVGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersExponentialDecayFields" time_levs="1">
+			<var_array name="IRFTracersExponentialDecayRate" type="real" dimensions="Time" packages="IRFTracersExponentialDecayPKG">
+				 <var name="IRF_1ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49ExponentialDecayRate" array_group="IRFEDRGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersIdealAgeFields" time_levs="1">
+			<var_array name="IRFTracersIdealAgeMask" type="real" dimensions="nCells Time" packages="IRFTracersIdealAgePKG">
+				 <var name="IRF_1IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49IdealAgeMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+		<var_struct name="tracersTTDFields" time_levs="1">
+			<var_array name="IRFTracersTTDMask" type="real" dimensions="nCells Time" packages="IRFTracersTTDPKG">
+				 <var name="IRF_1TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_2TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_3TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_4TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_5TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_6TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_7TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_8TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				 <var name="IRF_9TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_10TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_11TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_12TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_13TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_14TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_15TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_16TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_17TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_18TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_19TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_20TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_21TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_22TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_23TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_24TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_25TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_26TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_27TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_28TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_29TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_30TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_31TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_32TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_33TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_34TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_35TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_36TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_37TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_38TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_39TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_40TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_41TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_42TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_43TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_44TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_45TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_46TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_47TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_48TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+				<var name="IRF_49TTDMask" array_group="IRFGRP" units="IRF unit m^{-3}"/>
+			</var_array>
+		</var_struct>
+	</var_struct>
+
+	<var_struct name="diagnostics" time_levs="1">
+		<var_array name="IRFTracersNonLocalTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49NonLocalTend" array_group="IRFTracersNonLocalTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
+		<var_array name="IRFTracersHorAdvTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49HorAdvTend" array_group="IRFTracersHorAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
+		<var_array name="IRFTracersVertAdvTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49VertAdvTend" array_group="IRFTracersVertAdvTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
+		<var_array name="IRFTracersVertMixTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
+	</var_struct>

--- a/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
+++ b/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
@@ -891,4 +891,55 @@
 			<var name="IRF_48VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 			<var name="IRF_49VertMixTend" array_group="IRFTracersVertMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
 		</var_array>
+		<var_array name="IRFTracersHorMixTend" type="real" dimensions="nVertLevels nCells Time" packages="IRFTracerBudgetPKG">
+			 <var name="IRF_1HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_2HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_3HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_4HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_5HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_6HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_7HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_8HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			 <var name="IRF_9HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_10HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_11HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_12HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_13HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_14HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_15HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_16HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_17HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_18HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_19HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_20HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_21HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_22HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_23HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_24HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_25HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_26HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_27HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_28HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_29HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_30HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_31HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_32HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_33HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_34HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_35HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_36HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_37HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_38HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_39HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_40HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_41HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_42HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_43HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_44HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_45HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_46HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_47HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_48HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+			<var name="IRF_49HorMixTend" array_group="IRFTracersHorMixTendGroup" units="IRF unit m^{-3} s^{-1}"/>
+		</var_array>
 	</var_struct>

--- a/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
+++ b/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
@@ -3,6 +3,10 @@
 			description="if true, the 'IRFGRP' category is enabled for the run"
 			possible_values=".true. or .false."
 		/>
+		<nml_option name="config_normalize_IRFTracers_by_layerThickness" type="logical" default_value=".false." units="unitless"
+			description="if true, the IRFTracers Tend variables are divided by layerThickness"
+			possible_values=".true. or .false."
+		/>
 		<nml_option name="config_use_IRFTracers_surface_bulk_forcing" type="logical" default_value=".false." units="unitless"
 			description="if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'IRFGRP' category"
 			possible_values=".true. or .false."

--- a/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
+++ b/src/core_ocean/tracer_groups/Registry_ImpulseResponseFunctions.xml
@@ -3,7 +3,11 @@
 			description="if true, the 'IRFGRP' category is enabled for the run"
 			possible_values=".true. or .false."
 		/>
-		<nml_option name="config_normalize_IRFTracers_by_layerThickness" type="logical" default_value=".false." units="unitless"
+		<nml_option name="config_IRFTracers_limit_advection" type="logical" default_value=".false." units="unitless"
+			description="if true, the IRFTracers limiter for advection is on"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_IRFTracers_normalize_by_layerThickness" type="logical" default_value=".false." units="unitless"
 			description="if true, the IRFTracers Tend variables are divided by layerThickness"
 			possible_values=".true. or .false."
 		/>

--- a/src/core_ocean/tracer_groups/Registry_debugTracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_debugTracers.xml
@@ -11,6 +11,10 @@
 					description="Integer specifying number of layers at top to reset 2 at end of each timestep. Default is 20, chosen to be near a typical mixed layer depth of 200m."
 					possible_values="Any positive integer value greater than or equal to 0."
 		/>
+		<nml_option name="config_debugTracers_limit_advection" type="logical" default_value=".false." units="unitless"
+			description="if true, the debugTracers limiter for advection is on"
+			possible_values=".true. or .false."
+		/>
 		<nml_option name="config_use_debugTracers_surface_bulk_forcing" type="logical" default_value=".false." units="unitless"
 			description="if true, surface bulk forcing from coupler is added to surfaceTracerFlux in 'debugTracers' category"
 			possible_values=".true. or .false."

--- a/src/core_ocean/tracer_groups/Registry_tracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_tracers.xml
@@ -3,4 +3,5 @@
 #include "Registry_ecosys.xml"
 #include "Registry_DMS.xml"
 #include "Registry_MacroMolecules.xml"
+#include "Registry_ImpulseResponseFunctions.xml"
 //#include "Registry_TEMPLATEGRP.xml"

--- a/src/core_ocean/tracer_groups/Registry_tracers.xml
+++ b/src/core_ocean/tracer_groups/Registry_tracers.xml
@@ -3,5 +3,5 @@
 #include "Registry_ecosys.xml"
 #include "Registry_DMS.xml"
 #include "Registry_MacroMolecules.xml"
-#include "Registry_ImpulseResponseFunctions.xml"
+#include "Registry_IRF.xml"
 //#include "Registry_TEMPLATEGRP.xml"

--- a/testing_and_setup/add_tracer3.py
+++ b/testing_and_setup/add_tracer3.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+'''
+This script creates an initial condition file for MPAS-Ocean.
+'''
+# import packages {{{
+import os
+import shutil
+import numpy as np
+import netCDF4 as nc
+from netCDF4 import Dataset
+import argparse
+# }}}
+
+
+def main():
+    # {{{
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input_file', dest='input_file',
+                        default='base_mesh.nc',
+                        help='Input file, containing base mesh'
+                        )
+    parser.add_argument('-o', '--output_file', dest='output_file',
+                        default='initial_state.nc',
+                        help='Output file, containing initial variables'
+                        )
+    parser.add_argument('-L', '--nVertLevels', dest='nVertLevels',
+                        default=3,
+                        type=int,
+                        help='Number of vertical levels'
+                        )
+    parser.add_argument('-H',
+        '--thicknessAllLayers',
+        dest='thicknessAllLayers',
+        default=1000,
+        type=float,
+        help='thickness of each layer, [m]')
+    thicknessAllLayers = parser.parse_args().thicknessAllLayers
+    nVertLevels = parser.parse_args().nVertLevels
+
+    input_file = parser.parse_args().input_file
+    output_file = parser.parse_args().output_file
+    shutil.copy2(input_file, output_file)
+    ds = Dataset(output_file, 'a', format='NETCDF3_64BIT_OFFSET')
+
+    #vertical_init(ds, thicknessAllLayers, nVertLevels)
+    tracer_init(ds, thicknessAllLayers)
+    #velocity_init(ds)
+    #coriolis_init(ds)
+    #others_init(ds)
+
+    ds.close()
+# }}}
+
+
+def vertical_init(ds, thicknessAllLayers, nVertLevels):
+    # {{{
+
+    # create new variables # {{{
+    ds.createDimension('nVertLevels', nVertLevels)
+    refLayerThickness = ds.createVariable(
+        'refLayerThickness', np.float64, ('nVertLevels',))
+    maxLevelCell = ds.createVariable('maxLevelCell', np.int32, ('nCells',))
+    refBottomDepth = ds.createVariable(
+        'refBottomDepth', np.float64, ('nVertLevels',))
+    refZMid = ds.createVariable('refZMid', np.float64, ('nVertLevels',))
+    bottomDepth = ds.createVariable('bottomDepth', np.float64, ('nCells',))
+    bottomDepthObserved = ds.createVariable(
+        'bottomDepthObserved', np.float64, ('nCells',))
+    layerThickness = ds.createVariable(
+        'layerThickness', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    restingThickness = ds.createVariable(
+        'restingThickness', np.float64, ('nCells', 'nVertLevels',))
+    vertCoordMovementWeights = ds.createVariable(
+        'vertCoordMovementWeights', np.float64, ('nVertLevels',))
+    # }}}
+    ssh = ds.createVariable(
+        'ssh', np.float64, ('Time', 'nCells',))
+
+    # evenly spaced vertical grid
+    refLayerThickness[:] = thicknessAllLayers
+    # make first layer deep to avoid z^2 derivative problems near zero.
+    refLayerThickness[0] = 1000
+
+    nVertLevels = len(ds.dimensions['nVertLevels'])
+    nCells = len(ds.dimensions['nCells'])
+    lonCell = ds.variables['lonCell']
+    latCell = ds.variables['latCell']
+
+    latCenterDeg = 0.0 # center point in degrees
+    lonCenterDeg = 180.0 # center point in degrees
+    sphere_radius = 6371220.
+    GaussianWidth = 100e3/ sphere_radius
+    
+    latCenter = np.deg2rad(latCenterDeg)
+    lonCenter = np.deg2rad(lonCenterDeg)
+
+    for iCell in range(0, nCells):
+        # Halversine formula for distance
+        d = np.sin((latCell[iCell] - latCenter)/2)**2 \
+            + np.cos(latCenter)*np.cos(latCell[iCell]) \
+            * np.sin((lonCell[iCell] - lonCenter)/2)**2
+        ssh[0, iCell] = 1.0*np.exp(-0.5*(d/GaussianWidth)**2.0)
+        layerThickness[0,iCell,:]= (thicknessAllLayers + ssh[0,iCell])/nVertLevels
+    # Create other variables from refLayerThickness
+    refBottomDepth[0] = refLayerThickness[0]
+    refZMid[0] = -0.5 * refLayerThickness[0]
+    for k in range(1, nVertLevels):
+        refBottomDepth[k] = refBottomDepth[k - 1] + refLayerThickness[k]
+        refZMid[k] = -refBottomDepth[k - 1] - 0.5 * refLayerThickness[k]
+    vertCoordMovementWeights[:] = 1.0
+
+    # flat bottom, no bathymetry
+    maxLevelCell[:] = nVertLevels
+    bottomDepth[:] = refBottomDepth[nVertLevels - 1]
+    bottomDepthObserved[:] = refBottomDepth[nVertLevels - 1]
+    for k in range(nVertLevels):
+        restingThickness[:, k] = refLayerThickness[k]
+# }}}
+
+
+def tracer_init(ds, thicknessAllLayers):
+    S0 = 35 # constant salinity in psu
+    T0 = 10 # constant temperature in C
+
+    h = thicknessAllLayers
+    # create new variables # {{{
+    #temperature = ds.createVariable(
+    #    'temperature', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    #salinity = ds.createVariable(
+    #    'salinity', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    #tracer1 = ds.createVariable(
+    #    'tracer1', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    #tracer2 = ds.createVariable(
+    #    'tracer2', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    tracer3 = ds.createVariable(
+        'tracer3', np.float64, ('Time', 'nCells', 'nVertLevels',))
+    # }}}
+
+    # obtain dimensions and mesh variables # {{{
+    nVertLevels = len(ds.dimensions['nVertLevels'])
+    nCells = len(ds.dimensions['nCells'])
+    lonCell = ds.variables['lonCell']
+    latCell = ds.variables['latCell']
+    # For periodic domains, the max cell coordinate is also the domain width
+    Lx = max(lonCell)
+    Ly = max(latCell)
+    refZMid = ds.variables['refZMid']
+    refBottomDepth = ds.variables['refBottomDepth']
+    H = max(refBottomDepth)
+    # }}}
+
+    for iCell in range(0, nCells):
+        x = lonCell[iCell]
+        y = latCell[iCell]
+        for k in range(0, nVertLevels):
+            z = refZMid[k]
+
+            #salinity[0, iCell, k] = S0
+            #temperature[0,iCell,k] = T0
+            #tracer1[0,iCell,k] = 0.0
+            #tracer2[0,iCell,k] = 0.0
+            tracer3[0,iCell,k] = np.sin(6*x)*np.cos(4*y)*np.sin(2*z/H*2.0*np.pi)
+    #salinity = S0
+    #temperature = T0
+    #tracer1 = 0.0
+    #tracer2 = 0.0
+
+def velocity_init(ds):
+    # {{{
+    normalVelocity = ds.createVariable(
+        'normalVelocity', np.float64, ('Time', 'nEdges', 'nVertLevels',))
+    normalVelocity[:] = 0.0
+# }}}
+
+
+def coriolis_init(ds):
+    # {{{
+    fEdge = ds.createVariable('fEdge', np.float64, ('nEdges',))
+    fEdge[:] = 0.0
+    fVertex = ds.createVariable('fVertex', np.float64, ('nVertices',))
+    fVertex[:] = 0.0
+    fCell = ds.createVariable('fCell', np.float64, ('nCells',))
+    fCell[:] = 0.0
+# }}}
+
+
+def others_init(ds):
+    # {{{
+    surfaceStress = ds.createVariable(
+        'surfaceStress', np.float64, ('Time', 'nEdges',))
+    surfaceStress[:] = 0.0
+    atmosphericPressure = ds.createVariable(
+        'atmosphericPressure', np.float64, ('Time', 'nCells',))
+    atmosphericPressure[:] = 0.0
+    boundaryLayerDepth = ds.createVariable(
+        'boundaryLayerDepth', np.float64, ('Time', 'nCells',))
+    boundaryLayerDepth[:] = 0.0
+
+
+    # obtain dimensions and mesh variables # {{{
+    nVertLevels = len(ds.dimensions['nVertLevels'])
+    nCells = len(ds.dimensions['nCells'])
+    lonCell = ds.variables['lonCell']
+    latCell = ds.variables['latCell']
+    # For periodic domains, the max cell coordinate is also the domain width
+    Lx = max(lonCell)
+    Ly = max(latCell)
+    refZMid = ds.variables['refZMid']
+    refBottomDepth = ds.variables['refBottomDepth']
+    H = max(refBottomDepth)
+
+# }}}
+
+
+if __name__ == '__main__':
+    # If called as a primary module, run main
+    main()
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/testing_and_setup/namelist.ocean
+++ b/testing_and_setup/namelist.ocean
@@ -1,0 +1,880 @@
+&run_modes
+    config_ocean_run_mode = 'forward'
+/
+&time_management
+    config_do_restart = .false.
+    config_restart_timestamp_name = 'Restart_timestamp'
+    config_start_time = '0001-01-01_00:00:00'
+    config_stop_time = 'none'
+    config_run_duration = '00-00-02_00:00:00'
+    config_calendar_type = 'gregorian_noleap'
+/
+&io
+    config_write_output_on_startup = .false.
+    config_pio_num_iotasks = 0
+    config_pio_stride = 1
+/
+&decomposition
+    config_num_halos = 3
+    config_block_decomp_file_prefix = 'graph.info.part.'
+    config_number_of_blocks = 0
+    config_explicit_proc_decomp = .false.
+    config_proc_decomp_file_prefix = 'graph.info.part.'
+/
+&time_integration
+    config_dt = '02:00:00'
+    config_time_integrator = 'split_explicit'
+/
+&hmix
+    config_hmix_scaleWithMesh = .true.
+    config_maxMeshDensity = -1.0
+    config_hmix_use_ref_cell_width = .false.
+    config_hmix_ref_cell_width = 30.0e3
+    config_apvm_scale_factor = 0.0
+/
+&hmix_del2
+    config_use_mom_del2 = .true.
+    config_mom_del2 = 1000.0
+    config_use_tracer_del2 = .false.
+    config_tracer_del2 = 10.0
+/
+&hmix_del4
+    config_use_mom_del4 = .true.
+    config_mom_del4 = 1.2e11
+    config_mom_del4_div_factor = 1.0
+    config_use_tracer_del4 = .false.
+    config_tracer_del4 = 0.0
+/
+&hmix_Leith
+    config_use_Leith_del2 = .false.
+    config_Leith_parameter = 1.0
+    config_Leith_dx = 15000.0
+    config_Leith_visc2_max = 2.5e3
+/
+&mesoscale_eddy_parameterizations
+    config_eddying_resolution_taper = 'ramp'
+    config_eddying_resolution_ramp_min = 20e3
+    config_eddying_resolution_ramp_max = 30e3
+/
+&Redi_isopycnal_mixing
+    config_use_Redi = .true.
+    config_Redi_closure = 'constant'
+    config_Redi_constant_kappa = 600.0
+    config_Redi_maximum_slope = 0.3
+    config_Redi_use_slope_taper = .true.
+    config_Redi_use_surface_taper = .true.
+    config_Redi_N2_based_taper_enable = .true.
+    config_Redi_N2_based_taper_min = 0.1
+    config_Redi_N2_based_taper_limit_term1 = .true.
+/
+&GM_eddy_parameterization
+    config_use_GM = .true.
+    config_GM_closure = 'EdenGreatbatch'
+    config_GM_constant_kappa = 600.0
+    config_GM_constant_gravWaveSpeed = 0.3
+    config_GM_spatially_variable_min_kappa = 300.0
+    config_GM_spatially_variable_max_kappa = 1800.0
+    config_GM_spatially_variable_baroclinic_mode = 1.0
+    config_GM_Visbeck_alpha = 0.005
+    config_GM_Visbeck_max_depth = 1000.0
+    config_GM_EG_riMin = 200.0
+    config_GM_EG_kappa_factor = 3.0
+    config_GM_EG_Rossby_factor = 2.0
+    config_GM_EG_Rhines_factor = 0.3
+/
+&Rayleigh_damping
+    config_Rayleigh_friction = .true.
+    config_Rayleigh_damping_coeff = 1.0e-4
+    config_Rayleigh_damping_depth_variable = .false.
+    config_Rayleigh_bottom_friction = .false.
+    config_Rayleigh_bottom_damping_coeff = 1.0e-4
+/
+&cvmix
+    config_use_cvmix = .true.
+    config_cvmix_prandtl_number = 1.0
+    config_cvmix_background_scheme = 'constant'
+    config_cvmix_background_diffusion = 1.0e-5
+    config_cvmix_background_viscosity = 1.0e-4
+    config_cvmix_BryanLewis_bl1 = 8.0e-5
+    config_cvmix_BryanLewis_bl2 = 1.05E-4
+    config_cvmix_BryanLewis_transitionDepth = 2500
+    config_cvmix_BryanLewis_transitionWidth = 222.
+    config_use_cvmix_convection = .true.
+    config_cvmix_convective_diffusion = 1.0
+    config_cvmix_convective_viscosity = 1.0
+    config_cvmix_convective_basedOnBVF = .true.
+    config_cvmix_convective_triggerBVF = 0.0
+    config_use_cvmix_shear = .true.
+    config_cvmix_num_ri_smooth_loops = 2
+    config_cvmix_use_BLD_smoothing = .true.
+    config_cvmix_shear_mixing_scheme = 'KPP'
+    config_cvmix_shear_PP_nu_zero = 0.005
+    config_cvmix_shear_PP_alpha = 5.0
+    config_cvmix_shear_PP_exp = 2.0
+    config_cvmix_shear_KPP_nu_zero = 0.005
+    config_cvmix_shear_KPP_Ri_zero = 0.7
+    config_cvmix_shear_KPP_exp = 3
+    config_use_cvmix_tidal_mixing = .false.
+    config_use_cvmix_double_diffusion = .false.
+    config_use_cvmix_kpp = .true.
+    config_use_cvmix_fixed_boundary_layer = .false.
+    config_cvmix_kpp_boundary_layer_depth = 30.0
+    config_cvmix_kpp_criticalBulkRichardsonNumber = 0.25
+    config_cvmix_kpp_matching = 'SimpleShapes'
+    config_cvmix_kpp_EkmanOBL = .false.
+    config_cvmix_kpp_MonObOBL = .false.
+    config_cvmix_kpp_interpolationOMLType = 'quadratic'
+    config_cvmix_kpp_surface_layer_extent = 0.1
+    config_cvmix_kpp_surface_layer_averaging = 5.0
+    configure_cvmix_kpp_minimum_OBL_under_sea_ice = 10.0
+    config_cvmix_kpp_stop_OBL_search = 100.0
+    config_cvmix_kpp_use_enhanced_diff = .true.
+    config_cvmix_kpp_nonlocal_with_implicit_mix = .false.
+    config_cvmix_kpp_use_theory_wave = .false.
+    config_cvmix_kpp_langmuir_mixing_opt = 'NONE'
+    config_cvmix_kpp_langmuir_entrainment_opt = 'NONE'
+/
+&forcing
+    config_use_variable_drag = .false.
+    config_use_bulk_wind_stress = .true.
+    config_use_bulk_thickness_flux = .true.
+    config_flux_attenuation_coefficient = 0.001
+    config_flux_attenuation_coefficient_runoff = 0.001
+/
+&time_varying_forcing
+    config_use_time_varying_atmospheric_forcing = .false.
+    config_time_varying_atmospheric_forcing_type = 'WINDPRES'
+    config_time_varying_atmospheric_forcing_start_time = '0001-01-01_00:00:00'
+    config_time_varying_atmospheric_forcing_reference_time = '0001-01-01_00:00:00'
+    config_time_varying_atmospheric_forcing_cycle_start = '0001-01-01_00:00:00'
+    config_time_varying_atmospheric_forcing_cycle_duration = '2-00-00_00:00:00'
+    config_time_varying_atmospheric_forcing_interval = '01:00:00'
+    config_time_varying_atmospheric_forcing_ramp = 10.0
+    config_time_varying_atmospheric_forcing_ramp_delay = 0.0
+    config_use_time_varying_land_ice_forcing = .false.
+    config_time_varying_land_ice_forcing_start_time = '0001-01-01_00:00:00'
+    config_time_varying_land_ice_forcing_reference_time = '0001-01-01_00:00:00'
+    config_time_varying_land_ice_forcing_cycle_start = '0001-01-01_00:00:00'
+    config_time_varying_land_ice_forcing_cycle_duration = '2-00-00_00:00:00'
+    config_time_varying_land_ice_forcing_interval = '01:00:00'
+/
+&coupling
+    config_ssh_grad_relax_timescale = 0.0
+    config_remove_AIS_coupler_runoff = .false.
+/
+&shortwaveRadiation
+    config_sw_absorption_type = 'none'
+    config_jerlov_water_type = 3
+    config_surface_buoyancy_depth = 1
+    config_enable_shortwave_energy_fixer = .false.
+/
+&tidal_forcing
+    config_use_tidal_forcing = .false.
+    config_use_tidal_forcing_tau = 10000
+    config_tidal_forcing_type = 'off'
+    config_tidal_forcing_model = 'off'
+    config_tidal_forcing_monochromatic_amp = 2.0
+    config_tidal_forcing_monochromatic_period = 0.5
+    config_tidal_forcing_monochromatic_phaseLag = 0.0
+    config_tidal_forcing_monochromatic_baseline = 0.0
+/
+&tidal_potential_forcing
+    config_use_tidal_potential_forcing = .false.
+    config_tidal_potential_reference_time = '0001-01-01_00:00:00'
+    config_use_tidal_potential_forcing_M2 = .true.
+    config_use_tidal_potential_forcing_S2 = .true.
+    config_use_tidal_potential_forcing_N2 = .true.
+    config_use_tidal_potential_forcing_K2 = .true.
+    config_use_tidal_potential_forcing_K1 = .true.
+    config_use_tidal_potential_forcing_O1 = .true.
+    config_use_tidal_potential_forcing_Q1 = .true.
+    config_use_tidal_potential_forcing_P1 = .true.
+    config_tidal_potential_ramp = 10.0
+    config_self_attraction_and_loading_beta = 0.09
+/
+&vegetation_drag
+    config_use_vegetation_drag = .false.
+    config_use_vegetation_manning_equation = .false.
+    config_vegetation_drag_coefficient = 1.09
+/
+&frazil_ice
+    config_use_frazil_ice_formation = .false.
+    config_frazil_in_open_ocean = .true.
+    config_frazil_under_land_ice = .true.
+    config_frazil_heat_of_fusion = 3.34e5
+    config_frazil_ice_density = 1000.0
+    config_frazil_fractional_thickness_limit = 0.1
+    config_specific_heat_sea_water = 3985.0
+    config_frazil_maximum_depth = 100.0
+    config_frazil_sea_ice_reference_salinity = 4.0
+    config_frazil_land_ice_reference_salinity = 0.0
+    config_frazil_maximum_freezing_temperature = 0.0
+    config_frazil_use_surface_pressure = .true.
+/
+&land_ice_fluxes
+    config_land_ice_flux_mode = 'off'
+    config_land_ice_flux_formulation = 'Jenkins'
+    config_land_ice_flux_useHollandJenkinsAdvDiff = .false.
+    config_land_ice_flux_attenuation_coefficient = 10.0
+    config_land_ice_flux_boundaryLayerThickness = 10.0
+    config_land_ice_flux_boundaryLayerNeighborWeight = 0.0
+    config_land_ice_flux_cp_ice = 2.009e3
+    config_land_ice_flux_rho_ice = 918
+    config_land_ice_flux_topDragCoeff = 2.5e-3
+    config_land_ice_flux_ISOMIP_gammaT = 1e-4
+    config_land_ice_flux_rms_tidal_velocity = 5e-2
+    config_land_ice_flux_jenkins_heat_transfer_coefficient = 0.011
+    config_land_ice_flux_jenkins_salt_transfer_coefficient = 3.1e-4
+/
+&advection
+    config_vert_tracer_adv = 'stencil'
+    config_vert_tracer_adv_order = 3
+    config_horiz_tracer_adv_order = 3
+    config_coef_3rd_order = 0.25
+    config_monotonic = .true.
+/
+&bottom_drag
+    config_use_implicit_bottom_drag = .true.
+    config_implicit_bottom_drag_coeff = 1.0e-3
+    config_use_implicit_bottom_drag_variable = .false.
+    config_use_implicit_bottom_drag_variable_mannings = .false.
+    config_use_explicit_bottom_drag = .false.
+    config_explicit_bottom_drag_coeff = 1.0e-3
+/
+&wetting_drying
+    config_use_wetting_drying = .false.
+    config_prevent_drying = .false.
+    config_drying_min_cell_height = 1.0e-3
+    config_zero_drying_velocity = .false.
+    config_verify_not_dry = .false.
+    config_thickness_flux_type = 'centered'
+    config_drying_safety_height = 1.0e-10
+/
+&ocean_constants
+    config_density0 = 1026.0
+/
+&pressure_gradient
+    config_pressure_gradient_type = 'Jacobian_from_TS'
+    config_common_level_weight = 0.5
+/
+&eos
+    config_eos_type = 'jm'
+    config_open_ocean_freezing_temperature_coeff_0 = 0.0
+    config_open_ocean_freezing_temperature_coeff_S = 0.0
+    config_open_ocean_freezing_temperature_coeff_p = 0.0
+    config_open_ocean_freezing_temperature_coeff_pS = 0.0
+    config_open_ocean_freezing_temperature_coeff_mushy_az1_liq = -18.48
+    config_land_ice_cavity_freezing_temperature_coeff_0 = 6.22e-2
+    config_land_ice_cavity_freezing_temperature_coeff_S = -5.63e-2
+    config_land_ice_cavity_freezing_temperature_coeff_p = -7.43e-8
+    config_land_ice_cavity_freezing_temperature_coeff_pS = -1.74e-10
+/
+&eos_linear
+    config_eos_linear_alpha = 0.2
+    config_eos_linear_beta = 0.8
+    config_eos_linear_Tref = 5.0
+    config_eos_linear_Sref = 35.0
+    config_eos_linear_densityref = 1000.0
+/
+&eos_wright
+    config_eos_wright_ref_pressure = 0.0
+/
+&split_timestep_share
+    config_n_ts_iter = 2
+    config_n_bcl_iter_beg = 1
+    config_n_bcl_iter_mid = 2
+    config_n_bcl_iter_end = 2
+/
+&split_explicit_ts
+    config_btr_dt = '00:06:00'
+    config_n_btr_cor_iter = 2
+    config_vel_correction = .true.
+    config_btr_subcycle_loop_factor = 2
+    config_btr_gam1_velWt1 = 0.5
+    config_btr_gam2_SSHWt1 = 1.0
+    config_btr_gam3_velWt2 = 1.0
+    config_btr_solve_SSH2 = .false.
+/
+&semi_implicit_ts
+    config_btr_si_preconditioner = 'ras'
+    config_btr_si_tolerance = 1.0e-9
+    config_n_btr_si_outer_iter = 2
+    config_btr_si_partition_match_mode = .false.
+/
+&ALE_vertical_grid
+    config_vert_coord_movement = 'uniform_stretching'
+    config_ALE_thickness_proportionality = 'restingThickness_times_weights'
+    config_vert_taper_weight_depth_1 = 250.0
+    config_vert_taper_weight_depth_2 = 500.0
+    config_use_min_max_thickness = .false.
+    config_min_thickness = 1.0
+    config_max_thickness_factor = 6.0
+    config_dzdk_positive = .false.
+/
+&ALE_frequency_filtered_thickness
+    config_use_freq_filtered_thickness = .false.
+    config_thickness_filter_timescale = 5.0
+    config_use_highFreqThick_restore = .false.
+    config_highFreqThick_restore_time = 30.0
+    config_use_highFreqThick_del2 = .false.
+    config_highFreqThick_del2 = 100.0
+/
+&debug
+    config_check_zlevel_consistency = .false.
+    config_check_ssh_consistency = .true.
+    config_filter_btr_mode = .false.
+    config_prescribe_velocity = .false.
+    config_prescribe_thickness = .false.
+    config_include_KE_vertex = .false.
+    config_check_tracer_monotonicity = .false.
+    config_compute_active_tracer_budgets = .true.
+    config_disable_thick_all_tend = .false.
+    config_disable_thick_hadv = .false.
+    config_disable_thick_vadv = .false.
+    config_disable_thick_sflux = .false.
+    config_disable_vel_all_tend = .false.
+    config_disable_vel_coriolis = .false.
+    config_disable_vel_pgrad = .false.
+    config_disable_vel_hmix = .false.
+    config_disable_vel_surface_stress = .false.
+    config_disable_vel_explicit_bottom_drag = .false.
+    config_disable_vel_vmix = .false.
+    config_disable_vel_vadv = .false.
+    config_disable_tr_all_tend = .false.
+    config_disable_tr_adv = .false.
+    config_disable_tr_hmix = .false.
+    config_disable_tr_vmix = .false.
+    config_disable_tr_sflux = .false.
+    config_disable_tr_nonlocalflux = .false.
+    config_disable_redi_k33 = .false.
+    config_read_nearest_restart = .false.
+/
+&testing
+    config_conduct_tests = .false.
+    config_test_tensors = .false.
+    config_tensor_test_function = 'sph_uCosCos'
+/
+&init_mode_vert_levels
+    config_vert_levels = -1
+/
+&tracer_forcing_activeTracers
+    config_use_activeTracers = .true.
+    config_use_activeTracers_surface_bulk_forcing = .false.
+    config_use_activeTracers_surface_restoring = .false.
+    config_use_activeTracers_interior_restoring = .false.
+    config_use_activeTracers_exponential_decay = .false.
+    config_use_activeTracers_idealAge_forcing = .false.
+    config_use_activeTracers_ttd_forcing = .false.
+    config_use_surface_salinity_monthly_restoring = .false.
+    config_surface_salinity_monthly_restoring_compute_interval = '0000-00-01_00:00:00'
+    config_salinity_restoring_constant_piston_velocity = 1.585e-5
+    config_salinity_restoring_max_difference = 100.0
+    config_salinity_restoring_under_sea_ice = .false.
+/
+&tracer_forcing_debugTracers
+    config_use_debugTracers = .true.
+    config_reset_debugTracers_near_surface = .false.
+    config_reset_debugTracers_top_nLayers = 20
+    config_debugTracers_limit_advection = .false.
+    config_use_debugTracers_surface_bulk_forcing = .false.
+    config_use_debugTracers_surface_restoring = .false.
+    config_use_debugTracers_interior_restoring = .false.
+    config_use_debugTracers_exponential_decay = .false.
+    config_use_debugTracers_idealAge_forcing = .false.
+    config_use_debugTracers_ttd_forcing = .false.
+/
+&tracer_forcing_ecosysTracers
+    config_use_ecosysTracers = .false.
+    config_ecosys_atm_co2_option = 'none'
+    config_ecosys_atm_alt_co2_option = 'none'
+    config_ecosys_atm_alt_co2_use_eco = .true.
+    config_ecosys_atm_co2_constant_value = 379.0
+    config_use_ecosysTracers_surface_bulk_forcing = .false.
+    config_use_ecosysTracers_surface_restoring = .false.
+    config_use_ecosysTracers_interior_restoring = .false.
+    config_use_ecosysTracers_exponential_decay = .false.
+    config_use_ecosysTracers_idealAge_forcing = .false.
+    config_use_ecosysTracers_ttd_forcing = .false.
+    config_use_ecosysTracers_surface_value = .false.
+    config_use_ecosysTracers_sea_ice_coupling = .false.
+    config_ecosysTracers_diagnostic_fields_level1 = .false.
+    config_ecosysTracers_diagnostic_fields_level2 = .false.
+    config_ecosysTracers_diagnostic_fields_level3 = .false.
+    config_ecosysTracers_diagnostic_fields_level4 = .false.
+    config_ecosysTracers_diagnostic_fields_level5 = .false.
+/
+&tracer_forcing_DMSTracers
+    config_use_DMSTracers = .false.
+    config_use_DMSTracers_surface_bulk_forcing = .false.
+    config_use_DMSTracers_surface_restoring = .false.
+    config_use_DMSTracers_interior_restoring = .false.
+    config_use_DMSTracers_exponential_decay = .false.
+    config_use_DMSTracers_idealAge_forcing = .false.
+    config_use_DMSTracers_ttd_forcing = .false.
+    config_use_DMSTracers_surface_value = .false.
+    config_use_DMSTracers_sea_ice_coupling = .false.
+/
+&tracer_forcing_MacroMoleculesTracers
+    config_use_MacroMoleculesTracers = .false.
+    config_use_MacroMoleculesTracers_surface_bulk_forcing = .false.
+    config_use_MacroMoleculesTracers_surface_restoring = .false.
+    config_use_MacroMoleculesTracers_interior_restoring = .false.
+    config_use_MacroMoleculesTracers_exponential_decay = .false.
+    config_use_MacroMoleculesTracers_idealAge_forcing = .false.
+    config_use_MacroMoleculesTracers_ttd_forcing = .false.
+    config_use_MacroMoleculesTracers_surface_value = .false.
+    config_use_MacroMoleculesTracers_sea_ice_coupling = .false.
+/
+&tracer_forcing_IRFTracers
+    config_use_IRFTracers = .true.
+    config_IRFTracers_limit_advection = .false.
+    config_IRFTracers_normalize_by_layerThickness = .true.
+    config_use_IRFTracers_surface_bulk_forcing = .false.
+    config_use_IRFTracers_surface_restoring = .false.
+    config_use_IRFTracers_interior_restoring = .false.
+    config_use_IRFTracers_exponential_decay = .false.
+    config_use_IRFTracers_idealAge_forcing = .false.
+    config_use_IRFTracers_ttd_forcing = .false.
+    config_use_IRFTracers_surface_value = .false.
+    config_use_IRFTracers_sea_ice_coupling = .false.
+/
+&AM_globalStats
+    config_AM_globalStats_enable = .true.
+    config_AM_globalStats_compute_interval = 'output_interval'
+    config_AM_globalStats_compute_on_startup = .true.
+    config_AM_globalStats_write_on_startup = .true.
+    config_AM_globalStats_text_file = .true.
+    config_AM_globalStats_directory = 'analysis_members'
+    config_AM_globalStats_output_stream = 'globalStatsOutput'
+/
+&AM_surfaceAreaWeightedAverages
+    config_AM_surfaceAreaWeightedAverages_enable = .false.
+    config_AM_surfaceAreaWeightedAverages_compute_on_startup = .true.
+    config_AM_surfaceAreaWeightedAverages_write_on_startup = .true.
+    config_AM_surfaceAreaWeightedAverages_compute_interval = 'output_interval'
+    config_AM_surfaceAreaWeightedAverages_output_stream = 'surfaceAreaWeightedAveragesOutput'
+/
+&AM_waterMassCensus
+    config_AM_waterMassCensus_enable = .false.
+    config_AM_waterMassCensus_compute_interval = 'output_interval'
+    config_AM_waterMassCensus_output_stream = 'waterMassCensusOutput'
+    config_AM_waterMassCensus_compute_on_startup = .false.
+    config_AM_waterMassCensus_write_on_startup = .false.
+    config_AM_waterMassCensus_minTemperature = -2.0
+    config_AM_waterMassCensus_maxTemperature = 30.0
+    config_AM_waterMassCensus_minSalinity = 32.0
+    config_AM_waterMassCensus_maxSalinity = 37.0
+    config_AM_waterMassCensus_compute_predefined_regions = .true.
+    config_AM_waterMassCensus_region_group = ''
+/
+&AM_layerVolumeWeightedAverage
+    config_AM_layerVolumeWeightedAverage_enable = .false.
+    config_AM_layerVolumeWeightedAverage_compute_interval = 'output_interval'
+    config_AM_layerVolumeWeightedAverage_compute_on_startup = .false.
+    config_AM_layerVolumeWeightedAverage_write_on_startup = .false.
+    config_AM_layerVolumeWeightedAverage_output_stream = 'layerVolumeWeightedAverageOutput'
+/
+&AM_zonalMean
+    config_AM_zonalMean_enable = .false.
+    config_AM_zonalMean_compute_on_startup = .true.
+    config_AM_zonalMean_write_on_startup = .true.
+    config_AM_zonalMean_compute_interval = 'output_interval'
+    config_AM_zonalMean_output_stream = 'zonalMeanOutput'
+    config_AM_zonalMean_num_bins = 180
+    config_AM_zonalMean_min_bin = -1.0e34
+    config_AM_zonalMean_max_bin = -1.0e34
+/
+&AM_okuboWeiss
+    config_AM_okuboWeiss_enable = .false.
+    config_AM_okuboWeiss_compute_on_startup = .true.
+    config_AM_okuboWeiss_write_on_startup = .true.
+    config_AM_okuboWeiss_compute_interval = 'output_interval'
+    config_AM_okuboWeiss_output_stream = 'okuboWeissOutput'
+    config_AM_okuboWeiss_directory = 'analysis_members'
+    config_AM_okuboWeiss_threshold_value = -0.2
+    config_AM_okuboWeiss_normalization = 1e-10
+    config_AM_okuboWeiss_lambda2_normalization = 1e-10
+    config_AM_okuboWeiss_use_lat_lon_coords = .true.
+    config_AM_okuboWeiss_compute_eddy_census = .true.
+    config_AM_okuboWeiss_eddy_min_cells = 20
+/
+&AM_meridionalHeatTransport
+    config_AM_meridionalHeatTransport_enable = .false.
+    config_AM_meridionalHeatTransport_compute_interval = 'output_interval'
+    config_AM_meridionalHeatTransport_compute_on_startup = .true.
+    config_AM_meridionalHeatTransport_write_on_startup = .true.
+    config_AM_meridionalHeatTransport_output_stream = 'meridionalHeatTransportOutput'
+    config_AM_meridionalHeatTransport_num_bins = 180
+    config_AM_meridionalHeatTransport_min_bin = -1.0e34
+    config_AM_meridionalHeatTransport_max_bin = -1.0e34
+    config_AM_meridionalHeatTransport_region_group = ''
+/
+&AM_testComputeInterval
+    config_AM_testComputeInterval_enable = .false.
+    config_AM_testComputeInterval_compute_interval = '00-00-01_00:00:00'
+    config_AM_testComputeInterval_compute_on_startup = .true.
+    config_AM_testComputeInterval_write_on_startup = .true.
+    config_AM_testComputeInterval_output_stream = 'testComputeIntervalOutput'
+/
+&AM_highFrequencyOutput
+    config_AM_highFrequencyOutput_enable = .false.
+    config_AM_highFrequencyOutput_compute_interval = 'output_interval'
+    config_AM_highFrequencyOutput_output_stream = 'highFrequencyOutput'
+    config_AM_highFrequencyOutput_compute_on_startup = .true.
+    config_AM_highFrequencyOutput_write_on_startup = .true.
+/
+&AM_timeFilters
+    config_AM_timeFilters_enable = .false.
+    config_AM_timeFilters_compute_interval = 'dt'
+    config_AM_timeFilters_output_stream = 'timeFiltersOutput'
+    config_AM_timeFilters_restart_stream = 'timeFiltersRestart'
+    config_AM_timeFilters_compute_on_startup = .true.
+    config_AM_timeFilters_write_on_startup = .true.
+    config_AM_timeFilters_initialize_filters = .true.
+    config_AM_timeFilters_tau = '90_00:00:00'
+    config_AM_timeFilters_compute_cell_centered_values = .true.
+/
+&AM_lagrPartTrack
+    config_AM_lagrPartTrack_enable = .false.
+    config_AM_lagrPartTrack_compute_interval = 'dt'
+    config_AM_lagrPartTrack_compute_on_startup = .false.
+    config_AM_lagrPartTrack_output_stream = 'lagrPartTrackOutput'
+    config_AM_lagrPartTrack_restart_stream = 'lagrPartTrackRestart'
+    config_AM_lagrPartTrack_input_stream = 'lagrPartTrackInput'
+    config_AM_lagrPartTrack_write_on_startup = .true.
+    config_AM_lagrPartTrack_filter_number = 0
+    config_AM_lagrPartTrack_timeIntegration = 2
+    config_AM_lagrPartTrack_reset_criteria = 'none'
+    config_AM_lagrPartTrack_reset_global_timestamp = '0000_00:00:00'
+    config_AM_lagrPartTrack_region_stream = 'lagrPartTrackRegions'
+    config_AM_lagrPartTrack_reset_if_outside_region = .false.
+    config_AM_lagrPartTrack_reset_if_inside_region = .false.
+    config_AM_lagrPartTrack_sample_horizontal_interp = .true.
+    config_AM_lagrPartTrack_sample_temperature = .true.
+    config_AM_lagrPartTrack_sample_salinity = .true.
+    config_AM_lagrPartTrack_sample_DIC = .false.
+    config_AM_lagrPartTrack_sample_ALK = .false.
+    config_AM_lagrPartTrack_sample_PO4 = .false.
+    config_AM_lagrPartTrack_sample_NO3 = .false.
+    config_AM_lagrPartTrack_sample_SiO3 = .false.
+    config_AM_lagrPartTrack_sample_NH4 = .false.
+    config_AM_lagrPartTrack_sample_Fe = .false.
+    config_AM_lagrPartTrack_sample_O2 = .false.
+/
+&AM_eliassenPalm
+    config_AM_eliassenPalm_enable = .false.
+    config_AM_eliassenPalm_compute_interval = 'output_interval'
+    config_AM_eliassenPalm_output_stream = 'eliassenPalmOutput'
+    config_AM_eliassenPalm_restart_stream = 'eliassenPalmRestart'
+    config_AM_eliassenPalm_compute_on_startup = .true.
+    config_AM_eliassenPalm_write_on_startup = .true.
+    config_AM_eliassenPalm_debug = .false.
+    config_AM_eliassenPalm_nBuoyancyLayers = 45
+    config_AM_eliassenPalm_rhomin_buoycoor = 900
+    config_AM_eliassenPalm_rhomax_buoycoor = 1080
+/
+&AM_mixedLayerDepths
+    config_AM_mixedLayerDepths_enable = .true.
+    config_AM_mixedLayerDepths_compute_interval = 'dt'
+    config_AM_mixedLayerDepths_output_stream = 'mixedLayerDepthsOutput'
+    config_AM_mixedLayerDepths_write_on_startup = .true.
+    config_AM_mixedLayerDepths_compute_on_startup = .true.
+    config_AM_mixedLayerDepths_Tthreshold = .true.
+    config_AM_mixedLayerDepths_Dthreshold = .true.
+    config_AM_mixedLayerDepths_crit_temp_threshold = 0.2
+    config_AM_mixedLayerDepths_crit_dens_threshold = 0.03
+    config_AM_mixedLayerDepths_reference_pressure = 1.0E5
+    config_AM_mixedLayerDepths_Tgradient = .false.
+    config_AM_mixedLayerDepths_Dgradient = .false.
+    config_AM_mixedLayerDepths_temp_gradient_threshold = 5E-7
+    config_AM_mixedLayerDepths_den_gradient_threshold = 5E-8
+    config_AM_mixedLayerDepths_interp_method = 1
+/
+&AM_regionalStatsDaily
+    config_AM_regionalStatsDaily_enable = .false.
+    config_AM_regionalStatsDaily_compute_on_startup = .false.
+    config_AM_regionalStatsDaily_write_on_startup = .false.
+    config_AM_regionalStatsDaily_compute_interval = 'output_interval'
+    config_AM_regionalStatsDaily_output_stream = 'regionalStatsDailyOutput'
+    config_AM_regionalStatsDaily_restart_stream = 'regionalMasksInput'
+    config_AM_regionalStatsDaily_input_stream = 'regionalMasksInput'
+    config_AM_regionalStatsDaily_operation = 'avg'
+    config_AM_regionalStatsDaily_region_type = 'cell'
+    config_AM_regionalStatsDaily_region_group = 'all'
+    config_AM_regionalStatsDaily_1d_weighting_function = 'mul'
+    config_AM_regionalStatsDaily_2d_weighting_function = 'mul'
+    config_AM_regionalStatsDaily_1d_weighting_field = 'areaCell'
+    config_AM_regionalStatsDaily_2d_weighting_field = 'volumeCell'
+    config_AM_regionalStatsDaily_vertical_mask = 'cellMask'
+    config_AM_regionalStatsDaily_vertical_dimension = 'nVertLevels'
+/
+&AM_regionalStatsWeekly
+    config_AM_regionalStatsWeekly_enable = .false.
+    config_AM_regionalStatsWeekly_compute_on_startup = .false.
+    config_AM_regionalStatsWeekly_write_on_startup = .false.
+    config_AM_regionalStatsWeekly_compute_interval = 'output_interval'
+    config_AM_regionalStatsWeekly_output_stream = 'regionalStatsWeeklyOutput'
+    config_AM_regionalStatsWeekly_restart_stream = 'regionalMasksInput'
+    config_AM_regionalStatsWeekly_input_stream = 'regionalMasksInput'
+    config_AM_regionalStatsWeekly_operation = 'avg'
+    config_AM_regionalStatsWeekly_region_type = 'cell'
+    config_AM_regionalStatsWeekly_region_group = 'all'
+    config_AM_regionalStatsWeekly_1d_weighting_function = 'mul'
+    config_AM_regionalStatsWeekly_2d_weighting_function = 'mul'
+    config_AM_regionalStatsWeekly_1d_weighting_field = 'areaCell'
+    config_AM_regionalStatsWeekly_2d_weighting_field = 'volumeCell'
+    config_AM_regionalStatsWeekly_vertical_mask = 'cellMask'
+    config_AM_regionalStatsWeekly_vertical_dimension = 'nVertLevels'
+/
+&AM_regionalStatsMonthly
+    config_AM_regionalStatsMonthly_enable = .false.
+    config_AM_regionalStatsMonthly_compute_on_startup = .false.
+    config_AM_regionalStatsMonthly_write_on_startup = .false.
+    config_AM_regionalStatsMonthly_compute_interval = 'output_interval'
+    config_AM_regionalStatsMonthly_output_stream = 'regionalStatsMonthlyOutput'
+    config_AM_regionalStatsMonthly_restart_stream = 'regionalMasksInput'
+    config_AM_regionalStatsMonthly_input_stream = 'regionalMasksInput'
+    config_AM_regionalStatsMonthly_operation = 'avg'
+    config_AM_regionalStatsMonthly_region_type = 'cell'
+    config_AM_regionalStatsMonthly_region_group = 'all'
+    config_AM_regionalStatsMonthly_1d_weighting_function = 'mul'
+    config_AM_regionalStatsMonthly_2d_weighting_function = 'mul'
+    config_AM_regionalStatsMonthly_1d_weighting_field = 'areaCell'
+    config_AM_regionalStatsMonthly_2d_weighting_field = 'volumeCell'
+    config_AM_regionalStatsMonthly_vertical_mask = 'cellMask'
+    config_AM_regionalStatsMonthly_vertical_dimension = 'nVertLevels'
+/
+&AM_regionalStatsCustom
+    config_AM_regionalStatsCustom_enable = .false.
+    config_AM_regionalStatsCustom_compute_on_startup = .false.
+    config_AM_regionalStatsCustom_write_on_startup = .false.
+    config_AM_regionalStatsCustom_compute_interval = 'output_interval'
+    config_AM_regionalStatsCustom_output_stream = 'regionalStatsCustomOutput'
+    config_AM_regionalStatsCustom_restart_stream = 'regionalMasksInput'
+    config_AM_regionalStatsCustom_input_stream = 'regionalMasksInput'
+    config_AM_regionalStatsCustom_operation = 'avg'
+    config_AM_regionalStatsCustom_region_type = 'cell'
+    config_AM_regionalStatsCustom_region_group = 'all'
+    config_AM_regionalStatsCustom_1d_weighting_function = 'mul'
+    config_AM_regionalStatsCustom_2d_weighting_function = 'mul'
+    config_AM_regionalStatsCustom_1d_weighting_field = 'areaCell'
+    config_AM_regionalStatsCustom_2d_weighting_field = 'volumeCell'
+    config_AM_regionalStatsCustom_vertical_mask = 'cellMask'
+    config_AM_regionalStatsCustom_vertical_dimension = 'nVertLevels'
+/
+&AM_timeSeriesStatsDaily
+    config_AM_timeSeriesStatsDaily_enable = .false.
+    config_AM_timeSeriesStatsDaily_compute_on_startup = .false.
+    config_AM_timeSeriesStatsDaily_write_on_startup = .false.
+    config_AM_timeSeriesStatsDaily_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsDaily_output_stream = 'timeSeriesStatsDailyOutput'
+    config_AM_timeSeriesStatsDaily_restart_stream = 'timeSeriesStatsDailyRestart'
+    config_AM_timeSeriesStatsDaily_operation = 'avg'
+    config_AM_timeSeriesStatsDaily_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsDaily_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsDaily_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsDaily_reset_intervals = '00-00-01_00:00:00'
+    config_AM_timeSeriesStatsDaily_backward_output_offset = '00-00-01_00:00:00'
+/
+&AM_timeSeriesStatsMonthly
+    config_AM_timeSeriesStatsMonthly_enable = .true.
+    config_AM_timeSeriesStatsMonthly_compute_on_startup = .false.
+    config_AM_timeSeriesStatsMonthly_write_on_startup = .false.
+    config_AM_timeSeriesStatsMonthly_compute_interval = '00-00-00_00:00:01'
+    config_AM_timeSeriesStatsMonthly_output_stream = 'timeSeriesStatsMonthlyOutput'
+    config_AM_timeSeriesStatsMonthly_restart_stream = 'timeSeriesStatsMonthlyRestart'
+    config_AM_timeSeriesStatsMonthly_operation = 'avg'
+    config_AM_timeSeriesStatsMonthly_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthly_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthly_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthly_reset_intervals = '00-00-02_00:00:00'
+    config_AM_timeSeriesStatsMonthly_backward_output_offset = '00-00-02_00:00:00'
+/
+&AM_timeSeriesStatsClimatology
+    config_AM_timeSeriesStatsClimatology_enable = .false.
+    config_AM_timeSeriesStatsClimatology_compute_on_startup = .false.
+    config_AM_timeSeriesStatsClimatology_write_on_startup = .false.
+    config_AM_timeSeriesStatsClimatology_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsClimatology_output_stream = 'timeSeriesStatsClimatologyOutput'
+    config_AM_timeSeriesStatsClimatology_restart_stream = 'timeSeriesStatsClimatologyRestart'
+    config_AM_timeSeriesStatsClimatology_operation = 'avg'
+    config_AM_timeSeriesStatsClimatology_reference_times = '00-03-01_00:00:00;00-06-01_00:00:00;00-09-01_00:00:00;00-12-01_00:00:00'
+    config_AM_timeSeriesStatsClimatology_duration_intervals = '00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_repeat_intervals = '01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_reset_intervals = '1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00'
+    config_AM_timeSeriesStatsClimatology_backward_output_offset = '00-03-00_00:00:00'
+/
+&AM_timeSeriesStatsMonthlyMax
+    config_AM_timeSeriesStatsMonthlyMax_enable = .false.
+    config_AM_timeSeriesStatsMonthlyMax_compute_on_startup = .false.
+    config_AM_timeSeriesStatsMonthlyMax_write_on_startup = .false.
+    config_AM_timeSeriesStatsMonthlyMax_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsMonthlyMax_output_stream = 'timeSeriesStatsMonthlyMaxOutput'
+    config_AM_timeSeriesStatsMonthlyMax_restart_stream = 'timeSeriesStatsMonthlyMaxRestart'
+    config_AM_timeSeriesStatsMonthlyMax_operation = 'max'
+    config_AM_timeSeriesStatsMonthlyMax_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthlyMax_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthlyMax_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthlyMax_reset_intervals = '00-01-00_00:00:00'
+    config_AM_timeSeriesStatsMonthlyMax_backward_output_offset = '00-01-00_00:00:00'
+/
+&AM_timeSeriesStatsMonthlyMin
+    config_AM_timeSeriesStatsMonthlyMin_enable = .false.
+    config_AM_timeSeriesStatsMonthlyMin_compute_on_startup = .false.
+    config_AM_timeSeriesStatsMonthlyMin_write_on_startup = .false.
+    config_AM_timeSeriesStatsMonthlyMin_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsMonthlyMin_output_stream = 'timeSeriesStatsMonthlyMinOutput'
+    config_AM_timeSeriesStatsMonthlyMin_restart_stream = 'timeSeriesStatsMonthlyMinRestart'
+    config_AM_timeSeriesStatsMonthlyMin_operation = 'min'
+    config_AM_timeSeriesStatsMonthlyMin_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsMonthlyMin_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsMonthlyMin_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsMonthlyMin_reset_intervals = '00-01-00_00:00:00'
+    config_AM_timeSeriesStatsMonthlyMin_backward_output_offset = '00-01-00_00:00:00'
+/
+&AM_timeSeriesStatsCustom
+    config_AM_timeSeriesStatsCustom_enable = .false.
+    config_AM_timeSeriesStatsCustom_compute_on_startup = .false.
+    config_AM_timeSeriesStatsCustom_write_on_startup = .false.
+    config_AM_timeSeriesStatsCustom_compute_interval = '00-00-00_01:00:00'
+    config_AM_timeSeriesStatsCustom_output_stream = 'timeSeriesStatsCustomOutput'
+    config_AM_timeSeriesStatsCustom_restart_stream = 'timeSeriesStatsCustomRestart'
+    config_AM_timeSeriesStatsCustom_operation = 'avg'
+    config_AM_timeSeriesStatsCustom_reference_times = 'initial_time'
+    config_AM_timeSeriesStatsCustom_duration_intervals = 'repeat_interval'
+    config_AM_timeSeriesStatsCustom_repeat_intervals = 'reset_interval'
+    config_AM_timeSeriesStatsCustom_reset_intervals = '00-00-07_00:00:00'
+    config_AM_timeSeriesStatsCustom_backward_output_offset = '00-00-01_00:00:00'
+/
+&AM_pointwiseStats
+    config_AM_pointwiseStats_enable = .false.
+    config_AM_pointwiseStats_compute_interval = 'output_interval'
+    config_AM_pointwiseStats_output_stream = 'pointwiseStatsOutput'
+    config_AM_pointwiseStats_compute_on_startup = .true.
+    config_AM_pointwiseStats_write_on_startup = .true.
+/
+&AM_debugDiagnostics
+    config_AM_debugDiagnostics_enable = .false.
+    config_AM_debugDiagnostics_compute_interval = 'output_interval'
+    config_AM_debugDiagnostics_output_stream = 'debugDiagnosticsOutput'
+    config_AM_debugDiagnostics_compute_on_startup = .true.
+    config_AM_debugDiagnostics_write_on_startup = .true.
+    config_AM_debugDiagnostics_check_state = .false.
+/
+&AM_rpnCalculator
+    config_AM_rpnCalculator_enable = .false.
+    config_AM_rpnCalculator_compute_on_startup = .true.
+    config_AM_rpnCalculator_write_on_startup = .false.
+    config_AM_rpnCalculator_compute_interval = '0010-00-00_00:00:00'
+    config_AM_rpnCalculator_output_stream = 'none'
+    config_AM_rpnCalculator_variable_a = 'layerThickness'
+    config_AM_rpnCalculator_variable_b = 'areaCell'
+    config_AM_rpnCalculator_variable_c = 'none'
+    config_AM_rpnCalculator_variable_d = 'none'
+    config_AM_rpnCalculator_variable_e = 'none'
+    config_AM_rpnCalculator_variable_f = 'none'
+    config_AM_rpnCalculator_variable_g = 'none'
+    config_AM_rpnCalculator_variable_h = 'none'
+    config_AM_rpnCalculator_expression_1 = 'a b *'
+    config_AM_rpnCalculator_expression_2 = 'none'
+    config_AM_rpnCalculator_expression_3 = 'none'
+    config_AM_rpnCalculator_expression_4 = 'none'
+    config_AM_rpnCalculator_output_name_1 = 'volumeCell'
+    config_AM_rpnCalculator_output_name_2 = 'none'
+    config_AM_rpnCalculator_output_name_3 = 'none'
+    config_AM_rpnCalculator_output_name_4 = 'none'
+/
+&AM_transectTransport
+    config_AM_transectTransport_enable = .false.
+    config_AM_transectTransport_compute_interval = 'output_interval'
+    config_AM_transectTransport_output_stream = 'transectTransportOutput'
+    config_AM_transectTransport_compute_on_startup = .true.
+    config_AM_transectTransport_write_on_startup = .true.
+    config_AM_transectTransport_transect_group = 'all'
+/
+&AM_eddyProductVariables
+    config_AM_eddyProductVariables_enable = .false.
+    config_AM_eddyProductVariables_compute_interval = 'dt'
+    config_AM_eddyProductVariables_output_stream = 'eddyProductVariablesOutput'
+    config_AM_eddyProductVariables_compute_on_startup = .true.
+    config_AM_eddyProductVariables_write_on_startup = .false.
+/
+&AM_mocStreamfunction
+    config_AM_mocStreamfunction_enable = .false.
+    config_AM_mocStreamfunction_compute_interval = 'output_interval'
+    config_AM_mocStreamfunction_output_stream = 'mocStreamfunctionOutput'
+    config_AM_mocStreamfunction_compute_on_startup = .true.
+    config_AM_mocStreamfunction_write_on_startup = .true.
+    config_AM_mocStreamfunction_min_bin = -1.0e34
+    config_AM_mocStreamfunction_max_bin = -1.0e34
+    config_AM_mocStreamfunction_num_bins = 180
+    config_AM_mocStreamfunction_region_group = 'all'
+    config_AM_mocStreamfunction_transect_group = 'all'
+/
+&AM_oceanHeatContent
+    config_AM_oceanHeatContent_enable = .false.
+    config_AM_oceanHeatContent_compute_interval = 'output_interval'
+    config_AM_oceanHeatContent_output_stream = 'oceanHeatContentOutput'
+    config_AM_oceanHeatContent_compute_on_startup = .true.
+    config_AM_oceanHeatContent_write_on_startup = .true.
+/
+&AM_mixedLayerHeatBudget
+    config_AM_mixedLayerHeatBudget_enable = .false.
+    config_AM_mixedLayerHeatBudget_compute_interval = 'output_interval'
+    config_AM_mixedLayerHeatBudget_output_stream = 'mixedLayerHeatBudgetOutput'
+    config_AM_mixedLayerHeatBudget_compute_on_startup = .true.
+    config_AM_mixedLayerHeatBudget_write_on_startup = .true.
+/
+&AM_sedimentFluxIndex
+    config_AM_sedimentFluxIndex_enable = .false.
+    config_AM_sedimentFluxIndex_compute_on_startup = .true.
+    config_AM_sedimentFluxIndex_write_on_startup = .true.
+    config_AM_sedimentFluxIndex_compute_interval = 'output_interval'
+    config_AM_sedimentFluxIndex_output_stream = 'sedimentFluxIndexOutput'
+    config_AM_sedimentFluxIndex_directory = 'analysis_members'
+    config_AM_sedimentFluxIndex_use_lat_lon_coords = .true.
+/
+&AM_sedimentTransport
+    config_AM_sedimentTransport_enable = .false.
+    config_AM_sedimentTransport_compute_on_startup = .true.
+    config_AM_sedimentTransport_write_on_startup = .true.
+    config_AM_sedimentTransport_compute_interval = 'output_interval'
+    config_AM_sedimentTransport_output_stream = 'sedimentTransportOutput'
+    config_AM_sedimentTransport_directory = 'analysis_members'
+    config_AM_sedimentTransport_grain_size = 2.5e-4
+    config_AM_sedimentTransport_ws_formula = 'VanRijn1993'
+    config_AM_sedimentTransport_bedld_formula = 'Soulsby-Damgaard'
+    config_AM_sedimentTransport_SSC_ref_formula = 'Lee2004'
+    config_AM_sedimentTransport_drag_coefficient = 2.5e-3
+    config_AM_sedimentTransport_erate = 5.0e-4
+    config_AM_sedimentTransport_tau_ce = 0.1
+    config_AM_sedimentTransport_tau_cd = 0.1
+    config_AM_sedimentTransport_Manning_coef = 0.022
+    config_AM_sedimentTransport_grain_porosity = 0.5
+    config_AM_sedimentTransport_water_density = 1020
+    config_AM_sedimentTransport_grain_density = 2650
+    config_AM_sedimentTransport_alpha = 1e-2
+    config_AM_sedimentTransport_kinematic_viscosity = 1e-6
+    config_AM_sedimentTransport_vertical_diffusion_coefficient = 1e-2
+    config_AM_sedimentTransport_bedload = .true.
+    config_AM_sedimentTransport_suspended = .true.
+    config_AM_sedimentTransport_use_lat_lon_coords = .true.
+/
+&AM_harmonicAnalysis
+    config_AM_harmonicAnalysis_enable = .false.
+    config_AM_harmonicAnalysis_compute_interval = 'output_interval'
+    config_AM_harmonicAnalysis_start = '0001-01-01_00:00:00'
+    config_AM_harmonicAnalysis_end = '0001-01-01_00:00:00'
+    config_AM_harmonicAnalysis_output_stream = 'harmonicAnalysisOutput'
+    config_AM_harmonicAnalysis_restart_stream = 'harmonicAnalysisRestart'
+    config_AM_harmonicAnalysis_compute_on_startup = .false.
+    config_AM_harmonicAnalysis_write_on_startup = .false.
+    config_AM_harmonicAnalysis_use_M2 = .true.
+    config_AM_harmonicAnalysis_use_S2 = .true.
+    config_AM_harmonicAnalysis_use_N2 = .true.
+    config_AM_harmonicAnalysis_use_K2 = .true.
+    config_AM_harmonicAnalysis_use_K1 = .true.
+    config_AM_harmonicAnalysis_use_O1 = .true.
+    config_AM_harmonicAnalysis_use_Q1 = .true.
+    config_AM_harmonicAnalysis_use_P1 = .true.
+/

--- a/testing_and_setup/streams.ocean
+++ b/testing_and_setup/streams.ocean
@@ -1,0 +1,203 @@
+<streams>
+
+<!-- instantaneous output (snapshots) -->
+<stream name="output"
+	filename_template="output/mpaso.snapshot.$Y-$M-$D_$h.$m.$s.nc"
+	clobber_mode="truncate"
+	reference_time="0001-01-01_00:00:00"
+	type="output"
+	filename_interval="00-00-02_00:00:00"
+	output_interval="00-00-02_00:00:00">
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<stream name="mesh"/>
+	<var name="layerThickness"/>
+	<var_array name="activeTracers"/>
+	<var_array name="debugTracers"/>
+	<var name="ssh"/>
+	<var name="kineticEnergyCell"/>
+	<var name="refZMid"/>
+	<var name="refLayerThickness"/>
+</stream>
+
+<!-- time averaged output -->
+<stream name="timeSeriesStatsMonthlyOutput"
+	type="output"
+	filename_template="output/mpaso.timeAverage.$Y-$M-$D.nc"
+	reference_time="01-01-01_00:00:00"
+	clobber_mode="truncate"
+	io_type="pnetcdf"
+	packages="timeSeriesStatsMonthlyAMPKG"
+	filename_interval="00-00-02_00:00:00"
+	output_interval="00-00-02_00:00:00" >
+
+	<var name="daysSinceStartOfSim"/>
+	<var name="ssh"/>
+	<var name="velocityMeridional"/>
+	<var name="velocityZonal"/>
+	<var name="layerThickness"/>
+	<var_array name="activeTracers"/>
+	<var_array name="debugTracers"/>
+	<var name="vertViscTopOfCell"/>
+	<var_struct name="tracersSurfaceFlux"/>
+	<var_array name="activeTracersTend"/>
+	<var_array name="debugTracersTend"/>
+	<var_array name="IRFTracersTend"/>
+	<var_array name="activeTracerHorizontalAdvectionTendency"/>
+	<var_array name="activeTracerVerticalAdvectionTendency"/>
+	<var_array name="activeTracerVertMixTendency"/>
+	<var_array name="activeTracerSurfaceFluxTendency"/>
+	<var_array name="activeTracerNonLocalTendency"/>
+	<var_array name="temperatureShortWaveTendency"/>
+	<var_array name="IRFTracersHorAdvTend"/>
+	<var_array name="IRFTracersVertAdvTend"/>
+	<var_array name="IRFTracersHorMixTend"/>
+	<var_array name="IRFTracersVertMixTend"/>
+</stream>
+
+<!-- optional, IRF instantaneous output -->
+<stream name="IRFoutput"
+	filename_template="output/IRFoutput.$Y-$M-$D_$h.$m.$s.nc"
+	filename_interval="01-00-00_00:00:00"
+	clobber_mode="truncate"
+	reference_time="0001-01-01_00:00:00"
+	type="output"
+	output_interval="none">
+
+	<stream name="mesh"/>
+	<var name="xtime"/>
+	<var_array name="IRFTracersHorAdvTend"/>
+	<var_array name="IRFTracersVertAdvTend"/>
+	<var_array name="IRFTracersHorMixTend"/>
+	<var_array name="IRFTracersVertMixTend"/>
+</stream>
+
+<immutable_stream name="mesh"
+		  type="input"
+		  filename_template="init.nc"
+		  input_interval="initial_only"/>
+
+<immutable_stream name="input"
+		  type="input"
+		  filename_template="init.nc"
+		  input_interval="initial_only"/>
+
+<immutable_stream name="restart"
+		  type="input;output"
+		  filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
+		  filename_interval="output_interval"
+		  reference_time="0001-01-01_00:00:00"
+		  clobber_mode="truncate"
+		  input_interval="initial_only"
+		  output_interval="00-00-10_00:00:00"/>
+
+<immutable_stream name="atmospheric_forcing"
+		  type="input"
+		  filename_template="atmospheric_forcing.nc"
+		  filename_interval="none"
+		  packages="timeVaryingAtmosphericForcingPKG"
+		  input_interval="none"/>
+
+<immutable_stream name="land_ice_forcing"
+		  type="input"
+		  filename_template="land_ice_forcing.nc"
+		  filename_interval="none"
+		  packages="timeVaryingLandIceForcingPKG"
+		  input_interval="none"/>
+
+<stream name="block_debug_output"
+	filename_template="output_debug_block_$B.nc"
+	filename_interval="1000-00-00_00:00:00"
+	clobber_mode="truncate"
+	reference_time="0001-01-01_00:00:00"
+	type="output"
+	output_interval="1000-00-00_00:00:00">
+
+	<stream name="mesh"/>
+	<var_struct name="tracers"/>
+	<var name="xtime"/>
+	<var name="layerThickness"/>
+	<var name="normalVelocity"/>
+	<var name="ssh"/>
+</stream>
+
+<stream name="globalStatsOutput"
+	runtime_format="single_file"
+	filename_interval="01-00-00_00:00:00"
+	clobber_mode="append"
+	output_interval="0001_00:00:00"
+	reference_time="0001-01-01_00:00:00"
+	filename_template="analysis_members/globalStats.$Y-$M-$D_$h.$m.$s.nc"
+	packages="globalStatsAMPKG"
+	type="output">
+
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var_array name="minGlobalStats"/>
+	<var_array name="maxGlobalStats"/>
+	<var_array name="avgGlobalStats"/>
+	<var name="volumeCellGlobal"/>
+	<var name="CFLNumberGlobal"/>
+</stream>
+
+<stream name="forcing_data"
+	filename_template="forcing_data.nc"
+	input_interval="initial_only"
+	type="input">
+
+	<var_struct name="tracersSurfaceRestoringFields"/>
+	<var_struct name="tracersInteriorRestoringFields"/>
+	<var_struct name="tracersExponentialDecayFields"/>
+	<var_struct name="tracersIdealAgeFields"/>
+	<var_struct name="tracersTTDFields"/>
+	<var name="windStressZonal"/>
+	<var name="windStressMeridional"/>
+	<var name="landIceSurfaceTemperature"/>
+	<var name="atmosphericPressure"/>
+	<var name="latentHeatFlux"/>
+	<var name="sensibleHeatFlux"/>
+	<var name="shortWaveHeatFlux"/>
+	<var name="evaporationFlux"/>
+	<var name="rainFlux"/>
+</stream>
+
+<stream name="shortwave_forcing_data"
+	filename_template="shortwaveData.nc"
+	input_interval="none"
+	type="input">
+
+	<var name="xtime"/>
+	<var name="chlorophyllData"/>
+	<var name="zenithAngle"/>
+	<var name="clearSkyRadiation"/>
+</stream>
+
+<stream name="mixedLayerDepthsOutput"
+	runtime_format="single_file"
+	filename_interval="01-00-00_00:00:00"
+	clobber_mode="truncate"
+	reference_time="0001-01-01_00:00:00"
+	output_interval="00-00-01_00:00:00"
+	filename_template="analysis_members/mixedLayerDepths.$Y-$M-$D.nc"
+	packages="mixedLayerDepthsAMPKG"
+	type="output">
+
+	<var name="xtime"/>
+	<var name="dThreshMLD"/>
+	<var name="tThreshMLD"/>
+</stream>
+
+<stream name="timeSeriesStatsMonthlyRestart"
+	type="input;output"
+	filename_template="restarts/mpaso.rst.am.timeSeriesStatsMonthly.$Y-$M-$D_$S.nc"
+	filename_interval="output_interval"
+	reference_time="0001-01-01_00:00:00"
+	clobber_mode="truncate"
+	packages="timeSeriesStatsMonthlyAMPKG"
+	input_interval="initial_only"
+	output_interval="stream:restart:output_interval" >
+
+</stream>
+
+</streams>


### PR DESCRIPTION
This PR adds a new tracer group for Impulse Response Functions (IRFs), which are used to record the effects of each tendency term. The IRFs are reset to their original values of 1s and 0s at the end of each timestep. The time averages of the tendency terms for each IRF are saved for later analysis, to be used by implicit solvers to find equilibrium solutions and to speed up the spin-up process.

