### PR TITLE
Simplify computing landIcePressure and vertical grid in ocean init mode

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2400,8 +2400,8 @@
 		<var name="pressure" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
 			 description="pressure used in the momentum equation"
 		/>
-		<var name="modifySSHMask" type="integer" dimensions="nCells Time" units="unitless"
-			description="A mask indicating where the SSH can be modified from refSSH through iteriative init/forward runs.  The mask is 1 under (and perhaps near) ice shelves and 0 elsenwere."
+		<var name="modifyLandIcePressureMask" type="integer" dimensions="nCells Time" units="unitless"
+			description="A mask indicating where landIcePressure can be modified during iterative init.  The mask is 1 under (and perhaps near) ice shelves and 0 elsewhere."
 			packages="initMode"
 		/>
 		<var name="normalTransportVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -3425,17 +3425,6 @@
 		<var name="btrvel_temp" persistence="scratch" type="real" dimensions="nEdgesP1" units=""
 			 description="btrvel_temp"
 		/>
-		<!-- FIELDS FOR LAND-ICE PRESSURE AND SSH INITIALIZATION -->
-		<var name="scratchZMid"
-			persistence="scratch"
-			type="real" dimensions="nVertLevels nCells" units="m"
-			description="reference z-midpoint of cells for vertical interpolation of tracers"
-		/>
-		<var name="scratchMaxLevelCell"
-			persistence="scratch"
-			type="integer" dimensions="nCells" units="unitless"
-			description="reference maxLevelCell for vertical interpolation of tracers"
-		/>
 		<!-- FIELDS FOR HORIZONTAL SMOOTHING DURING INITIALIZATION -->
 		<var name="smoothedField"
 			persistence="scratch"

--- a/src/core_ocean/mode_init/Registry.xml
+++ b/src/core_ocean/mode_init/Registry.xml
@@ -77,12 +77,6 @@
 					possible_values="Any positive non-zero integer."
 		/>
 	</nml_record>
-	<nml_record name="init_ssh_and_landIcePressure" mode="init">
-		<nml_option name="config_iterative_init_variable" type="character" default_value="landIcePressure" units="unitless"
-					description="Which variable, ssh or landIcePressure, is computed from the other.  If landIcePressure is to be computed, 'landIcePressure_from_top_density' indicates that the top density (rather than the mean density displaced by land ice) should be used to compute the landIcePressure."
-					possible_values="'ssh', 'landIcePressure_from_top_density' or 'landIcePressure'"
-		/>
-	</nml_record>
 	<nml_record name="constrain_Haney_number" mode="init">
 		<nml_option name="config_use_rx1_constraint" type="logical" default_value=".false." units="unitless"
 					description="Initialize using Haney number constraint under ice shelves"

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -195,13 +195,13 @@ contains
          call ocn_init_setup_global_ocean_interpolate_land_ice_topography(domain, iErr)
       end if
 
-      call mpas_log_write( 'Initializing vertical coordinate with ssh = 0.')
+      call mpas_log_write( 'Initializing vertical coordinate.')
       ! compute the vertical grid (layerThickness, restingThickness, maxLevelCell, zMid)
       ! based on bottomDepth and refBottomDepth and apply PBCs if requested
-      call ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)
+      call ocn_init_vertical_grid(domain, iErr=iErr)
 
       if(iErr .ne. 0) then
-        call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_vertical_grid failed.', MPAS_LOG_CRIT)
+        call mpas_log_write( 'ocn_init_vertical_grid failed.', MPAS_LOG_CRIT)
         call mpas_dmpar_finalize(domain % dminfo)
       end if
 
@@ -489,9 +489,8 @@ contains
          call mpas_log_write('Modifying temperature and surface restoring under land ice.')
          call ocn_init_setup_global_ocean_modify_temp_under_land_ice(domain, iErr)
 
-         call mpas_log_write( 'Recalculating ocean layer topography due to land ice depression')
-         ! compute or update the land-ice pressure (or possibly SSH), also computing density along the way
-         ! If this is the initial guess, the vertical grid and activeTracers may also be recomputed based on SSH
+         call mpas_log_write('Calculating land-ice pressure from the weight of ice shelves')
+         ! compute the land-ice pressure, also computing density along the way.
          call ocn_init_ssh_and_landIcePressure_balance(domain, iErr)
 
          if(iErr .ne. 0) then
@@ -1169,7 +1168,7 @@ contains
 
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
-          modifySSHMask(:) = 0
+          modifyLandIcePressureMask(:) = 0
           landIcePressure(:) = 0.0_RKIND
           do iCell = 1, nCells
 
@@ -1180,24 +1179,10 @@ contains
              ! nothing to do here if the cell is land
              if (maxLevelCell(iCell) <= 0) cycle
 
