### PR TITLE
Add landice ismip6 calving & melting params., phase 2

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1138,7 +1138,7 @@ is the value of that variable from the *previous* time level!
                      description="mask of grid cells at which front ablation will be applied. Determined by settings of applyToGrounded, applyToFloating, and applyToGroundingLine in routines that call li_apply_front_ablation_velocity."
                 />
                 />
-		<var name="faceMeltSpeed" type="real" dimensions="nCells Time" units="m s^{-1}" packages="ismip6GroundedFaceMelt"
+		<var name="faceMeltSpeed" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
 		     description="linear speed of submarine melting at grounded glacier front"
   		/>
                 <var name="ismip6Runoff" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1050,11 +1050,11 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."
                 />
-                <var name="uncalvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was left uncalved from required calving flux at non-dynamic cells"
+                <var name="unablatedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved or unmelted from required calving or melting flux at non-dynamic cells"
                 />
-                <var name="uncalvedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was left uncalved from required calving flux at dynamic cells"
+                <var name="unablatedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was left uncalved or unmelted from required calving or melting flux at dynamic cells"
                 />
                 <var name="calvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was calved from non-dynamic cells"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1134,8 +1134,8 @@ is the value of that variable from the *previous* time level!
                      description="Optional field of offset that should be applied to the melt field calculated by the ISMIP6 melt method.  Can be used to run in anomaly mode, but this is not the anomaly.  See Registry.xml for details."
                 />
                 <!-- Variables needed for ISMIP6 grounded face melt parameterization -->
-                <var name="groundedMarineMarginMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
-                     description="mask of grid cells that are grounded and adjacent to the ocean. 0=interior, 1=grounded ice margin"
+                <var name="frontAblationMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
+                     description="mask of grid cells at which front ablation will be applied. Determined by settings of applyToGrounded, applyToFloating, and applyToGroundingLine in routines that call li_apply_front_ablation_velocity."
                 />
                 />
 		<var name="faceMeltSpeed" type="real" dimensions="nCells Time" units="m s^{-1}" packages="ismip6GroundedFaceMelt"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1133,10 +1133,10 @@ is the value of that variable from the *previous* time level!
                 <var name="ismip6shelfMelt_offset" type="real" dimensions="nCells" units="kg m^{-2} s^{-1}" packages="ismip6ShelfMelt" default_value="0.0"
                      description="Optional field of offset that should be applied to the melt field calculated by the ISMIP6 melt method.  Can be used to run in anomaly mode, but this is not the anomaly.  See Registry.xml for details."
                 />
-                <var name="groundedMarineMarginMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
+                <!-- Variables needed for ISMIP6 grounded face melt parameterization -->
+                <var name="groundedMarineMarginMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
                      description="mask of grid cells that are grounded and adjacent to the ocean. 0=interior, 1=grounded ice margin"
                 />
-                <!-- Variables needed for ISMIP6 grounded face melt parameterization -->
                 <var name="faceMeltRateApplied" type="real" dimensions="nCells Time" units="m^{3} s^{-1}" packages="ismip6GroundedFaceMelt"
                      description="Volumetric submarine melt rate applied at grounded marine margin"
                 />
@@ -1155,7 +1155,6 @@ is the value of that variable from the *previous* time level!
                <var name="unmeltedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left unmelted from required facemelt flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
 		/>
->>>>>>> trevor/landice/ismip6_calving_melting_phase1
                 <!--  description="Optional field of offset that should be appliped to the melt field calculated by the ISMIP6 melt method.  This field is added directly to the melt field calculated by the method and can be used to use the method in anomaly mode.  Note this field is NOT the anomaly.  Let m be the final melt field generated, m_t be the ISMIP6 melt calculation at any time, m_t0 the ISMIP6 melt at time 0, and m_0 a reference melt field (e.g. observed melt field used for initialization).  The melt anomaly would be defined as (delta m)=m_t-m_t0. Then, m=(delta m) + m_0.  Rearranging, m=m_t+(m_0-m_t0).  ismip6shelfMelt_offset is the term in parentheses.  Note that the general usage requires that the first time step be run with ismip6shelfMelt_offset=0 in order to determine m_t0, and then NCO or similar tool used to generate the (m_0-m_t0) field to be input as ismip6shelfMelt_offset in the forward run." -->
                 />
                 <var name="upliftRate"            type="real"     dimensions="nCells Time"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1056,22 +1056,22 @@ is the value of that variable from the *previous* time level!
                 <var name="unablatedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left uncalved or unmelted from required calving or melting flux at dynamic cells"
                 />
-                <var name="calvedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was calved from non-dynamic cells"
+                <var name="ablatedVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was ablated from non-dynamic cells"
                 />
-                <var name="calvedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
-                     description="volume of ice that was calved from dynamic cells"
+                <var name="ablatedVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                     description="volume of ice that was ablated from dynamic cells"
                 />
-                <var name="requiredCalvingVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                <var name="requiredAblationVolumeNonDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="bookkeeping field for how much volume should be removed from a non-dynamic cell"
                 />
-                <var name="requiredCalvingVolumeNonDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                <var name="requiredAblationVolumeNonDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
                      description="bookkeeping field for how much volume should be removed from a non-dynamic edge"
                 />
-                <var name="requiredCalvingVolumeDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
+                <var name="requiredAblationVolumeDynEdge" type="real" dimensions="nEdges Time" units="m^3" time_levs="1"
                      description="bookkeeping field for how much volume should be removed from a dynamic edge"
                 />
-                <var name="requiredCalvingVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
+                <var name="requiredAblationVolumeDynCell" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="bookkeeping field for how much volume should be removed from a dynamic edge"
                 />
                 <var name="basalWaterThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1137,8 +1137,6 @@ is the value of that variable from the *previous* time level!
                 <var name="groundedMarineMarginMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
                      description="mask of grid cells that are grounded and adjacent to the ocean. 0=interior, 1=grounded ice margin"
                 />
-                <var name="faceMeltRateApplied" type="real" dimensions="nCells Time" units="m^{3} s^{-1}" packages="ismip6GroundedFaceMelt"
-                     description="Volumetric submarine melt rate applied at grounded marine margin"
                 />
 		<var name="faceMeltSpeed" type="real" dimensions="nCells Time" units="m s^{-1}" packages="ismip6GroundedFaceMelt"
 		     description="linear speed of submarine melting at grounded glacier front"

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -181,7 +181,7 @@
 			    possible_values="Any positive real value"
 		/>
                 <nml_option name="config_floating_von_Mises_threshold_stress" type="real" default_value="1.0e6" units="Pa"
-                            description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on floating ice. Generally seems to need to be low (1e5 to 2e5 for Humboldt Glacier) to allow floating ice to retreat. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
+                            description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on floating ice. Generally seems to need to be low (1e5 to 2e5 for Humboldt Glacier) to allow floating ice to retreat. If set to 0.0, floating ice will be removed from dynamic cells each timestep; calvingThickness will be correct, but calvingVelocity will not be correct for those cells. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
                             possible_values="Any positive real value"
                 />
 	</nml_record>

--- a/src/core_landice/mode_forward/Makefile
+++ b/src/core_landice/mode_forward/Makefile
@@ -51,7 +51,7 @@ mpas_li_calving.o: mpas_li_thermal.o \
 
 mpas_li_thermal.o:
 
-mpas_li_iceshelf_melt.o:
+mpas_li_iceshelf_melt.o: mpas_li_calving.o
 
 mpas_li_diagnostic_vars.o: mpas_li_thermal.o
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1758,10 +1758,9 @@ module li_calving
 
           ! a2.Set thicknessForAblation and ablationVelocity of stranded non-dynamic cells to
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
-          ! identified as those that still have thicknessForAblation == 0.0
+          ! identified as those with frontAblationMask == 3
       do iCell = 1, nCells
-         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. frontAblationMask(iCell)>0 &
-              .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+         if ( frontAblationMask(iCell) == 3.0 ) then
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
             uvelSum = 0.0_RKIND

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1124,7 +1124,6 @@ module li_calving
       real(kind=RKIND) :: calvingSubtotal
       integer :: err_tmp
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
-      logical :: applyCalving, applyMelting
 
       err = 0
 
@@ -1132,8 +1131,6 @@ module li_calving
       applyToGrounded = .true.
       applyToFloating = .true.
       applyToGroundingLine = .false.
-      applyCalving = .true.
-      applyMelting = .false.
 
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_scalar_value', &
@@ -1195,10 +1192,20 @@ module li_calving
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
 
-         ! Convert calvingVelocity to calvingThickness
-          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, applyCalving, &
-                                              applyMelting, domain, err)
+         call mpas_log_write("calling li_apply_front_ablation_velocity from eigencalving")
+          ! Convert calvingVelocity to calvingThickness
+          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
+                                              calvingThickness, calvingVelocity, applyToGrounded, &
+                                              applyToFloating, applyToGroundingLine, domain, err)
+         ! Update halos on calvingThickness or faceMeltingThickness before
+         ! applying it.
+         ! Testing seemed to indicate this is not necessary, but I don't
+         ! understand
+         ! why not, so leaving it.
+         ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+         call mpas_timer_stop("halo updates")
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -1311,7 +1318,6 @@ module li_calving
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress       
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
-      logical :: applyCalving, applyMelting
 
       err = 0
 
@@ -1319,8 +1325,6 @@ module li_calving
       applyToGrounded = .true.
       applyToFloating = .true.
       applyToGroundingLine = .false.
-      applyCalving = .true.
-      applyMelting = .false.
       
       call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
@@ -1398,10 +1402,20 @@ module li_calving
              endif
           enddo
 
-          ! Convert calvingVelocity to calvingThickness
-          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                      applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
-
+          call mpas_log_write("calling li_apply_front_ablation_velocity from von Mises stress calving routine")
+         ! Convert calvingVelocity to calvingThickness
+          call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
+                                              calvingThickness, calvingVelocity, applyToGrounded, &
+                                              applyToFloating, applyToGroundingLine, domain, err)
+         ! Update halos on calvingThickness or faceMeltingThickness before
+         ! applying it.
+         ! Testing seemed to indicate this is not necessary, but I don't
+         ! understand
+         ! why not, so leaving it.
+         ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+         call mpas_timer_stop("halo updates")
 
           ! If floating VM threshold is zero, remove floating ice.
           if ( config_floating_von_Mises_threshold_stress .eq. 0.0_RKIND ) then
@@ -1471,10 +1485,11 @@ module li_calving
 !> otherwise it is applied to the last grounded cell.
 !> If applyToFloating = .true., ablation is applied to dynamic floating margin cells
 !> The output of this routine is calvingThickness or faceMeltingThickness, which then needs to be applied to thickness
-!> by the calling routine.
+!> by the calling routine. The calling routine should perform a halo update
+!> after the call and before applying ablation.
 !-----------------------------------------------------------------------
 
-   subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
+   subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, ablationThickness, ablationVelocity, applyToGrounded, applyToFloating, applyToGroundingLine, domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1483,13 +1498,13 @@ module li_calving
       type (mpas_pool_type), pointer, intent(in) :: velocityPool !< Input: velocity pool
       logical, intent(in) :: applyToFloating, applyToGrounded, &
                              applyToGroundingLine
-      logical, intent(in) :: applyCalving, applyMelting
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain          !< Input: domain object
       type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
-
+      real (kind=RKIND), dimension(:), intent(in) :: ablationVelocity
+      real (kind=RKIND), dimension(:), intent(out) :: ablationThickness
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
@@ -1510,7 +1525,6 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity, faceMeltSpeed
-      real (kind=RKIND), dimension(:), allocatable :: ablationVelocity, ablationThickness
       real (kind=RKIND), dimension(:), pointer :: areaCell
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructX
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructY
@@ -1630,14 +1644,8 @@ module li_calving
       endif
 
       
-
-
-      ! Init fields for accounting
-      calvingThickness(:) = 0.0_RKIND
-      faceMeltingThickness(:) = 0.0_RKIND
       
       ! Init fields for accounting
-      allocate(ablationThickness(nCells+1))
       ablationThickness(:) = 0.0_RKIND
       ablatedVolumeNonDynCell(:) = 0.0_RKIND
       ablatedVolumeDynCell(:) = 0.0_RKIND
@@ -1651,18 +1659,7 @@ module li_calving
       requiredAblationVolumeDynCell(:) = 0.0_RKIND
       allocate(thicknessForAblation(nCells+1))
       thicknessForAblation = 0.0_RKIND
-      allocate(ablationVelocity(nCells+1))
 
-      ablationVelocity(:) = 0.0_RKIND
-
-      if ( applyCalving ) then
-         ablationVelocity(:) = calvingVelocity(:)
-      else if ( applyMelting ) then
-         !ablationVelocity(:) = faceMeltSpeed(:) * abs(config_sea_level - lowerSurface(:)) / thickness(:) ! faceMeltSpeed is only submarine, so spread this across the whole height of the ice front
-         where ( (thickness > 0.0_RKIND) .and. (lowerSurface < 0.0_RKIND) )
-               ablationVelocity(:) = faceMeltSpeed(:) * abs(lowerSurface(:)) / thickness(:)
-         end where
-      end if
 
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
@@ -1881,22 +1878,8 @@ module li_calving
       endif
 
 
-      ! Update halos on calvingThickness or faceMeltingThickness before applying it.
-      ! Testing seemed to indicate this is not necessary, but I don't understand why not, so leaving it.
-      ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
-      call mpas_timer_start("halo updates")
-      if ( applyMelting ) then 
-         faceMeltingThickness(:) = ablationThickness(:)
-         call mpas_dmpar_field_halo_exch(domain, 'faceMeltingThickness')
-      else if ( applyCalving ) then
-         calvingThickness(:) = ablationThickness(:)
-         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
-      end if
-      call mpas_timer_stop("halo updates")
-
       deallocate(cellVolume)
       deallocate(thicknessForAblation)
-      deallocate(ablationVelocity)
       call mpas_log_write("Finished with li_apply_front_ablation_velocity")
 
     end subroutine li_apply_front_ablation_velocity

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -44,7 +44,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front, apply_front_ablation_velocity
+   public :: li_calve_ice, li_restore_calving_front, li_apply_front_ablation_velocity
 
    !--------------------------------------------------------------------
    !
@@ -1196,7 +1196,7 @@ module li_calving
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
 
          ! Convert calvingVelocity to calvingThickness
-          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, applyCalving, &
                                               applyMelting, domain, err)
 
@@ -1315,7 +1315,7 @@ module li_calving
 
       err = 0
 
-      ! Logical arrays needed for apply_front_ablation_velocity
+      ! Logical arrays needed for li_apply_front_ablation_velocity
       applyToGrounded = .true.
       applyToFloating = .true.
       applyToGroundingLine = .false.
@@ -1324,6 +1324,11 @@ module li_calving
       
       call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
+
+      if ( config_grounded_von_Mises_threshold_stress <=  0.0_RKIND ) then
+         call mpas_log_write("config_grounded_von_Mises_threshold_stress must be >0.0", MPAS_LOG_ERR)
+         err = 1
+      endif
       !call mpas_pool_get_config(liConfigs, 'config_default_flowParamA',
       !config_default_flowParamA) ! REMOVE THIS ONCE YOU CAN GET A FROM
       !ALBANY!!!!!
@@ -1384,6 +1389,9 @@ module li_calving
              if ( .not. li_mask_is_floating_ice(cellMask(iCell)) ) then
                 calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
                                          vonMisesStress(iCell) / config_grounded_von_Mises_threshold_stress
+             ! If config_floating_von_Mises_threshold_stress is not 0.0, calculate
+             ! calvingVelocity. If config_floating_von_Mises_threshold_stress is
+             ! 0.0, remove floating ice in loop below.
              elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
                 calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
                                          vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress
@@ -1391,7 +1399,7 @@ module li_calving
           enddo
 
           ! Convert calvingVelocity to calvingThickness
-          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
                                       applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
 
 
@@ -1423,7 +1431,7 @@ module li_calving
  
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine apply_front_ablation_velocity
+!    routine li_apply_front_ablation_velocity
 !
 !> \brief Convert a calving or melting velocity to an ice thickness removal
 !> \author Matthew Hoffman and Trevor Hillebrand
@@ -1459,7 +1467,7 @@ module li_calving
 !> by the calling routine.
 !-----------------------------------------------------------------------
 
-   subroutine apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
+   subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -1749,7 +1757,7 @@ module li_calving
                   ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
                   if (requiredAblationVolumeDynEdge(iEdge) > 0.0_RKIND) then
                      call mpas_log_write("Unexpectedly found a dynamic edge that already has calving assigned to it." // &
-                           "  There is a flaw in apply_front_ablation_velocity that needs to be fixed!", MPAS_LOG_ERR)
+                           "  There is a flaw in li_apply_front_ablation_velocity that needs to be fixed!", MPAS_LOG_ERR)
                      err_tmp = 1
                      err = ior(err, err_tmp)
                   endif
