### PR TITLE
Fix BMB restart problem

### DIFF
--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -686,6 +686,7 @@
                         <var name="basalHeatFlux" packages="thermal;hydro"/>
                         <var name="basalFrictionFlux" packages="thermal;hydro"/>
                         <var name="heatDissipation" packages="thermal"/>
+                        <var name="betaSolve" packages="thermal"/>
 			<var name="cellMask"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>

--- a/src/core_landice/mode_forward/mpas_li_thermal.F
+++ b/src/core_landice/mode_forward/mpas_li_thermal.F
@@ -1237,7 +1237,7 @@ module li_thermal
 
                      call mpas_log_write('li_thermal, energy conservation error: iCell=$i, imbalance=$r (W/m2):', MPAS_LOG_WARN, &
                              intArgs=(/indexToCellID(iCell)/), realArgs=(/(finalEnergy - initialEnergy - deltaEnergy)/deltat/))
-                     err = 0
+                     !err = ior(err, 1)
 
                   endif  ! energy conservation error
 
@@ -1325,6 +1325,9 @@ module li_thermal
 
             enddo   ! iCell
 
+         case default
+            call mpas_log_write("Unknown thermal solver specified: " // trim(config_thermal_solver), MPAS_LOG_ERR)
+            err = ior(err, 1)
          end select   ! config_thermal_solver
 
          ! It is possible that internal melting was computed above for floating ice and assigned


### PR DESCRIPTION
This merge fixes an issue where the temperature solver and basal mass balance calculation was not BFB on a restart in some situations.  It also adds a missing error check in the temperature solver.
