### PR TITLE
Add missing err initialization

### DIFF
--- a/src/core_landice/shared/mpas_li_setup.F
+++ b/src/core_landice/shared/mpas_li_setup.F
@@ -194,6 +194,8 @@ contains
       integer :: k
       real (kind=RKIND) :: fractionTotal
 
+      err = 0
+
       ! Get pool stuff
       call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)


### PR DESCRIPTION
This merge adds a missing err initialization to
li_setup_vertical_grid.  Without this fix and using gnu
compilers under Linux, the err had a garbage value that triggered
MALI to quit with a generic error:

```
ERROR: An error has occurred in landice_init_block.
CRITICAL ERROR: An error has occurred in li_core_init. Aborting...
```