### PR TITLE
Enable mpas_timekeeping module to work with the full, external ESMF library

### DIFF
--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -31,12 +31,6 @@ module mpas_derived_types
    use pio_types
 
    use ESMF
-   use ESMF_BaseMod
-   use ESMF_Stubs
-   use ESMF_CalendarMod
-   use ESMF_ClockMod
-   use ESMF_TimeMod
-   use ESMF_TimeIntervalMod
 
 #include "mpas_attlist_types.inc"
 

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1576,6 +1576,7 @@ module mpas_timekeeping
       integer :: days, sn, sd, hours, minutes
       integer (kind=I8KIND) :: seconds
       real (kind=R8KIND) :: seconds_real
+      character (len=1) :: neg
       integer :: local_ierr
 
 
@@ -1663,12 +1664,18 @@ module mpas_timekeeping
                                    d=days, h=hours, m=minutes, s_i8=seconds, sN=sn, sD=sd, rc=ierr)
          seconds_real = real(seconds,kind=R8KIND) + (real(sn, kind=R8KIND) / real(sd, kind=R8KIND))
 
-         ! Seconds should not be negative, so there is no need to handle negative cases, below
-         if (seconds_real < 10.0_R8KIND) then
-            write(timeString,'(i9.9,a,i2.2,a,i2.2,a,f11.9)') days, '_', hours, ':', minutes, ':0', seconds_real
-         else
-            write(timeString,'(i9.9,a,i2.2,a,i2.2,a,f12.9)') days, '_', hours, ':', minutes, ':', seconds_real
+         !
+         ! If the time interval is negative, the ESMF library will return negative values for
+         ! non-zero components of the interval, so days, hours, minutes, and seconds_real must
+         ! be checked in order to determine whether a '-' needs to be prepended to the timeString
+         !
+         neg = ''
+         if (days < 0 .or. hours < 0 .or. minutes < 0 .or. seconds_real < 0.0_R8KIND) then
+            neg = '-'
          end if
+
+         write(timeString,'(a,i9.9,a,i2.2,a,i2.2,a,i2.2,f10.9)') trim(neg), abs(days), '_', abs(hours), ':', abs(minutes), ':', &
+                                                               int(abs(seconds_real)), abs(seconds_real) - int(abs(seconds_real))
 #endif
       end if
 

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1309,7 +1309,11 @@ module mpas_timekeeping
 
       call ESMF_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
       call ESMF_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
+#ifndef MPAS_EXTERNAL_ESMF_LIB
       call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
+#else
+      call ESMF_TimeGet(curr_time % t, timeStringISOFrac=dateTimeString, rc=ierr)
+#endif
 
       !
       ! In case an external ESMF library that returns ISO timestamps is being used,

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -107,7 +107,7 @@ module mpas_timekeeping
          call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
 #endif
 #endif
-     else if (trim(calendar) == '360day') then
+      else if (trim(calendar) == '360day') then
         TheCalendar = MPAS_360DAY
 #ifndef MPAS_NO_ESMF_INIT
 #ifndef MPAS_EXTERNAL_ESMF_LIB

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -14,12 +14,6 @@ module mpas_timekeeping
    use mpas_log
 
    use ESMF
-   use ESMF_BaseMod
-   use ESMF_Stubs
-   use ESMF_CalendarMod
-   use ESMF_ClockMod
-   use ESMF_TimeMod
-   use ESMF_TimeIntervalMod
 
    private :: mpas_calibrate_alarms
    private :: mpas_in_ringing_envelope
@@ -98,18 +92,31 @@ module mpas_timekeeping
       if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
 #ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
+#else
+         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN)
+#endif
 #endif
       else if (trim(calendar) == 'gregorian_noleap') then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
 #ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
+#else
+         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
 #endif
-!     else if (trim(calendar) == '360day') then
-!        TheCalendar = MPAS_360DAY
-!#ifndef MPAS_NO_ESMF_INIT
+#endif
+     else if (trim(calendar) == '360day') then
+        TheCalendar = MPAS_360DAY
+#ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
 !        call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_360DAY)