@@ -1847,7 +1855,7 @@ module li_calving
       if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.1_RKIND) .and. &
           (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
          call mpas_log_write("Failed to ablate an amount greater than 10% of the ice ablated.  " // &
-                 "Try reducing time step or apply_front_ablation_velocity may need improvements.", &
+                 "Try reducing time step or li_apply_front_ablation_velocity may need improvements.", &
                  MPAS_LOG_ERR, realArgs=(/globalInfo(5) + globalInfo(6), &
                  100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
          err_tmp = 1
@@ -1857,7 +1865,7 @@ module li_calving
          ! If stranded ice deletion results in more than a small amount of the total calving flux, this routine will not
          ! be accurate.  If this error gets triggered, either try using a smaller timstep or this routine needs improving.
          call mpas_log_write("Deleting stranded floating cells accounts for more than 1% of ablation loss." // &
-                 "  Try using a smaller timestep or apply_front_ablation_velocity may need improvements for this simulation.")
+                 "  Try using a smaller timestep or li_apply_front_ablation_velocity may need improvements for this simulation.")
          err_tmp = 1
          err = ior(err, err_tmp)
       endif
@@ -1883,12 +1891,12 @@ module li_calving
       deallocate(requiredAblationVolumeDynCell)
       deallocate(thicknessForAblation)
       deallocate(ablationVelocity)
-      call mpas_log_write("Finished with apply_front_ablation_velocity")
+      call mpas_log_write("Finished with li_apply_front_ablation_velocity")
 
-    end subroutine apply_front_ablation_velocity
+    end subroutine li_apply_front_ablation_velocity
 
 
-    ! Helper function for subroutine apply_front_ablation_velocity
+    ! Helper function for subroutine li_apply_front_ablation_velocity
     ! Calculates the amount to scale an edge length based on the orientation of the edge with the surface velocity
     function scale_edge_length(angleEdgeHere, u, v)
        real(kind=RKIND), intent(in) :: angleEdgeHere

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1723,7 +1723,7 @@ module li_calving
 
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if ((frontAblationMask(iCell)>0) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
             ! a1. Translate the calving front height based on dynamic cells to the non-dynamic locations
             ! find mean (or min?) of thickness in dynamic neighbors
@@ -1757,7 +1757,7 @@ module li_calving
           ! a2.Set thicknessForAblation and ablationVelocity of stranded non-dynamic cells to
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
           ! identified as those that still have thicknessForAblation == 0.0
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if ( thicknessForAblation(iCell) == 0.0_RKIND .and. frontAblationMask(iCell)>0 &
               .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ablationVelSum = 0.0_RKIND
@@ -1790,7 +1790,7 @@ module li_calving
 
             ! b. Translate the ablationVelocity and thickness from non-dynamic cells to their ocean-going edges
             !    to calculate the calving volume on those edges and this cell
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if (frontAblationMask(iCell)>0 .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
 
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1813,7 +1813,7 @@ module li_calving
             ablatedVolumeNonDynCell(iCell) = removeVolumeHere
             unablatedVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            ablationSubtotal1 = ablationSubtotal1 + removeVolumeHere
+            if (iCell <= nCellsSolve) ablationSubtotal1 = ablationSubtotal1 + removeVolumeHere
          endif
       enddo
       call mpas_timer_start("halo updates")
@@ -1828,7 +1828,7 @@ module li_calving
 
       ! 2a1. for grounded dynamic margins, don't use the thickness there because it may be unrealistically thin due to ablation
       ! from previous time steps.  Instead copy forward the thickness from the row cells behind.
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if (frontAblationMask(iCell)>0 .and. li_mask_is_margin(cellMask(iCell)) .and. li_mask_is_grounded_ice(cellMask(iCell))) then
             thkSum = 0.0_RKIND
             thkCount = 0
@@ -1850,7 +1850,7 @@ module li_calving
       enddo
 
       ! a. Calculate calving on dynamic margin edges
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if ( frontAblationMask(iCell)>0 .and. li_mask_is_dynamic_ice(cellMask(iCell)) & ! a dynamic cell in the mask...
             .and. li_mask_is_margin(cellMask(iCell)) ) then                            ! that is at the edge of the ice
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1915,7 +1915,7 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       ! c. Now apply ablation to each cell
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
             ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.
             ! Note, we ignore any leftover calving/melting if it would be applied to cells where the bed is above sea level.
@@ -1931,14 +1931,14 @@ module li_calving
             ablatedVolumeDynCell(iCell) = removeVolumeHere
             unablatedVolumeDynCell(iCell) = requiredAblationVolumeDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
+            if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
          endif
       enddo
       !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
 
 
       ! Clean up to account for roundoff level errors that can occur
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
             ablationThickness(iCell) = thickness(iCell)
          endif
@@ -1946,7 +1946,7 @@ module li_calving
 
       ! Clean up - zap any stranded ice.  This only needs to be considered for floating ice.
       ablationSubtotal3 = 0.0_RKIND
-      do iCell = 1, nCellsSolve
+      do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             thkCount = 0
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -1957,7 +1957,7 @@ module li_calving
             enddo
             if (thkCount == 0) then
                ablationThickness(iCell) = thickness(iCell)
-               ablationSubtotal3 = ablationSubtotal3 + ablationThickness(iCell)
+               if (iCell <= nCellsSolve) ablationSubtotal3 = ablationSubtotal3 + ablationThickness(iCell)
             endif
          endif
          if (isnan(areaCell(iCell))) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1760,7 +1760,7 @@ module li_calving
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
           ! identified as those with frontAblationMask == 3
       do iCell = 1, nCells
-         if ( frontAblationMask(iCell) == 3.0 ) then
+         if ( frontAblationMask(iCell) == 3 ) then
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
             uvelSum = 0.0_RKIND

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1123,7 +1123,7 @@ module li_calving
       logical :: dynamicNeighbor
       real(kind=RKIND) :: calvingSubtotal
       integer :: err_tmp
-      logical :: applyToGrounded, applyToFloating
+      logical :: applyToGrounded, applyToFloating, applyToGroundingLine
       logical :: applyCalving, applyMelting
 
       err = 0
@@ -1131,6 +1131,7 @@ module li_calving
       ! Logical arrays needed for apply_ablation_velocity
       applyToGrounded = .true.
       applyToFloating = .true.
+      applyToGroundingLine = .false.
       applyCalving = .true.
       applyMelting = .false.
 
@@ -1196,7 +1197,8 @@ module li_calving
 
          ! Convert calvingVelocity to calvingThickness
           call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                              applyToFloating, applyCalving, applyMelting, domain, err)
+                                              applyToFloating, applyToGroundingLine, applyCalving, &
+                                              applyMelting, domain, err)
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -1308,7 +1310,7 @@ module li_calving
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress       
-      logical :: applyToGrounded, applyToFloating
+      logical :: applyToGrounded, applyToFloating, applyToGroundingLine
       logical :: applyCalving, applyMelting
 
       err = 0
@@ -1316,6 +1318,7 @@ module li_calving
       ! Logical arrays needed for apply_front_ablation_velocity
       applyToGrounded = .true.
       applyToFloating = .true.
+      applyToGroundingLine = .false.
       applyCalving = .true.
       applyMelting = .false.
       
@@ -1399,7 +1402,7 @@ module li_calving
 
           ! Convert calvingVelocity to calvingThickness
           call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                      applyToFloating, applyCalving, applyMelting, domain, err)
+                                      applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
 
 
           ! === apply calving ===
@@ -1455,14 +1458,15 @@ module li_calving
 !> by the calling routine.
 !-----------------------------------------------------------------------
 
-   subroutine apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyCalving, applyMelting, domain, err)
+   subroutine apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
       type (mpas_pool_type), pointer, intent(in) :: velocityPool !< Input: velocity pool
-      logical, intent(in) :: applyToFloating, applyToGrounded
+      logical, intent(in) :: applyToFloating, applyToGrounded, &
+                             applyToGroundingLine
       logical, intent(in) :: applyCalving, applyMelting
       !-----------------------------------------------------------------
       ! input/output variables
@@ -1551,12 +1555,13 @@ module li_calving
       groundedMarineMarginMask(:) = 0
       
       if ( applyToGrounded ) then
-         do iCell = 1, nCells
-         ! Define marine marginal cells as those that are (1) at the ice
+         do iCell = 1, nCellsSolve
+
+         ! If applyToGrounded: Define marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
-
+ 
          ! Check if neighboring cells contain ice and have bed topo below sea level
             nEmptyNeighbors = 0
             do iEdge = 1, nEdgesOnCell(iCell)
@@ -1580,7 +1585,32 @@ module li_calving
                groundedMarineMarginMask(iCell) = 0
             endif
          enddo
+      
+      else if ( applyToGroundingLine ) then
+         do iCell = 1,nCellsSolve
+
+         ! If applyToGroundingLine: Define marine marginal cells as those that
+         ! are at the margin (defined by li_mask_is_grounding_line) if no
+         ! floating ice or are the first floating cell if there is floating ice.
+           if ( bedTopography(iCell) < config_sea_level &
+                .and. li_mask_is_grounded_ice(cellMask(iCell)) ) then
+
+              do iEdge = 1, nEdgesOnCell(iCell)
+                iNeighbor = cellsOnCell(iEdge, iCell)
+                 if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
+                      .and. li_mask_is_floating_ice(cellMask(iNeighbor)) ) then
+                    groundedMarineMarginMask(iNeighbor) = 1
+                 else if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
+                      .and. (.not. li_mask_is_floating_ice(cellMask(iNeighbor))) ) then
+                    groundedMarineMarginMask(iCell) = 1
+                 endif
+              enddo ! end loop over edges
+           endif      
+         enddo !end loop over cells
+
       endif
+
+      
 
 
       ! Init fields for accounting

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -45,7 +45,7 @@ module li_calving
    !
    !--------------------------------------------------------------------
 
-   public :: li_calve_ice, li_restore_calving_front
+   public :: li_calve_ice, li_restore_calving_front, apply_front_ablation_velocity
 
    !--------------------------------------------------------------------
    !
@@ -1315,7 +1315,7 @@ module li_calving
 
       err = 0
 
-      ! Logical arrays needed for apply_ablation_velocity
+      ! Logical arrays needed for apply_front_ablation_velocity
       applyToGrounded = .true.
       applyToFloating = .true.
       applyCalving = .true.

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1519,7 +1519,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, edgeMask
-      integer, dimension(:), pointer :: groundedMarineMarginMask
+      integer, dimension(:), pointer :: frontAblationMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, faceMeltingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: dvEdge
@@ -1576,7 +1576,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'unablatedVolumeDynCell', unablatedVolumeDynCell)
       call mpas_pool_get_array(geometryPool, 'ablatedVolumeNonDynCell', ablatedVolumeNonDynCell)
       call mpas_pool_get_array(geometryPool, 'ablatedVolumeDynCell', ablatedVolumeDynCell)
-      call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
+      call mpas_pool_get_array(geometryPool, 'frontAblationMask', frontAblationMask)
       call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeNonDynEdge', requiredAblationVolumeNonDynEdge)
       call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeDynEdge', requiredAblationVolumeDynEdge)
       call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeNonDynCell', requiredAblationVolumeNonDynCell)
@@ -1585,7 +1585,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
-      groundedMarineMarginMask(:) = 0
+      frontAblationMask(:) = 0
       
       if ( applyToGrounded ) then
          do iCell = 1, nCellsSolve
@@ -1613,13 +1613,21 @@ module li_calving
                .and. bedTopography(iCell) < config_sea_level &
                .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
 
-               groundedMarineMarginMask(iCell) = 1
-            else
-               groundedMarineMarginMask(iCell) = 0
+               frontAblationMask(iCell) = 1
+               ! Include adjacent non-dynamic cells
+               do iEdge = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(iEdge, iCell)
+                  if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
+                        .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
+
+                     frontAblationMask(iNeighbor) = 1
+                  endif
+               enddo
             endif
          enddo
-      
-      else if ( applyToGroundingLine ) then
+      endif
+
+      if ( applyToGroundingLine ) then
          do iCell = 1,nCellsSolve
 
          ! If applyToGroundingLine: Define marine marginal cells as those that
@@ -1632,10 +1640,14 @@ module li_calving
                 iNeighbor = cellsOnCell(iEdge, iCell)
                  if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
                       .and. li_mask_is_floating_ice(cellMask(iNeighbor)) ) then
-                    groundedMarineMarginMask(iNeighbor) = 1
+
+                    frontAblationMask(iNeighbor) = 1
+
                  else if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
                       .and. (.not. li_mask_is_floating_ice(cellMask(iNeighbor))) ) then
-                    groundedMarineMarginMask(iCell) = 1
+
+                    frontAblationMask(iCell) = 1
+
                  endif
               enddo ! end loop over edges
            endif      
@@ -1643,7 +1655,28 @@ module li_calving
 
       endif
 
-      
+      if ( applyToFloating ) then
+         do iCell = 1,nCellsSolve
+
+           ! If applyToFloating: marine marginal cells are dynamic floating margin
+           ! cells
+            if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
+               li_mask_is_dynamic_margin(cellMask(iCell)) ) then
+             
+               frontAblationMask(iCell) = 1
+               ! Include adjacent non-dynamic cells
+               do iEdge = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(iEdge, iCell)
+                  if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
+                        .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
+ 
+                     frontAblationMask(iNeighbor) = 1
+                  endif
+               enddo
+             endif
+             
+         enddo
+      endif 
       
       ! Init fields for accounting
       ablationThickness(:) = 0.0_RKIND
@@ -1754,10 +1787,7 @@ module li_calving
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
-         if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
-                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
-              .and. li_mask_is_margin(cellMask(iCell)) ) then
-            ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
+         if ( frontAblationMask(iCell) == 1 ) then 
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1194,7 +1194,6 @@ module li_calving
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
 
-
          ! Convert calvingVelocity to calvingThickness
           call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
                                               applyToFloating, applyCalving, applyMelting, domain, err)
@@ -1603,8 +1602,8 @@ module li_calving
          ablationVelocity(:) = calvingVelocity(:)
       else if ( applyMelting ) then
          !ablationVelocity(:) = faceMeltSpeed(:) * abs(config_sea_level - lowerSurface(:)) / thickness(:) ! faceMeltSpeed is only submarine, so spread this across the whole height of the ice front
-         where (thickness > 0.0_RKIND)
-               ablationVelocity(:) = faceMeltSpeed(:) * lowerSurface(:) / thickness(:)
+         where ( (thickness > 0.0_RKIND) .and. (lowerSurface < 0.0_RKIND) )
+               ablationVelocity(:) = faceMeltSpeed(:) * abs(lowerSurface(:)) / thickness(:)
          end where
       end if
 
@@ -1664,9 +1663,8 @@ module li_calving
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
          if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
-                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
-              .and. li_mask_is_margin(cellMask(iCell)) ) then
-            ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
+              .and. li_mask_is_margin(cellMask(iCell)) ) .or.  (groundedMarineMarginMask(iCell) == 1) ) then            
+! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -29,7 +29,6 @@ module li_calving
    use li_mask
    use li_constants
 
-
    implicit none
    private
 
@@ -1472,6 +1471,7 @@ module li_calving
       integer :: nEmptyNeighbors
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: lowerSurface
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, edgeMask
@@ -1523,6 +1523,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
@@ -1596,10 +1597,15 @@ module li_calving
       thicknessForAblation = 0.0_RKIND
       allocate(ablationVelocity(nCells+1))
 
+      ablationVelocity(:) = 0.0_RKIND
+
       if ( applyCalving ) then
          ablationVelocity(:) = calvingVelocity(:)
       else if ( applyMelting ) then
-         ablationVelocity(:) = faceMeltSpeed(:)
+         !ablationVelocity(:) = faceMeltSpeed(:) * abs(config_sea_level - lowerSurface(:)) / thickness(:) ! faceMeltSpeed is only submarine, so spread this across the whole height of the ice front
+         where (thickness > 0.0_RKIND)
+               ablationVelocity(:) = faceMeltSpeed(:) * lowerSurface(:) / thickness(:)
+         end where
       end if
 
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
@@ -1825,7 +1831,7 @@ module li_calving
       if ( applyMelting ) then 
          meltingThickness(:) = ablationThickness(:)
          call mpas_dmpar_field_halo_exch(domain, 'meltingThickness')
-      else if (applyCalving ) then
+      else if ( applyCalving ) then
          calvingThickness(:) = ablationThickness(:)
          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
       end if
@@ -1838,6 +1844,7 @@ module li_calving
       deallocate(requiredAblationVolumeDynCell)
       deallocate(thicknessForAblation)
       deallocate(ablationVelocity)
+      call mpas_log_write("Finished with apply_front_ablation_velocity")
 
     end subroutine apply_front_ablation_velocity
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1606,6 +1606,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
+
       ! Step 0: Define the frontAblationMask that will be used to determine where ablation should be applied.
       ! This mask can be for 1. a floating calving front, 2. a grounded marine margin (no dynamic floating ice shelf attached),
       ! 3. along the grounding line (whether or not there is floating ice adjacent), or any combination of the three.
