### PR TITLE
Port ocean diagnostics to GPU - Phase 1

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2603,9 +2603,6 @@
 		<var name="betaEdge" type="real" dimensions="nEdges Time" units="m^{-1} s^{-1}"
 			description="meridional gradient of the coriolis parameter"
 		/>
-		<var name="c_Visbeck" type="real" dimensions="nEdges Time" units="m s^{-1}"
-			description="baroclinic wave speed from Visbeck parameterization"
-		/>
 		<var name="eddyLength" type="real" dimensions="nEdges Time" units="m"
 			description="eddy length scale in Visbeck 1997 closure"
 		/>

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -801,12 +801,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -856,12 +856,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -913,12 +913,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -974,12 +974,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
@@ -988,12 +988,12 @@ module ocn_time_integration_rk4
       call ocn_tend_vel(tendPool, provisStatePool, forcingPool, 1, dt)
 
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
@@ -2543,11 +2543,11 @@ module ocn_time_integration_si
             ! layerThickness has not yet been computed for time level 2.
             call mpas_timer_start('thick vert trans vel top')
             if (associated(highFreqThicknessNew)) then
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
                  layerThicknessCur, layerThickEdge, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, err, highFreqThicknessNew)
             else
-               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, &
+               call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
                  layerThicknessCur, layerThickEdge, normalTransportVelocity, &
                  sshCur, dt, vertAleTransportTop, err)
             endif

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -529,17 +529,31 @@ module ocn_time_integration_split
          ! normalTransportVelocity) for momentum advection.
          ! Use the most recent time level available.
 
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update device(layerThickEdge)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, scratchPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, scratchPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update host(vertAleTransportTop)
+#endif
 
          call ocn_tend_vel(tendPool, statePool, forcingPool, &
                            stage1_tend_time, dt)
@@ -1465,17 +1479,31 @@ module ocn_time_integration_split
          ! layerThickEdge because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, sshCur)
+         !$acc update device(layerThickEdge, normalTransportVelocity)
+#endif
          if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+            !$acc enter data copyin(highFreqThicknessNew)
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, scratchPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
+#ifdef MPAS_OPENACC
+            !$acc exit data delete(highFreqThicknessNew)
+#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, scratchPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(layerThicknessCur, sshCur)
+         !$acc update host(vertAleTransportTop, normalTransportVelocity)
+#endif
          call mpas_timer_stop('thick vert trans vel top')
 
          call ocn_tend_thick(tendPool, forcingPool, meshPool)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -538,7 +538,7 @@ module ocn_time_integration_split
             !$acc enter data copyin(highFreqThicknessNew)
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
@@ -546,7 +546,7 @@ module ocn_time_integration_split
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
@@ -1488,7 +1488,7 @@ module ocn_time_integration_split
             !$acc enter data copyin(highFreqThicknessNew)
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
@@ -1496,7 +1496,7 @@ module ocn_time_integration_split
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
-                 verticalMeshPool, scratchPool, layerThicknessCur, &
+                 verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif

--- a/src/core_ocean/mode_init/Makefile
+++ b/src/core_ocean/mode_init/Makefile
@@ -84,6 +84,10 @@ mpas_ocn_init_hurricane.o: $(UTILS)
 
 mpas_ocn_init_tidal_boundary.o: $(UTILS)
 
+mpas_ocn_init_dam_break.o: $(UTILS)
+
+mpas_ocn_init_cosine_bell.o: $(UTILS)
+
 #mpas_ocn_init_TEMPLATE.o: $(UTILS)
 
 clean:

--- a/src/core_ocean/shared/Makefile
+++ b/src/core_ocean/shared/Makefile
@@ -90,7 +90,7 @@ mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -156,7 +156,7 @@ mpas_ocn_test.o:  mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_constants.o mpas_ocn_config.o:
 
-mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_restoring.o
+mpas_ocn_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing_restoring.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_surface_bulk_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equation_of_state.o
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1302,7 +1302,7 @@ contains
       !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
       !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop, invAreaCell) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-      !$acc                  dvEdge_temp, k, r_tmp) 
+      !$acc                  dvEdge_temp, k, r_tmp)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -1348,7 +1348,7 @@ contains
          end do
       end do
 #ifdef MPAS_OPENACC
-      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus) 
+      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus)
 #else
       !$omp end do
       !$omp end parallel
@@ -1361,7 +1361,7 @@ contains
       !$acc parallel loop gang vector &
       !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
       !$acc                  maxLevelEdgeTop, normalVelocity) &
-      !$acc          private(i, eoe, weightsOnEdge_temp, k) 
+      !$acc          private(i, eoe, weightsOnEdge_temp, k)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -985,11 +985,20 @@ contains
       if(config_use_cvmix_kpp) then
 
         nCells = nCellsOwned
+        surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
 
+#ifdef MPAS_OPENACC
+        !$acc enter data copyin(layerThickness, activeTracers)
+
+        !$acc parallel loop gang vector &
+        !$acc          present(tracersSurfaceLayerValue, indexSurfaceLayerDepth, maxLevelCell, &
+        !$acc                  layerThickness, activeTracers) &
+        !$acc          private(sumSurfaceLayer, k, rSurfaceLayer)
+#else
         !$omp parallel
         !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+#endif
         do iCell=1,nCells
-          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
           tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
           indexSurfaceLayerDepth(iCell) = -9.e30
@@ -1003,7 +1012,6 @@ contains
              exit
            endif
           end do
-          tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
           do k=1,int(rSurfaceLayer)
             tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
                                               * layerThickness(k,iCell)
@@ -1012,8 +1020,13 @@ contains
           tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
                                             * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
         enddo
+#ifdef MPAS_OPENACC
+        !$acc update host(tracersSurfaceLayerValue, indexSurfaceLayerDepth)
+        !$acc exit data delete(layerThickness, activeTracers)
+#else
         !$omp end do
         !$omp end parallel
+#endif
 
         nEdges = nEdgesOwned
 
@@ -1022,13 +1035,23 @@ contains
         ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
         !
 
+        surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
+#ifdef MPAS_OPENACC
+        !$acc enter data copyin(normalVelocity)
+        !$acc update device(layerThicknessEdge)
+
+        !$acc parallel loop gang vector &
+        !$acc          present(normalVelocitySurfaceLayer, cellsOnEdge, maxLevelEdgeTop, &
+        !$acc                  layerThicknessEdge, normalVelocity) &
+        !$acc          private(cell1, cell2, rSurfaceLayer, sumSurfaceLayer, k)
+#else
         !$omp parallel
         !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+#endif
         do iEdge=1,nEdges
           normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
           cell1=cellsOnEdge(1,iEdge)
           cell2=cellsOnEdge(2,iEdge)
-          surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
           rSurfaceLayer = min(minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge))
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
@@ -1051,8 +1074,13 @@ contains
                                               * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
           end if
         enddo
+#ifdef MPAS_OPENACC
+        !$acc update host(normalVelocitySurfaceLayer)
+        !$acc exit data delete(normalVelocity)
+#else
         !$omp end do
         !$omp end parallel
+#endif
 
       endif
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1849,7 +1849,6 @@ contains
 #ifdef MPAS_OPENACC
       !$acc enter data create(div_hu, projectedSSH, ALE_Thickness)
 
-! DEBUG, MDT :: need to add OpenACC
       !$acc parallel loop &
       !$acc          present(div_hu, invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
       !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1876,12 +1876,12 @@ contains
          end do
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
-!#ifdef MPAS_OPENACC
+#ifdef MPAS_OPENACC
       !$acc update host(projectedSSH)
-!#else
+#else
       !$omp end do
       !$omp end parallel
-!#endif
+#endif
 
       !
       ! Compute desired thickness at new time

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -154,7 +154,6 @@ contains
 !      !$acc enter data copyin(normalVelocity)
 !#endif
 
-      ! debug, mdt :: this is run only on the host
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
       coef_3rd_order = config_coef_3rd_order
@@ -169,15 +168,12 @@ contains
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
-!#ifdef MPAS_OPENACC
-!      !$acc update device(normalVelocity)
-!#endif
-
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
 !#ifdef MPAS_OPENACC
-!      !$acc update self(relativeVorticity, circulation)
-!      !$acc exit data delete(normalVelocity)
+!      !$acc update device(relativeVorticity, layerThickEdge, normalVelocity, &
+!      !$acc               normalTransportVelocity, normalGMBolusVelocity, &
+!      !$acc               vertVelocityTop) async(1)
 !#endif
 
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
@@ -185,6 +181,12 @@ contains
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
+
+!#ifdef MPAS_OPENACC
+!      !$acc update self(vertTransportVelocityTop, vertGMBolusVelocityTop, &
+!      !$acc             relativeVorticityCell, divergence, kineticEnergyCell, &
+!      !$acc             tangentialVelocity) async(1)
+!#endif
 
       !
       ! Compute kinetic energy
@@ -666,8 +668,19 @@ contains
 
       nVertices = nVerticesHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(layerThickness, fVertex) &
+      !$acc            create(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
+      !$acc update device(relativeVorticity)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(areaTriangle, maxLevelVertexBot, layerThickness, kiteAreasOnVertex, &
+      !$acc                  relativeVorticity, fVertex) &
+      !$acc          private(invAreaTri1, layerThicknessVertex, k, i)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
+#endif
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = 1, maxLevelVertexBot(iVertex)
@@ -683,13 +696,25 @@ contains
             normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
          end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(layerThickness, fVertex)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       nEdges = nEdgesHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+      !$acc                  verticesOnEdge, maxLevelEdgeBot, normalizedRelativeVorticityVertex, &
+      !$acc                  normalizedPlanetaryVorticityVertex) &
+      !$acc          private(vertex1, vertex2, k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(vertex1, vertex2, k)
+#endif
       do iEdge = 1, nEdges
         normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
         normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
@@ -702,13 +727,25 @@ contains
                                                      + normalizedPlanetaryVorticityVertex(k, vertex2))
         end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc update self(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge)
+      !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       nCells = nCellsHalo ( 1 )
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(normalizedRelativeVorticityCell, maxLevelCell, nEdgesOnCell, &
+      !$acc                  areaCell, kiteIndexOnCell, verticesOnCell, kiteAreasOnVertex) &
+      !$acc          private(invAreaCell1, i, j, iVertex, k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+#endif
       do iCell = 1, nCells
         normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -722,8 +759,12 @@ contains
           end do
         end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc update self(normalizedRelativeVorticityCell)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       nCells = nCellsAll
       nVertices = nVerticesAll
@@ -1128,8 +1169,15 @@ contains
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsOwned
 
+!#ifdef MPAS_OPENACC
+!      !$acc parallel loop gang vector &
+!      !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
+!      !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
+!      !$acc                  relativeVorticity) async(1)
+!#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
+!#endif
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -1154,10 +1202,23 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
+!#ifdef MPAS_OPENACC
+!      !$acc enter data create(div_hu, div_huTransport, div_huGMBolus) async(1)
+!
+!      !$acc parallel loop gang vector &
+!      !$acc          present(divergence, kineticEnergyCell, div_hu, div_huTransport, &
+!      !$acc                  div_huGMBolus, areaCell, nEdgesOnCell, edgesOnCell, &
+!      !$acc                  dcEdge, dvEdge, maxLevelCell, normalVelocity, layerThicknessEdge, &
+!      !$acc                  kineticEnergyCell, normalTransportVelocity, normalGMBolusVelocity, &
+!      !$acc                  vertVelocityTop, vertTransportVelocityTop, vertGMBolusVelocityTop) &
+!      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+!      !$acc                  dvEdge_temp, k, r_tmp) async(1)
+!#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
       !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
+!#endif
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -1199,11 +1260,23 @@ contains
       !$omp end do
       !$omp end parallel
 
+!#ifdef MPAS_OPENACC
+!      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus) async(1)
+!#endif
+
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
       nEdges = nEdgesHalo( 2 )
+
+!#ifdef MPAS_OPENACC
+!      !$acc parallel loop gang &
+!      !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
+!      !$acc                  maxLevelEdgeTop, normalVelocity) &
+!      !$acc          private(i, eoe, weightsOnEdge_temp, k) async(1)
+!#else
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+!#endif
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,12 +150,6 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocity)
-      !$acc update device(normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
-      !$acc               vertTransportVelocityTop, vertGMBolusVelocityTop)
-#endif
-
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
 #ifdef MPAS_OPENACC
@@ -165,6 +159,8 @@ contains
       coef_3rd_order = config_coef_3rd_order
 
       !
+      ! TODO: Move this and the data transfers up right after
+      !       allocates and before any calls
       ! set the velocity and height at dummy address
       !    used -1e34 so error clearly occurs if these values are used.
       !
@@ -175,7 +171,11 @@ contains
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
 #ifdef MPAS_OPENACC
-      !$acc update device(normalVelocity)
+      !$acc enter data copyin (layerThickness, normalVelocity, &
+      !$acc                    activeTracers, ssh, seaIcePressure, &
+      !$acc                    atmosphericPressure)
+      !$acc update device (normalTransportVelocity, &
+      !$acc                normalGMBolusVelocity)
 #endif
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
@@ -197,11 +197,8 @@ contains
       !
       if ( ke_vertex_flag == 1 ) then
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
+         !$acc update device(kineticEnergyCell)
       end if
-
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThickness)
-#endif
 
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
@@ -209,7 +206,8 @@ contains
                 normalizedRelativeVorticityCell)
 
 #ifdef MPAS_OPENACC
-      !$acc update self(normPlanetVortEdge)
+      !$acc update self(normRelVortEdge, normPlanetVortEdge, &
+      !$acc             normalizedRelativeVorticityCell)
 #endif
 
       !
@@ -220,18 +218,17 @@ contains
                 seaIcePressure, surfacePressure)
 
 #ifdef MPAS_OPENACC
-      !$acc enter data create(ssh)
+      !$acc update device(surfacePressure)
 #endif
 
       !
       ! Z-coordinates
       ! This section must be placed in the code before computing the density.
       !
-      call ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)
+      call ocn_diagnostic_solve_z_coordinates(layerThickness, zMid, zTop, ssh)
 
 #ifdef MPAS_OPENACC
-      !$acc update host(zMid, zTop)
-      !$acc exit data copyout(ssh)
+      !$acc update host(zMid, zTop, ssh)
 #endif
 
       !
@@ -262,8 +259,10 @@ contains
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
-      call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
+      call ocn_diagnostic_solve_pressure(layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)
+
+      !$acc update device (montgomeryPotential, pressure)
 
       nCells = nCellsAll
 
@@ -276,14 +275,10 @@ contains
                 normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)
 
 #ifdef MPAS_OPENACC
-         !$acc update host(RiTopOfCell)
+         !$acc update host(RiTopOfCell, BruntVaisalaFreqTop)
 #endif
 
       end if    ! full_compute
-
-#ifdef MPAS_OPENACC
-      !$acc update host(zMid)
-#endif
 
       !
       ! extrapolate tracer values to ocean surface
@@ -298,6 +293,7 @@ contains
          tracersSurfaceValue(:, iCell) = activeTracers(:, minLevelCell(iCell), iCell)
       end do
       !$omp end do
+      !$acc update device (tracersSurfaceValue)
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
@@ -317,10 +313,6 @@ contains
 
       if ( full_compute ) then
 
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(activeTracers)
-#endif
-
          !
          ! average tracer values over the ocean surface layer
          ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
@@ -330,16 +322,14 @@ contains
                 sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
 
 #ifdef MPAS_OPENACC
-         !$acc exit data delete(activeTracers)
-         !$acc update host(tracersSurfaceLayerValue, indexSurfaceLayerDepth, &
+         !$acc update host(tracersSurfaceLayerValue, &
+         !$acc             indexSurfaceLayerDepth, &
          !$acc             normalVelocitySurfaceLayer)
+         !$acc update device (sfcFlxAttCoeff, &
+         !$acc                surfaceFluxAttenuationCoefficientRunoff)
 #endif
 
       end if ! full_compute
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(layerThickness, normalVelocity)
-#endif
 
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
@@ -350,8 +340,13 @@ contains
 
          call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, pressureAdjustedSSH, &
                 gradSSH)
+         !$acc update device(pressureAdjustedSSH, gradSSH)
 
       end if ! full_compute
+
+      !$acc exit data delete (layerThickness, normalVelocity, &
+      !$acc                   activeTracers, ssh, seaIcePressure, &
+      !$acc                   atmosphericPressure)
 
       call mpas_timer_stop('diagnostic solve')
 
@@ -429,8 +424,10 @@ contains
             end do
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
    !--------------------------------------------------------------------
 
@@ -722,11 +719,14 @@ contains
       nVertices = nVerticesHalo( 2 )
 
 #ifdef MPAS_OPENACC
-      !$acc enter data &
-      !$acc            create(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
+      !$acc enter data create(normalizedRelativeVorticityVertex, &
+      !$acc                   normalizedPlanetaryVorticityVertex)
       !$acc parallel loop gang vector &
-      !$acc          present(areaTriangle, maxLevelVertexBot, layerThickness, kiteAreasOnVertex, &
-      !$acc                  relativeVorticity, fVertex) &
+      !$acc          present(areaTriangle, maxLevelVertexBot, &
+      !$acc                  layerThickness, kiteAreasOnVertex, &
+      !$acc                  relativeVorticity, fVertex, &
+      !$acc                  normalizedRelativeVorticityVertex, &
+      !$acc                  normalizedPlanetaryVorticityVertex) &
       !$acc          private(invAreaTri1, layerThicknessVertex, k, i)
 #else
       !$omp parallel
@@ -747,15 +747,19 @@ contains
             normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
       nEdges = nEdgesHalo( 2 )
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-      !$acc                  verticesOnEdge, maxLevelEdgeBot, normalizedRelativeVorticityVertex, &
+      !$acc          present(normalizedRelativeVorticityEdge, &
+      !$acc                  normalizedPlanetaryVorticityEdge, &
+      !$acc                  verticesOnEdge, maxLevelEdgeBot, &
+      !$acc                  normalizedRelativeVorticityVertex, &
       !$acc                  normalizedPlanetaryVorticityVertex) &
       !$acc          private(vertex1, vertex2, k)
 #else
@@ -774,10 +778,7 @@ contains
                                                      + normalizedPlanetaryVorticityVertex(k, vertex2))
         end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc update host(normalizedRelativeVorticityEdge)
-      !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
-#else
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
@@ -807,9 +808,7 @@ contains
           end do
         end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc update self(normalizedRelativeVorticityCell)
-#else
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
@@ -825,6 +824,10 @@ contains
                   vorticityGradientTangentialComponent(nVertLevels, nEdges))
 
          nEdges = nEdgesHalo( 1 )
+
+         !$acc update self(normalizedRelativeVorticityCell, &
+         !$acc             normalizedRelativeVorticityVertex, &
+         !$acc             normalizedRelativeVorticityEdge)
 
          !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
@@ -868,11 +871,15 @@ contains
          !$omp end do
          !$omp end parallel
 
+         !$acc update device(normalizedRelativeVorticityEdge)
+
          deallocate(vorticityGradientNormalComponent, &
                     vorticityGradientTangentialComponent)
 
       endif
 
+      !$acc exit data delete(normalizedRelativeVorticityVertex, &
+      !$acc                  normalizedPlanetaryVorticityVertex)
       deallocate(normalizedPlanetaryVorticityVertex, &
                  normalizedRelativeVorticityVertex)
 
@@ -954,8 +961,10 @@ contains
               / (zMid(k-1,iCell) - zMid(k,iCell))
           end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
       !
       ! Gradient Richardson number
@@ -988,8 +997,10 @@ contains
           end do
           RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
 #ifdef MPAS_OPENACC
       !$acc update host(BruntVaisalaFreqTop)
@@ -1101,8 +1112,10 @@ contains
           tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
                                             * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
         enddo
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
         nEdges = nEdgesOwned
 
@@ -1147,8 +1160,10 @@ contains
                                               * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
           end if
         enddo
+#ifndef MPAS_OPENACC
         !$omp end do
         !$omp end parallel
+#endif
 
       endif
 
@@ -1265,8 +1280,10 @@ contains
           end do
         end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
       ! Need 0,1,2 halo cells
       nCells = nCellsHalo( 2 )
@@ -1361,8 +1378,10 @@ contains
             end do
          end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
+#endif
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
 