-!#endif
+         call mpas_log_write('mpas_timekeeping_init: 360-day calendar not supported with the built-in ESMF timekeeping library', MPAS_LOG_ERR)
+#else
+         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_360DAY)
+#endif
+#endif
       else
          call mpas_log_write('mpas_timekeeping_init: Invalid calendar type', MPAS_LOG_ERR)
       end if
@@ -153,7 +160,14 @@ module mpas_timekeeping
 
       yearWidth = yearWidthIn
 
+     !
+     ! The external ESMF library does not provide the ESMF_setYearWidth subroutine,
+     ! though this may not be a problem, since the library appears to return time strings
+     ! with as many digits as are needed to represent the year.
+     !
+#ifndef MPAS_EXTERNAL_ESMF_LIB
       call ESMF_setYearWidth(yearWidthIn)
+#endif
 
    end subroutine mpas_timekeeping_set_year_width!}}}
 
@@ -1291,9 +1305,24 @@ module mpas_timekeeping
       character (len=StrKIND), intent(out), optional :: dateTimeString
       integer, intent(out), optional :: ierr
 
+      integer :: idx
+
       call ESMF_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
       call ESMF_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
       call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
+
+      !
+      ! In case an external ESMF library that returns ISO timestamps is being used,
+      ! convert a 'T' (if it exists in the string) to an '_' to match the format
+      ! used throughout MPAS
+      !
+      if (present(dateTimeString)) then
+         idx = index(dateTimeString, 'T')
+         if (idx > 0) then
+            dateTimeString(idx:idx) = '_'
+         end if
+      end if
+
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
@@ -1544,21 +1573,37 @@ module mpas_timekeeping
       real (kind=RKIND), intent(out), optional :: dt
       integer, intent(out), optional :: ierr
 
-      integer :: days, sn, sd
+      integer :: days, sn, sd, hours, minutes
       integer (kind=I8KIND) :: seconds
+      real (kind=R8KIND) :: seconds_real
+      integer :: local_ierr
 
 
 
       if (present(StartTimeIn)) then
          call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
       else
+#ifndef MPAS_EXTERNAL_ESMF_LIB
           if ( interval % ti % YR /= 0 .or. interval % ti % MM /= 0 ) then
              if (present(ierr)) ierr = 1
              call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
                  'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
              return
           end if
-          call ESMF_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
+#endif
+          call ESMF_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=local_ierr)
+          if (present(ierr)) ierr = local_ierr
+#ifdef MPAS_EXTERNAL_ESMF_LIB
+          !
+          ! With an external ESMF library, treat the time interval type as opaque, and just
+          ! assume that a non-success error code will be returned if the interval cannot be retrieved.
+          !
+          if (local_ierr /= ESMF_SUCCESS) then
+             call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
+                 'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
+             return
+          end if
+#endif
       endif
 
       if (sd == 0) then   ! may only occur if (sn == 0)?
@@ -1606,7 +1651,25 @@ module mpas_timekeeping
       end if
 
       if (present(timeString)) then
+#ifndef MPAS_EXTERNAL_ESMF_LIB
          call ESMF_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
+#else
+         !
+         ! In case an external ESMF library is being used, the time interval may be returned in
+         ! ISO period format, in which case it is easier to build a time interval string in MPAS
+         ! format given days, hours, minutes, and seconds.
+         !
+         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, &
+                                   d=days, h=hours, m=minutes, s_i8=seconds, sN=sn, sD=sd, rc=ierr)
+         seconds_real = real(seconds,kind=R8KIND) + (real(sn, kind=R8KIND) / real(sd, kind=R8KIND))
+
+         ! Seconds should not be negative, so there is no need to handle negative cases, below
+         if (seconds_real < 10.0_R8KIND) then
+            write(timeString,'(i9.9,a,i2.2,a,i2.2,a,f11.9)') days, '_', hours, ':', minutes, ':0', seconds_real
+         else
+            write(timeString,'(i9.9,a,i2.2,a,i2.2,a,f12.9)') days, '_', hours, ':', minutes, ':', seconds_real
+         end if
+#endif
       end if
 
       if (present(ierr)) then
