### PR TITLE
fix for a PGI array syntax problem in ocean tracer tend routine

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -524,7 +524,7 @@ contains
       !
       ! local integers/reals/logicals
       !
-      integer :: err, iCell, iEdge, k, timeLevel, nTracersEcosys
+      integer :: err, iCell, iEdge, k, n, timeLevel, nTracersEcosys
       logical :: activeTracersOnly, isActiveTracer    ! if true, only compute for active tracers
 
       ! Scratch Arrays
@@ -948,7 +948,13 @@ contains
                            !$omp parallel
                            !$omp do schedule(runtime)
                            do iCell = 1, nCells
-                              activeTracerNonLocalTendency(:,:,iCell) = tracerGroupTend(:,:,iCell)-activeTracerNonLocalTendency(:,:,iCell)
+                           do k = 1, nVertLevels
+                           do n = 1, nTracerGroup
+                              activeTracerNonLocalTendency(n,k,iCell) = &
+                                           tracerGroupTend(n,k,iCell) - &
+                              activeTracerNonLocalTendency(n,k,iCell)
+                           end do
+                           end do
                            end do
                            !$omp end do
                            !$omp end parallel


### PR DESCRIPTION
This replaces array syntax in one loop in the ocean tend_tracer routine with explicit loops to
work around a compiler issue with PGI.

I did not have a good test case to exercise this section of code, but should be bit-for-bit. Reviewers should at least verify loop order/limits.

Fixes #805 
