### PR TITLE
Add the option for inactive top cells

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1648,6 +1648,7 @@
 			<var name="layerThickness"/>
 			<var name="ssh"/>
 			<var name="maxLevelEdgeTop"/>
+			<var name="minLevelEdgeBot"/>
 			<var name="vertCoordMovementWeights"/>
 			<var name="edgeMask"/>
 			<var name="vertexMask"/>
@@ -2171,16 +2172,32 @@
 		<var name="maxLevelCell" type="integer" dimensions="nCells" units="unitless"
 			 description="Index to the last active ocean cell in each column."
 		/>
+		<var name="minLevelEdgeTop" type="integer" dimensions="nEdges" units="unitless"
+			 description="Index to the first edge in a column with at least one active ocean cell on either side of it."
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="maxLevelEdgeTop" type="integer" dimensions="nEdges" units="unitless"
 			 description="Index to the last edge in a column with active ocean cells on both sides of it."
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="minLevelEdgeBot" type="integer" dimensions="nEdges" units="unitless"
+			 description="Index to the first edge in a column with active ocean cells on both sides of it."
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="maxLevelEdgeBot" type="integer" dimensions="nEdges" units="unitless"
 			 description="Index to the last edge in a column with at least one active ocean cell on either side of it."
 			 packages="forwardMode;analysisMode"
 		/>
+		<var name="minLevelVertexTop" type="integer" dimensions="nVertices" units="unitless"
+			 description="Index to the first vertex in a column with at least one active ocean cell around it."
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="maxLevelVertexTop" type="integer" dimensions="nVertices" units="unitless"
 			 description="Index to the last vertex in a column with all active cells around it."
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="minLevelVertexBot" type="integer" dimensions="nVertices" units="unitless"
+			 description="Index to the first vertex in a column with all active cells around it."
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="maxLevelVertexBot" type="integer" dimensions="nVertices" units="unitless"

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1412,6 +1412,7 @@
 			<var name="refBottomDepth"/>
 			<var name="bottomDepth"/>
 			<var name="bottomDepthObserved"/>
+			<var name="minLevelCell"/>
 			<var name="maxLevelCell"/>
 			<var name="vertCoordMovementWeights"/>
 			<var name="edgeMask"/>
@@ -1506,6 +1507,7 @@
 			<var name="fVertex"/>
 			<var name="fCell"/>
 			<var name="bottomDepth"/>
+			<var name="minLevelCell"/>
 			<var name="maxLevelCell"/>
 			<var name="refBottomDepth" packages="forwardMode;analysisMode"/>
 			<var name="restingThickness" packages="forwardMode;analysisMode"/>
@@ -2162,6 +2164,9 @@
 		/>
 		<var name="coeffs_reconstruct" type="real" dimensions="R3 maxEdges nCells" units="unitless"
 			 description="Coefficients to reconstruct velocity vectors at cells centers."
+		/>
+		<var name="minLevelCell" type="integer" dimensions="nCells" units="unitless" default_value="1"
+			 description="Index to the first active ocean cell in each column."
 		/>
 		<var name="maxLevelCell" type="integer" dimensions="nCells" units="unitless"
 			 description="Index to the last active ocean cell in each column."

--- a/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/src/core_ocean/mode_analysis/mpas_ocn_analysis_mode.F
@@ -112,7 +112,7 @@ module ocn_analysis_mode
 
       call ocn_init_routines_vert_coord(domain)
 
-      call ocn_init_routines_compute_max_level(domain)
+      call ocn_init_routines_compute_min_max_level(domain)
 
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
       call mpas_get_timeInterval(timeStep, dt=dt)

--- a/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_forward_mode.F
@@ -253,7 +253,7 @@ module ocn_forward_mode
 
       call ocn_init_routines_vert_coord(domain)
 
-      call ocn_init_routines_compute_max_level(domain)
+      call ocn_init_routines_compute_min_max_level(domain)
 
       call mpas_pool_get_config(domain % configs, 'config_time_integrator', config_time_integrator)
 

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -1745,7 +1745,7 @@ module ocn_time_integration_split
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
-                           do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
+                           do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                 tracersGroupNew(1,k,iCell) = 2.0_RKIND
                            end do
 
@@ -1757,11 +1757,11 @@ module ocn_time_integration_split
                                 .or.lat>- 2.5.and.lat<  2.5 &
                                 .or.lat> 35.0.and.lat< 40.0 &
                                 .or.lat> 55.0.and.lat< 60.0 ) then
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(2,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(2,k,iCell) = 1.0_RKIND
                               end do
                            end if
@@ -1775,11 +1775,11 @@ module ocn_time_integration_split
                                 .or.lat> 10.0.and.lat< 15.0 &
                                 .or.lat> 30.0.and.lat< 35.0 &
                                 .or.lat> 50.0.and.lat< 55.0 ) then
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(3,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(3,k,iCell) = 1.0_RKIND
                               end do
                            end if
@@ -2186,8 +2186,8 @@ module ocn_time_integration_split
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                layerThicknessEdge1 = 0.5_RKIND* &
-                                     (layerThickness(minLevelCell(iCell),cell1) + &
-                                      layerThickness(minLevelCell(iCell),cell2) )
+                                     (layerThickness(minLevelCell(cell1),cell1) + &
+                                      layerThickness(minLevelCell(cell2),cell2) )
                normalThicknessFluxSum = layerThicknessEdge1* &
                                         normalVelocity(minLevelEdgeBot(iEdge),iEdge)
                layerThicknessSum = layerThicknessEdge1

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -2152,6 +2152,8 @@ module ocn_time_integration_split
 
          call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
          !*** Compute barotropic velocity at first timestep

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_split.F
@@ -387,7 +387,7 @@ module ocn_time_integration_split
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCellsAll
          sshNew(iCell) = sshCur(iCell)
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
       end do
@@ -408,7 +408,7 @@ module ocn_time_integration_split
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCellsAll
-               do k = 1, maxLevelCell(iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
                   tracersGroupNew(:,k,iCell) = &
                   tracersGroupCur(:,k,iCell)
                end do
@@ -506,7 +506,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) private(k)
             do iCell = 1, nCellsAll
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h^{hf}_{n+1}
                highFreqThicknessNew(k,iCell) = &
                highFreqThicknessCur(k,iCell) + dt* &
@@ -573,7 +573,7 @@ module ocn_time_integration_split
                cell2 = cellsOnEdge(2,iEdge)
                ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
                uTemp = 0.0_RKIND
-               do k = 1, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
                   ! normalBaroclinicVelocityNew =
                   ! normalBaroclinicVelocityOld +
@@ -593,11 +593,11 @@ module ocn_time_integration_split
                ! on land boundaries maxLevelEdgeTop=0, but we want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
-               normalThicknessFluxSum = layerThickEdge(1,iEdge)* &
-                                        uTemp(1)
-               thicknessSum = layerThickEdge(1,iEdge)
+               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)* &
+                                        uTemp(minLevelEdgeBot(iEdge))
+               thicknessSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
 
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                  layerThickEdge(k,iEdge)*uTemp(k)
                   thicknessSum = thicknessSum + &
@@ -606,7 +606,7 @@ module ocn_time_integration_split
                barotropicForcing(iEdge) = splitFact* &
                               normalThicknessFluxSum/thicknessSum/dt
 
-               do k = 1, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
                   !{\bf u}'_{k,n+1} =
                   !    {\bf u}'_{k,n} - \Delta t {\overline {\bf G}}
@@ -1395,11 +1395,11 @@ module ocn_time_integration_split
                ! on land boundaries maxLevelEdgeTop=0, but I want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
-               normalThicknessFluxSum = layerThickEdge(1,iEdge)* &
-                                        uTemp(1)
-               thicknessSum  = layerThickEdge(1,iEdge)
+               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)* &
+                                        uTemp(minLevelEdgeBot(iEdge))
+               thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
 
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                            layerThickEdge(k,iEdge)*&
                                            uTemp(k)
@@ -1542,7 +1542,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
             do iCell = 1, nCellsAll
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                ! this is h_{n+1}
                temp_h = layerThicknessCur(k,iCell) + dt* &
@@ -1572,7 +1572,7 @@ module ocn_time_integration_split
                !$omp parallel
                !$omp do schedule(runtime) private(k, temp)
                do iCell = 1, nCellsAll
-               do k = 1, maxLevelCell(iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
 
@@ -1628,7 +1628,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) private(k)
             do iCell = 1, nCellsAll
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h_{n+1}
                layerThicknessNew(k,iCell) = &
                                      layerThicknessCur(k,iCell) + &
@@ -1643,7 +1643,7 @@ module ocn_time_integration_split
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iEdge = 1, nEdgesAll
-               do k= 1, maxLevelEdgeTop(iEdge)
+               do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
                        layerThickEdge(k,iEdge)
@@ -1653,7 +1653,7 @@ module ocn_time_integration_split
 
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCellsAll
-               do k= 1, maxLevelCell(iCell)
+               do k= minLevelCell(iCell), maxLevelCell(iCell)
                   activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
                   activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
                             layerThicknessNew(k,iCell)
@@ -1708,7 +1708,7 @@ module ocn_time_integration_split
                      !$omp parallel
                      !$omp do schedule(runtime) private(k)
                      do iCell = 1, nCellsAll
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
                         tracersGroupNew(:,k,iCell) = &
                        (tracersGroupCur(:,k,iCell) * &
                         layerThicknessCur(k,iCell) + dt* &
@@ -1725,7 +1725,7 @@ module ocn_time_integration_split
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
                         do iCell = 1, nCellsAll
-                        do k = 1, maxLevelCell(iCell)
+                        do k = minLevelCell(iCell), maxLevelCell(iCell)
                            tracersGroupNew(indexSalinity,k,iCell) = &
                            max(0.001_RKIND,  &
                            tracersGroupNew(indexSalinity,k,iCell))
@@ -1745,7 +1745,7 @@ module ocn_time_integration_split
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
-                           do k = 1, config_reset_debugTracers_top_nLayers
+                           do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
                                 tracersGroupNew(1,k,iCell) = 2.0_RKIND
                            end do
 
@@ -1757,11 +1757,11 @@ module ocn_time_integration_split
                                 .or.lat>- 2.5.and.lat<  2.5 &
                                 .or.lat> 35.0.and.lat< 40.0 &
                                 .or.lat> 55.0.and.lat< 60.0 ) then
-                              do k = 1, config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
                                  tracersGroupNew(2,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = 1, config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
                                  tracersGroupNew(2,k,iCell) = 1.0_RKIND
                               end do
                            end if
@@ -1775,11 +1775,11 @@ module ocn_time_integration_split
                                 .or.lat> 10.0.and.lat< 15.0 &
                                 .or.lat> 30.0.and.lat< 35.0 &
                                 .or.lat> 50.0.and.lat< 55.0 ) then
-                              do k = 1, config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
                                  tracersGroupNew(3,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = 1, config_reset_debugTracers_top_nLayers
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers
                                  tracersGroupNew(3,k,iCell) = 1.0_RKIND
                               end do
                            end if
@@ -1795,7 +1795,7 @@ module ocn_time_integration_split
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCellsAll
-               do k = 1, maxLevelCell(iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
 
@@ -1828,7 +1828,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) private(k)
             do iEdge = 1, nEdgesAll
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
                                normalBarotropicVelocityNew(iEdge) + &
                              2*normalBaroclinicVelocityNew(k,iEdge) - &
@@ -1956,9 +1956,9 @@ module ocn_time_integration_split
       !$omp do schedule(runtime)
       do iCell = 1, nCellsAll
          surfaceVelocity(indexSurfaceVelocityZonal,iCell) = &
-                                   velocityZonal(1,iCell)
+                                   velocityZonal(minLevelCell(iCell),iCell)
          surfaceVelocity(indexSurfaceVelocityMeridional,iCell) = &
-                                   velocityMeridional(1,iCell)
+                                   velocityMeridional(minLevelCell(iCell),iCell)
 
          SSHGradient(indexSSHGradientZonal,iCell) = gradSSHZonal(iCell)
          SSHGradient(indexSSHGradientMeridional,iCell) = &
@@ -2168,7 +2168,7 @@ module ocn_time_integration_split
 
             if (config_filter_btr_mode) then
                do iCell = 1, nCells
-                  layerThickness(1,iCell) = refBottomDepth(1)
+                  layerThickness(minLevelCell(iCell),iCell) = refBottomDepth(minLevelCell(iCell))
                enddo
             endif
 
@@ -2186,13 +2186,13 @@ module ocn_time_integration_split
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                layerThicknessEdge1 = 0.5_RKIND* &
-                                     (layerThickness(1,cell1) + &
-                                      layerThickness(1,cell2) )
+                                     (layerThickness(minLevelCell(iCell),cell1) + &
+                                      layerThickness(minLevelCell(iCell),cell2) )
                normalThicknessFluxSum = layerThicknessEdge1* &
-                                        normalVelocity(1,iEdge)
+                                        normalVelocity(minLevelEdgeBot(iEdge),iEdge)
                layerThicknessSum = layerThicknessEdge1
 
-               do k=2, kmax
+               do k=minLevelEdgeBot(iEdge)+1, kmax
                   layerThicknessEdge1 = 0.5_RKIND* &
                                        (layerThickness(k,cell1) + &
                                         layerThickness(k,cell2))
@@ -2209,7 +2209,7 @@ module ocn_time_integration_split
 
                ! normalBaroclinicVelocity = normalVelocity -
                !     normalBarotropicVelocity
-               do k = 1, kmax
+               do k = minLevelEdgeBot(iEdge), kmax
                   normalBaroclinicVelocity(k,iEdge) = &
                             normalVelocity(k,iEdge) - &
                     normalBarotropicVelocity(iEdge)

--- a/src/core_ocean/mode_init/Registry.xml
+++ b/src/core_ocean/mode_init/Registry.xml
@@ -23,16 +23,16 @@
 	<!--**********************************-->
 	<!-- Namelists for init run mode only -->
 	<!--**********************************-->
-	<nml_record name="partial_bottom_cells" mode="init">
-		<nml_option name="config_alter_ICs_for_pbcs" type="logical" default_value=".false." units="unitless"
-					description="If true, initial conditions are altered according to the config_pbc_alteration_type flag."
+	<nml_record name="partial_cells" mode="init">
+		<nml_option name="config_alter_ICs_for_pcs" type="logical" default_value=".false." units="unitless"
+					description="If true, initial conditions are altered according to the config_pc_alteration_type flag."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_pbc_alteration_type" type="character" default_value="full_cell" units="unitless"
-					description="Determines the method of initial condition alteration for partial bottom cells. 'partial_cell' alters layerThickness, interpolates all tracers in the bottom cell based on the bottomDepth variable, and alters bottomDepth to enforce the minimum pbc fraction. 'full_cell' alters bottomDepth to have full cells everywhere, based on the refBottomDepth variable."
+		<nml_option name="config_pc_alteration_type" type="character" default_value="full_cell" units="unitless"
+					description="Determines the method of initial condition alteration for partial bottom (and possibly top) cells. 'partial_cell' alters layerThickness, interpolates all tracers in the bottom (and top) cell based on the bottomDepth (or ssh) variable, and alters bottomDepth (or ssh) to enforce the minimum pc fraction. 'full_cell' alters bottomDepth (or ssh) to have full cells everywhere, based on the refBottomDepth variable."
 					possible_values="'full_cell' or 'partial_cell'"
 		/>
-		<nml_option name="config_min_pbc_fraction" type="real" default_value="0.10" units="unitless"
+		<nml_option name="config_min_pc_fraction" type="real" default_value="0.10" units="unitless"
 					description="Determines the minimum fraction of a cell altering the initial conditions can create."
 					possible_values="Any real between 0 and 1."
 		/>
@@ -73,11 +73,13 @@
 					possible_values="Any positive non-zero integer."
 		/>
 	</nml_record>
-	<nml_record name="constrain_Haney_number" mode="init">
-		<nml_option name="config_use_rx1_constraint" type="logical" default_value=".false." units="unitless"
-					description="Initialize using Haney number constraint under ice shelves"
-					possible_values=".true. or .false."
+	<nml_record name="init_vertical_grid" mode="init">
+		<nml_option name="config_init_vertical_grid_type" type="character" default_value="z-star" units="unitless"
+					description="Which vertical grid to initialize with.  Without ice-shelf cavities (i.e. ssh=0 everywhere), 'z-star' and 'z-level' are the same."
+					possible_values="'z-star', 'z-level', or 'haney-number'"
 		/>
+	</nml_record>
+	<nml_record name="constrain_Haney_number" mode="init">
 		<nml_option name="config_rx1_outer_iter_count" type="integer" default_value="20" units="unitless"
 					description="The number of outer iterations (first smoothing then rx1 constraint) during initialization of the vertical grid."
 					possible_values="any positive integer"

--- a/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_global_ocean.F
@@ -775,7 +775,7 @@ contains
 
        type (field1DInteger), pointer :: maxLevelCellField
        type (field1DReal), pointer :: bottomDepthField
-       integer, dimension(:), pointer :: maxLevelCell, nEdgesOnCell
+       integer, dimension(:), pointer :: minLevelCell, maxLevelCell, nEdgesOnCell
        integer, dimension(:, :), pointer :: cellsOnCell
 
        integer :: iCell, coc, j, k, maxLevelNeighbors
@@ -859,7 +859,10 @@ contains
           call mpas_pool_get_array(meshPool, 'bottomDepthObserved', bottomDepthObserved)
           call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
           call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+          call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+          minLevelCell(:) = 1
 
           do iCell = 1, nCells
              ! Record depth of the bottom of the ocean, before any alterations for modeling purposes.
@@ -951,10 +954,14 @@ contains
           call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', refLayerThickness)
           call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
 
-          ! Compute refLayerThickness and refZMid
-          call ocn_compute_layerThickness_zMid_from_bottomDepth(refLayerThickness,refZMid, &
-               refBottomDepth,refBottomDepth(nVertLevels), &
-               nVertLevels,nVertLevels,iErr)
+          ! Compute refLayerThickness
+          call ocn_compute_z_level_layerThickness(refLayerThickness, refBottomDepth, 0.0_RKIND, &
+                                                  refBottomDepth(nVertLevels), 1,               &
+                                                  nVertLevels, nVertLevels, iErr)
+
+          ! Compute refZMid
+          call ocn_compute_zMid_from_layerThickness(refZMid, refLayerThickness, 0.0_RKIND, 1, &
+                                                    nVertLevels, nVertLevels, iErr)
 
           block_ptr => block_ptr % next
        end do

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip.F
@@ -100,7 +100,7 @@ contains
       integer, pointer :: index_temperature, index_salinity, index_tracer1
 
       ! Define variable pointers
-      integer, dimension(:), pointer :: maxLevelCell, landIceMask
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, landIceMask
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell,refBottomDepth, &
                                                   vertCoordMovementWeights, bottomDepth, &
                                                   fCell, fEdge, fVertex, dcEdge, &
@@ -207,6 +207,7 @@ contains
         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
         call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
         call mpas_pool_get_array(meshPool, 'fCell', fCell)
         call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
@@ -235,6 +236,7 @@ contains
         call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersSurfaceRestoringValue', &
             activeTracersSurfaceRestoringValue, 1)
 