-             if(config_iterative_init_variable == 'ssh') then
-                ! we compute the land-ice pressure first and find out the SSH
-                landIcePressure(iCell) = max(0.0_RKIND, config_land_ice_flux_rho_ice &
-                   * gravity * landIceThkObserved(iCell))
-                if(landIcePressure(iCell) > 0.0_RKIND) then
-                   modifySSHMask(iCell) = 1
-                end if
-             else if(config_iterative_init_variable == 'landIcePressure' &
-                .or. config_iterative_init_variable == 'landIcePressure_from_top_density') then
-                ! we compute the SSH first and find out the land-ice pressure
-                ssh(iCell) = min(0.0_RKIND,landIceDraftObserved(iCell))
-                if(ssh(iCell) < 0.0_RKIND) then
-                   modifySSHMask(iCell) = 1
-                end if
-             else
-                call mpas_log_write( 'Invalid choice of config_iterative_init_variable.', MPAS_LOG_CRIT)
-                iErr = 1
-                call mpas_dmpar_finalize(domain % dminfo)
+             ! we compute the SSH first and find out the land-ice pressure
+             ssh(iCell) = min(0.0_RKIND, landIceDraftObserved(iCell))
+             if(ssh(iCell) < 0.0_RKIND) then
+                modifyLandIcePressureMask(iCell) = 1
              end if
           end do
 
@@ -3033,7 +3018,7 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
 
       end if
 
-      if ( config_global_ocean_depress_by_land_ice) then
+      if (config_global_ocean_depress_by_land_ice) then
          if (trim(config_global_ocean_land_ice_topo_file) == 'none') then
             call mpas_log_write( 'Validation failed for global ocean. '// &
                'Invalid filename for config_global_ocean_land_ice_topo_file', MPAS_LOG_CRIT)

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
@@ -268,7 +268,7 @@ contains
 
         landIceFraction(:) = 0.0_RKIND
         landIceSurfaceTemperature(:) = -25.0_RKIND !doesn't matter because ice is insulating
-        modifySSHMask(:) = 0
+        modifyLandIcePressureMask(:) = 0
         landIceMask(:) = 0
 
 
@@ -295,7 +295,7 @@ contains
           end if
 
           if(ssh(iCell) < 0.0_RKIND) then
-            modifySSHMask(iCell) = 1
+            modifyLandIcePressureMask(iCell) = 1
           end if
 
           if(.not. associated(activeTracers)) then
@@ -341,20 +341,19 @@ contains
 
       ! compute the vertical grid (layerThickness, restingThickness, maxLevelCell, zMid)
       !  based on ssh, bottomDepth and refBottomDepth
-      call ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)
+      call ocn_init_vertical_grid(domain, iErr=iErr)
 
       if(iErr .ne. 0) then
-        call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_vertical_grid failed.', MPAS_LOG_CRIT)
-        return
+        call mpas_log_write( 'ocn_init_vertical_grid failed.', MPAS_LOG_CRIT)
+        call mpas_dmpar_finalize(domain % dminfo)
       end if
 
-      ! compute or update the land-ice pressure (or possibly SSH), also computing density along the way
-      ! If this is the initial guess, the vertical grid and activeTracers may also be recomputed based on SSH
+      ! compute the land-ice pressure, also computing density along the way.
       call ocn_init_ssh_and_landIcePressure_balance(domain, iErr)
 
       if(iErr .ne. 0) then
          call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_balance failed.', MPAS_LOG_CRIT)
-         return
+         call mpas_dmpar_finalize(domain % dminfo)
       end if
 
       block_ptr => domain % blocklist

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
@@ -168,11 +168,11 @@ contains
       call ocn_init_isomip_plus_destroy_topo_fields()
 
       ! compute the vertical grid (layerThickness, restingThickness, maxLevelCell, zMid) bottomDepth and refBottomDepth
-      call ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)
+      call ocn_init_vertical_grid(domain, iErr=iErr)
 
       if(iErr .ne. 0) then
-        call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_vertical_grid failed.', MPAS_LOG_CRIT)
-        return
+        call mpas_log_write( 'ocn_init_vertical_grid failed.', MPAS_LOG_CRIT)
+        call mpas_dmpar_finalize(domain % dminfo)
       end if
 
       block_ptr => domain % blocklist
@@ -203,13 +203,12 @@ contains
       end do
 
 
-      ! compute or update the land-ice pressure (or possibly SSH), also computing density and bottomPressure along the way
-      ! If this is the initial guess, the vertical grid and activeTracers may also be recomputed based on SSH
+      ! compute the land-ice pressure, also computing density along the way.
       call ocn_init_ssh_and_landIcePressure_balance(domain, iErr)
 
       if(iErr .ne. 0) then
         call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_balance failed.', MPAS_LOG_CRIT)
-        return
+        call mpas_dmpar_finalize(domain % dminfo)
       end if
 
 
@@ -524,9 +523,9 @@ contains
 
           do iCell = 1,nCells
             if(landIceFraction(iCell) > 0.01_RKIND) then
-              modifySSHMask(iCell) = 1
+              modifyLandIcePressureMask(iCell) = 1
             else
-              modifySSHMask(iCell) = 0
+              modifyLandIcePressureMask(iCell) = 0
             end if
           end do
 
@@ -598,7 +597,7 @@ contains
               ssh(iCell) = 0.0_RKIND
               landIceFraction(iCell) = 0.0_RKIND
               landIceMask(iCell) = 0
