### PR TITLE
Move surface pressure and zMid before EOS

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2351,6 +2351,9 @@
 				 description="Meridional surface velocity reconstructed at cell centers"
 			/>
 		</var_array>
+		<var name="surfacePressure" type="real" dimensions="nCells Time" units="Pa"
+			description="Pressure at the sea surface due to atmosphere, sea ice, frazil and land ice"
+		/>
 		<var_array name="SSHGradient" type="real" dimensions="nCells Time" packages="forwardMode;analysisMode">
 			<var name="SSHGradientZonal" array_group="ssh_zonal" units="m m^{-1}"
 				 description="Zonal gradient of SSH reconstructed at cell centers"

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -192,6 +192,12 @@ contains
                 seaIcePressure, surfacePressure)
 
       !
+      ! Z-coordinates
+      ! This section must be placed in the code before computing the density.
+      !
+      call ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)
+
+      !
       ! equation of state
       !
 
@@ -220,7 +226,7 @@ contains
       ! This section must be placed in the code after computing the density.
       !
       call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
-                surfacePressure, montgomeryPotential, pressure, zMid, zTop, ssh)
+                surfacePressure, montgomeryPotential, pressure)
 
       nCells = nCellsAll
 
@@ -1297,18 +1303,99 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_diagnostic_solve_z_coordinates
+!
+!> \brief   Computes diagnostic variables for mid- and top-layer z, and ssh
+!> \author  Xylar Asay-Davis
+!> \date    Jan. 2021
+!> \details
+!>  This routine computes the diagnostic variables for the z-coordinates at the
+!>    middle and top of each layer, and the sea-surface height
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)!{{{
+
+      use ocn_mesh     ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zMid
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         zTop
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         ssh
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells
+      integer :: iCell
+      integer :: k
+
+      nCells = nCellsAll
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k)
+      do iCell = 1, nCells
+
+         ! Compute zMid, the z-coordinate of the middle of the layer.
+         ! Compute zTop, the z-coordinate of the top of the layer.
+         ! Note the negative sign, since bottomDepth is positive
+         ! and z-coordinates are negative below the surface.
+         k = maxLevelCell(iCell)
+         zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
+         zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
+
+         do k = maxLevelCell(iCell)-1, 1, -1
+            zMid(k,iCell) = zMid(k+1,iCell)  &
+              + 0.5_RKIND*(  layerThickness(k+1,iCell) &
+                           + layerThickness(k  ,iCell))
+            zTop(k,iCell) = zTop(k+1,iCell)  &
+              + layerThickness(k  ,iCell)
+         end do
+
+         ! copy zTop(1,iCell) into sea-surface height array
+         ssh(iCell) = zTop(1,iCell)
+
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_z_coordinates!}}}
+
+!***********************************************************************
+!
 !  routine ocn_diagnostic_solve_pressure
 !
-!> \brief   Computes diagnostic variables for pressure, montgomery potential, and ssh
-!> \author  Matt Turner
-!> \date    October 2020
+!> \brief   Computes diagnostic variables for pressure or montgomery potential
+!> \author  Matt Turner, Xylar Asay-Davis
+!> \date    Jan. 2021
 !> \details
-!>  This routine computes the diagnostic variables for pressure, montgomery potential,
-!>    and ssh
+!>  This routine computes the diagnostic variables for pressure or montgomery potential
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
-                surfacePressure, montgomeryPotential, pressure, zMid, zTop, ssh)!{{{
+                surfacePressure, montgomeryPotential, pressure)!{{{
 
       use ocn_mesh     ! debug, mdt :: this should be module-level
 
@@ -1338,12 +1425,6 @@ contains
          montgomeryPotential
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          pressure
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         zMid
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         zTop
-      real (kind=RKIND), dimension(:), intent(out) :: &
-         ssh
 
       !-----------------------------------------------------------------
       !
@@ -1410,25 +1491,6 @@ contains
                 + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
                                      + density(k  ,iCell)*layerThickness(k  ,iCell))
            end do
-
-           ! Compute zMid, the z-coordinate of the middle of the layer.
-           ! Compute zTop, the z-coordinate of the top of the layer.
-           ! Note the negative sign, since bottomDepth is positive
-           ! and z-coordinates are negative below the surface.
-           k = maxLevelCell(iCell)
-           zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
-           zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) +     layerThickness(k,iCell)
-
-           do k = maxLevelCell(iCell)-1, 1, -1
-              zMid(k,iCell) = zMid(k+1,iCell)  &
-                + 0.5_RKIND*(  layerThickness(k+1,iCell) &
-                       + layerThickness(k  ,iCell))
-              zTop(k,iCell) = zTop(k+1,iCell)  &
-                       + layerThickness(k  ,iCell)
-           end do
-
-           ! copy zTop(1,iCell) into sea-surface height array
-           ssh(iCell) = zTop(1,iCell)
 
         end do
         !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -185,6 +185,13 @@ contains
                 normalizedRelativeVorticityCell)
 
       !
+      ! Surface pressure
+      ! This section must be placed in the code before computing the density.
+      !
+      call ocn_diagnostic_solve_surface_pressure(forcingPool, atmosphericPressure, &
+                seaIcePressure, surfacePressure)
+
+      !
       ! equation of state
       !
 
@@ -213,8 +220,7 @@ contains
       ! This section must be placed in the code after computing the density.
       !
       call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
-                atmosphericPressure, seaIcePressure, montgomeryPotential, pressure, &
-                zMid, zTop, ssh)
+                surfacePressure, montgomeryPotential, pressure, zMid, zTop, ssh)
 
       nCells = nCellsAll
 
