### PR TITLE
Seaice threading bugfix

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -2312,7 +2312,8 @@ contains
        abortMessage = ""
 
        !$omp parallel do default(shared) private(iCategory,iBioTracers,iBioData,&
-       !$omp&   abortMessage) firstprivate(newlyFormedIceLogical,oceanBioConcentrationsUsed) &
+       !$omp&   totalCarbonInitial,abortMessage,oceanBioFluxesTemp,totalCarbonFinal,&
+       !$omp&   carbonError) firstprivate(newlyFormedIceLogical,oceanBioConcentrationsUsed) &
        !$omp&   reduction(.or.:abortFlag)
        do iCell = 1, nCellsSolve
 


### PR DESCRIPTION
This PR fixes a bug in the OpenMP directives for a single loop in `core_seaice/shared/mpas_seaice_column.F` that caused failures in a few E3SM tests that included BGC and more than 1 thread.