@@ -1453,7 +1472,7 @@ contains
 !>    middle and top of each layer, and the sea-surface height
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)!{{{
+   subroutine ocn_diagnostic_solve_z_coordinates(layerThickness, zMid, zTop, ssh)!{{{
 
       implicit none
 
@@ -1463,7 +1482,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness
 
@@ -1538,7 +1556,7 @@ contains
 !>  This routine computes the diagnostic variables for pressure or montgomery potential
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
+   subroutine ocn_diagnostic_solve_pressure(layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)!{{{
 
       implicit none
@@ -1549,7 +1567,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -1743,7 +1760,7 @@ contains
 !>  cell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, scratchPool, oldLayerThickness, layerThicknessEdge, &
+   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdge, &
      normalVelocity, oldSSH, dt, vertAleTransportTop, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
@@ -1757,8 +1774,6 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          verticalMeshPool   !< Input: vertical mesh information
-
-      type (mpas_pool_type), intent(in) :: scratchPool !< Input: scratch variables
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          oldLayerThickness    !< Input: layer thickness at old time
@@ -1814,6 +1829,7 @@ contains
 
       if (config_vert_coord_movement.eq.'impermeable_interfaces') then
         vertAleTransportTop=0.0_RKIND
+        !$acc update device(vertAleTransportTop)
         return
       end if
 
@@ -1834,11 +1850,11 @@ contains
       !$acc enter data create(div_hu, projectedSSH, ALE_Thickness)
 
 ! DEBUG, MDT :: need to add OpenACC
-!      !$acc parallel loop &
-!      !$acc          present(div_hu, invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
-!      !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &
-!      !$acc                  oldSSH, projectedSSH) &
-!      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k)
+      !$acc parallel loop &
+      !$acc          present(div_hu, invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
+      !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &
+      !$acc                  oldSSH, projectedSSH) &
+      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr)
@@ -1860,7 +1876,7 @@ contains
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
 !#ifdef MPAS_OPENACC
-!      !$acc update host(projectedSSH)
+      !$acc update host(projectedSSH)
 !#else
       !$omp end do
       !$omp end parallel
@@ -1883,7 +1899,8 @@ contains
       ! and using ALE_Thickness for thickness at the new time.
 
 #ifdef MPAS_OPENACC
-      !$acc update device(div_hu, ALE_Thickness)
+!      !$acc update device(div_hu, ALE_Thickness)
+      !$acc update device(ALE_Thickness)
 
       !$acc parallel loop gang vector &
       !$acc          present(vertAleTransportTop, maxLevelCell, div_hu, ALE_Thickness, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -195,10 +195,20 @@ contains
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(layerThickness)
+      !$acc update device(relativeVorticity)
+#endif
+
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
                 normRelVortEdge, normPlanetVortEdge, &
                 normalizedRelativeVorticityCell)
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(layerThickness)
+      !$acc update self(normPlanetVortEdge)
+#endif
 
       !
       ! Surface pressure
@@ -669,9 +679,8 @@ contains
       nVertices = nVerticesHalo( 2 )
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThickness, fVertex) &
+      !$acc enter data &
       !$acc            create(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
-      !$acc update device(relativeVorticity)
 
       !$acc parallel loop gang vector &
       !$acc          present(areaTriangle, maxLevelVertexBot, layerThickness, kiteAreasOnVertex, &
@@ -696,12 +705,8 @@ contains
             normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(layerThickness, fVertex)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
       nEdges = nEdgesHalo( 2 )
 
@@ -728,7 +733,7 @@ contains
         end do
       end do
 #ifdef MPAS_OPENACC
-      !$acc update self(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge)
+      !$acc update self(normalizedRelativeVorticityEdge)
       !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
 #else
       !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2025,8 +2025,17 @@ contains
       !
       ! Put f*normalBaroclinicVelocity^{perp} in u as a work variable
       !
+#ifdef MPAS_OPENACC
+      !$acc enter data create(normalVelocity) copyin(normalBaroclinicVelocity)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(cellsOnEdge, maxLevelEdgeTop, normalVelocity, nEdgesOnEdge, &
+      !$acc                  edgesOnEdge, weightsOnEdge, fEdge, normalBaroclinicVelocity) &
+      !$acc          private(cell1, cell2, k, j, eoe)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, k, eoe)
+#endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -2041,8 +2050,12 @@ contains
             end do
          end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc exit data copyout(normalVelocity) delete(normalBaroclinicVelocity)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       call mpas_timer_stop("ocn_fuperp")
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -874,8 +874,18 @@ contains
       !
 
       nCells = nCellsHalo( 2 )
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocity)
+      !$acc update device(zMid, BruntVaisalaFreqTop, edgeAreaFractionOfCell)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(RiTopOfCell, maxLevelCell, nEdgesOnCell, edgesOnCell, normalVelocity, &
+      !$acc                  edgeAreaFractionOfCell, zMid, BruntVaisalaFreqTop) &
+      !$acc          private(k, i, iEdge, delU2, shearSquared, shearMean)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
+#endif
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
          do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
@@ -892,8 +902,13 @@ contains
           end do
           RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
       end do
+#ifdef MPAS_OPENACC
+      !$acc update host(RiTopOfCell)
+      !$acc exit data delete(normalVelocity)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
    end subroutine ocn_diagnostic_solve_richardson!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1810,7 +1810,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, iCell, k, i, nCells
+      integer :: iEdge, iCell, k, i, nCells, kmin, kmax
 
       real (kind=RKIND) :: flux, invAreaCell1, div_hu_btr
 
@@ -1853,10 +1853,10 @@ contains
       !$acc          present(div_hu, invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
       !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &
       !$acc                  oldSSH, projectedSSH) &
-      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k)
+      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k, kmin, kmax)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr)
+      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr, kmin, kmax)
 #endif
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
@@ -1864,8 +1864,10 @@ contains
          invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
 
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            do k = kmin, kmax
                flux = layerThicknessEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
                     * invAreaCell1
                div_hu(k,iCell) = div_hu(k,iCell) - flux

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,7 +150,20 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocity) async(1)
+      !$acc update device(normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
+      !$acc               vertTransportVelocityTop, vertGMBolusVelocityTop) async(1)
+#endif
+
+>>>>>>> Optimize diagnostics solve GPU data transfers
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
+
+#ifdef MPAS_OPENACC
+      !$acc update device(layerThickEdge) async(1)
+#endif
 
       coef_3rd_order = config_coef_3rd_order
 
@@ -164,7 +177,19 @@ contains
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
+<<<<<<< HEAD
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
+=======
+#ifdef MPAS_OPENACC
+      !$acc update device(normalVelocity) async(1)
+#endif
+
+      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
+
+#ifdef MPAS_OPENACC
+      !$acc update device(relativeVorticity) async(1)
+#endif
+>>>>>>> Optimize diagnostics solve GPU data transfers
 
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
@@ -172,6 +197,15 @@ contains
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc update host(tangentialVelocity, relativeVorticityCell, kineticEnergyCell, &
+      !$acc             divergence, vertVelocityTop, vertTransportVelocityTop, &
+      !$acc             vertGMBolusVelocityTop)
+#endif
+
+>>>>>>> Optimize diagnostics solve GPU data transfers
       !
       ! Compute kinetic energy
       !
@@ -179,11 +213,19 @@ contains
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(layerThickness)
+#endif
+
+>>>>>>> Optimize diagnostics solve GPU data transfers
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
                 normRelVortEdge, normPlanetVortEdge, &
                 normalizedRelativeVorticityCell)
 
+<<<<<<< HEAD
       !
       ! Surface pressure
       ! This section must be placed in the code before computing the density.
@@ -196,6 +238,11 @@ contains
       ! This section must be placed in the code before computing the density.
       !
       call ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)
+=======
+#ifdef MPAS_OPENACC
+      !$acc update self(normPlanetVortEdge)
+#endif
+>>>>>>> Optimize diagnostics solve GPU data transfers
 
       !
       ! equation of state
@@ -225,8 +272,17 @@ contains
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
+#ifdef MPAS_OPENACC
+      !$acc enter data create(ssh)
+#endif
+
       call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)
+
+#ifdef MPAS_OPENACC
+      !$acc update host(zMid, zTop)
+      !$acc exit data copyout(ssh)
+#endif
 
       nCells = nCellsAll
 
@@ -237,6 +293,10 @@ contains
          !
          call ocn_diagnostic_solve_richardson(displacedDensity, density, zMid, &
                 normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)
+
+#ifdef MPAS_OPENACC
+         !$acc update host(RiTopOfCell)
+#endif
 
       end if    ! full_compute
 
@@ -272,6 +332,10 @@ contains
                 sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
 
       end if ! full_compute
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(layerThickness, normalVelocity)
+#endif
 
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
@@ -875,8 +939,7 @@ contains
 
       nCells = nCellsHalo( 2 )
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocity)
-      !$acc update device(zMid, BruntVaisalaFreqTop, edgeAreaFractionOfCell)
+      !$acc update device(BruntVaisalaFreqTop, edgeAreaFractionOfCell)
 
       !$acc parallel loop gang vector &
       !$acc          present(RiTopOfCell, maxLevelCell, nEdgesOnCell, edgesOnCell, normalVelocity, &
@@ -902,13 +965,8 @@ contains
           end do
           RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
       end do
-#ifdef MPAS_OPENACC
-      !$acc update host(RiTopOfCell)
-      !$acc exit data delete(normalVelocity)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
    end subroutine ocn_diagnostic_solve_richardson!}}}
 
@@ -1037,7 +1095,6 @@ contains
 
         surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
 #ifdef MPAS_OPENACC
-        !$acc enter data copyin(normalVelocity)
         !$acc update device(layerThicknessEdge)
 
         !$acc parallel loop gang vector &
@@ -1076,7 +1133,6 @@ contains
         enddo
 #ifdef MPAS_OPENACC
         !$acc update host(normalVelocitySurfaceLayer)
-        !$acc exit data delete(normalVelocity)
 #else
         !$omp end do
         !$omp end parallel
@@ -1176,6 +1232,16 @@ contains
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsOwned
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
+      !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
+      !$acc                  relativeVorticity, kiteAreasOnVertex) &
+      !$acc          private(invAreaCell1, i, j, iVertex, k) wait(1)
+#else
+>>>>>>> Optimize diagnostics solve GPU data transfers
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
       do iCell = 1, nCells
@@ -1205,12 +1271,7 @@ contains
 <<<<<<< HEAD
 =======
 #ifdef MPAS_OPENACC
-      !$acc enter data create(div_hu, div_huTransport, div_huGMBolus)  &
-      !$acc            copyin(normalVelocity)
-      !$acc update device(layerThicknessEdge, normalTransportVelocity, normalGMBolusVelocity, &
-      !$acc               vertVelocityTop, vertTransportVelocityTop, vertGMBolusVelocityTop, &
-      !$acc               areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
-      !$acc               maxLevelCell)
+      !$acc enter data create(div_hu, div_huTransport, div_huGMBolus)
 
       !$acc parallel loop gang vector &
       !$acc          present(divergence, kineticEnergyCell, div_hu, div_huTransport, div_huGMBolus, &
@@ -1219,7 +1280,7 @@ contains
       !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
       !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-      !$acc                  dvEdge_temp, k, r_tmp)
+      !$acc                  dvEdge_temp, k, r_tmp) 
 #else
 >>>>>>> Finish porting diagnostics_solve to GPU
       !$omp parallel
@@ -1273,9 +1334,7 @@ contains
       !$omp end parallel
 =======
 #ifdef MPAS_OPENACC
-      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus, normalVelocity) 
-      !$acc update self(divergence, kineticEnergyCell, vertVelocityTop, vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop)
+      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus) 
 #else
       !$omp end do
       !$omp end parallel
@@ -1291,8 +1350,6 @@ contains
 =======
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocity)
-
       !$acc parallel loop gang &
       !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
       !$acc                  maxLevelEdgeTop, normalVelocity) &
@@ -1315,6 +1372,7 @@ contains
          end do
       end do
 <<<<<<< HEAD
+<<<<<<< HEAD
       !$omp end do
       !$omp end parallel
 =======
@@ -1326,6 +1384,10 @@ contains
       !$omp end parallel
 #endif
 >>>>>>> Finish porting diagnostics_solve to GPU
+=======
+      !$omp end do
+      !$omp end parallel
+>>>>>>> Optimize diagnostics solve GPU data transfers
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
 
@@ -1597,10 +1659,56 @@ contains
                                      + density(k  ,iCell)*layerThickness(k  ,iCell))
            end do
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+        !$acc parallel loop gang vector &
+        !$acc          present(maxLevelCell, zMid, layerThickness, zTop, bottomDepth) &
+        !$acc          private(k)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+#endif
+        do iCell = 1, nCells
+           ! Compute zMid, the z-coordinate of the middle of the layer.
+           ! Compute zTop, the z-coordinate of the top of the layer.
+           ! Note the negative sign, since bottomDepth is positive
+           ! and z-coordinates are negative below the surface.
+           k = maxLevelCell(iCell)
+           zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
+           zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) +     layerThickness(k,iCell)
+>>>>>>> Optimize diagnostics solve GPU data transfers
         end do
         !$omp end do
         !$omp end parallel
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+        !$acc parallel loop gang vector  &
+        !$acc          present(maxLevelCell, zMid, layerThickness, zTop, ssh) &
+        !$acc          private(k)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+#endif
+        do iCell = 1, nCells
+           do k = maxLevelCell(iCell)-1, 1, -1
+              zMid(k,iCell) = zMid(k+1,iCell)  &
+                + 0.5_RKIND*(  layerThickness(k+1,iCell) &
+                       + layerThickness(k  ,iCell))
+              zTop(k,iCell) = zTop(k+1,iCell)  &
+                       + layerThickness(k  ,iCell)
+           end do
+
+           ! copy zTop(1,iCell) into sea-surface height array
+           ssh(iCell) = zTop(1,iCell)
+
+        end do
+        !$omp end do
+        !$omp end parallel
+
+>>>>>>> Optimize diagnostics solve GPU data transfers
       endif
 
    end subroutine ocn_diagnostic_solve_pressure!}}}

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -186,11 +186,14 @@ contains
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
+<<<<<<< HEAD
 #ifdef MPAS_OPENACC
       !$acc update device(relativeVorticity)
 #endif
 >>>>>>> Optimize diagnostics solve GPU data transfers
 
+=======
+>>>>>>> Add new invAreaCell to ocn_mesh
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
@@ -202,7 +205,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc update host(tangentialVelocity, relativeVorticityCell, kineticEnergyCell, &
       !$acc             divergence, vertVelocityTop, vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop)
+      !$acc             vertGMBolusVelocityTop, relativeVorticity, circulation)
 #endif
 
 >>>>>>> Optimize diagnostics solve GPU data transfers
@@ -280,7 +283,7 @@ contains
                 surfacePressure, montgomeryPotential, pressure)
 
 #ifdef MPAS_OPENACC
-      !$acc update host(zMid, zTop)
+      !$acc update host(zTop)
       !$acc exit data copyout(ssh)
 #endif
 
@@ -299,6 +302,10 @@ contains
 #endif
 
       end if    ! full_compute
+
+#ifdef MPAS_OPENACC
+      !$acc update host(zMid)
+#endif
 
       !
       ! extrapolate tracer values to ocean surface
@@ -332,6 +339,10 @@ contains
 
       if ( full_compute ) then
 
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(activeTracers)
+#endif
+
          !
          ! average tracer values over the ocean surface layer
          ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
@@ -339,6 +350,12 @@ contains
                 layerThickEdge, normalVelocity, tracersSurfaceLayerValue,  &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
                 sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
+
+#ifdef MPAS_OPENACC
+         !$acc exit data delete(activeTracers)
+         !$acc update host(tracersSurfaceLayerValue, indexSurfaceLayerDepth, &
+         !$acc             normalVelocitySurfaceLayer)
+#endif
 
       end if ! full_compute
 
@@ -457,12 +474,8 @@ contains
             end do
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc update host(circulation, relativeVorticity)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
    !--------------------------------------------------------------------
 
@@ -643,7 +656,7 @@ contains
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
       do iCell = 1, nCells
         kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        invAreaCell1 = invAreaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)
           j = kiteIndexOnCell(i, iCell)
           iVertex = verticesOnCell(i, iCell)
@@ -795,16 +808,33 @@ contains
                                                      + normalizedPlanetaryVorticityVertex(k, vertex2))
         end do
       end do
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc update host(normalizedRelativeVorticityEdge)
+      !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
+#else
+>>>>>>> Add new invAreaCell to ocn_mesh
       !$omp end do
       !$omp end parallel
 
       nCells = nCellsHalo ( 1 )
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(normalizedRelativeVorticityCell, maxLevelCell, nEdgesOnCell, &
+      !$acc                  areaCell, kiteIndexOnCell, verticesOnCell, kiteAreasOnVertex, &
+      !$acc                  invAreaCell) &
+      !$acc          private(invAreaCell1, i, j, iVertex, k)
+#else
+>>>>>>> Add new invAreaCell to ocn_mesh
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
       do iCell = 1, nCells
         normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        invAreaCell1 = invAreaCell(iCell)
 
         do i = 1, nEdgesOnCell(iCell)
           j = kiteIndexOnCell(i, iCell)
@@ -945,8 +975,14 @@ contains
       ! Brunt-Vaisala frequency (this has units of s^{-2})
       !
       coef = -gravity / rho_sw
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(BruntVaisalaFreqTop, displacedDensity, density, zMid, maxLevelCell) &
+      !$acc          private(k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iCell = 1, nCellsAll
          BruntVaisalaFreqTop(minLevelCell(iCell),iCell) = 0.0_RKIND
          do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
@@ -963,7 +999,7 @@ contains
 
       nCells = nCellsHalo( 2 )
 #ifdef MPAS_OPENACC
-      !$acc update device(BruntVaisalaFreqTop, edgeAreaFractionOfCell)
+      !$acc update device(edgeAreaFractionOfCell)
 
       !$acc parallel loop gang vector &
       !$acc          present(RiTopOfCell, maxLevelCell, nEdgesOnCell, edgesOnCell, normalVelocity, &
@@ -971,7 +1007,7 @@ contains
       !$acc          private(k, i, iEdge, delU2, shearSquared, shearMean)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
+      !$omp do schedule(runtime) private(k, shearSquared, i, iEdge, delU2, shearMean)
 #endif
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
@@ -991,6 +1027,10 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
+#ifdef MPAS_OPENACC
+      !$acc update host(BruntVaisalaFreqTop)
+#endif
 
    end subroutine ocn_diagnostic_solve_richardson!}}}
 
@@ -1070,8 +1110,6 @@ contains
         surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
 
 #ifdef MPAS_OPENACC
-        !$acc enter data copyin(activeTracers)
-
         !$acc parallel loop gang vector &
         !$acc          present(tracersSurfaceLayerValue, indexSurfaceLayerDepth, maxLevelCell, &
         !$acc                  layerThickness, activeTracers) &
@@ -1102,13 +1140,8 @@ contains
           tracersSurfaceLayerValue(:,iCell) = (tracersSurfaceLayerValue(:,iCell) + fraction(rSurfaceLayer) &
                                             * activeTracers(:,k,iCell) * layerThickness(k,iCell)) / surfaceLayerDepth
         enddo
-#ifdef MPAS_OPENACC
-        !$acc update host(tracersSurfaceLayerValue, indexSurfaceLayerDepth)
-        !$acc exit data delete(activeTracers)
-#else
         !$omp end do
         !$omp end parallel
-#endif
 
         nEdges = nEdgesOwned
 
@@ -1119,8 +1152,6 @@ contains
 
         surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
 #ifdef MPAS_OPENACC
-        !$acc update device(layerThicknessEdge)
-
         !$acc parallel loop gang vector &
         !$acc          present(normalVelocitySurfaceLayer, cellsOnEdge, maxLevelEdgeTop, &
         !$acc                  layerThicknessEdge, normalVelocity) &
@@ -1155,12 +1186,8 @@ contains
                                               * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
           end if
         enddo
-#ifdef MPAS_OPENACC
-        !$acc update host(normalVelocitySurfaceLayer)
-#else
         !$omp end do
         !$omp end parallel
-#endif
 
       endif
 
@@ -1262,7 +1289,7 @@ contains
       !$acc parallel loop gang vector &
       !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
       !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
-      !$acc                  relativeVorticity, kiteAreasOnVertex) &
+      !$acc                  relativeVorticity, kiteAreasOnVertex, invAreaCell) &
       !$acc          private(invAreaCell1, i, j, iVertex, k)
 #else
 >>>>>>> Optimize diagnostics solve GPU data transfers
@@ -1270,7 +1297,7 @@ contains
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
-        invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+        invAreaCell1 = invAreaCell(iCell)
 
         do i = 1, nEdgesOnCell(iCell)
           j = kiteIndexOnCell(i, iCell)
@@ -1302,7 +1329,7 @@ contains
       !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
       !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdge, &
       !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
-      !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop) &
+      !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop, invAreaCell) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k, r_tmp) 
 #else
@@ -1321,7 +1348,7 @@ contains
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
          div_huGMBolus(:) = 0.0_RKIND
-         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+         invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
@@ -1894,7 +1921,7 @@ contains
 
       integer :: iEdge, iCell, k, i, nCells
 
-      real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
+      real (kind=RKIND) :: flux, invAreaCell1, div_hu_btr
 
       ! Scratch Arrays
       ! projectedSSH: projected SSH at a new time
@@ -1928,17 +1955,17 @@ contains
       !
       ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell, i, iEdge, k, flux, div_hu_btr)
+      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr)
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
          div_hu_btr = 0.0_RKIND
-         invAreaCell = 1.0_RKIND / areaCell(iCell)
+         invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
 
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                flux = layerThicknessEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
-                    * invAreaCell
+                    * invAreaCell1
                div_hu(k,iCell) = div_hu(k,iCell) - flux
                div_hu_btr = div_hu_btr - flux
             end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -314,12 +314,21 @@ contains
       end do
       !$omp end do
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(normalVelocity, normalVelocitySurfaceLayer)
+#else
       !$omp do schedule(runtime)
+#endif
       do iEdge = 1, nEdges
          normalVelocitySurfaceLayer(iEdge) = normalVelocity(minLevelEdgeBot(iEdge), iEdge)
       end do
+#ifdef MPAS_OPENACC
+      !$acc update host(normalVelocitySurfaceLayer)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       if ( full_compute ) then
 
@@ -421,9 +430,22 @@ contains
 
       err = 0
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocity)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
+      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex) &
+      !$acc          private(invAreaTri1, i, iEdge, k, r_tmp)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
+<<<<<<< HEAD
       do iVertex = 1, nVertices
+=======
+#endif
+      do iVertex = 1, nVerticesAll
+>>>>>>> Port ocn_relativeVorticity_circulation to GPU
          circulation(:, iVertex) = 0.0_RKIND
          relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -437,8 +459,13 @@ contains
             end do
          end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc update host(circulation, relativeVorticity)