+        minLevelCell(:) = 1
 
         ! flat bottom
         maxLevelCell(:) = nVertLevels
@@ -257,10 +259,14 @@ contains
             refBottomDepth(k) = refBottomDepth(k-1) + columnThicknessFraction(k)*abs(config_isomip_bottom_depth)
         end do
 
-        ! Compute refLayerThickness and refZMid
-        call ocn_compute_layerThickness_zMid_from_bottomDepth(refLayerThickness,refZMid, &
-             refBottomDepth,refBottomDepth(nVertLevels), &
-             nVertLevels,nVertLevels,iErr)
+        ! Compute refLayerThickness
+        call ocn_compute_z_level_layerThickness(refLayerThickness, refBottomDepth, 0.0_RKIND, &
+                                                refBottomDepth(nVertLevels), 1,               &
+                                                nVertLevels, nVertLevels, iErr)
+
+        ! Compute refZMid
+        call ocn_compute_zMid_from_layerThickness(refZMid, refLayerThickness, 0.0_RKIND, 1, &
+                                                  nVertLevels, nVertLevels, iErr)
 
         fCell(:) = config_isomip_coriolis_parameter
         fEdge(:) = config_isomip_coriolis_parameter

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
@@ -152,10 +152,14 @@ contains
             refBottomDepth(k) = refBottomDepth(k-1) + columnThicknessFraction(k)*abs(config_isomip_plus_max_bottom_depth)
         end do
 
-        ! Compute refLayerThickness and refZMid
-        call ocn_compute_layerThickness_zMid_from_bottomDepth(refLayerThickness,refZMid, &
-             refBottomDepth,refBottomDepth(nVertLevels), &
-             nVertLevels,nVertLevels,iErr)
+        ! Compute refLayerThickness
+        call ocn_compute_z_level_layerThickness(refLayerThickness, refBottomDepth, 0.0_RKIND, &
+                                                refBottomDepth(nVertLevels), 1,               &
+                                                nVertLevels, nVertLevels, iErr)
+
+        ! Compute refZMid
+        call ocn_compute_zMid_from_layerThickness(refZMid, refLayerThickness, 0.0_RKIND, 1, &
+                                                  nVertLevels, nVertLevels, iErr)
 
         block_ptr => block_ptr % next
       end do
@@ -482,7 +486,7 @@ contains
 
        integer, pointer :: nCells, nVertLevels
 
-       integer, dimension(:), pointer :: maxLevelCell
+       integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
        integer :: iCell, k, maxLevel
 
@@ -507,6 +511,7 @@ contains
           call mpas_pool_get_array(meshPool, 'xCell', xCell)
           call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
           call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+          call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
           call mpas_pool_get_array(meshPool, 'bottomDepthObserved', bottomDepthObserved)
           call mpas_pool_get_array(meshPool, 'oceanFracObserved', oceanFracObserved)
@@ -570,6 +575,8 @@ contains
               else
                  landIceMask(iCell) = 1
               end if
+
+              minLevelCell(iCell) = 1
 
               maxLevelCell(iCell) = -1
               do k = 1, nVertLevels

--- a/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -101,6 +101,8 @@ contains
      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceDraft, &
                                                  effectiveDensityInLandIce
 
+     integer, dimension(:), pointer :: minLevelCell
+
      integer, pointer :: nCells
 
      integer :: iCell
@@ -138,6 +140,8 @@ contains
 
        call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
+       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
@@ -165,9 +169,10 @@ contains
            cycle
          end if
 
-         landIcePressure(iCell) = max(0.0_RKIND, -density(1,iCell)*gravity*ssh(iCell))
+         landIcePressure(iCell) = &
+           max(0.0_RKIND, -density(minLevelCell(iCell), iCell)*gravity*ssh(iCell))
          if (associated(effectiveDensityInLandIce)) &
-           effectiveDensityInLandIce(iCell) = density(1,iCell)
+           effectiveDensityInLandIce(iCell) = density(minLevelCell(iCell), iCell)
        end do
 
        ! copy the SSH into the landIceDraft so we can use it later to remove it when

--- a/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
@@ -23,6 +23,7 @@ module ocn_init_sub_ice_shelf_2D
    use mpas_pool_routines
    use mpas_constants
    use mpas_dmpar
+   use mpas_io
 
    use ocn_constants
    use ocn_config
@@ -280,6 +281,8 @@ module ocn_init_sub_ice_shelf_2D
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+        call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
         call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
@@ -293,14 +296,22 @@ module ocn_init_sub_ice_shelf_2D
            ! Set temperature
            idx = index_temperature
            do k = 1, nVertLevels
-              activeTracers(idx, k, iCell) = config_sub_ice_shelf_2D_temperature
+              if (k >= minLevelCell(iCell) .and. k <= maxLevelCell(iCell)) then
+                 activeTracers(idx, k, iCell) = config_sub_ice_shelf_2D_temperature
+              else
+                 activeTracers(idx, k, iCell) = MPAS_REAL_FILLVAL
+              end if
            end do
 
            ! Set up salinity stratification
            idx = index_salinity
            do k = 1, nVertLevels
-              activeTracers(idx, k, iCell) = surfaceSalinity + (bottomSalinity - surfaceSalinity) &
-                                                             * (zMid(k,iCell)/(-config_sub_ice_shelf_2D_bottom_depth))
+              if (k >= minLevelCell(iCell) .and. k <= maxLevelCell(iCell)) then
+                 activeTracers(idx, k, iCell) = surfaceSalinity + (bottomSalinity - surfaceSalinity) &
+                                                                * (zMid(k,iCell)/(-config_sub_ice_shelf_2D_bottom_depth))
+              else
+                 activeTracers(idx, k, iCell) = MPAS_REAL_FILLVAL
+              end if
            end do
         end do
 

--- a/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
@@ -97,7 +97,7 @@ module ocn_init_sub_ice_shelf_2D
      integer, pointer :: index_temperature, index_salinity
 
      ! Define variable pointers
-     integer, dimension(:), pointer :: maxLevelCell, landIceMask
+     integer, dimension(:), pointer :: minLevelCell, maxLevelCell, landIceMask
      real (kind=RKIND), dimension(:), pointer :: xCell, yCell,refBottomDepth, refZMid, &
           vertCoordMovementWeights, bottomDepth, &
           fCell, fEdge, fVertex, dcEdge, refLayerThickness
@@ -188,6 +188,7 @@ module ocn_init_sub_ice_shelf_2D
         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
         call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
@@ -205,10 +206,14 @@ module ocn_init_sub_ice_shelf_2D
            refBottomDepth(k) = config_sub_ice_shelf_2D_bottom_depth * interfaceLocations(k+1)
         end do
 
-        ! Compute refLayerThickness and refZMid
-        call ocn_compute_layerThickness_zMid_from_bottomDepth(refLayerThickness,refZMid, &
-             refBottomDepth,refBottomDepth(nVertLevels), &
-             nVertLevels,nVertLevels,iErr)
+        ! Compute refLayerThickness
+        call ocn_compute_z_level_layerThickness(refLayerThickness, refBottomDepth, 0.0_RKIND, &
+                                                refBottomDepth(nVertLevels), 1,               &
+                                                nVertLevels, nVertLevels, iErr)
+
+        ! Compute refZMid
+        call ocn_compute_zMid_from_layerThickness(refZMid, refLayerThickness, 0.0_RKIND, 1, &
+                                                  nVertLevels, nVertLevels, iErr)
 
         ! Set vertCoordMovementWeights
         vertCoordMovementWeights(:) = 1.0_RKIND
@@ -238,6 +243,8 @@ module ocn_init_sub_ice_shelf_2D
               modifyLandIcePressureMask(iCell) = 1
            end if
         end do
+
+        minLevelCell(:) = 1
 
         do iCell = 1, nCells
            if (yCell(iCell) < y3 ) then

--- a/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_tidal_boundary.F
@@ -66,7 +66,7 @@ contains
 !  routine ocn_init_setup_tidal_boundary
 !
 !> \brief   Setup for Tidal Boundary on drying slope
-!> \author  Phillip Wolfram
+!> \author  Phillip Wolfram, Xylar Asay-Davis
 !> \date    04/05/2019
 !> \details
 !>  This routine sets up the initial conditions for the tidal_boundary test case.
@@ -100,7 +100,7 @@ contains
     integer, pointer :: index_temperature, index_salinity, index_tracer1
 
     ! Define arrays
-    integer, dimension(:), pointer :: maxLevelCell
+    integer, dimension(:), pointer :: minLevelCell, maxLevelCell
     integer, dimension(:), pointer :: vegetationMask
     real (kind=RKIND), dimension(:), pointer :: vegetationHeight,vegetationDensity, vegetationDiameter
     real (kind=RKIND), dimension(:), pointer :: yCell, refBottomDepth, bottomDepth, vertCoordMovementWeights, dcEdge
@@ -173,6 +173,7 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
       call mpas_pool_get_dimension(tracersPool, 'index_tracer1', index_tracer1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
@@ -296,7 +297,7 @@ contains
         end do
       end if
 
-      if (.not. config_alter_ICs_for_pbcs .and. trim(config_tidal_boundary_layer_type) == 'zstar') then
+      if (.not. config_alter_ICs_for_pcs .and. trim(config_tidal_boundary_layer_type) == 'zstar') then
         do iCell = 1, nCellsSolve
           do k = 1,nVertLevels
             if (refBottomDepth(k) > bottomDepth(iCell)) then
@@ -306,6 +307,8 @@ contains
           end do
         end do
       end if
+
+      minLevelCell(:) = 1
 
       if(trim(config_tidal_boundary_layer_type) == 'zstar') then
 
@@ -373,12 +376,19 @@ contains
         end do
       else
         do iCell = 1, nCellsSolve
-          ! Set layerThickness and restingThickness
-          call ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness(:,iCell), zMid(:,iCell), &
-            refBottomDepth, bottomDepth(iCell), maxLevelCell(iCell), nVertLevels, iErr, &
-            restingThickness=restingThickness(:,iCell), &
-            ssh=ssh(iCell))
-          ! also computes zMid
+          ! restingThickness is z-level, with ssh = 0
+          call ocn_compute_z_level_layerThickness(restingThickness(:,iCell), refBottomDepth, 0.0_RKIND, &
+                                                  bottomDepth(iCell), minLevelCell(iCell),              &
+                                                  maxLevelCell(iCell), nVertLevels, iErr)
+
+          ! stretch restingThickness to get the z-star layerThickness
+          call ocn_compute_z_star_layerThickness(layerThickness(:,iCell), restingThickness(:,iCell),  &
+                                                 ssh(iCell), bottomDepth(iCell), minLevelCell(iCell), &
+                                                 maxLevelCell(iCell), nVertLevels, iErr)
+
+          ! compute zMid
+          call ocn_compute_zMid_from_layerThickness(zMid(:,iCell), layerThickness(:,iCell), ssh(iCell), &
+                                                    minLevelCell(iCell), maxLevelCell(iCell), nVertLevels, iErr)
           do k = 1, maxLevelCell(iCell)
             restingThickness(k, iCell) = layerThickness(k, iCell)
           end do
@@ -399,7 +409,7 @@ contains
         end if
       end do
 
-      ! check that there is some tidalInputMask 
+      ! check that there is some tidalInputMask
       if (.not. sum(tidalInputMask) > 0) then
         call mpas_log_write('Input mask for tidal case is not set!', MPAS_LOG_CRIT)
       end if

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -735,10 +735,11 @@ contains
       real (kind=RKIND), dimension(:), pointer :: ssh, rx1MaxLevel
 
       integer, pointer :: nCells, nVertLevels, nEdges
+      integer, dimension(:), pointer :: minLevelCell
       integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:,:), pointer :: cellsOnEdge
 
-      integer :: iEdge, c1, c2, k, maxLevelEdge
+      integer :: iEdge, c1, c2, k, minLevelEdge, maxLevelEdge
 
       real (kind=RKIND) :: dzVert1, dzVert2, dzEdgeK, dzEdgeKp1, rx1, localMaxRx1Edge
 
@@ -762,6 +763,7 @@ contains
         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
         call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
@@ -776,9 +778,10 @@ contains
           c2 = cellsOnEdge(2,iEdge)
           ! not a valid edge
           if((c1 > nCells) .or. (c2 > nCells)) cycle
+          minLevelEdge = max(minLevelCell(c1), minLevelCell(c2))
           maxLevelEdge = min(maxLevelCell(c1), maxLevelCell(c2))
-          do k = 1,maxLevelEdge
-            if(k == 1) then
+          do k = minLevelEdge,maxLevelEdge
+            if(k == minLevelEdge) then
               dzVert1 = 2.0_RKIND*(ssh(c1)-zMid(k,c1))
               dzVert2 = 2.0_RKIND*(ssh(c2)-zMid(k,c2))
               dzEdgeK = ssh(c2)-ssh(c1)

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -828,11 +828,14 @@ contains
 !> \details
 !>  This routine sets up the vertical grid (layerThickness, zMid and
 !>  restingThickness) needed for computing land-ice pressure from SSH.
-!>  bottomDepth, refBottomDepth, maxLevelCell must have been computed by the
-!>  test case before calling this routine.  For tests with ice-shelf cavities,
-!>  ssh must be computed before calling this routine. If the test case is
-!>  using a z-star coordinate, this routine will take care of setting up
-!>  partial bottom cells by calling ocn_alter_bottomDepth_for_pbcs(). If using
+!>  bottomDepth, refBottomDepth, must have been computed by the test case
+!>  before calling this routine.  For coordinates other than z-level,
+!>  minLevelCell and maxLevelCell must also be computed before calling this
+!>  routine.  For z-level, they are computed here.  For tests with ice-shelf
+!>  cavities, ssh must be computed before calling this routine. If the test
+!>  case is using a z-star or z-level coordinate, this routine will take care
+!>  of setting  up partial bottom (and, for z-level, top) cells by calling
+!>  ocn_alter_bottomDepth_for_pbcs() and ocn_alter_ssh_for_ptcs() . If using
 !>  the Haney-number-constrained coordinate, another approach is used to handle
 !>  maintaining a minimum layer thickness.
 !-----------------------------------------------------------------------
@@ -856,9 +859,11 @@ contains
      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
 
-     integer :: iCell
+     integer :: iCell, k
 
      logical :: useZStar, useZLevel
+
+     real (kind=RKIND) :: depth
 
    !--------------------------------------------------------------------
 
@@ -967,6 +972,32 @@ contains
          call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
          call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+         ! compute minLevelCell and maxLevelCell based on refBottomDepth, ssh and bottomDepth
+         do iCell = 1, nCells
+           maxLevelCell(iCell) = -1
+           minLevelCell(iCell) = -1
+
+           if ((bottomDepth(iCell) == 0.0_RKIND) .or. (bottomDepth(iCell) <= -ssh(iCell))) then
+              cycle
+           end if
+
+           do k = 1, nVertLevels
+             depth = refBottomDepth(k)
+             if (depth >= bottomDepth(iCell)) then
+               maxLevelCell(iCell) = k
+               exit
+             end if
+           end do
+
+           do k = 1, nVertLevels
+             depth = -refBottomDepth(k)
+             if (depth < ssh(iCell)) then
+               minLevelCell(iCell) = k
+               exit
+             end if
+           end do
+         end do
 
          do iCell = 1, nCells
            ! alter pbcs

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -703,7 +703,7 @@ contains
             ssh = minSSH
          end if
       else if (config_pc_alteration_type == 'full_cell') then
