### PR TITLE
 Add freshwater temperature flux field to pass to the atm

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -3091,6 +3091,22 @@
 			 description="Short wave flux at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;ecosysTracersPKG"
 		/>
+		<var name="rainTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Heat flux associated with rain at cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="evapTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Heat flux associated with Evaporation at cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="seaIceFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Heat flux associated with sea ice melt water at cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="icebergFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Heat flux associated with iceberg melt at cell centers sent to coupler. Positive into the ocean."
+		/>
+
+		<var name="totalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
 
 
 		<!-- Coupling fields associated with mass or salinity fluxes -->
@@ -3183,6 +3199,9 @@
 		<var name="filteredSSHGradientMeridional" type="real" dimensions="nCells Time" units="m m^{-1}"
 			description="Time filtered meridional gradient of SSH"
 			packages="forwardMode;analysisMode"
+		/>
+		<var name="avgTotalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="degC m s^{-1}"
+			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 
 		<!-- Input fields from coupler or initial condition for forcing under land ice -->

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1907,8 +1907,8 @@ contains
 
       ! real pointers
       real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
-           surfaceThicknessFluxRunoff, rainFlux, evaporationFlux, &
-           icebergFreshWaterFlux, seaIceFreshWaterFlux
+           surfaceThicknessFluxRunoff, rainTemperatureFlux, evapTemperatureFlux, &
+           icebergFreshWaterTemperatureFlux, seaIceFreshWaterTemperatureFlux
 
       real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
       real (kind=RKIND), dimension(:,:), pointer ::  &
@@ -1967,10 +1967,10 @@ contains
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
       call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
-      call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
-      call mpas_pool_get_array(forcingPool, 'evaporationFlux', evaporationFlux)
-      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
-      call mpas_pool_get_array(forcingPool, 'icebergFreshWaterFlux', icebergFreshWaterFlux)
+      call mpas_pool_get_array(forcingPool, 'rainTemperatureFlux', rainTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'evapTemperatureFlux', evapTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterTemperatureFlux', seaIceFreshWaterTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergFreshWaterTemperatureFlux', icebergFreshWaterTemperatureFlux)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
       call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
@@ -2023,11 +2023,9 @@ contains
 
          nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = activeTracersSurfaceFlux(indexTempFlux,iCell) &
                  + penetrativeTemperatureFlux(iCell) - penetrativeTemperatureFluxOBL(iCell)  &
-                 - fracAbsorbed * (rainFlux(iCell) + evaporationFlux(iCell)) * activeTracers(indexTempFlux,1,iCell)/rho_sw &
-                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell)* min(activeTracers(indexTempFlux,1,iCell),0.0_RKIND)/rho_sw &
-                 - fracAbsorbed * (seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell)) * &
-                 ocn_freezing_temperature( activeTracers(indexSaltFlux, 1, iCell), pressure=0.0_RKIND, inLandIceCavity=.false.)&
-                  / rho_sw
+                 - fracAbsorbed * (rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
+                                   seaIceFreshWaterTemperatureFlux(iCell) + icebergFreshWaterTemperatureFlux(iCell)) &
+                 - fracAbsorbedRunoff * activeTracersSurfaceFluxRunoff(indexTempFlux, iCell)
 
          nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = activeTracersSurfaceFlux(indexSaltFlux,iCell) &
                  - fracAbsorbed * surfaceThicknessFlux(iCell) * activeTracers(indexSaltFlux,1,iCell) &

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -462,6 +462,9 @@ contains
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, seaIceSalinityFlux, iceRunoffFlux
       real (kind=RKIND), dimension(:), pointer :: shortWaveHeatFlux, penetrativeTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: snowFlux, rainFlux
+      real (kind=RKIND), dimension(:), pointer :: rainTemperatureFlux, evapTemperatureFlux, &
+                                                  seaIceFreshWaterTemperatureFlux, icebergFreshWaterTemperatureFlux, &
+                                                  totalFreshWaterTemperatureFlux
       real (kind=RKIND) :: requiredSalt, allowedSalt
 
       err = 0
@@ -490,6 +493,12 @@ contains
       call mpas_pool_get_array(forcingPool, 'iceRunoffFlux', iceRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'riverRunoffFlux', riverRunoffFlux)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