+      !$acc exit data delete(normalVelocity)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
    !--------------------------------------------------------------------
 
@@ -1046,7 +1073,7 @@ contains
         surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
 
 #ifdef MPAS_OPENACC
-        !$acc enter data copyin(layerThickness, activeTracers)
+        !$acc enter data copyin(activeTracers)
 
         !$acc parallel loop gang vector &
         !$acc          present(tracersSurfaceLayerValue, indexSurfaceLayerDepth, maxLevelCell, &
@@ -1054,7 +1081,7 @@ contains
         !$acc          private(sumSurfaceLayer, k, rSurfaceLayer)
 #else
         !$omp parallel
-        !$omp do schedule(runtime) private(surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        !$omp do schedule(runtime) private(sumSurfaceLayer, k, rSurfaceLayer)
 #endif
         do iCell=1,nCells
           sumSurfaceLayer=0.0_RKIND
@@ -1080,7 +1107,7 @@ contains
         enddo
 #ifdef MPAS_OPENACC
         !$acc update host(tracersSurfaceLayerValue, indexSurfaceLayerDepth)
-        !$acc exit data delete(layerThickness, activeTracers)
+        !$acc exit data delete(activeTracers)
 #else
         !$omp end do
         !$omp end parallel
@@ -1871,7 +1898,6 @@ contains
       integer :: iEdge, iCell, k, i, nCells
 
       real (kind=RKIND) :: flux, invAreaCell, div_hu_btr
-      integer, dimension(:, :), pointer :: edgeSignOnCell
 
       ! Scratch Arrays
       ! projectedSSH: projected SSH at a new time
@@ -1890,8 +1916,6 @@ contains
         vertAleTransportTop=0.0_RKIND
         return
       end if
-
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
       ncells = nCellsAll
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -495,8 +495,6 @@ contains
    subroutine ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, &
                 layerThicknessEdge)!{{{
 
-      use ocn_mesh   ! debug, mdt :: this should be module-level
-
       implicit none
 
       !-----------------------------------------------------------------
@@ -593,8 +591,6 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_kineticEnergy(normalVelocity, &
                 kineticEnergyCell)!{{{
-
-      use ocn_mesh   ! debug, mdt :: this should be module-level
 
       implicit none
 
@@ -701,8 +697,6 @@ contains
                 layerThickness, relativeVorticity, &
                 normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
                 normalizedRelativeVorticityCell)!{{{
-
-      use ocn_mesh   ! debug, mdt :: this should be module-level
 
       implicit none
 
@@ -928,8 +922,6 @@ contains
    subroutine ocn_diagnostic_solve_richardson(displacedDensity, density, zMid, &
                 normalVelocity, edgeAreaFractionOfCell, BruntVaisalaFreqTop, RiTopOfCell)!{{{
 
-      use ocn_mesh   ! debug, mdt :: this should be module-level
-
       implicit none
 
       !-----------------------------------------------------------------
@@ -1050,8 +1042,6 @@ contains
                 layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
                 surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)!{{{
-
-      use ocn_mesh   ! debug, mdt :: this should be module-level
 
       implicit none
 
@@ -1401,7 +1391,7 @@ contains
 =======
 
 #ifdef MPAS_OPENACC
-      !$acc parallel loop gang &
+      !$acc parallel loop gang vector &
       !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
       !$acc                  maxLevelEdgeTop, normalVelocity) &
       !$acc          private(i, eoe, weightsOnEdge_temp, k) 
@@ -1615,8 +1605,6 @@ contains
    subroutine ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)!{{{
 
-      use ocn_mesh     ! debug, mdt :: this should be module-level
-
       implicit none
 
       !-----------------------------------------------------------------
@@ -1777,8 +1765,6 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, pressureAdjustedSSH, &
                 gradSSH)!{{{
-
-      use ocn_mesh     ! debug, mdt :: this should be module-level
 
       implicit none
 
@@ -1954,8 +1940,19 @@ contains
       ! thickness-weighted divergence and barotropic divergence
       !
       ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
+#ifdef MPAS_OPENACC
+      !$acc enter data create(div_hu, projectedSSH, ALE_Thickness)
+
+! DEBUG, MDT :: need to add OpenACC
+!      !$acc parallel loop &
+!      !$acc          present(div_hu, invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
+!      !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &
+!      !$acc                  oldSSH, projectedSSH) &
+!      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr)
+#endif
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
          div_hu_btr = 0.0_RKIND
@@ -1972,8 +1969,12 @@ contains
          end do
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
+!#ifdef MPAS_OPENACC
+!      !$acc update host(projectedSSH)
+!#else
       !$omp end do
       !$omp end parallel
+!#endif
 
       !
       ! Compute desired thickness at new time
@@ -1991,8 +1992,17 @@ contains
       ! Here we are using solving the continuity equation for vertAleTransportTop ($w^t$),
       ! and using ALE_Thickness for thickness at the new time.
 
+#ifdef MPAS_OPENACC
+      !$acc update device(div_hu, ALE_Thickness)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(vertAleTransportTop, maxLevelCell, div_hu, ALE_Thickness, &
+      !$acc                  oldLayerThickness) &
+      !$acc          private(k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iCell = 1,nCells
          vertAleTransportTop(1,iCell) = 0.0_RKIND
          vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
@@ -2001,8 +2011,12 @@ contains
               - (ALE_Thickness(k,iCell) - oldLayerThickness(k,iCell))/dt
          end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(div_hu, projectedSSH, ALE_Thickness)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       deallocate(div_hu, &
                  projectedSSH, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1202,10 +1202,34 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc enter data create(div_hu, div_huTransport, div_huGMBolus)  &
+      !$acc            copyin(normalVelocity)
+      !$acc update device(layerThicknessEdge, normalTransportVelocity, normalGMBolusVelocity, &
+      !$acc               vertVelocityTop, vertTransportVelocityTop, vertGMBolusVelocityTop, &
+      !$acc               areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
+      !$acc               maxLevelCell)
+
+      !$acc parallel loop gang vector &
+      !$acc          present(divergence, kineticEnergyCell, div_hu, div_huTransport, div_huGMBolus, &
+      !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
+      !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdge, &
+      !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
+      !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop) &
+      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+      !$acc                  dvEdge_temp, k, r_tmp)
+#else
+>>>>>>> Finish porting diagnostics_solve to GPU
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
       !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
+<<<<<<< HEAD
+=======
+#endif
+>>>>>>> Finish porting diagnostics_solve to GPU
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -1244,14 +1268,40 @@ contains
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
+<<<<<<< HEAD
       !$omp end do
       !$omp end parallel
+=======
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus, normalVelocity) 
+      !$acc update self(divergence, kineticEnergyCell, vertVelocityTop, vertTransportVelocityTop, &
+      !$acc             vertGMBolusVelocityTop)
+#else
+      !$omp end do
+      !$omp end parallel
+#endif
+>>>>>>> Finish porting diagnostics_solve to GPU
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
       nEdges = nEdgesHalo( 2 )
+<<<<<<< HEAD
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+=======
+
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocity)
+
+      !$acc parallel loop gang &
+      !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
+      !$acc                  maxLevelEdgeTop, normalVelocity) &
+      !$acc          private(i, eoe, weightsOnEdge_temp, k) 
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+#endif
+>>>>>>> Finish porting diagnostics_solve to GPU
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -1264,8 +1314,18 @@ contains
             end do
          end do
       end do
+<<<<<<< HEAD
       !$omp end do
       !$omp end parallel
+=======
+#ifdef MPAS_OPENACC
+      !$acc update self(tangentialVelocity)
+      !$acc exit data delete(normalVelocity)
+#else
+      !$omp end do
+      !$omp end parallel
+#endif
+>>>>>>> Finish porting diagnostics_solve to GPU
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,15 +150,12 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(normalVelocity)
       !$acc update device(normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
       !$acc               vertTransportVelocityTop, vertGMBolusVelocityTop)
 #endif
 
->>>>>>> Optimize diagnostics solve GPU data transfers
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
 #ifdef MPAS_OPENACC
@@ -177,38 +174,24 @@ contains
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
-<<<<<<< HEAD
-      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
-=======
 #ifdef MPAS_OPENACC
       !$acc update device(normalVelocity)
 #endif
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
-<<<<<<< HEAD
-#ifdef MPAS_OPENACC
-      !$acc update device(relativeVorticity)
-#endif
->>>>>>> Optimize diagnostics solve GPU data transfers
-
-=======
->>>>>>> Add new invAreaCell to ocn_mesh
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc update host(tangentialVelocity, relativeVorticityCell, kineticEnergyCell, &
       !$acc             divergence, vertVelocityTop, vertTransportVelocityTop, &
       !$acc             vertGMBolusVelocityTop, relativeVorticity, circulation)
 #endif
 
->>>>>>> Optimize diagnostics solve GPU data transfers
       !
       ! Compute kinetic energy
       !
@@ -216,19 +199,19 @@ contains
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThickness)
 #endif
 
->>>>>>> Optimize diagnostics solve GPU data transfers
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
                 normRelVortEdge, normPlanetVortEdge, &
                 normalizedRelativeVorticityCell)
 
-<<<<<<< HEAD
+#ifdef MPAS_OPENACC
+      !$acc update self(normPlanetVortEdge)
+#endif
+
       !
       ! Surface pressure
       ! This section must be placed in the code before computing the density.
@@ -236,16 +219,20 @@ contains
       call ocn_diagnostic_solve_surface_pressure(forcingPool, atmosphericPressure, &
                 seaIcePressure, surfacePressure)
 
+#ifdef MPAS_OPENACC
+      !$acc enter data create(ssh)
+#endif
+
       !
       ! Z-coordinates
       ! This section must be placed in the code before computing the density.
       !
       call ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)
-=======
+
 #ifdef MPAS_OPENACC
-      !$acc update self(normPlanetVortEdge)
+      !$acc update host(zMid, zTop)
+      !$acc exit data copyout(ssh)
 #endif
->>>>>>> Optimize diagnostics solve GPU data transfers
 
       !
       ! equation of state
@@ -275,17 +262,8 @@ contains
       ! Pressure
       ! This section must be placed in the code after computing the density.
       !
-#ifdef MPAS_OPENACC
-      !$acc enter data create(ssh)
-#endif
-
       call ocn_diagnostic_solve_pressure(forcingPool, layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)
-
-#ifdef MPAS_OPENACC
-      !$acc update host(zTop)
-      !$acc exit data copyout(ssh)
-#endif
 
       nCells = nCellsAll
 
@@ -391,16 +369,13 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)!{{{
+   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity
@@ -426,24 +401,8 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iVertex, iEdge, i, k
-      integer, pointer :: nEdges, nVertices, vertexDegree
-      integer, dimension(:), pointer :: maxLevelVertexBot
-      integer, dimension(:,:), pointer :: edgesOnVertex, edgeSignOnVertex
 
       real (kind=RKIND) :: invAreaTri1, r_tmp
-      real (kind=RKIND), dimension(:), pointer :: &
-              dcEdge, areaTriangle
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
       err = 0
 
@@ -455,12 +414,8 @@ contains
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
-<<<<<<< HEAD
-      do iVertex = 1, nVertices
-=======
 #endif
       do iVertex = 1, nVerticesAll
->>>>>>> Port ocn_relativeVorticity_circulation to GPU
          circulation(:, iVertex) = 0.0_RKIND
          relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -766,8 +721,17 @@ contains
 
       nVertices = nVerticesHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc enter data &
+      !$acc            create(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
+      !$acc parallel loop gang vector &
+      !$acc          present(areaTriangle, maxLevelVertexBot, layerThickness, kiteAreasOnVertex, &
+      !$acc                  relativeVorticity, fVertex) &
+      !$acc          private(invAreaTri1, layerThicknessVertex, k, i)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
+#endif
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = 1, maxLevelVertexBot(iVertex)
@@ -788,8 +752,16 @@ contains
 
       nEdges = nEdgesHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+      !$acc                  verticesOnEdge, maxLevelEdgeBot, normalizedRelativeVorticityVertex, &
+      !$acc                  normalizedPlanetaryVorticityVertex) &
+      !$acc          private(vertex1, vertex2, k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(vertex1, vertex2, k)
+#endif
       do iEdge = 1, nEdges
         normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
         normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
@@ -802,20 +774,16 @@ contains
                                                      + normalizedPlanetaryVorticityVertex(k, vertex2))
         end do
       end do
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc update host(normalizedRelativeVorticityEdge)
       !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
 #else
->>>>>>> Add new invAreaCell to ocn_mesh
       !$omp end do
       !$omp end parallel
+#endif
 
       nCells = nCellsHalo ( 1 )
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(normalizedRelativeVorticityCell, maxLevelCell, nEdgesOnCell, &
@@ -823,9 +791,9 @@ contains
       !$acc                  invAreaCell) &
       !$acc          private(invAreaCell1, i, j, iVertex, k)
 #else
->>>>>>> Add new invAreaCell to ocn_mesh
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+#endif
       do iCell = 1, nCells
         normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
         invAreaCell1 = invAreaCell(iCell)
@@ -839,8 +807,12 @@ contains
           end do
         end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc update self(normalizedRelativeVorticityCell)
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       nCells = nCellsAll
       nVertices = nVerticesAll
@@ -992,7 +964,6 @@ contains
       nCells = nCellsHalo( 2 )
 #ifdef MPAS_OPENACC
       !$acc update device(edgeAreaFractionOfCell)
-
       !$acc parallel loop gang vector &
       !$acc          present(RiTopOfCell, maxLevelCell, nEdgesOnCell, edgesOnCell, normalVelocity, &
       !$acc                  edgeAreaFractionOfCell, zMid, BruntVaisalaFreqTop) &
@@ -1098,7 +1069,6 @@ contains
 
         nCells = nCellsOwned
         surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
-
 #ifdef MPAS_OPENACC
         !$acc parallel loop gang vector &
         !$acc          present(tracersSurfaceLayerValue, indexSurfaceLayerDepth, maxLevelCell, &
@@ -1122,6 +1092,7 @@ contains
              exit
            endif
           end do
+          tracersSurfaceLayerValue(:, iCell) = 0.0_RKIND
           do k=1,int(rSurfaceLayer)
             tracersSurfaceLayerValue(:,iCell) = tracersSurfaceLayerValue(:,iCell) + activeTracers(:,k,iCell) &
                                               * layerThickness(k,iCell)
@@ -1148,7 +1119,7 @@ contains
         !$acc          private(cell1, cell2, rSurfaceLayer, sumSurfaceLayer, k)
 #else
         !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, surfaceLayerDepth, sumSurfaceLayer, k, rSurfaceLayer)
+        !$omp do schedule(runtime) private(cell1, cell2, sumSurfaceLayer, k, rSurfaceLayer)
 #endif
         do iEdge=1,nEdges
           normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
@@ -1213,8 +1184,6 @@ contains
                 vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
                 kineticEnergyCell, tangentialVelocity)!{{{
 
-      use ocn_mesh
-
       implicit none
 
       !-----------------------------------------------------------------
@@ -1273,8 +1242,6 @@ contains
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsOwned
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
@@ -1282,9 +1249,9 @@ contains
       !$acc                  relativeVorticity, kiteAreasOnVertex, invAreaCell) &
       !$acc          private(invAreaCell1, i, j, iVertex, k)
 #else
->>>>>>> Optimize diagnostics solve GPU data transfers
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
+#endif
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
         invAreaCell1 = invAreaCell(iCell)
@@ -1309,11 +1276,8 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc enter data create(div_hu, div_huTransport, div_huGMBolus)
-
       !$acc parallel loop gang vector &
       !$acc          present(divergence, kineticEnergyCell, div_hu, div_huTransport, div_huGMBolus, &
       !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
@@ -1323,15 +1287,11 @@ contains
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k, r_tmp) 
 #else
->>>>>>> Finish porting diagnostics_solve to GPU
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
       !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
-<<<<<<< HEAD
-=======
 #endif
->>>>>>> Finish porting diagnostics_solve to GPU
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -1370,26 +1330,16 @@ contains
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
-<<<<<<< HEAD
-      !$omp end do
-      !$omp end parallel
-=======
 #ifdef MPAS_OPENACC
       !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus) 
 #else
       !$omp end do
       !$omp end parallel
 #endif
->>>>>>> Finish porting diagnostics_solve to GPU
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
       nEdges = nEdgesHalo( 2 )
-<<<<<<< HEAD
-      !$omp parallel
-      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
-=======
-
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
@@ -1399,7 +1349,6 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
 #endif
->>>>>>> Finish porting diagnostics_solve to GPU
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -1412,23 +1361,8 @@ contains
             end do
          end do
       end do
-<<<<<<< HEAD
-<<<<<<< HEAD
       !$omp end do
       !$omp end parallel
-=======
-#ifdef MPAS_OPENACC
-      !$acc update self(tangentialVelocity)
-      !$acc exit data delete(normalVelocity)
-#else
-      !$omp end do
-      !$omp end parallel
-#endif
->>>>>>> Finish porting diagnostics_solve to GPU
-=======
-      !$omp end do
-      !$omp end parallel
->>>>>>> Optimize diagnostics solve GPU data transfers
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
 
@@ -1445,8 +1379,6 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_surface_pressure(forcingPool, atmosphericPressure, &
                 seaIcePressure, surfacePressure)!{{{
-
-      use ocn_mesh     ! debug, mdt :: this should be module-level
 
       implicit none
 
@@ -1523,8 +1455,6 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_z_coordinates(forcingPool, layerThickness, zMid, zTop, ssh)!{{{
 
-      use ocn_mesh     ! debug, mdt :: this should be module-level
-
       implicit none
 
       !-----------------------------------------------------------------
@@ -1562,8 +1492,14 @@ contains
 
       nCells = nCellsAll
 
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(maxLevelCell, zMid, layerThickness, zTop, bottomDepth, ssh) &
+      !$acc          private(k)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iCell = 1, nCells
 
          ! Compute zMid, the z-coordinate of the middle of the layer.
@@ -1698,56 +1634,10 @@ contains
                                      + density(k  ,iCell)*layerThickness(k  ,iCell))
            end do
 
-<<<<<<< HEAD
-=======
-#ifdef MPAS_OPENACC
-        !$acc parallel loop gang vector &
-        !$acc          present(maxLevelCell, zMid, layerThickness, zTop, bottomDepth) &
-        !$acc          private(k)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k)
-#endif
-        do iCell = 1, nCells
-           ! Compute zMid, the z-coordinate of the middle of the layer.
-           ! Compute zTop, the z-coordinate of the top of the layer.
-           ! Note the negative sign, since bottomDepth is positive
-           ! and z-coordinates are negative below the surface.
-           k = maxLevelCell(iCell)
-           zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
-           zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) +     layerThickness(k,iCell)
->>>>>>> Optimize diagnostics solve GPU data transfers
         end do
         !$omp end do
         !$omp end parallel
 
-<<<<<<< HEAD
-=======
-#ifdef MPAS_OPENACC
-        !$acc parallel loop gang vector  &
-        !$acc          present(maxLevelCell, zMid, layerThickness, zTop, ssh) &
-        !$acc          private(k)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k)
-#endif
-        do iCell = 1, nCells
-           do k = maxLevelCell(iCell)-1, 1, -1
-              zMid(k,iCell) = zMid(k+1,iCell)  &
-                + 0.5_RKIND*(  layerThickness(k+1,iCell) &
-                       + layerThickness(k  ,iCell))
-              zTop(k,iCell) = zTop(k+1,iCell)  &
-                       + layerThickness(k  ,iCell)
-           end do
-
-           ! copy zTop(1,iCell) into sea-surface height array
-           ssh(iCell) = zTop(1,iCell)
-
-        end do
-        !$omp end do
-        !$omp end parallel
-
->>>>>>> Optimize diagnostics solve GPU data transfers
       endif
 
    end subroutine ocn_diagnostic_solve_pressure!}}}
@@ -2270,21 +2160,24 @@ contains
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(densitySurfaceDisplaced, &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
+
       ! compute EOS by displacing SST/SSS to every vertical layer in column
       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 0, 'surfaceDisplaced', densitySurfaceDisplaced, &
                                          err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
-<<<<<<< HEAD
-=======
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(densitySurfaceDisplaced, &
       !$acc                   thermalExpansionCoeff,   &
       !$acc                   salineContractionCoeff)
 #endif
 
->>>>>>> Continued GPU data transfer optimization
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(fracAbsorbed, fracAbsorbedRunoff, sumSurfaceStressSquared, i, iEdge)
@@ -2346,6 +2239,12 @@ contains
       enddo
       !$omp end do
       !$omp end parallel
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(densitySurfaceDisplaced, &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
 
       ! deallocate scratch space
       deallocate(thermalExpansionCoeff, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,6 +150,11 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
+!#ifdef MPAS_OPENACC
+!      !$acc enter data copyin(normalVelocity)
+!#endif
+
+      ! debug, mdt :: this is run only on the host
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
       coef_3rd_order = config_coef_3rd_order
@@ -164,7 +169,16 @@ contains
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
-      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
+!#ifdef MPAS_OPENACC
+!      !$acc update device(normalVelocity)
+!#endif
+
+      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
+
+!#ifdef MPAS_OPENACC
+!      !$acc update self(relativeVorticity, circulation)
+!      !$acc exit data delete(normalVelocity)
+!#endif
 
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
@@ -301,16 +315,13 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)!{{{
+   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
-
-      type (mpas_pool_type), intent(in) :: &
-         meshPool
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity
@@ -336,31 +347,14 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iVertex, iEdge, i, k
-      integer, pointer :: nEdges, nVertices, vertexDegree
-      integer, dimension(:), pointer :: maxLevelVertexBot, minLevelVertexTop
-      integer, dimension(:,:), pointer :: edgesOnVertex, edgeSignOnVertex
 
       real (kind=RKIND) :: invAreaTri1, r_tmp
-      real (kind=RKIND), dimension(:), pointer :: &
-              dcEdge, areaTriangle
-
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', minLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
-
-      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
       err = 0
 
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
-      do iVertex = 1, nVertices
+      do iVertex = 1, nVerticesAll
          circulation(:, iVertex) = 0.0_RKIND
          relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -1985,11 +1979,23 @@ contains
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsHalo( 2 )
 
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(densitySurfaceDisplaced, &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
+
       ! compute EOS by displacing SST/SSS to every vertical layer in column
       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 0, 'surfaceDisplaced', densitySurfaceDisplaced, &
                                          err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
+
+#ifdef MPAS_OPENACC
+      !$acc exit data copyout( &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
 
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -2052,6 +2058,12 @@ contains
       enddo
       !$omp end do
       !$omp end parallel
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(densitySurfaceDisplaced, &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
 
       ! deallocate scratch space
       deallocate(thermalExpansionCoeff, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -153,16 +153,16 @@ contains
 <<<<<<< HEAD
 =======
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocity) async(1)
+      !$acc enter data copyin(normalVelocity)
       !$acc update device(normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
-      !$acc               vertTransportVelocityTop, vertGMBolusVelocityTop) async(1)
+      !$acc               vertTransportVelocityTop, vertGMBolusVelocityTop)
 #endif
 
 >>>>>>> Optimize diagnostics solve GPU data transfers
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
 #ifdef MPAS_OPENACC
-      !$acc update device(layerThickEdge) async(1)
+      !$acc update device(layerThickEdge)
 #endif
 
       coef_3rd_order = config_coef_3rd_order
@@ -181,13 +181,13 @@ contains
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 =======
 #ifdef MPAS_OPENACC
-      !$acc update device(normalVelocity) async(1)
+      !$acc update device(normalVelocity)
 #endif
 
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
 #ifdef MPAS_OPENACC
-      !$acc update device(relativeVorticity) async(1)
+      !$acc update device(relativeVorticity)
 #endif
 >>>>>>> Optimize diagnostics solve GPU data transfers
 
@@ -431,8 +431,6 @@ contains
       err = 0
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(normalVelocity)
-
       !$acc parallel loop gang vector &
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex) &
@@ -461,7 +459,6 @@ contains
       end do
 #ifdef MPAS_OPENACC
       !$acc update host(circulation, relativeVorticity)
-      !$acc exit data delete(normalVelocity)
 #else
       !$omp end do
       !$omp end parallel
@@ -1266,7 +1263,7 @@ contains
       !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
       !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
       !$acc                  relativeVorticity, kiteAreasOnVertex) &
-      !$acc          private(invAreaCell1, i, j, iVertex, k) wait(1)
+      !$acc          private(invAreaCell1, i, j, iVertex, k)
 #else
 >>>>>>> Optimize diagnostics solve GPU data transfers
       !$omp parallel
@@ -2238,6 +2235,15 @@ contains
                                          err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
 
+<<<<<<< HEAD
+=======
+#ifdef MPAS_OPENACC
+      !$acc exit data copyout(densitySurfaceDisplaced, &
+      !$acc                   thermalExpansionCoeff,   &
+      !$acc                   salineContractionCoeff)
+#endif
+
+>>>>>>> Continued GPU data transfer optimization
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(fracAbsorbed, fracAbsorbedRunoff, sumSurfaceStressSquared, i, iEdge)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -150,10 +150,6 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
 
-!#ifdef MPAS_OPENACC
-!      !$acc enter data copyin(normalVelocity)
-!#endif
-
       call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
 
       coef_3rd_order = config_coef_3rd_order
@@ -168,25 +164,13 @@ contains
       activeTracers(indexTemperature,:,nCells+1) = -1e34
       activeTracers(indexSalinity,:,nCells+1) = -1e34
 
-      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
-
-!#ifdef MPAS_OPENACC
-!      !$acc update device(relativeVorticity, layerThickEdge, normalVelocity, &
-!      !$acc               normalTransportVelocity, normalGMBolusVelocity, &
-!      !$acc               vertVelocityTop) async(1)
-!#endif
+      call ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)
 
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
-
-!#ifdef MPAS_OPENACC
-!      !$acc update self(vertTransportVelocityTop, vertGMBolusVelocityTop, &
-!      !$acc             relativeVorticityCell, divergence, kineticEnergyCell, &
-!      !$acc             tangentialVelocity) async(1)
-!#endif
 
       !
       ! Compute kinetic energy
@@ -195,20 +179,10 @@ contains
          call ocn_diagnostic_solve_kineticEnergy(normalVelocity, kineticEnergyCell)
       end if
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(layerThickness)
-      !$acc update device(relativeVorticity)
-#endif
-
       call ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
                 layerThickness, relativeVorticity, &
                 normRelVortEdge, normPlanetVortEdge, &
                 normalizedRelativeVorticityCell)
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(layerThickness)
-      !$acc update self(normPlanetVortEdge)
-#endif
 
       !
       ! Surface pressure
@@ -327,13 +301,16 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)!{{{
+   subroutine ocn_relativeVorticity_circulation(relativeVorticity, circulation, meshPool, normalVelocity, err)!{{{
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity
@@ -359,14 +336,30 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iVertex, iEdge, i, k
+      integer, pointer :: nEdges, nVertices, vertexDegree
+      integer, dimension(:), pointer :: maxLevelVertexBot
+      integer, dimension(:,:), pointer :: edgesOnVertex, edgeSignOnVertex
 
       real (kind=RKIND) :: invAreaTri1, r_tmp
+      real (kind=RKIND), dimension(:), pointer :: &
+              dcEdge, areaTriangle
+
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
+      call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
+      call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
+
+      call mpas_pool_get_array(meshPool, 'areaTriangle', areaTriangle)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
       err = 0
 
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
-      do iVertex = 1, nVerticesAll
+      do iVertex = 1, nVertices
          circulation(:, iVertex) = 0.0_RKIND
          relativeVorticity(:, iVertex) = 0.0_RKIND
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -678,18 +671,8 @@ contains
 
       nVertices = nVerticesHalo( 2 )
 
-#ifdef MPAS_OPENACC
-      !$acc enter data &
-      !$acc            create(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
-
-      !$acc parallel loop gang vector &
-      !$acc          present(areaTriangle, maxLevelVertexBot, layerThickness, kiteAreasOnVertex, &
-      !$acc                  relativeVorticity, fVertex) &
-      !$acc          private(invAreaTri1, layerThicknessVertex, k, i)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
-#endif
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = 1, maxLevelVertexBot(iVertex)
@@ -710,16 +693,8 @@ contains
 
       nEdges = nEdgesHalo( 2 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-      !$acc                  verticesOnEdge, maxLevelEdgeBot, normalizedRelativeVorticityVertex, &
-      !$acc                  normalizedPlanetaryVorticityVertex) &
-      !$acc          private(vertex1, vertex2, k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(vertex1, vertex2, k)
-#endif
       do iEdge = 1, nEdges
         normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
         normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
@@ -732,25 +707,13 @@ contains
                                                      + normalizedPlanetaryVorticityVertex(k, vertex2))
         end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc update self(normalizedRelativeVorticityEdge)
-      !$acc exit data delete(normalizedRelativeVorticityVertex, normalizedPlanetaryVorticityVertex)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsHalo ( 1 )
 
-#ifdef MPAS_OPENACC
-      !$acc parallel loop gang vector &
-      !$acc          present(normalizedRelativeVorticityCell, maxLevelCell, nEdgesOnCell, &
-      !$acc                  areaCell, kiteIndexOnCell, verticesOnCell, kiteAreasOnVertex) &
-      !$acc          private(invAreaCell1, i, j, iVertex, k)
-#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
-#endif
       do iCell = 1, nCells
         normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -764,12 +727,8 @@ contains
           end do
         end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc update self(normalizedRelativeVorticityCell)
-#else
       !$omp end do
       !$omp end parallel
-#endif
 
       nCells = nCellsAll
       nVertices = nVerticesAll
@@ -1174,15 +1133,8 @@ contains
       ! Need owned cells for relativeVorticityCell
       nCells = nCellsOwned
 
-!#ifdef MPAS_OPENACC
-!      !$acc parallel loop gang vector &
-!      !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
-!      !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
-!      !$acc                  relativeVorticity) async(1)
-!#else
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
-!#endif
       do iCell = 1, nCells
         relativeVorticityCell(:,iCell) = 0.0_RKIND
         invAreaCell1 = 1.0_RKIND / areaCell(iCell)
@@ -1207,23 +1159,10 @@ contains
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
 
-!#ifdef MPAS_OPENACC
-!      !$acc enter data create(div_hu, div_huTransport, div_huGMBolus) async(1)
-!
-!      !$acc parallel loop gang vector &
-!      !$acc          present(divergence, kineticEnergyCell, div_hu, div_huTransport, &
-!      !$acc                  div_huGMBolus, areaCell, nEdgesOnCell, edgesOnCell, &
-!      !$acc                  dcEdge, dvEdge, maxLevelCell, normalVelocity, layerThicknessEdge, &
-!      !$acc                  kineticEnergyCell, normalTransportVelocity, normalGMBolusVelocity, &
-!      !$acc                  vertVelocityTop, vertTransportVelocityTop, vertGMBolusVelocityTop) &
-!      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-!      !$acc                  dvEdge_temp, k, r_tmp) async(1)
-!#else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
       !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
-!#endif
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
@@ -1265,23 +1204,11 @@ contains
       !$omp end do
       !$omp end parallel
 
-!#ifdef MPAS_OPENACC
-!      !$acc exit data delete(div_hu, div_huTransport, div_huGMBolus) async(1)
-!#endif
-
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
       nEdges = nEdgesHalo( 2 )
-
-!#ifdef MPAS_OPENACC
-!      !$acc parallel loop gang &
-!      !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
-!      !$acc                  maxLevelEdgeTop, normalVelocity) &
-!      !$acc          private(i, eoe, weightsOnEdge_temp, k) async(1)
-!#else
       !$omp parallel
       !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
-!#endif
       do iEdge = 1, nEdges
          tangentialVelocity(:, iEdge) = 0.0_RKIND
          ! Compute v (tangential) velocities
@@ -2057,23 +1984,11 @@ contains
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsHalo( 2 )
 
-#ifdef MPAS_OPENACC
-      !$acc enter data copyin(densitySurfaceDisplaced, &
-      !$acc                   thermalExpansionCoeff,   &
-      !$acc                   salineContractionCoeff)
-#endif
-
       ! compute EOS by displacing SST/SSS to every vertical layer in column
       call ocn_equation_of_state_density(statePool, meshPool, tracersSurfaceValue, &
                                          nCells, 0, 'surfaceDisplaced', densitySurfaceDisplaced, &
                                          err, thermalExpansionCoeff, salineContractionCoeff, &
                                          timeLevel)
-
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout( &
-      !$acc                   thermalExpansionCoeff,   &
-      !$acc                   salineContractionCoeff)
-#endif
 
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -2136,12 +2051,6 @@ contains
       enddo
       !$omp end do
       !$omp end parallel
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(densitySurfaceDisplaced, &
-      !$acc                   thermalExpansionCoeff,   &
-      !$acc                   salineContractionCoeff)
-#endif
 
       ! deallocate scratch space
       deallocate(thermalExpansionCoeff, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -676,19 +676,19 @@ contains
 
    subroutine ocn_diagnostics_variables_destroy(err) !{{{
 
-      ! Input variables                                                                                      
-                                                                                                             
-      ! Output variables                                                                                     
-                                                                                                             
-      integer, intent(out) :: &                                                                              
-         err                   ! returned error flag                                                         
-                                                                                                             
-      ! Local variables                                                                                      
-                                                                                                             
-      !***                                                                                                   
-      !*** end of preamble, begin code                                                                       
-      !***                                                                                                   
-                                                                                                             
+      ! Input variables
+
+      ! Output variables
+
+      integer, intent(out) :: &
+         err                   ! returned error flag
+
+      ! Local variables
+
+      !***
+      !*** end of preamble, begin code
+      !***
+
       err = 0
 
       ! Remove data from the device
@@ -897,7 +897,191 @@ contains
       !$acc                   )
 
       ! Nullify pointers
-      ! debug, mdt :: still need to do this
+      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
+         nullify(topDrag,                         &
+                 topDragMag,                      &
+                 indexBLT,                        &
+                 indexBLS,                        &
+                 indexHeatTrans,                  &
+                 indexSaltTrans,                  &
+                 landIceBoundaryLayerTracers,     &
+                 landIceTracerTransferVelocities, &
+                 landIceFrictionVelocity)
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' ) then
+         nullify(rx1Edge,                  &
+                 rx1Cell,                  &
+                 rx1MaxEdge,               &
+                 modifySSHMask,            &
+                 smoothingMask,            &
+                 verticalStretch,          &
+                 globalVerticalStretchMax, &
+                 globalVerticalStretchMin)
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' .or. &
+                config_AM_debugDiagnostics_enable ) then
+         nullify(rx1MaxCell,               &
+                 globalRx1Max)
+      end if
+      if ( trim(config_ocean_run_mode) == 'forward' .or. &
+           trim(config_ocean_run_mode) == 'analysis' ) then
+         nullify(k33,                             &
+                 gradSSH,                         &
+                 gradSSHX,                        &
+                 gradSSHY,                        &
+                 gradSSHZ,                        &
+                 viscosity,                       &
+                 velocityX,                       &
+                 velocityY,                       &
+                 velocityZ,                       &
+                 divergence,                      &
+                 RiTopOfCell,                     &
+                 RiTopOfEdge,                     &
+                 SSHGradient,                     &
+                 circulation,                     &
+                 slopeTriadUp,                    &
+                 gradSSHZonal,                    &
+                 cGMphaseSpeed,                   &
+                 velocityZonal,                   &
+                 GMStreamFuncX,                   &
+                 GMStreamFuncY,                   &
+                 GMStreamFuncZ,                   &
+                 layerThickEdge,                  &
+                 slopeTriadDown,                  &
+                 normRelVortEdge,                 &
+                 surfaceVelocity,                 &
+                 vertVelocityTop,                 &
+                 GMBolusVelocityX,                &
+                 GMBolusVelocityY,                &
+                 GMBolusVelocityZ,                &
+                 vertNonLocalFlux,                &
+                 vertViscTopOfEdge,               &
+                 gradSSHMeridional,               &
+                 barotropicForcing,               &
+                 vertViscTopOfCell,               &
+                 vertDiffTopOfCell,               &
+                 GMStreamFuncZonal,               &
+                 relativeVorticity,               &
+                 kineticEnergyCell,               &
+                 normPlanetVortEdge,              &
+                 velocityMeridional,              &
+                 transportVelocityX,              &
+                 transportVelocityY,              &
+                 transportVelocityZ,              &
+                 tangentialVelocity,              &
+                 montgomeryPotential,             &
+                 BruntVaisalaFreqTop,             &
+                 vertAleTransportTop,             &
+                 GMBolusVelocityZonal,            &
+                 bulkRichardsonNumber,            &
+                 gmStreamFuncTopOfCell,           &
+                 gmStreamFuncTopOfEdge,           &
+                 indexSSHGradientZonal,           &
+                 relativeVorticityCell,           &
+                 normalGMBolusVelocity,           &
+                 vertGMBolusVelocityTop,          &
+                 transportVelocityZonal,          &
+                 GMStreamFuncMeridional,          &
+                 indexSurfaceLayerDepth,          &
+                 surfaceBuoyancyForcing,          &
+                 surfaceFrictionVelocity,         &
+                 indexBoundaryLayerDepth,         &
+                 barotropicThicknessFlux,         &
+                 normalTransportVelocity,         &
+                 vertTransportVelocityTop,        &
+                 bulkRichardsonNumberBuoy,        &
+                 tracersSurfaceLayerValue,        &
+                 GMBolusVelocityMeridional,       &
+                 bulkRichardsonNumberShear,       &
+                 indexSurfaceVelocityZonal,       &
+                 normalVelocitySurfaceLayer,      &
+                 index_vertNonLocalFluxTemp,      &
+                 indexSSHGradientMeridional,      &
+                 transportVelocityMeridional,     &
+                 penetrativeTemperatureFluxOBL,   &
+                 indexSurfaceVelocityMeridional,  &
+                 normalizedRelativeVorticityCell)
+      end if
+      if ( trim(config_ocean_run_mode) == 'forward' ) then
+         nullify(wettingVelocity)
+      end if
+      if ( config_use_GM ) then
+         nullify(RediKappa,         &
+                 gmBolusKappa,      &
+                 gmKappaScaling,    &
+                 RediKappaScaling,  &
+                 rediLimiterCount,  &
+                 RediKappaSfcTaper, &
+                 gmResolutionTaper)
+      end if
+      if ( config_compute_active_tracer_budgets ) then
+         nullify(activeTracerHorMixTendency,              &
+                 activeTracerVertMixTendency,             &
+                 temperatureShortWaveTendency,            &
+                 activeTracerNonLocalTendency,            &
+                 activeTracerSurfaceFluxTendency,         &
+                 activeTracerVerticalAdvectionTopFlux,    &
+                 activeTracerVerticalAdvectionTendency,   &
+                 activeTracerHorizontalAdvectionTendency, &
+                 activeTracerHorizontalAdvectionEdgeFlux)
+      end if
+      if ( config_use_activeTracers_surface_restoring ) then
+         nullify(salinitySurfaceRestoringTendency)
+      end if
+      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+         nullify(CGvec_r0,              &
+                 CGvec_r00,             &
+                 CGvec_r1,              &
+                 CGvec_rh0,             &
+                 CGvec_rh1,             &
+                 CGvec_ph0,             &
+                 CGvec_ph1,             &
+                 CGvec_v0,              &
+                 CGvec_v1,              &
+                 CGvec_s0,              &
+                 CGvec_s1,              &
+                 CGvec_sh0,             &
+                 CGvec_sh1,             &
+                 CGvec_t0,              &
+                 CGvec_t1,              &
+                 CGvec_q0,              &
+                 CGvec_q1,              &
+                 CGvec_qh0,             &
+                 CGvec_w0,              &
+                 CGvec_w1,              &
+                 CGvec_wh0,             &
+                 CGvec_wh1,             &
+                 CGvec_y0,              &
+                 CGvec_z0,              &
+                 CGvec_z1,              &
+                 CGvec_zh0,             &
+                 CGvec_zh1,             &
+                 barotropicCoriolisTerm)
+      end if
+
+      nullify(zMid,                                    &
+              zTop,                                    &
+              xtime,                                   &
+              indMLD,                                  &
+              density,                                 &
+              betaEdge,                                &
+              eddyTime,                                &
+              pressure,                                &
+              eddyLength,                              &
+              thermExpCoeff,                           &
+              sfcFlxAttCoeff,                          &
+              surfacePressure,                         &
+              potentialDensity,                        &
+              displacedDensity,                        &
+              boundaryLayerDepth,                      &
+              salineContractCoeff,                     &
+              pressureAdjustedSSH,                     &
+              tracersSurfaceValue,                     &
+              daysSinceStartOfSim,                     &
+              simulationStartTime,                     &
+              edgeAreaFractionOfCell,                  &
+              boundaryLayerDepthSmooth,                &
+              surfaceFluxAttenuationCoefficientRunoff)
 
     end subroutine ocn_diagnostics_variables_destroy!}}}
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -233,196 +233,350 @@ contains
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
 
-      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
-      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
-      call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
-      call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', relativeVorticity)
-      call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', relativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedPlanetaryVorticityEdge', normPlanetVortEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityEdge', normRelVortEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'normalizedRelativeVorticityCell', normalizedRelativeVorticityCell)
-      call mpas_pool_get_array(diagnosticsPool, 'density', density)
-      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', displacedDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', potentialDensity)
-      call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', montgomeryPotential)
-      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituThermalExpansionCoeff',thermExpCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'inSituSalineContractionCoeff', salineContractCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', BruntVaisalaFreqTop)
-      call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', tangentialVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', layerThickEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', kineticEnergyCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', vertVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', vertTransportVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', vertGMBolusVelocityTop)
-      call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', normalGMBolusVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'normalTransportVelocity', normalTransportVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'pressureAdjustedSSH', pressureAdjustedSSH)
-
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceValue', tracersSurfaceValue)
-      call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', tracersSurfaceLayerValue)
-      call mpas_pool_get_array(diagnosticsPool, 'normalVelocitySurfaceLayer', normalVelocitySurfaceLayer)
-
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficient', sfcFlxAttCoeff)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFluxAttenuationCoefficientRunoff', surfaceFluxAttenuationCoefficientRunoff)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceFrictionVelocity', landIceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
-      call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
-      call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
-      call mpas_pool_get_array(diagnosticsPool, 'bottomLayerShortwaveTemperatureFlux', bottomLayerShortwaveTemperatureFlux)
-      call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
-
-      !
-      ! set pointers for fields related forcing at ocean surface
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', surfaceBuoyancyForcing)
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', surfaceFrictionVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', surfacePressure)
-
-      call mpas_pool_get_array(diagnosticsPool, 'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerTemperature', indexBLT)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceBoundaryLayerSalinity', indexBLS)
-
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', transportVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', transportVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', transportVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', transportVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'transportVelocityMeridional', transportVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', GMBolusVelocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', GMBolusVelocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', GMBolusVelocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', GMBolusVelocityZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', GMBolusVelocityMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', gmStreamFuncTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', GMStreamFuncX)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', GMStreamFuncY)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', GMStreamFuncZ)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', GMStreamFuncZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', GMStreamFuncMeridional)
-
-      if(jenkinsOn .or. hollandJenkinsOn) then
-        call mpas_pool_get_array(diagnosticsPool, 'landIceTracerTransferVelocities', landIceTracerTransferVelocities)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceHeatTransferVelocity', indexHeatTrans)
-        call mpas_pool_get_dimension(diagnosticsPool, 'index_landIceSaltTransferVelocity', indexSaltTrans)
+      if ( trim(config_ocean_run_mode) == 'forward' ) then
+         call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', &
+                   wettingVelocity)
+         call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', &
+                   wettingVelocityField)
       end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', rx1MaxCell, 1)
+      if ( config_use_GM ) then
+         call mpas_pool_get_array(diagnosticsPool, 'RediKappa', &
+                   RediKappa)
+         call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', &
+                   RediKappaScaling)
+         call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', &
+                   RediKappaSfcTaper)
+         call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', &
+                   rediLimiterCount)
 
-      call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', globalRx1Max, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMax', globalVerticalStretchMax, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'globalVerticalStretchMin', globalVerticalStretchMin, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa',  &
+                   gmBolusKappa)
+         call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', &
+                   gmKappaScaling)
+         call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', &
+                   gmResolutionTaper)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMask, 1)
-      call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', verticalStretch, 1)
-      call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', smoothingMaskField, 1)
-      call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', verticalStretchField, 1)
+      if ( config_compute_active_tracer_budgets ) then
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerSurfaceFluxTendency', &
+                   activeTracerSurfaceFluxTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'temperatureShortWaveTendency', &
+                   temperatureShortWaveTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerNonLocalTendency', &
+                   activeTracerNonLocalTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerHorMixTendency', &
+                   activeTracerHorMixTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerVerticalAdvectionTopFlux', &
+                   activeTracerVerticalAdvectionTopFlux)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerHorizontalAdvectionEdgeFlux', &
+                   activeTracerHorizontalAdvectionEdgeFlux)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerHorizontalAdvectionTendency', &
+                   activeTracerHorizontalAdvectionTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerVerticalAdvectionTendency',  &
+                   activeTracerVerticalAdvectionTendency)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'activeTracerVertMixTendency', &
+                   activeTracerVertMixTendency)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'modifyLandIcePressureMask', modifyLandIcePressureMask)
+      if ( config_use_activeTracers_surface_restoring ) then
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'salinitySurfaceRestoringTendency', &
+                   salinitySurfaceRestoringTendency)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', velocityMeridional)
-      call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', velocityZonal)
+      ! Retrieve pointers for configurations where land_ice_flux_mode is enabled
+      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
+         call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
+         call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                   'index_landIceBoundaryLayerTemperature', indexBLT)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                   'index_landIceBoundaryLayerSalinity', indexBLS)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                   'index_landIceHeatTransferVelocity', indexHeatTrans)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                   'index_landIceSaltTransferVelocity', indexSaltTrans)
+         call mpas_pool_get_array(diagnosticsPool, &
+                   'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
+         call mpas_pool_get_array(diagnosticsPool, &
+                   'landIceTracerTransferVelocities', &
+                    landIceTracerTransferVelocities)
+         call mpas_pool_get_array(diagnosticsPool, &
+                   'landIceFrictionVelocity', landIceFrictionVelocity)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
+      if ( trim(config_ocean_run_mode) == 'init' ) then
+         call mpas_pool_get_array(diagnosticsPool, 'rx1Edge', rx1Edge, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'rx1Cell', rx1Cell, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'rx1MaxEdge', rx1MaxEdge, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'rx1InitSmoothingMask', &
+                   smoothingMask, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'verticalStretch', &
+                   verticalStretch, 1)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'globalVerticalStretchMax', &
+                   globalVerticalStretchMax, 1)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'globalVerticalStretchMin', &
+                   globalVerticalStretchMin, 1)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
-      call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', gmKappaScaling)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', slopeTriadUp)
-      call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', slopeTriadDown)
-      call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
-      call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
+      if ( trim(config_ocean_run_mode) == 'init' .or. &
+                config_AM_debugDiagnostics_enable ) then
+         call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', &
+                   rx1MaxCell, 1)
+         call mpas_pool_get_array(diagnosticsPool, 'globalRx1Max', &
+                   globalRx1Max, 1)
+      end if
 