@@ -1214,6 +1220,83 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_diagnostic_solve_surface_pressure
+!
+!> \brief   Computes diagnostic variables for surface pressure
+!> \author  Xylar Asay-Davis
+!> \date    Jan 2021
+!> \details
+!>  This routine computes the diagnostic variable for surface pressure
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_surface_pressure(forcingPool, atmosphericPressure, &
+                seaIcePressure, surfacePressure)!{{{
+
+      use ocn_mesh     ! debug, mdt :: this should be module-level
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         atmosphericPressure
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         seaIcePressure
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+         surfacePressure
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells
+      integer :: iCell
+
+      real (kind=RKIND), dimension(:), pointer :: &
+        frazilSurfacePressure, landIcePressure
+
+      !
+      ! Pressure
+      ! This section must be placed in the code after computing the density.
+      !
+      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
+      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+
+      nCells = nCellsAll
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCells
+         ! Pressure for generalized coordinates.
+         ! Pressure at top surface may be due to atmospheric pressure, frazil
+         ! ice, sea ice or the weight of an ice shelf
+         surfacePressure(iCell) = atmosphericPressure(iCell) + seaIcePressure(iCell)
+         if ( associated(frazilSurfacePressure) ) &
+            surfacePressure(iCell) = surfacePressure(iCell) + frazilSurfacePressure(iCell)
+         if ( associated(landIcePressure) ) &
+            surfacePressure(iCell) = surfacePressure(iCell) + landIcePressure(iCell)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_diagnostic_solve_surface_pressure!}}}
+
+!***********************************************************************
+!
 !  routine ocn_diagnostic_solve_pressure
 !
 !> \brief   Computes diagnostic variables for pressure, montgomery potential, and ssh
@@ -1225,8 +1308,7 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
-                atmosphericPressure, seaIcePressure, montgomeryPotential, pressure, &
-                zMid, zTop, ssh)!{{{
+                surfacePressure, montgomeryPotential, pressure, zMid, zTop, ssh)!{{{
 
       use ocn_mesh     ! debug, mdt :: this should be module-level
 
@@ -1244,9 +1326,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          density
       real (kind=RKIND), dimension(:), intent(in) :: &
-         atmosphericPressure
-      real (kind=RKIND), dimension(:), intent(in) :: &
-         seaIcePressure
+         surfacePressure
 
       !-----------------------------------------------------------------
       !
@@ -1277,15 +1357,10 @@ contains
 
       real (kind=RKIND), dimension(:), allocatable:: pTop
 
-      real (kind=RKIND), dimension(:), pointer :: &
-        frazilSurfacePressure, landIcePressure
-
       !
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
-      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
       nCells = nCellsAll
       if (config_pressure_gradient_type.eq.'MontgomeryPotential') then
@@ -1327,17 +1402,13 @@ contains
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
            ! Pressure for generalized coordinates.
-           ! Pressure at top surface may be due to atmospheric pressure
-           ! or an ice-shelf depression.
-           pressure(1,iCell) = atmosphericPressure(iCell) + seaIcePressure(iCell)
-           if ( associated(frazilSurfacePressure) ) pressure(1,iCell) = pressure(1,iCell) + frazilSurfacePressure(iCell)
-           if ( associated(landIcePressure) ) pressure(1,iCell) = pressure(1,iCell) + landIcePressure(iCell)
-           pressure(1,iCell) = pressure(1,iCell) + density(1,iCell)*gravity*0.5_RKIND*layerThickness(1,iCell)
+           pressure(1,iCell) = surfacePressure(iCell) &
+             + density(1,iCell)*gravity*0.5_RKIND*layerThickness(1,iCell)
 
            do k = 2, maxLevelCell(iCell)
               pressure(k,iCell) = pressure(k-1,iCell)  &
                 + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
-                               + density(k  ,iCell)*layerThickness(k  ,iCell))
+                                     + density(k  ,iCell)*layerThickness(k  ,iCell))
            end do
 
            ! Compute zMid, the z-coordinate of the middle of the layer.

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -89,6 +89,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), dimension(:), pointer :: surfaceBuoyancyForcing
    real (kind=RKIND), dimension(:), pointer :: surfaceFrictionVelocity
+   real (kind=RKIND), dimension(:), pointer :: surfacePressure
 
    real (kind=RKIND), dimension(:,:), pointer :: &
       transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
@@ -284,6 +285,7 @@ contains
       !
       call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
       call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
+      call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', surfacePressure)
 
       call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
       call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)


### PR DESCRIPTION
This merge adds a ``surfacePressure ``variable to the forcing pool
and adds a subroutine to compute it separately from the full
3D pressure.  The computation  of ``zMid``, ``zTop`` and ``ssh`` is 
also moved to its own subroutine within  diagnostics, separate
from the pressure.

These two new subroutines are called before the equation of state
 (EOS) with the idea that future EOSes could depend on each of
these variables, none of which depends on the density computed
by the EOS itself.