-         ssh = zBot
+         ssh = zTop
       else
          call mpas_log_write(' Error: Incorrect choice of config_pc_alteration_type: '// config_pc_alteration_type)
          iErr = 1

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -24,6 +24,7 @@ module ocn_init_vertical_grids
    use mpas_pool_routines
    use mpas_constants
    use mpas_timer
+   use mpas_io
 
    use ocn_constants
    use ocn_config
@@ -46,8 +47,11 @@ module ocn_init_vertical_grids
    !--------------------------------------------------------------------
 
    public :: ocn_generate_vertical_grid, &
-             ocn_compute_layerThickness_zMid_from_bottomDepth, &
+             ocn_compute_z_level_layerThickness, &
+             ocn_compute_zMid_from_layerThickness, &
+             ocn_compute_z_star_layerThickness, &
              ocn_alter_bottomDepth_for_pbcs, &
+             ocn_alter_ssh_for_ptcs, &
              ocn_compute_Haney_number, &
              ocn_init_vertical_grid, &
              ocn_init_vertical_grid_with_max_rx1
@@ -484,50 +488,40 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_compute_layerThickness_zMid_from_bottomDepth
+!  routine ocn_compute_z_level_layerThickness
 !
 !> \brief   Compute auxiliary z-variables from bottomDepth
-!> \author  Mark Petersen
+!> \author  Mark Petersen, Xylar Asay-Davis
 !> \date    10/17/2015
 !> \details
 !>  This routine computes auxiliary z-variables from bottomDepth
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness,zMid,refBottomDepth,bottomDepth, &
-                                                                maxLevelCell,nVertLevels,iErr,restingThickness,ssh)!{{{
-      real (kind=RKIND), dimension(nVertLevels), intent(out) :: layerThickness, zMid
+    subroutine ocn_compute_z_level_layerThickness(layerThickness, refBottomDepth, ssh, bottomDepth, &
+                                                  minLevelCell, maxLevelCell, nVertLevels, iErr)!{{{
+      real (kind=RKIND), dimension(nVertLevels), intent(out) :: layerThickness
       real (kind=RKIND), dimension(nVertLevels), intent(in) :: refBottomDepth
-      real (kind=RKIND), intent(in) :: bottomDepth
-      integer, intent(in) :: maxLevelCell, nVertLevels
+      real (kind=RKIND), intent(in) :: ssh, bottomDepth
+      integer, intent(in) :: minLevelCell, maxLevelCell, nVertLevels
       integer, intent(out) :: iErr
-      real (kind=RKIND), dimension(nVertLevels), intent(out), optional :: restingThickness
-      real (kind=RKIND), intent(in), optional :: ssh
 
       integer :: k
-      real (kind=RKIND) :: layerStretch, zTop
 
       iErr = 0
 
-      layerThickness(:) = 0.0_RKIND
-      zMid(:) = 0.0_RKIND
-
-      if(present(ssh) .and. .not. present(restingThickness)) then
-         call mpas_log_write( ' Error: ssh present but restingThickness not present ' &
-                           // 'in ocn_compute_layerThickness_zMid_from_bottomDepth')
-         iErr = 1
-         return
-      end if
+      layerThickness(:) = 0.0_RKIND  ! = MPAS_REAL_FILLVAL
 
       if (maxLevelCell<=0) return
 
-      ! first, compute the resting layer thickness (same as layer thickness if ssh not present)
-      if (maxLevelCell==1) then
-         layerThickness(1) = bottomDepth
+      ! compute the z-level layer thickness
+      if (maxLevelCell==minLevelCell) then
+         layerThickness(minLevelCell) = bottomDepth + ssh
       else
-         layerThickness(1) = refBottomDepth(1)
+         k = minLevelCell
+         layerThickness(k) = refBottomDepth(k) + ssh
 
-         do k = 2, maxLevelCell-1
+         do k = minLevelCell+1, maxLevelCell-1
             layerThickness(k) = refBottomDepth(k) - refBottomDepth(k-1)
          end do
 
@@ -536,27 +530,82 @@ contains
 
       endif
 
-      zTop = 0.0_RKIND
-      ! copy to layerThickness to restingThickness
-      if (present(restingThickness)) then
-         restingThickness(:) = layerThickness(:)
-         ! stretch layers if ssh is present
-         if(present(ssh)) then
-            layerStretch = (ssh + bottomDepth)/bottomDepth
-            zTop = ssh
-            do k=1,maxLevelCell
-               layerThickness(k) = layerStretch*restingThickness(k)
-            end do
-         end if
-      end if
+    end subroutine ocn_compute_z_level_layerThickness  !}}}
 
+!***********************************************************************
+!
+!  routine ocn_compute_zMid_from_layerThickness
+!
+!> \brief   Compute zMid from layerThickness
+!> \author  Xylar Asay-Davis
+!> \date    02/14/2021
+!> \details
+!>  This routine computes zMid from ssh and layerThickness for any vertical coordinate
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_compute_zMid_from_layerThickness(zMid, layerThickness, ssh, minLevelCell, &
+                                                    maxLevelCell, nVertLevels, iErr)!{{{
+      real (kind=RKIND), dimension(nVertLevels), intent(out) :: zMid
+      real (kind=RKIND), dimension(nVertLevels), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: ssh
+      integer, intent(in) :: minLevelCell, maxLevelCell, nVertLevels
+      integer, intent(out) :: iErr
+
+      integer :: k
+      real (kind=RKIND) :: zTop
+
+      iErr = 0
+
+      zMid(:) = 0.0_RKIND  ! MPAS_REAL_FILLVAL
+
+      if (maxLevelCell<=0) return
+
+      zTop = ssh
       ! compute zMid based on the layer thickness
-      do k = 1, maxLevelCell
-         zMid(k) = zTop - 0.5_RKIND*layerThickness(k)
+      do k = minLevelCell, maxLevelCell
+         zMid(k) = zTop - 0.5_RKIND * layerThickness(k)
          zTop = zTop - layerThickness(k)
       end do
 
-    end subroutine ocn_compute_layerThickness_zMid_from_bottomDepth  !}}}
+    end subroutine ocn_compute_zMid_from_layerThickness  !}}}
+
+
+!***********************************************************************
+!
+!  routine ocn_compute_z_star_layerThickness
+!
+!> \brief   Compute z-star layerThickness
+!> \author  Xylar Asay-Davis
+!> \date    02/14/2021
+!> \details
+!>  This routine computes z-star layerThickness from restingThickness, bottomDepth, and ssh
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_compute_z_star_layerThickness(layerThickness, restingThickness, ssh, bottomDepth, &
+                                                 minLevelCell, maxLevelCell, nVertLevels, iErr)!{{{
+      real (kind=RKIND), dimension(nVertLevels), intent(out) :: layerThickness
+      real (kind=RKIND), dimension(nVertLevels), intent(in) :: restingThickness
+      real (kind=RKIND), intent(in) :: ssh, bottomDepth
+      integer, intent(in) :: minLevelCell, maxLevelCell, nVertLevels
+      integer, intent(out) :: iErr
+
+      integer :: k
+      real (kind=RKIND) :: layerStretch
+
+      iErr = 0
+
+      layerThickness(:) = 0.0_RKIND  ! = MPAS_REAL_FILLVAL
+
+      if (maxLevelCell<=0) return
+
+      layerStretch = (ssh + bottomDepth)/bottomDepth
+      do k = minLevelCell, maxLevelCell
+         layerThickness(k) = layerStretch * restingThickness(k)
+      end do
+
+    end subroutine ocn_compute_z_star_layerThickness  !}}}
 
 
 !***********************************************************************
@@ -567,14 +616,14 @@ contains
 !> \author  Mark Petersen
 !> \date    10/19/2015
 !> \details
-!>  This routine alters the bottom depth in a single column based on pbc settings
+!>  This routine alters the bottom depth in a single column based on partial cell settings
 !
 !-----------------------------------------------------------------------
     subroutine ocn_alter_bottomDepth_for_pbcs(bottomDepth, refBottomDepth, maxLevelCell, iErr)
 
       real (kind=RKIND), intent(inout) :: bottomDepth
       integer, intent(inout) :: maxLevelCell
-      real (kind=RKIND), dimension(maxLevelCell), intent(in) :: refBottomDepth
+      real (kind=RKIND), dimension(:), intent(in) :: refBottomDepth
       integer, intent(out) :: iErr
       integer :: k
       real (kind=RKIND) :: minBottomDepth, minBottomDepthMid
@@ -582,12 +631,12 @@ contains
       iErr = 0
 
       if (maxLevelCell > 1) then
-         if (config_alter_ICs_for_pbcs) then
+         if (config_alter_ICs_for_pcs) then
 
-            if (config_pbc_alteration_type .eq. 'partial_cell') then
+            if (config_pc_alteration_type .eq. 'partial_cell') then
                ! Change value of maxLevelCell for partial bottom cells
                k = maxLevelCell
-               minBottomDepth = refBottomDepth(k) - (1.0-config_min_pbc_fraction)*(refBottomDepth(k) - refBottomDepth(k-1))
+               minBottomDepth = refBottomDepth(k) - (1.0-config_min_pc_fraction)*(refBottomDepth(k) - refBottomDepth(k-1))
                minBottomDepthMid = 0.5_RKIND*(minBottomDepth + refBottomDepth(k-1))
                if (bottomDepth .lt. minBottomDepthMid) then
                   ! Round up to cell above
@@ -597,16 +646,71 @@ contains
                   ! Round down cell to the min_pbc_fraction.
                   bottomDepth = minBottomDepth
                end if
-            elseif (config_pbc_alteration_type .eq. 'full_cell') then
+            elseif (config_pc_alteration_type .eq. 'full_cell') then
                bottomDepth = refBottomDepth(maxLevelCell)
             else
-               call mpas_log_write( ' Error: Incorrect choice of config_pbc_alteration_type: '// config_pbc_alteration_type)
+               call mpas_log_write( ' Error: Incorrect choice of config_pc_alteration_type: '// config_pc_alteration_type)
                iErr = 1
             endif
          endif
       endif
 
     end subroutine ocn_alter_bottomDepth_for_pbcs
+
+!***********************************************************************
+!
+!  routine ocn_alter_ssh_for_ptcs
+!
+!> \brief   Alter sea surface height for partial top cells
+!> \author  Xylar Asay-Davis
+!> \date    02/14/2021
+!> \details
+!>  This routine alters the sea surface height in a single column based on partial cell settings
+!
+!-----------------------------------------------------------------------
+    subroutine ocn_alter_ssh_for_ptcs(ssh, refBottomDepth, minLevelCell, iErr)
+
+      real (kind=RKIND), intent(inout) :: ssh
+      integer, intent(inout) :: minLevelCell
+      real (kind=RKIND), dimension(:), intent(in) :: refBottomDepth
+      integer, intent(out) :: iErr
+      real (kind=RKIND) :: minSSH, minSSHMid, zTop, zBot
+
+      iErr = 0
+
+      if (.not. config_alter_ICs_for_pcs) return
+
+      if (minLevelCell < 1) return
+
+      if (minLevelCell == 1) then
+         zTop = 0.0_RKIND
+      else
+         zTop = -refBottomDepth(minLevelCell-1)
+      end if
+
+      zBot = -refBottomDepth(minLevelCell)
+
+      if (config_pc_alteration_type == 'partial_cell') then
+         ! Change value of minLevelCell for partial top cells
+         minSSH = zBot + config_min_pc_fraction*(zTop - zBot)
+         minSSHMid = 0.5_RKIND*(minSSH + zBot)
+         if (ssh < minSSHMid) then
+            ! Move down to the cell below
+            minLevelCell = minLevelCell + 1
+            ssh = zBot
+         else if (ssh < minSSH) then
+            ! Move up to min_pc_fraction.
+            ssh = minSSH
+         end if
+      else if (config_pc_alteration_type == 'full_cell') then
+         ssh = zBot
+      else
+         call mpas_log_write(' Error: Incorrect choice of config_pc_alteration_type: '// config_pc_alteration_type)
+         iErr = 1
+      endif
+
+    end subroutine ocn_alter_ssh_for_ptcs
+
 
 !***********************************************************************
 !
@@ -748,17 +852,28 @@ contains
      integer, pointer :: nCells, nVertLevels
 
      ! Define variable pointers
-     integer, dimension(:), pointer :: maxLevelCell
+     integer, dimension(:), pointer :: minLevelCell, maxLevelCell
      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, bottomDepth, ssh
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, restingThickness
 
      integer :: iCell
 
+     logical :: useZStar, useZLevel
+
    !--------------------------------------------------------------------
 
      iErr = 0
 
-     if(config_use_rx1_constraint) then
+     if (config_init_vertical_grid_type /= 'z-level' .and. &
+         config_init_vertical_grid_type /= 'z-star' .and. &
+         config_init_vertical_grid_type /= 'haney-number') then
+
+         call mpas_log_write('Unexpected value for config_init_vertical_grid_type ' // &
+                             trim(config_init_vertical_grid_type), MPAS_LOG_CRIT)
+
+     end if
+
+     if(config_init_vertical_grid_type == 'haney-number') then
        ! We already know the ssh and landIcePressure we want to use.
        ! Compute the layer thicknesses and zMid based on topography and ssh.
        ! Use rx1 constraint to recompute the vertical grid.
@@ -769,34 +884,11 @@ contains
          return
        end if
 
-     else
-
-       ! we're initializing to z-star
-
-       ! alter pbcs
-       block_ptr => domain % blocklist
-       do while(associated(block_ptr))
-         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
-
-         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-
-         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
-         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
-         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-
-         do iCell = 1, nCells
-           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
-           if(iErr .ne. 0) then
-             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
-             return
-           end if
-         end do
-         block_ptr => block_ptr % next
-       end do !block_ptr
+     else if(config_init_vertical_grid_type == 'z-star') then
 
        block_ptr => domain % blocklist
        do while(associated(block_ptr))
+
          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
          call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
@@ -806,6 +898,7 @@ contains
 
          call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
          call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -814,14 +907,102 @@ contains
          call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
          do iCell = 1, nCells
-           call ocn_compute_layerThickness_zMid_from_bottomDepth(layerThickness(:,iCell),zMid(:,iCell), &
-                refBottomDepth,bottomDepth(iCell), &
-                maxLevelCell(iCell),nVertLevels,iErr, &
-                restingThickness=restingThickness(:,iCell), &
-                ssh=ssh(iCell))
+           ! alter pbcs
+           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! restingThickness is z-level, with ssh = 0
+           call ocn_compute_z_level_layerThickness(restingThickness(:,iCell), refBottomDepth, 0.0_RKIND, &
+                                                   bottomDepth(iCell), minLevelCell(iCell),              &
+                                                   maxLevelCell(iCell), nVertLevels, iErr)
 
            if(iErr .ne. 0) then
-             call mpas_log_write( 'ocn_compute_layerThickness_zMid_from_bottomDepth failed.', MPAS_LOG_CRIT)
+             call mpas_log_write( 'ocn_compute_z_level_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! stretch restingThickness to get the z-star layerThickness
+           call ocn_compute_z_star_layerThickness(layerThickness(:,iCell), restingThickness(:,iCell),  &
+                                                  ssh(iCell), bottomDepth(iCell), minLevelCell(iCell), &
+                                                  maxLevelCell(iCell), nVertLevels, iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_z_star_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! compute zMid
+           call ocn_compute_zMid_from_layerThickness(zMid(:,iCell), layerThickness(:,iCell), ssh(iCell), &
+                                                     minLevelCell(iCell), maxLevelCell(iCell), nVertLevels, iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_zMid_from_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+         end do !iCell
+
+         block_ptr => block_ptr % next
+       end do !block_ptr
+     else  ! config_init_vertical_grid_type == 'z-level'
+
+       block_ptr => domain % blocklist
+       do while(associated(block_ptr))
+
+         call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
+         call mpas_pool_get_subpool(block_ptr % structs, 'verticalMesh', verticalMeshPool)
+
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+         call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
+         call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+
+         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+         do iCell = 1, nCells
+           ! alter pbcs
+           call ocn_alter_bottomDepth_for_pbcs(bottomDepth(iCell), refBottomDepth, maxLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_bottomDepth_for_pbcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! alter ptcs
+           call ocn_alter_ssh_for_ptcs(ssh(iCell), refBottomDepth, minLevelCell(iCell), iErr)
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_alter_ssh_for_ptcs failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! layerThickness is z-level
+           call ocn_compute_z_level_layerThickness(layerThickness(:,iCell), refBottomDepth, ssh(iCell), &
+                                                   bottomDepth(iCell), minLevelCell(iCell),             &
+                                                   maxLevelCell(iCell), nVertLevels, iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_z_level_layerThickness failed.', MPAS_LOG_CRIT)
+             return
+           end if
+
+           ! restingThickness is the same as layerThickness
+           restingThickness(:,iCell) = layerThickness(:,iCell)
+
+           ! compute zMid
+           call ocn_compute_zMid_from_layerThickness(zMid(:,iCell), layerThickness(:,iCell), ssh(iCell),    &
+                                                     minLevelCell(iCell), maxLevelCell(iCell), nVertLevels, &
+                                                     iErr)
+
+           if(iErr .ne. 0) then
+             call mpas_log_write( 'ocn_compute_zMid_from_layerThickness failed.', MPAS_LOG_CRIT)
              return
            end if
          end do !iCell

--- a/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_vertical_grids.F
@@ -863,7 +863,7 @@ contains
 
      logical :: useZStar, useZLevel
 
-     real (kind=RKIND) :: depth
+     real (kind=RKIND) :: depth, layerStretch
 
    !--------------------------------------------------------------------
 
@@ -1024,8 +1024,15 @@ contains
              return
            end if
 
-           ! restingThickness is the same as layerThickness
-           restingThickness(:,iCell) = layerThickness(:,iCell)
+           ! cases with SSH > 0 require a resting thickness that is stretched to compensate for the SSH
+           restingThickness(:, iCell) = 0.0_RKIND
+
+           if (maxLevelCell(iCell)  > 0) then
+             layerStretch = (ssh(iCell) + bottomDepth(iCell))/bottomDepth(iCell)
+             do k = minLevelCell(iCell), maxLevelCell(iCell)
+               restingThickness(k, iCell) = layerThickness(k, iCell)/layerStretch
+             end do
+           end if
 
            ! compute zMid
            call ocn_compute_zMid_from_layerThickness(zMid(:,iCell), layerThickness(:,iCell), ssh(iCell),    &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -978,7 +978,7 @@ contains
           sumSurfaceLayer=0.0_RKIND
           tracersSurfaceLayerValue(:,iCell) = 0.0_RKIND
           indexSurfaceLayerDepth(iCell) = -9.e30
-          do k=1,maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
            sumSurfaceLayer = sumSurfaceLayer + layerThickness(k,iCell)
            rSurfaceLayer = maxLevelCell(iCell)
            if(sumSurfaceLayer.gt.surfaceLayerDepth) then
@@ -1015,8 +1015,8 @@ contains
           cell2=cellsOnEdge(2,iEdge)
           surfaceLayerDepth = config_cvmix_kpp_surface_layer_averaging
           sumSurfaceLayer=0.0_RKIND
-          rSurfaceLayer = min(1, maxLevelEdgeTop(iEdge))
-          do k=1,maxLevelEdgeTop(iEdge)
+          rSurfaceLayer = min(minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge))
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
            rSurfaceLayer = k
            sumSurfaceLayer = sumSurfaceLayer + layerThicknessEdge(k,iEdge)
            if(sumSurfaceLayer.gt.surfaceLayerDepth) then
@@ -1026,10 +1026,10 @@ contains
            endif
           end do
           normalVelocitySurfaceLayer(iEdge) = 0.0_RKIND
-          do k=1,int(rSurfaceLayer)
+          do k = minLevelEdgeBot(iEdge),int(rSurfaceLayer)
             normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + normalVelocity(k,iEdge) &
                                               * layerThicknessEdge(k,iEdge)
-          enddo
+          end do
           k=int(rSurfaceLayer)+1
           if(k.le.maxLevelEdgeTop(iEdge)) then
             normalVelocitySurfaceLayer(iEdge) = (normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1142,7 +1142,7 @@ contains
         do i = 1, nEdgesOnCell(iCell)
           j = kiteIndexOnCell(i, iCell)
           iVertex = verticesOnCell(i, iCell)
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             relativeVorticityCell(k, iCell) = relativeVorticityCell(k, iCell) + kiteAreasOnVertex(j, iVertex) &
                                             * relativeVorticity(k, iVertex) * invAreaCell1
           end do
@@ -1175,7 +1175,7 @@ contains
             edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
             dcEdge_temp = dcEdge(iEdge)
             dvEdge_temp = dvEdge(iEdge)
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
 
                divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
@@ -1194,7 +1194,7 @@ contains
          end do
          ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
          vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-         do k=maxLevelCell(iCell),1,-1
+         do k = maxLevelCell(iCell), 1, -1
             vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
             vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
@@ -1214,7 +1214,7 @@ contains
          do i = 1, nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(i,iEdge)
             weightsOnEdge_temp = weightsOnEdge(i, iEdge)
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) &
                                               + weightsOnEdge_temp * normalVelocity(k, eoe)
             end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2397,19 +2397,19 @@ contains
 
          ! Check for errors in the state fields
          do iCell = 1, nCellsSolve
-            do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                thickNanFound = thickNanFound .or. ( .not. layerThickness(k, iCell) == layerThickness(k, iCell) )
                do iTracer = 1, size(activeTracers, dim=1)
                   tracersNanFound = tracersNanFound .or. &
                                   ( .not. activeTracers(iTracer, k, iCell) == activeTracers(iTracer, k, iCell) )
                end do
-            end do !mlc-end-do
+            end do
          end do
 
          do iEdge = 1, nEdgesSolve
-            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge) !mlc-do-k
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
                velNanFound = velNanFound .or. ( .not. normalVelocity(k, iEdge) == normalVelocity(k, iEdge) )
-            end do !mlc-end-do
+            end do
          end do
 
          ! If an error was found, we need to open the file to write data out.

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1367,7 +1367,7 @@ contains
          zMid(k:nVertLevels,iCell) = -bottomDepth(iCell) + 0.5_RKIND*layerThickness(k,iCell)
          zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
 
-         do k = maxLevelCell(iCell)-1, 1, -1
+         do k = maxLevelCell(iCell)-1, minLevelCell(iCell), -1
             zMid(k,iCell) = zMid(k+1,iCell)  &
               + 0.5_RKIND*(  layerThickness(k+1,iCell) &
                            + layerThickness(k  ,iCell))
@@ -1376,7 +1376,7 @@ contains
          end do
 
          ! copy zTop(1,iCell) into sea-surface height array
-         ssh(iCell) = zTop(1,iCell)
+         ssh(iCell) = zTop(minLevelCell(iCell),iCell)
 
       end do
       !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2147,11 +2147,11 @@ contains
          cell2 = cellsOnEdge(2, iEdge)
 
          ! top drag tau = - CD*|u|*u, where |u| = sqrt(2*KE) = sqrt(KE1 + KE2) from the neighboring cells
-         velocityMagnitude = sqrt(kineticEnergyCell(1,cell1) + kineticEnergyCell(1,cell2))
+         velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell1),cell2))
          landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
          topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &
-                          * velocityMagnitude * normalVelocity(1,iEdge)
+                          * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
       end do
       !$omp end do
@@ -2161,11 +2161,12 @@ contains
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
-                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(1,iCell)
+                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
 
          ! the friction velocity is the square root of the top drag + variance of tidal velocity
          ! (computed regardless of land-ice coverage)
-         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * (2.0_RKIND * kineticEnergyCell(1,iCell) &
+         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * &
+                                   (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
                                    + config_land_ice_flux_rms_tidal_velocity**2))
       end do
       !$omp end do
@@ -2176,7 +2177,7 @@ contains
          blThickness = 0.0_RKIND
          blTempScratch(iCell) = 0.0_RKIND
          blSaltScratch(iCell) = 0.0_RKIND
-         do iLevel = 1, maxLevelCell(iCell)
+         do iLevel = minLevelCell(iCell), maxLevelCell(iCell)
             dz = min(layerThickness(iLevel,iCell),config_land_ice_flux_boundaryLayerThickness-blThickness)
             if(dz <= 0.0_RKIND) exit
             blTempScratch(iCell) = blTempScratch(iCell) + activeTracers(indexT, iLevel, iCell)*dz
@@ -2200,10 +2201,10 @@ contains
                cell2 = cellsOnCell(i,iCell)
 
                landIceBoundaryLayerTracers(indexBLT, iCell) = landIceBoundaryLayerTracers(indexBLT, iCell) &
-                 + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
                landIceBoundaryLayerTracers(indexBLS, iCell) = landIceBoundaryLayerTracers(indexBLS, iCell) &
-                 + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
-               weightSum = weightSum + cellMask(1,cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
+               weightSum = weightSum + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
             end do
             landIceBoundaryLayerTracers(:, iCell) = landIceBoundaryLayerTracers(:, iCell)/weightSum
          end if

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1795,7 +1795,7 @@ contains
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
-         do k = 1, maxLevelEdgeTop(iEdge)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
             normalVelocity(k,iEdge) = 0.0_RKIND
             do j = 1,nEdgesOnEdge(iEdge)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -337,7 +337,7 @@ contains
 
       integer :: iVertex, iEdge, i, k
       integer, pointer :: nEdges, nVertices, vertexDegree
-      integer, dimension(:), pointer :: maxLevelVertexBot
+      integer, dimension(:), pointer :: maxLevelVertexBot, minLevelVertexTop
       integer, dimension(:,:), pointer :: edgesOnVertex, edgeSignOnVertex
 
       real (kind=RKIND) :: invAreaTri1, r_tmp
@@ -349,6 +349,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
 
       call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
+      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', minLevelVertexTop)
       call mpas_pool_get_array(meshPool, 'edgesOnVertex', edgesOnVertex)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', edgeSignOnVertex)
 
@@ -365,7 +366,7 @@ contains
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
-            do k = 1, maxLevelVertexBot(iVertex)
+            do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
               r_tmp = dcEdge(iEdge) * normalVelocity(k, iEdge)
 
               circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1703,7 +1703,7 @@ contains
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
 
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                flux = layerThicknessEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
                     * invAreaCell
                div_hu(k,iCell) = div_hu(k,iCell) - flux
@@ -1736,7 +1736,7 @@ contains
       do iCell = 1,nCells
          vertAleTransportTop(1,iCell) = 0.0_RKIND
          vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
-         do k = maxLevelCell(iCell),2,-1
+         do k = maxLevelCell(iCell), minLevelCell(iCell)+1, -1
             vertAleTransportTop(k,iCell) = vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
               - (ALE_Thickness(k,iCell) - oldLayerThickness(k,iCell))/dt
          end do

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -250,13 +250,13 @@ contains
       !$omp parallel
       !$omp do schedule(runtime)
       do iCell = 1, nCells
-         tracersSurfaceValue(:, iCell) = activeTracers(:,1, iCell)
+         tracersSurfaceValue(:, iCell) = activeTracers(:, minLevelCell(iCell), iCell)
       end do
       !$omp end do
 
       !$omp do schedule(runtime)
       do iEdge = 1, nEdges
-         normalVelocitySurfaceLayer(iEdge) = normalVelocity(1, iEdge)
+         normalVelocitySurfaceLayer(iEdge) = normalVelocity(minLevelEdgeBot(iEdge), iEdge)
       end do
       !$omp end do
       !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -700,7 +700,7 @@ contains
         normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
         vertex1 = verticesOnEdge(1, iEdge)
         vertex2 = verticesOnEdge(2, iEdge)
-        do k = 1, maxLevelEdgeBot(iEdge)
+        do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
           normalizedRelativeVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedRelativeVorticityVertex(k, vertex1) &
                                                     + normalizedRelativeVorticityVertex(k, vertex2))
           normalizedPlanetaryVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedPlanetaryVorticityVertex(k, vertex1) &
@@ -721,7 +721,7 @@ contains
         do i = 1, nEdgesOnCell(iCell)
           j = kiteIndexOnCell(i, iCell)
           iVertex = verticesOnCell(i, iCell)
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             normalizedRelativeVorticityCell(k, iCell) = normalizedRelativeVorticityCell(k, iCell) &
               + kiteAreasOnVertex(j, iVertex) * normalizedRelativeVorticityVertex(k, iVertex) * invAreaCell1
           end do
@@ -753,7 +753,7 @@ contains
             invLength = 1.0_RKIND / dcEdge(iEdge)
             ! Compute gradient of PV in normal direction
             !   ( this computes the gradient for all edges bounding real cells )
-            do k=1,maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                vorticityGradientNormalComponent(k,iEdge) = &
                   (normalizedRelativeVorticityCell(k,cell2) - normalizedRelativeVorticityCell(k,cell1)) * invLength
             enddo
@@ -761,7 +761,7 @@ contains
             invLength = 1.0_RKIND / dvEdge(iEdge)
             ! Compute gradient of PV in the tangent direction
             !   ( this computes the gradient at all edges bounding real cells and distance-1 ghost cells )
-            do k = 1,maxLevelEdgeBot(iEdge)
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
               vorticityGradientTangentialComponent(k,iEdge) = &
                  (normalizedRelativeVorticityVertex(k,vertex2) - normalizedRelativeVorticityVertex(k,vertex1)) * invLength
             enddo
@@ -774,12 +774,12 @@ contains
          !
          !$omp do schedule(runtime) private(k)
          do iEdge = 1,nEdges
-            do k = 1,maxLevelEdgeBot(iEdge)
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
               normalizedRelativeVorticityEdge(k,iEdge) = normalizedRelativeVorticityEdge(k,iEdge) &
                 - config_apvm_scale_factor * dt * &
                     (  normalVelocity(k,iEdge)     * vorticityGradientNormalComponent(k,iEdge)      &
                      + tangentialVelocity(k,iEdge) * vorticityGradientTangentialComponent(k,iEdge) )
-            enddo
+            end do
          enddo
          !$omp end do
          !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2407,9 +2407,9 @@ contains
          end do
 
          do iEdge = 1, nEdgesSolve
-            do k = 1, maxLevelEdgeBot(iEdge)
+            do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge) !mlc-do-k
                velNanFound = velNanFound .or. ( .not. normalVelocity(k, iEdge) == normalVelocity(k, iEdge) )
-            end do
+            end do !mlc-end-do
          end do
 
          ! If an error was found, we need to open the file to write data out.

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -442,7 +442,7 @@ contains
           layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             ! central differenced
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
           end do
@@ -459,7 +459,7 @@ contains
               layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
               cell1 = cellsOnEdge(1,iEdge)
               cell2 = cellsOnEdge(2,iEdge)
-              do k = 1, maxLevelEdgeTop(iEdge)
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                 ! upwind
                 if (normalVelocity(k, iEdge) > 0.0_RKIND) then
                   layerThicknessEdge(k,iEdge) = layerThickness(k,cell1)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1461,7 +1461,7 @@ contains
            pTop(1) = 0.0_RKIND
            ! At top layer it is g*SSH, where SSH may be off by a
            ! constant (ie, bottomDepth can be relative to top or bottom)
-           montgomeryPotential(1,iCell) = gravity &
+           montgomeryPotential(minLevelCell(iCell),iCell) = gravity &
               * (bottomDepth(iCell) + sum(layerThickness(1:nVertLevels,iCell)))
 
            do k = 2, nVertLevels
@@ -1484,10 +1484,10 @@ contains
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCells
            ! Pressure for generalized coordinates.
-           pressure(1,iCell) = surfacePressure(iCell) &
-             + density(1,iCell)*gravity*0.5_RKIND*layerThickness(1,iCell)
+           pressure(minLevelCell(iCell),iCell) = surfacePressure(iCell) &
+             + density(minLevelCell(iCell),iCell)*gravity*0.5_RKIND*layerThickness(minLevelCell(iCell),iCell)
 
-           do k = 2, maxLevelCell(iCell)
+           do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
               pressure(k,iCell) = pressure(k-1,iCell)  &
                 + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
                                      + density(k  ,iCell)*layerThickness(k  ,iCell))

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -683,6 +683,7 @@ contains
                                     * kiteAreasOnVertex(i,iVertex)
             end do
             layerThicknessVertex = layerThicknessVertex * invAreaTri1
+            if (layerThicknessVertex == 0) cycle
 
             normalizedRelativeVorticityVertex(k,iVertex) = relativeVorticity(k,iVertex) / layerThicknessVertex
             normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1194,6 +1194,7 @@ contains
             end do
          end do
          ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+         vertVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
          vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
          do k = maxLevelCell(iCell), 1, -1
             vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -860,8 +860,8 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCellsAll
-         BruntVaisalaFreqTop(1,iCell) = 0.0_RKIND
-         do k = 2, maxLevelCell(iCell)
+         BruntVaisalaFreqTop(minLevelCell(iCell),iCell) = 0.0_RKIND
+         do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
             BruntVaisalaFreqTop(k,iCell) = coef * (displacedDensity(k-1,iCell) - density(k,iCell)) &
               / (zMid(k-1,iCell) - zMid(k,iCell))
           end do
@@ -878,7 +878,7 @@ contains
       !$omp do schedule(runtime) private(invAreaCell1, k, shearSquared, i, iEdge, delU2, shearMean)
       do iCell=1,nCells
          RiTopOfCell(:,iCell) = 100.0_RKIND
-         do k=2,maxLevelCell(iCell)
+         do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
            shearSquared = 0.0_RKIND
            do i = 1, nEdgesOnCell(iCell)
              iEdge = edgesOnCell(i, iCell)
@@ -890,7 +890,7 @@ contains
            shearMean = shearMean / (zMid(k-1,iCell) - zMid(k,iCell))
            RiTopOfCell(k,iCell) = BruntVaisalaFreqTop(k,iCell) / (shearMean**2 + 1.0e-10_RKIND)
           end do
-          RiTopOfCell(1,iCell) = RiTopOfCell(2,iCell)
+          RiTopOfCell(minLevelCell(iCell),iCell) = RiTopOfCell(minLevelCell(iCell)+1,iCell)
       end do
       !$omp end do
       !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2397,13 +2397,13 @@ contains
 
          ! Check for errors in the state fields
          do iCell = 1, nCellsSolve
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
                thickNanFound = thickNanFound .or. ( .not. layerThickness(k, iCell) == layerThickness(k, iCell) )
                do iTracer = 1, size(activeTracers, dim=1)
                   tracersNanFound = tracersNanFound .or. &
                                   ( .not. activeTracers(iTracer, k, iCell) == activeTracers(iTracer, k, iCell) )
                end do
-            end do
+            end do !mlc-end-do
          end do
 
          do iEdge = 1, nEdgesSolve

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2149,7 +2149,7 @@ contains
          cell2 = cellsOnEdge(2, iEdge)
 
          ! top drag tau = - CD*|u|*u, where |u| = sqrt(2*KE) = sqrt(KE1 + KE2) from the neighboring cells
-         velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell1),cell2))
+         velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell2),cell2))
          landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
          topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -140,7 +140,7 @@ contains
         do iCell = 1, nCells
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, sfcFlxAttCoeff(iCell))
-           do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
               zBot = zTop - layerThickness(k,iCell)
               transmissionCoeffBot = ocn_forcing_transmission(zBot, sfcFlxAttCoeff(iCell))
 