-      call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
+      if ( trim(config_ocean_run_mode) == 'forward' .or. &
+           trim(config_ocean_run_mode) == 'analysis' ) then
+         call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
 
-      call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
-      call mpas_pool_get_array(diagnosticsPool, 'wettingVelocity', wettingVelocity)
-      call mpas_pool_get_field(diagnosticsPool, 'wettingVelocity', wettingVelocityField)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSH', gradSSH)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSHX', gradSSHX)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSHY', gradSSHY)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZ', gradSSHZ)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', &
+                   gradSSHZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', &
+                   gradSSHMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
 
-      !
-      ! set pointers for viscosity/diffusivity and initialize to zero
-      !
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', vertViscTopOfEdge)
-      call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', vertViscTopOfCell)
-      call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', vertDiffTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'viscosity', viscosity)
+         call mpas_pool_get_array(diagnosticsPool, 'divergence', divergence)
+         call mpas_pool_get_array(diagnosticsPool, 'circulation', circulation)
 
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', bulkRichardsonNumber)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepth', boundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'boundaryLayerDepthSmooth', boundaryLayerDepthSmooth)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',bulkRichardsonNumberBuoy)
-      call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',bulkRichardsonNumberShear)
-      call mpas_pool_get_array(diagnosticsPool, 'indexBoundaryLayerDepth',indexBoundaryLayerDepth)
-      call mpas_pool_get_array(diagnosticsPool, 'edgeAreaFractionOfCell', edgeAreaFractionOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityX', velocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityY', velocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZ', velocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityMeridional', &
+                   velocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'velocityZonal', &
+                   velocityZonal)
 
