### PR TITLE
Do not zero N under floating ice in Interface

### DIFF
--- a/src/core_landice/mode_forward/Interface_velocity_solver.cpp
+++ b/src/core_landice/mode_forward/Interface_velocity_solver.cpp
@@ -1252,8 +1252,6 @@ void importFields(std::vector<std::pair<int, int> >& marineBdyExtensionMap,  dou
     }
 
     bool floating = rho_ice * thicknessData[iv] + rho_ocean * bedTopographyData[iv] < 0;
-    if (floating && (effecPress_F != 0))
-      effecPressData[iv] = 0.0;
   }
 }
 


### PR DESCRIPTION
This commit removes code that zeros effective pressure beneath floating
ice in the Interface to Albany.  This is unneeded because Albany zeros
beta at quadrature points, and zeroing it here at FEM nodes interferes
with that.  At best it's redundant, and at worst (which is if N were to
be assigned nonzero values under floating ice), it results in
significant errors in the solve.  This is also redundant because MPAS
hydro model and ocean_connection_N parameterization will already zero N
under floating ice.

The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