@@ -148,7 +148,7 @@ contains
 
               zTop = zBot
               transmissionCoeffTop = transmissionCoeffBot
-           end do !mlc-end-do
+           end do
         end do
 
 !  now do river runoff separately
@@ -156,7 +156,7 @@ contains
         do iCell = 1, nCells
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, surfaceFluxAttenuationCoefficientRunoff(iCell))
-           do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
               zBot = zTop - layerThickness(k,iCell)
               transmissionCoeffBot = ocn_forcing_transmission(zBot, surfaceFluxAttenuationCoefficientRunoff(iCell))
 
@@ -164,7 +164,7 @@ contains
 
               zTop = zBot
               transmissionCoeffTop = transmissionCoeffBot
-           end do !mlc-end-do
+           end do
         end do
 
     end subroutine ocn_forcing_build_fraction_absorbed_array!}}}

--- a/src/core_ocean/shared/mpas_ocn_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_forcing.F
@@ -115,7 +115,7 @@ contains
 
         integer :: iCell, k, timeLevel, nCells
 
-        integer, dimension(:), pointer :: maxLevelCell, nCellsArray
+        integer, dimension(:), pointer :: minLevelCell, maxLevelCell, nCellsArray
 
         err = 0
 
@@ -127,6 +127,7 @@ contains
 
         call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -139,7 +140,7 @@ contains
         do iCell = 1, nCells
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, sfcFlxAttCoeff(iCell))
-           do k = 1, maxLevelCell(iCell)
+           do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
               zBot = zTop - layerThickness(k,iCell)
               transmissionCoeffBot = ocn_forcing_transmission(zBot, sfcFlxAttCoeff(iCell))
 