@@ -1682,7 +1683,7 @@ module li_calving
                iNeighbor = cellsOnCell(iEdge, iCell)
                if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
                   .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
-                  frontAblationMask(iNeighbor) = 2
+                  frontAblationMask(iNeighbor) = 2 ! Use 2 for these non-dynamic floating neighbors
                endif
             enddo
          endif
@@ -1693,9 +1694,9 @@ module li_calving
             ! Check if this non-dynamic masked cell has any non-dynamic, floating, but unmasked neighbors we need to include
             do iEdge = 1, nEdgesOnCell(iCell)
                iNeighbor = cellsOnCell(iEdge, iCell)
-               if ((.not. li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. li_mask_is_floating_ice(iNeighbor) &
+               if ((.not. li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. li_mask_is_floating_ice(cellMask(iNeighbor)) &
                   .and. frontAblationMask(iNeighbor) == 0) then
-                  frontAblationMask(iNeighbor) = 1
+                  frontAblationMask(iNeighbor) = 3 ! Use 3 for these extended non-dynamic neighbors
                endif
             enddo
          endif
@@ -1715,7 +1716,7 @@ module li_calving
       requiredAblationVolumeDynEdge(:) = 0.0_RKIND
       requiredAblationVolumeDynCell(:) = 0.0_RKIND
       allocate(thicknessForAblation(nCells+1))
-      thicknessForAblation = 0.0_RKIND
+      thicknessForAblation = thickness
       allocate(uvelForAblation(nCells+1))
       uvelForAblation(:) = uReconstructX(1,:)
       allocate(vvelForAblation(nCells+1))
@@ -1735,7 +1736,7 @@ module li_calving
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(cellMask(jCell))) then
-                  thkSum = thkSum + thickness(jCell)
+                  thkSum = thkSum + thicknessForAblation(jCell)
                   uvelSum = uvelSum + uvelForAblation(jCell)
                   vvelSum = vvelSum + vvelforAblation(jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
@@ -1754,6 +1755,7 @@ module li_calving
          endif
       enddo
 
+
           ! a2.Set thicknessForAblation and ablationVelocity of stranded non-dynamic cells to
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
           ! identified as those that still have thicknessForAblation == 0.0
@@ -1769,7 +1771,7 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if ( li_mask_is_floating_ice(cellMask(jCell)) &
                     .and. (.not. li_mask_is_dynamic_ice(cellMask(jCell))) ) then
-                  thkSum = thkSum + thickness(jCell)
+                  thkSum = thkSum + thicknessForAblation(jCell)
                   uvelSum = uvelSum + uvelForAblation(jCell)
                   vvelSum = vvelSum + vvelForAblation(jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
@@ -1834,9 +1836,9 @@ module li_calving
             thkCount = 0
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_dynamic_ice(cellMask(jCell)) .and. li_mask_is_grounded_ice(cellMask(iCell)) .and. &
-                       .not. li_mask_is_margin(cellMask(iCell))) then
-                  thkSum = thkSum + thickness(jCell)
+               if (li_mask_is_dynamic_ice(cellMask(jCell)) .and. li_mask_is_grounded_ice(cellMask(jCell)) .and. &
+                       .not. li_mask_is_margin(cellMask(jCell))) then
+                  thkSum = thkSum + thicknessForAblation(jCell)
                   thkCount = thkCount + 1
                endif
             enddo
@@ -1859,7 +1861,7 @@ module li_calving
                   iEdge = edgesOnCell(iNeighbor, iCell)
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
                   requiredAblationVolumeDynEdge(iEdge) = ablationVelocity(iCell) * &
-                          edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
+                          edgeLengthScaling * dvEdge(iEdge) * thicknessForAblation(iCell) * deltat
                endif
             enddo
          endif

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1718,8 +1718,9 @@ module li_calving
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
          if ( ( (li_mask_is_floating_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) & ! floating dynamic
-              .and. li_mask_is_margin(cellMask(iCell)) ) .or.  (groundedMarineMarginMask(iCell) == 1) ) then            
-! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
+                .or.  (groundedMarineMarginMask(iCell) == 1) ) &
+              .and. li_mask_is_margin(cellMask(iCell)) ) then
+            ! only consider dynamic margins adjacent to open ocean (need to exclude dynamic margins adjacent to land)
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1300,7 +1300,9 @@ module li_calving
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-      integer :: iCell, err_tmp
+      integer :: iCell, jCell, iNeighbor, nGroundedNeighbors, err_tmp
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool, meshPool, &
                                         velocityPool, scratchPool, thermalPool
@@ -1349,6 +1351,8 @@ module li_calving
           call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
           call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
          ! get fields
+          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
           call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
           call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
           call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
@@ -1417,12 +1421,28 @@ module li_calving
          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
          call mpas_timer_stop("halo updates")
 
-          ! If floating VM threshold is zero, remove floating ice.
+          ! If floating VM threshold is zero, remove floating ice. Remove
+          ! non-dynamic cells adjacent to floating ice, but leave
+          ! non-dynamic cells adjacent to grounded ice.
+          ! TODO: Make an exception for the case of floating ice surrounded by grounded ice
+          ! (i.e., floating on a subglacial lake) using a flood fill routine
           if ( config_floating_von_Mises_threshold_stress .eq. 0.0_RKIND ) then
              do iCell = 1,nCells
                 if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
                      li_mask_is_dynamic_ice(cellMask(iCell)) ) then
                      calvingThickness(iCell) = thickness(iCell)
+                elseif ( li_mask_is_floating_ice(cellMask(icell)) .and. &
+                    (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
+                    nGroundedNeighbors = 0
+                    do iNeighbor = 1, nEdgesOnCell(iCell)
+                       jCell = cellsOnCell(iNeighbor, iCell)
+                       if ( li_mask_is_grounded_ice(cellMask(jCell)) ) then 
+                           nGroundedNeighbors = nGroundedNeighbors + 1
+                       endif
+                    enddo
+                    if ( nGroundedNeighbors == 0 ) then
+                       calvingThickness(iCell) = thickness(iCell)
+                    endif
                 endif
              enddo
           endif

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1387,16 +1387,6 @@ module li_calving
              elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
                 calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
                                          vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress
-             !if gloating VM threshold is zero, remove floating ice
-             elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .eq. 0.0_RKIND &
-                       .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
-                thickness(iCell) = 0.0_RKIND
-                ! update mask
-                call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-                err = ior(err, err_tmp)
-
-                call remove_small_islands(meshPool, geometryPool)
-
              endif
           enddo
 
@@ -1405,6 +1395,17 @@ module li_calving
                                       applyToFloating, applyToGroundingLine, applyCalving, applyMelting, domain, err)
 
 
+          ! If floating VM threshold is zero, remove floating ice.
+          if ( config_floating_von_Mises_threshold_stress .eq. 0.0_RKIND ) then
+             do iCell = 1,nCells
+                if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
+                     li_mask_is_dynamic_ice(cellMask(iCell)) ) then
+                     calvingThickness(iCell) = thickness(iCell)
+                endif
+             enddo
+          endif
+
+             
           ! === apply calving ===
           thickness(:) = thickness(:) - calvingThickness(:)
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1124,8 +1124,16 @@ module li_calving
       logical :: dynamicNeighbor
       real(kind=RKIND) :: calvingSubtotal
       integer :: err_tmp
+      logical :: applyToGrounded, applyToFloating
+      logical :: applyCalving, applyMelting
 
       err = 0
+
+      ! Logical arrays needed for apply_ablation_velocity
+      applyToGrounded = .true.
+      applyToFloating = .true.
+      applyCalving = .true.
+      applyMelting = .false.
 
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_scalar_value', &
@@ -1189,8 +1197,8 @@ module li_calving
 
 
          ! Convert calvingVelocity to calvingThickness
-         call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
-
+          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+                                              applyToFloating, applyCalving, applyMelting, domain, err)
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -1302,7 +1310,16 @@ module li_calving
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress       
+      logical :: applyToGrounded, applyToFloating
+      logical :: applyCalving, applyMelting
+
       err = 0
+
+      ! Logical arrays needed for apply_ablation_velocity
+      applyToGrounded = .true.
+      applyToFloating = .true.
+      applyCalving = .true.
+      applyMelting = .false.
       
       call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
@@ -1373,7 +1390,8 @@ module li_calving
           enddo
 
           ! Convert calvingVelocity to calvingThickness
-          call apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+                                      applyToFloating, applyCalving, applyMelting, domain, err)
 
 
           ! === apply calving ===
@@ -1393,12 +1411,12 @@ module li_calving
  
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine apply_calving_velocity
+!    routine apply_front_ablation_velocity
 !
-!> \brief Convert a calving velocity to an ice thickness removal
-!> \author Matthew Hoffman
+!> \brief Convert a calving or melting velocity to an ice thickness removal
+!> \author Matthew Hoffman and Trevor Hillebrand
 !> \date   March 2020
-!> \details This routine takes a calving velocity and converts it to a
+!> \details This routine takes a calving or front melting velocity and converts it to a
 !> thickness removal.  The basic idea is to multiply the calving velocity
 !> by the edge length and height to get a volume flux.  However, the details
 !> are complicated by the unstructured Voronoi mesh and the use of partially-filled
@@ -1429,14 +1447,15 @@ module li_calving
 !> by the calling routine.
 !-----------------------------------------------------------------------
 
-   subroutine apply_calving_velocity(meshPool, geometryPool, velocityPool, domain, err)
+   subroutine apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, applyToFloating, applyCalving, applyMelting, domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
       type (mpas_pool_type), pointer, intent(in) :: velocityPool !< Input: velocity pool
-
+      logical, intent(in) :: applyToFloating, applyToGrounded
+      logical, intent(in) :: applyCalving, applyMelting
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -1457,11 +1476,12 @@ module li_calving
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, edgeMask
       integer, dimension(:), pointer :: groundedMarineMarginMask
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness, meltingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
-      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity, faceMeltSpeed
+      real (kind=RKIND), dimension(:), allocatable :: ablationVelocity, ablationThickness
       real (kind=RKIND), dimension(:), pointer :: areaCell
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeDynEdge
       real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynCell, requiredCalvingVolumeDynCell
@@ -1469,21 +1489,20 @@ module li_calving
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructY
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
-      real (kind=RKIND), dimension(:), allocatable :: thicknessForCalving
-      real (kind=RKIND), dimension(:), pointer :: calvedVolumeNonDynCell, calvedVolumeDynCell
-      real (kind=RKIND), dimension(:), pointer :: uncalvedVolumeNonDynCell, uncalvedVolumeDynCell
+      real (kind=RKIND), dimension(:), allocatable :: thicknessForAblation
+      real (kind=RKIND), dimension(:), allocatable :: requiredAblationVolumeNonDynEdge, requiredAblationVolumeNonDynCell
+      real (kind=RKIND), dimension(:), allocatable :: requiredAblationVolumeDynEdge, requiredAblationVolumeDynCell
+      real (kind=RKIND), dimension(:), pointer :: unablatedVolumeNonDynCell, unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
-      real(kind=RKIND) :: calvingSubtotal1, calvingSubtotal2, calvingSubtotal3
+      real(kind=RKIND) :: ablationSubtotal1, ablationSubtotal2, ablationSubtotal3
       real(kind=RKIND) :: thkSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
-      real(kind=RKIND) :: volumeAvailableToPass !< a temp. var. for accounting purposes that indicates how much volume
-                          !< to be calved is 'leftover' after trying to calve non-dynamic cells and can be transferred to
-                          !< neighboring dynamic cells
-      real(kind=RKIND) :: calvLengthCell, calvLengthEdge
+      real(kind=RKIND) :: volumeAvailableToPass
+      real(kind=RKIND) :: ablateLengthCell, ablateLengthEdge
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
-      real(kind=RKIND), parameter :: calvingSmallThk = 1.0e-8 ! in meters, a small thickness threshold
+      real(kind=RKIND), parameter :: ablationSmallThk = 1.0e-8 ! in meters, a small thickness threshold
       integer :: err_tmp
 
       err = 0
@@ -1501,15 +1520,15 @@ module li_calving
       call mpas_pool_get_array(velocityPool, 'uReconstructX', uReconstructX)
       call mpas_pool_get_array(velocityPool, 'uReconstructY', uReconstructY)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+      call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'uncalvedVolumeNonDynCell', uncalvedVolumeNonDynCell)
-      call mpas_pool_get_array(geometryPool, 'uncalvedVolumeDynCell', uncalvedVolumeDynCell)
-      call mpas_pool_get_array(geometryPool, 'calvedVolumeNonDynCell', calvedVolumeNonDynCell)
-      call mpas_pool_get_array(geometryPool, 'calvedVolumeDynCell', calvedVolumeDynCell)
+      call mpas_pool_get_array(geometryPool, 'meltingThickness', meltingThickness)
+      call mpas_pool_get_array(geometryPool, 'unablatedVolumeNonDynCell', unablatedVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'unablatedVolumeDynCell', unablatedVolumeDynCell)
       call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeNonDynEdge', requiredCalvingVolumeNonDynEdge)
       call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeDynEdge', requiredCalvingVolumeDynEdge)
@@ -1520,56 +1539,71 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
       groundedMarineMarginMask(:) = 0
-      do iCell = 1, nCells
-         ! Define grounded marine marginal cells as those that are (1) at the ice
+      
+      if ( applyToGrounded ) then
+         do iCell = 1, nCells
+         ! Define marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
 
          ! Check if neighboring cells contain ice and have bed topo below sea level
-         nEmptyNeighbors = 0
-         do iEdge = 1, nEdgesOnCell(iCell)
-           iNeighbor = cellsOnCell(iEdge, iCell)
-           if ( (((thickness(iNeighbor) == 0.0_RKIND) &
-              .and. bedTopography(iNeighbor) < config_sea_level)) &
-              .or. ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
-              .and. li_mask_is_margin(cellMask(iNeighbor)) &
-              .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
-               nEmptyNeighbors = nEmptyNeighbors + 1
-           endif
+            nEmptyNeighbors = 0
+            do iEdge = 1, nEdgesOnCell(iCell)
+              iNeighbor = cellsOnCell(iEdge, iCell)
+              if ( (((thickness(iNeighbor) == 0.0_RKIND) &
+                 .and. bedTopography(iNeighbor) < config_sea_level)) &
+                 .or. ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
+                 .and. li_mask_is_margin(cellMask(iNeighbor)) &
+                 .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
+                 nEmptyNeighbors = nEmptyNeighbors + 1
+              endif
+            enddo
+
+            if ( nEmptyNeighbors > 0 &
+               .and. li_mask_is_grounded_ice(cellMask(iCell)) &
+               .and. bedTopography(iCell) < config_sea_level &
+               .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
+
+               groundedMarineMarginMask(iCell) = 1
+            else
+               groundedMarineMarginMask(iCell) = 0
+            endif
          enddo
-
-         if ( nEmptyNeighbors > 0 &
-           .and. li_mask_is_grounded_ice(cellMask(iCell)) &
-           .and. bedTopography(iCell) < config_sea_level &
-           .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
-
-            groundedMarineMarginMask(iCell) = 1
-         else
-            groundedMarineMarginMask(iCell) = 0
-         endif
-      enddo
+      endif
 
 
       ! Init fields for accounting
       calvingThickness(:) = 0.0_RKIND
-      calvedVolumeNonDynCell(:) = 0.0_RKIND
-      calvedVolumeDynCell(:) = 0.0_RKIND
-      uncalvedVolumeNonDynCell(:) = 0.0_RKIND
-      uncalvedVolumeDynCell(:) = 0.0_RKIND
+      meltingThickness(:) = 0.0_RKIND
+      
+      ! Init fields for accounting
+      allocate(ablationThickness(nCells+1))
+      ablationThickness(:) = 0.0_RKIND
+      unablatedVolumeNonDynCell(:) = 0.0_RKIND
+      unablatedVolumeDynCell(:) = 0.0_RKIND
       allocate(cellVolume(nCells+1))
       cellVolume(:) = areaCell(:) * thickness(:)
-      requiredCalvingVolumeNonDynEdge(:) = 0.0_RKIND
-      requiredCalvingVolumeNonDynCell(:) = 0.0_RKIND
-      requiredCalvingVolumeDynEdge(:) = 0.0_RKIND
-      requiredCalvingVolumeDynCell(:) = 0.0_RKIND
-      allocate(thicknessForCalving(nCells+1))
-      thicknessForCalving = 0.0_RKIND
+      allocate(requiredAblationVolumeNonDynEdge(nEdges+1))
+      allocate(requiredAblationVolumeNonDynCell(nCells+1))
+      allocate(requiredAblationVolumeDynEdge(nEdges+1))
+      allocate(requiredAblationVolumeDynCell(nCells+1))
+      requiredAblationVolumeNonDynEdge(:) = 0.0_RKIND
+      requiredAblationVolumeNonDynCell(:) = 0.0_RKIND
+      requiredAblationVolumeDynEdge(:) = 0.0_RKIND
+      requiredAblationVolumeDynCell(:) = 0.0_RKIND
+      allocate(thicknessForAblation(nCells+1))
+      thicknessForAblation = 0.0_RKIND
+      allocate(ablationVelocity(nCells+1))
 
+      if ( applyCalving ) then
+         ablationVelocity(:) = calvingVelocity(:)
+      else if ( applyMelting ) then
+         ablationVelocity(:) = faceMeltSpeed(:)
+      end if
 
-
-      ! 1. Calculate calving rate for all non-dynamic cells by working with their ocean-going edges
-      calvingSubtotal1 = 0.0_RKIND
+      ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
+      ablationSubtotal1 = 0.0_RKIND
       do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ! a. Translate the calving front height based on dynamic cells to the non-dynamic locations
@@ -1587,9 +1621,9 @@ module li_calving
                !call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
                !   intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
             else
-               thicknessForCalving(iCell) = thkSum / real(thkCount, kind=RKIND)
+               thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
             endif
-            ! b. Translate the calvingVelocity and thickness from non-dynamic cells to their ocean-going edges
+            ! b. Translate the ablationVelocity and thickness from non-dynamic cells to their ocean-going edges
             !    to calculate the calving volume on those edges and this cell
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
@@ -1598,19 +1632,18 @@ module li_calving
                    .not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level & ! ensure margin is w/ocn
                    ) then
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                  requiredCalvingVolumeNonDynEdge(iEdge) = calvingVelocity(iCell) * &
-                          edgeLengthScaling * dvEdge(iEdge) * thicknessForCalving(iCell) * deltat
-                  requiredCalvingVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) + &
-                          requiredCalvingVolumeNonDynEdge(iEdge) ! Keep running total
+                  requiredAblationVolumeNonDynEdge(iEdge) = ablationVelocity(iCell) * &
+                          edgeLengthScaling * dvEdge(iEdge) * thicknessForAblation(iCell) * deltat
+                  requiredAblationVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) + &
+                          requiredAblationVolumeNonDynEdge(iEdge) ! Keep running total
                endif
             enddo
-            ! c. Calculate calvingThickness here
-            removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeNonDynCell(iCell))  ! Don't use more than available
-            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
-            calvedVolumeNonDynCell(iCell) = removeVolumeHere
-            uncalvedVolumeNonDynCell(iCell) = requiredCalvingVolumeNonDynCell(iCell) - removeVolumeHere
+            ! c. Apply calving here
+            removeVolumeHere = min(cellVolume(iCell), requiredAblationVolumeNonDynCell(iCell))  ! Don't use more than available
+            ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            unablatedVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            calvingSubtotal1 = calvingSubtotal1 + removeVolumeHere
+            ablationSubtotal1 = ablationSubtotal1 + removeVolumeHere
          endif
       enddo
       call mpas_timer_start("halo updates")