@@ -1692,7 +1755,21 @@ module mpas_timekeeping
       type (MPAS_TimeInterval_type), intent(in) :: ti
       integer (kind=I8KIND), intent(in) :: n8
 
+#ifndef MPAS_EXTERNAL_ESMF_LIB
       mul_ti_n8 % ti = ti % ti * n8
+#else
+      !
+      ! At present, the external ESMF library does not support multiplying a time interval
+      ! by an 8-byte integer, so we convert to a 4-byte integer whenever possible.
+      ! However, if the value of the 8-byte integer exceeds what can be represented by
+      ! a 4-byte integer, stop with a critical error.
+      !
+      if (n8 > huge(int(n8)) .or. n8 < -huge(int(n8))) then
+         call mpas_log_write('(time interval) * 64-bit integer: integer out of range for external ESMF library', &
+                             messageType=MPAS_LOG_CRIT)
+      end if
+      mul_ti_n8 % ti = ti % ti * int(n8)
+#endif
 
    end function mul_ti_n8
 
@@ -2154,7 +2231,7 @@ module mpas_timekeeping
 
         call mpas_set_time(curTime, dateTimeString=timeStamp)
 
-        call mpas_get_time(curTime, YYYY=year)
+        call mpas_get_time(curTime, YYYY=year, MM=month, DD=day, H=hour, M=minute, S=second)
 
         write(yearFormat, '(a,i10,a)') '(i0.',yearWidth,')'
 
@@ -2170,15 +2247,12 @@ module mpas_timekeeping
                if (charExpand) then
                   select case (inString(i:i))
                      case ('Y')
-                         call mpas_get_time(curTime, YYYY=year)
                          write(timePart, yearFormat) year
                          outString = trim(outString) // trim(timePart)
                      case ('M')
-                         call mpas_get_time(curTime, MM=month)
                          write(timePart, '(i0.2)') month
                          outString = trim(outString) // trim(timePart)
                      case ('D')
-                         call mpas_get_time(curTime, DD=day)
                          write(timePart, '(i0.2)') day
                          outString = trim(outString) // trim(timePart)
                      case ('d')
@@ -2186,21 +2260,15 @@ module mpas_timekeeping
                          write(timePart, '(i0.3)') DoY
                          outString = trim(outString) // trim(timePart)
                      case ('h')
-                         call mpas_get_time(curTime, H=hour)
                          write(timePart, '(i0.2)') hour
                          outString = trim(outString) // trim(timePart)
                      case ('m')
-                         call mpas_get_time(curTime, M=minute)
                          write(timePart, '(i0.2)') minute
                          outString = trim(outString) // trim(timePart)
                      case ('s')
-                         call mpas_get_time(curTime, S=second)
                          write(timePart, '(i0.2)') second
                          outString = trim(outString) // trim(timePart)
                      case ('S')
-                         call mpas_get_time(curTime, H=hour)
-                         call mpas_get_time(curTime, M=minute)
-                         call mpas_get_time(curTime, S=second)
                          second = second + 60 * minute + 3600 * hour
                          write(timePart, '(i0.5)') second
                          outString = trim(outString) // trim(timePart)


### PR DESCRIPTION
This PR enables the mpas_timekeeping module to work with the full, external ESMF
library.

While the MPAS repository includes an old, Fortran-only implementation of
the ESMF time manager, coupled systems in which MPAS is a component may link
with the full (and more recent) ESMF library. This PR makes changes in
the mpas_timekeeping module to enable it to use the full, external ESMF library
in place of the built-in, Fortran-only time manager library by compiling
the MPAS framework with the MPAS_EXTERNAL_ESMF_LIB pre-processing macro defined.

Note that this PR does not include changes to Makefiles to set the module
include paths to an external ESMF library, nor does it include changes to handle
linking with an external ESMF library. The intended use case for these changes 
is a coupled model (e.g., CESM with the ESMF-based NUOPC driver) in which MPAS
models are components. In this case, the stand-alone MPAS Makefiles are unlikely
to be used, and all MPAS code is compiled with the build system of the coupled
model.