### PR TITLE
Bugfix for calculating moist air density in init_atm_core

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4758,7 +4758,8 @@ call mpas_log_write('Done with soil consistency check')
             t(k,iCell) = t(k,iCell) * (p0 / pressure(k,iCell)) ** (rgas / cp)
 
             ! RHO_ZZ
-            rho_zz(k,iCell) = pressure(k,iCell) / rgas / (p(k,iCell) * t(k,iCell))
+            rho_zz(k,iCell) = pressure(k,iCell) / rgas / (p(k,iCell) * t(k,iCell) &
+                              * (1.0 + (rvord - 1.0) * scalars(index_qv,k,iCell)))
             rho_zz(k,iCell) = rho_zz(k,iCell) / (1.0 + scalars(index_qv,k,iCell))
          end do
       end do


### PR DESCRIPTION
This is a one line bug fix, part of MPAS-JEDI modifications documented in this issue https://github.com/MPAS-Dev/MPAS-Model/issues/789.

When calculating moist air density, should use virtual temperature instead of temperature.
```
Tv = T*(1+0.608*qv)
```