-      call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', vertNonLocalFlux)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_vertNonLocalFluxTemp', index_vertNonLocalFluxTemp)
+         call mpas_pool_get_array(diagnosticsPool, 'RiTopOfCell', RiTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'RiTopOfEdge', RiTopOfEdge)
 
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'rediLimiterCount', rediLimiterCount)
-      if (config_compute_active_tracer_budgets) then
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerSurfaceFluxTendency',activeTracerSurfaceFluxTendency)
-         call mpas_pool_get_array(diagnosticsPool,'temperatureShortWaveTendency',temperatureShortWaveTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerNonLocalTendency',activeTracerNonLocalTendency)
-         call mpas_pool_get_array(diagnosticsPool,'activeTracerHorMixTendency',activeTracerHorMixTendency)
-      endif
+         call mpas_pool_get_array(diagnosticsPool, 'slopeTriadUp', &
+                   slopeTriadUp)
+         call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', &
+                   slopeTriadDown)
 
-      call mpas_pool_get_array(diagnosticsPool,         &
-             'activeTracerVerticalAdvectionTopFlux',    &
-              activeTracerVerticalAdvectionTopFlux)
-      call mpas_pool_get_array(diagnosticsPool,         &
-             'activeTracerHorizontalAdvectionEdgeFlux', &
-              activeTracerHorizontalAdvectionEdgeFlux)
-      call mpas_pool_get_array(diagnosticsPool,         &
-             'activeTracerHorizontalAdvectionTendency', &
-              activeTracerHorizontalAdvectionTendency)
-      call mpas_pool_get_array(diagnosticsPool,         &
-             'activeTracerVerticalAdvectionTendency',   &
-              activeTracerVerticalAdvectionTendency)
+         ! GM-related fields
+         call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', &
+                   cGMphaseSpeed)
+         call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', &
+                   gmStreamFuncTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', &
+                   gmStreamFuncTopOfEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', &
+                   GMStreamFuncX)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncY', &
+                   GMStreamFuncY)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZ', &
+                   GMStreamFuncZ)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncZonal', &
+                   GMStreamFuncZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', &
+                   GMStreamFuncMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', &
+                   GMBolusVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', &
+                   GMBolusVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', &
+                   GMBolusVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', &
+                   GMBolusVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', &
+                   GMBolusVelocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', &
+                   normalGMBolusVelocity)
+         call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', &
+                   vertGMBolusVelocityTop)
+
+         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', &
+                   layerThickEdge)
+
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalizedRelativeVorticityEdge', &
+                   normRelVortEdge)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalizedPlanetaryVorticityEdge', &
+                   normPlanetVortEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticity', &
+                   relativeVorticity)
+         call mpas_pool_get_array(diagnosticsPool, 'relativeVorticityCell', &
+                   relativeVorticityCell)
+
+         call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', &
+                   surfaceVelocity)
+
+         call mpas_pool_get_array(diagnosticsPool, 'vertVelocityTop', &
+                   vertVelocityTop)
+         call mpas_pool_get_array(diagnosticsPool, 'vertNonLocalFlux', &
+                   vertNonLocalFlux)
+         call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfEdge', &
+                   vertViscTopOfEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'vertViscTopOfCell', &
+                   vertViscTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'vertDiffTopOfCell', &
+                   vertDiffTopOfCell)
+         call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', &
+                   vertAleTransportTop)
+         call mpas_pool_get_array(diagnosticsPool, 'vertTransportVelocityTop', &
+                   vertTransportVelocityTop)
+
+         call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', &
+                   barotropicForcing)
+         call mpas_pool_get_array(diagnosticsPool, 'kineticEnergyCell', &
+                   kineticEnergyCell)
+
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityX', &
+                   transportVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityY', &
+                   transportVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZ', &
+                   transportVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'transportVelocityZonal', &
+                   transportVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'transportVelocityMeridional', &
+                   transportVelocityMeridional)
+
+         call mpas_pool_get_array(diagnosticsPool, 'tangentialVelocity', &
+                   tangentialVelocity)
+         call mpas_pool_get_array(diagnosticsPool, 'montgomeryPotential', &
+                   montgomeryPotential)
+         call mpas_pool_get_array(diagnosticsPool, 'BruntVaisalaFreqTop', &
+                   BruntVaisalaFreqTop)
+
+         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumber', &
+                   bulkRichardsonNumber)
+         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberBuoy',&
+                   bulkRichardsonNumberBuoy)
+         call mpas_pool_get_array(diagnosticsPool, 'bulkRichardsonNumberShear',&
+                   bulkRichardsonNumberShear)
+
+         ! set pointers for fields related forcing at ocean surface
+         call mpas_pool_get_array(diagnosticsPool, 'surfaceBuoyancyForcing', &
+                   surfaceBuoyancyForcing)
+         call mpas_pool_get_array(diagnosticsPool, 'surfaceFrictionVelocity', &
+                   surfaceFrictionVelocity)
+
+         call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', &
+                   barotropicThicknessFlux)
+
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalTransportVelocity', &
+                   normalTransportVelocity)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalVelocitySurfaceLayer', &
+                   normalVelocitySurfaceLayer)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'penetrativeTemperatureFluxOBL', &
+                   penetrativeTemperatureFluxOBL)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalizedRelativeVorticityCell', &
+                   normalizedRelativeVorticityCell)
+
+         call mpas_pool_get_array(diagnosticsPool, 'tracersSurfaceLayerValue', &
+                   tracersSurfaceLayerValue)
+
+         ! Set pointer for index variables
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                  'index_surfaceVelocityZonal', &
+                   indexSurfaceVelocityZonal)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                  'index_surfaceVelocityMeridional', &
+                   indexSurfaceVelocityMeridional)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                  'index_vertNonLocalFluxTemp', &
+                   index_vertNonLocalFluxTemp)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                  'index_SSHGradientMeridional', &
+                   indexSSHGradientMeridional)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'indexSurfaceLayerDepth', &
+                   indexSurfaceLayerDepth)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'indexBoundaryLayerDepth', &
+                   indexBoundaryLayerDepth)
+         call mpas_pool_get_dimension(diagnosticsPool, &
+                  'index_SSHGradientZonal', &
+                   indexSSHGradientZonal)
+      end if
+
       call mpas_pool_get_array(diagnosticsPool, &
-         'activeTracerVertMixTendency',activeTracerVertMixTendency)
-
-      call mpas_pool_get_array(diagnosticsPool, "daysSinceStartOfSim", daysSinceStartOfSim)
+               "daysSinceStartOfSim", &
+                daysSinceStartOfSim)
       call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
-      call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime',simulationStartTime)
+      call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', &
+                simulationStartTime)
 
-      call mpas_pool_get_array(diagnosticsPool,'salinitySurfaceRestoringTendency',salinitySurfaceRestoringTendency)
-
-      call mpas_pool_get_array(diagnosticsPool, 'surfaceVelocity', surfaceVelocity)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSHZonal', gradSSHZonal)
-      call mpas_pool_get_array(diagnosticsPool, 'gradSSHMeridional', gradSSHMeridional)
-
-      call mpas_pool_get_array(diagnosticsPool, 'barotropicForcing', barotropicForcing)
-      call mpas_pool_get_array(diagnosticsPool, 'barotropicCoriolisTerm', barotropicCoriolisTerm)
-      call mpas_pool_get_array(diagnosticsPool, 'barotropicThicknessFlux', barotropicThicknessFlux)
-
-      call mpas_pool_get_array(diagnosticsPool, 'SSHGradient', SSHGradient)
-
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityZonal', indexSurfaceVelocityZonal)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_surfaceVelocityMeridional', indexSurfaceVelocityMeridional)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientZonal', indexSSHGradientZonal)
-      call mpas_pool_get_dimension(diagnosticsPool, 'index_SSHGradientMeridional', indexSSHGradientMeridional)
-
+      call mpas_pool_get_array(diagnosticsPool, 'zMid', zMid)
+      call mpas_pool_get_array(diagnosticsPool, 'zTop', zTop)
+      call mpas_pool_get_array(diagnosticsPool, 'density', density)
+      call mpas_pool_get_array(diagnosticsPool, 'pressure', pressure)
+      call mpas_pool_get_array(diagnosticsPool, 'displacedDensity', &
+                displacedDensity)
+      call mpas_pool_get_array(diagnosticsPool, 'potentialDensity', &
+                potentialDensity)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'inSituThermalExpansionCoeff', &
+                thermExpCoeff)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'inSituSalineContractionCoeff', &
+                salineContractCoeff)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'pressureAdjustedSSH', &
+                pressureAdjustedSSH)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'tracersSurfaceValue', &
+                tracersSurfaceValue)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'surfaceFluxAttenuationCoefficient', &
+                sfcFlxAttCoeff)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'surfaceFluxAttenuationCoefficientRunoff', &
+                surfaceFluxAttenuationCoefficientRunoff)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'boundaryLayerDepth', &
+                boundaryLayerDepth)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'boundaryLayerDepthSmooth', &
+                boundaryLayerDepthSmooth)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'edgeAreaFractionOfCell', &
+                edgeAreaFractionOfCell)
+      call mpas_pool_get_array(diagnosticsPool, 'barotropicCoriolisTerm', &
+                barotropicCoriolisTerm)
       call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
       call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)
       call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)
-      call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'bottomLayerShortwaveTemperatureFlux', &
+                bottomLayerShortwaveTemperatureFlux)
+      call mpas_pool_get_field(diagnosticsPool, 'rx1InitSmoothingMask', &
+                smoothingMaskField, 1)
+      call mpas_pool_get_field(diagnosticsPool, 'verticalStretch', &
+                verticalStretchField, 1)
+      call mpas_pool_get_array(diagnosticsPool, &
+               'modifyLandIcePressureMask', &
+                modifyLandIcePressureMask)
+      call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
+      call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', &
+                surfacePressure)
 
       ! Semi-implicit Array Pointer retrievals
       if (trim(config_time_integrator) == 'semi_implicit') then

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -113,11 +113,9 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: velocityMeridional
    real (kind=RKIND), dimension(:,:), pointer :: velocityZonal
 
-   real(kind=RKIND), dimension(:,:), pointer :: kappaGMCell
    real(kind=RKIND), dimension(:,:), pointer :: gmKappaScaling
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaScaling
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaSfcTaper
-   real(kind=RKIND), dimension(:,:), pointer :: RediKappaCell
    real(kind=RKIND), dimension(:,:), pointer :: k33
    real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
    real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
@@ -344,7 +342,6 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
 
       call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', cGMphaseSpeed)
-      call mpas_pool_get_array(diagnosticsPool, 'kappaGMCell', kappaGMCell)
       call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', gmKappaScaling)
       call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', RediKappaScaling)
       call mpas_pool_get_array(diagnosticsPool, 'RediKappaSfcTaper', RediKappaSfcTaper)
@@ -353,7 +350,6 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'k33', k33)
       call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', gmStreamFuncTopOfCell)
       call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
-      call mpas_pool_get_array(diagnosticsPool, 'RediKappaCell', RediKappaCell)
 
       call mpas_pool_get_array(diagnosticsPool, 'vertAleTransportTop', vertAleTransportTop)
 
@@ -468,6 +464,10 @@ contains
          !$acc                   topDragMag,                       &
          !$acc                   landIceBoundaryLayerTracers,      &
          !$acc                   landIceTracerTransferVelocities,  &
+         !$acc                   indexBLT,      &
+         !$acc                   indexBLS,      &
+         !$acc                   indexHeatTrans,      &
+         !$acc                   indexSaltTrans,      &
          !$acc                   landIceFrictionVelocity)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
@@ -476,70 +476,89 @@ contains
          !$acc                   rx1Cell,            &
          !$acc                   rx1MaxEdge,         &
          !$acc                   rx1MaxCell,         &
+         !$acc                   smoothingMask,            &
+         !$acc                   verticalStretch,            &
+         !$acc                   modifySSHMask,            &
          !$acc                   globalRx1Max)
          ! debug, mdt :: rx1MaxCell and globalRx1Max are in both initMode and debugDiagnosticsAMPKG 
          !               package, but I can't find a config option for debugDiagnosticsAMPKG
       end if
+      if ( trim(config_ocean_run_mode) == 'forward' .or. &
+           trim(config_ocean_run_mode) == 'analysis' ) then
+         !$acc enter data copyin( &
+         !$acc                   divergence,              &
+         !$acc                   circulation,             &
+         !$acc                   relativeVorticity,       &
+         !$acc                   relativeVorticityCell,   &
+         !$acc                   normPlanetVortEdge,      &
+         !$acc                   normRelVortEdge,      &
+         !$acc                   normalizedRelativeVorticityCell,      &
+         !$acc                   montgomeryPotential,      &
+         !$acc                   BruntVaisalaFreqTop,      &
+         !$acc                   tangentialVelocity,      &
+         !$acc                   layerThickEdge,      &
+         !$acc                   kineticEnergyCell,      &
+         !$acc                   vertVelocityTop,      &
+         !$acc                   vertTransportVelocityTop,      &
+         !$acc                   vertGMBolusVelocityTop,      &
+         !$acc                   normalTransportVelocity,      &
+         !$acc                   normalGMBolusVelocity,      &
+         !$acc                   RiTopOfCell,      &
+         !$acc                   RiTopOfEdge,      &
+         !$acc                   gradSSH,      &
+         !$acc                   tracersSurfaceLayerValue,      &
+         !$acc                   normalVelocitySurfaceLayer,      &
+         !$acc                   indexSurfaceLayerDepth,      &
+         !$acc                   surfaceBuoyancyForcing,      &
+         !$acc                   penetrativeTemperatureFluxOBL,      &
+         !$acc                   surfaceFrictionVelocity,            &
+         !$acc                   gmStreamFuncTopOfEdge,            &
+         !$acc                   GMStreamFuncX,            &
+         !$acc                   GMStreamFuncY,            &
+         !$acc                   GMStreamFuncZ,            &
+         !$acc                   GMStreamFuncZonal,            &
+         !$acc                   GMStreamFuncMeridional,            &
+         !$acc                   gmStreamFuncTopOfCell,            &
+         !$acc                   k33,            &
+         !$acc                   cGMphaseSpeed,            &
+         !$acc                   slopeTriadUp,            &
+         !$acc                   slopeTriadDown,            &
+         !$acc                   transportVelocityX,            &
+         !$acc                   transportVelocityY,            &
+         !$acc                   transportVelocityZ,            &
+         !$acc                   transportVelocityZonal,            &
+         !$acc                   transportVelocityMeridional,            &
+         !$acc                   GMBolusVelocityX,            &
+         !$acc                   GMBolusVelocityY,            &
+         !$acc                   GMBolusVelocityZ,            &
+         !$acc                   GMBolusVelocityZonal,            &
+         !$acc                   GMBolusVelocityMeridional,            &
+         !$acc                   velocityMeridional,            &
+         !$acc                   velocityZonal             &
+         !$acc                   )
+      end if
+      if ( config_use_GM ) then
+         !$acc enter data copyin( &
+         !$acc                   gmKappaScaling,            &
+         !$acc                   RediKappaScaling,            &
+         !$acc                   RediKappaSfcTaper,            &
+         !$acc                   gmBolusKappa             &
+         !$acc                   )
+      end if
+
       !$acc enter data copyin( &
       !$acc                   zMid,                    &
       !$acc                   zTop,                    &
-      !$acc                   divergence,              &
-      !$acc                   circulation,             &
-      !$acc                   relativeVorticity,       &
-      !$acc                   relativeVorticityCell,   &
-      !$acc                   normPlanetVortEdge,      &
-      !$acc                   normRelVortEdge,      &
-      !$acc                   normalizedRelativeVorticityCell,      &
       !$acc                   potentialDensity,      &
       !$acc                   displacedDensity,      &
       !$acc                   density,      &
-      !$acc                   montgomeryPotential,      &
       !$acc                   pressure,      &
       !$acc                   thermExpCoeff,      &
       !$acc                   salineContractCoeff,      &
-      !$acc                   BruntVaisalaFreqTop,      &
-      !$acc                   tangentialVelocity,      &
-      !$acc                   layerThickEdge,      &
-      !$acc                   kineticEnergyCell,      &
-      !$acc                   vertVelocityTop,      &
-      !$acc                   vertTransportVelocityTop,      &
-      !$acc                   vertGMBolusVelocityTop,      &
-      !$acc                   normalTransportVelocity,      &
-      !$acc                   normalGMBolusVelocity,      &
-      !$acc                   RiTopOfCell,      &
-      !$acc                   RiTopOfEdge,      &
-      !$acc                   gradSSH,      &
       !$acc                   pressureAdjustedSSH,      &
       !$acc                   tracersSurfaceValue,      &
-      !$acc                   tracersSurfaceLayerValue,      &
-      !$acc                   normalVelocitySurfaceLayer,      &
-      !$acc                   indexSurfaceLayerDepth,      &
       !$acc                   sfcFlxAttCoeff,      &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff,      &
-      !$acc                   indexBLT,      &
-      !$acc                   indexBLS,      &
-      !$acc                   indexHeatTrans,      &
-      !$acc                   indexSaltTrans,      &
-      !$acc                   surfaceBuoyancyForcing,      &
-      !$acc                   penetrativeTemperatureFluxOBL,      &
-      !$acc                   surfaceFrictionVelocity,            &
-      !$acc                   transportVelocityX,            &
-      !$acc                   transportVelocityY,            &
-      !$acc                   transportVelocityZ,            &
-      !$acc                   transportVelocityZonal,            &
-      !$acc                   transportVelocityMeridional,            &
-      !$acc                   GMBolusVelocityX,            &
-      !$acc                   GMBolusVelocityY,            &
-      !$acc                   GMBolusVelocityZ,            &
-      !$acc                   GMBolusVelocityZonal,            &
-      !$acc                   GMBolusVelocityMeridional,            &
-      !$acc                   gmStreamFuncTopOfEdge,            &
-      !$acc                   GMStreamFuncX,            &
-      !$acc                   GMStreamFuncY,            &
-      !$acc                   GMStreamFuncZ,            &
-      !$acc                   GMStreamFuncZonal,            &
-      !$acc                   GMStreamFuncMeridional,            &
-      !$acc                   gmStreamFuncTopOfCell             &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff       &
       !$acc                   )
       ! debug, mdt :: not all diagnostics variables are being copied yet....
 