+
+      call mpas_pool_get_array(forcingPool, 'rainTemperatureFlux', rainTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'evapTemperatureFlux', evapTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterTemperatureFlux', seaIceFreshWaterTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergFreshWaterTemperatureFlux', icebergFreshWaterTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'totalFreshWaterTemperatureFlux', totalFreshWaterTemperatureFlux)
 
       nCells = nCellsArray( 3 )
 
@@ -537,18 +546,26 @@ contains
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature
-           tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
-                      + (rainFlux(iCell) + evaporationFlux(iCell)) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           rainTemperatureFlux(iCell) = rainFlux(iCell) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           evapTemperatureFlux(iCell) = evaporationFlux(iCell) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
                       * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
 
            ! Accumulate fluxes that use the freezing point
+           seaIceFreshWaterTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
+               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, &
+                                         inLandIceCavity=.false.) / rho_sw
+           icebergFreshWaterTemperatureFlux(iCell) = icebergFreshWaterFlux(iCell) * &
+               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, &
+                                         inLandIceCavity=.false.) / rho_sw
+
+           totalFreshWaterTemperatureFlux(iCell) = rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
+                                                   seaIceFreshWaterTemperatureFlux(iCell) + icebergFreshWaterFlux(iCell)
+
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
-               + (seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell)) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, inLandIceCavity=.false.)&
-               / rho_sw
+              + totalFreshWaterTemperatureFlux(iCell)
 
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux

--- a/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
+++ b/src/core_ocean/shared/mpas_ocn_time_average_coupled.F
@@ -53,7 +53,7 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, avgSSHGradient, &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
 
-        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce
+        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux
 
         integer :: iCell
         integer, pointer :: nAccumulatedCoupled, nCells
@@ -86,6 +86,7 @@ module ocn_time_average_coupled
         call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
+        call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
 
         !$omp parallel
         !$omp do schedule(runtime)
@@ -93,6 +94,7 @@ module ocn_time_average_coupled
            avgSurfaceVelocity(:, iCell) = 0.0_RKIND
            avgTracersSurfaceValue(:, iCell) = 0.0_RKIND
            avgSSHGradient(:, iCell) = 0.0_RKIND
+           avgTotalFreshWaterTemperatureFlux(iCell) = 0.0_RKIND
         end do
         !$omp end do
         !$omp end parallel
@@ -207,7 +209,8 @@ module ocn_time_average_coupled
         integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled, nCells
         real (kind=RKIND), dimension(:,:), pointer :: &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
-        real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce
+        real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
+                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux
 
         type (mpas_pool_type), pointer :: tracersPool
 
@@ -241,6 +244,9 @@ module ocn_time_average_coupled
         call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
         call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
 
+        call mpas_pool_get_array(forcingPool, 'totalFreshWaterTemperatureFlux', totalFreshWaterTemperatureFlux)
+        call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
+
         call mpas_pool_get_dimension(forcingPool, 'nCells', nCells)
         call mpas_pool_get_dimension(forcingPool, 'index_avgTemperatureSurfaceValue', index_temperature)
         call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_SSHzonal)
@@ -262,6 +268,9 @@ module ocn_time_average_coupled
                                                  + gradSSHMeridional(iCell) ) / ( nAccumulatedCoupled + 1 )
            avgSurfaceVelocity(:, iCell) = ( avgSurfaceVelocity(:, iCell) * nAccumulatedCoupled + surfaceVelocity(:, iCell) ) &
                                         / ( nAccumulatedCoupled + 1 )
+           avgTotalFreshWaterTemperatureFlux(iCell) = ( avgTotalFreshWaterTemperatureFlux(iCell) * nAccumulatedCoupled &
+                                               + totalFreshWaterTemperatureFlux(iCell) ) / ( nAccumulatedCoupled + 1 )
+
         end do
         !$omp end do
         !$omp end parallel


### PR DESCRIPTION
Adds the calculation of a freshwater temperature flux, with the intention of passing it through the coupler to the atm. This is to help track some terms missing from the heat budget, due to water coming in to the ocean with a specific temperature that the rest of the system does not know about.

[non-BFB] due to some order of operations changes