@@ -147,7 +148,7 @@ contains
 
               zTop = zBot
               transmissionCoeffTop = transmissionCoeffBot
-           end do
+           end do !mlc-end-do
         end do
 
 !  now do river runoff separately
@@ -155,7 +156,7 @@ contains
         do iCell = 1, nCells
            zTop = 0.0_RKIND
            transmissionCoeffTop = ocn_forcing_transmission(zTop, surfaceFluxAttenuationCoefficientRunoff(iCell))
-           do k = 1, maxLevelCell(iCell)
+           do k = minLevelCell(iCell), maxLevelCell(iCell) !mlc-do-k
               zBot = zTop - layerThickness(k,iCell)
               transmissionCoeffBot = ocn_forcing_transmission(zBot, surfaceFluxAttenuationCoefficientRunoff(iCell))
 
@@ -163,7 +164,7 @@ contains
 
               zTop = zBot
               transmissionCoeffTop = transmissionCoeffBot
-           end do
+           end do !mlc-end-do
         end do
 
     end subroutine ocn_forcing_build_fraction_absorbed_array!}}}

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -683,8 +683,8 @@ end subroutine ocn_init_routines_compute_min_max_level!}}}
 
       if (.not. config_do_restart) then
          do iCell=1,nCells
-            boundaryLayerDepth(iCell) = layerThickness(1, iCell) * 0.5_RKIND
-            indMLD(iCell) = 1
+            boundaryLayerDepth(iCell) = layerThickness(minLevelCell(iCell), iCell) * 0.5_RKIND
+            indMLD(iCell) = minLevelCell(iCell)
          end do
       end if
 
@@ -700,6 +700,8 @@ end subroutine ocn_init_routines_compute_min_max_level!}}}
          normalVelocity(maxLevelEdgeTop(iEdge)+1:maxLevelEdgeBot(iEdge), iEdge) = 0.0_RKIND
 
          normalVelocity(maxLevelEdgeBot(iEdge)+1:nVertLevels,iEdge) = -1.0e34_RKIND
+         
+         normalVelocity(1:minLevelEdgeTop(iEdge)-1,iEdge) = -1.0e34_RKIND
       end do
 
       call mpas_pool_begin_iteration(tracersPool)
@@ -709,6 +711,7 @@ end subroutine ocn_init_routines_compute_min_max_level!}}}
             if ( associated(tracersGroup) ) then
                do iCell=1,nCells
                   tracersGroup(:, maxLevelCell(iCell)+1:nVertLevels,iCell) =  -1.0e34_RKIND
+                  tracersGroup(:, 1:minLevelCell(iCell)-1,iCell) =  -1.0e34_RKIND
                end do
             end if
          end if

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -145,15 +145,26 @@ subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
       call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
 
       ! minLevelEdgeTop is the minimum (shallowest) of the surrounding cells
+      ! if the water column is dry, set minLevelCell outside of bounds
+      
+      ! prevent dry cells from determining minimum
+      do iCell = 1, nCells+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
+      end do
       do iEdge = 1, nEdges
          minLevelEdgeTop(iEdge) = &
             min( minLevelCell(cellsOnEdge(1,iEdge)), &
                  minLevelCell(cellsOnEdge(2,iEdge)) )
       end do
+      ! set back to default
+      do iCell = 1, nCells+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
+      end do
 
       minLevelEdgeTop(nEdges+1) = 0
 
       ! minLevelEdgeBot is the maximum (deepest) of the surrounding cells
+      
       do iEdge = 1, nEdges
          minLevelEdgeBot(iEdge) = &
             max( minLevelCell(cellsOnEdge(1,iEdge)), &
@@ -175,6 +186,8 @@ subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
       minLevelVertexBot(nVertices+1) = 0
 
       ! minLevelVertexTop is the minimum (shallowest) of the surrounding cells
+      ! if the water column is dry, set minLevelCell outside of bounds
+      
       do iVertex = 1,nVertices
          minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
          do i = 2, vertexDegree

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -65,7 +65,7 @@ module ocn_init_routines
    !--------------------------------------------------------------------
 
    public :: &
-      ocn_init_routines_compute_max_level, &
+      ocn_init_routines_compute_min_max_level, &
       ocn_init_routines_compute_mesh_scaling, &
       ocn_init_routines_setup_sign_and_index_fields, &
       ocn_init_routines_vert_coord, &
@@ -84,7 +84,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_init_routines_compute_max_level
+!  routine ocn_init_routines_compute_min_max_level
 !
 !> \brief  initialize max level and boundary mask variables
 !> \author Doug Jacobsen, Mark Petersen, Todd Ringler
@@ -93,7 +93,7 @@ contains
 !>  This routine initializes max level and boundary mask variables
 !
 !-----------------------------------------------------------------------
-subroutine ocn_init_routines_compute_max_level(domain)!{{{
+subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
 ! Initialize maxLevel and boundary mesh variables.
 
    type (domain_type), intent(inout) :: domain
@@ -105,6 +105,8 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
    integer, pointer :: nCells, nEdges, nVertices, nVertLevels, vertexDegree
 
    integer, dimension(:), pointer :: &
+      minLevelCell, minLevelEdgeTop, minLevelEdgeBot, &
+      minLevelVertexTop, minLevelVertexBot, &
       maxLevelCell, maxLevelEdgeTop, maxLevelEdgeBot, &
       maxLevelVertexTop, maxLevelVertexBot
    integer, dimension(:,:), pointer :: &
@@ -117,10 +119,15 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', maxLevelVertexTop)
       call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', maxLevelVertexBot)
+      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', minLevelVertexTop)
+      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', minLevelVertexBot)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
       call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
@@ -136,6 +143,48 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
       call mpas_pool_get_dimension(meshPool, 'nVertices ', nVertices)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'vertexDegree', vertexDegree)
+
+      ! minLevelEdgeTop is the minimum (shallowest) of the surrounding cells
+      do iEdge = 1, nEdges
+         minLevelEdgeTop(iEdge) = &
+            min( minLevelCell(cellsOnEdge(1,iEdge)), &
+                 minLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+
+      minLevelEdgeTop(nEdges+1) = 0
+
+      ! minLevelEdgeBot is the maximum (deepest) of the surrounding cells
+      do iEdge = 1, nEdges
+         minLevelEdgeBot(iEdge) = &
+            max( minLevelCell(cellsOnEdge(1,iEdge)), &
+                 minLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+
+      minLevelEdgeBot(nEdges+1) = 0
+
+      ! minLevelVertexBot is the maximum (deepest) of the surrounding cells
+      do iVertex = 1,nVertices
+         minLevelVertexBot(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            minLevelVertexBot(iVertex) = &
+               max( minLevelVertexBot(iVertex), &
+                    minLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+
+      minLevelVertexBot(nVertices+1) = 0
+
+      ! minLevelVertexTop is the minimum (shallowest) of the surrounding cells
+      do iVertex = 1,nVertices
+         minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            minLevelVertexTop(iVertex) = &
+               min( minLevelVertexTop(iVertex), &
+                    minLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+
+      minLevelVertexTop(nVertices+1) = 0
 
       ! maxLevelEdgeTop is the minimum (shallowest) of the surrounding cells
       do iEdge = 1, nEdges
@@ -185,8 +234,8 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
 
 
       do iEdge = 1, nEdges
-         boundaryEdge(1:maxLevelEdgeTop(iEdge),iEdge)=0
-         edgeMask(1:maxLevelEdgeTop(iEdge),iEdge)=1
+         boundaryEdge(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge),iEdge)=0
+         edgeMask(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge),iEdge)=1
       end do
 
       !
@@ -211,7 +260,8 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
 
       do iCell = 1, nCells
          do k = 1, nVertLevels
-            if ( maxLevelCell(iCell) >= k ) then
+            if ( minLevelCell(iCell) <= k .and. &
+                 maxLevelCell(iCell) >= k ) then
                cellMask(k, iCell) = 1
             end if
          end do
@@ -219,7 +269,8 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
 
       do iVertex = 1, nVertices
          do k = 1, nVertLevels
-            if ( maxLevelVertexBot(iVertex) >= k ) then
+            if ( minLevelVertexTop(iVertex) <= k .and. &
+                 maxLevelVertexBot(iVertex) >= k ) then
                vertexMask(k, iVertex) = 1
             end if
          end do
@@ -231,7 +282,7 @@ subroutine ocn_init_routines_compute_max_level(domain)!{{{
    ! Note: We do not update halos on maxLevel* variables.  I want the
    ! outside edge of a halo to be zero on each processor.
 
-end subroutine ocn_init_routines_compute_max_level!}}}
+end subroutine ocn_init_routines_compute_min_max_level!}}}
 
 !***********************************************************************
 !
@@ -453,6 +504,7 @@ end subroutine ocn_init_routines_compute_max_level!}}}
          call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', refBottomDepthTopOfCell)
          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
          call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
          call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
@@ -502,24 +554,27 @@ end subroutine ocn_init_routines_compute_max_level!}}}
             consistentSSH = .true.
             if ( associated(landIceMask) ) then
               do iCell = 1,nCells
-                 if (landIceMask(iCell)==0.and.abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
+                 if (landIceMask(iCell)==0 .and. &
+                     abs(sum(layerThickness(minLevelCell(iCell):maxLevelCell(iCell),iCell))- &
+                     bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
                     call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
-                    call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
-                       intArgs=(/iCell, maxLevelCell(iCell) /), &
-                       realArgs=(/ bottomDepth(iCell),sum(layerThickness(1:maxLevelCell(iCell),iCell)) /) )
+                    call mpas_log_write(' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
+                       intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
+                       realArgs=(/ bottomDepth(iCell),sum(layerThickness(minLevelCell(iCell):maxLevelCell(iCell),iCell)) /) )
                  endif
                enddo
             else ! landIceMask not associated, so no ice shelves
               do iCell = 1,nCells
-                 if (abs(sum(layerThickness(1:maxLevelCell(iCell),iCell))-bottomDepth(iCell))>20.0_RKIND) then
+                 if (abs(sum(layerThickness(minLevelCell(iCell):maxLevelCell(iCell),iCell))- &
+                     bottomDepth(iCell))>20.0_RKIND) then
                     consistentSSH = .false.
                     call mpas_log_write(' Warning: Sea surface height is outside of acceptable physical range, i.e. abs(sum(h)-bottomDepth)>20m.', &
                        MPAS_LOG_ERR)
-                    call mpas_log_write(' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r, sum(h): $r', &
-                       intArgs=(/iCell, maxLevelCell(iCell) /), &
-                       realArgs=(/ bottomDepth(iCell),sum(layerThickness(1:maxLevelCell(iCell),iCell)) /) )
+                    call mpas_log_write(' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
+                       intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
+                       realArgs=(/ bottomDepth(iCell),sum(layerThickness(minLevelCell(iCell):maxLevelCell(iCell),iCell)) /) )
                  endif
                enddo
             endif

--- a/src/core_ocean/shared/mpas_ocn_init_routines.F
+++ b/src/core_ocean/shared/mpas_ocn_init_routines.F
@@ -156,15 +156,15 @@ subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
             min( minLevelCell(cellsOnEdge(1,iEdge)), &
                  minLevelCell(cellsOnEdge(2,iEdge)) )
       end do
-      ! set back to default
-      do iCell = 1, nCells+1
-         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
-      end do
 
       minLevelEdgeTop(nEdges+1) = 0
 
       ! minLevelEdgeBot is the maximum (deepest) of the surrounding cells
       
+      ! prevent dry cells from determining maximum
+      do iCell = 1, nCells+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
+      end do
       do iEdge = 1, nEdges
          minLevelEdgeBot(iEdge) = &
             max( minLevelCell(cellsOnEdge(1,iEdge)), &
@@ -188,6 +188,10 @@ subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
       ! minLevelVertexTop is the minimum (shallowest) of the surrounding cells
       ! if the water column is dry, set minLevelCell outside of bounds
       
+      ! prevent dry cells from determining minimum
+      do iCell = 1, nCells+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
+      end do
       do iVertex = 1,nVertices
          minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
          do i = 2, vertexDegree
@@ -199,6 +203,11 @@ subroutine ocn_init_routines_compute_min_max_level(domain)!{{{
 
       minLevelVertexTop(nVertices+1) = 0
 
+      ! if the water column is dry, set minLevelCell = 1
+      do iCell = 1, nCells+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1
+      end do
+      
       ! maxLevelEdgeTop is the minimum (shallowest) of the surrounding cells
       do iEdge = 1, nEdges
          maxLevelEdgeTop(iEdge) = &

--- a/src/core_ocean/shared/mpas_ocn_mesh.F
+++ b/src/core_ocean/shared/mpas_ocn_mesh.F
@@ -62,6 +62,11 @@ module ocn_mesh
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
       nEdgesOnCell, &! number of edges associated with each cell center
+      minLevelCell, &! max ocean level at bottom of cell
+      minLevelEdgeTop, &! max ocean level at top    of edge column
+      minLevelEdgeBot, &! max ocean level at bottom of edge column
+      minLevelVertexTop, &! max ocean level at top    of each vertex
+      minLevelVertexBot, &! max ocean level at bottom of each vertex
       maxLevelCell, &! max ocean level at bottom of cell
       maxLevelEdgeTop, &! max ocean level at top    of edge column
       maxLevelEdgeBot, &! max ocean level at bottom of edge column
@@ -307,6 +312,16 @@ contains
                                   nEdgesOnEdge)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', &
                                   nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', &
+                                  minLevelCell)
+         call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
+                                  minLevelEdgeTop)
+         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+                                  minLevelEdgeBot)
+         call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
+                                  minLevelVertexTop)
+         call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
+                                  minLevelVertexBot)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', &
                                   maxLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
@@ -519,6 +534,11 @@ contains
          !$acc                   nVerticesHalo,            &
          !$acc                   nEdgesOnEdge,             &
          !$acc                   nEdgesOnCell,             &
+         !$acc                   minLevelCell,             &
+         !$acc                   minLevelEdgeTop,          &
+         !$acc                   minLevelEdgeBot,          &
+         !$acc                   minLevelVertexTop,        &
+         !$acc                   minLevelVertexBot,        &
          !$acc                   maxLevelCell,             &
          !$acc                   maxLevelEdgeTop,          &
          !$acc                   maxLevelEdgeBot,          &
@@ -650,6 +670,11 @@ contains
       !$acc                  nVerticesHalo,     &
       !$acc                  nEdgesOnEdge,      &
       !$acc                  nEdgesOnCell,      &
+      !$acc                  minLevelCell,      &
+      !$acc                  minLevelEdgeTop,   &
+      !$acc                  minLevelEdgeBot,   &
+      !$acc                  minLevelVertexTop, &
+      !$acc                  minLevelVertexBot, &
       !$acc                  maxLevelCell,      &
       !$acc                  maxLevelEdgeTop,   &
       !$acc                  maxLevelEdgeBot,   &
@@ -739,6 +764,11 @@ contains
 
       nullify (nEdgesOnEdge, &
                nEdgesOnCell, &
+               minLevelCell, &
+               minLevelEdgeTop, &
+               minLevelEdgeBot, &
+               minLevelVertexTop, &
+               minLevelVertexBot, &
                maxLevelCell, &
                maxLevelEdgeTop, &
                maxLevelEdgeBot, &
@@ -1086,6 +1116,11 @@ contains
       !$acc               nVerticesHalo,            &
       !$acc               nEdgesOnEdge,             &
       !$acc               nEdgesOnCell,             &
+      !$acc               minLevelCell,             &
+      !$acc               minLevelEdgeTop,          &
+      !$acc               minLevelEdgeBot,          &
+      !$acc               minLevelVertexTop,        &
+      !$acc               minLevelVertexBot,        &
       !$acc               maxLevelCell,             &
       !$acc               maxLevelEdgeTop,          &
       !$acc               maxLevelEdgeBot,          &

--- a/src/core_ocean/shared/mpas_ocn_thick_ale.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_ale.F
@@ -109,10 +109,11 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iCell, k, i, kMax
+      integer :: iCell, k, i, kMax, kMin
       integer, pointer :: nVertLevels
       integer :: nCells
       integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell
       integer, dimension(:), pointer :: nCellsArray
 
       real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness, thicknessWithRemainder
@@ -131,6 +132,7 @@ contains
       call mpas_pool_get_package(ocnPackages, 'thicknessFilterActive', thicknessFilterActive)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
 
       call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
@@ -152,15 +154,16 @@ contains
          !$omp do schedule(runtime) private(kMax, thicknessSum, k)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
    
             thicknessSum = 1e-14_RKIND
-            do k = 1, kMax
+            do k = kMin, kMax
                thicknessSum = thicknessSum + vertCoordMovementWeights(k) * restingThickness(k, iCell)
             end do
    
             ! Note that restingThickness is nonzero, and remaining terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
-            do k = 1, kMax
+            do k = kMin, kMax
                ALE_thickness(k, iCell) = restingThickness(k, iCell) &
                   + ( SSH(iCell) * vertCoordMovementWeights(k) * restingThickness(k, iCell) ) &
                     / thicknessSum
@@ -174,13 +177,14 @@ contains
          !$omp do schedule(runtime) private(kMax, weightSum, k)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
    
             weightSum = 1e-14_RKIND
-            do k = 1, kMax
+            do k = kMin, kMax
                weightSum = weightSum + vertCoordMovementWeights(k) 
             end do
    
-            do k = 1, kMax
+            do k = kMin, kMax
                ! Using this, we must require that sum(restingThickness(k, iCell))
                ! summed over k is equal to bottomDepth.
                ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
@@ -199,10 +203,11 @@ contains
          !$omp do schedule(runtime) private(kMax)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
 
-            ALE_thickness(1:kMax, iCell) = &
-                ALE_thickness(1:kMax, iCell) &
-              + newHighFreqThickness(1:kMax,iCell)
+            ALE_thickness(kMin:kMax, iCell) = &
+                ALE_thickness(kMin:kMax, iCell) &
+              + newHighFreqThickness(kMin:kMax,iCell)
          enddo
          !$omp end do
          !$omp end parallel
@@ -219,11 +224,12 @@ contains
          !$omp         min_ALE_thickness_down, min_ALE_thickness_up)
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
+            kMin = minLevelCell(iCell)
 
             ! go down the column:
-            prelim_ALE_thickness(1:kMax) = ALE_thickness(1:kMax, iCell)
+            prelim_ALE_thickness(kMin:kMax) = ALE_thickness(kMin:kMax, iCell)
             remainder = 0.0_RKIND
-            do k = 1, kMax
+            do k = kMin, kMax
                newThickness = max( min(prelim_ALE_thickness(k) + remainder, &
                                       config_max_thickness_factor * restingThickness(k,iCell) ), &
                                   config_min_thickness)
@@ -233,18 +239,18 @@ contains
 
             ! go back up the column:
             min_ALE_thickness_up(kMax) = 0.0_RKIND
-            prelim_ALE_thickness(1:kMax) = prelim_ALE_thickness(1:kMax) + min_ALE_thickness_down(1:kMax)
-            do k = kMax-1, 1, -1
+            prelim_ALE_thickness(kMin:kMax) = prelim_ALE_thickness(kMin:kMax) + min_ALE_thickness_down(kMin:kMax)
+            do k = kMax-1, kMin, -1
                newThickness = max( min(prelim_ALE_thickness(k) + remainder, &
                                       config_max_thickness_factor * restingThickness(k,iCell) ), &
                                   config_min_thickness)
                min_ALE_thickness_up(k) = newThickness - prelim_ALE_thickness(k)
                remainder = remainder - min_ALE_thickness_up(k)
             end do
-            min_ALE_thickness_up(1) = min_ALE_thickness_up(1) + remainder
+            min_ALE_thickness_up(kMin) = min_ALE_thickness_up(kMin) + remainder
 
-            ALE_thickness(1:kMax, iCell) = ALE_thickness(1:kMax, iCell) + min_ALE_thickness_down(1:kMax) &
-                                         + min_ALE_thickness_up(1:kMax)
+            ALE_thickness(kMin:kMax, iCell) = ALE_thickness(kMin:kMax, iCell) + min_ALE_thickness_down(kMin:kMax) &
+                                         + min_ALE_thickness_up(kMin:kMax)
 
          enddo
          !$omp end do

--- a/src/core_ocean/shared/mpas_ocn_thick_hadv.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_hadv.F
@@ -114,7 +114,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, MaxLevelCell, nEdgesOnCell
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, MaxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: flux, invAreaCell, invAreaCell1, invAreaCell2
@@ -138,6 +138,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -155,7 +156,7 @@ contains
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThicknessEdge(k, iEdge)
             tend(k, iCell) = tend(k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell
           end do

--- a/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_surface_flux.F
@@ -118,7 +118,7 @@ contains
       integer :: iCell, k, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real (kind=RKIND) :: remainingFlux, remainingFluxRunoff
 
@@ -128,6 +128,7 @@ contains
 
       call mpas_timer_start("thick surface flux")
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
@@ -139,7 +140,7 @@ contains
       do iCell = 1, nCells
         remainingFlux = 1.0_RKIND
         remainingFluxRunoff = 1.0_RKIND
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           remainingFlux = remainingFlux - transmissionCoefficients(k, iCell)
           remainingFluxRunoff = remainingFluxRunoff - transmissionCoefficientsRunoff(k, iCell)
 

--- a/src/core_ocean/shared/mpas_ocn_thick_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_thick_vadv.F
@@ -110,7 +110,7 @@ contains
       integer :: iCell, k, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: MaxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       !-----------------------------------------------------------------
       !
@@ -126,6 +126,7 @@ contains
 
       call mpas_timer_start("thick vadv")
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
@@ -136,7 +137,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             tend(k,iCell) = tend(k,iCell) + vertAleTransportTop(k+1,iCell) - vertAleTransportTop(k,iCell)
          end do
       end do

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -102,7 +102,9 @@ module ocn_tracer_advection
          advCoefs, advCoefs3rd ! advection coefficients
 
       integer, dimension(:), pointer, contiguous :: &
+         minLevelCell,    &! index of min level at each cell
          maxLevelCell,    &! index of max level at each cell
+         minLevelEdgeBot, &! min level at edge with both cells active
          maxLevelEdgeTop, &! max level at edge with both cells active
          nAdvCellsForEdge  ! number of advective cells for each edge
       integer, dimension(:,:), pointer, contiguous :: &!
@@ -122,7 +124,9 @@ module ocn_tracer_advection
       ! extract pool variables
       call mpas_pool_get_array(meshPool, 'advCoefs', advCoefs)
       call mpas_pool_get_array(meshPool, 'advCoefs3rd', advCoefs3rd)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'highOrderAdvectionMask', &
                                           highOrderAdvectionMask)
@@ -139,7 +143,8 @@ module ocn_tracer_advection
                                              normalThicknessFlux, w, dt,       &
                                              advCoefs, advCoefs3rd,            &
                                              nAdvCellsForEdge, advCellsForEdge,&
-                                             maxLevelCell, maxLevelEdgeTop,    &
+                                             minLevelCell, maxLevelCell,       &
+                                             minLevelEdgeBot, maxLevelEdgeTop, &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
                                              computeBudgets)

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_mono.F
@@ -94,7 +94,8 @@ module ocn_tracer_advection_mono
                                              normalThicknessFlux, w, dt,       &
                                              advCoefs, advCoefs3rd,            &
                                              nAdvCellsForEdge, advCellsForEdge,&
-                                             maxLevelCell, maxLevelEdgeTop,    &
+                                             minLevelCell, maxLevelCell,       &
+                                             minLevelEdgeBot, maxLevelEdgeTop, &
                                              highOrderAdvectionMask,           &
                                              edgeSignOnCell, meshPool,         &
                                              computeBudgets)!{{{
@@ -125,7 +126,11 @@ module ocn_tracer_advection_mono
       integer, dimension(:,:), intent(in) :: &
          advCellsForEdge     !< [in] List of advection cells for each edge
       integer, dimension(:), intent(in) :: &
+         minLevelCell        !< [in] Index to min level at cell center
+      integer, dimension(:), intent(in) :: &
          maxLevelCell        !< [in] Index to max level at cell center
+      integer, dimension(:), intent(in) :: &
+         minLevelEdgeBot     !< [in] Indx min edge lvl with both non-land cells
       integer, dimension(:), intent(in) :: &
          maxLevelEdgeTop     !< [in] Indx max edge lvl with both non-land cells
       integer, dimension(:,:), intent(in) :: &
@@ -143,7 +148,7 @@ module ocn_tracer_advection_mono
          i, iCell, iEdge, &! horz indices
          cell1, cell2,    &! neighbor cell indices
          nCells, nEdges,  &! numbers of cells or edges
-         k,k2,kmax,       &! vert index variants
+         k,k2,kmin, kmax, &! vert index variants
          nVertLevels,     &! total num vertical levels
          iTracer,         &! tracer index
          numTracers        ! total number of tracers
@@ -226,24 +231,25 @@ module ocn_tracer_advection_mono
       ! See notes in commit 2cd4a89d.
 
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, kmax, k, i, iEdge, signedFactor)
+      !$omp do schedule(runtime) private(invAreaCell1, kmin, kmax, k, i, iEdge, signedFactor)
       do iCell = 1, nCells
         invAreaCell1 = dt/areaCell(iCell)
+        kmin = minLevelCell(iCell)
         kmax = maxLevelCell(iCell)
-        do k = 1, kmax
+        do k = kmin, kmax
           hProv(k, iCell) = layerThickness(k, iCell)
         end do
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i,iCell)
           signedFactor = invAreaCell1*dvEdge(iEdge)*edgeSignOnCell(i,iCell)
           ! Provisional layer thickness is after horizontal thickness flux only
-          do k = 1, kmax
+          do k = kmin, kmax
             hProv(k, iCell) = hProv(k, iCell) &
                             + signedFactor*normalThicknessFlux(k,iEdge)
           end do
         end do
         ! New layer thickness is after horizontal and vertical thickness flux
-        do k = 1, kmax
+        do k = kmin, kmax
           hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
           hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
                                          dt*w(k,iCell) + dt*w(k+1, iCell))
@@ -289,14 +295,16 @@ module ocn_tracer_advection_mono
         ! surrounding cells for later limiting.
 
         !$omp parallel
-        !$omp do schedule(runtime) private(k, i, cell2, kmax)
+        !$omp do schedule(runtime) private(k, i, cell2, kmin, kmax)
         do iCell = 1, nCells
-          do k=1, maxLevelCell(iCell)
+          do k=minLevelCell(iCell), maxLevelCell(iCell)
             tracerMin(k,iCell) = tracerCur(k,iCell)
             tracerMax(k,iCell) = tracerCur(k,iCell)
           end do
           do i = 1, nEdgesOnCell(iCell)
             cell2 = cellsOnCell(i,iCell)
+            kmin  = max(minLevelCell(iCell), &
+                        minLevelCell(cell2))
             kmax  = min(maxLevelCell(iCell), &
                         maxLevelCell(cell2))
             do k=1, kmax
@@ -337,7 +345,7 @@ module ocn_tracer_advection_mono
             iCell = advCellsForEdge(i,iEdge)
             coef1 = advCoefs       (i,iEdge)
             coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
               flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
                           wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
             end do ! k loop
@@ -351,7 +359,7 @@ module ocn_tracer_advection_mono
           ! Also compute low order upwind horizontal flux (monotonic and diffused)
           ! Remove low order flux from the high order flux
           ! Store left over high order flux in highOrderFlx array
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             tracerWeight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) &
                          * (dvEdge(iEdge) * 0.5_RKIND)                 &
                          * normalThicknessFlux(k, iEdge)
@@ -408,7 +416,7 @@ module ocn_tracer_advection_mono
             cell2 = cellsOnEdge(2,iEdge)
             signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
 
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               ! Here workTend is the advection tendency due to the
               ! upwind (low order) fluxes.
               workTend(k,iCell) = workTend(k,iCell) &
@@ -427,7 +435,7 @@ module ocn_tracer_advection_mono
           ! Computed using the bounds that were computed previously,
           ! and the bounds on the newly updated value
           ! Factors are placed in the flxIn and flxOut arrays
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             ! Here workTend is the upwind tendency
             tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
                              + dt*workTend(k,iCell)) * hProvInv(k,iCell)
@@ -460,7 +468,7 @@ module ocn_tracer_advection_mono
         do iEdge = 1, nEdges
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
                                     min(flxOut(k,cell1), flxIn (k,cell2)) &
                                   + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
@@ -485,7 +493,7 @@ module ocn_tracer_advection_mono
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             signedFactor = invAreaCell1 * edgeSignOnCell(i, iCell)
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               ! workTend on the RHS is the upwind tendency
               ! workTend on the LHS is the total horizontal advection tendency
               workTend(k,iCell) = workTend(k,iCell) &
@@ -493,7 +501,7 @@ module ocn_tracer_advection_mono
             end do
           end do
 
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             ! workTend on the RHS is the total horizontal advection tendency
             ! tracerCur on LHS is the  provisional tracer after horizontal fluxes only.
             tracerCur(k,iCell) = (tracerCur(k,iCell)*layerThickness(k,iCell) &
@@ -515,7 +523,7 @@ module ocn_tracer_advection_mono
            !$omp parallel
            !$omp do schedule(runtime) private(k)
            do iEdge = 1,nEdgesArray( 2 )
-           do k = 1,maxLevelEdgeTop(iEdge)
+           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
               ! Save u*h*T flux on edge for analysis. This variable will be
               ! divided by h at the end of the time step.
               activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
@@ -526,7 +534,7 @@ module ocn_tracer_advection_mono
 
            !$omp do schedule(runtime) private(k)
            do iCell = 1, nCellsArray( 1 )
-           do k = 1, maxLevelCell(iCell)
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
               activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
                                                      workTend(k,iCell)
            end do
@@ -543,7 +551,7 @@ module ocn_tracer_advection_mono
            !$omp parallel
            !$omp do schedule(runtime) private(k)
            do iCell = 1, nCells
-           do k = 1, maxLevelCell(iCell)
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
               if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
                  call mpas_log_write( &
                     'Horizontal minimum out of bounds on tracer: $i $r $r ', &
@@ -603,16 +611,17 @@ module ocn_tracer_advection_mono
 
         ! Determine bounds on tracerCur from neighbor values for limiting
         !$omp parallel
-        !$omp do schedule(runtime) private(kmax, k)
+        !$omp do schedule(runtime) private(kmin, kmax, k)
         do iCell = 1, nCells
+          kmin = minLevelCell(iCell)
           kmax = maxLevelCell(iCell)
 
           ! take care of top cell
-          tracerMax(1,iCell) = max(tracerCur(1,iCell), &
-                                   tracerCur(2,iCell))
-          tracerMin(1,iCell) = min(tracerCur(1,iCell), &
-                                   tracerCur(2,iCell))
-          do k=2,kmax-1
+          tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
+                                      tracerCur(2,iCell))
+          tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
+                                      tracerCur(2,iCell))
+          do k=kmin+1,kmax-1
             tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
                                      tracerCur(k  ,iCell), &
                                      tracerCur(k+1,iCell))
@@ -636,10 +645,11 @@ module ocn_tracer_advection_mono
         case (vertOrder4)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(kmax, k)
+          !$omp do schedule(runtime) private(kmin, kmax, k)
           do iCell = 1, nCells
+            kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
-            do k=3,kmax-1
+            do k=kmin+2,kmax-1
               highOrderFlx(k, iCell) = w(k,iCell)*( &
                   7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
                             (tracerCur(k+1,iCell) + tracerCur(k-2,iCell)))/ &
@@ -653,10 +663,11 @@ module ocn_tracer_advection_mono
         case (vertOrder3)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(kmax, k)
+          !$omp do schedule(runtime) private(kmin, kmax, k)
           do iCell = 1, nCells
