### PR TITLE
Removes shortwave energy conservation fix

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -2686,6 +2686,10 @@
 			 description="CVMix/KPP: Penetrative temperature flux at the bottom of boundary layer due to solar radiation. Positive is into the ocean."
 			 packages="forwardMode;analysisMode"
 		/>
+		<var name="bottomLayerShortwaveTemperatureFlux" type="real" dimensions="nCells Time" units="W m^{-2}"
+			 description="Solar flux that reaches bottom of the ocean and does not impact temperature"
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="surfaceBuoyancyForcing" type="real" dimensions="nCells Time" units="m^2 s^{-3}"
 			 description="CVMix/KPP: diagnosed surface buoyancy flux due to heat, salt and freshwater fluxes. Positive flux increases buoyancy."
 			 packages="forwardMode;analysisMode"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -682,6 +682,10 @@
 					description="Depth over which to apply penetrating SW to sfcBuoyancyFlux"
 					possible_values="Real Values greater than zero less than bottomDepth"
 		/>
+		<nml_option name="config_enable_shortwave_energy_fixer" type="logical" default_value=".false." units="unitless"
+					description="Flag to enable the shortwave energy fixer for shallow ocean cells"
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="tidal_forcing" mode="init;forward">
 		<nml_option name="config_use_tidal_forcing" type="logical" default_value=".false." units="unitless"

--- a/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics_variables.F
@@ -86,6 +86,7 @@ module ocn_diagnostics_variables
    integer, pointer :: indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
 
    real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFluxOBL
+   real (kind=RKIND), dimension(:), pointer :: bottomLayerShortwaveTemperatureFlux
 
    real (kind=RKIND), dimension(:), pointer :: surfaceBuoyancyForcing
    real (kind=RKIND), dimension(:), pointer :: surfaceFrictionVelocity
@@ -278,6 +279,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
       call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
       call mpas_pool_get_array(diagnosticsPool, 'penetrativeTemperatureFluxOBL', penetrativeTemperatureFluxOBL)
+      call mpas_pool_get_array(diagnosticsPool, 'bottomLayerShortwaveTemperatureFlux', bottomLayerShortwaveTemperatureFlux)
       call mpas_pool_get_array(diagnosticsPool, 'indexSurfaceLayerDepth', indexSurfaceLayerDepth)
 
       !

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -912,7 +912,8 @@ contains
                   endif
 
                   call ocn_tracer_short_wave_absorption_tend(meshPool, swForcingPool, forcingPool, indexTemperature, &
-                           layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tracerGroupTend, err)
+                           layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tracerGroupTend, &
+                           bottomLayerShortwaveTemperatureFlux, err)
 
                   if (config_compute_active_tracer_budgets) then
                      !$omp parallel

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption.F
@@ -65,7 +65,8 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_short_wave_absorption_tend(meshPool, swForcingPool, forcingPool, index_temperature, & !{{{
-                    layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, err)
+                    layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                    bottomLayerShortwaveTemperatureFlux, err)
 
       !-----------------------------------------------------------------
       !
@@ -81,6 +82,9 @@ contains
 
       real (kind=RKIND), dimension(:), intent(inout) :: &
          penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         bottomLayerShortwaveTemperatureFlux
 
       real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
 
@@ -116,10 +120,12 @@ contains
       err = 0
       if(useJerlov) then
          call ocn_tracer_short_wave_absorption_jerlov_tend(meshPool, forcingPool, index_temperature, layerThickness, &
-                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, err)
+                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                        bottomLayerShortwaveTemperatureFLux, err)
       else
          call ocn_tracer_short_wave_absorption_variable_tend(meshPool,swForcingPool, forcingPool, index_temperature, &
-                                        layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL,tend,err)
+                                        layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL,tend, &
+                                        bottomLayerShortwaveTemperatureFlux, err)
       endif
 
       call mpas_timer_stop("short wave")

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -130,7 +130,7 @@ contains
 
       integer, dimension(:), pointer :: maxLevelCell
 
-      real (kind=RKIND) :: depth, fluxRemaining
+      real (kind=RKIND) :: depth, fluxRemaining, layerFraction
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth
       real (kind=RKIND), dimension(:), allocatable :: weights
 