-              modifySSHMask(iCell) = 0
+              modifyLandIcePressureMask(iCell) = 0
             end if
           end do !iCell
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -73,7 +73,7 @@ contains
 !>  This routine produces an initial guess at land-ice pressure using the
 !>  density of the topmost layer as the effective density of seawater within
 !>  the land ice. The resulting land-ice pressure is approximately consistent
-!>  with the in the sense that the horizontal pressure-gradient force (HPGF)
+!>  with the ice draft in the sense that the horizontal pressure-gradient force (HPGF)
 !>  should be small at the ocean surface.
 !>  ocn_init_vertical_grid() should be called to produce the appropriate
 !>  vertical grid before calling this subroutine and activeTracers should be

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -30,8 +30,6 @@ module ocn_init_ssh_and_landIcePressure
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
-   use ocn_init_interpolation
-   use ocn_init_vertical_grids
 
    use ocn_equation_of_state
 
@@ -51,8 +49,7 @@ module ocn_init_ssh_and_landIcePressure
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_init_ssh_and_landIcePressure_vertical_grid, &
-             ocn_init_ssh_and_landIcePressure_balance
+   public :: ocn_init_ssh_and_landIcePressure_balance
 
 
    !--------------------------------------------------------------------
@@ -65,67 +62,23 @@ module ocn_init_ssh_and_landIcePressure
 
 contains
 