@@ -1620,7 +1653,7 @@ module li_calving
 
 
       ! 2. Calculate calving for dynamic cells
-      calvingSubtotal2 = 0.0_RKIND
+      ablationSubtotal2 = 0.0_RKIND
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
@@ -1633,32 +1666,32 @@ module li_calving
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
                   iEdge = edgesOnCell(iNeighbor, iCell)
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                  requiredCalvingVolumeDynEdge(iEdge) = calvingVelocity(iCell) * &
+                  requiredAblationVolumeDynEdge(iEdge) = ablationVelocity(iCell) * &
                           edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
                endif
             enddo
          endif
       enddo
-      ! b. copy calving remaining in non-dynamic cells to dynamic edges
+      ! b. copy ablation remaining in non-dynamic cells to dynamic edges
       ! Assume height and velocity are uniform, but edge length is not.
       do iCell = 1, nCells
          if ( (.not. li_mask_is_dynamic_ice(cellMask(iCell))) .and. &
-                 uncalvedVolumeNonDynCell(iCell) > 0.0_RKIND) then
+                 unablatedVolumeNonDynCell(iCell) > 0.0_RKIND) then
             ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
 
             !call mpas_log_write("Passing calving from non-dynamic cell $i.  $r available to pass", &
             !        realArgs=(/uncalvedVolumeNonDynCell(iCell)/), intArgs=(/iCell/))
 
-            volumeAvailableToPass = uncalvedVolumeNonDynCell(iCell)
+            volumeAvailableToPass = unablatedVolumeNonDynCell(iCell)
 
-            ! Find total length of interface with dynamic cells at this cell (i.e. calculate calvLengthCell)
-            calvLengthCell = 0.0_RKIND
+            ! Find total length of interface with dynamic cells at this cell
+            ablateLengthCell = 0.0_RKIND
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                  calvLengthEdge = edgeLengthScaling * dvEdge(iEdge)
-                  calvLengthCell = calvLengthCell + calvLengthEdge
+                  ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
+                  ablateLengthCell = ablateLengthCell + ablateLengthEdge
                endif
             enddo
 
@@ -1668,15 +1701,15 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                  calvLengthEdge = edgeLengthScaling * dvEdge(iEdge)
-                  if (requiredCalvingVolumeDynEdge(iEdge) > 0.0_RKIND) then
+                  ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
+                  if (requiredAblationVolumeDynEdge(iEdge) > 0.0_RKIND) then
                      call mpas_log_write("Unexpectedly found a dynamic edge that already has calving assigned to it." // &
-                           "  There is a flaw in apply_calving_velocity that needs to be fixed!", MPAS_LOG_ERR)
+                           "  There is a flaw in apply_front_ablation_velocity that needs to be fixed!", MPAS_LOG_ERR)
                      err_tmp = 1
                      err = ior(err, err_tmp)
                   endif
-                  requiredCalvingVolumeDynEdge(iEdge) = calvLengthEdge / calvLengthCell * volumeAvailableToPass
-                  uncalvedVolumeNonDynCell(iCell) = uncalvedVolumeNonDynCell(iCell) - requiredCalvingVolumeDynEdge(iEdge)
+                  requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
+                  unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
                   !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
                   !        realArgs=(/requiredCalvingVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
                endif
@@ -1687,37 +1720,36 @@ module li_calving
       call mpas_dmpar_field_halo_exch(domain, 'requiredCalvingVolumeDynEdge')
       call mpas_timer_stop("halo updates")
 
-      ! c. Now calculate calvingThickness for each cell
+      ! c. Now apply ablation to each cell
       do iCell = 1, nCellsSolve
          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
             ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                ! No need to check what type of edge this is - only required edges are nonzero
-               requiredCalvingVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) + &
-                          requiredCalvingVolumeDynEdge(iEdge) ! Keep running total
+               requiredAblationVolumeDynCell(iCell) = requiredAblationVolumeDynCell(iCell) + &
+                          requiredAblationVolumeDynEdge(iEdge) ! Keep running total
             enddo
             ! c. Apply calving here
-            removeVolumeHere = min(cellVolume(iCell), requiredCalvingVolumeDynCell(iCell))  ! Don't use more than available
-            calvingThickness(iCell) = removeVolumeHere / areaCell(iCell)
-            calvedVolumeDynCell(iCell) = removeVolumeHere
-            uncalvedVolumeDynCell(iCell) = requiredCalvingVolumeDynCell(iCell) - removeVolumeHere
+            removeVolumeHere = min(cellVolume(iCell), requiredAblationVolumeDynCell(iCell))  ! Don't use more than available
+            ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            unablatedVolumeDynCell(iCell) = requiredAblationVolumeDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-            calvingSubtotal2 = calvingSubtotal2 + removeVolumeHere
+            ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
          endif
       enddo