+            kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
-            do k=3,kmax-1
+            do k=kmin+2,kmax-1
               highOrderFlx(k, iCell) = (w(k,iCell)* &
                    (7.0_RKIND*(tracerCur(k  ,iCell) + tracerCur(k-1,iCell)) - &
                               (tracerCur(k+1,iCell) + tracerCur(k-2,iCell))) - &
@@ -674,10 +685,11 @@ module ocn_tracer_advection_mono
        case (vertOrder2)
 
           !$omp parallel
-          !$omp do schedule(runtime) private(kmax, k, verticalWeightK, verticalWeightKm1)
+          !$omp do schedule(runtime) private(kmin, kmax, k, verticalWeightK, verticalWeightKm1)
           do iCell = 1, nCells
+            kmin = minLevelCell(iCell)
             kmax = maxLevelCell(iCell)
-            do k=3,kmax-1
+            do k=kmin+2,kmax-1
               verticalWeightK   = hProv(k-1,iCell) / &
                                  (hProv(k  ,iCell) + hProv(k-1,iCell))
               verticalWeightKm1 = hProv(k  ,iCell) / &
@@ -697,22 +709,24 @@ module ocn_tracer_advection_mono
         ! Remove low order flux from the high order flux.
         ! Store left over high order flux in highOrderFlx array.
         !$omp parallel
-        !$omp do schedule(runtime) private(kmax, verticalWeightK, verticalWeightKm1, k)
+        !$omp do schedule(runtime) private(kmin, kmax, verticalWeightK, verticalWeightKm1, k)
         do iCell = 1, nCells
+          kmin = minLevelCell(iCell)
           kmax = maxLevelCell(iCell)
           ! Next-to-top cell in column is second-order
-          highOrderFlx(1,iCell) = 0.0_RKIND
-          if (kmax > 1) then
-            verticalWeightK   = hProv(1,iCell) / &
-                               (hProv(2,iCell) + hProv(1, iCell))
-            verticalWeightKm1 = hProv(2,iCell) / &
-                               (hProv(2,iCell) + hProv(1, iCell))
-            highOrderFlx(2,iCell) = w(2,iCell)* &
-                               (verticalWeightK  *tracerCur(2,iCell) + &
-                                verticalWeightKm1*tracerCur(1,iCell))
+          highOrderFlx(kmin,iCell) = 0.0_RKIND
+          if (kmax > kmin) then
+            k = kmin+1
+            verticalWeightK   = hProv(k-1,iCell) / &
+                               (hProv(k  ,iCell) + hProv(k-1,iCell))
+            verticalWeightKm1 = hProv(k  ,iCell) / &
+                               (hProv(k  ,iCell) + hProv(k-1,iCell))
+            highOrderFlx(k,iCell) = w(k,iCell)* &
+                               (verticalWeightK  *tracerCur(k  ,iCell) + &
+                                verticalWeightKm1*tracerCur(k-1,iCell))
           end if
           ! Deepest vertical cell in column is second order
-          k = max(2,kmax)
+          k = max(kmin+1,kmax)
           verticalWeightK   = hProv(k-1,iCell) / &
                              (hProv(k  ,iCell) + hProv(k-1,iCell))
           verticalWeightKm1 = hProv(k  ,iCell) / &
@@ -723,8 +737,8 @@ module ocn_tracer_advection_mono
           highOrderFlx(k+1,iCell) = 0.0_RKIND
 
           ! Compute low order (upwind) flux and remove from high order
-          lowOrderFlx(1,iCell) = 0.0_RKIND
-          do k = 2, kmax
+          lowOrderFlx(kmin,iCell) = 0.0_RKIND
+          do k = kmin+1, kmax
             lowOrderFlx(k,iCell) = &
                 min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
                 max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
@@ -738,7 +752,7 @@ module ocn_tracer_advection_mono
           !          it is positive.
           ! flxOut contains the total remaining high order flux out of iCell
           !           it is negative
-          do k = 1, kmax
+          do k = kmin, kmax
             workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
                               - lowOrderFlx(k  ,iCell)
             flxIn (k, iCell) = max(0.0_RKIND, highOrderFlx(k+1, iCell)) &
@@ -766,7 +780,7 @@ module ocn_tracer_advection_mono
           ! and the bounds on the newly updated value
           ! Factors are placed in the flxIn and flxOut arrays
 
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             ! workTend on the RHS is the upwind tendency
             tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
                          + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
@@ -797,11 +811,12 @@ module ocn_tracer_advection_mono
         ! Accumulate the scaled high order vertical tendencies
         ! and the upwind tendencies
         !$omp parallel
-        !$omp do schedule(runtime) private(kmax, k, flux)
+        !$omp do schedule(runtime) private(kmin, kmax, k, flux)
         do iCell = 1, nCells
+          kmin = minLevelCell(iCell)
           kmax = maxLevelCell(iCell)
           ! rescale the high order vertical flux
-          do k = 2, kmax
+          do k = kmin+1, kmax
             flux =  highOrderFlx(k,iCell)
             highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
                                     min(flxOut(k  ,iCell), &
@@ -811,7 +826,7 @@ module ocn_tracer_advection_mono
                                         flxIn (k  ,iCell))
           end do ! k loop
 
-          do k = 1,kmax
+          do k = kmin,kmax
             ! workTend on the RHS is the upwind tendency
             ! workTend on the LHS is the total vertical advection tendency
             workTend(k, iCell) = workTend(k, iCell)       &
@@ -833,11 +848,11 @@ module ocn_tracer_advection_mono
            !$omp parallel
            !$omp do schedule(runtime) private(k)
            do iCell = 1, nCells
-              do k = 2, maxLevelCell(iCell)
+              do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
                  activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
                     lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
               end do
-              do k = 1, maxLevelCell(iCell)
+              do k = minLevelCell(iCell), maxLevelCell(iCell)
                  activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
                     workTend(k,iCell)
               end do
@@ -852,7 +867,7 @@ module ocn_tracer_advection_mono
           !$omp parallel
           !$omp do schedule(runtime) private(k, tracerNew)
           do iCell = 1, nCells
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
              ! workTend on the RHS is the total vertical advection tendency
              tracerNew = (tracerCur(k, iCell)*hProv(k, iCell) &
                           + dt*workTend(k, iCell))*hNewInv(k, iCell)

--- a/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -134,7 +134,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, edgeMask, &
+      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
       !$acc            sfcFlxAttCoeff, sfcStress, layerThickEdge, &
       !$acc            tend) &
       !$acc    private(k, kmax, cell1, cell2, zBot, zTop, &
@@ -157,7 +157,7 @@ contains
         transCoeffTop = 1.0_RKIND
         remainingStress = 1.0_RKIND
         kmax = maxLevelEdgeTop(iEdge)
-        do k = 1, kmax
+        do k = minLevelEdgeBot(iEdge), kmax
            zBot = zTop - layerThickEdge(k,iEdge)
            attDepth = max(zBot/attCoeff, maxAttDepth)
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -56,7 +56,7 @@ module ocn_vel_hadv_coriolis
                            ! use disabled since default is on
 
    logical :: &
-      usePlanetVorticity   ! multiplicative mask for including 
+      usePlanetVorticity   ! multiplicative mask for including
                            ! planetary vorticity term
 
 !***********************************************************************
@@ -70,8 +70,8 @@ contains
 !> \brief   Computes tendency term for horizontal advection and coriolis force
 !> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
 !> \date    September 2011
-!> \details This routine computes the horizontal advection and 
-!>          coriolis advection tendencies for momentum based on 
+!> \details This routine computes the horizontal advection and
+!>          coriolis advection tendencies for momentum based on
 !>          current state.
 !
 !-----------------------------------------------------------------------
@@ -187,7 +187,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
-      !$acc            maxLevelEdgeTop, qArr, tmpVorticity, &
+      !$acc            minLevelEdgeBot, maxLevelEdgeTop, qArr, tmpVorticity, &
       !$acc            normalVelocity, layerThickEdge) &
       !$acc    private(k, j, eoe, edgeWeight, avgVorticity)
 #else
@@ -205,7 +205,7 @@ contains
             eoe = edgesOnEdge(j, iEdge)
             edgeWeight = weightsOnEdge(j, iEdge)
 
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                avgVorticity = 0.5_RKIND* &
                               (tmpVorticity(k,iEdge) + &
                                tmpVorticity(k,eoe))
@@ -222,7 +222,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, edgeMask, &
+      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
       !$acc            dcEdge, tend, qArr, kineticEnergyCell) &
       !$acc    private(cell1, cell2, invLength, k)
 #else
@@ -234,7 +234,7 @@ contains
          cell2 = cellsOnEdge(2,iEdge)
          invLength = 1.0_RKIND / dcEdge(iEdge)
 
-         do k = 1, maxLevelEdgeTop(iEdge)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             tend(k,iEdge) = tend(k,iEdge) + &
                         edgeMask(k,iEdge)* (qArr(k,iEdge) - &
                            (kineticEnergyCell(k,cell2) &
@@ -298,19 +298,19 @@ contains
 
       case ('split_explicit')
          ! For split explicit, Coriolis tendency uses eta/h because
-         ! the Coriolis term is added separately to the momentum 
+         ! the Coriolis term is added separately to the momentum
          ! tendencies.
          usePlanetVorticity = .false.
 
       case ('unsplit_explicit')
          ! For unsplit explicit, Coriolis tendency uses eta/h because
-         ! the Coriolis term is added separately to the momentum 
+         ! the Coriolis term is added separately to the momentum
          ! tendencies.
          usePlanetVorticity = .false.
 
       case ('semi_implicit')
          ! For semi-implicit, Coriolis tendency uses eta/h because
-         ! the Coriolis term is added separately to the momentum 
+         ! the Coriolis term is added separately to the momentum
          ! tendencies.
          usePlanetVorticity = .false.
 

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del2.F
@@ -129,9 +129,9 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, verticesOnEdge, &
-      !$acc            edgeMask, dcEdge, dvEdge, meshScalingDel2, &
-      !$acc            div, relVort, tend) &
+      !$acc    present(cellsOnEdge, maxLevelEdgeTop, minLevelEdgeBot, &
+      !$acc            verticesOnEdge, edgeMask, dcEdge, dvEdge, &
+      !$acc            meshScalingDel2, div, relVort, tend) &
       !$acc    private(k, cell1, cell2, uDiff, vertex1, vertex2, &
       !$acc            dcEdgeInv, dvEdgeInv, visc2)
 #else
@@ -151,7 +151,7 @@ contains
 
          visc2 =  viscDel2*meshScalingDel2(iEdge)
 
-         do k = 1, maxLevelEdgeTop(iEdge)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
             ! Here -( relativeVorticity(k,vertex2) - 
             !         relativeVorticity(k,vertex1) ) / dvEdge(iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -58,8 +58,8 @@ module ocn_vel_pressure_grad
       pGradOff    ! flag for turning pressure gradient on/off
 
    integer :: &
-      pGradType   ! id for pressure radient method selected
- 
+      pGradType   ! id for pressure gradient method selected
+
    integer, parameter ::        &! ids for supported methods
       pGradTypeNone        = 0, &! none selected
       pGradTypeSSHgrad     = 1, &! ssh gradient
@@ -144,7 +144,7 @@ contains
       integer ::           &
          iEdge, iCell, k,  &! loop indices for edge, cell, vertical loops
          cell1, cell2,     &! neighbor cell indices across edge
-         kMax               ! deepest active layer
+         kMin, kMax         ! shallowest and deepest active layer
 
       real (kind=RKIND) :: &
          invdcEdge,        &! temporary for 1/dcEdge
@@ -181,21 +181,22 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
          !$acc            tend, edgeMask, ssh) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMax)
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(cell1, cell2, invdcEdge, k, kMax)
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
-            kMax  = maxLevelEdgeTop(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
+            kMax = maxLevelEdgeTop(iEdge)
 
-            do k=1,kMax
+            do k=kMin,kMax
                tend(k,iEdge) = tend(k,iEdge) - &
                                gravity*edgeMask(k,iEdge)*invdcEdge* &
                                (ssh(cell2) - ssh(cell1))
@@ -213,21 +214,22 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, zMid, &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, zMid, &
          !$acc            tend, edgeMask, pressure, density) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMax)
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(cell1, cell2, invdcEdge, k, kMax)
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
 
-            do k=1,kMax
+            do k=kMin,kMax
                tend(k,iEdge) = tend(k,iEdge) + &
                                edgeMask(k,iEdge)*invdcEdge*( &
                                - density0Inv*(pressure(k,cell2) - &
@@ -249,21 +251,22 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
          !$acc            tend, edgeMask, montgomeryPotential) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMax)
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(cell1, cell2, invdcEdge, k, kMax)
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
 
-            do k=1,kMax
+            do k=kMin,kMax
                tend(k,iEdge) = tend(k,iEdge) + &
                                edgeMask(k,iEdge)*invdcEdge* ( &
                                - (montgomeryPotential(k,cell2) - &
@@ -286,22 +289,23 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, dcEdge, maxLevelEdgeTop, &
+         !$acc    present(cellsOnEdge, dcEdge, minLevelEdgeBot, maxLevelEdgeTop, &
          !$acc            edgeMask, tend, montgomeryPotential, &
          !$acc            pressure, potentialDensity) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMax)
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(cell1, cell2, invdcEdge, k, kMax)
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
 
-            do k=1,kMax
+            do k=kMin,kMax
                tend(k,iEdge) = tend(k,iEdge) + &
                                edgeMask(k,iEdge)*invdcEdge*( &
                                - (montgomeryPotential(k,cell2) - &
@@ -324,30 +328,31 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
          !$acc            edgeMask, pressure, density, zMid, tend, &
          !$acc            JacobianDxDs) &
-         !$acc    private(cell1, cell2, invdcEdge, k, kMax, pGrad, &
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax, pGrad, &
          !$acc            Area, zStar, zC, zGamma, rhoL, rhoR)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(cell1, cell2, invdcEdge, k, kMax, pGrad, &
+         !$omp    private(cell1, cell2, invdcEdge, k, kMin, kMax, pGrad, &
          !$omp            Area, zStar, zC, zGamma, rhoL, rhoR)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
 
             ! Compute the density-Jacobian in common_level form.
-            ! See Shchepetkin and McWilliams (2003) Ocean Modeling, 
+            ! See Shchepetkin and McWilliams (2003) Ocean Modeling,
             !   sections 2-4
 
-            JacobianDxDs(1,iEdge) = 0.0_RKIND
+            JacobianDxDs(kMin,iEdge) = 0.0_RKIND
 
-            do k=2,kMax
+            do k=kMin+1,kMax
 
                ! eqn 2.7 in Shchepetkin and McWilliams (2003)
                ! Note delta x was removed.  It must be an error in the
@@ -379,9 +384,9 @@ contains
                JacobianDxDs(k,iEdge) = Area * (rhoL - rhoR)
             end do
 
-            ! In layer 1, use pressure for generalized coordinates
+            ! In the top layer, use pressure for generalized coordinates
             ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
-            k = 1
+            k = kMin
             pGrad = edgeMask(k,iEdge)*invdcEdge*( &
                     - density0Inv*(pressure(k,cell2) - &
                                    pressure(k,cell1)) &
@@ -391,7 +396,7 @@ contains
 
             tend(k,iEdge) = tend(k,iEdge) + pGrad
 
-            do k=2,kMax
+            do k=kMin+1,kMax
 
                ! note JacobianDxDs includes negative sign, so
                ! pGrad is - g/rho_0 dP/dx
@@ -420,32 +425,33 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, &
+         !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, dcEdge, &
          !$acc            zMid, tracers, edgeMask, pressure, &
          !$acc            density, tend, thermExpCoeff, &
          !$acc            salineContractCoeff, &
          !$acc            JacobianTz, JacobianSz, JacobianDxDs) &
-         !$acc    private(cell1, cell2, invdcEdge, k,kMax, alpha, beta,&
+         !$acc    private(cell1, cell2, invdcEdge, k, kMin, kMax, alpha, beta,&
          !$acc         TL, TR, SL, SR, Area, zStar, zC, zGamma, pGrad)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp private(cell1, cell2, invdcEdge, k, kMax, alpha, beta, &
+         !$omp private(cell1, cell2, invdcEdge, k, kMin, kMax, alpha, beta, &
          !$omp         TL, TR, SL, SR, Area, zStar, zC, zGamma, pGrad)
 #endif
          do iEdge=1,nEdgesOwned
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+            kMin = minLevelEdgeBot(iEdge)
             kMax = maxLevelEdgeTop(iEdge)
 
-            ! compute J(T,z) and J(S,z) 
+            ! compute J(T,z) and J(S,z)
             ! in Shchepetkin and McWilliams (2003) (7.16)
 
-            JacobianTz(1,iEdge) = 0.0_RKIND
-            JacobianSz(1,iEdge) = 0.0_RKIND
+            JacobianTz(kMin,iEdge) = 0.0_RKIND
+            JacobianSz(kMin,iEdge) = 0.0_RKIND
 
-            do k=2,kMax
+            do k=kMin+1,kMax
 
                ! eqn 2.7 in Shchepetkin and McWilliams (2003)
                ! Note delta x was removed.  It must be an error in the
@@ -487,10 +493,10 @@ contains
                JacobianSz(k,iEdge) = Area*(SL - SR)
             end do
 
-            ! In layer 1, use pressure for generalized coordinates
+            ! In top layer, use pressure for generalized coordinates
             ! pGrad = -1/density_0 (grad p_k + density g grad z_k^{mid})
 
-            k = 1
+            k = kMin
             pGrad = edgeMask(k,iEdge)*invdcEdge*( &
                     - density0Inv*(pressure(k,cell2) - &
                                    pressure(k,cell1)) &
@@ -500,7 +506,7 @@ contains
 
             tend(k,iEdge) = tend(k,iEdge) + pGrad
 
-            do k=2,kMax
+            do k=kMin+1,kMax
 
                ! Average alpha and beta over four data points of the Jacobian cell.
                ! Note that thermExpCoeff and salineContractCoeff include a 1/density factor,

--- a/src/core_ocean/shared/mpas_ocn_vel_vadv.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_vadv.F
@@ -103,13 +103,13 @@ contains
 
       integer ::       &
          iEdge, k,     &! loop indices for edge, vertical loops
-         kmax,         &! deepest active layer on edge
+         kmin, kmax,   &! shallowest and deepest active layer on edge
          cell1, cell2   ! neighbor cell indices across edge
 
       real (kind=RKIND) :: &
          wAvg           ! ALE transport velocity across top edge
 
-      real (kind=RKIND), dimension(:,:), allocatable :: & 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
          w_dudzTopEdge  ! w*du/dz at top of edge
 
       ! End preamble
@@ -129,22 +129,23 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, maxLevelEdgeTop, w_dudzTopEdge, &
+      !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, w_dudzTopEdge, &
       !$acc            vertAleTransportTop, normalVelocity, &
       !$acc            layerThickEdge) &
-      !$acc    private(cell1, cell2, k, kmax, wAvg)
+      !$acc    private(cell1, cell2, k, kmin, kmax, wAvg)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp    private(cell1, cell2, k, kmax, wAvg)
+      !$omp    private(cell1, cell2, k, kmin, kmax, wAvg)
 #endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
+         kmin  = minLevelEdgeBot(iEdge)
          kmax  = maxLevelEdgeTop(iEdge)
 
-         w_dudzTopEdge(1,iEdge) = 0.0_RKIND ! flux is zero at top
-         do k = 2,kmax
+         w_dudzTopEdge(kmin,iEdge) = 0.0_RKIND ! flux is zero at top
+         do k = kmin+1,kmax
 
             ! Average w from cell center to edge
             wAvg = 0.5_RKIND*(vertAleTransportTop(k,cell1) + &
@@ -167,14 +168,14 @@ contains
       ! Average w*du/dz from vertical interface to vertical middle of cell
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(maxLevelEdgeTop, tend, edgeMask, w_dudzTopEdge)&
+      !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, tend, edgeMask, w_dudzTopEdge)&
       !$acc    private(k)
 #else
       !$omp do schedule(runtime) &
       !$omp    private(k)
 #endif
       do iEdge = 1, nEdgesOwned
-      do k = 1, maxLevelEdgeTop(iEdge)
+      do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
          tend(k,iEdge) = tend(k,iEdge) - edgeMask(k,iEdge)* &
                          0.5_RKIND*(w_dudzTopEdge(k  ,iEdge) + &
                                     w_dudzTopEdge(k+1,iEdge))

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -1023,7 +1023,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
+      integer, dimension(:), pointer :: maxLevelCell, minLevelCell, maxLevelEdgeTop, minLevelEdgeTop
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       type (mpas_pool_iterator_type) :: groupItr
@@ -1048,7 +1048,9 @@ contains
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
@@ -1074,7 +1076,7 @@ contains
             vertViscTopOfEdge(:, iEdge) = 0.0_RKIND
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            do k=1,maxLevelEdgeTop(iEdge)
+            do k=minLevelEdgeTop(iEdge),maxLevelEdgeTop(iEdge)
                vertViscTopOfEdge(k,iEdge) = 0.5_RKIND*(vertViscTopOfCell(k,cell2)+vertViscTopOfCell(k,cell1))
             end do
          end do

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -398,11 +398,11 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer :: iEdge, k, cell1, cell2, N, Nsurf, nEdges
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop
+      integer, dimension(:), pointer :: maxLevelEdgeTop, minLevelEdgeBot
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -416,17 +416,18 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
       nEdges = nEdgesArray( 1 )
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
-      A(1)=0.0_RKIND
 
       !$omp parallel
       !$omp do schedule(runtime) private(N, cell1, cell2, A, B, C, velTemp, k)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
+        Nsurf = minLevelEdgeBot(iEdge)
         if (N .gt. 0) then
 
          ! Compute A(k), B(k), C(k)
@@ -434,27 +435,30 @@ contains
          ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = 1, N
+         do k = Nsurf, N
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
          end do
 
          ! A is lower diagonal term
-         do k = 2, N
+         A(1:Nsurf)=0.0_RKIND
+         do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
                / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! C is upper diagonal term
-         do k = 1, N-1
+         C(1:Nsurf-1)=0.0_RKIND
+         do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
                / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! B is diagonal term
-         B(1) = 1.0_RKIND - C(1)
-         do k = 2, N-1
+         B(1:Nsurf-1)=0.0_RKIND
+         B(Nsurf) = 1.0_RKIND - C(Nsurf)
+         do k = Nsurf+1, N-1
             B(k) = 1.0_RKIND - A(k) - C(k)
          enddo
 
@@ -463,9 +467,10 @@ contains
          B(N) = 1.0_RKIND - A(N) + dt*implicitBottomDragCoef &
               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge)
 
-         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+         call tridiagonal_solve(A(Nsurf+1:N),B(Nsurf:N),C(Nsurf:N-1),normalVelocity(Nsurf:N,iEdge),velTemp(Nsurf:N),N-Nsurf+1)
 
-         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(1:Nsurf-1,iEdge) = 0.0_RKIND
+         normalVelocity(Nsurf:N,iEdge) = velTemp(Nsurf:N)
          normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
 
         end if

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -922,11 +922,11 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iCell, k, num_tracers, N, nCells
+      integer :: iCell, k, num_tracers, N, Nsurf, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: maxLevelCell, minLevelCell
 
       real (kind=RKIND), dimension(:), allocatable :: A,B,C
       real (kind=RKIND), dimension(:,:), allocatable :: tracersTemp, rhs
@@ -940,6 +940,7 @@ contains
       num_tracers = size(tracers, dim=1)
 
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),tracersTemp(num_tracers,nVertLevels))
       allocate(rhs(num_tracers,nVertLevels))
@@ -951,40 +952,42 @@ contains
       !$omp do schedule(runtime) private(N, A, B, C, rhs, tracersTemp, k)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
+         Nsurf = minLevelCell(iCell)
          N = maxLevelCell(iCell)
 
          ! A is lower diagonal term
-         A(1)=0.0_RKIND
-         do k = 2, N
+         A(Nsurf)=0.0_RKIND
+         do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertDiffTopOfCell(k,iCell) &
                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) / layerThickness(k,iCell)
          enddo
 
          ! C is upper diagonal term
-         do k = 1, N-1
+         do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertDiffTopOfCell(k+1,iCell) &
                  / (layerThickness(k,iCell) + layerThickness(k+1,iCell)) / layerThickness(k,iCell)
          enddo
          C(N) = 0.0_RKIND
 
          ! B is diagonal term
-         do k = 1, N
+         do k = Nsurf, N
             B(k) = 1.0_RKIND - A(k) - C(k)
          enddo
 
          if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
             call ocn_compute_kpp_rhs(tracers(:,:,iCell), rhs(:,:), dt, N, num_tracers, &
                              layerThickness(:,iCell), vertNonLocalFlux(:,:,iCell), &
-                             tracerGroupSurfaceFlux(:,iCell))
+                             tracerGroupSurfaceFlux(:,iCell)) !mlc-arguments may need to be changed
          else
             rhs(:,:) = tracers(:,:,iCell)
          endif
 
