### PR TITLE
Landice/specified calving velocity

### DIFF
--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -227,6 +227,11 @@ module li_calving
          call von_Mises_calving(domain, err_tmp)
          err = ior(err, err_tmp)
 
+      elseif (trim(config_calving) == 'specified_calving_velocity') then
+
+         call specified_calving_velocity(domain, err_tmp)
+         err = ior(err, err_tmp)
+
       else
 
          call mpas_log_write("Invalid option for config_calving specified: " // trim(config_calving), MPAS_LOG_ERR)


### PR DESCRIPTION
This adds a missing call to the subroutine specified_calving_velocity from li_calve_ice in mpas_li_calving.F. Previously, if config_calving = 'specified_calving_velocity' in namelist.landice, that routine was not called and an error would result.