-      !call mpas_log_write("Done calculating calving for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+      !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
 
 
       ! Clean up to account for roundoff level errors that can occur
       do iCell = 1, nCellsSolve
-         if (abs(calvingThickness(iCell) - thickness(iCell)) < calvingSmallThk) then
-            calvingThickness(iCell) = thickness(iCell)
+         if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
+            ablationThickness(iCell) = thickness(iCell)
          endif
       enddo
 
       ! Clean up - zap any stranded ice
-      calvingSubtotal3 = 0.0_RKIND
+      ablationSubtotal3 = 0.0_RKIND
       do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             thkCount = 0
@@ -1728,8 +1760,8 @@ module li_calving
                endif
             enddo
             if (thkCount == 0) then
-               calvingThickness(iCell) = thickness(iCell)
-               calvingSubtotal3 = calvingSubtotal3 + calvingThickness(iCell)
+               ablationThickness(iCell) = thickness(iCell)
+               ablationSubtotal3 = ablationSubtotal3 + ablationThickness(iCell)
             endif
          endif
          if (isnan(areaCell(iCell))) then
@@ -1741,36 +1773,36 @@ module li_calving
 
       ! Clean up to account for roundoff level errors that can occur
       do iCell = 1, nCells
-         if (abs(calvingThickness(iCell) - thickness(iCell)) < calvingSmallThk) then
-            calvingThickness(iCell) = thickness(iCell)
+         if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
+            ablationThickness(iCell) = thickness(iCell)
          endif
       enddo
 
 
       ! End of routine accounting/reporting
-      localInfo(1) = calvingSubtotal1
-      localInfo(2) = calvingSubtotal2
-      localInfo(3) = calvingSubtotal3
-      localInfo(4) = sum(calvingThickness(1:nCellsSolve) * areaCell(1:nCellsSolve))
-      localInfo(5) = sum(uncalvedVolumeNonDynCell(1:nCellsSolve))
-      localInfo(6) = sum(uncalvedVolumeDynCell(1:nCellsSolve))
+      localInfo(1) = ablationSubtotal1
+      localInfo(2) = ablationSubtotal2
+      localInfo(3) = ablationSubtotal3
+      localInfo(4) = sum(ablationThickness(1:nCellsSolve) * areaCell(1:nCellsSolve))
+      localInfo(5) = sum(unablatedVolumeNonDynCell(1:nCellsSolve))
+      localInfo(6) = sum(unablatedVolumeDynCell(1:nCellsSolve))
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_dmpar_sum_real_array(domain % dminfo, 6, localInfo, globalInfo)
-      call mpas_log_write("== Calving complete. Total calved                    = $r", realArgs = (/globalInfo(4)/))
-      call mpas_log_write("==                   Calved from non-dynamic cells   = $r", realArgs = (/globalInfo(1)/))
-      call mpas_log_write("==                   Calved from dynamic cells       = $r", realArgs = (/globalInfo(2)/))
+      call mpas_log_write("== Ablation complete. Total calved                    = $r", realArgs = (/globalInfo(4)/))
+      call mpas_log_write("==                   Ablated from non-dynamic cells   = $r", realArgs = (/globalInfo(1)/))
+      call mpas_log_write("==                   Ablated from dynamic cells       = $r", realArgs = (/globalInfo(2)/))
       call mpas_log_write("==                   Stranded floating cells deleted = $r", realArgs = (/globalInfo(3)/))
-      call mpas_log_write("== Uncalved volumes: Non-dynamic cells=$r; Dynamic cells=$r", realArgs=(/globalInfo(5),globalInfo(6)/))
+      call mpas_log_write("== Unablated volumes: Non-dynamic cells=$r; Dynamic cells=$r", realArgs=(/globalInfo(5),globalInfo(6)/))
       if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.001_RKIND) .and. &
           (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
-         call mpas_log_write("Calving scheme failed to calve $r m^3. ($r% of total calved)", MPAS_LOG_WARN, &
+         call mpas_log_write("Failed to ablate $r m^3. ($r% of total ablated)", MPAS_LOG_WARN, &
                  realArgs=(/globalInfo(5) + globalInfo(6), &
                  100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
       endif
       if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.1_RKIND) .and. &
           (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
-         call mpas_log_write("Calving scheme failed to calve an amount greater than 10% of the ice calved.  " // &
-                 "Try reducing time step or apply_calving_velocity may need improvements.", &
+         call mpas_log_write("Failed to ablate an amount greater than 10% of the ice ablated.  " // &
+                 "Try reducing time step or apply_front_ablation_velocity may need improvements.", &
                  MPAS_LOG_ERR, realArgs=(/globalInfo(5) + globalInfo(6), &
                  100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
          err_tmp = 1
@@ -1779,27 +1811,38 @@ module li_calving
       if (globalInfo(3) / (globalInfo(4) + 1.0e-30_RKIND) > 0.01_RKIND) then
          ! If stranded ice deletion results in more than a small amount of the total calving flux, this routine will not
          ! be accurate.  If this error gets triggered, either try using a smaller timstep or this routine needs improving.
-         call mpas_log_write("Deleting stranded floating cells accounts for more than 1% of calving loss." // &
-                 "  Try using a smaller timestep or apply_calving_velocity may need improvements for this simulation.")
+         call mpas_log_write("Deleting stranded floating cells accounts for more than 1% of ablation loss." // &
+                 "  Try using a smaller timestep or apply_front_ablation_velocity may need improvements for this simulation.")
          err_tmp = 1
          err = ior(err, err_tmp)
       endif
 
 
-      ! Update halos on calvingThickness before applying it.
+      ! Update halos on calvingThickness or meltingThickness before applying it.
       ! Testing seemed to indicate this is not necessary, but I don't understand why not, so leaving it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+      if ( applyMelting ) then 
+         meltingThickness(:) = ablationThickness(:)
+         call mpas_dmpar_field_halo_exch(domain, 'meltingThickness')
+      else if (applyCalving ) then
+         calvingThickness(:) = ablationThickness(:)
+         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+      end if
       call mpas_timer_stop("halo updates")
 
       deallocate(cellVolume)
-      deallocate(thicknessForCalving)
+      deallocate(requiredAblationVolumeNonDynEdge)
+      deallocate(requiredAblationVolumeNonDynCell)
+      deallocate(requiredAblationVolumeDynEdge)
+      deallocate(requiredAblationVolumeDynCell)
+      deallocate(thicknessForAblation)
+      deallocate(ablationVelocity)
 
-    end subroutine apply_calving_velocity
+    end subroutine apply_front_ablation_velocity
 
 
-    ! Helper function for subroutine apply_calving_velocity
+    ! Helper function for subroutine apply_front_ablation_velocity
     ! Calculates the amount to scale an edge length based on the orientation of the edge with the surface velocity
     function scale_edge_length(angleEdgeHere, u, v)
        real(kind=RKIND), intent(in) :: angleEdgeHere

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1551,13 +1551,14 @@ module li_calving
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), allocatable :: thicknessForAblation
+      real (kind=RKIND), dimension(:), allocatable :: uvelForAblation, vvelForAblation
       real (kind=RKIND), dimension(:), pointer :: requiredAblationVolumeNonDynEdge, requiredAblationVolumeNonDynCell
       real (kind=RKIND), dimension(:), pointer :: requiredAblationVolumeDynEdge, requiredAblationVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: ablatedVolumeNonDynCell, ablatedVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: unablatedVolumeNonDynCell, unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
       real(kind=RKIND) :: ablationSubtotal1, ablationSubtotal2, ablationSubtotal3
-      real(kind=RKIND) :: thkSum, ablationVelSum
+      real(kind=RKIND) :: thkSum, ablationVelSum, uvelSum, vvelSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: volumeAvailableToPass !< a temp. var. for accounting purposes that indicates how much volume
@@ -1715,6 +1716,10 @@ module li_calving
       requiredAblationVolumeDynCell(:) = 0.0_RKIND
       allocate(thicknessForAblation(nCells+1))
       thicknessForAblation = 0.0_RKIND
+      allocate(uvelForAblation(nCells+1))
+      uvelForAblation(:) = 0.0_RKIND
+      allocate(vvelForAblation(nCells+1))
+      vvelForAblation(:) = 0.0_RKIND
 
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
@@ -1724,11 +1729,15 @@ module li_calving
             ! find mean (or min?) of thickness in dynamic neighbors
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
+            uvelSum = 0.0_RKIND
+            vvelSum = 0.0_RKIND
             thkCount = 0
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(cellMask(jCell))) then
                   thkSum = thkSum + thickness(jCell)
+                  uvelSum = uvelSum + uReconstructX(1, jCell)
+                  vvelSum = vvelSum + uReconstructY(1, jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
                   thkCount = thkCount + 1
                endif
@@ -1739,6 +1748,8 @@ module li_calving
             else
                thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
                ablationVelocity(iCell) = ablationVelSum / real(thkCount, kind=RKIND)
+               uvelForAblation(iCell) = uvelSum / real(thkCount, kind=RKIND)
+               vvelForAblation(iCell) = vvelSum / real(thkCount, kind=RKIND)
             endif
          endif
       enddo
@@ -1751,12 +1762,16 @@ module li_calving
               .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
+            uvelSum = 0.0_RKIND
+            vvelSum = 0.0_RKIND
             thkCount = 0
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ( li_mask_is_floating_ice(cellMask(jCell)) &
                     .and. (.not. li_mask_is_dynamic_ice(cellMask(jCell))) ) then
                   thkSum = thkSum + thickness(jCell)
+                  uvelSum = uvelSum + uReconstructX(1, jCell)
+                  vvelSum = vvelSum + uReconstructY(1, jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
                   thkCount = thkCount + 1
                endif
@@ -1767,6 +1782,8 @@ module li_calving
             else
                 thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
                 ablationVelocity(iCell) = ablationVelSum / real(thkCount, kind=RKIND)
+                uvelForAblation(iCell) = uvelSum / real(thkCount, kind=RKIND)
+                vvelForAblation(iCell) = vvelSum / real(thkCount, kind=RKIND)
             endif
          endif
       enddo
@@ -1782,7 +1799,7 @@ module li_calving
                if (li_mask_is_margin(edgeMask(iEdge)) .and. & !< edge is a margin
                    .not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level & ! ensure margin is w/ocn
                    ) then
-                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
                   requiredAblationVolumeNonDynEdge(iEdge) = ablationVelocity(iCell) * &
                           edgeLengthScaling * dvEdge(iEdge) * thicknessForAblation(iCell) * deltat
                   requiredAblationVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) + &
@@ -1816,7 +1833,7 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
                   iEdge = edgesOnCell(iNeighbor, iCell)
-                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
                   requiredAblationVolumeDynEdge(iEdge) = ablationVelocity(iCell) * &
                           edgeLengthScaling * dvEdge(iEdge) * thickness(iCell) * deltat
                endif
@@ -1840,31 +1857,33 @@ module li_calving
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
-                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
+                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
                   ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
                   ablateLengthCell = ablateLengthCell + ablateLengthEdge
                endif
             enddo
 
             ! Now that we know calvLengthCell, pass along the required calving volume relative to the interface length
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(iNeighbor, iCell)
-               jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
-                  edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
-                  ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
-                  if (requiredAblationVolumeDynEdge(iEdge) > 0.0_RKIND) then
-                     call mpas_log_write("Unexpectedly found a dynamic edge that already has calving assigned to it." // &
-                           "  There is a flaw in li_apply_front_ablation_velocity that needs to be fixed!", MPAS_LOG_ERR)
-                     err_tmp = 1
-                     err = ior(err, err_tmp)
+            if ( ablateLengthCell > 0.0_RKIND ) then
+               do iNeighbor = 1, nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(iNeighbor, iCell)
+                  jCell = cellsOnCell(iNeighbor, iCell)
+                  if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
+                     edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
+                     ablateLengthEdge = edgeLengthScaling * dvEdge(iEdge)
+                     if (requiredAblationVolumeDynEdge(iEdge) > 0.0_RKIND) then
+                        call mpas_log_write("Unexpectedly found a dynamic edge that already has calving assigned to it." // &
+                              "  There is a flaw in li_apply_front_ablation_velocity that needs to be fixed!", MPAS_LOG_ERR)
+                        err_tmp = 1
+                        err = ior(err, err_tmp)
+                     endif
+                     requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
+                     unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
+                    !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
+                    !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
                   endif
-                  requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
-                  unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
-                  !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
-                  !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
-               endif
-            enddo
+               enddo
+            endif
          endif
       enddo
       call mpas_timer_start("halo updates")
@@ -1973,6 +1992,8 @@ module li_calving
 
       deallocate(cellVolume)
       deallocate(thicknessForAblation)
+      deallocate(uvelForAblation)
+      deallocate(vvelForAblation)
       call mpas_log_write("Finished with li_apply_front_ablation_velocity")
 
     end subroutine li_apply_front_ablation_velocity

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1717,9 +1717,9 @@ module li_calving
       allocate(thicknessForAblation(nCells+1))
       thicknessForAblation = 0.0_RKIND
       allocate(uvelForAblation(nCells+1))
-      uvelForAblation(:) = 0.0_RKIND
+      uvelForAblation(:) = uReconstructX(1,:)
       allocate(vvelForAblation(nCells+1))
-      vvelForAblation(:) = 0.0_RKIND
+      vvelForAblation(:) = uReconstructY(1,:)
 
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
@@ -1736,8 +1736,8 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(cellMask(jCell))) then
                   thkSum = thkSum + thickness(jCell)
-                  uvelSum = uvelSum + uReconstructX(1, jCell)
-                  vvelSum = vvelSum + uReconstructY(1, jCell)
+                  uvelSum = uvelSum + uvelForAblation(jCell)
+                  vvelSum = vvelSum + vvelforAblation(jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
                   thkCount = thkCount + 1
                endif
@@ -1770,8 +1770,8 @@ module li_calving
                if ( li_mask_is_floating_ice(cellMask(jCell)) &
                     .and. (.not. li_mask_is_dynamic_ice(cellMask(jCell))) ) then
                   thkSum = thkSum + thickness(jCell)
-                  uvelSum = uvelSum + uReconstructX(1, jCell)
-                  vvelSum = vvelSum + uReconstructY(1, jCell)
+                  uvelSum = uvelSum + uvelForAblation(jCell)
+                  vvelSum = vvelSum + vvelForAblation(jCell)
                   ablationVelSum = ablationVelSum + ablationVelocity(jCell)
                   thkCount = thkCount + 1
                endif
@@ -2011,7 +2011,7 @@ module li_calving
 
        mag = sqrt(u**2 + v**2)
        if (mag == 0.0_RKIND) mag = 1.0_RKIND
-       scale_edge_length =  abs(u/mag * cos(-1.0*angleEdgeHere) + v/mag * sin(-1.0*angleEdgeHere))  ! dot product of unit vectors
+       scale_edge_length =  abs(u/mag * cos(angleEdgeHere) + v/mag * sin(angleEdgeHere))  ! dot product of unit vectors
        !scale_edge_length = abs(cos(angleEdgeHere - atan2(v, u)))
     end function scale_edge_length
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1503,7 +1503,7 @@ module li_calving
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain          !< Input: domain object
       type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
-      real (kind=RKIND), dimension(:), intent(in) :: ablationVelocity
+      real (kind=RKIND), dimension(:), intent(inout) :: ablationVelocity
       real (kind=RKIND), dimension(:), intent(out) :: ablationThickness
       !-----------------------------------------------------------------
       ! output variables
@@ -1537,7 +1537,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: unablatedVolumeNonDynCell, unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
       real(kind=RKIND) :: ablationSubtotal1, ablationSubtotal2, ablationSubtotal3
-      real(kind=RKIND) :: thkSum
+      real(kind=RKIND) :: thkSum, ablationVelSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
       real(kind=RKIND) :: volumeAvailableToPass !< a temp. var. for accounting purposes that indicates how much volume
@@ -1660,19 +1660,20 @@ module li_calving
       allocate(thicknessForAblation(nCells+1))
       thicknessForAblation = 0.0_RKIND
 
-
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
       do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
-            ! a. Translate the calving front height based on dynamic cells to the non-dynamic locations
+            ! a1. Translate the calving front height based on dynamic cells to the non-dynamic locations
             ! find mean (or min?) of thickness in dynamic neighbors
+            ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
             thkCount = 0
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_dynamic_ice(cellMask(jCell))) then
                   thkSum = thkSum + thickness(jCell)
+                  ablationVelSum = ablationVelSum + ablationVelocity(jCell)
                   thkCount = thkCount + 1
                endif
             enddo
@@ -1681,9 +1682,44 @@ module li_calving
                !   intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
             else
                thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
+               ablationVelocity(iCell) = ablationVelSum / real(thkCount, kind=RKIND)
             endif
+         endif
+      enddo
+
+          ! a2.Set thicknessForAblation and ablationVelocity of stranded non-dynamic cells to
+          ! average of non-dynamic neighbors. Stranded non-dynamic cells are
+          ! identified as those that still have thicknessForAblation == 0.0
+      do iCell = 1, nCellsSolve
+         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. li_mask_is_floating_ice(cellMask(iCell)) &
+              .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+            ablationVelSum = 0.0_RKIND
+            thkSum = 0.0_RKIND
+            thkCount = 0
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if ( li_mask_is_floating_ice(cellMask(jCell)) &
+                    .and. (.not. li_mask_is_dynamic_ice(cellMask(jCell))) ) then
+                  thkSum = thkSum + thickness(jCell)
+                  ablationVelSum = ablationVelSum + ablationVelocity(jCell)
+                  thkCount = thkCount + 1
+               endif
+            enddo
+            if (thkCount == 0) then
+                !call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
+               !   intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
+            else
+                thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
+                ablationVelocity(iCell) = ablationVelSum / real(thkCount, kind=RKIND)
+            endif
+         endif
+      enddo
+
             ! b. Translate the ablationVelocity and thickness from non-dynamic cells to their ocean-going edges
             !    to calculate the calving volume on those edges and this cell
+      do iCell = 1, nCellsSolve
+         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
@@ -1697,7 +1733,8 @@ module li_calving
                           requiredAblationVolumeNonDynEdge(iEdge) ! Keep running total
                endif
             enddo
-            ! c. Apply calving here
+
+            ! c. Apply ablationThickness here
             removeVolumeHere = min(cellVolume(iCell), requiredAblationVolumeNonDynCell(iCell))  ! Don't use more than available
             ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
             ablatedVolumeNonDynCell(iCell) = removeVolumeHere

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1591,39 +1591,51 @@ module li_calving
       ! The mask includes both the dynamic AND non-dynamic cells along the prescribed interface type(s).
       frontAblationMask(:) = 0
 
-      if ( applyToGrounded ) then
-         do iCell = 1, nCells
+      ! First identify the dynamic cells for each mask type.
 
+      if ( applyToGrounded .or. applyToGroundingLine ) then
+         do iCell = 1, nCells
          ! If applyToGrounded: Define marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
-
-         ! Check if neighboring cells contain ice and have bed topo below sea level
-            nEmptyNeighbors = 0
-            do iEdge = 1, nEdgesOnCell(iCell)
-              iNeighbor = cellsOnCell(iEdge, iCell)
-              if ( (((thickness(iNeighbor) == 0.0_RKIND) &
-                 .and. bedTopography(iNeighbor) < config_sea_level)) &
-                 .or. ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
-                 .and. li_mask_is_margin(cellMask(iNeighbor)) &
-                 .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
-                 nEmptyNeighbors = nEmptyNeighbors + 1
-              endif
-            enddo
-
-            if ( nEmptyNeighbors > 0 &
-               .and. li_mask_is_grounded_ice(cellMask(iCell)) &
+            if (li_mask_is_grounding_line(cellMask(iCell)) &
+               !< GL here means cell is grounded but has a neighbor that is floating or ocean
                .and. bedTopography(iCell) < config_sea_level &
                .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
 
-               frontAblationMask(iCell) = 1
-               ! Include adjacent non-dynamic cells
+               ! Check if neighboring cells contain ice and have bed topo below sea level
+               nEmptyNeighbors = 0
                do iEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(iEdge, iCell)
-                  if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
-                        .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
+                  if ( (((thickness(iNeighbor) == 0.0_RKIND) .and. bedTopography(iNeighbor) < config_sea_level)) &
+                     !< these previous conditions are open ocean
+                     .or. &
+                     !> these following conditions are inactive floating margin cells
+                     ((li_mask_is_floating_ice(cellMask(iNeighbor)) &
+                     .and. li_mask_is_margin(cellMask(iNeighbor)) &
+                     .and. (.not. li_mask_is_dynamic_ice(cellMask(iNeighbor)))))) then
+                     nEmptyNeighbors = nEmptyNeighbors + 1
+                  endif
+               enddo
+               if (nEmptyNeighbors > 0) then
+                  frontAblationMask(iCell) = 1
+               endif ! nEmptyNeighbors
+            endif ! cell is GL etc.
+         enddo ! nCells loop
+      endif ! applyToGrounded
 
+      if ( applyToGroundingLine ) then
+         ! If applyToGroundingLine: Define marine marginal cells as those that
+         ! are at the margin (defined by li_mask_is_grounding_line) if no
+         ! floating ice or are the first floating cell if there is floating ice.
+         ! The case of no floating ice was handled above already, so only looking for
+         ! GL locations with floating ice here.
+         do iCell = 1,nCells
+            if ( li_mask_is_grounding_line(cellMask(iCell)) ) then
+               do iEdge = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(iEdge, iCell)
+                  if (li_mask_is_floating_ice(cellMask(iNeighbor)) .and. li_mask_is_dynamic_ice(cellMask(iNeighbor))) then
                      frontAblationMask(iNeighbor) = 1
                   endif
                enddo
@@ -1631,56 +1643,43 @@ module li_calving
          enddo
       endif
 
-      if ( applyToGroundingLine ) then
-         do iCell = 1,nCellsSolve
-
-         ! If applyToGroundingLine: Define marine marginal cells as those that
-         ! are at the margin (defined by li_mask_is_grounding_line) if no
-         ! floating ice or are the first floating cell if there is floating ice.
-           if ( bedTopography(iCell) < config_sea_level &
-                .and. li_mask_is_grounded_ice(cellMask(iCell)) ) then
-
-              do iEdge = 1, nEdgesOnCell(iCell)
-                iNeighbor = cellsOnCell(iEdge, iCell)
-                 if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
-                      .and. li_mask_is_floating_ice(cellMask(iNeighbor)) ) then
-
-                    frontAblationMask(iNeighbor) = 1
-
-                 else if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) &
-                      .and. (.not. li_mask_is_floating_ice(cellMask(iNeighbor))) ) then
-
-                    frontAblationMask(iCell) = 1
-
-                 endif
-              enddo ! end loop over edges
-           endif
-         enddo !end loop over cells
-
-      endif
-
       if ( applyToFloating ) then
-         do iCell = 1,nCellsSolve
-
-           ! If applyToFloating: marine marginal cells are dynamic floating margin
-           ! cells
+         do iCell = 1,nCells
+            ! If applyToFloating: marine marginal cells are dynamic floating margin cells
             if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
                li_mask_is_dynamic_margin(cellMask(iCell)) ) then
-
                frontAblationMask(iCell) = 1
-               ! Include adjacent non-dynamic cells
-               do iEdge = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(iEdge, iCell)
-                  if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
-                        .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
-
-                     frontAblationMask(iNeighbor) = 1
-                  endif
-               enddo
-             endif
-
+            endif
          enddo
       endif
+
+      ! Now extend the mask forward to include non-dynamic floating neighbors (appropriate for any of the mask types)
+      ! Use value 2 to indicate the non-dynamic cells
+      do iCell = 1,nCells
+         if (frontAblationMask(iCell) == 1) then
+            do iEdge = 1, nEdgesOnCell(iCell)
+               iNeighbor = cellsOnCell(iEdge, iCell)
+               if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
+                  .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
+                  frontAblationMask(iNeighbor) = 2
+               endif
+            enddo
+         endif
+      enddo
+      ! Make a second pass to include potentially 'stranded' nondynamic floating cells
+      do iCell = 1, nCells
+         if (frontAblationMask(iCell) == 2) then
+            ! Check if this non-dynamic masked cell has any non-dynamic, floating, but unmasked neighbors we need to include
+            do iEdge = 1, nEdgesOnCell(iCell)
+               iNeighbor = cellsOnCell(iEdge, iCell)
+               if ((.not. li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. li_mask_is_floating_ice(iNeighbor) &
+                  .and. frontAblationMask(iNeighbor) == 0) then
+                  frontAblationMask(iNeighbor) = 1
+               endif
+            enddo
+         endif
+      enddo
+
 
       ! Init fields for accounting
       ablationThickness(:) = 0.0_RKIND
@@ -1700,7 +1699,7 @@ module li_calving
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
       do iCell = 1, nCellsSolve
-         if ((frontAblationMask(iCell)==1) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
+         if ((frontAblationMask(iCell)>0) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
             ! a1. Translate the calving front height based on dynamic cells to the non-dynamic locations
             ! find mean (or min?) of thickness in dynamic neighbors
             ablationVelSum = 0.0_RKIND
@@ -1728,7 +1727,7 @@ module li_calving
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
           ! identified as those that still have thicknessForAblation == 0.0
       do iCell = 1, nCellsSolve
-         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. frontAblationMask(iCell)==1 &
+         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. frontAblationMask(iCell)>0 &
               .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
@@ -1755,7 +1754,7 @@ module li_calving
             ! b. Translate the ablationVelocity and thickness from non-dynamic cells to their ocean-going edges
             !    to calculate the calving volume on those edges and this cell
       do iCell = 1, nCellsSolve
-         if (frontAblationMask(iCell)==1 .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+         if (frontAblationMask(iCell)>0 .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
 
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
@@ -1791,7 +1790,7 @@ module li_calving
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
-         if ( frontAblationMask(iCell) == 1 .and. li_mask_is_dynamic_ice(cellMask(iCell)) & ! a dynamic cell in the mask...
+         if ( frontAblationMask(iCell)>0 .and. li_mask_is_dynamic_ice(cellMask(iCell)) & ! a dynamic cell in the mask...
             .and. li_mask_is_margin(cellMask(iCell)) ) then                            ! that is at the edge of the ice
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1990,8 +1990,8 @@ module li_calving
 
        mag = sqrt(u**2 + v**2)
        if (mag == 0.0_RKIND) mag = 1.0_RKIND
-       !scale_edge_length =  abs(u/mag * cos(-1.0*angleEdgeHere) + v/mag * sin(-1.0*angleEdgeHere))  ! dot product of unit vectors
-       scale_edge_length = abs(cos(angleEdgeHere - atan2(v, u)))
+       scale_edge_length =  abs(u/mag * cos(-1.0*angleEdgeHere) + v/mag * sin(-1.0*angleEdgeHere))  ! dot product of unit vectors
+       !scale_edge_length = abs(cos(angleEdgeHere - atan2(v, u)))
     end function scale_edge_length
 
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1585,16 +1585,20 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
+      ! Step 0: Define the frontAblationMask that will be used to determine where ablation should be applied.
+      ! This mask can be for 1. a floating calving front, 2. a grounded marine margin (no dynamic floating ice shelf attached),
+      ! 3. along the grounding line (whether or not there is floating ice adjacent), or any combination of the three.
+      ! The mask includes both the dynamic AND non-dynamic cells along the prescribed interface type(s).
       frontAblationMask(:) = 0
-      
+
       if ( applyToGrounded ) then
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCells
 
          ! If applyToGrounded: Define marine marginal cells as those that are (1) at the ice
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
- 
+
          ! Check if neighboring cells contain ice and have bed topo below sea level
             nEmptyNeighbors = 0
             do iEdge = 1, nEdgesOnCell(iCell)
@@ -1650,7 +1654,7 @@ module li_calving
 
                  endif
               enddo ! end loop over edges
-           endif      
+           endif
          enddo !end loop over cells
 
       endif
@@ -1662,22 +1666,22 @@ module li_calving
            ! cells
             if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
                li_mask_is_dynamic_margin(cellMask(iCell)) ) then
-             
+
                frontAblationMask(iCell) = 1
                ! Include adjacent non-dynamic cells
                do iEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(iEdge, iCell)
                   if ( li_mask_is_floating_ice(cellMask(iNeighbor)) .and. &
                         .not. li_mask_is_dynamic_ice(cellMask(iNeighbor)) ) then
- 
+
                      frontAblationMask(iNeighbor) = 1
                   endif
                enddo
              endif
-             
+
          enddo
-      endif 
-      
+      endif
+
       ! Init fields for accounting
       ablationThickness(:) = 0.0_RKIND
       ablatedVolumeNonDynCell(:) = 0.0_RKIND
@@ -1696,7 +1700,7 @@ module li_calving
       ! 1. Calculate ablation rate for all non-dynamic cells by working with their ocean-going edges
       ablationSubtotal1 = 0.0_RKIND
       do iCell = 1, nCellsSolve
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+         if ((frontAblationMask(iCell)==1) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
             ! a1. Translate the calving front height based on dynamic cells to the non-dynamic locations
             ! find mean (or min?) of thickness in dynamic neighbors
             ablationVelSum = 0.0_RKIND
@@ -1724,7 +1728,7 @@ module li_calving
           ! average of non-dynamic neighbors. Stranded non-dynamic cells are
           ! identified as those that still have thicknessForAblation == 0.0
       do iCell = 1, nCellsSolve
-         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. li_mask_is_floating_ice(cellMask(iCell)) &
+         if ( thicknessForAblation(iCell) == 0.0_RKIND .and. frontAblationMask(iCell)==1 &
               .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
             ablationVelSum = 0.0_RKIND
             thkSum = 0.0_RKIND
@@ -1751,12 +1755,12 @@ module li_calving
             ! b. Translate the ablationVelocity and thickness from non-dynamic cells to their ocean-going edges
             !    to calculate the calving volume on those edges and this cell
       do iCell = 1, nCellsSolve
-         if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
+         if (frontAblationMask(iCell)==1 .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
 
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_floating_ice(edgeMask(iEdge)) .and. li_mask_is_margin(edgeMask(iEdge)) .and. &
+               if (li_mask_is_margin(edgeMask(iEdge)) .and. & !< edge is a margin
                    .not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level & ! ensure margin is w/ocn
                    ) then
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uReconstructX(1,iCell), uReconstructY(1,iCell))
@@ -1787,7 +1791,8 @@ module li_calving
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve
-         if ( frontAblationMask(iCell) == 1 ) then 
+         if ( frontAblationMask(iCell) == 1 .and. li_mask_is_dynamic_ice(cellMask(iCell)) & ! a dynamic cell in the mask...
+            .and. li_mask_is_margin(cellMask(iCell)) ) then                            ! that is at the edge of the ice
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
@@ -1851,6 +1856,7 @@ module li_calving
       do iCell = 1, nCellsSolve
          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
             ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.
+            ! Note, we ignore any leftover calving/melting if it would be applied to cells where the bed is above sea level.
             do iNeighbor = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(iNeighbor, iCell)
                ! No need to check what type of edge this is - only required edges are nonzero
@@ -1876,7 +1882,7 @@ module li_calving
          endif
       enddo
 
-      ! Clean up - zap any stranded ice
+      ! Clean up - zap any stranded ice.  This only needs to be considered for floating ice.
       ablationSubtotal3 = 0.0_RKIND
       do iCell = 1, nCellsSolve
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1662,7 +1662,7 @@ module li_calving
          endif
       enddo
       call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'uncalvedVolumeNonDynCell')
+      call mpas_dmpar_field_halo_exch(domain, 'unablatedVolumeNonDynCell')
       call mpas_timer_stop("halo updates")
       !call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
@@ -1694,7 +1694,7 @@ module li_calving
             ! This is a non-dynamic location that still has calving to offer - a location where calving needs to be propagated
 
             !call mpas_log_write("Passing calving from non-dynamic cell $i.  $r available to pass", &
-            !        realArgs=(/uncalvedVolumeNonDynCell(iCell)/), intArgs=(/iCell/))
+            !        realArgs=(/unablatedVolumeNonDynCell(iCell)/), intArgs=(/iCell/))
 
             volumeAvailableToPass = unablatedVolumeNonDynCell(iCell)
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1381,9 +1381,19 @@ module li_calving
              if ( .not. li_mask_is_floating_ice(cellMask(iCell)) ) then
                 calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
                                          vonMisesStress(iCell) / config_grounded_von_Mises_threshold_stress
-             elseif ( li_mask_is_floating_ice(cellMask(iCell)) ) then
-                calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
+             elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
+                calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
                                          vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress
+             !if gloating VM threshold is zero, remove floating ice
+             elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .eq. 0.0_RKIND &
+                       .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
+                thickness(iCell) = 0.0_RKIND
+                ! update mask
+                call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+                err = ior(err, err_tmp)
+
+                call remove_small_islands(meshPool, geometryPool)
+
              endif
           enddo
 

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1822,8 +1822,32 @@ module li_calving
       !call mpas_log_write("Done calculating calving for non-dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal1/))
 
 
+
       ! 2. Calculate calving for dynamic cells
       ablationSubtotal2 = 0.0_RKIND
+
+      ! 2a1. for grounded dynamic margins, don't use the thickness there because it may be unrealistically thin due to ablation
+      ! from previous time steps.  Instead copy forward the thickness from the row cells behind.
+      do iCell = 1, nCellsSolve
+         if (frontAblationMask(iCell)>0 .and. li_mask_is_margin(cellMask(iCell)) .and. li_mask_is_grounded_ice(cellMask(iCell))) then
+            thkSum = 0.0_RKIND
+            thkCount = 0
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               if (li_mask_is_dynamic_ice(cellMask(jCell)) .and. li_mask_is_grounded_ice(cellMask(iCell)) .and. &
+                       .not. li_mask_is_margin(cellMask(iCell))) then
+                  thkSum = thkSum + thickness(jCell)
+                  thkCount = thkCount + 1
+               endif
+            enddo
+            if (thkCount == 0) then
+               !call mpas_log_write("Found a stranded non-dynamic floating cell: cell $i with thickness=$r m.", MPAS_LOG_WARN, &
+               !   intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
+            else
+               thicknessForAblation(iCell) = thkSum / real(thkCount, kind=RKIND)
+            endif
+         endif
+      enddo
 
       ! a. Calculate calving on dynamic margin edges
       do iCell = 1, nCellsSolve

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -1463,7 +1463,14 @@ module li_calving
 !> This is done by weighting the flux to be distrbuted by the length of each such edge in the direction
 !> perpendicular to the calving flux.
 !>
-!> The output of this routine is calvingThickness, which then needs to be applied to thickness
+!> The location at which ablation is controlled by applyToGrounded, applyToFloating, and applyToGroundingLine,
+!> which are set by the calling routine.
+!> If applyToGrounded = .true., ablation is applied to grounded marine margin cells, which do not have dynamic ice shelf neighbors
+!> If applyToGroundingLine = .true., ablation is applied to grounding line, regardless of whether there is an ice shelf or not.
+!> If there in dynamic floating ice, ablation is applied to the floating cell adjacent to grounding line; 
+!> otherwise it is applied to the last grounded cell.
+!> If applyToFloating = .true., ablation is applied to dynamic floating margin cells
+!> The output of this routine is calvingThickness or faceMeltingThickness, which then needs to be applied to thickness
 !> by the calling routine.
 !-----------------------------------------------------------------------
 
@@ -1498,29 +1505,30 @@ module li_calving
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, edgeMask
       integer, dimension(:), pointer :: groundedMarineMarginMask
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness, meltingThickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness, faceMeltingThickness
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity, faceMeltSpeed
       real (kind=RKIND), dimension(:), allocatable :: ablationVelocity, ablationThickness
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynEdge, requiredCalvingVolumeDynEdge
-      real (kind=RKIND), dimension(:), pointer :: requiredCalvingVolumeNonDynCell, requiredCalvingVolumeDynCell
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructX
       real (kind=RKIND), dimension(:,:), pointer :: uReconstructY
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), dimension(:), allocatable :: thicknessForAblation
-      real (kind=RKIND), dimension(:), allocatable :: requiredAblationVolumeNonDynEdge, requiredAblationVolumeNonDynCell
-      real (kind=RKIND), dimension(:), allocatable :: requiredAblationVolumeDynEdge, requiredAblationVolumeDynCell
+      real (kind=RKIND), dimension(:), pointer :: requiredAblationVolumeNonDynEdge, requiredAblationVolumeNonDynCell
+      real (kind=RKIND), dimension(:), pointer :: requiredAblationVolumeDynEdge, requiredAblationVolumeDynCell
+      real (kind=RKIND), dimension(:), pointer :: ablatedVolumeNonDynCell, ablatedVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: unablatedVolumeNonDynCell, unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), allocatable :: cellVolume
       real(kind=RKIND) :: ablationSubtotal1, ablationSubtotal2, ablationSubtotal3
       real(kind=RKIND) :: thkSum
       integer :: thkCount
       real(kind=RKIND) :: removeVolumeHere
-      real(kind=RKIND) :: volumeAvailableToPass
+      real(kind=RKIND) :: volumeAvailableToPass !< a temp. var. for accounting purposes that indicates how much volume
+                          !< to be calved is 'leftover' after trying to calve non-dynamic cells and can be transferred to
+                          !< neighboring dynamic cells
       real(kind=RKIND) :: ablateLengthCell, ablateLengthEdge
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
@@ -1549,14 +1557,16 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-      call mpas_pool_get_array(geometryPool, 'meltingThickness', meltingThickness)
+      call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
       call mpas_pool_get_array(geometryPool, 'unablatedVolumeNonDynCell', unablatedVolumeNonDynCell)
       call mpas_pool_get_array(geometryPool, 'unablatedVolumeDynCell', unablatedVolumeDynCell)
+      call mpas_pool_get_array(geometryPool, 'ablatedVolumeNonDynCell', ablatedVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'ablatedVolumeDynCell', ablatedVolumeDynCell)
       call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeNonDynEdge', requiredCalvingVolumeNonDynEdge)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeDynEdge', requiredCalvingVolumeDynEdge)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeNonDynCell', requiredCalvingVolumeNonDynCell)
-      call mpas_pool_get_array(geometryPool, 'requiredCalvingVolumeDynCell', requiredCalvingVolumeDynCell)
+      call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeNonDynEdge', requiredAblationVolumeNonDynEdge)
+      call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeDynEdge', requiredAblationVolumeDynEdge)
+      call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeNonDynCell', requiredAblationVolumeNonDynCell)
+      call mpas_pool_get_array(geometryPool, 'requiredAblationVolumeDynCell', requiredAblationVolumeDynCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
@@ -1624,19 +1634,17 @@ module li_calving
 
       ! Init fields for accounting
       calvingThickness(:) = 0.0_RKIND
-      meltingThickness(:) = 0.0_RKIND
+      faceMeltingThickness(:) = 0.0_RKIND
       
       ! Init fields for accounting
       allocate(ablationThickness(nCells+1))
       ablationThickness(:) = 0.0_RKIND
+      ablatedVolumeNonDynCell(:) = 0.0_RKIND
+      ablatedVolumeDynCell(:) = 0.0_RKIND
       unablatedVolumeNonDynCell(:) = 0.0_RKIND
       unablatedVolumeDynCell(:) = 0.0_RKIND
       allocate(cellVolume(nCells+1))
       cellVolume(:) = areaCell(:) * thickness(:)
-      allocate(requiredAblationVolumeNonDynEdge(nEdges+1))
-      allocate(requiredAblationVolumeNonDynCell(nCells+1))
-      allocate(requiredAblationVolumeDynEdge(nEdges+1))
-      allocate(requiredAblationVolumeDynCell(nCells+1))
       requiredAblationVolumeNonDynEdge(:) = 0.0_RKIND
       requiredAblationVolumeNonDynCell(:) = 0.0_RKIND
       requiredAblationVolumeDynEdge(:) = 0.0_RKIND
@@ -1695,6 +1703,7 @@ module li_calving
             ! c. Apply calving here
             removeVolumeHere = min(cellVolume(iCell), requiredAblationVolumeNonDynCell(iCell))  ! Don't use more than available
             ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            ablatedVolumeNonDynCell(iCell) = removeVolumeHere
             unablatedVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             ablationSubtotal1 = ablationSubtotal1 + removeVolumeHere
@@ -1764,13 +1773,13 @@ module li_calving
                   requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
                   unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
                   !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
-                  !        realArgs=(/requiredCalvingVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
+                  !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
                endif
             enddo
          endif
       enddo
       call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'requiredCalvingVolumeDynEdge')
+      call mpas_dmpar_field_halo_exch(domain, 'requiredAblationVolumeDynEdge')
       call mpas_timer_stop("halo updates")
 
       ! c. Now apply ablation to each cell
@@ -1786,6 +1795,7 @@ module li_calving
             ! c. Apply calving here
             removeVolumeHere = min(cellVolume(iCell), requiredAblationVolumeDynCell(iCell))  ! Don't use more than available
             ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
+            ablatedVolumeDynCell(iCell) = removeVolumeHere
             unablatedVolumeDynCell(iCell) = requiredAblationVolumeDynCell(iCell) - removeVolumeHere
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
@@ -1871,13 +1881,13 @@ module li_calving
       endif
 
 
-      ! Update halos on calvingThickness or meltingThickness before applying it.
+      ! Update halos on calvingThickness or faceMeltingThickness before applying it.
       ! Testing seemed to indicate this is not necessary, but I don't understand why not, so leaving it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_timer_start("halo updates")
       if ( applyMelting ) then 
-         meltingThickness(:) = ablationThickness(:)
-         call mpas_dmpar_field_halo_exch(domain, 'meltingThickness')
+         faceMeltingThickness(:) = ablationThickness(:)
+         call mpas_dmpar_field_halo_exch(domain, 'faceMeltingThickness')
       else if ( applyCalving ) then
          calvingThickness(:) = ablationThickness(:)
          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
@@ -1885,10 +1895,6 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       deallocate(cellVolume)
-      deallocate(requiredAblationVolumeNonDynEdge)
-      deallocate(requiredAblationVolumeNonDynCell)
-      deallocate(requiredAblationVolumeDynEdge)
-      deallocate(requiredAblationVolumeDynCell)
       deallocate(thicknessForAblation)
       deallocate(ablationVelocity)
       call mpas_log_write("Finished with li_apply_front_ablation_velocity")

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -48,7 +48,7 @@ module li_iceshelf_melt
    !
    !--------------------------------------------------------------------
 
-   public :: li_basal_melt_floating_ice, grounded_face_melt_ismip6
+   public :: li_basal_melt_floating_ice, li_grounded_face_melt_ismip6
 
    !--------------------------------------------------------------------
    !
@@ -226,7 +226,7 @@ module li_iceshelf_melt
 
       if ( trim(config_front_mass_bal_grounded) == 'ismip6' &
           .or. trim(config_front_mass_bal_grounded) == 'uniform' ) then
-         call grounded_face_melt_ismip6(domain, err_tmp)
+         call li_grounded_face_melt_ismip6(domain, err_tmp)
          err = ior(err, err_tmp)
 
       endif
@@ -1147,7 +1147,7 @@ module li_iceshelf_melt
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  !  routine grounded_face_melt_ismip6
+!  !  routine li_grounded_face_melt_ismip6
 !
 !> \brief Calculate grounded glacier submarine melt rate using parameterization from ISMIP6
 !> \author Trevor Hillebrand
@@ -1164,7 +1164,7 @@ module li_iceshelf_melt
 !-----------------------------------------------------------------------
 
 
-    subroutine grounded_face_melt_ismip6(domain, err)
+    subroutine li_grounded_face_melt_ismip6(domain, err)
 
       use li_calving  
       !-----------------------------------------------------------------
@@ -1215,7 +1215,7 @@ module li_iceshelf_melt
       err = 0
       call mpas_log_write('Starting face melt routine')
 
-      ! Define logicals for call to apply_front_ablation_velocity
+      ! Define logicals for call to li_apply_front_ablation_velocity
       applyToFloating = .false. ! if true, only apply to floating ice
       applyToGrounded = .false.  ! if true, only apply to grounded
       applyToGroundingLine = .true. ! if true, apply at grounding line
@@ -1308,10 +1308,9 @@ module li_iceshelf_melt
 
          enddo
 
-         call mpas_log_write("calling apply_front_ablation_velocity")
+         call mpas_log_write("calling li_apply_front_ablation_velocity")
          ! Distribute melt among neighbors
-       !  call distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err_tmp)
-         call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
                                             applyToFloating, applyToGroundingLine, applyCalving, &
                                             applyMelting, domain, err)
 
@@ -1328,171 +1327,9 @@ module li_iceshelf_melt
          block => block % next
       enddo    ! associated(block)
 
-    end subroutine grounded_face_melt_ismip6
+    end subroutine li_grounded_face_melt_ismip6
 !-----------------------------------------------------------------------
 
-!-----------------------------------------------------------------------
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  !  routine distribute_face_melt_flux
-!
-!> \brief Applies a specified melt rate along a grounded marine margin
-!> \author Trevor Hillebrand, Matthew Hoffman
-!> \date   April 2020
-!> \details Applied a specific melt rate along a grounded marine margin. 
-!> This is based on distribute_calving_flux subroutine in mpas_li_calving.F
-!> and adapted for grounded ice.
-!> The melt rate (faceMeltRateApplied) is calculated in subroutine grounded_face_melt_ismip6.
-!> The melt volume needs to be distributed in three ways:
-!> 1. We need to first remove any "thin" ice in front of this cell
-!> 2. Then we remove ice from this cell
-!> 3. If there is still additional ice to be removed, we have to recursively
-!>    remove ice "inland" of this cell until the total required mass is removed
-!-----------------------------------------------------------------------
-
-   subroutine distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err)
-
-
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer, intent(in) :: meshPool !< Input: Mesh pool
-      type (mpas_pool_type), pointer, intent(in) :: scratchPool !< Input: scratch pool
-      integer, dimension(:), intent(in) :: groundedMarineMarginMask
-
-      !-----------------------------------------------------------------
-      ! input/output variables
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-      real (kind=RKIND), dimension(:), pointer :: faceMeltRateApplied, faceMeltingThickness, &
-                                                  thickness, areaCell, cellVolume, &
-                                                  unmeltedVolume, bedTopography                                
-      real (kind=RKIND), pointer :: deltat
-      integer, dimension(:), pointer :: nEdgesOnCell, cellMask
-      integer, dimension(:,:), pointer :: cellsOnCell
-      integer, pointer :: nCells
-      integer :: unmeltedCount, inwardNeighbors, iCell, iNeighbor, jCell
-      real (kind=RKIND) :: volumeLeft, removeVolumeHere, unmeltedTotal
-      type (field1dReal), pointer :: cellVolumeField
-
-      err = 0
-
-      ! get fields
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(meshPool, 'deltat', deltat)
-      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
-      call mpas_pool_get_array(geometryPool, 'faceMeltRateApplied', faceMeltRateApplied)
-      call mpas_pool_get_array(geometryPool, 'unmeltedVolume', unmeltedVolume)
-      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-
-      call mpas_pool_get_field(scratchPool, 'workCell',  cellVolumeField)
-      call mpas_allocate_scratch_field(cellVolumeField, .true.)
-      cellVolume => cellVolumeField % array
-
-      faceMeltingThickness(:) = 0.0_RKIND
-      unmeltedVolume(:) = 0.0_RKIND
-
-      cellVolume(:) = areaCell(:) * thickness(:)
-
-      do iCell = 1, nCells
-         if (groundedMarineMarginMask(iCell) == 1) then
-            volumeLeft = faceMeltRateApplied(iCell) * deltat  ! units m^3
-
-            ! First remove ice from "thin" neighbors
-            do iNeighbor = 1, nEdgesOnCell(iCell)
-               jCell = cellsOnCell(iNeighbor, iCell)
-               if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
-                  ! this is a thin neighbor - remove as much ice from here as we
-                  ! can
-                  ! TODO: could distribute this evenly amongst neighbors
-                  removeVolumeHere = min(volumeLeft, cellVolume(jCell)) ! how much we want to remove here
-                  faceMeltingThickness(jCell) = faceMeltingThickness(jCell) + removeVolumeHere / areaCell(jCell)
-                      ! < apply to the field that will be used, in thickness
-                      ! units
-                  cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
-                  volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
-               endif
-            enddo
-
-            if (volumeLeft > 0.0_RKIND) then
-               ! Now remove ice from iCell
-               removeVolumeHere = min(volumeLeft, cellVolume(iCell))
-               faceMeltingThickness(iCell) = faceMeltingThickness(iCell) + removeVolumeHere / areaCell(iCell)
-                  ! < apply to the field that will be used in thickness units
-               cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere ! update accounting on cell volume
-               volumeLeft = volumeLeft - removeVolumeHere ! update accounting on how much left to distribute from current iCell
-            endif
-
-            if (volumeLeft > 0.0_RKIND) then
-               ! Now remove ice from neighbors inland of margin;
-               ! first count up how many there are
-               inwardNeighbors = 0
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if  ( li_mask_is_dynamic_ice(cellMask(jCell)) .and. (.not. li_mask_is_dynamic_margin(cellMask(jCell))) &
-                        .and. bedTopography(jCell) < 0.0_RKIND ) then
-                     inwardNeighbors = inwardNeighbors + 1
-                  endif
-               enddo
-
-               ! Now distribute the flux evenly amongst the neighbors
-               do iNeighbor = 1, nEdgesOnCell(iCell)
-                  jCell = cellsOnCell(iNeighbor, iCell)
-                  if ( li_mask_is_dynamic_ice(cellMask(jCell)) .and. (.not. li_mask_is_dynamic_margin(cellMask(jCell))) &
-                        .and. bedTopography(jCell) < 0.0_RKIND ) then
-                     ! this is thick neighbor that is not itself a margin -
-                     ! remove as much ice from here as we can
-                     removeVolumeHere = min(volumeLeft / real(inwardNeighbors, kind=RKIND), cellVolume(jCell))
-                        ! < how much we want to remove here
-                     faceMeltingThickness(jCell) = faceMeltingThickness(jCell) + removeVolumeHere / areaCell(jCell)
-                        ! < apply to the field that will be used in thickness
-                        ! units
-                     cellVolume(jCell) = cellVolume(jCell) - removeVolumeHere ! update accounting on cell volume
-                     volumeLeft = volumeLeft - removeVolumeHere
-                        ! < update accounting on how much left to distribute
-                        ! from current iCell
-                  endif
-               enddo
-               !TODO: need to recursively distribute across neighbors until
-               !fully depleted :(
-            endif
-
-            ! If we didn't melt enough ice, record that to allow assessment of    
-            ! how bad that is.
-            if (volumeLeft > 0.0_RKIND) then
-               unmeltedVolume(iCell) = 0.0_RKIND
-            endif
-         endif ! if cell is melting margin
-      enddo ! cell loop
-      if (maxval(unmeltedVolume) > 0.0_RKIND) then
-         unmeltedTotal = sum(unmeltedVolume)
-         unmeltedCount = count(unmeltedVolume > 0.0_RKIND)
-         call mpas_log_write("distribute_face_melt_flux failed to distribute all required melt - " // &
-                    " ice was left after depleting all neighbors." // &
-                    "  Search needs to be expanded to neighbors' neighbors.")
-         call mpas_log_write("   On this processor: $i cells contain unmelted ice, " // &
-                 "for a total unmelted volume of $r m^3 ($r%).", &
-                 MPAS_LOG_WARN, intArgs=(/unmeltedCount/), &
-                 realArgs=(/unmeltedTotal, 100.0_RKIND * unmeltedTotal/(faceMeltRateApplied(iCell) * deltat)/))
-      endif
-      call mpas_deallocate_scratch_field(cellVolumeField, .true.)
-
-   end subroutine distribute_face_melt_flux
-!-----------------------------------------------------------------------
 
   !***********************************************************************
   end module li_iceshelf_melt

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1189,6 +1189,7 @@ module li_iceshelf_melt
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool, meshPool, scratchPool, velocityPool
       real (kind=RKIND), pointer :: seaLevel
+      real (kind=RKIND), pointer :: deltat
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: thickness, lowerSurface, faceMeltingThickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
@@ -1263,7 +1264,10 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
          call mpas_pool_get_array(geometryPool, 'faceMeltRateApplied', faceMeltRateApplied)
          call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
-         
+         call mpas_pool_get_array(meshPool, 'deltat', deltat)
+
+         faceMeltRateApplied(:) = 0.0_RKIND
+         faceMeltSpeed(:) = 0.0_RKIND 
        ! Calculate retreat rate for each cell
          do iCell = 1, nCellsSolve
             ! Define grounded marine marginal cells as those that have at least one 
@@ -1285,18 +1289,17 @@ module li_iceshelf_melt
                  endif
             enddo 
             
-            if ( nEmptyNeighbors > 0 &
-               .and. li_mask_is_grounded_ice(cellMask(iCell)) &
-               .and. bedTopography(iCell) < seaLevel ) then
-                
-                groundedMarineMarginMask(iCell) = 1
+            if ( bedTopography(iCell) < 0.0_RKIND ) then
                 waterDepth = seaLevel - bedTopography(iCell)
-                          
-                submergedFaceArea = waterDepth * oceanEdgeLength
+            else
+                waterDepth = 0.0
+            endif
+           
+            submergedFaceArea = waterDepth * oceanEdgeLength
                 
                 if (trim(config_front_mass_bal_grounded) == 'ismip6') then                
                 ! Calculate ice front melt rate at each cell
-                   faceMeltSpeed(iCell) = (aSubglacial * waterDepth * & ! m s^-1
+               faceMeltSpeed(iCell) = (aSubglacial * waterDepth * & ! m s^-1
                          (ismip6Runoff(iCell) / rhow * secPerDay)**alphaSubglacial &
                          + B) * (TFocean(iCell) + addTFocean)**betaTF / secPerDay
                 elseif (trim(config_front_mass_bal_grounded) == 'uniform') then   

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1297,20 +1297,15 @@ module li_iceshelf_melt
            
             submergedFaceArea = waterDepth * oceanEdgeLength
                 
-                if (trim(config_front_mass_bal_grounded) == 'ismip6') then                
+            if (trim(config_front_mass_bal_grounded) == 'ismip6') then                
                 ! Calculate ice front melt rate at each cell
                faceMeltSpeed(iCell) = (aSubglacial * waterDepth * & ! m s^-1
                          (ismip6Runoff(iCell) / rhow * secPerDay)**alphaSubglacial &
-                         + B) * (TFocean(iCell) + addTFocean)**betaTF / secPerDay
-                elseif (trim(config_front_mass_bal_grounded) == 'uniform') then   
+                         + B) *  max(0.0_RKIND, TFocean(iCell) + addTFocean)**betaTF / secPerDay
+            elseif (trim(config_front_mass_bal_grounded) == 'uniform') then   
                    faceMeltSpeed(iCell) = config_uniform_face_melt_rate
-                endif
-                faceMeltRateApplied(iCell) = faceMeltSpeed(iCell) * submergedFaceArea ! m^3 s^-1
-            else 
-                groundedMarineMarginMask(iCell) = 0
-                faceMeltRateApplied(iCell) = 0.0_RKIND     
-                faceMeltSpeed(iCell) = 0.0_RKIND
-            endif           
+            endif
+
          enddo
 
          call mpas_log_write("calling apply_front_ablation_velocity")
@@ -1323,6 +1318,7 @@ module li_iceshelf_melt
 
          ! Apply facemelt: open the Ark
          thickness(:) = thickness(:) - faceMeltingThickness(:)
+         faceMeltRateApplied = faceMeltingThickness(:) * areaCell(:) / deltat     
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -48,7 +48,7 @@ module li_iceshelf_melt
    !
    !--------------------------------------------------------------------
 
-   public :: li_basal_melt_floating_ice
+   public :: li_basal_melt_floating_ice, grounded_face_melt_ismip6
 
    !--------------------------------------------------------------------
    !
@@ -1210,8 +1210,9 @@ module li_iceshelf_melt
       integer :: err_tmp
       logical :: applyToFloating, applyToGrounded
       logical :: applyMelting, applyCalving
-
+       
       err = 0
+      call mpas_log_write('Starting face melt routine')
 
       ! Define logicals for call to apply_front_ablation_velocity
       applyToFloating = .false.
@@ -1309,12 +1310,13 @@ module li_iceshelf_melt
             endif           
          enddo
 
+         call mpas_log_write("calling apply_front_ablation_velocity")
          ! Distribute melt among neighbors
        !  call distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err_tmp)
          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
                                             applyToFloating, applyCalving, applyMelting, domain, err)
 
-         err = ior(err, err_tmp)
+         call mpas_log_write("Back to melting routine")
 
          ! Apply facemelt: open the Ark
          thickness(:) = thickness(:) - faceMeltingThickness(:)

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1209,15 +1209,16 @@ module li_iceshelf_melt
       integer, dimension(:), pointer :: groundedMarineMarginMask
       real (kind=RKIND), dimension(:), pointer :: faceMeltRateApplied, faceMeltSpeed
       integer :: err_tmp
-      logical :: applyToFloating, applyToGrounded
+      logical :: applyToFloating, applyToGrounded, applyToGroundingLine
       logical :: applyMelting, applyCalving
        
       err = 0
       call mpas_log_write('Starting face melt routine')
 
       ! Define logicals for call to apply_front_ablation_velocity
-      applyToFloating = .false.
-      applyToGrounded = .true.
+      applyToFloating = .false. ! if true, only apply to floating ice
+      applyToGrounded = .false.  ! if true, only apply to grounded
+      applyToGroundingLine = .true. ! if true, apply at grounding line
       applyMelting = .true.
       applyCalving = .false.
 
@@ -1312,7 +1313,8 @@ module li_iceshelf_melt
          ! Distribute melt among neighbors
        !  call distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err_tmp)
          call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                            applyToFloating, applyCalving, applyMelting, domain, err)
+                                            applyToFloating, applyToGroundingLine, applyCalving, &
+                                            applyMelting, domain, err)
 
          call mpas_log_write("Back to melting routine")
 

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -48,7 +48,7 @@ module li_iceshelf_melt
    !
    !--------------------------------------------------------------------
 
-   public :: li_basal_melt_floating_ice, li_grounded_face_melt_ismip6
+   public :: li_basal_melt_floating_ice, li_face_melt_grounded_ice
 
    !--------------------------------------------------------------------
    !
@@ -60,7 +60,64 @@ module li_iceshelf_melt
    contains
 !***********************************************************************
 
+
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  !  routine li_face_melt_grounded_ice
+!
+!> \brief MPAS land ice solver for face melt of grounded ice
+!> \author Trevor Hillebrand
+!> \date   February 2021
+!> \details
+!>  This routine computes face melting for floating ice.
+!>  The following options are supported:
+!>  (1) Do nothing (config_front_mass_bal_grounded = 'none')
+!>  (2) Prescribed uniform face melt speed (config_front_mass_bal_grounded = 'uniform')
+!>  (3) Face melt speed as in ISMIP6 (config_front_mass_bal_grounded = 'ismip6')
+
+!-----------------------------------------------------------------------
+
+   subroutine li_face_melt_grounded_ice(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: &
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      character(len=StrKIND), pointer :: &
+           config_front_mass_bal_grounded ! option for submarine mass balance
+                                          ! at grounded glacier front
+
+      integer :: err_tmp
+
+      err = 0
+      err_tmp = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
+
+      if ( trim(config_front_mass_bal_grounded) == 'ismip6' &
+          .or. trim(config_front_mass_bal_grounded) == 'uniform' ) then
+         call grounded_face_melt_ismip6(domain, err_tmp)
+         err = ior(err, err_tmp)
+      endif
+
+   end subroutine li_face_melt_grounded_ice
+!-----------------------------------------------------------------------
+!||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||r
 !
 !  !  routine li_basal_melt_floating_ice
 !
@@ -222,13 +279,6 @@ module li_iceshelf_melt
          if (config_print_thermal_info) then
             call mpas_log_write('GLdepth=$r, CFdepth=$r', realArgs=(/GLdepth, CFdepth/))
          endif
-      endif
-
-      if ( trim(config_front_mass_bal_grounded) == 'ismip6' &
-          .or. trim(config_front_mass_bal_grounded) == 'uniform' ) then
-         call li_grounded_face_melt_ismip6(domain, err_tmp)
-         err = ior(err, err_tmp)
-
       endif
 
       if (trim(config_basal_mass_bal_float) == 'ismip6') then
@@ -1147,7 +1197,7 @@ module li_iceshelf_melt
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  !  routine li_grounded_face_melt_ismip6
+!  !  routine grounded_face_melt_ismip6
 !
 !> \brief Calculate grounded glacier submarine melt rate using parameterization from ISMIP6
 !> \author Trevor Hillebrand
@@ -1164,7 +1214,7 @@ module li_iceshelf_melt
 !-----------------------------------------------------------------------
 
 
-    subroutine li_grounded_face_melt_ismip6(domain, err)
+    subroutine grounded_face_melt_ismip6(domain, err)
 
       use li_calving  
       !-----------------------------------------------------------------
@@ -1285,7 +1335,7 @@ module li_iceshelf_melt
                faceMeltSpeedVertAvg(:) = faceMeltSpeed(:) * abs(lowerSurface(:)) / thickness(:)
          end where
 
-         call mpas_log_write("calling li_apply_front_ablation_velocity from li_grounded_face_melt_ismip6")
+         call mpas_log_write("calling li_apply_front_ablation_velocity from grounded_face_melt_ismip6")
          ! Distribute melt among neighbors
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                             faceMeltingThickness, faceMeltSpeedVertAvg, applyToGrounded, &
@@ -1312,7 +1362,7 @@ module li_iceshelf_melt
 
     deallocate(faceMeltSpeedVertAvg)
 
-    end subroutine li_grounded_face_melt_ismip6
+    end subroutine grounded_face_melt_ismip6
 !-----------------------------------------------------------------------
 
 

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1166,6 +1166,7 @@ module li_iceshelf_melt
 
     subroutine grounded_face_melt_ismip6(domain, err)
 
+      use li_calving  
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -1207,8 +1208,16 @@ module li_iceshelf_melt
       integer, dimension(:), pointer :: groundedMarineMarginMask
       real (kind=RKIND), dimension(:), pointer :: faceMeltRateApplied, faceMeltSpeed
       integer :: err_tmp
+      logical :: applyToFloating, applyToGrounded
+      logical :: applyMelting, applyCalving
 
       err = 0
+
+      ! Define logicals for call to apply_front_ablation_velocity
+      applyToFloating = .false.
+      applyToGrounded = .true.
+      applyMelting = .true.
+      applyCalving = .false.
 
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
@@ -1301,7 +1310,10 @@ module li_iceshelf_melt
          enddo
 
          ! Distribute melt among neighbors
-         call distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err_tmp)
+       !  call distribute_face_melt_flux(meshPool, geometryPool, scratchPool, groundedMarineMarginMask, err_tmp)
+         call apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
+                                            applyToFloating, applyCalving, applyMelting, domain, err)
+
          err = ior(err, err_tmp)
 
          ! Apply facemelt: open the Ark
@@ -1310,6 +1322,7 @@ module li_iceshelf_melt
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
+
          block => block % next
       enddo    ! associated(block)
 

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1195,7 +1195,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: cellMask, nEdgesOnCell
+      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
@@ -1251,6 +1251,7 @@ module li_iceshelf_melt
         
          ! Get mesh and geometry arrays
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -1271,24 +1272,22 @@ module li_iceshelf_melt
          faceMeltSpeed(:) = 0.0_RKIND 
        ! Calculate retreat rate for each cell
          do iCell = 1, nCellsSolve
-            ! Define grounded marine marginal cells as those that have at least one 
-            ! neighboring cell without ice and with bed topography below sea
-            ! level OR are adjacent to an inactive floating margin cell
-            nEmptyNeighbors = 0
+            ! Define marine marginal cells as those that are (1) at the ice
+            ! margin, (2) have at least one neighboring cell without ice, (3) contain
+            ! grounded ice, and (4) have bed topography below sea level.
+            ! OR is adjacent to an inactive floating margin cell
             oceanEdgeLength = 0.0_RKIND
-            ! Check if neighboring cells contain ice and have bed topo below sea
-            ! level
-            do iEdge = 1, nEdgesOnCell(iCell)
-               iNeighbor = cellsOnCell(iEdge, iCell)
-                 if ( ((thickness(iNeighbor) == 0.0_RKIND) & 
-                    .and. bedTopography(iNeighbor) < seaLevel) &
-                    .or. ( li_mask_is_floating_ice(cellMask(iNeighbor)) & 
-                    .and. li_mask_is_margin(cellMask(iNeighbor)) &
-                    .and. (.not. li_mask_is_albany_active(cellMask(iNeighbor))) ) ) then
-                     nEmptyNeighbors = nEmptyNeighbors + 1
-                     oceanEdgeLength = oceanEdgeLength + dvEdge(edgesOnCell(iEdge, iCell))
+            
+            ! Calculate length of grounding line for each cell
+            if ( bedTopography(iCell) < seaLevel &
+                .and. li_mask_is_grounded_ice(cellMask(iCell)) ) then
+               do iEdge = 1, nEdgesOnCell(iCell)
+                 iNeighbor = cellsOnCell(iEdge, iCell)
+                 if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) ) then 
+                    oceanEdgeLength = oceanEdgeLength + dvEdge(edgesOnCell(iEdge, iCell))
                  endif