-         call tridiagonal_solve_mult(A(2:N), B, C(1:N-1), rhs(:,:), &
-              tracersTemp, N, nVertLevels, num_tracers)
+         call tridiagonal_solve_mult(A(Nsurf+1:N), B(Nsurf:N), C(Nsurf:N-1), rhs(:,Nsurf:N), &
+              tracersTemp(:,Nsurf:N), N, nVertLevels, num_tracers) !mlc-arguments need to be changed
 
-         tracers(:,1:N,iCell) = tracersTemp(:,1:N)
+         tracers(:,Nsurf:N,iCell) = tracersTemp(:,Nsurf:N)
          tracers(:,N+1:nVertLevels,iCell) = -1e34
+         tracers(:,1:Nsurf-1,iCell) = -1e34
       end do
       !$omp end do
       !$omp end parallel

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -983,7 +983,7 @@ contains
          endif
 
          call tridiagonal_solve_mult(A(Nsurf+1:N), B(Nsurf:N), C(Nsurf:N-1), rhs(:,Nsurf:N), &
-              tracersTemp(:,Nsurf:N), N, nVertLevels, num_tracers) !mlc-arguments need to be changed
+              tracersTemp(:,Nsurf:N), N-Nsurf+1, num_tracers)
 
          tracers(:,Nsurf:N,iCell) = tracersTemp(:,Nsurf:N)
          tracers(:,N+1:nVertLevels,iCell) = -1e34
@@ -1324,12 +1324,12 @@ contains
 !>  c sup-diagonal, filled from 1:n-1  (c(1) apears on row 1)
 !
 !-----------------------------------------------------------------------
-subroutine tridiagonal_solve_mult(a,b,c,r,x,n,nDim,nSystems)!{{{
+subroutine tridiagonal_solve_mult(a,b,c,r,x,n,nSystems)!{{{
 
-   integer,intent(in) :: n, nDim, nSystems
+   integer,intent(in) :: n, nSystems
    real (KIND=RKIND), dimension(n), intent(in) :: a,b,c
-   real (KIND=RKIND), dimension(nSystems,nDim), intent(in) :: r
-   real (KIND=RKIND), dimension(nSystems,nDim), intent(out) :: x
+   real (KIND=RKIND), dimension(nSystems,n), intent(in) :: r
+   real (KIND=RKIND), dimension(nSystems,n), intent(out) :: x
    real (KIND=RKIND), dimension(n) :: bTemp
    real (KIND=RKIND), dimension(nSystems,n) :: rTemp
    real (KIND=RKIND) :: m

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -137,7 +137,7 @@ contains
       type(cvmix_data_type) :: cvmix_variables
 
       integer, dimension(:), pointer :: &
-        maxLevelCell, nEdgesOnCell, maxLevelEdgeTop
+        maxLevelCell, minLevelCell, nEdgesOnCell, maxLevelEdgeTop, minLevelEdgeBot
 
       real (kind=RKIND), dimension(:), pointer :: &
         latCell, lonCell, bottomDepth, fCell, &
@@ -219,7 +219,9 @@ contains
       ! set pointers for fields related to vertical mesh
       !
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -324,10 +326,16 @@ contains
 
          ! fill vertical position of column
          ! CVMix assume top of ocean is at z=0, so building all z-coordinate data based on layerThickness
-         cvmix_variables % zw_iface(1) = 0.0_RKIND
-         cvmix_variables % dzw(1) = layerThickness(1,iCell)/2.0_RKIND
-         cvmix_variables % zt_cntr(1) = -layerThickness(1,iCell)/2.0_RKIND
-         do k=2,maxLevelCell(iCell)
+         do k = 1, minLevelCell(iCell) - 1
+            cvmix_variables % zw_iface(k) = 0.0_RKIND
+            cvmix_variables % zt_cntr(k) = 0.0_RKIND
+            cvmix_variables % dzw(k) = 0.0_RKIND
+            cvmix_variables % dzt(k) = 0.0_RKIND
+         enddo
+         cvmix_variables % zw_iface(minLevelCell(iCell)) = 0.0_RKIND
+         cvmix_variables % dzw(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+         cvmix_variables % zt_cntr(minLevelCell(iCell)) = -layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
+         do k=minLevelCell(iCell)+1,maxLevelCell(iCell)
             cvmix_variables % zw_iface(k) = cvmix_variables % zw_iface(k-1) - layerThickness(k-1,iCell)
             cvmix_variables % zt_cntr(k) = cvmix_variables %  zw_iface(k) - layerThickness(k,iCell)/2.0_RKIND
             cvmix_variables % dzw(k) = cvmix_variables % zt_cntr(k-1) - cvmix_variables % zt_cntr(k)
@@ -384,7 +392,9 @@ contains
          endif
 
          ! fill BVF
-         BVFSmoothed(1:maxLevelCell(iCell)) = max(0.0_RKIND,BruntVaisalaFreqTop(1:maxLevelCell(iCell),iCell))
+         BVFSmoothed(minLevelCell(iCell):maxLevelCell(iCell)) = max(0.0_RKIND, &
+                        BruntVaisalaFreqTop(minLevelCell(iCell):maxLevelCell(iCell),iCell))
+         BVFSmoothed(1:minLevelCell(iCell)-1) = max(0.0_RKIND,BVFSmoothed(minLevelCell(iCell)))
          BVFSmoothed(maxLevelCell(iCell)+1) = max(0.0_RKIND,BVFSmoothed(maxLevelCell(iCell)))
          cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed(1:maxLevelCell(iCell)+1)
 
@@ -435,9 +445,10 @@ contains
             else
 
               ! set stratification
-              do k=1,maxLevelCell(iCell)
+              do k=minLevelCell(iCell),maxLevelCell(iCell)
                   Nsqr_iface(k) = BVFSmoothed(k)
               enddo
+              Nsqr_iface(1:minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
               k=min(maxLevelCell(iCell)+1,nVertLevels)
               Nsqr_iface(k:maxLevelCell(iCell)+1) = Nsqr_iface(k-1)
 
@@ -463,11 +474,11 @@ contains
               ! assume boundary layer depth is at bottom of every kIndexOBL cell
               bulkRichardsonNumberStop = config_cvmix_kpp_stop_OBL_search * config_cvmix_kpp_criticalBulkRichardsonNumber
               bulkRichardsonFlag = .false.
-              topIndex = 1
+              topIndex = minLevelCell(iCell)
 !             call mpas_timer_start('Bulk Richardson kIndexOBL loops')
               ! compute the index of the last cell in the KPP defined surface layer
               ! this index is used for the necessary surface layer averages of buoyancy and momentum
-              do kIndexOBL = 1, maxLevelCell(iCell)
+              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
 
                  ! Reset deltaVelocitySquared and bulkRichardsonNumber at this layer for the later computation
                  deltaVelocitySquared(kIndexOBL) = 0.0_RKIND
@@ -481,7 +492,7 @@ contains
                  interfaceForcings(kIndexOBL) = cvmix_variables % SurfaceBuoyancyForcing
 
                  ! initialize the surfaceAverageIndex for cases when the if statement below is not true
-                 surfaceAverageIndex(kIndexOBL) = 1
+                 surfaceAverageIndex(kIndexOBL) = minLevelCell(iCell)
                  ! move progressively downward to find the bottom most layer within the surface layer
                  sfc_layer_depth = cvmix_variables % BoundaryLayerDepth * config_cvmix_kpp_surface_layer_extent
                  do kav=topIndex,kIndexOBL
@@ -506,18 +517,19 @@ contains
               do i = 1, nEdgesOnCell(iCell)
                  iEdge = edgesOnCell(i, iCell)
 
-                 deltaVelocitySquared(1) = 0.0_RKIND
+                 deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
 
-                 normalVelocitySum(1) = normalVelocity(1, iEdge)*layerThickEdge(1,iEdge)
-                 layerThicknessEdgeSum(1) = layerThickEdge(1,iEdge)
+                 normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
+                                                          layerThickEdge(minLevelCell(iCell),iEdge)
+                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdge(minLevelCell(iCell),iEdge)
 
-                 do kIndexOBL = 2, maxLevelCell(iCell)
+                 do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
                     normalVelocitySum(kIndexOBL) = normalVelocitySum(kIndexOBL-1) + &
                                       layerThickEdge(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
                     layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdge(kIndexOBL, iEdge)
                  end do
 
-                 do kIndexOBL = 1, maxLevelCell(iCell)
+                 do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
                     normalVelocityAv = normalVelocitySum(surfaceAverageIndex(kIndexOBL )) / &
                         layerThicknessEdgeSum(surfaceAverageIndex(kIndexOBL))
                     delU2 = ( normalVelocityAv - normalVelocity(kIndexOBL, iEdge) )**2
@@ -525,15 +537,16 @@ contains
                  end do
               end do
 
-              potentialDensitySum(1) = potentialDensity(1, iCell)*layerThickness(1, iCell)
-              layerThicknessSum(1) = layerThickness(1, iCell)
-              do kIndexOBL = 2, maxLevelCell(iCell)
+              potentialDensitySum(minLevelCell(iCell)) = potentialDensity(minLevelCell(iCell), iCell)* &
+                                                         layerThickness(minLevelCell(iCell), iCell)
+              layerThicknessSum(minLevelCell(iCell)) = layerThickness(minLevelCell(iCell), iCell)
+              do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
                 layerThicknessSum(kIndexOBL) = layerThicknessSum(kIndexOBL-1) + layerThickness(kIndexOBL, iCell)
                 potentialDensitySum(kIndexOBL) = potentialDensitySum(kIndexOBL-1) + &
                     layerThickness(kIndexOBL, iCell)*potentialDensity(kIndexOBL, iCell)
               end do
 
-              do kIndexOBL = 1, maxLevelCell(iCell)
+              do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)
                 ! !compute shear contribution assuming BLdepth is cell bottom
                 !Note that the factor of two is from averaging dot products to cell centers on a C-grid
                 bulkRichardsonNumberShear(kIndexOBL,iCell) = max(2.0_RKIND*deltaVelocitySquared(kIndexOBL), 1.0e-15_RKIND)
@@ -571,8 +584,8 @@ contains
              endif  ! if (config_use_cvmix_fixed_boundary_layer) then
 
              ! apply minimum limit to OBL
-             if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(1,iCell)/2.0_RKIND) then
-                cvmix_variables % BoundaryLayerDepth = layerThickness(1,iCell)/2.0_RKIND
+             if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND) then
+                cvmix_variables % BoundaryLayerDepth = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
                 cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
                           zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1),&
                           zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
@@ -611,7 +624,7 @@ contains
             end do
 
             !must reapply max and min limits to boundaryLayerDepth
-            blTemp = max(boundaryLayerDepth(iCell), layerThickness(1,iCell)/2.0_RKIND)
+            blTemp = max(boundaryLayerDepth(iCell), layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND)
             boundaryLayerDepth(iCell) = min(blTemp, abs(cvmix_variables%zt_cntr(maxLevelCell(iCell))))
 
             cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
@@ -686,7 +699,9 @@ contains
                   vertDiffTopOfCell(k,iCell) = vertDiffTopOfCell(k,iCell) + cvmix_variables % Tdiff_iface(k)
                enddo
             else
-               do k = 1, maxLevelCell(iCell) + 1
+               vertViscTopOfCell(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+               vertDiffTopOfCell(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+               do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
                   vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + cvmix_variables % Mdiff_iface(k)
                   vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + cvmix_variables % Tdiff_iface(k)
                end do
@@ -704,8 +719,8 @@ contains
 
          ! computation of viscosity/diffusivity complete
          ! impose no-flux boundary conditions at top and bottom by zero viscosity/diffusivity
-         vertViscTopOfCell(1, iCell) = 0.0_RKIND
-         vertDiffTopOfCell(1, iCell) = 0.0_RKIND
+         vertViscTopOfCell(1:minLevelCell(iCell), iCell) = 0.0_RKIND
+         vertDiffTopOfCell(1:minLevelCell(iCell), iCell) = 0.0_RKIND
          do k = maxLevelCell(iCell)+1, nVertLevelsP1
             vertViscTopOfCell(k, iCell)=0.0_RKIND
             vertDiffTopOfCell(k, iCell)=0.0_RKIND
@@ -730,10 +745,10 @@ contains
             do iEdge = 1,nEdges
                iNeighbor = cellsOnCell(iEdge,iCell)
                boundaryLayerDepthSmooth(iCell) = boundaryLayerDepthSmooth(iCell) +  &
-                             2.0_RKIND * cellMask(1,iNeighbor) * areaCell(iNeighbor)    &
+                             2.0_RKIND * cellMask(minLevelCell(iNeighbor),iNeighbor) * areaCell(iNeighbor)    &
                              * boundaryLayerDepth(iNeighbor)
-               areaSum = areaSum + 2.0_RKIND * areaCell(iNeighbor) * cellMask(1,iNeighbor)
-               edgeCount = edgeCount + cellMask(1,iNeighbor)
+               areaSum = areaSum + 2.0_RKIND * areaCell(iNeighbor) * cellMask(minLevelCell(iNeighbor),iNeighbor)
+               edgeCount = edgeCount + cellMask(minLevelCell(iNeighbor),iNeighbor)
             end do
             areaSum = areaSum + edgeCount * areaCell(iCell)
             boundaryLayerDepthSmooth(iCell) = boundaryLayerDepthSmooth(iCell) +   &


### PR DESCRIPTION
Inactive top cells are introduced to add flexibility to the vertical coordinate below ice shelves. 

This PR introduces phase 1 in the development documented in https://github.com/MPAS-Dev/MPAS-Model/pull/811, which touches only the code needed to run a basic ice shelf test case.

The variable `minLevelCell` and related `minLevelEdge*` and `minLevelVertex*` variables are introduced by analogy with `maxLevel*` variables. By default, there are no inactive top cells and `minLevel*` = 1. The main code changes are to k-loop limits and designating surface quantities as those at `minLevel*`. 