-
-!***********************************************************************
-!
-!  routine ocn_init_ssh_and_landIcePressure_vertical_grid
-!
-!> \brief   Initialize z* vertical grid based on SSH
-!> \author  Xylar Asay-Davis
-!> \date    10/21/2015
-!> \details
-!>  This routine sets up the vertical grid (layerThickness,
-!>  zMid and restingThickness) needed for computing SSH from
-!>  land-ice pressure or visa versa. bottomDepth, refBottomDepth, maxLevelCell
-!>  and modifySSHMask must have been computed by the test case
-!>  before calling this routine.  If
-!>  config_iterative_init_variable = 'landIcePressure' or 'landIcePressure_from_top_density', the test
-!>  case must compute ssh before calling this routine.
-!>  modifySSHMask should be set to 1 wherever the ssh or landIcePressure
-!>  should be modified for consistency (e.g. under land ice). This
-!>  routine will take care of setting up partial bottom cells
-!>  by calling ocn_alter_bottomDepth_for_pbcs (except for the
-!>  Haney-number-constrained coordinate, which handle thin bottom
-!>  cells via the Haney-number constraint.
-
-!-----------------------------------------------------------------------
-
-   subroutine ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)!{{{
-
-   !--------------------------------------------------------------------
-
-     type (domain_type), intent(inout) :: domain
-     integer, intent(out) :: iErr
-
-   !--------------------------------------------------------------------
-
-     iErr = 0
-     call ocn_init_vertical_grid(domain, updateWithSSH=.false., iErr=iErr)
-
-   end subroutine ocn_init_ssh_and_landIcePressure_vertical_grid
-
 !***********************************************************************
 !
 !  routine ocn_init_ssh_and_landIcePressure_balance
 !
-!> \brief   Compute the balance land-ice pressure given the SSH or visa versa
+!> \brief   Compute the balance land-ice pressure given the SSH
 !> \author  Xylar Asay-Davis
 !> \date    8/8/2016
 !> \details
-!>  This routine either updates SSH based on land-ice pressure (if config_iterative_init_variable = 'ssh')
-!>  or visa versa (if config_iterative_init_variable = 'landIcePressure' or 'landIcePressure_from_top_density').
-!>  The routine produces an initial guess at land-ice pressure or SSH using either the density of the topmost layer
-!>  ('landIcePressure_from_top_density') or of all layers above the SSH ('ssh' or 'landIcePressure')
-!>  to determine the effective density of seawater within the land ice.
-!>  The resulting land-ice pressure and SSH are approximately consistent with one another
-!>  in the sense that the horizontal pressure-gradient force (HPGF)
+!>  This routine produces an initial guess at land-ice pressure using the
+!>  density of the topmost layer as the effective density of seawater within
+!>  the land ice. The resulting land-ice pressure is approximately consistent
+!>  with the in the sense that the horizontal pressure-gradient force (HPGF)
 !>  should be small at the ocean surface.
-!>  ocn_init_ssh_and_landIcePressure_vertical_grid should be called to produce
-!>  the appropriate vertical grid before calling this subroutine.
-!>  activeTracers should be initialized based on this vertical grid.
-!>  Upon completion, the vertical grid will have been updated
-!>  to be consistent with the SSH and the activeTracers will have been
-!>  interpolated to the new grid.
+!>  ocn_init_vertical_grid() should be called to produce the appropriate
+!>  vertical grid before calling this subroutine and activeTracers should be
+!>  initialized based on that vertical grid, so that density can be computed
+!>  here.
 
 !-----------------------------------------------------------------------
 
@@ -139,30 +92,22 @@ contains
      type (block_type), pointer :: block_ptr
 
      type (mpas_pool_type), pointer :: meshPool, forcingPool, statePool, &
-                                       verticalMeshPool, scratchPool
+                                       verticalMeshPool
 
      type (mpas_pool_type), pointer :: tracersPool
 
-     integer, dimension(:), pointer :: maxLevelCell
      real (kind=RKIND), dimension(:), pointer :: ssh
-
-     real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
-     real (kind=RKIND), dimension(:,:), pointer :: layerThickness
 
      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceDraft, &
                                                  effectiveDensityInLandIce
 
-     real(kind=RKIND), dimension(:,:), pointer :: origZMid
-     integer, dimension(:), pointer :: origMaxLevelCell
-     type (field2DReal), pointer :: origZMidField
-     type (field1DInteger), pointer :: origMaxLevelCellField
-     integer, pointer :: nCells, nVertLevels
+     integer, pointer :: nCells
 
      integer :: iCell
 
      iErr = 0
 
-     ! compute density (needed regardless of config_iterative_init_variable)
+     ! compute density
 
      block_ptr => domain % blocklist
      do while(associated(block_ptr))
@@ -183,89 +128,15 @@ contains
        block_ptr => block_ptr % next
      end do !block_ptr
 
-     ! first, handle the simple case where we're going to compute landIcePressure from the density at the top.
-     ! In this case, we already computed the correct vertical grid with the ssh, so all we have to do is
-     ! landIcePressure from the denisty we just got.
-     if(config_iterative_init_variable ==  'landIcePressure_from_top_density') then
-       block_ptr => domain % blocklist
-       do while(associated(block_ptr))
-         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-         call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-
-         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-         call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
-
-         call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
-             nCells, 0, 'relative', density, iErr, &
-             timeLevelIn=1)
-
-         if(iErr .ne. 0) then
-           call mpas_log_write( 'ocn_equation_of_state_density failed.', MPAS_LOG_CRIT)
-           return
-         end if
-
-         do iCell = 1, nCells
-           if(modifySSHMask(iCell) == 0) then
-             ssh(iCell) = 0.0_RKIND
-             landIcePressure(iCell) = 0.0_RKIND
-
-             if (associated(effectiveDensityInLandIce)) &
-               ! effective density cannot be determined
-               effectiveDensityInLandIce(iCell) = 0.0_RKIND
-             cycle
-           end if
-
-           landIcePressure(iCell) = max(0.0_RKIND, -density(1,iCell)*gravity*ssh(iCell))
-           if (associated(effectiveDensityInLandIce)) &
-             effectiveDensityInLandIce(iCell) = density(1,iCell)
-         end do
-
-         ! copy the SSH into the landIceDraft so we can use it later to remove it when
-         ! computing sea-surface tilt
-         landIceDraft(:) = ssh(:)
-
-         block_ptr => block_ptr % next
-       end do !block_ptr
-
-       return
-     end if
-
-     ! The other cases are more complicated and require interpolating the activeTracers
-     ! once the ssh or landIcePressure is determined
-
-     call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
-
-     call mpas_pool_get_field(scratchPool, 'scratchZMid', origZMidField)
-     call mpas_allocate_scratch_field(origZMidField, .false.)
-     call mpas_pool_get_field(scratchPool, 'scratchMaxLevelCell', origMaxLevelCellField)
-     call mpas_allocate_scratch_field(origMaxLevelCellField, .false.)
-
      block_ptr => domain % blocklist
      do while(associated(block_ptr))
        call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
-       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
 
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
@@ -273,10 +144,6 @@ contains
 
        call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
        call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityInLandIce, 1)
-
-       call mpas_pool_get_array(scratchPool, 'scratchZMid', origZMid)
-       call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
-
 
        call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
            nCells, 0, 'relative', density, iErr, &
@@ -288,37 +155,20 @@ contains
        end if
 
        do iCell = 1, nCells
-         if(modifySSHMask(iCell) == 0) then
+         if(modifyLandIcePressureMask(iCell) == 0) then
            ssh(iCell) = 0.0_RKIND
            landIcePressure(iCell) = 0.0_RKIND
 
            if (associated(effectiveDensityInLandIce)) &
              ! effective density cannot be determined
              effectiveDensityInLandIce(iCell) = 0.0_RKIND
-
            cycle
          end if
 
-         if(config_iterative_init_variable == 'ssh') then
-           ! compute ssh where pressure equals landIcePressure
-           ssh(iCell) = find_z_given_pressure(landIcePressure(iCell), density(:,iCell), &
-                                              layerThickness(:,iCell), nVertLevels, maxLevelCell(iCell))
-         else
-           ! compute landIcePressure based on hydrostatic pressure at SSH
-           landIcePressure(iCell) = max(0.0_RKIND, find_pressure_given_z(ssh(iCell), density(:,iCell), &
-                                              layerThickness(:,iCell), nVertLevels, maxLevelCell(iCell)))
-         end if
-
-         if (associated(effectiveDensityInLandIce)) then
-           ! the effective density of ocean water in land ice is determined from the land-ice pressure and SSH
-           effectiveDensityInLandIce(iCell) = -landIcePressure(iCell)/(gravity*ssh(iCell))
-         end if
-
+         landIcePressure(iCell) = max(0.0_RKIND, -density(1,iCell)*gravity*ssh(iCell))
+         if (associated(effectiveDensityInLandIce)) &
+           effectiveDensityInLandIce(iCell) = density(1,iCell)
        end do
-
-       ! save the old zMid for use in tracer inerpolation
-       origZMid(:,:) = zMid(:,:)
-       origMaxLevelCell(:) = maxLevelCell(:)
 
        ! copy the SSH into the landIceDraft so we can use it later to remove it when
        ! computing sea-surface tilt
@@ -327,354 +177,9 @@ contains
        block_ptr => block_ptr % next
      end do !block_ptr
 
-     ! update the vertical grid based on the new ssh
-     call ocn_init_vertical_grid(domain, updateWithSSH=.true., iErr=iErr)
-
-     if(iErr .ne. 0) then
-       call mpas_log_write( 'ocn_init_vertical_grid failed.', MPAS_LOG_CRIT)
-       return
-     end if
-
-     block_ptr => domain % blocklist
-     do while(associated(block_ptr))
-       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'scratch', scratchPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-       call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-
-       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-
-       call mpas_pool_get_array(scratchPool, 'scratchZMid', origZMid)
-       call mpas_pool_get_array(scratchPool, 'scratchMaxLevelCell', origMaxLevelCell)
-
-       ! interpolate active tracers to the new zMid
-       call interpolate_activeTracers(meshPool, origZMid, zMid, &
-                                      origMaxLevelCell, maxLevelCell, &
-                                      activeTracers, iErr)
-       if(iErr .ne. 0) then
-         call mpas_log_write( 'interpolate_activeTracers failed.', MPAS_LOG_CRIT)
-         return
-       end if
-
-       block_ptr => block_ptr % next
-     end do !block_ptr
-
-     call mpas_deallocate_scratch_field(origZMidField, .false.)
-     call mpas_deallocate_scratch_field(origMaxLevelCellField, .false.)
-
    !--------------------------------------------------------------------
 
    end subroutine ocn_init_ssh_and_landIcePressure_balance
-
-!***********************************************************************
-!
-! PRIVATE SUBROUTINES
-!
-!***********************************************************************
-
-!***********************************************************************
-!
-!  routine ocn_init_vertical_grid
-!
-!> \brief   Initialize z* vertical grid based on SSH
-!> \author  Xylar Asay-Davis
-!> \date    8/8/2016
-!> \details
-!>  This routine sets up the vertical grid (layerThickness,
-!>  zMid and restingThickness) needed for computing SSH from
-!>  land-ice pressure or visa versa. bottomDepth, refBottomDepth and maxLevelCell
-!>  must have been computed by the test case before calling this
-!>  routine.  If config_iterative_init_variable = 'landIcePressure' or 'landIcePressure_from_top_density', the test
-!>  case must compute ssh before calling this routine.  This
-!>  routine will take care of setting up partial bottom cells
-!>  by calling ocn_alter_bottomDepth_for_pbcs (except for the
-!>  Haney-number-constrained coordinate, which handle thin bottom
-!>  cells via the Haney-number constraint.
-!-----------------------------------------------------------------------
-
-   subroutine ocn_init_vertical_grid(domain, updateWithSSH, iErr)!{{{
-
-   !--------------------------------------------------------------------
-
-     type (domain_type), intent(inout) :: domain
-     logical, intent(in) :: updateWithSSH
-     integer, intent(out) :: iErr
-
-     type (block_type), pointer :: block_ptr
-
-     type (mpas_pool_type), pointer :: meshPool, statePool, verticalMeshPool
-
-     ! Define dimension pointers
-     integer, pointer :: nCells, nVertLevels
-
-     ! Define variable pointers
-     integer, dimension(:), pointer :: maxLevelCell
-     real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
-     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
-
-     integer :: iCell
-
-     logical :: initWithSSH, initRx1WithSSH
-
-   !--------------------------------------------------------------------
-
-     iErr = 0
-
-     if(config_iterative_init_variable .ne. 'ssh' &
-        .and. config_iterative_init_variable .ne. 'landIcePressure_from_top_density' &
-        .and. config_iterative_init_variable .ne. 'landIcePressure') then
-       iErr = 1
-       call mpas_log_write( 'invalid value for config_iterative_init_variable'// trim(config_iterative_init_variable), MPAS_LOG_CRIT)
-       return
-     end if
-
-     ! one reason for using config_iterative_init_variable == 'landIcePressure_from_top_density' is that we can immediately compute
-     ! the vertical grid displaced by the ssh
-     initWithSSH = updateWithSSH .or. (config_iterative_init_variable == 'landIcePressure_from_top_density')
-     initRx1WithSSH = initWithSSH .and. config_use_rx1_constraint
-
-     if(.not. config_use_rx1_constraint .and. .not. updateWithSSH) then
-       ! only alter pbcs if we're initializing for the first time (updateWithSSH == .false.) so we haven't done it already
-       ! and we're not going to handle bottomDepth another way (with the Haney-number-constrained coordinate)
-
-       block_ptr => domain % blocklist
-       do while(associated(block_ptr))
-         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-         do iCell = 1, nCells
-           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
-           if(iErr .ne. 0) then
-             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
-             return
-           end if
-         end do
-         block_ptr => block_ptr % next
-       end do !block_ptr
-     end if
-
-     if(initRx1WithSSH) then
-       ! We already know the ssh and landIcePressure we want to use.
-       ! Compute the layer thicknesses and zMid based on topography and ssh.
-       ! Use rx1 constraint to recompute the vertical grid.
-       call ocn_init_vertical_grid_with_max_rx1(domain, iErr)
-
-       if(iErr .ne. 0) then
-         call mpas_log_write( 'ocn_init_vertical_grid_with_max_rx1 failed.', MPAS_LOG_CRIT)
-         return
-       end if
-
-     else
-       ! we're initializing to z-star
-       block_ptr => domain % blocklist
-       do while(associated(block_ptr))
-         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
-
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
-         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
-         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
-
-         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
-
-         do iCell = 1, nCells
-           if(initWithSSH) then
-             ! we already know the ssh and landIcePressure we want to use.
-             ! compute the layer thicknesses and zMid based on topography and ssh
-             call ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness(:,iCell),zMid(:,iCell), &
-                  refBottomDepth,bottomDepth(iCell), &
-                  maxLevelCell(iCell),nVertLevels,iErr, &
-                  restingThickness=restingThickness(:,iCell), &
-                  ssh=ssh(iCell))
-           else
-             ! We don't know the ssh or landIcePressure yet, and we need tracers on a reference grid to figure it out.
-             ! compute restingThickness and reference layerThickness and zMid based on topography with ssh=0
-             ! (omitting ssh argument)
-             call ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness(:,iCell),zMid(:,iCell), &
-                  refBottomDepth,bottomDepth(iCell), &
-                  maxLevelCell(iCell),nVertLevels,iErr, &
-                  restingThickness=restingThickness(:,iCell))
-           end if
-
-           if(iErr .ne. 0) then
-             call mpas_log_write( 'ocn_compute_layerThickness_zMid_from_bottomDepth failed.', MPAS_LOG_CRIT)
-             return
-           end if
-         end do !iCell
-
-         block_ptr => block_ptr % next
-       end do !block_ptr
-     end if
-
-   end subroutine ocn_init_vertical_grid
-
-!***********************************************************************
-!
-!  routine interpolate_activeTracers
-!
-!> \brief   interpolate the active tracers from reference fields
-!> \author  Xylar Asay-Davis
-!> \date    10/12/2015
-!> \details
-!>  Perform linear interpolation of T and S from reference fields without
-!>  the sea-surface height (SSH) displacement at refZMid to new locations
-!>  zMid that take the SSH into account.
-
-!-----------------------------------------------------------------------
-
-   subroutine interpolate_activeTracers(meshPool, inZMid, outZMid, &
-                                        inMaxLevelCell, outMaxLevelCell, &
-                                        activeTracers, iErr)!{{{
-
-   !--------------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: meshPool
-      real (kind=RKIND), dimension(:,:), intent(in) :: inZMid, outZMid
-      integer, dimension(:), intent(in) :: inMaxLevelCell, outMaxLevelCell
-
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: activeTracers
-      integer, intent(out) :: iErr
-
-      ! Define dimension pointers
-      integer, pointer :: nCells, nVertLevels
-
-      ! Define variable pointers
-      integer :: iCell, inKMax, outKMax
-
-      real (kind=RKIND), dimension(:), allocatable :: inTracerColumn, outTracerColumn
-
-      integer :: nTracers, iTracer
-
-      iErr = 0
-
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-      nTracers = size(activeTracers, dim=1)
-      allocate(inTracerColumn(nVertLevels),outTracerColumn(nVertLevels))
-
-      do iCell = 1, nCells
-        inKMax = inMaxLevelCell(iCell)
-        outKMax = outMaxLevelCell(iCell)
-        if((inKMax <= 0) .or. (outKMax <= 0))  cycle
-
-        do iTracer = 1, nTracers
-          inTracerColumn(:) = activeTracers(iTracer,:,iCell)
-          outTracerColumn(:) = -9.969209968386869e+36_RKIND
-          call ocn_init_interpolation_linear_vert(inZMid(1:inKMax,iCell), &
-                                                  inTracerColumn(1:inKMax), &
-                                                  inKMax, &
-                                                  outZMid(1:outKMax,iCell), &
-                                                  outTracerColumn(1:outKMax), &
-                                                  outKMax, &
-                                                  extrapolate=.true.)
-          activeTracers(iTracer,:,iCell) = outTracerColumn(:)
-        end do
-      end do
-
-      deallocate(inTracerColumn, outTracerColumn)
-
-   !--------------------------------------------------------------------
-
-   end subroutine interpolate_activeTracers!}}}
-
-!***********************************************************************
-!
-!  funciton find_pressure_given_z
-!
-!> \brief   Determine the pressure at a given depth
-!> \author  Xylar Asay-Davis
-!> \date    8/8/2016
-!> \details
-!>  In a column, find the hydrostatic pressure at a given depth with
-!>  the given density profile.
-
-!-----------------------------------------------------------------------
-
-   function find_pressure_given_z(z, density, layerThickness, nVertLevels, maxLevelCell) result(pressure)
-      real (kind=RKIND), intent(in) :: z
-      real (kind=RKIND), intent(in), dimension(nVertLevels) :: density, layerThickness
-      integer, intent(in) :: nVertLevels, maxLevelCell
-      real (kind=RKIND) :: pressure
-
-      integer :: k
-      real (kind=RKIND) :: pressureTop, pressureBot, zTop, zBot
-
-      pressure = 0.0_RKIND
-      zTop = 0.0_RKIND
-
-      if(maxLevelCell <= 0) return
-
-      do k = 1, maxLevelCell
-        zBot = zTop - layerThickness(k)
-        if(z > zBot) then
-           ! note: this will simply extrapolate if z is positive for some reason
-           pressure = pressure + density(k)*gravity*(zTop - z)
-           return
-        end if
-        pressure = pressure + density(k)*gravity*layerThickness(k)
-        zTop = zBot
-     end do
-
-   end function find_pressure_given_z
-
-!***********************************************************************
-!
-!  funciton find_z_given_pressure
-!
-!> \brief  Find the depth at which pressure has a given value
-!> \author  Xylar Asay-Davis
-!> \date    10/13/2015
-!> \details
-!>  In a column, find the depth at which the hydrostatic pressure reaches a given
-!>  value provided a density profile.
-
-!-----------------------------------------------------------------------
-
-   function find_z_given_pressure(pressure, density, layerThickness, nVertLevels, maxLevelCell) result(z)
-      real (kind=RKIND), intent(in) :: pressure
-      real (kind=RKIND), intent(in), dimension(nVertLevels) :: density, layerThickness
-      integer, intent(in) :: nVertLevels, maxLevelCell
-      real (kind=RKIND) :: z
-
-      integer :: k
-      real (kind=RKIND) :: pressureTop, pressureBot
-
-      pressureTop = 0.0_RKIND
-      z = 0.0_RKIND
-
-      if(maxLevelCell <= 0) return
-
-      do k = 1, maxLevelCell
-        pressureBot = pressureTop + density(k)*gravity*layerThickness(k)
-        if(pressure < pressureBot) then
-           ! note: this will simply extrapolate if presssure is negative for some reason
-           z = z - (pressure - pressureTop)/(pressureBot - pressureTop)*layerThickness(k)
-           return
-        end if
-        z = z - layerThickness(k)
-        pressureTop = pressureBot
-     end do
-
-   end function find_z_given_pressure
 
 !***********************************************************************
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
@@ -217,7 +217,7 @@ module ocn_init_sub_ice_shelf_2D
 
         if(associated(landIceFraction)) &
           landIceFraction(:) = 0.0_RKIND
-        modifySSHMask(:) = 0
+        modifyLandIcePressureMask(:) = 0
         if(associated(landIceMask)) &
           landIceMask(:) = 0
 
@@ -235,7 +235,7 @@ module ocn_init_sub_ice_shelf_2D
            ssh(iCell) = -config_sub_ice_shelf_2D_bottom_depth + totalSubIceThickness
 
            if(ssh(iCell) < 0.0_RKIND) then
-              modifySSHMask(iCell) = 1
+              modifyLandIcePressureMask(iCell) = 1
            end if
         end do
 
@@ -259,12 +259,12 @@ module ocn_init_sub_ice_shelf_2D
 
      ! compute the vertical grid (layerThickness, restingThickness, maxLevelCell, zMid) based on ssh,
      ! bottomDepth and refBottomDepth
-     call ocn_init_ssh_and_landIcePressure_vertical_grid(domain, iErr)
+      call ocn_init_vertical_grid(domain, iErr=iErr)
 
-     if(iErr .ne. 0) then
-        call mpas_log_write( 'ocn_init_ssh_and_landIcePressure_vertical_grid failed.', MPAS_LOG_CRIT)
+      if(iErr .ne. 0) then
+        call mpas_log_write( 'ocn_init_vertical_grid failed.', MPAS_LOG_CRIT)
         call mpas_dmpar_finalize(domain % dminfo)
-     end if
+      end if
 
      block_ptr => domain % blocklist
      do while(associated(block_ptr))
@@ -300,8 +300,7 @@ module ocn_init_sub_ice_shelf_2D
         block_ptr => block_ptr % next
      end do
 
-     ! compute or update the land-ice pressure (or possibly SSH), also computing density along the way
-     ! If this is the initial guess, the vertical grid and activeTracers may also be recomputed based on SSH
+     ! compute the land-ice pressure, also computing density along the way.
      call ocn_init_ssh_and_landIcePressure_balance(domain, iErr)
 
      if(iErr .ne. 0) then

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -49,6 +49,7 @@ module ocn_init_vertical_grids
              ocn_compute_layerThickness_zMid_from_bottomDepth, &
              ocn_alter_bottomDepth_for_pbcs, &
              ocn_compute_Haney_number, &
+             ocn_init_vertical_grid, &
              ocn_init_vertical_grid_with_max_rx1
 
    !--------------------------------------------------------------------
@@ -712,6 +713,124 @@ contains
       deallocate(rx1MaxLevel)
 
     end subroutine ocn_compute_Haney_number
+
+!***********************************************************************
+!
+!  routine ocn_init_vertical_grid
+!
+!> \brief   Initialize z-star vertical grid based on SSH
+!> \author  Xylar Asay-Davis
+!> \date    8/8/2016
+!> \details
+!>  This routine sets up the vertical grid (layerThickness, zMid and
+!>  restingThickness) needed for computing land-ice pressure from SSH.
+!>  bottomDepth, refBottomDepth, maxLevelCell must have been computed by the
+!>  test case before calling this routine.  For tests with ice-shelf cavities,
+!>  ssh must be computed before calling this routine. If the test case is
+!>  using a z-star coordinate, this routine will take care of setting up
+!>  partial bottom cells by calling ocn_alter_bottomDepth_for_pbcs(). If using
+!>  the Haney-number-constrained coordinate, another approach is used to handle
+!>  maintaining a minimum layer thickness.
+!-----------------------------------------------------------------------
+
+   subroutine ocn_init_vertical_grid(domain, iErr)!{{{
+
+   !--------------------------------------------------------------------
+
+     type (domain_type), intent(inout) :: domain
+     integer, intent(out) :: iErr
+
+     type (block_type), pointer :: block_ptr
+
+     type (mpas_pool_type), pointer :: meshPool, statePool, verticalMeshPool
+
+     ! Define dimension pointers
+     integer, pointer :: nCells, nVertLevels
+
+     ! Define variable pointers
+     integer, dimension(:), pointer :: maxLevelCell
+     real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
+     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
+
+     integer :: iCell
+
+   !--------------------------------------------------------------------
+
+     iErr = 0
+
+     if(config_use_rx1_constraint) then
+       ! We already know the ssh and landIcePressure we want to use.
+       ! Compute the layer thicknesses and zMid based on topography and ssh.
+       ! Use rx1 constraint to recompute the vertical grid.
+       call ocn_init_vertical_grid_with_max_rx1(domain, iErr)
+
+       if(iErr .ne. 0) then
+         call mpas_log_write( 'ocn_init_vertical_grid_with_max_rx1 failed.', MPAS_LOG_CRIT)
+         return
+       end if
+
+     else
+
+       ! we're initializing to z-star
+
+       ! alter pbcs
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+         do iCell = 1, nCells
+           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+         end do
+         block_ptr => block_ptr % next
+       end do !block_ptr
+
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
+
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+
+         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+         do iCell = 1, nCells
+           call ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness(:,iCell),zMid(:,iCell), &
+                refBottomDepth,bottomDepth(iCell), &
+                maxLevelCell(iCell),nVertLevels,iErr, &
+                restingThickness=restingThickness(:,iCell), &
+                ssh=ssh(iCell))
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_layerThickness_zMid_from_bottomDepth failed.', MPAS_LOG_CRIT)
+             return
+           end if
+         end do !iCell
+
+         block_ptr => block_ptr % next
+       end do !block_ptr
+     end if
+
+   end subroutine ocn_init_vertical_grid
 
 !***********************************************************************
 !

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -107,7 +107,7 @@ module ocn_diagnostics_variables
    integer, dimension(:), pointer :: smoothingMask
    real (kind=RKIND), dimension(:,:), pointer :: verticalStretch
 
-   integer, dimension(:), pointer :: modifySSHMask
+   integer, dimension(:), pointer :: modifyLandIcePressureMask
 
    real (kind=RKIND), dimension(:,:), pointer :: velocityMeridional
    real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
@@ -330,7 +330,7 @@ contains
       call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMaskField, 1)
       call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', verticalStretchField, 1)
 
-      call mpas_pool_get_array(diagnosticsPool, 'modifySSHMask', modifySSHMask)
+      call mpas_pool_get_array(diagnosticsPool, 'modifyLandIcePressureMask', modifyLandIcePressureMask)
 
       call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
       call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)


### PR DESCRIPTION
This merge affects only `init` mode.  It modifies the main registry and diagnostics variables to rename an init-mode variable.  All other changes are in the `mode_init` directory.

While we have supported 3 options for initializing the ice draft (SSH) and `landIcePressure`, we now only use the simplest one, which uses the density in the top layer as a guess for the effective density of the ocean.

This merge significantly simplifies and clarifies the process for creating the vertical coordinate and later initializing `landIcePressure` in several test cases by getting rid of the unused options.  The subroutine for creating the vertical coordinate `ocn_init_vertical_grid()` has been moved to `ocn_init_vertical_grids` (where it clearly belongs).

The namelist option `config_iterative_init_variable` is no longer needed and has been removed because we always initialize
`landIcePressure` (not SSH) and we always use the density in the top layer.

The init mode diagnostic variable `modifySSHMask` has been renamed `modifyLandIcePressureMask` to be consistent with these changes.   We now only modify `landIcePressure`, not SSH.

The 4 test cases with ice-shelf cavities:
* `global_ocean`
* `isomip`
* `isomip_plus`
* `sub_ice_shelf_2D`
have been updated with these changes. 