-            enddo 
+               enddo 
+            endif
             
             if ( bedTopography(iCell) < 0.0_RKIND ) then
                 waterDepth = seaLevel - bedTopography(iCell)

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -98,10 +98,13 @@ module li_iceshelf_melt
       ! local variables
       !-----------------------------------------------------------------
 
+      type (block_type), pointer :: block
+
+      type (mpas_pool_type), pointer :: geometryPool
       character(len=StrKIND), pointer :: &
            config_front_mass_bal_grounded ! option for submarine mass balance
                                           ! at grounded glacier front
-
+      real (kind=RKIND), dimension(:), pointer :: faceMeltSpeed, faceMeltingThickness
       integer :: err_tmp
 
       err = 0
@@ -113,6 +116,25 @@ module li_iceshelf_melt
           .or. trim(config_front_mass_bal_grounded) == 'uniform' ) then
          call grounded_face_melt_ismip6(domain, err_tmp)
          err = ior(err, err_tmp)
+      elseif ( trim(config_front_mass_bal_grounded) == 'none' ) then
+         ! Zero entire field
+
+         ! block loop
+         block => domain % blocklist
+         do while (associated(block))
+            call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+            call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
+            call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
+
+            faceMeltSpeed(:) = 0.0_RKIND
+            faceMeltingThickness(:) = 0.0_RKIND
+
+            block => block % next
+         enddo   ! associated(block)
+      else
+         call mpas_log_write('Unknown option selected for config_front_mass_bal_grounded:' // &
+                             trim(config_front_mass_bal_grounded), MPAS_LOG_ERR)
+         err = ior(err, 1)
       endif
 
    end subroutine li_face_melt_grounded_ice

