### PR TITLE
Fix memory leaks in mpas_geotile_manager and mpas_parse_index

### DIFF
--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -171,27 +171,19 @@ module mpas_geotile_manager
         ! reported in section 3-53 of the WRF-ARW User's Guide
         !
         if (.not. associated(endian)) then
-            allocate(endian)
-            endian = "big"
-            call mpas_pool_add_config(mgr % pool, 'endian', endian)
+            call mpas_pool_add_config(mgr % pool, 'endian', "big")
         endif
 
         if (.not. associated(scalefactor)) then
-            allocate(scalefactor)
-            scalefactor = 1.0_RKIND
-            call mpas_pool_add_config(mgr % pool, 'scale_factor', scalefactor)
+            call mpas_pool_add_config(mgr % pool, 'scale_factor', 1.0_RKIND)
         endif
 
         if (.not. associated(signed)) then
-            allocate(signed)
-            signed = 0 ! 0 = 'no', 1 = 'yes'
-            call mpas_pool_add_config(mgr % pool, 'signed', signed)
+            call mpas_pool_add_config(mgr % pool, 'signed', 0)
         endif
 
         if (.not. associated(tile_bdr)) then
-            allocate(tile_bdr)
-            tile_bdr = 0
-            call mpas_pool_add_config(mgr % pool, 'tile_bdr', tile_bdr)
+            call mpas_pool_add_config(mgr % pool, 'tile_bdr', 0)
         endif
 
         !
@@ -235,33 +227,23 @@ module mpas_geotile_manager
             call mpas_pool_get_config(mgr % pool, 'isoilwater', isoilwater)
 
             if (.not. associated(iswater)) then
-                allocate(iswater)
-                iswater = 16
-                call mpas_pool_add_config(mgr % pool, 'iswater', iswater)
+                call mpas_pool_add_config(mgr % pool, 'iswater', 16)
             endif
 
             if (.not. associated(islake)) then
-                allocate(islake)
-                islake = -1
-                call mpas_pool_add_config(mgr % pool, 'islake', islake)
+                call mpas_pool_add_config(mgr % pool, 'islake', -1)
             endif
 
             if (.not. associated(isice)) then
-                allocate(isice)
-                isice = 24
-                call mpas_pool_add_config(mgr % pool, 'isice', isice)
+                call mpas_pool_add_config(mgr % pool, 'isice', 24)
             endif
 
             if (.not. associated(isurban)) then
-                allocate(isurban)
-                isurban = 1
-                call mpas_pool_add_config(mgr % pool, 'isurban', isurban)
+                call mpas_pool_add_config(mgr % pool, 'isurban', 1)
             endif
 
             if (.not. associated(isoilwater)) then
-                allocate(isoilwater)
-                isoilwater = 14
-                call mpas_pool_add_config(mgr % pool, 'isoilwater', isoilwater)
+                call mpas_pool_add_config(mgr % pool, 'isoilwater', 14)
             endif
         endif
 

--- a/src/core_init_atmosphere/mpas_parse_geoindex.F
+++ b/src/core_init_atmosphere/mpas_parse_geoindex.F
@@ -62,10 +62,10 @@ module mpas_parse_geoindex
       integer :: i, k
       logical :: res
 
-      character (len=StrKIND), pointer :: char_t
+      character (len=StrKIND) :: char_t
       integer :: iceiling, ifloor
-      integer, pointer :: int_t
-      real(kind=RKIND), pointer :: real_t
+      integer :: int_t
+      real(kind=RKIND) :: real_t
 
       ierr = 0
 
@@ -133,7 +133,6 @@ module mpas_parse_geoindex
                 .or. trim(lhs) == 'endian' &
                 .or. trim(lhs) == 'mminlu'   ) then
 
-            allocate(char_t)
             char_t = rhs
             call mpas_pool_add_config(geo_pool, trim(lhs), char_t)
 
@@ -152,7 +151,6 @@ module mpas_parse_geoindex
                   .or. trim(lhs) == 'truelat2' &
                   .or. trim(lhs) == 'missing_value' ) then
 
-            allocate(real_t)
             read(rhs, *, iostat=read_stat, iomsg=read_err_msg) real_t
             call mpas_pool_add_config(geo_pool, trim(lhs), real_t)
 
@@ -178,7 +176,6 @@ module mpas_parse_geoindex
             ! Because each compiler handles reporting type errors when transferring
             ! data in a read statement a little bit differently, we will have to type check
             ! integer values ourselves.
-            allocate(real_t)
             read(rhs, *, iostat=read_stat, iomsg=read_err_msg) real_t
             iceiling = ceiling(real_t)
             ifloor = floor(real_t)
@@ -192,9 +189,7 @@ module mpas_parse_geoindex
                return
             endif
 
-            allocate(int_t)
             int_t = int(real_t)
-            deallocate(real_t)
             call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
 
          !
@@ -202,11 +197,9 @@ module mpas_parse_geoindex
          !
          else if (lhs == 'signed') then
             if (trim(rhs) == 'yes') then
-               allocate(int_t)
                int_t = 1
                call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
             else if (trim(rhs) == 'no') then
-               allocate(int_t)
                int_t = 0
                call mpas_pool_add_config(geo_pool, trim(lhs), int_t)
             else


### PR DESCRIPTION
This merge fixes memory leaks that were present in the geotile_manager and parse_index modules. The leaks came from the false assumption that fields added to a pool via mpas_pool_add_config were not copied (and simply pointed to the added field) and would be deallocated when mpas_pool_destory was called; however, this was not the case as mpas_pool_add_config *copies* the added field. Thus, the previous allocations were added to the heap and never deallocated.

In mpas_parse_index has been updated to allocate variables on the stack, rather than dynamically, which will prevent lost variables on the heap. In the geotile_manager variables are kept as pointers so that they can be used to determine if variables defined in an index files exists or to use the default values, but these pointer variables are never allocated.