@@ -575,82 +594,107 @@ contains
       err = 0
 
       ! Remove data from the device
-      if ( config_land_ice_flux_mode /= 'off' ) then
-         !$acc exit data delete(                                   &
-         !$acc                  topDrag,                           &
-         !$acc                  topDragMag,                        &
-         !$acc                  landIceBoundaryLayerTracers,       &
-         !$acc                  landIceTracerTransferVelocities,   &
-         !$acc                  landIceFrictionVelocity)
+      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
+         !$acc exit data delete(                                  &
+         !$acc                   topDrag,                          &
+         !$acc                   topDragMag,                       &
+         !$acc                   landIceBoundaryLayerTracers,      &
+         !$acc                   landIceTracerTransferVelocities,  &
+         !$acc                   indexBLT,      &
+         !$acc                   indexBLS,      &
+         !$acc                   indexHeatTrans,      &
+         !$acc                   indexSaltTrans,      &
+         !$acc                   landIceFrictionVelocity)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
          !$acc exit data delete(                    &
-         !$acc                  rx1Edge,            &
-         !$acc                  rx1Cell,            &
-         !$acc                  rx1MaxEdge,         &
-         !$acc                  rx1MaxCell,         &
-         !$acc                  globalRx1Max)
+         !$acc                   rx1Edge,            &
+         !$acc                   rx1Cell,            &
+         !$acc                   rx1MaxEdge,         &
+         !$acc                   rx1MaxCell,         &
+         !$acc                   smoothingMask,            &
+         !$acc                   verticalStretch,            &
+         !$acc                   modifySSHMask,            &
+         !$acc                   globalRx1Max)
+         ! debug, mdt :: rx1MaxCell and globalRx1Max are in both initMode and debugDiagnosticsAMPKG 
+         !               package, but I can't find a config option for debugDiagnosticsAMPKG
       end if
+      if ( trim(config_ocean_run_mode) == 'forward' .or. &
+           trim(config_ocean_run_mode) == 'analysis' ) then
+         !$acc exit data delete( &
+         !$acc                   divergence,              &
+         !$acc                   circulation,             &
+         !$acc                   relativeVorticity,       &
+         !$acc                   relativeVorticityCell,   &
+         !$acc                   normPlanetVortEdge,      &
+         !$acc                   normRelVortEdge,      &
+         !$acc                   normalizedRelativeVorticityCell,      &
+         !$acc                   montgomeryPotential,      &
+         !$acc                   BruntVaisalaFreqTop,      &
+         !$acc                   tangentialVelocity,      &
+         !$acc                   layerThickEdge,      &
+         !$acc                   kineticEnergyCell,      &
+         !$acc                   vertVelocityTop,      &
+         !$acc                   vertTransportVelocityTop,      &
+         !$acc                   vertGMBolusVelocityTop,      &
+         !$acc                   normalTransportVelocity,      &
+         !$acc                   normalGMBolusVelocity,      &
+         !$acc                   RiTopOfCell,      &
+         !$acc                   RiTopOfEdge,      &
+         !$acc                   gradSSH,      &
+         !$acc                   tracersSurfaceLayerValue,      &
+         !$acc                   normalVelocitySurfaceLayer,      &
+         !$acc                   indexSurfaceLayerDepth,      &
+         !$acc                   surfaceBuoyancyForcing,      &
+         !$acc                   penetrativeTemperatureFluxOBL,      &
+         !$acc                   surfaceFrictionVelocity,            &
+         !$acc                   gmStreamFuncTopOfEdge,            &
+         !$acc                   GMStreamFuncX,            &
+         !$acc                   GMStreamFuncY,            &
+         !$acc                   GMStreamFuncZ,            &
+         !$acc                   GMStreamFuncZonal,            &
+         !$acc                   GMStreamFuncMeridional,            &
+         !$acc                   gmStreamFuncTopOfCell,            &
+         !$acc                   k33,            &
+         !$acc                   cGMphaseSpeed,            &
+         !$acc                   slopeTriadUp,            &
+         !$acc                   slopeTriadDown,            &
+         !$acc                   transportVelocityX,            &
+         !$acc                   transportVelocityY,            &
+         !$acc                   transportVelocityZ,            &
+         !$acc                   transportVelocityZonal,            &
+         !$acc                   transportVelocityMeridional,            &
+         !$acc                   GMBolusVelocityX,            &
+         !$acc                   GMBolusVelocityY,            &
+         !$acc                   GMBolusVelocityZ,            &
+         !$acc                   GMBolusVelocityZonal,            &
+         !$acc                   GMBolusVelocityMeridional,            &
+         !$acc                   velocityMeridional,            &
+         !$acc                   velocityZonal             &
+         !$acc                   )
+      end if
+      if ( config_use_GM ) then
+         !$acc exit data delete( &
+         !$acc                   gmKappaScaling,            &
+         !$acc                   RediKappaScaling,            &
+         !$acc                   RediKappaSfcTaper,            &
+         !$acc                   gmBolusKappa             &
+         !$acc                   )
+      end if
+
       !$acc exit data delete( &
       !$acc                   zMid,                    &
       !$acc                   zTop,                    &
-      !$acc                   divergence,              &
-      !$acc                   circulation,             &
-      !$acc                   relativeVorticity,       &
-      !$acc                   relativeVorticityCell,   &
-      !$acc                   normPlanetVortEdge,      &
-      !$acc                   normRelVortEdge,      &
-      !$acc                   normalizedRelativeVorticityCell,      &
-      !$acc                   displacedDensity,      &
       !$acc                   potentialDensity,      &
+      !$acc                   displacedDensity,      &
       !$acc                   density,      &
-      !$acc                   montgomeryPotential,      &
       !$acc                   pressure,      &
       !$acc                   thermExpCoeff,      &
       !$acc                   salineContractCoeff,      &
-      !$acc                   BruntVaisalaFreqTop,      &
-      !$acc                   tangentialVelocity,      &
-      !$acc                   layerThickEdge,      &
-      !$acc                   kineticEnergyCell,      &
-      !$acc                   vertVelocityTop,      &
-      !$acc                   vertTransportVelocityTop,      &
-      !$acc                   vertGMBolusVelocityTop,      &
-      !$acc                   normalTransportVelocity,      &
-      !$acc                   normalGMBolusVelocity,      &
-      !$acc                   RiTopOfCell,      &
-      !$acc                   RiTopOfEdge,      &
-      !$acc                   gradSSH,      &
       !$acc                   pressureAdjustedSSH,      &
       !$acc                   tracersSurfaceValue,      &
-      !$acc                   tracersSurfaceLayerValue,      &
-      !$acc                   normalVelocitySurfaceLayer,      &
-      !$acc                   indexSurfaceLayerDepth,      &
       !$acc                   sfcFlxAttCoeff,      &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff,      &
-      !$acc                   indexBLT,      &
-      !$acc                   indexBLS,      &
-      !$acc                   indexHeatTrans,      &
-      !$acc                   indexSaltTrans,      &
-      !$acc                   surfaceBuoyancyForcing,      &
-      !$acc                   penetrativeTemperatureFluxOBL,      &
-      !$acc                   surfaceFrictionVelocity,      &
-      !$acc                   transportVelocityX,            &
-      !$acc                   transportVelocityY,            &
-      !$acc                   transportVelocityZ,            &
-      !$acc                   transportVelocityZonal,            &
-      !$acc                   transportVelocityMeridional,            &
-      !$acc                   GMBolusVelocityX,            &
-      !$acc                   GMBolusVelocityY,            &
-      !$acc                   GMBolusVelocityZ,            &
-      !$acc                   GMBolusVelocityZonal,            &
-      !$acc                   GMBolusVelocityMeridional,            &
-      !$acc                   gmStreamFuncTopOfEdge,            &
-      !$acc                   GMStreamFuncX,            &
-      !$acc                   GMStreamFuncY,            &
-      !$acc                   GMStreamFuncZ,            &
-      !$acc                   GMStreamFuncZonal,            &
-      !$acc                   GMStreamFuncMeridional,            &
-      !$acc                   gmStreamFuncTopOfCell             &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff       &
       !$acc                   )
       ! debug, mdt :: not all diagnostics variables are being copied yet....
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -473,7 +473,6 @@ contains
          !$acc                   rx1Edge,                  &
          !$acc                   rx1Cell,                  &
          !$acc                   rx1MaxEdge,               &
-         !$acc                   modifySSHMask,            &
          !$acc                   smoothingMask,            &
          !$acc                   verticalStretch,          &
          !$acc                   globalVerticalStretchMax, &
@@ -709,7 +708,6 @@ contains
          !$acc                   rx1Edge,                  &
          !$acc                   rx1Cell,                  &
          !$acc                   rx1MaxEdge,               &
-         !$acc                   modifySSHMask,            &
          !$acc                   smoothingMask,            &
          !$acc                   verticalStretch,          &
          !$acc                   globalVerticalStretchMax, &
@@ -912,7 +910,6 @@ contains
          nullify(rx1Edge,                  &
                  rx1Cell,                  &
                  rx1MaxEdge,               &
-                 modifySSHMask,            &
                  smoothingMask,            &
                  verticalStretch,          &
                  globalVerticalStretchMax, &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -646,6 +646,7 @@ contains
       !$acc                   eddyLength,                              &
       !$acc                   thermExpCoeff,                           &
       !$acc                   sfcFlxAttCoeff,                          &
+      !$acc                   surfacePressure,                         &
       !$acc                   potentialDensity,                        &
       !$acc                   displacedDensity,                        &
       !$acc                   boundaryLayerDepth,                      &
@@ -881,6 +882,7 @@ contains
       !$acc                   eddyLength,                              &
       !$acc                   thermExpCoeff,                           &
       !$acc                   sfcFlxAttCoeff,                          &
+      !$acc                   surfacePressure,                         &
       !$acc                   potentialDensity,                        &
       !$acc                   displacedDensity,                        &
       !$acc                   boundaryLayerDepth,                      &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -204,6 +204,7 @@ module ocn_diagnostics_variables
    !--------------------------------------------------------------------
 
    public :: ocn_diagnostics_variables_init
+   public :: ocn_diagnostics_variables_destroy
 
 !***********************************************************************
 
@@ -460,9 +461,203 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'CGvec_zh1', CGvec_zh1)
       end if
 
+      ! Copy diagnostic variables to accelerator
+      if ( trim(config_land_ice_flux_mode) /= 'off' ) then
+         !$acc enter data copyin(                                  &
+         !$acc                   topDrag,                          &
+         !$acc                   topDragMag,                       &
+         !$acc                   landIceBoundaryLayerTracers,      &
+         !$acc                   landIceTracerTransferVelocities,  &
+         !$acc                   landIceFrictionVelocity)
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' ) then
+         !$acc enter data copyin(                    &
+         !$acc                   rx1Edge,            &
+         !$acc                   rx1Cell,            &
+         !$acc                   rx1MaxEdge,         &
+         !$acc                   rx1MaxCell,         &
+         !$acc                   globalRx1Max)
+         ! debug, mdt :: rx1MaxCell and globalRx1Max are in both initMode and debugDiagnosticsAMPKG 
+         !               package, but I can't find a config option for debugDiagnosticsAMPKG
+      end if
+      !$acc enter data copyin( &
+      !$acc                   zMid,                    &
+      !$acc                   zTop,                    &
+      !$acc                   divergence,              &
+      !$acc                   circulation,             &
+      !$acc                   relativeVorticity,       &
+      !$acc                   relativeVorticityCell,   &
+      !$acc                   normPlanetVortEdge,      &
+      !$acc                   normRelVortEdge,      &
+      !$acc                   normalizedRelativeVorticityCell,      &
+      !$acc                   potentialDensity,      &
+      !$acc                   displacedDensity,      &
+      !$acc                   density,      &
+      !$acc                   montgomeryPotential,      &
+      !$acc                   pressure,      &
+      !$acc                   thermExpCoeff,      &
+      !$acc                   salineContractCoeff,      &
+      !$acc                   BruntVaisalaFreqTop,      &
+      !$acc                   tangentialVelocity,      &
+      !$acc                   layerThickEdge,      &
+      !$acc                   kineticEnergyCell,      &
+      !$acc                   vertVelocityTop,      &
+      !$acc                   vertTransportVelocityTop,      &
+      !$acc                   vertGMBolusVelocityTop,      &
+      !$acc                   normalTransportVelocity,      &
+      !$acc                   normalGMBolusVelocity,      &
+      !$acc                   RiTopOfCell,      &
+      !$acc                   RiTopOfEdge,      &
+      !$acc                   gradSSH,      &
+      !$acc                   pressureAdjustedSSH,      &
+      !$acc                   tracersSurfaceValue,      &
+      !$acc                   tracersSurfaceLayerValue,      &
+      !$acc                   normalVelocitySurfaceLayer,      &
+      !$acc                   indexSurfaceLayerDepth,      &
+      !$acc                   sfcFlxAttCoeff,      &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff,      &
+      !$acc                   indexBLT,      &
+      !$acc                   indexBLS,      &
+      !$acc                   indexHeatTrans,      &
+      !$acc                   indexSaltTrans,      &
+      !$acc                   surfaceBuoyancyForcing,      &
+      !$acc                   penetrativeTemperatureFluxOBL,      &
+      !$acc                   surfaceFrictionVelocity,            &
+      !$acc                   transportVelocityX,            &
+      !$acc                   transportVelocityY,            &
+      !$acc                   transportVelocityZ,            &
+      !$acc                   transportVelocityZonal,            &
+      !$acc                   transportVelocityMeridional,            &
+      !$acc                   GMBolusVelocityX,            &
+      !$acc                   GMBolusVelocityY,            &
+      !$acc                   GMBolusVelocityZ,            &
+      !$acc                   GMBolusVelocityZonal,            &
+      !$acc                   GMBolusVelocityMeridional,            &
+      !$acc                   gmStreamFuncTopOfEdge,            &
+      !$acc                   GMStreamFuncX,            &
+      !$acc                   GMStreamFuncY,            &
+      !$acc                   GMStreamFuncZ,            &
+      !$acc                   GMStreamFuncZonal,            &
+      !$acc                   GMStreamFuncMeridional,            &
+      !$acc                   gmStreamFuncTopOfCell             &
+      !$acc                   )
+      ! debug, mdt :: not all diagnostics variables are being copied yet....
+
     end subroutine ocn_diagnostics_variables_init!}}}
 
-!***********************************************************************
+!*******************************************************************************
+!
+!  ocn_diagnostics_variables_destroy
+!
+!> \brief Remove diagnostics variables from device
+!> \author Rob Aulwes and Phil Jones
+!> \date   14 Jan 2020
+!> \details
+!> This module removes the diagnostics variables from the device
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_diagnostics_variables_destroy(err) !{{{
+
+      ! Input variables                                                                                      
+                                                                                                             
+      ! Output variables                                                                                     
+                                                                                                             
+      integer, intent(out) :: &                                                                              
+         err                   ! returned error flag                                                         
+                                                                                                             
+      ! Local variables                                                                                      
+                                                                                                             
+      !***                                                                                                   
+      !*** end of preamble, begin code                                                                       
+      !***                                                                                                   
+                                                                                                             
+      err = 0
+
+      ! Remove data from the device
+      if ( config_land_ice_flux_mode /= 'off' ) then
+         !$acc exit data delete(                                   &
+         !$acc                  topDrag,                           &
+         !$acc                  topDragMag,                        &
+         !$acc                  landIceBoundaryLayerTracers,       &
+         !$acc                  landIceTracerTransferVelocities,   &
+         !$acc                  landIceFrictionVelocity)
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' ) then
+         !$acc exit data delete(                    &
+         !$acc                  rx1Edge,            &
+         !$acc                  rx1Cell,            &
+         !$acc                  rx1MaxEdge,         &
+         !$acc                  rx1MaxCell,         &
+         !$acc                  globalRx1Max)
+      end if
+      !$acc exit data delete( &
+      !$acc                   zMid,                    &
+      !$acc                   zTop,                    &
+      !$acc                   divergence,              &
+      !$acc                   circulation,             &
+      !$acc                   relativeVorticity,       &
+      !$acc                   relativeVorticityCell,   &
+      !$acc                   normPlanetVortEdge,      &
+      !$acc                   normRelVortEdge,      &
+      !$acc                   normalizedRelativeVorticityCell,      &
+      !$acc                   displacedDensity,      &
+      !$acc                   potentialDensity,      &
+      !$acc                   density,      &
+      !$acc                   montgomeryPotential,      &
+      !$acc                   pressure,      &
+      !$acc                   thermExpCoeff,      &
+      !$acc                   salineContractCoeff,      &
+      !$acc                   BruntVaisalaFreqTop,      &
+      !$acc                   tangentialVelocity,      &
+      !$acc                   layerThickEdge,      &
+      !$acc                   kineticEnergyCell,      &
+      !$acc                   vertVelocityTop,      &
+      !$acc                   vertTransportVelocityTop,      &
+      !$acc                   vertGMBolusVelocityTop,      &
+      !$acc                   normalTransportVelocity,      &
+      !$acc                   normalGMBolusVelocity,      &
+      !$acc                   RiTopOfCell,      &
+      !$acc                   RiTopOfEdge,      &
+      !$acc                   gradSSH,      &
+      !$acc                   pressureAdjustedSSH,      &
+      !$acc                   tracersSurfaceValue,      &
+      !$acc                   tracersSurfaceLayerValue,      &
+      !$acc                   normalVelocitySurfaceLayer,      &
+      !$acc                   indexSurfaceLayerDepth,      &
+      !$acc                   sfcFlxAttCoeff,      &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff,      &
+      !$acc                   indexBLT,      &
+      !$acc                   indexBLS,      &
+      !$acc                   indexHeatTrans,      &
+      !$acc                   indexSaltTrans,      &
+      !$acc                   surfaceBuoyancyForcing,      &
+      !$acc                   penetrativeTemperatureFluxOBL,      &
+      !$acc                   surfaceFrictionVelocity,      &
+      !$acc                   transportVelocityX,            &
+      !$acc                   transportVelocityY,            &
+      !$acc                   transportVelocityZ,            &
+      !$acc                   transportVelocityZonal,            &
+      !$acc                   transportVelocityMeridional,            &
+      !$acc                   GMBolusVelocityX,            &
+      !$acc                   GMBolusVelocityY,            &
+      !$acc                   GMBolusVelocityZ,            &
+      !$acc                   GMBolusVelocityZonal,            &
+      !$acc                   GMBolusVelocityMeridional,            &
+      !$acc                   gmStreamFuncTopOfEdge,            &
+      !$acc                   GMStreamFuncX,            &
+      !$acc                   GMStreamFuncY,            &
+      !$acc                   GMStreamFuncZ,            &
+      !$acc                   GMStreamFuncZonal,            &
+      !$acc                   GMStreamFuncMeridional,            &
+      !$acc                   gmStreamFuncTopOfCell             &
+      !$acc                   )
+      ! debug, mdt :: not all diagnostics variables are being copied yet....
+
+      ! Nullify pointers
+      ! debug, mdt :: still need to do this
+
+    end subroutine ocn_diagnostics_variables_destroy!}}}
 
 end module ocn_diagnostics_variables
 

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -163,7 +163,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), dimension(:), pointer :: salinitySurfaceRestoringTendency
 