--- a/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
+++ b/src/core_landice/mode_forward/mpas_li_iceshelf_melt.F
@@ -1183,20 +1183,18 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
-      integer, pointer :: nCellsSolve, nEdgesSolve, maxEdges
-      integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnCell, edgesOnCell
-      real (kind=RKIND) :: waterDepth, submergedFaceArea, oceanEdgeLength
+      integer, pointer :: nCells, nCellsSolve
+      integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
+      real (kind=RKIND) :: waterDepth
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: geometryPool, meshPool, scratchPool, velocityPool
+      type (mpas_pool_type), pointer :: geometryPool, meshPool, velocityPool
       real (kind=RKIND), pointer :: seaLevel
-      real (kind=RKIND), pointer :: deltat
-      real (kind=RKIND), dimension(:), pointer :: dvEdge
-      real (kind=RKIND), dimension(:), pointer :: thickness, lowerSurface, faceMeltingThickness
+      real (kind=RKIND), dimension(:), pointer :: thickness, faceMeltingThickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
       real (kind=RKIND), pointer :: B ! param B
@@ -1206,11 +1204,12 @@ module li_iceshelf_melt
       character(len=StrKIND), pointer :: config_front_mass_bal_grounded
       real (kind=RKIND), parameter :: secPerDay = 86400.0
       real (kind=RKIND), parameter :: rhow = 1000.0 ! subglacial runoff density