@@ -189,6 +189,23 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      if(config_enable_shortwave_energy_fixer) then
+#ifndef CPRPGI
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, layerFraction)
+#endif
+         do iCell = 1, nCells
+            layerFraction = bottomlayerShortwaveTemperatureFlux(iCell) / (maxLevelCell(iCell) + 1.0E-15_RKIND)
+            do k=1,maxLevelCell(iCell)
+               tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + layerFraction
+            end do
+         end do
+#ifndef CPRPGI
+         !$omp end do
+         !$omp end parallel
+#endif
+      end if
 
       deallocate(weights)
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -76,7 +76,8 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_short_wave_absorption_jerlov_tend(meshPool, forcingPool, index_temperature, layerThickness, &
-                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, err)!{{{
+                                        penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                        bottomLayerShortwaveTemperatureFlux, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -92,6 +93,9 @@ contains
 
       real (kind=RKIND), dimension(:), intent(out) :: &
         penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        bottomLayerShortwaveTemperatureFlux
 
       real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
 
@@ -161,10 +165,10 @@ contains
             fluxRemaining = fluxRemaining - (weights(k) - weights(k+1))
          end do
 
+         ! based on coupled testing we only track the solar induced warming incident on the bottom ocean
          k = maxLevelCell(iCell)
          if(k > 0 .and. fluxRemaining > 0.0_RKIND) then
-            tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell) &
-                                              * fluxRemaining
+            bottomLayerShortwaveTemperatureFlux(iCell) = penetrativeTemperatureFlux(iCell) * fluxRemaining
          end if
 
          depth = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -72,7 +72,8 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_short_wave_absorption_variable_tend(meshPool, swForcingPool, forcingPool, index_temperature, & !{{{
-                                  layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, err)
+                                  layerThickness, penetrativeTemperatureFlux, penetrativeTemperatureFluxOBL, tend, &
+                                  bottomLayerShortwaveTemperatureFlux, err)
 
       !-----------------------------------------------------------------
       !
@@ -91,6 +92,9 @@ contains
 
       real (kind=RKIND), dimension(:), intent(out) :: &
         penetrativeTemperatureFluxOBL
+
+      real (kind=RKIND), dimension(:), intent(out) :: &
+        bottomLayerShortwaveTemperatureFlux
 
       real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness !< Input: Layer thicknesses
 
@@ -173,10 +177,10 @@ contains
           fluxRemaining = fluxRemaining - (weights(k) - weights(k+1))
         end do
 
+        ! based on coupled testing we simply log the shortwave temperature flux incident on the bottom of the ocean
         k = maxLevelCell(iCell)
         if(k > 0 .and. fluxRemaining > 0.0_RKIND) then
-           tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + penetrativeTemperatureFlux(iCell) &
-                                             * fluxRemaining
+           bottomLayerShortwaveTemperatureFlux(iCell) = penetrativeTemperatureFlux(iCell) * fluxRemaining
         end if
 
         depth = 0.0_RKIND

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -129,7 +129,7 @@ contains
 
       integer, dimension(:), pointer :: maxLevelCell
 
-      real (kind=RKIND) :: depth
+      real (kind=RKIND) :: depth, layerFraction
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth
       real (kind=RKIND), dimension(:), allocatable :: weights
       real (kind=RKIND), dimension(:), pointer :: chlorophyllA, zenithAngle, clearSkyRadiation
@@ -199,6 +199,23 @@ contains
       end do
       !$omp end do
       !$omp end parallel
+
+      if(config_enable_shortwave_energy_fixer) then!
+#ifndef CPRPGI!
+         !$omp parallel!
+         !$omp do schedule(runtime) private(k, layerFraction)!
+#endif!
+         do iCell = 1, nCells!
+            layerFraction = bottomlayerShortwaveTemperatureFlux(iCell) / (maxLevelCell(iCell) + 1.0E-15_RKIND)!
+            do k=1,maxLevelCell(iCell)!
+               tend(index_temperature, k, iCell) = tend(index_temperature, k, iCell) + layerFraction!
+            end do!
+         end do!
+#ifndef CPRPGI!
+         !$omp end do!
+         !$omp end parallel!
+#endif
+      end if
 
       deallocate(weights)
 


### PR DESCRIPTION
Coupled testing showed unexpected extremely strong sensitivity to the
previous shortwave radiation energy fixer.  In that fix the excess
energy was used to heat the bottom layer.  This yielded a strong
response in tropical precipitation, dramatically increasing the double
ITCZ bias.  This removes that energy fixer and only tracks the solar
radiation that is discarded for extremely shallow cells