-   real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity, avgSurfaceVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: surfaceVelocity
    real (kind=RKIND), dimension(:), pointer :: gradSSHZonal, gradSSHMeridional
    real (kind=RKIND), dimension(:), pointer :: gradSSHX
    real (kind=RKIND), dimension(:), pointer :: gradSSHY
@@ -185,7 +185,6 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: betaEdge
    real (kind=RKIND), dimension(:), pointer :: eddyLength
    real (kind=RKIND), dimension(:), pointer :: eddyTime
-   real (kind=RKIND), dimension(:), pointer :: c_visbeck
    real (kind=RKIND), dimension(:), pointer :: gmResolutionTaper
 
    ! Semi-implicit Array Pointers
@@ -423,7 +422,6 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
       call mpas_pool_get_array(diagnosticsPool, 'eddyLength', eddyLength)
       call mpas_pool_get_array(diagnosticsPool, 'eddyTime', eddyTime)
-      call mpas_pool_get_array(diagnosticsPool, 'c_visbeck', c_visbeck)
       call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
 
       ! Semi-implicit Array Pointer retrievals
@@ -459,108 +457,207 @@ contains
 
       ! Copy diagnostic variables to accelerator
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
-         !$acc enter data copyin(                                  &
-         !$acc                   topDrag,                          &
-         !$acc                   topDragMag,                       &
-         !$acc                   landIceBoundaryLayerTracers,      &
-         !$acc                   landIceTracerTransferVelocities,  &
-         !$acc                   indexBLT,      &
-         !$acc                   indexBLS,      &
-         !$acc                   indexHeatTrans,      &
-         !$acc                   indexSaltTrans,      &
+         !$acc enter data copyin(                                 &
+         !$acc                   topDrag,                         &
+         !$acc                   topDragMag,                      &
+         !$acc                   indexBLT,                        &
+         !$acc                   indexBLS,                        &
+         !$acc                   indexHeatTrans,                  &
+         !$acc                   indexSaltTrans,                  &
+         !$acc                   landIceBoundaryLayerTracers,     &
+         !$acc                   landIceTracerTransferVelocities, &
          !$acc                   landIceFrictionVelocity)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
-         !$acc enter data copyin(                    &
-         !$acc                   rx1Edge,            &
-         !$acc                   rx1Cell,            &
-         !$acc                   rx1MaxEdge,         &
-         !$acc                   rx1MaxCell,         &
-         !$acc                   smoothingMask,            &
-         !$acc                   verticalStretch,            &
+         !$acc enter data copyin(                          &
+         !$acc                   rx1Edge,                  &
+         !$acc                   rx1Cell,                  &
+         !$acc                   rx1MaxEdge,               &
          !$acc                   modifySSHMask,            &
+         !$acc                   smoothingMask,            &
+         !$acc                   verticalStretch,          &
+         !$acc                   globalVerticalStretchMax, &
+         !$acc                   globalVerticalStretchMin  &
+         !$acc                   )
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' .or. &
+                config_AM_debugDiagnostics_enable ) then
+         !$acc enter data copyin(                          &
+         !$acc                   rx1MaxCell,               &
          !$acc                   globalRx1Max)
-         ! debug, mdt :: rx1MaxCell and globalRx1Max are in both initMode and debugDiagnosticsAMPKG 
-         !               package, but I can't find a config option for debugDiagnosticsAMPKG
       end if
       if ( trim(config_ocean_run_mode) == 'forward' .or. &
            trim(config_ocean_run_mode) == 'analysis' ) then
-         !$acc enter data copyin( &
-         !$acc                   divergence,              &
-         !$acc                   circulation,             &
-         !$acc                   relativeVorticity,       &
-         !$acc                   relativeVorticityCell,   &
-         !$acc                   normPlanetVortEdge,      &
-         !$acc                   normRelVortEdge,      &
-         !$acc                   normalizedRelativeVorticityCell,      &
-         !$acc                   montgomeryPotential,      &
-         !$acc                   BruntVaisalaFreqTop,      &
-         !$acc                   tangentialVelocity,      &
-         !$acc                   layerThickEdge,      &
-         !$acc                   kineticEnergyCell,      &
-         !$acc                   vertVelocityTop,      &
-         !$acc                   vertTransportVelocityTop,      &
-         !$acc                   vertGMBolusVelocityTop,      &
-         !$acc                   normalTransportVelocity,      &
-         !$acc                   normalGMBolusVelocity,      &
-         !$acc                   RiTopOfCell,      &
-         !$acc                   RiTopOfEdge,      &
-         !$acc                   gradSSH,      &
-         !$acc                   tracersSurfaceLayerValue,      &
-         !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   indexSurfaceLayerDepth,      &
-         !$acc                   surfaceBuoyancyForcing,      &
-         !$acc                   penetrativeTemperatureFluxOBL,      &
-         !$acc                   surfaceFrictionVelocity,            &
-         !$acc                   gmStreamFuncTopOfEdge,            &
-         !$acc                   GMStreamFuncX,            &
-         !$acc                   GMStreamFuncY,            &
-         !$acc                   GMStreamFuncZ,            &
-         !$acc                   GMStreamFuncZonal,            &
-         !$acc                   GMStreamFuncMeridional,            &
-         !$acc                   gmStreamFuncTopOfCell,            &
-         !$acc                   k33,            &
-         !$acc                   cGMphaseSpeed,            &
-         !$acc                   slopeTriadUp,            &
-         !$acc                   slopeTriadDown,            &
-         !$acc                   transportVelocityX,            &
-         !$acc                   transportVelocityY,            &
-         !$acc                   transportVelocityZ,            &
-         !$acc                   transportVelocityZonal,            &
-         !$acc                   transportVelocityMeridional,            &
-         !$acc                   GMBolusVelocityX,            &
-         !$acc                   GMBolusVelocityY,            &
-         !$acc                   GMBolusVelocityZ,            &
+         !$acc enter data copyin(                                 &
+         !$acc                   k33,                             &
+         !$acc                   gradSSH,                         &
+         !$acc                   gradSSHX,                        &
+         !$acc                   gradSSHY,                        &
+         !$acc                   gradSSHZ,                        &
+         !$acc                   viscosity,                       &
+         !$acc                   velocityX,                       &
+         !$acc                   velocityY,                       &
+         !$acc                   velocityZ,                       &
+         !$acc                   divergence,                      &
+         !$acc                   RiTopOfCell,                     &
+         !$acc                   RiTopOfEdge,                     &
+         !$acc                   SSHGradient,                     &
+         !$acc                   circulation,                     &
+         !$acc                   slopeTriadUp,                    &
+         !$acc                   gradSSHZonal,                    &
+         !$acc                   cGMphaseSpeed,                   &
+         !$acc                   velocityZonal,                   &
+         !$acc                   GMStreamFuncX,                   &
+         !$acc                   GMStreamFuncY,                   &
+         !$acc                   GMStreamFuncZ,                   &
+         !$acc                   layerThickEdge,                  &
+         !$acc                   slopeTriadDown,                  &
+         !$acc                   normRelVortEdge,                 &
+         !$acc                   surfaceVelocity,                 &
+         !$acc                   vertVelocityTop,                 &
+         !$acc                   GMBolusVelocityX,                &
+         !$acc                   GMBolusVelocityY,                &
+         !$acc                   GMBolusVelocityZ,                &
+         !$acc                   vertNonLocalFlux,                &
+         !$acc                   vertViscTopOfEdge,               &
+         !$acc                   gradSSHMeridional,               &
+         !$acc                   barotropicForcing,               &
+         !$acc                   vertViscTopOfCell,               &
+         !$acc                   vertDiffTopOfCell,               &
+         !$acc                   GMStreamFuncZonal,               &
+         !$acc                   relativeVorticity,               &
+         !$acc                   kineticEnergyCell,               &
+         !$acc                   normPlanetVortEdge,              &
+         !$acc                   velocityMeridional,              &
+         !$acc                   transportVelocityX,              &
+         !$acc                   transportVelocityY,              &
+         !$acc                   transportVelocityZ,              &
+         !$acc                   tangentialVelocity,              &
+         !$acc                   montgomeryPotential,             &
+         !$acc                   BruntVaisalaFreqTop,             &
+         !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   GMBolusVelocityMeridional,            &
-         !$acc                   velocityMeridional,            &
-         !$acc                   velocityZonal             &
+         !$acc                   bulkRichardsonNumber,            &
+         !$acc                   gmStreamFuncTopOfCell,           &
+         !$acc                   gmStreamFuncTopOfEdge,           &
+         !$acc                   indexSSHGradientZonal,           &
+         !$acc                   relativeVorticityCell,           &
+         !$acc                   normalGMBolusVelocity,           &
+         !$acc                   vertGMBolusVelocityTop,          &
+         !$acc                   transportVelocityZonal,          &
+         !$acc                   GMStreamFuncMeridional,          &
+         !$acc                   indexSurfaceLayerDepth,          &
+         !$acc                   surfaceBuoyancyForcing,          &
+         !$acc                   surfaceFrictionVelocity,         &
+         !$acc                   indexBoundaryLayerDepth,         &
+         !$acc                   barotropicThicknessFlux,         &
+         !$acc                   normalTransportVelocity,         &
+         !$acc                   vertTransportVelocityTop,        &
+         !$acc                   bulkRichardsonNumberBuoy,        &
+         !$acc                   tracersSurfaceLayerValue,        &
+         !$acc                   GMBolusVelocityMeridional,       &
+         !$acc                   bulkRichardsonNumberShear,       &
+         !$acc                   indexSurfaceVelocityZonal,       &
+         !$acc                   normalVelocitySurfaceLayer,      &
+         !$acc                   index_vertNonLocalFluxTemp,      &
+         !$acc                   indexSSHGradientMeridional,      &
+         !$acc                   transportVelocityMeridional,     &
+         !$acc                   penetrativeTemperatureFluxOBL,   &
+         !$acc                   indexSurfaceVelocityMeridional,  &
+         !$acc                   normalizedRelativeVorticityCell  &
+         !$acc                   )
+      end if
+      if ( trim(config_ocean_run_mode) == 'forward' ) then
+         !$acc enter data copyin( &
+         !$acc                   wettingVelocity              &
          !$acc                   )
       end if
       if ( config_use_GM ) then
-         !$acc enter data copyin( &
-         !$acc                   gmKappaScaling,            &
-         !$acc                   RediKappaScaling,            &
-         !$acc                   RediKappaSfcTaper,            &
-         !$acc                   gmBolusKappa             &
+         !$acc enter data copyin(                   &
+         !$acc                   RediKappa,         &
+         !$acc                   gmBolusKappa,      &
+         !$acc                   gmKappaScaling,    &
+         !$acc                   RediKappaScaling,  &
+         !$acc                   rediLimiterCount,  &
+         !$acc                   RediKappaSfcTaper, &
+         !$acc                   gmResolutionTaper  &
+         !$acc                   )
+      end if
+      if ( config_compute_active_tracer_budgets ) then
+         !$acc enter data copyin(                                         &
+         !$acc                   activeTracerHorMixTendency,              &
+         !$acc                   activeTracerVertMixTendency,             &
+         !$acc                   temperatureShortWaveTendency,            &
+         !$acc                   activeTracerNonLocalTendency,            &
+         !$acc                   activeTracerSurfaceFluxTendency,         &
+         !$acc                   activeTracerVerticalAdvectionTopFlux,    &
+         !$acc                   activeTracerVerticalAdvectionTendency,   &
+         !$acc                   activeTracerHorizontalAdvectionTendency, &
+         !$acc                   activeTracerHorizontalAdvectionEdgeFlux  &
+         !$acc                   )
+      end if
+      if ( config_use_activeTracers_surface_restoring ) then
+         !$acc enter data copyin(                                  &
+         !$acc                   salinitySurfaceRestoringTendency  &
+         !$acc                   )
+      end if
+      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+         !$acc enter data copyin(                       &
+         !$acc                   CGvec_r0,              &
+         !$acc                   CGvec_r00,             &
+         !$acc                   CGvec_r1,              &
+         !$acc                   CGvec_rh0,             &
+         !$acc                   CGvec_rh1,             &
+         !$acc                   CGvec_ph0,             &
+         !$acc                   CGvec_ph1,             &
+         !$acc                   CGvec_v0,              &
+         !$acc                   CGvec_v1,              &
+         !$acc                   CGvec_s0,              &
+         !$acc                   CGvec_s1,              &
+         !$acc                   CGvec_sh0,             &
+         !$acc                   CGvec_sh1,             &
+         !$acc                   CGvec_t0,              &
+         !$acc                   CGvec_t1,              &
+         !$acc                   CGvec_q0,              &
+         !$acc                   CGvec_q1,              &
+         !$acc                   CGvec_qh0,             &
+         !$acc                   CGvec_w0,              &
+         !$acc                   CGvec_w1,              &
+         !$acc                   CGvec_wh0,             &
+         !$acc                   CGvec_wh1,             &
+         !$acc                   CGvec_y0,              &
+         !$acc                   CGvec_z0,              &
+         !$acc                   CGvec_z1,              &
+         !$acc                   CGvec_zh0,             &
+         !$acc                   CGvec_zh1,             &
+         !$acc                   barotropicCoriolisTerm &
          !$acc                   )
       end if
 
-      !$acc enter data copyin( &
-      !$acc                   zMid,                    &
-      !$acc                   zTop,                    &
-      !$acc                   potentialDensity,      &
-      !$acc                   displacedDensity,      &
-      !$acc                   density,      &
-      !$acc                   pressure,      &
-      !$acc                   thermExpCoeff,      &
-      !$acc                   salineContractCoeff,      &
-      !$acc                   pressureAdjustedSSH,      &
-      !$acc                   tracersSurfaceValue,      &
-      !$acc                   sfcFlxAttCoeff,      &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff       &
+      !$acc enter data copyin(                                         &
+      !$acc                   zMid,                                    &
+      !$acc                   zTop,                                    &
+      !$acc                   xtime,                                   &
+      !$acc                   indMLD,                                  &
+      !$acc                   density,                                 &
+      !$acc                   betaEdge,                                &
+      !$acc                   eddyTime,                                &
+      !$acc                   pressure,                                &
+      !$acc                   eddyLength,                              &
+      !$acc                   thermExpCoeff,                           &
+      !$acc                   sfcFlxAttCoeff,                          &
+      !$acc                   potentialDensity,                        &
+      !$acc                   displacedDensity,                        &
+      !$acc                   boundaryLayerDepth,                      &
+      !$acc                   salineContractCoeff,                     &
+      !$acc                   pressureAdjustedSSH,                     &
+      !$acc                   tracersSurfaceValue,                     &
+      !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   simulationStartTime,                     &
+      !$acc                   edgeAreaFractionOfCell,                  &
+      !$acc                   boundaryLayerDepthSmooth,                &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
       !$acc                   )
-      ! debug, mdt :: not all diagnostics variables are being copied yet....
 
     end subroutine ocn_diagnostics_variables_init!}}}
 
@@ -596,107 +693,206 @@ contains
       ! Remove data from the device
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
          !$acc exit data delete(                                  &
-         !$acc                   topDrag,                          &
-         !$acc                   topDragMag,                       &
-         !$acc                   landIceBoundaryLayerTracers,      &
-         !$acc                   landIceTracerTransferVelocities,  &
-         !$acc                   indexBLT,      &
-         !$acc                   indexBLS,      &
-         !$acc                   indexHeatTrans,      &
-         !$acc                   indexSaltTrans,      &
+         !$acc                   topDrag,                         &
+         !$acc                   indexBLT,                        &
+         !$acc                   indexBLS,                        &
+         !$acc                   topDragMag,                      &
+         !$acc                   indexHeatTrans,                  &
+         !$acc                   indexSaltTrans,                  &
+         !$acc                   landIceBoundaryLayerTracers,     &
+         !$acc                   landIceTracerTransferVelocities, &
          !$acc                   landIceFrictionVelocity)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
-         !$acc exit data delete(                    &
-         !$acc                   rx1Edge,            &
-         !$acc                   rx1Cell,            &
-         !$acc                   rx1MaxEdge,         &
-         !$acc                   rx1MaxCell,         &
-         !$acc                   smoothingMask,            &
-         !$acc                   verticalStretch,            &
+         !$acc exit data delete(                           &
+         !$acc                   rx1Edge,                  &
+         !$acc                   rx1Cell,                  &
+         !$acc                   rx1MaxEdge,               &
          !$acc                   modifySSHMask,            &
+         !$acc                   smoothingMask,            &
+         !$acc                   verticalStretch,          &
+         !$acc                   globalVerticalStretchMax, &
+         !$acc                   globalVerticalStretchMin  &
+         !$acc                   )
+      end if
+      if ( trim(config_ocean_run_mode) == 'init' .or. &
+                config_AM_debugDiagnostics_enable ) then
+         !$acc exit data delete(                           &
+         !$acc                   rx1MaxCell,               &
          !$acc                   globalRx1Max)
-         ! debug, mdt :: rx1MaxCell and globalRx1Max are in both initMode and debugDiagnosticsAMPKG 
-         !               package, but I can't find a config option for debugDiagnosticsAMPKG
       end if
       if ( trim(config_ocean_run_mode) == 'forward' .or. &
            trim(config_ocean_run_mode) == 'analysis' ) then
-         !$acc exit data delete( &
-         !$acc                   divergence,              &
-         !$acc                   circulation,             &
-         !$acc                   relativeVorticity,       &
-         !$acc                   relativeVorticityCell,   &
-         !$acc                   normPlanetVortEdge,      &
-         !$acc                   normRelVortEdge,      &
-         !$acc                   normalizedRelativeVorticityCell,      &
-         !$acc                   montgomeryPotential,      &
-         !$acc                   BruntVaisalaFreqTop,      &
-         !$acc                   tangentialVelocity,      &
-         !$acc                   layerThickEdge,      &
-         !$acc                   kineticEnergyCell,      &
-         !$acc                   vertVelocityTop,      &
-         !$acc                   vertTransportVelocityTop,      &
-         !$acc                   vertGMBolusVelocityTop,      &
-         !$acc                   normalTransportVelocity,      &
-         !$acc                   normalGMBolusVelocity,      &
-         !$acc                   RiTopOfCell,      &
-         !$acc                   RiTopOfEdge,      &
-         !$acc                   gradSSH,      &
-         !$acc                   tracersSurfaceLayerValue,      &
-         !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   indexSurfaceLayerDepth,      &
-         !$acc                   surfaceBuoyancyForcing,      &
-         !$acc                   penetrativeTemperatureFluxOBL,      &
-         !$acc                   surfaceFrictionVelocity,            &
-         !$acc                   gmStreamFuncTopOfEdge,            &
-         !$acc                   GMStreamFuncX,            &
-         !$acc                   GMStreamFuncY,            &
-         !$acc                   GMStreamFuncZ,            &
-         !$acc                   GMStreamFuncZonal,            &
-         !$acc                   GMStreamFuncMeridional,            &
-         !$acc                   gmStreamFuncTopOfCell,            &
-         !$acc                   k33,            &
-         !$acc                   cGMphaseSpeed,            &
-         !$acc                   slopeTriadUp,            &
-         !$acc                   slopeTriadDown,            &
-         !$acc                   transportVelocityX,            &
-         !$acc                   transportVelocityY,            &
-         !$acc                   transportVelocityZ,            &
-         !$acc                   transportVelocityZonal,            &
-         !$acc                   transportVelocityMeridional,            &
-         !$acc                   GMBolusVelocityX,            &
-         !$acc                   GMBolusVelocityY,            &
-         !$acc                   GMBolusVelocityZ,            &
+         !$acc exit data delete(                                  &
+         !$acc                   k33,                             &
+         !$acc                   gradSSH,                         &
+         !$acc                   gradSSHX,                        &
+         !$acc                   gradSSHY,                        &
+         !$acc                   gradSSHZ,                        &
+         !$acc                   viscosity,                       &
+         !$acc                   velocityX,                       &
+         !$acc                   velocityY,                       &
+         !$acc                   velocityZ,                       &
+         !$acc                   divergence,                      &
+         !$acc                   RiTopOfCell,                     &
+         !$acc                   RiTopOfEdge,                     &
+         !$acc                   SSHGradient,                     &
+         !$acc                   circulation,                     &
+         !$acc                   slopeTriadUp,                    &
+         !$acc                   gradSSHZonal,                    &
+         !$acc                   cGMphaseSpeed,                   &
+         !$acc                   velocityZonal,                   &
+         !$acc                   GMStreamFuncX,                   &
+         !$acc                   GMStreamFuncY,                   &
+         !$acc                   GMStreamFuncZ,                   &
+         !$acc                   layerThickEdge,                  &
+         !$acc                   slopeTriadDown,                  &
+         !$acc                   normRelVortEdge,                 &
+         !$acc                   surfaceVelocity,                 &
+         !$acc                   vertVelocityTop,                 &
+         !$acc                   GMBolusVelocityX,                &
+         !$acc                   GMBolusVelocityY,                &
+         !$acc                   GMBolusVelocityZ,                &
+         !$acc                   vertNonLocalFlux,                &
+         !$acc                   vertViscTopOfEdge,               &
+         !$acc                   gradSSHMeridional,               &
+         !$acc                   barotropicForcing,               &
+         !$acc                   vertViscTopOfCell,               &
+         !$acc                   vertDiffTopOfCell,               &
+         !$acc                   GMStreamFuncZonal,               &
+         !$acc                   relativeVorticity,               &
+         !$acc                   kineticEnergyCell,               &
+         !$acc                   normPlanetVortEdge,              &
+         !$acc                   velocityMeridional,              &
+         !$acc                   transportVelocityX,              &
+         !$acc                   transportVelocityY,              &
+         !$acc                   transportVelocityZ,              &
+         !$acc                   tangentialVelocity,              &
+         !$acc                   montgomeryPotential,             &
+         !$acc                   BruntVaisalaFreqTop,             &
+         !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   GMBolusVelocityMeridional,            &
-         !$acc                   velocityMeridional,            &
-         !$acc                   velocityZonal             &
+         !$acc                   bulkRichardsonNumber,            &
+         !$acc                   gmStreamFuncTopOfCell,           &
+         !$acc                   gmStreamFuncTopOfEdge,           &
+         !$acc                   indexSSHGradientZonal,           &
+         !$acc                   relativeVorticityCell,           &
+         !$acc                   normalGMBolusVelocity,           &
+         !$acc                   vertGMBolusVelocityTop,          &
+         !$acc                   transportVelocityZonal,          &
+         !$acc                   GMStreamFuncMeridional,          &
+         !$acc                   indexSurfaceLayerDepth,          &
+         !$acc                   surfaceBuoyancyForcing,          &
+         !$acc                   surfaceFrictionVelocity,         &
+         !$acc                   indexBoundaryLayerDepth,         &
+         !$acc                   barotropicThicknessFlux,         &
+         !$acc                   normalTransportVelocity,         &
+         !$acc                   vertTransportVelocityTop,        &
+         !$acc                   bulkRichardsonNumberBuoy,        &
+         !$acc                   tracersSurfaceLayerValue,        &
+         !$acc                   GMBolusVelocityMeridional,       &
+         !$acc                   bulkRichardsonNumberShear,       &
+         !$acc                   indexSurfaceVelocityZonal,       &
+         !$acc                   normalVelocitySurfaceLayer,      &
+         !$acc                   index_vertNonLocalFluxTemp,      &
+         !$acc                   indexSSHGradientMeridional,      &
+         !$acc                   transportVelocityMeridional,     &
+         !$acc                   penetrativeTemperatureFluxOBL,   &
+         !$acc                   indexSurfaceVelocityMeridional,  &
+         !$acc                   normalizedRelativeVorticityCell  &
+         !$acc                   )
+      end if
+      if ( trim(config_ocean_run_mode) == 'forward' ) then
+         !$acc exit data delete(                              &
+         !$acc                   wettingVelocity              &
          !$acc                   )
       end if
       if ( config_use_GM ) then
-         !$acc exit data delete( &
-         !$acc                   gmKappaScaling,            &
-         !$acc                   RediKappaScaling,            &
-         !$acc                   RediKappaSfcTaper,            &
-         !$acc                   gmBolusKappa             &
+         !$acc exit data delete(                    &
+         !$acc                   RediKappa,         &
+         !$acc                   gmBolusKappa,      &
+         !$acc                   gmKappaScaling,    &
+         !$acc                   RediKappaScaling,  &
+         !$acc                   rediLimiterCount,  &
+         !$acc                   RediKappaSfcTaper, &
+         !$acc                   gmResolutionTaper  &
+         !$acc                   )
+      end if
+      if ( config_compute_active_tracer_budgets ) then
+         !$acc exit data delete(                                          &
+         !$acc                   activeTracerHorMixTendency,              &
+         !$acc                   activeTracerVertMixTendency,             &
+         !$acc                   temperatureShortWaveTendency,            &
+         !$acc                   activeTracerNonLocalTendency,            &
+         !$acc                   activeTracerSurfaceFluxTendency,         &
+         !$acc                   activeTracerVerticalAdvectionTopFlux,    &
+         !$acc                   activeTracerVerticalAdvectionTendency,   &
+         !$acc                   activeTracerHorizontalAdvectionTendency, &
+         !$acc                   activeTracerHorizontalAdvectionEdgeFlux  &
+         !$acc                   )
+      end if
+      if ( config_use_activeTracers_surface_restoring ) then
+         !$acc exit data delete(                                   &
+         !$acc                   salinitySurfaceRestoringTendency  &
+         !$acc                   )
+      end if
+      if ( trim(config_time_integrator) == 'semi_implicit' ) then
+         !$acc exit data delete(                        &
+         !$acc                   CGvec_r0,              &
+         !$acc                   CGvec_r00,             &
+         !$acc                   CGvec_r1,              &
+         !$acc                   CGvec_rh0,             &
+         !$acc                   CGvec_rh1,             &
+         !$acc                   CGvec_ph0,             &
+         !$acc                   CGvec_ph1,             &
+         !$acc                   CGvec_v0,              &
+         !$acc                   CGvec_v1,              &
+         !$acc                   CGvec_s0,              &
+         !$acc                   CGvec_s1,              &
+         !$acc                   CGvec_sh0,             &
+         !$acc                   CGvec_sh1,             &
+         !$acc                   CGvec_t0,              &
+         !$acc                   CGvec_t1,              &
+         !$acc                   CGvec_q0,              &
+         !$acc                   CGvec_q1,              &
+         !$acc                   CGvec_qh0,             &
+         !$acc                   CGvec_w0,              &
+         !$acc                   CGvec_w1,              &
+         !$acc                   CGvec_wh0,             &
+         !$acc                   CGvec_wh1,             &
+         !$acc                   CGvec_y0,              &
+         !$acc                   CGvec_z0,              &
+         !$acc                   CGvec_z1,              &
+         !$acc                   CGvec_zh0,             &
+         !$acc                   CGvec_zh1,             &
+         !$acc                   barotropicCoriolisTerm &
          !$acc                   )
       end if
 
-      !$acc exit data delete( &
-      !$acc                   zMid,                    &
-      !$acc                   zTop,                    &
-      !$acc                   potentialDensity,      &
-      !$acc                   displacedDensity,      &
-      !$acc                   density,      &
-      !$acc                   pressure,      &
-      !$acc                   thermExpCoeff,      &
-      !$acc                   salineContractCoeff,      &
-      !$acc                   pressureAdjustedSSH,      &
-      !$acc                   tracersSurfaceValue,      &
-      !$acc                   sfcFlxAttCoeff,      &
-      !$acc                   surfaceFluxAttenuationCoefficientRunoff       &
+      !$acc exit data delete(                                          &
+      !$acc                   zMid,                                    &
+      !$acc                   zTop,                                    &
+      !$acc                   xtime,                                   &
+      !$acc                   indMLD,                                  &
+      !$acc                   density,                                 &
+      !$acc                   betaEdge,                                &
+      !$acc                   eddyTime,                                &
+      !$acc                   pressure,                                &
+      !$acc                   eddyLength,                              &
+      !$acc                   thermExpCoeff,                           &
+      !$acc                   sfcFlxAttCoeff,                          &
+      !$acc                   potentialDensity,                        &
+      !$acc                   displacedDensity,                        &
+      !$acc                   boundaryLayerDepth,                      &
+      !$acc                   salineContractCoeff,                     &
+      !$acc                   pressureAdjustedSSH,                     &
+      !$acc                   tracersSurfaceValue,                     &
+      !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   simulationStartTime,                     &
+      !$acc                   edgeAreaFractionOfCell,                  &
+      !$acc                   boundaryLayerDepthSmooth,                &
+      !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
       !$acc                   )
-      ! debug, mdt :: not all diagnostics variables are being copied yet....
 
       ! Nullify pointers
       ! debug, mdt :: still need to do this

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -399,8 +399,6 @@ contains
       !$omp end parallel
 #endif
 
-      call mpas_log_write('leaving eq of state')
-
       deallocate(p,p2)
       deallocate(tracerTemp)
       deallocate(tracerSalt)
@@ -610,9 +608,7 @@ contains
       endif
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(p, p2, tracerTemp, tracerSalt, &
-      !$acc&                  thermalExpansionCoeff,  &
-      !$acc&                  salineContractionCoeff)
+      !$acc enter data copyin(p, p2, tracerTemp, tracerSalt)
       !$acc parallel loop gang vector collapse(2)     &
       !$acc&   present(density, p, p2, tracerTemp, tracerSalt, &
       !$acc&           thermalExpansionCoeff,         &
@@ -718,9 +714,7 @@ contains
       !$acc update host(density,                &
       !$acc&            thermalExpansionCoeff,  &
       !$acc&            salineContractionCoeff)
-      !$acc exit data delete(p, p2, tracerTemp, tracerSalt, &
-      !$acc&                 thermalExpansionCoeff,  &
-      !$acc&                 salineContractionCoeff)
+      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
 #else
       !$omp end do
       !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -337,7 +337,7 @@ contains
       endif
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt)
+      !$acc enter data copyin(p, p2, tracerTemp, tracerSalt)
       !$acc parallel loop gang vector collapse(2) &
       !$acc&   present(density, p, p2, tracerTemp, tracerSalt)
 #else
@@ -391,9 +391,10 @@ contains
 
       end do
       end do
+      call mpas_log_write('leaving eq of state')
 #ifdef MPAS_OPENACC
       !$acc update host(density)
-      !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt)
+      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
 #else
       !$omp end do
       !$omp end parallel
@@ -608,7 +609,7 @@ contains
       endif
 
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(density, p, p2, tracerTemp, tracerSalt, &
+      !$acc enter data copyin(p, p2, tracerTemp, tracerSalt, &
       !$acc&                  thermalExpansionCoeff,  &
       !$acc&                  salineContractionCoeff)
       !$acc parallel loop gang vector collapse(2)     &
@@ -716,7 +717,7 @@ contains
       !$acc update host(density,                &
       !$acc&            thermalExpansionCoeff,  &
       !$acc&            salineContractionCoeff)
-      !$acc exit data delete(density, p, p2, tracerTemp, tracerSalt, &
+      !$acc exit data delete(p, p2, tracerTemp, tracerSalt, &
       !$acc&                 thermalExpansionCoeff,  &
       !$acc&                 salineContractionCoeff)
 #else

--- a/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
+++ b/src/core_ocean/shared/mpas_ocn_equation_of_state_jm.F
@@ -391,7 +391,6 @@ contains
 
       end do
       end do
-      call mpas_log_write('leaving eq of state')
 #ifdef MPAS_OPENACC
       !$acc update host(density)
       !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
@@ -399,6 +398,8 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      call mpas_log_write('leaving eq of state')
 
       deallocate(p,p2)
       deallocate(tracerTemp)

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -135,6 +135,7 @@ contains
       real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz
       real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines, shearEdgeInv
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
+      real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
       ! Dimensions
       integer :: nsmooth, nCells, nEdges
       integer, pointer :: nVertLevels
@@ -578,7 +579,7 @@ contains
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            !$omp parallel
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
-           !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2)
+           !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2, c_Visbeck)
            do iEdge = 1, nEdges
               k=1
               sumN2 = 0.0_RKIND
@@ -605,12 +606,12 @@ contains
               end do
 
               if (countN2 > 0) then
-                c_Visbeck(iEdge) = sqrt(sumN2*ltsum)
+                c_Visbeck = sqrt(sumN2*ltsum)
                 sumRi = sumRi / (ltsum + 1.0E-11_RKIND)
 
-                eddyLength(iEdge) = min(c_Visbeck(iEdge)/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
-                                sqrt(c_Visbeck(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
-                eddyTime(iEdge) = 1.0_RKIND / (max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_Visbeck(iEdge)*betaEdge(iEdge))) /  &
+                eddyLength(iEdge) = min(c_Visbeck/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
+                                sqrt(c_Visbeck/ (2.0_RKIND*betaEdge(iEdge))))
+                eddyTime(iEdge) = 1.0_RKIND / (max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_Visbeck*betaEdge(iEdge))) /  &
                                       (1.0E-11_RKIND + sqrt(sumRi)))
                 gmBolusKappa(iEdge) = config_GM_Visbeck_alpha * eddyLength(iEdge)**2.0_RKIND / (1.0E-15 + eddyTime(iEdge))
                 gmBolusKappa(iEdge) = max(config_GM_spatially_variable_min_kappa, min(gmBolusKappa(iEdge),  &

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -518,10 +518,10 @@ contains
          end do
          end do
 
-         do n = 1, nCellsAll    ! debug, mdt :: areaCell(nCellsAll+1 is later set to 1e-34)
+         do n = 1, nCellsAll
             invAreaCell(n) = 1.0_RKIND / areaCell(n)
          end do
-         invAreaCell(nCellsAll+1) = 0.0_RKIND    ! debug, mdt
+         invAreaCell(nCellsAll+1) = 0.0_RKIND
 
          ! Copy structure and components to accelerator
          ! Must manually do a deep copy with structure itself copied first.

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -121,6 +121,9 @@ module ocn_mesh
       meshDensity, &! density of mesh
       angleEdge        ! angle the edge normal makes with local east
 
+   real(kind=RKIND), public, dimension(:), allocatable :: &
+      invAreaCell   ! inverse of area of each cell
+
    ! Multiplicative masks and vectors for various conditions
    real(kind=RKIND), public, dimension(:, :), allocatable :: &
       edgeMask, &! mask to denote active edges    with depth
@@ -468,16 +471,17 @@ contains
          call mpas_pool_get_array(meshPool, 'boundaryCell', &
                                   boundaryCellTmp)
 
-         allocate ( &
-            edgeMask(nVertLevels, nEdgesAll+1), &
-            cellMask(nVertLevels, nCellsAll+1), &
-            vertexMask(nVertLevels, nVerticesAll+1), &
-            boundaryEdge(nVertLevels, nEdgesAll+1), &
-            boundaryCell(nVertLevels, nCellsAll+1), &
-            boundaryVertex(nVertLevels, nVerticesAll+1), &
-            edgeSignOnCell(maxEdges, nCellsAll+1), &
-            edgeSignOnVertex(maxEdges, nVerticesAll+1), &
-            highOrderAdvectionMask(nVertLevels, nEdgesAll+1))
+         allocate (                                           &
+            edgeMask(nVertLevels, nEdgesAll+1),               &
+            cellMask(nVertLevels, nCellsAll+1),               &
+            vertexMask(nVertLevels, nVerticesAll+1),          &
+            boundaryEdge(nVertLevels, nEdgesAll+1),           &
+            boundaryCell(nVertLevels, nCellsAll+1),           &
+            boundaryVertex(nVertLevels, nVerticesAll+1),      &
+            edgeSignOnCell(maxEdges, nCellsAll+1),            &
+            edgeSignOnVertex(maxEdges, nVerticesAll+1),       &
+            highOrderAdvectionMask(nVertLevels, nEdgesAll+1), &
+            invAreaCell(nCellsAll+1))
 
          do n = 1, nCellsAll+1
          do k = 1, nVertLevels
@@ -513,6 +517,11 @@ contains
             edgeSignOnVertex(k, n) = real(edgeSignOnVertexTmp(k, n), RKIND)
          end do
          end do
+
+         do n = 1, nCellsAll    ! debug, mdt :: areaCell(nCellsAll+1 is later set to 1e-34)
+            invAreaCell(n) = 1.0_RKIND / areaCell(n)
+         end do
+         invAreaCell(nCellsAll+1) = 0.0_RKIND    ! debug, mdt
 
          ! Copy structure and components to accelerator
          ! Must manually do a deep copy with structure itself copied first.
@@ -579,6 +588,7 @@ contains
          !$acc                   dcEdge,                   &
          !$acc                   dvEdge,                   &
          !$acc                   areaCell,                 &
+         !$acc                   invAreaCell,              &
          !$acc                   areaTriangle,             &
          !$acc                   bottomDepth,              &
          !$acc                   refBottomDepth,           &
@@ -715,6 +725,7 @@ contains
       !$acc                  dcEdge,            &
       !$acc                  dvEdge,            &
       !$acc                  areaCell,          &
+      !$acc                  invAreaCell,       &
       !$acc                  areaTriangle,      &
       !$acc                  bottomDepth,       &
       !$acc                  refBottomDepth,    &
@@ -829,18 +840,19 @@ contains
                cellTangentPlane, &
                coeffs_reconstruct)
 
-      deallocate (nEdgesHalo, &
-                  nCellsHalo, &
-                  nVerticesHalo, &
-                  edgeMask, &
-                  cellMask, &
-                  vertexMask, &
-                  boundaryEdge, &
-                  boundaryCell, &
-                  boundaryVertex, &
-                  edgeSignOnCell, &
-                  edgeSignOnVertex, &
-                  highOrderAdvectionMask)
+      deallocate (nEdgesHalo,             &
+                  nCellsHalo,             &
+                  nVerticesHalo,          &
+                  edgeMask,               &
+                  cellMask,               &
+                  vertexMask,             &
+                  boundaryEdge,           &
+                  boundaryCell,           &
+                  boundaryVertex,         &
+                  edgeSignOnCell,         &
+                  edgeSignOnVertex,       &
+                  highOrderAdvectionMask, &
+                  invAreaCell)
 
 !-------------------------------------------------------------------------------
 
@@ -1161,6 +1173,7 @@ contains
       !$acc               dcEdge,                   &
       !$acc               dvEdge,                   &
       !$acc               areaCell,                 &
+      !$acc               invAreaCell,              &
       !$acc               areaTriangle,             &
       !$acc               bottomDepth,              &
       !$acc               refBottomDepth,           &

--- a/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -189,8 +189,7 @@ contains
       call mpas_timer_start("top_drag", .false.)
 
       !*** Transfer data to device
-      !$acc enter data &
-      !$acc    copyin(topDrag, topDragMag)
+      !$acc update device (topDrag, topDragMag)
 
       !*** simply add input values to accumulated stresses
 
@@ -223,8 +222,6 @@ contains
 #endif
 
       !*** Transfer any needed data back to host and delete inputs
-      !$acc exit data &
-      !$acc    delete(topDrag, topDragMag)
 
       call mpas_timer_stop("top_drag")
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -305,14 +305,12 @@ contains
       !$acc update device(zMid, divergence, relativeVorticity, normPlanetVortEdge, &
       !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
       !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
-      !$acc               layerThickEdge, kineticEnergyCell, sfcFlxAttCoeff)
+      !$acc               layerThickEdge, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
+      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity)
       !$acc enter data &
       !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
       !$acc    ssh, normalVelocity, &
-      !$acc    potentialDensity, &
-      !$acc    layerThickness, activeTracers, &
-      !$acc    vertAleTransportTop, vertViscTopOfEdge, &
-      !$acc    wettingVelocity)
+      !$acc    layerThickness, activeTracers)
 
       !*** Set output variables to zero before accumulating results
       
@@ -420,10 +418,7 @@ contains
       !$acc    copyout(tendVel, sfcStress, sfcStressMag) &
       !$acc    delete( &
       !$acc    ssh, normalVelocity, &
-      !$acc    potentialDensity, &
-      !$acc    layerThickness, activeTracers, &
-      !$acc    vertAleTransportTop, vertViscTopOfEdge, &
-      !$acc    wettingVelocity)
+      !$acc    layerThickness, activeTracers)
 
       ! stop the timer and exit
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -258,8 +258,7 @@ contains
 
       real (kind=RKIND), dimension(:,:), pointer :: &
          normalVelocity,     &! normal velocity
-         layerThickness, &
-         circulation
+         layerThickness
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
          activeTracers
@@ -303,15 +302,17 @@ contains
                                              sfcStressMag)
 
       !*** Transfer data to device