-      integer, dimension(:), pointer :: groundedMarineMarginMask
-      real (kind=RKIND), dimension(:), pointer :: faceMeltRateApplied, faceMeltSpeed
+      real (kind=RKIND), dimension(:), pointer :: faceMeltSpeed
+      real (kind=RKIND), dimension(:), allocatable :: faceMeltSpeedVertAvg !vertically averaged faceMeltSpeed 
+                                                                !to pass to  li_apply_front_ablation_velocity,
+                                                                !because faceMeltSpeed is only below water-line
       integer :: err_tmp
       logical :: applyToFloating, applyToGrounded, applyToGroundingLine
-      logical :: applyMelting, applyCalving
        
       err = 0
       call mpas_log_write('Starting face melt routine')
@@ -1219,8 +1218,6 @@ module li_iceshelf_melt
       applyToFloating = .false. ! if true, only apply to floating ice
       applyToGrounded = .false.  ! if true, only apply to grounded
       applyToGroundingLine = .true. ! if true, apply at grounding line
-      applyMelting = .true.
-      applyCalving = .false.
 
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
@@ -1239,55 +1236,33 @@ module li_iceshelf_melt
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
-         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
-         call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
          ! Get ISMIP6 forcing fields
          call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean) 
          call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
-         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
         
          ! Get mesh and geometry arrays
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface) 
-         call mpas_pool_get_array(geometryPool, 'groundedMarineMarginMask', groundedMarineMarginMask)
-         call mpas_pool_get_array(geometryPool, 'faceMeltRateApplied', faceMeltRateApplied)
          call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
-         call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
-         faceMeltRateApplied(:) = 0.0_RKIND
          faceMeltSpeed(:) = 0.0_RKIND 
-       ! Calculate retreat rate for each cell
+         allocate(faceMeltSpeedVertAvg(nCells+1))
+         faceMeltSpeedVertAvg(:) = 0.0_RKIND
+
+       ! Calculate face melting for each cell
          do iCell = 1, nCellsSolve
-            ! Define marine marginal cells as those that are (1) at the ice
-            ! margin, (2) have at least one neighboring cell without ice, (3) contain
-            ! grounded ice, and (4) have bed topography below sea level.
-            ! OR is adjacent to an inactive floating margin cell
-            oceanEdgeLength = 0.0_RKIND
-            
-            ! Calculate length of grounding line for each cell
-            if ( bedTopography(iCell) < seaLevel &
-                .and. li_mask_is_grounded_ice(cellMask(iCell)) ) then
-               do iEdge = 1, nEdgesOnCell(iCell)
-                 iNeighbor = cellsOnCell(iEdge, iCell)
-                 if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) ) then 
-                    oceanEdgeLength = oceanEdgeLength + dvEdge(edgesOnCell(iEdge, iCell))
-                 endif
-               enddo 
-            endif
             
             if ( bedTopography(iCell) < 0.0_RKIND ) then
                 waterDepth = seaLevel - bedTopography(iCell)
@@ -1295,8 +1270,6 @@ module li_iceshelf_melt
                 waterDepth = 0.0
             endif
            
-            submergedFaceArea = waterDepth * oceanEdgeLength
-                
             if (trim(config_front_mass_bal_grounded) == 'ismip6') then                
                 ! Calculate ice front melt rate at each cell
                faceMeltSpeed(iCell) = (aSubglacial * waterDepth * & ! m s^-1
@@ -1307,18 +1280,28 @@ module li_iceshelf_melt
             endif
 
          enddo
+        
+         where ( (thickness > 0.0_RKIND) .and. (lowerSurface < 0.0_RKIND) )
+               faceMeltSpeedVertAvg(:) = faceMeltSpeed(:) * abs(lowerSurface(:)) / thickness(:)
+         end where
 
-         call mpas_log_write("calling li_apply_front_ablation_velocity")
+         call mpas_log_write("calling li_apply_front_ablation_velocity from li_grounded_face_melt_ismip6")
          ! Distribute melt among neighbors
-         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, applyToGrounded, &
-                                            applyToFloating, applyToGroundingLine, applyCalving, &
-                                            applyMelting, domain, err)
+         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
+                                            faceMeltingThickness, faceMeltSpeedVertAvg, applyToGrounded, &
+                                            applyToFloating, applyToGroundingLine, domain, err)
 
-         call mpas_log_write("Back to melting routine")
+
+         ! Update halos on calvingThickness or faceMeltingThickness before applying it.
+         ! Testing seemed to indicate this is not necessary, but I don't understand
+         ! why not, so leaving it.
+         ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'faceMeltingThickness')
+         call mpas_timer_stop("halo updates")
 
          ! Apply facemelt: open the Ark
          thickness(:) = thickness(:) - faceMeltingThickness(:)
-         faceMeltRateApplied = faceMeltingThickness(:) * areaCell(:) / deltat     
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
@@ -1326,6 +1309,8 @@ module li_iceshelf_melt
 
          block => block % next
       enddo    ! associated(block)
+
+    deallocate(faceMeltSpeedVertAvg)
 
     end subroutine li_grounded_face_melt_ismip6
 !-----------------------------------------------------------------------

--- a/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
+++ b/src/core_landice/mode_forward/mpas_li_time_integration_fe.F
@@ -117,6 +117,13 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("advection prep")
 
+!TODO: Determine whether grounded melting should in fact be called first
+! === Face melting for grounded ice ===========
+      call mpas_timer_start("face melting for grounded ice")
+      call li_face_melt_grounded_ice(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("face melting for grounded ice")
+
 ! === Basal melting for floating ice ===========
       call mpas_timer_start("basal melting for floating ice")
       call li_basal_melt_floating_ice(domain, err_tmp)

--- a/src/core_landice/shared/mpas_li_mask.F
+++ b/src/core_landice/shared/mpas_li_mask.F
@@ -358,7 +358,7 @@ contains
           if (li_mask_is_ice(cellMask(i))) then
               isMargin = .false.
               do j=1,nEdgesOnCell(i) ! Check if any neighbors are non-ice
-                  if (cellsOnCell(j,i) > 0) then
+                  if (cellsOnCell(j,i) <= nCells) then
                      isMargin = ( isMargin .or. (.not. li_mask_is_ice(cellMask(cellsOnCell(j,i)))) )
                   endif
               enddo
@@ -417,7 +417,9 @@ contains
           if (li_mask_is_dynamic_ice(cellMask(i))) then
               isMargin = .false.
               do j=1,nEdgesOnCell(i) ! Check if any neighbors are not dynamic
-                  isMargin = ( isMargin .or. (.not. li_mask_is_dynamic_ice(cellMask(cellsOnCell(j,i)))) )
+                  if (cellsOnCell(j,i) <= nCells) then
+                     isMargin = ( isMargin .or. (.not. li_mask_is_dynamic_ice(cellMask(cellsOnCell(j,i)))) )
+                  endif
               enddo
               if (isMargin) then
                  cellMask(i) = ior(cellMask(i), li_mask_ValueDynamicMargin)


### PR DESCRIPTION
This is part 2 of a multi-part merge of the branch that includes ISMIP6 submarine face melting and calving parameterizations for Greenland. Builds on PR #810. 

The main purpose of this branch is to change the subroutine apply_calving_velocity to a generalized subroutine  called li_apply_front_ablation_velocity, which treats both face-melting (e.g., from config_front_mass_bal_grounded = 'ismip6' or 'uniform') and calving. Calving and melting velocities are calculating in the calling routines and passed to li_apply_front_ablation_velocity to be converted to a calving or melting thickness, which is passed back to the calling routines to be removed from the thickness field. The location at which ablation is applied is determined by logicals applyToGrounded, applyToFloating, and applyToGroundingLine, which are set within the calling routines. Front mass balance (i.e., submarine melting) is set to be applied at the grounding line (last grounded cell if no floating ice; first floating cell if floating ice), while eigencalving and von Mises stress calving are applied to grounded and floating marine margins. 

This branch includes a more rigorous treatment of floating non-dynamic cells, including those 'stranded' cells with only non-dynamic neighbors. There are also a number of critical bug fixes in li_apply_front_ablation (formerly apply_calving_velocity), including copying forward thickness and advective velocity from dynamic to non-dynamic cells, correcting indexing errors, and correcting the edge length scaling function. Also includes a bug fix in mpas_li_mask.F to properly treat edges of the mesh.

There is now an option to remove all dynamic floating ice in a timestep while also using the von Mises stress calving law by setting config_floating_von_Mises_threshold_stress = 0.0 in namelist. 