+      !$acc update device(zMid, divergence, relativeVorticity, normPlanetVortEdge, &
+      !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
+      !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
+      !$acc               layerThickEdge, kineticEnergyCell, sfcFlxAttCoeff)
       !$acc enter data &
       !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
-      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
-      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
-      !$acc    pressure, layerThickness, circulation, activeTracers, &
-      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
-      !$acc    normPlanetVortEdge, montgomeryPotential, &
-      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
-      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
+      !$acc    ssh, normalVelocity, &
+      !$acc    potentialDensity, &
+      !$acc    layerThickness, activeTracers, &
+      !$acc    vertAleTransportTop, vertViscTopOfEdge, &
+      !$acc    wettingVelocity)
 
       !*** Set output variables to zero before accumulating results
       
@@ -418,13 +419,11 @@ contains
       !$acc exit data &
       !$acc    copyout(tendVel, sfcStress, sfcStressMag) &
       !$acc    delete( &
-      !$acc    sfcFlxAttCoeff, ssh, layerThickEdge, normalVelocity, &
-      !$acc    tangentialVelocity, density, potentialDensity, zMid, &
-      !$acc    pressure, layerThickness, circulation, activeTracers, &
-      !$acc    relativeVorticity, kineticEnergyCell, normRelVortEdge, &
-      !$acc    normPlanetVortEdge, montgomeryPotential, &
-      !$acc    vertAleTransportTop, divergence, vertViscTopOfEdge, &
-      !$acc    thermExpCoeff, salineContractCoeff, wettingVelocity)
+      !$acc    ssh, normalVelocity, &
+      !$acc    potentialDensity, &
+      !$acc    layerThickness, activeTracers, &
+      !$acc    vertAleTransportTop, vertViscTopOfEdge, &
+      !$acc    wettingVelocity)
 
       ! stop the timer and exit
 


### PR DESCRIPTION
This PR is the first phase of porting the ocean diagnostics code to GPUs using OpenACC.  It contains a subset of the necessary changes for running on the GPU that retain bit-for-bit accuracy with the current version when running on the CPU.

A phase 2 PR will contain the loop structure changes for optimal GPU performance that result in roundoff-level changes for the CPU code.