### PR TITLE
Enhance inactive top cells feature

### DIFF
--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -242,7 +242,7 @@ module ocn_time_integration_rk4
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+            do k = 1, maxLevelEdgeTop(iEdge)
                normalVelocityNew(k, iEdge) = normalVelocityCur(k, iEdge)
             end do
          end do
@@ -250,7 +250,7 @@ module ocn_time_integration_rk4
 
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
+            do k = 1, maxLevelCell(iCell)
                layerThicknessNew(k, iCell) = layerThicknessCur(k, iCell)
             end do
          end do
@@ -269,7 +269,7 @@ module ocn_time_integration_rk4
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells  ! couple tracers to thickness
-                     do k = minLevelCell(iCell), maxLevelCell(iCell)
+                     do k = 1, maxLevelCell(iCell)
                         tracersNew(:, k, iCell) = tracersCur(:, k, iCell) * layerThicknessCur(k, iCell)
                      end do
                   end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -141,7 +141,7 @@ module ocn_time_integration_rk4
       ! Diagnostics Indices
 
       ! Mesh array pointers
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, maxLevelEdgeTop
       real (kind=RKIND), dimension(:), pointer :: bottomDepth
 
       ! Provis Array Pointers
@@ -234,10 +234,11 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceCur, 1)
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceNew, 2)
 
-         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+
+         ! Lower k-loop limit of 1 rather than minLevel* needed in *New = *Cur
+         ! assignments below are needed to maintain bit-for-bit results
 
          !$omp parallel
          !$omp do schedule(runtime) private(k)
@@ -622,6 +623,8 @@ module ocn_time_integration_rk4
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
@@ -721,8 +724,8 @@ module ocn_time_integration_rk4
          !$omp parallel
          !$omp do schedule(runtime) 
          do iCell = 1, nCells
-            surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(minLevelEdgeBot(iEdge), iCell)
-            surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(minLevelEdgeBot(iEdge), iCell)
+            surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(minLevelCell(iCell), iCell)
+            surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(minLevelCell(iCell), iCell)
 
             SSHGradient(indexSSHGradientZonal, iCell) = gradSSHZonal(iCell)
             SSHGradient(indexSSHGradientMeridional, iCell) = gradSSHMeridional(iCell)
@@ -1033,7 +1036,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupCur, tracersGroupProvis, tracersGroupTend
 
-      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, maxLevelEdgeTop
 
       logical, pointer :: config_use_tracerGroup
       type (mpas_pool_iterator_type) :: groupItr
@@ -1075,7 +1078,6 @@ module ocn_time_integration_rk4
 
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
       !$omp parallel

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1081,7 +1081,7 @@ module ocn_time_integration_rk4
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
-         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+         do k = 1, maxLevelEdgeTop(iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkSubstepWeight &
                                            * normalVelocityTend(k, iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
@@ -1091,7 +1091,7 @@ module ocn_time_integration_rk4
 
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-         do k = minLevelCell(iCell), maxLevelCell(iCell)
+         do k = 1, maxLevelCell(iCell)
             layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkSubstepWeight &
                                            * layerThicknessTend(k, iCell)
          end do
@@ -1115,7 +1115,7 @@ module ocn_time_integration_rk4
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
-                     do k = minLevelCell(iCell), maxLevelCell(iCell)
+                     do k = 1, maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
                                                  + rkSubstepWeight * tracersGroupTend(:, k, iCell) &
                                                    ) / layerThicknessProvis(k, iCell)

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -141,7 +141,7 @@ module ocn_time_integration_rk4
       ! Diagnostics Indices
 
       ! Mesh array pointers
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop
       real (kind=RKIND), dimension(:), pointer :: bottomDepth
 
       ! Provis Array Pointers
@@ -234,13 +234,15 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceCur, 1)
          call mpas_pool_get_array(statePool, 'lowFreqDivergence', lowFreqDivergenceNew, 2)
 
+         call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+         call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k, iEdge) = normalVelocityCur(k, iEdge)
             end do
          end do
@@ -248,7 +250,7 @@ module ocn_time_integration_rk4
 
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                layerThicknessNew(k, iCell) = layerThicknessCur(k, iCell)
             end do
          end do
@@ -267,7 +269,7 @@ module ocn_time_integration_rk4
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells  ! couple tracers to thickness
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
                         tracersNew(:, k, iCell) = tracersCur(:, k, iCell) * layerThicknessCur(k, iCell)
                      end do
                   end do
@@ -658,12 +660,12 @@ module ocn_time_integration_rk4
              if (tidalInputMask(iCell) == 1.0_RKIND) then
                ! compute total depth for relative thickness contribution
                totalDepth = 0.0_RKIND
-               do k = 1, maxLevelCell(iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
                  totalDepth = totalDepth + restingThickness(k,iCell)
                end do
 
                ! only modify layer thicknesses on tidal boundary
-               do k = 1, maxLevelCell(iCell)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
                  layerThicknessNew(k, iCell) = tidalInputMask(iCell)*(tidalBCValue(iCell) + bottomDepth(iCell))*(restingThickness(k,iCell)/totalDepth)
                  !(1.0_RKIND - tidalInputMask(iCell))*layerThicknessNew(k, iCell)  ! generalized tappered assumption code
                end do
@@ -719,8 +721,8 @@ module ocn_time_integration_rk4
          !$omp parallel
          !$omp do schedule(runtime) 
          do iCell = 1, nCells
-            surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(1, iCell)
-            surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(1, iCell)
+            surfaceVelocity(indexSurfaceVelocityZonal, iCell) = velocityZonal(minLevelEdgeBot(iEdge), iCell)
+            surfaceVelocity(indexSurfaceVelocityMeridional, iCell) = velocityMeridional(minLevelEdgeBot(iEdge), iCell)
 
             SSHGradient(indexSSHGradientZonal, iCell) = gradSSHZonal(iCell)
             SSHGradient(indexSSHGradientMeridional, iCell) = gradSSHMeridional(iCell)
@@ -1031,7 +1033,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupCur, tracersGroupProvis, tracersGroupTend
 
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop
 
       logical, pointer :: config_use_tracerGroup
       type (mpas_pool_iterator_type) :: groupItr
@@ -1071,13 +1073,15 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(tendPool, 'layerThickness', layerThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
-         do k = 1, maxLevelEdgeTop(iEdge)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityCur(k, iEdge) + rkSubstepWeight &
                                            * normalVelocityTend(k, iEdge)
             normalVelocityProvis(k, iEdge) = normalVelocityProvis(k, iEdge) * (1.0_RKIND - wettingVelocity(k, iEdge))
@@ -1087,7 +1091,7 @@ module ocn_time_integration_rk4
 
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             layerThicknessProvis(k, iCell) = layerThicknessCur(k, iCell) + rkSubstepWeight &
                                            * layerThicknessTend(k, iCell)
          end do
@@ -1111,7 +1115,7 @@ module ocn_time_integration_rk4
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
                         tracersGroupProvis(:, k, iCell) = ( layerThicknessCur(k, iCell) * tracersGroupCur(:, k, iCell)  &
                                                  + rkSubstepWeight * tracersGroupTend(:, k, iCell) &
                                                    ) / layerThicknessProvis(k, iCell)
@@ -1208,7 +1212,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew, tracersGroupTend
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       logical, pointer :: config_use_tracerGroup
       type (mpas_pool_iterator_type) :: groupItr
@@ -1243,12 +1247,13 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             layerThicknessNew(k, iCell) = layerThicknessNew(k, iCell) + rkWeight * layerThicknessTend(k, iCell)
          end do
       end do
@@ -1277,7 +1282,7 @@ module ocn_time_integration_rk4
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
                         tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) + rkWeight &
                                                 * tracersGroupTend(:, k, iCell)
                      end do
@@ -1326,7 +1331,7 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessNew, normalVelocityNew
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       logical, pointer :: config_use_tracerGroup
       type (mpas_pool_iterator_type) :: groupItr
@@ -1355,6 +1360,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       call mpas_pool_begin_iteration(tracersPool)
@@ -1365,7 +1371,7 @@ module ocn_time_integration_rk4
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells
-                 do k = 1, maxLevelCell(iCell)
+                 do k = minLevelCell(iCell), maxLevelCell(iCell)
                    tracersGroupNew(:, k, iCell) = tracersGroupNew(:, k, iCell) / layerThicknessNew(k, iCell)
                  end do
                end do

--- a/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
+++ b/src/core_ocean/mode_forward/mpas_ocn_time_integration_si.F
@@ -157,7 +157,7 @@ module ocn_time_integration_si
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       ! Mesh array pointers
-      integer, dimension(:), pointer :: maxLevelCell, maxLevelEdgeTop, nEdgesOnEdge, nEdgesOnCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnEdge, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgeMask, edgesOnEdge
       integer, dimension(:,:), pointer :: edgesOnCell, edgeSignOnCell
 
@@ -492,6 +492,7 @@ module ocn_time_integration_si
                call mpas_pool_get_subpool(tendPool, 'tracersTend', tracersTendPool)
 
                call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+               call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
                call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
                call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
@@ -518,7 +519,7 @@ module ocn_time_integration_si
                   cell2 = cellsOnEdge(2,iEdge)
 
                   uTemp = 0.0_RKIND  ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-                  do k = 1, maxLevelEdgeTop(iEdge)
+                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
                      ! normalBaroclinicVelocityNew = normalBaroclinicVelocityOld + dt*(-f*normalBaroclinicVelocityPerp
                      !                             + T(u*,w*,p*) + g*grad(SSH*) )
@@ -533,17 +534,17 @@ module ocn_time_integration_si
                   ! thicknessSum is initialized outside the loop because on land boundaries
                   ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
                   ! nonzero value to avoid a NaN.
-                  normalThicknessFluxSum = layerThickEdge(1,iEdge) * uTemp(1)
-                  thicknessSum  = layerThickEdge(1,iEdge)
+                  normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) * uTemp(minLevelEdgeBot(iEdge))
+                  thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
 
-                  do k = 2, maxLevelEdgeTop(iEdge)
+                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                      normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * uTemp(k)
                      thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
                   enddo
                   barotropicForcing(iEdge) = split * normalThicknessFluxSum / thicknessSum / dt
 
 
-                  do k = 1, maxLevelEdgeTop(iEdge)
+                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                      ! These two steps are together here:
                      !{\bf u}'_{k,n+1} = {\bf u}'_{k,n} - \Delta t {\overline {\bf G}}
                      !{\bf u}'_{k,n+1/2} = \frac{1}{2}\left({\bf u}^{'}_{k,n} +{\bf u}'_{k,n+1}\right)
@@ -2436,6 +2437,7 @@ module ocn_time_integration_si
             call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocityNew, 2)
             call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocityNew, 2)
 
+            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
             call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
             call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
 
@@ -2469,10 +2471,10 @@ module ocn_time_integration_si
                ! thicknessSum is initialized outside the loop because on land boundaries
                ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
                ! nonzero value to avoid a NaN.
-               normalThicknessFluxSum = layerThickEdge(1,iEdge) * uTemp(1)
-               thicknessSum  = layerThickEdge(1,iEdge)
+               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) * uTemp(minLevelEdgeBot(iEdge))
+               thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
 
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * uTemp(k)
                   thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
                enddo
@@ -2617,8 +2619,10 @@ module ocn_time_integration_si
             call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
             call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
+            call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
             call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
             call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
             call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
             call mpas_pool_get_array(tracersPool, 'activeTracers', tracersGroupCur, 1)
@@ -2664,7 +2668,7 @@ module ocn_time_integration_si
                !$omp do schedule(runtime) private(k, temp_h, temp, i)
                do iCell = 1, nCells
                   ! sshNew is a pointer, defined above.
-                  do k = 1, maxLevelCell(iCell)
+                  do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                      ! this is h_{n+1}
                      temp_h = layerThicknessCur(k,iCell) + dt * layerThicknessTend(k,iCell)
@@ -2689,7 +2693,7 @@ module ocn_time_integration_si
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, temp)
                   do iCell = 1, nCells
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                         ! h^{hf}_{n+1} was computed in Stage 1
 
@@ -2741,7 +2745,7 @@ module ocn_time_integration_si
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iCell = 1, nCells
-                  do k = 1, maxLevelCell(iCell)
+                  do k = minLevelCell(iCell), maxLevelCell(iCell)
                      ! this is h_{n+1}
                      layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell) + dt * layerThicknessTend(k,iCell)
                   end do
@@ -2753,7 +2757,7 @@ module ocn_time_integration_si
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iEdge = 1, nEdges
-                     do k= 1, maxLevelEdgeTop(iEdge)
+                     do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                         activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
                           activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
                           layerThickEdge(k,iEdge)
@@ -2763,7 +2767,7 @@ module ocn_time_integration_si
 
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
-                     do k= 1, maxLevelCell(iCell)
+                     do k= minLevelCell(iCell), maxLevelCell(iCell)
                         activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
                            activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
                            layerThicknessNew(k,iCell)
@@ -2805,7 +2809,7 @@ module ocn_time_integration_si
                         !$omp parallel
                         !$omp do schedule(runtime) private(k)
                         do iCell = 1, nCells
-                           do k = 1, maxLevelCell(iCell)
+                           do k = minLevelCell(iCell), maxLevelCell(iCell)
                               tracersGroupNew(:,k,iCell) = (tracersGroupCur(:,k,iCell) * layerThicknessCur(k,iCell) + dt &
                                                          * tracersGroupTend(:,k,iCell) ) / layerThicknessNew(k,iCell)
                            end do
@@ -2818,7 +2822,7 @@ module ocn_time_integration_si
                            !$omp parallel
                            !$omp do schedule(runtime) private(k)
                            do iCell = 1, nCells
-                              do k = 1, maxLevelCell(iCell)
+                              do k = minLevelCell(iCell), maxLevelCell(iCell)
                                  tracersGroupNew(indexSalinity,k,iCell) = max(0.001_RKIND, tracersGroupNew(indexSalinity,k,iCell))
                               end do
                            end do
@@ -2834,7 +2838,7 @@ module ocn_time_integration_si
                   !$omp parallel
                   !$omp do schedule(runtime) private(k)
                   do iCell = 1, nCells
-                     do k = 1, maxLevelCell(iCell)
+                     do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                         ! h^{hf}_{n+1} was computed in Stage 1
 
@@ -2859,7 +2863,7 @@ module ocn_time_integration_si
                !$omp parallel
                !$omp do schedule(runtime) private(k)
                do iEdge = 1, nEdges
-                  do k = 1, maxLevelEdgeTop(iEdge)
+                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                      normalVelocityNew(k,iEdge) = normalBarotropicVelocityNew(iEdge) + 2 * normalBaroclinicVelocityNew(k,iEdge) &
                                                 - normalBaroclinicVelocityCur(k,iEdge)
                   end do
@@ -3071,7 +3075,7 @@ module ocn_time_integration_si
       type (dm_info) :: dminfo
 
       integer :: iTracer, cell, cell1, cell2
-      integer, dimension(:), pointer :: maxLevelEdgeTop,maxLevelCell
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell
       integer, dimension(:,:), pointer :: cellsOnEdge
       real (kind=RKIND) :: normalThicknessFluxSum, layerThicknessSum, layerThickEdge1
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth, normalBarotropicVelocity
@@ -3140,7 +3144,9 @@ module ocn_time_integration_si
 
             call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
             call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+            call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
             call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+            call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
             call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
             call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
             call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
@@ -3167,11 +3173,11 @@ module ocn_time_integration_si
                   ! thicknessSum is initialized outside the loop because on land boundaries
                   ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
                   ! nonzero value to avoid a NaN.
-                  layerThickEdge1 = 0.5_RKIND*( layerThickness(1,cell1) + layerThickness(1,cell2) )
-                  normalThicknessFluxSum = layerThickEdge1 * normalVelocity(1,iEdge)
+                  layerThickEdge1 = 0.5_RKIND*( layerThickness(minLevelCell(cell1),cell1) + layerThickness(minLevelCell(cell2),cell2) )
+                  normalThicknessFluxSum = layerThickEdge1 * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
                   layerThicknessSum = layerThickEdge1
 
-                  do k=2, maxLevelEdgeTop(iEdge)
+                  do k=minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                      ! ocn_diagnostic_solve has not yet been called, so compute hEdge
                      ! just for this edge.
                      layerThickEdge1 = 0.5_RKIND*( layerThickness(k,cell1) + layerThickness(k,cell2) )
@@ -3184,7 +3190,7 @@ module ocn_time_integration_si
                   normalBarotropicVelocity(iEdge) = normalThicknessFluxSum / layerThicknessSum
 
                   ! normalBaroclinicVelocity(k,iEdge) = normalVelocity(k,iEdge) - normalBarotropicVelocity(iEdge)
-                  do k = 1, maxLevelEdgeTop(iEdge)
+                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                      normalBaroclinicVelocity(k,iEdge) = normalVelocity(k,iEdge) - normalBarotropicVelocity(iEdge)
                   enddo
 
@@ -3272,12 +3278,12 @@ module ocn_time_integration_si
                k = maxLevelCell(iCell)
                zTop(k:nVertLevels,iCell) = -bottomDepth(iCell) + layerThickness(k,iCell)
 
-               do k = maxLevelCell(iCell)-1, 1, -1
+               do k = maxLevelCell(iCell)-1, minLevelCell(iCell), -1
                   zTop(k,iCell) = zTop(k+1,iCell) + layerThickness(k  ,iCell)
                end do
 
                ! copy zTop(1,iCell) into sea-surface height array
-               sshCur(iCell) = zTop(1,iCell)
+               sshCur(iCell) = zTop(minLevelCell(iCell),iCell)
             end do
 
             tmp1 = minval(sshCur)

--- a/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
+++ b/src/core_ocean/mode_init/mpas_ocn_init_isomip_plus.F
@@ -104,7 +104,7 @@ contains
       integer, pointer :: nCells, nVertLevels
       integer, pointer :: index_temperature, index_salinity, index_tracer1
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real(kind=RKIND), dimension(:), pointer :: refBottomDepth, &
                                                  fCell, fEdge, fVertex, effectiveDensityInLandIce, xCell, &
@@ -186,6 +186,7 @@ contains
 
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
+        call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
         call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
         call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
@@ -194,7 +195,7 @@ contains
         call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
 
         do iCell = 1, nCells
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             frac = (0.0_RKIND-zMid(k, iCell))/(0.0_RKIND-config_isomip_plus_max_bottom_depth)
             activeTracers(index_temperature, k, iCell) = (1.0_RKIND - frac)*config_isomip_plus_init_top_temp &
                                                  + frac*config_isomip_plus_init_bot_temp

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1859,13 +1859,13 @@ contains
                                  tend_normalVelocity(maxLevelEdgeBot(iEdge),iEdge)
         thicknessSum  = layerThickEdge(maxLevelEdgeBot(iEdge),iEdge)
 
-        do k = maxLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+        do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
           normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * tend_normalVelocity(k,iEdge)
           thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
         enddo
 
         vertSum = normalThicknessFluxSum / thicknessSum
-        do k = maxLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+        do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
           tend_normalVelocity(k,iEdge) = tend_normalVelocity(k,iEdge) - vertSum
         enddo
       enddo ! iEdge

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2016,8 +2016,8 @@ contains
          !
 
          ! Compute fraction of thickness flux that is in the top model layer
-         fracAbsorbed = 1.0_RKIND - exp( max(-layerThickness(1, iCell) / config_flux_attenuation_coefficient, -100.0_RKIND) )
-         fracAbsorbedRunoff = 1.0_RKIND - exp( max(-layerThickness(1, iCell) / config_flux_attenuation_coefficient_runoff, &
+         fracAbsorbed = 1.0_RKIND - exp( max(-layerThickness(minLevelCell(iCell), iCell) / config_flux_attenuation_coefficient, -100.0_RKIND) )
+         fracAbsorbedRunoff = 1.0_RKIND - exp( max(-layerThickness(minLevelCell(iCell), iCell) / config_flux_attenuation_coefficient_runoff, &
                               -100.0_RKIND) )
          ! Store the total tracer flux below in nonLocalSurfaceTemperatureFlux for use in the CVMix nonlocal
          ! transport code.  This includes tracer forcing due to thickness
@@ -2029,12 +2029,12 @@ contains
                  - fracAbsorbedRunoff * activeTracersSurfaceFluxRunoff(indexTempFlux, iCell)
 
          nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = activeTracersSurfaceFlux(indexSaltFlux,iCell) &
-                 - fracAbsorbed * surfaceThicknessFlux(iCell) * activeTracers(indexSaltFlux,1,iCell) &
-                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell) * activeTracers(indexSaltFlux,1,iCell)
+                 - fracAbsorbed * surfaceThicknessFlux(iCell) * activeTracers(indexSaltFlux,minLevelCell(iCell),iCell) &
+                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell) * activeTracers(indexSaltFlux,minLevelCell(iCell),iCell)
 
-         surfaceBuoyancyForcing(iCell) =  thermalExpansionCoeff (1,iCell) &
+         surfaceBuoyancyForcing(iCell) =  thermalExpansionCoeff (minLevelCell(iCell),iCell) &
                 * nonLocalSurfaceTracerFlux(indexTempFlux,iCell) &
-                - salineContractionCoeff(1,iCell) * nonLocalSurfaceTracerFlux(indexSaltFlux,iCell)
+                - salineContractionCoeff(minLevelCell(iCell),iCell) * nonLocalSurfaceTracerFlux(indexSaltFlux,iCell)
 
          ! at this point, surfaceBuoyancyForcing has units of m/s
          ! change into units of m^2/s^3 (which can be thought of as the flux of buoyancy, units of buoyancy * velocity )

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1855,16 +1855,17 @@ contains
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
         ! nonzero value to avoid a NaN.
-        normalThicknessFluxSum = layerThickEdge(1,iEdge) * tend_normalVelocity(1,iEdge)
-        thicknessSum  = layerThickEdge(1,iEdge)
+        normalThicknessFluxSum = layerThickEdge(maxLevelEdgeBot(iEdge),iEdge) * &
+                                 tend_normalVelocity(maxLevelEdgeBot(iEdge),iEdge)
+        thicknessSum  = layerThickEdge(maxLevelEdgeBot(iEdge),iEdge)
 
-        do k = 2, maxLevelEdgeTop(iEdge)
+        do k = maxLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
           normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * tend_normalVelocity(k,iEdge)
           thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
         enddo
 
         vertSum = normalThicknessFluxSum / thicknessSum
-        do k = 1, maxLevelEdgeTop(iEdge)
+        do k = maxLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
           tend_normalVelocity(k,iEdge) = tend_normalVelocity(k,iEdge) - vertSum
         enddo
       enddo ! iEdge

--- a/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_frazil_forcing.F
@@ -167,7 +167,7 @@ contains
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND), dimension(:,:), pointer :: frazilLayerThicknessTendency
 
       err = 0
@@ -177,6 +177,7 @@ contains
       call mpas_timer_start("frazil thickness tendency")
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
 
@@ -187,7 +188,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + frazilLayerThicknessTendency(k,iCell)
         end do
       end do
@@ -248,7 +249,7 @@ contains
       integer, pointer :: indexTemperature
       integer, pointer :: indexSalinity
       integer, pointer, dimension(:) :: nCellsArray
-      integer, pointer, dimension(:) :: maxLevelCell
+      integer, pointer, dimension(:) :: minLevelCell, maxLevelCell
 
       real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
       real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
@@ -261,6 +262,7 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(forcingPool, 'frazilTemperatureTendency', frazilTemperatureTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSalinityTendency', frazilSalinityTendency)
@@ -272,7 +274,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           activeTracersTend(indexTemperature,k,iCell) = activeTracersTend(indexTemperature,k,iCell) &
                                                       + frazilTemperatureTendency(k,iCell)
           activeTracersTend(indexSalinity,k,iCell) = activeTracersTend(indexSalinity,k,iCell) + frazilSalinityTendency(k,iCell)
@@ -367,7 +369,7 @@ contains
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
       real (kind=RKIND), pointer, dimension(:,:,:) :: activeTracers
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       integer, pointer :: indexTemperature !< index in tracers array for temperature
       integer, pointer :: indexSalinity !< index in tracers array for salinity
       integer :: kBottomFrazil  ! k index where testing for frazil begins
@@ -393,6 +395,7 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
       ! get mesh information
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       ! get arrays
@@ -451,7 +454,7 @@ contains
 
         ! find deepest level where frazil can be created
         kBottomFrazil=maxLevelCell(iCell)
-        do k=maxLevelCell(iCell), 1, -1
+        do k=maxLevelCell(iCell), minLevelCell(iCell), -1
           ! add the ssh so frazil can form below land ice, where the ssh is depressed
           if (-zMid(k,iCell) < -ssh(iCell) + config_frazil_maximum_depth) then
             kBottomFrazil=k
@@ -461,7 +464,7 @@ contains
 
         ! find minimum temperature between 1:kBottomFrazil
         columnTemperatureMin = 1.0e30_RKIND
-        do k=1,kBottomFrazil
+        do k=minLevelCell(iCell),kBottomFrazil
           if ( activeTracers(indexTemperature,k,iCell) < columnTemperatureMin ) then
              columnTemperatureMin = activeTracers(indexTemperature,k,iCell)
           end if
@@ -475,7 +478,7 @@ contains
         sumNewThicknessWeightedSaltContent = 0.0_RKIND
 
         ! loop from maximum depth of frazil creation to surface
-        do k = kBottomFrazil, 1, -1
+        do k = kBottomFrazil, minLevelCell(iCell), -1
 
           ! get freezing temperature
           oceanFreezingTemperature = ocn_freezing_temperature(salinity=activeTracers(indexSalinity,k,iCell), &
@@ -570,7 +573,7 @@ contains
 
           endif  ! if (freezingEnergy < 0)
 
-        enddo   ! do k=kBottom,1-1
+        enddo   ! do k=kBottom,minLevelCell,-1
 
         ! accumulate frazil mass to column total
         ! note: the accumulatedFrazilIceMass (at both time levels) is reset to zero after being sent to the coupler

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -470,7 +470,7 @@ contains
          !$omp do schedule(runtime) private(k, h1, h2)
          do iEdge = 1, nEdges
             ! The interpolation can only be carried out on non-boundary edges
-            if (maxLevelEdgeTop(iEdge) .GE. 1) then
+            if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   h1 = layerThickEdge(k-1,iEdge)
                   h2 = layerThickEdge(k,iEdge)
@@ -493,7 +493,7 @@ contains
 
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
-            if (maxLevelEdgeTop(iEdge) .GE. 1) then
+            if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
                   gradDensityConstZTopOfEdge(k,iEdge) = gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
                                                    * gradZMidTopOfEdge(k,iEdge)
@@ -672,8 +672,8 @@ contains
 
             gmStreamFuncTopOfEdge(:, iEdge) = 0.0_RKIND
 
-            ! Construct the tridiagonal matrix
-            if (maxLevelEdgeTop(iEdge) .GE. 3) then
+            ! Construct the tridiagonal matrix if there are at least 3 active cells
+            if ((maxLevelEdgeTop(iEdge) - minLevelEdgeBot(iEdge)) .GE. 2) then
                ! First row
                k = minLevelEdgeBot(iEdge)+1
 

--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -124,7 +124,7 @@ contains
       real(kind=RKIND), dimension(:), pointer   :: &
                 ssh, fEdge
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
-      integer, dimension(:), pointer   :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
+      integer, dimension(:), pointer   :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell, nEdgesOnCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iter, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp
@@ -167,6 +167,8 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -236,7 +238,7 @@ contains
             !$omp parallel
             !$omp do schedule(runtime) private(maxLocation, k, BruntVaisalaFreqTopEdge, maxN)
             do iCell = 1, nCells
-               k = min(maxLevelCell(iCell) - 1, max(1, indMLD(iCell)))
+               k = min(maxLevelCell(iCell) - 1, max(minLevelCell(iCell), indMLD(iCell)))
                maxN = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
                do while (BruntVaisalaFreqTop(k + 1, iCell) > maxN .and. k < maxLevelCell(iCell) - 1)
                  k = k + 1
@@ -259,10 +261,10 @@ contains
             !$omp parallel
             !$omp do schedule (runtime) private(zMLD, k)
             do iCell = 1, nCells
-               k = max(1, indMLD(iCell))
+               k = max(minLevelCell(iCell), indMLD(iCell))
                zMLD = ssh(iCell) - zMid(k, iCell)
    
-               do k = 1, indMLD(iCell)
+               do k = minLevelCell(iCell), indMLD(iCell)
                   RediKappaSfcTaper(k, iCell) = abs((ssh(iCell) - zMid(k, iCell))/(zMLD))
                end do
             end do
@@ -281,7 +283,7 @@ contains
             k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
             k33Norm(1:maxLevelCell(iCell) + 1) = epsGM
             ! prep dz, dTdz and dSdz for this column
-            do k = 2, maxLevelCell(iCell)
+            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
                dzTop(k) = 0.5_RKIND*(layerThickness(k - 1, iCell) + layerThickness(k, iCell))
                dTdzTop(k) = (activeTracers(indexTemperature, k - 1, iCell) &
                              - activeTracers(indexTemperature, k, iCell)) &
@@ -290,9 +292,9 @@ contains
                              - activeTracers(indexSalinity, k, iCell)) &
                             /dzTop(k)
             end do
-            dzTop(1) = -1e-15_RKIND
-            dTdzTop(1) = -1e-15_RKIND
-            dSdzTop(1) = -1e-15_RKIND
+            dzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
+            dTdzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
+            dSdzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
             dzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
             dTdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
             dSdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
@@ -309,7 +311,7 @@ contains
                dcEdgeInv = 1.0_RKIND/dcEdge(iEdge)
                areaEdge = dcEdge(iEdge)*dvEdge(iEdge)
    
-               do k = 1, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   drhoDT = -thermExpCoeff(k, iCell)
                   drhoDS = salineContractCoeff(k, iCell)
                   dTdx = (activeTracers(indexTemperature, k, cell2) &
@@ -365,7 +367,7 @@ contains
                      slopeTaperDown*sfcTaperDown*slopeTriadDown(k, iCellSelf, iEdge)
    
                   ! Griffies 1998 eqn 34
-                  if (k > 1) then
+                  if (k > minLevelCell(iCell)) then
                      k33(k, iCell) = k33(k, iCell) +  &
                                      areaEdge*dzTop(k)*slopeTriadUp(k, iCellSelf, iEdge)**2
                      k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k)
@@ -381,10 +383,10 @@ contains
             end do ! nEdgesOnCell(iCell)
    
             ! Normalize k33
-            do k = 2, maxLevelCell(iCell)
+            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
                k33(k, iCell) = k33(k, iCell)/k33Norm(k)*RediKappaScaling(k, iCell)
             end do
-            k33(1, iCell) = 0.0_RKIND
+            k33(1:minLevelCell(iCell), iCell) = 0.0_RKIND
             k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
          end do ! iCell
          !$omp end do
@@ -420,7 +422,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(k, rtmp)
          do iCell = 1, nCells
-            do k = 2, maxLevelCell(iCell)
+            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
                rtmp = (displacedDensity(k-1,iCell) - density(k,iCell)) / (zMid(k-1,iCell) - zMid(k,iCell))
                dDensityDzTopOfCell(k,iCell) = min(rtmp, -epsGM)
             end do
@@ -428,7 +430,7 @@ contains
             ! Approximation of dDensityDzTopOfCell on the top and bottom interfaces through the idea of having
             ! ghost cells above the top and below the bottom layers of the same depths and density.
             ! Essentially, this enforces the boundary condition (d density)/dz = 0 at the top and bottom.
-            dDensityDzTopOfCell(1,iCell) = 0.0_RKIND
+            dDensityDzTopOfCell(1:minLevelCell(iCell),iCell) = 0.0_RKIND
             dDensityDzTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
          end do
          !$omp end do
@@ -440,7 +442,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(k, cell1, cell2)
          do iEdge = 1, nEdges
-            do k = 1, maxLevelEdgeTop(iEdge)+1
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                dDensityDzTopOfEdge(k,iEdge) = 0.5_RKIND * (dDensityDzTopOfCell(k,cell1) + dDensityDzTopOfCell(k,cell2))
@@ -458,7 +460,7 @@ contains
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
 
-            do k=1,maxLevelEdgeTop(iEdge)
+            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
                gradDensityEdge(k,iEdge) = (density(k,cell2) - density(k,cell1)) / dcEdge(iEdge)
                gradZMidEdge(k,iEdge) = (zMid(k,cell2) - zMid(k,cell1)) / dcEdge(iEdge)
             end do
@@ -469,7 +471,7 @@ contains
          do iEdge = 1, nEdges
             ! The interpolation can only be carried out on non-boundary edges
             if (maxLevelEdgeTop(iEdge) .GE. 1) then
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   h1 = layerThickEdge(k-1,iEdge)
                   h2 = layerThickEdge(k,iEdge)
                   ! Using second-order interpolation below
@@ -481,9 +483,9 @@ contains
 
                ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells 
                ! above the top and below the bottom layers of the same depths and density.
-               gradDensityTopOfEdge(1,iEdge) = gradDensityEdge(1,iEdge)
+               gradDensityTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradDensityEdge(minLevelEdgeBot(iEdge),iEdge)
                gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
-               gradZMidTopOfEdge(1,iEdge) = gradZMidEdge(1,iEdge)
+               gradZMidTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradZMidEdge(minLevelEdgeBot(iEdge),iEdge)
                gradZMidTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradZMidEdge(maxLevelEdgeTop(iEdge),iEdge)
             end if
          end do
@@ -492,7 +494,7 @@ contains
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
             if (maxLevelEdgeTop(iEdge) .GE. 1) then
-               do k = 1, maxLevelEdgeTop(iEdge)+1
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
                   gradDensityConstZTopOfEdge(k,iEdge) = gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
                                                    * gradZMidTopOfEdge(k,iEdge)
                end do
@@ -508,19 +510,19 @@ contains
             !$omp parallel
             !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
             do iEdge=1,nEdges
-               k=1
+               k=minLevelEdgeBot(iEdge)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                     BruntVaisalaFreqTop(k,cell2))
                maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                       BruntVaisalaFreqTop(k,cell2))
                  maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
                enddo
 
-               do k = 2, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
                                                        BruntVaisalaFreqTop(k,cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
@@ -546,7 +548,7 @@ contains
                cell2 = cellsOnEdge(2, iEdge)
                sumN2 = 0.0
 
-               do k = 2, maxLevelEdgeTop(iEdge)-1
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
 
                   lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                   lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
@@ -580,7 +582,7 @@ contains
            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
            !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2)
            do iEdge = 1, nEdges
-              k=1
+              k=minLevelEdgeBot(iEdge)
               sumN2 = 0.0_RKIND
               ltSum = 0.0_RKIND
               sumRi = 0.0_RKIND
@@ -588,7 +590,7 @@ contains
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
 
-              k = 2
+              k = minLevelEdgeBot(iEdge)+1
               zEdge = -layerThickEdge(k-1,iEdge)
               do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
@@ -637,7 +639,7 @@ contains
               Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
                        sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
-              do k=2,maxLevelEdgeTop(iEdge)
+              do k=minLevelEdgeBot(iEdge)+1,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
                  shearEdgeInv = (0.5_RKIND*(layerThickEdge(k-1,iEdge) + layerThickEdge(k,iEdge)))**2.0 &
@@ -673,7 +675,7 @@ contains
             ! Construct the tridiagonal matrix
             if (maxLevelEdgeTop(iEdge) .GE. 3) then
                ! First row
-               k = 2
+               k = minLevelEdgeBot(iEdge)+1
 
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
@@ -685,7 +687,7 @@ contains
                                       *gradDensityConstZTopOfEdge(k,iEdge)
 
                ! Second to next to the last rows
-               do k = 3, maxLevelEdgeTop(iEdge) - 1
+               do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
                   tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k - 1, iEdge) &
@@ -709,11 +711,14 @@ contains
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
                ! Total number of rows
-               N = maxLevelEdgeTop(iEdge) - 1
+               N = maxLevelEdgeTop(iEdge) - minLevelEdgeBot(iEdge)
 
                ! Call the tridiagonal solver
-               call tridiagonal_solve(tridiagA, tridiagB, tridiagC, rightHandSide, &
-                                      gmStreamFuncTopOfEdge(2:maxLevelEdgeTop(iEdge), iEdge), N)
+               call tridiagonal_solve(tridiagA(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge)), &
+                                      tridiagB(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge)), &
+                                      tridiagC(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge)), &
+                                      rightHandSide(minLevelEdgeBot(iEdge):maxLevelEdgeTop(iEdge)), &
+                                      gmStreamFuncTopOfEdge(minLevelEdgeBot(iEdge)+1:maxLevelEdgeTop(iEdge), iEdge), N)
             end if
          end do
          !!$omp end do
@@ -723,7 +728,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalGMBolusVelocity(k, iEdge) = gmResolutionTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
                       - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdge(k, iEdge)
             end do
@@ -743,7 +748,7 @@ contains
 
                areaEdge = 0.25_RKIND*dcEdge(iEdge)*dvEdge(iEdge)
 
-               do k = 1, maxLevelEdgeTop(iEdge)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   rtmp = 0.5_RKIND*(gmStreamFuncTopOfEdge(k, iEdge) + gmStreamFuncTopOfEdge(k + 1, iEdge))*areaEdge
                   gmStreamFuncTopOfCell(k, iCell) = gmStreamFuncTopOfCell(k, iCell) + gmResolutionTaper(iEdge) * rtmp
                end do

--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -546,19 +546,19 @@ contains
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature
-           rainTemperatureFlux(iCell) = rainFlux(iCell) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
-           evapTemperatureFlux(iCell) = evaporationFlux(iCell) * tracerGroup(index_temperature_flux,1,iCell) / rho_sw
+           rainTemperatureFlux(iCell) = rainFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
+           evapTemperatureFlux(iCell) = evaporationFlux(iCell) * tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell) / rho_sw
 
            ! Runoff can only have a minimum temperature of 0.0C, since it is fresh water.
            tracersSurfaceFluxRunoff(index_temperature_flux,iCell) = riverRunoffFlux(iCell) &
-                      * max(tracerGroup(index_temperature_flux,1,iCell), 0.0_RKIND) / rho_sw
+                      * max(tracerGroup(index_temperature_flux,minLevelCell(iCell),iCell), 0.0_RKIND) / rho_sw
 
            ! Accumulate fluxes that use the freezing point
            seaIceFreshWaterTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, &
+               ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
                                          inLandIceCavity=.false.) / rho_sw
            icebergFreshWaterTemperatureFlux(iCell) = icebergFreshWaterFlux(iCell) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, 1, iCell), pressure=0.0_RKIND, &
+               ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
                                          inLandIceCavity=.false.) / rho_sw
 
            totalFreshWaterTemperatureFlux(iCell) = rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -804,7 +804,7 @@ contains
                      call mpas_pool_get_subpool(forcingPool, 'tracersIdealAgeFields', tracersIdealAgeFieldsPool)
                      modifiedGroupName = trim(groupItr % memberName) // "IdealAgeMask"
                      call mpas_pool_get_array(tracersIdealAgeFieldsPool, trim(modifiedGroupName), tracerGroupIdealAgeMask)
-                     call ocn_tracer_ideal_age_compute(nTracerGroup, nCells, maxLevelCell, layerThickness, &
+                     call ocn_tracer_ideal_age_compute(nTracerGroup, nCells, minLevelCell, maxLevelCell, layerThickness, &
                           tracerGroupIdealAgeMask, tracerGroup, tracerGroupTend, err)
 
                      call mpas_timer_stop("ideal age " // trim(groupItr % memberName))

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -702,11 +702,11 @@ contains
                   call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, timeLevel)
                   nTracersEcosys = size(ecosysTracers, dim=1)
                   call ocn_tracer_DMS_compute(activeTracers, tracerGroup, nTracerGroup, ecosysTracers,   &
-                     nTracersEcosys, forcingPool, nCellsSolve, maxLevelCell,  &
+                     nTracersEcosys, forcingPool, nCellsSolve, minLevelCell, maxLevelCell,  &
                      nVertLevels, layerThickness, indexTemperature, indexSalinity, tracerGroupTend, err)
 
                   call ocn_tracer_DMS_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &
-                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux,  &
+                     nTracerGroup, nCellsSolve, zMid, minLevelCell, indexTemperature, indexSalinity, tracerGroupSurfaceFlux,  &
                      tracerGroupSurfaceFluxRemoved, err)
                endif
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -1037,7 +1037,7 @@ contains
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', maxLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
 

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -571,6 +571,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbed', fractionAbsorbed)
       call mpas_pool_get_array(forcingPool, 'fractionAbsorbedRunoff', fractionAbsorbedRunoff)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'latCell', latCell)
 
@@ -785,7 +786,7 @@ contains
                      modifiedGroupName = trim(groupItr % memberName) // "ExponentialDecayRate"
                      call mpas_pool_get_array(tracersExponentialDecayFieldsPool, trim(modifiedGroupName), &
                                               tracerGroupExponentialDecayRate)
-                     call ocn_tracer_exponential_decay_compute(nTracerGroup, nCells, maxLevelCell, layerThickness, &
+                     call ocn_tracer_exponential_decay_compute(nTracerGroup, nCells, minLevelCell, maxLevelCell, layerThickness, &
                         tracerGroup, tracerGroupExponentialDecayRate, tracerGroupTend, err)
 
                      call mpas_timer_stop("exponential decay " // trim(groupItr % memberName))

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -769,7 +769,7 @@ contains
                      modifiedGroupName = trim(groupItr % memberName) // "InteriorRestoringValue"
                      call mpas_pool_get_array(tracersInteriorRestoringFieldsPool, trim(modifiedGroupName), &
                                               tracerGroupInteriorRestoringValue)
-                     call ocn_tracer_interior_restoring_compute(nTracerGroup, nCells, maxLevelCell, layerThickness, &
+                     call ocn_tracer_interior_restoring_compute(nTracerGroup, nCells, minLevelCell, maxLevelCell, layerThickness, &
                         tracerGroup, tracerGroupInteriorRestoringRate, tracerGroupInteriorRestoringValue, tracerGroupTend, err)
                      call mpas_timer_stop("interior_restoring_" // trim(groupItr % memberName))
                 endif

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -1037,7 +1037,6 @@ contains
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
 
@@ -1072,7 +1071,8 @@ contains
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
 
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+          ! Note: changing loop limit to minLevelEdgeBot introduces non-bit-for-bit changes
+          do k = 1, maxLevelEdgeTop(iEdge)
             flux = layerThickEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) * invAreaCell
             div_hu(k) = div_hu(k) - flux
             div_hu_btr = div_hu_btr - flux

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -1035,7 +1035,9 @@ contains
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', maxLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
 
@@ -1070,15 +1072,15 @@ contains
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
 
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             flux = layerThickEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) * invAreaCell
             div_hu(k) = div_hu(k) - flux
             div_hu_btr = div_hu_btr - flux
           end do
         end do
 
-        totalThickness = sum(layerThickness(1:maxLevelCell(iCell),iCell))
-        do k = 1, maxLevelCell(iCell)
+        totalThickness = sum(layerThickness(minLevelCell(iCell):maxLevelCell(iCell),iCell))
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
 
            tend_lowFreqDivergence(k,iCell) = &
               -2.0 * pii / thickness_filter_timescale_sec &

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -718,7 +718,7 @@ contains
                   call mpas_pool_get_array(tracersPool, 'ecosysTracers', ecosysTracers, timeLevel)
                   nTracersEcosys = size(ecosysTracers, dim=1)
                   call ocn_tracer_MacroMolecules_compute(tracerGroup, nTracerGroup, ecosysTracers, nTracersEcosys, forcingPool, &
-                     nCellsSolve, maxLevelCell, nVertLevels, layerThickness,  &
+                     nCellsSolve, minLevelCell, maxLevelCell, nVertLevels, layerThickness,  &
                      tracerGroupTend, err)
 
                   call ocn_tracer_MacroMolecules_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &

--- a/src/core_ocean/shared/mpas_ocn_tendency.F
+++ b/src/core_ocean/shared/mpas_ocn_tendency.F
@@ -687,11 +687,11 @@ contains
                if ( trim(groupItr % memberName) == 'ecosysTracers' ) then
                   call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
                   call ocn_tracer_ecosys_compute(activeTracers, tracerGroup, forcingPool, nTracerGroup, &
-                     nCellsSolve, latCell, maxLevelCell, nVertLevels, layerThickness, zMid, indexTemperature, &
+                     nCellsSolve, latCell, minLevelCell, maxLevelCell, nVertLevels, layerThickness, zMid, indexTemperature, &
                      indexSalinity, tracerGroupTend, err)
 
                   call ocn_tracer_ecosys_surface_flux_compute(activeTracers, tracerGroup, forcingPool,  &
-                     nTracerGroup, nCellsSolve, zMid, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
+                     nTracerGroup, nCellsSolve, zMid, minLevelCell, indexTemperature, indexSalinity, tracerGroupSurfaceFlux, err)
                endif
 
                !

--- a/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
@@ -262,9 +262,7 @@ contains
           totalDepth = totalDepth + layerThickness(k,iCell)
         end do
 
-        do k = minLevelCell(iCell), maxLevelCell(iCell)
-          tidalLayerThicknessTendency(:,iCell) = 0.0_RKIND
-        end do
+        tidalLayerThicknessTendency(:,iCell) = 0.0_RKIND
         if (trim(config_tidal_forcing_type) == 'thickness_source') then
           ! distribute tidal forcing tendency fractionally over water column
           do k = minLevelCell(iCell), maxLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_tidal_forcing.F
@@ -107,7 +107,7 @@ contains
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND), dimension(:,:), pointer :: tidalLayerThicknessTendency
 
       err = 0
@@ -117,6 +117,7 @@ contains
       call mpas_timer_start("tidal thickness tendency")
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(forcingPool, 'tidalLayerThicknessTendency', &
                                              tidalLayerThicknessTendency)
@@ -128,7 +129,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iCell = 1, nCells
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           layerThicknessTend(k,iCell) = layerThicknessTend(k,iCell) + &
                                         tidalLayerThicknessTendency(k,iCell)
 
@@ -200,7 +201,7 @@ contains
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
-      integer, pointer, dimension(:) :: maxLevelCell
+      integer, pointer, dimension(:) :: minLevelCell, maxLevelCell
       integer, pointer :: nVertLevels
       real (kind=RKIND) :: dt
 
@@ -225,6 +226,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
 
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
@@ -256,16 +258,16 @@ contains
 
         ! compute total depth for relative thickness contribution
         totalDepth = 0.0_RKIND
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           totalDepth = totalDepth + layerThickness(k,iCell)
         end do
 
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           tidalLayerThicknessTendency(:,iCell) = 0.0_RKIND
         end do
         if (trim(config_tidal_forcing_type) == 'thickness_source') then
           ! distribute tidal forcing tendency fractionally over water column
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             tidalLayerThicknessTendency(k,iCell) = tidalInputMask(iCell) / config_use_tidal_forcing_tau &
               * (layerThickness(k,iCell)/totalDepth) * (tidalHeight - ssh(iCell))
           end do

--- a/src/core_ocean/shared/mpas_ocn_tracer_DMS.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_DMS.F
@@ -172,10 +172,10 @@ contains
 
       numColumns = 1
       column = 1
-      iLevelSurface = minLevelCell(iCell)
 
       !DWJ 08/05/2016: This loop needs OpenMP added to it.
       do iCell=1,nCellsSolve
+         iLevelSurface = minLevelCell(iCell)
          DMS_input%number_of_active_levels(column) = maxLevelCell(iCell) - minLevelCell(iCell) + 1
 
          DMS_forcing%ShortWaveFlux_surface(column)  = shortWaveHeatFlux(iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_DMS.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_DMS.F
@@ -97,7 +97,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_DMS_compute(activeTracers, DMSTracers, nTracersDMS, ecosysTracers, nTracersEcosys,   &
-      forcingPool, nCellsSolve, maxLevelCell,  &
+      forcingPool, nCellsSolve, minLevelCell, maxLevelCell, &
       nVertLevels, layerThickness, indexTemperature, indexSalinity, DMSTracersTend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -108,7 +108,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
 
       ! two dimensional arrays
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -172,18 +172,18 @@ contains
 
       numColumns = 1
       column = 1
-      iLevelSurface = 1
+      iLevelSurface = minLevelCell(iCell)
 
       !DWJ 08/05/2016: This loop needs OpenMP added to it.
       do iCell=1,nCellsSolve
-         DMS_input%number_of_active_levels(column) = maxLevelCell(iCell)
+         DMS_input%number_of_active_levels(column) = maxLevelCell(iCell) - minLevelCell(iCell) + 1
 
          DMS_forcing%ShortWaveFlux_surface(column)  = shortWaveHeatFlux(iCell)
          DMS_forcing%SST(column) = activeTracers(indexTemperature,iLevelSurface,iCell)
          DMS_forcing%SSS(column) = activeTracers(indexSalinity,iLevelSurface,iCell)
 
-         do iLevel=1,maxLevelCell(iCell)
-            DMS_input%cell_thickness(iLevel,column)    = layerThickness(iLevel,iCell)*convertLengthScale
+         do iLevel=1,DMS_input%number_of_active_levels(column)
+            DMS_input%cell_thickness(iLevel,column)    = layerThickness(iLevel + minLevelCell(iCell) - 1,iCell)*convertLengthScale
 
             DMS_input%DMS_tracers(iLevel,column,DMS_indices%dms_ind)  = DMSTracers(dmsIndices%dms_ind,iLevel,iCell)
             DMS_input%DMS_tracers(iLevel,column,DMS_indices%dmsp_ind) = DMSTracers(dmsIndices%dmsp_ind,iLevel,iCell)
@@ -207,7 +207,7 @@ contains
                              DMS_output, DMS_diagnostic_fields, nVertLevels,   &
                              numColumnsMax, numColumns)
 
-         do iLevel=1,maxLevelCell(iCell)
+         do iLevel=1,DMS_input%number_of_active_levels(column)
 
             DMSTracersTend(dmsIndices%dms_ind,iLevel,iCell) = DMSTracersTend(dmsIndices%dms_ind,iLevel,iCell)   &
                + DMS_output%DMS_tendencies(iLevel,column,DMS_indices%dms_ind)*layerThickness(iLevel,iCell)
@@ -237,7 +237,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_DMS_surface_flux_compute(activeTracers, DMSTracers, forcingPool,  &
-      nTracers, nCellsSolve, zMid, indexTemperature, indexSalinity, DMSSurfaceFlux, DMSSurfaceFluxRemoved, err)!{{{
+      nTracers, nCellsSolve, zMid, minLevelCell, indexTemperature, indexSalinity, DMSSurfaceFlux, DMSSurfaceFluxRemoved, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -260,6 +260,7 @@ contains
 
       ! scalars
       integer, intent(in) :: nTracers, nCellsSolve, indexTemperature, indexSalinity
+      integer, dimension(:), intent(in) :: minLevelCell
 
       type (mpas_pool_type), intent(inout) :: forcingPool
 
@@ -349,11 +350,11 @@ contains
 
       numColumns = 1
       column = 1
-      iLevelSurface = 1
 
       !DWJ 08/05/2016: This loop needs OpenMP added to it.
       do iCell=1,nCellsSolve
 
+         iLevelSurface = minLevelCell(iCell)
          DMS_forcing%surfacePressure(column) = atmosphericPressure(iCell)*PascalsToAtmospheres
          DMS_forcing%iceFraction(column) = iceFraction(iCell)
 !maltrud assume for now that if there is any land ice, it is all land ice

--- a/src/core_ocean/shared/mpas_ocn_tracer_MacroMolecules.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_MacroMolecules.F
@@ -91,7 +91,7 @@ contains
 
    subroutine ocn_tracer_MacroMolecules_compute(MacroMoleculesTracers, nTracersMacroMolecules,   &
       ecosysTracers, nTracersEcosys, forcingPool, &
-      nCellsSolve, maxLevelCell, nVertLevels, layerThickness, MacroMoleculesTracersTend, err)!{{{
+      nCellsSolve, minLevelCell, maxLevelCell, nVertLevels, layerThickness, MacroMoleculesTracersTend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -101,7 +101,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
 
       ! two dimensional arrays
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -158,9 +158,9 @@ contains
       column = 1
       !DWJ 08/05/2016: This loop needs OpenMP added to it
       do iCell=1,nCellsSolve
-         MacroMolecules_input%number_of_active_levels(column) = maxLevelCell(iCell)
-         do iLevel=1,maxLevelCell(iCell)
-            MacroMolecules_input%cell_thickness(iLevel,column)    = layerThickness(iLevel,iCell)*convertLengthScale
+         MacroMolecules_input%number_of_active_levels(column) = maxLevelCell(iCell) - minLevelCell(iCell) + 1
+         do iLevel=1,MacroMolecules_input%number_of_active_levels(column)
+            MacroMolecules_input%cell_thickness(iLevel,column)    = layerThickness(iLevel + minLevelCell(iCell) - 1,iCell)*convertLengthScale
 
             MacroMolecules_input%MACROS_tracers(iLevel,column,MacroMolecules_indices%prot_ind)  =   &
                MacroMoleculesTracers(macrosIndices%prot_ind,iLevel,iCell)
@@ -186,7 +186,7 @@ contains
                              MacroMolecules_output, MacroMolecules_diagnostic_fields, nVertLevels,   &
                              numColumnsMax, numColumns)
 
-         do iLevel=1,maxLevelCell(iCell)
+         do iLevel=1,MacroMolecules_input%number_of_active_levels(column)
 
             MacroMoleculesTracersTend(macrosIndices%prot_ind,iLevel,iCell) = &
                MacroMoleculesTracersTend(macrosIndices%prot_ind,iLevel,iCell)   &

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection.F
@@ -152,8 +152,8 @@ module ocn_tracer_advection
       else
          call ocn_tracer_advection_std_tend(tracers, advCoefs, advCoefs3rd, &
             nAdvCellsForEdge, advCellsForEdge, normalThicknessFlux, w, layerThickness, &
-            layerThickness, dt, meshPool, tend, maxLevelCell, maxLevelEdgeTop, &
-            highOrderAdvectionMask, edgeSignOnCell)
+            layerThickness, dt, meshPool, tend, minLevelCell, maxLevelCell, &
+            minLevelEdgeBot, maxLevelEdgeTop, highOrderAdvectionMask, edgeSignOnCell)
       endif
 
       call mpas_timer_stop("tracer adv")

--- a/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_advection_std.F
@@ -65,7 +65,7 @@ module ocn_tracer_advection_std
 !-----------------------------------------------------------------------
    subroutine ocn_tracer_advection_std_tend(tracers, adv_coefs, adv_coefs_3rd, nAdvCellsForEdge, advCellsForEdge, &!{{{
                                              normalThicknessFlux, w, layerThickness, verticalCellSize, dt, meshPool, &
-                                             tend, maxLevelCell, maxLevelEdgeTop, &
+                                             tend, minLevelCell, maxLevelCell, minLevelEdgeBot, maxLevelEdgeTop, &
                                              highOrderAdvectionMask, edgeSignOnCell)
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: tracers !< Input: current tracer values
@@ -80,8 +80,8 @@ module ocn_tracer_advection_std
       real (kind=RKIND), intent(in) :: dt !< Input: Timestep
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: tend !< Input/Output: Tracer tendency
-      integer, dimension(:), pointer :: maxLevelCell !< Input: Index to max level at cell center
-      integer, dimension(:), pointer :: maxLevelEdgeTop !< Input: Index to max level at edge with non-land cells on both sides
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell !< Input: Index to min,max level at cell center
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop !< Input: Index to min,max level at edge with non-land cells on both sides
       integer, dimension(:,:), pointer :: highOrderAdvectionMask !< Input: Mask for high order advection
       integer, dimension(:, :), pointer :: edgeSignOnCell !< Input: Sign for flux from edge on each cell.
 
@@ -145,12 +145,12 @@ module ocn_tracer_advection_std
         !  Compute the high order vertical flux. Also determine bounds on tracer_cur.
         !$omp do schedule(runtime) private(k, verticalWeightK, verticalWeightKm1)
         do iCell = 1, nCells
-          k = max(1, min(maxLevelCell(iCell), 2))
+          k = max(minLevelCell(iCell), min(maxLevelCell(iCell), minLevelCell(iCell)+1))
           verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
           verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
           high_order_vert_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
 
-          do k=3,maxLevelCell(iCell)-1
+          do k=minLevelCell(iCell)+2,maxLevelCell(iCell)-1
              select case (vertOrder)
              case (vertOrder4)
                high_order_vert_flux(k, iCell) = mpas_tracer_advection_vflux4( tracer_cur(k-2,iCell),tracer_cur(k-1,iCell),  &
@@ -166,7 +166,7 @@ module ocn_tracer_advection_std
              end select ! vertOrder
           end do
 
-          k = max(1, maxLevelCell(iCell))
+          k = max(minLevelCell(iCell), maxLevelCell(iCell))
           verticalWeightK = verticalCellSize(k-1, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
           verticalWeightKm1 = verticalCellSize(k, iCell) / (verticalCellSize(k, iCell) + verticalCellSize(k-1, iCell))
           high_order_vert_flux(k,iCell) = w(k,iCell)*(verticalWeightK*tracer_cur(k,iCell)+verticalWeightKm1*tracer_cur(k-1,iCell))
@@ -180,7 +180,7 @@ module ocn_tracer_advection_std
           cell2 = cellsOnEdge(2, iEdge)
 
           ! Compute 2nd order fluxes where needed.
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             tracer_weight = iand(highOrderAdvectionMask(k, iEdge)+1, 1) * (dvEdge(iEdge) * 0.5_RKIND) &
                            * normalThicknessFlux(k, iEdge)
 
@@ -191,7 +191,7 @@ module ocn_tracer_advection_std
           ! Compute 3rd or 4th fluxes where requested.
           do i = 1, nAdvCellsForEdge(iEdge)
             iCell = advCellsForEdge(i,iEdge)
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
               tracer_weight = highOrderAdvectionMask(k, iEdge) * (adv_coefs(i,iEdge) + coef3rdOrder &
                             * sign(1.0_RKIND,normalThicknessFlux(k,iEdge))*adv_coefs_3rd(i,iEdge))
 
@@ -208,7 +208,7 @@ module ocn_tracer_advection_std
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + edgeSignOnCell(i, iCell) * high_order_horiz_flux(k, iEdge) &
                                       * invAreaCell1
             end do
@@ -219,7 +219,7 @@ module ocn_tracer_advection_std
         ! Accumulate the scaled high order vertical tendencies.
         !$omp do schedule(runtime) private(k)
         do iCell = 1, nCellsSolve
-          do k = 1,maxLevelCell(iCell)
+          do k = minLevelCell(iCell),maxLevelCell(iCell)
             tend(iTracer, k, iCell) = tend(iTracer, k, iCell) + verticalDivergenceFactor(k) * (high_order_vert_flux(k+1, iCell) &
                                     - high_order_vert_flux(k, iCell))
           end do ! k loop

--- a/src/core_ocean/shared/mpas_ocn_tracer_ecosys.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_ecosys.F
@@ -101,7 +101,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_ecosys_compute(activeTracers, ecosysTracers, forcingPool, nTracers, nCellsSolve, &
-      latCell, maxLevelCell, nVertLevels, layerThickness, zMid, indexTemperature, indexSalinity, ecosysTracersTend, err)!{{{
+      latCell, minLevelCell, maxLevelCell, nVertLevels, layerThickness, zMid, indexTemperature, indexSalinity, ecosysTracersTend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -111,7 +111,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
       real (kind=RKIND), dimension(:), intent(in) :: &
          latCell
 
@@ -491,8 +491,9 @@ contains
 ! convert dust flux from kg/m2/s to g/cm2/s
          BGC_forcing%dust_FLUX_IN(column) = dust_FLUX_IN(iCell)*0.1_RKIND
          BGC_forcing%ShortWaveFlux_surface(column)  = shortWaveHeatFlux(iCell)
-         zTop = 0.0_RKIND
-         do iLevel=1,maxLevelCell(iCell)
+         zTop = 0.0_RKIND ! doesn't appear to be used but may need to changed if ecosys below ice shelves
+         ! iLevel may have to be adjusted in relation to minLevelCell on the LHS
+         do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
             BGC_input%PotentialTemperature(iLevel,column) = activeTracers(indexTemperature,iLevel,iCell)
             BGC_input%Salinity(iLevel,column) = activeTracers(indexSalinity,iLevel,iCell)
             BGC_input%cell_center_depth(iLevel,column) = -1.0_RKIND*zMid(iLevel,iCell)*convertLengthMKStoCGS
@@ -577,7 +578,7 @@ contains
                              BGC_output, BGC_diagnostic_fields, nVertLevels,   &
                              numColumnsMax, numColumns, config_ecosys_atm_alt_co2_use_eco)
 
-         do iLevel=1,maxLevelCell(iCell)
+         do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
 
             ecosysTracersTend(ecosysIndices%po4_ind,iLevel,iCell) =  &
                ecosysTracersTend(ecosysIndices%po4_ind,iLevel,iCell)   &
@@ -966,7 +967,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_ecosys_surface_flux_compute(activeTracers, ecosysTracers, forcingPool,  &
-      nTracers, nCellsSolve, zMid, indexTemperature, indexSalinity, ecosysSurfaceFlux, err)!{{{
+      nTracers, nCellsSolve, zMid, minLevelCell, indexTemperature, indexSalinity, ecosysSurfaceFlux, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -988,6 +989,7 @@ contains
 
       ! scalars
       integer, intent(in) :: nTracers, nCellsSolve, indexTemperature, indexSalinity
+      integer, dimension(:), intent(in) :: minLevelCell
 
       type (mpas_pool_type), intent(inout) :: forcingPool
 
@@ -1168,10 +1170,10 @@ contains
 
       numColumns = 1
       column = 1
-      iLevelSurface = 1
       !DWJ 08/05/2016: This loop needs OpenMP added to it.
       do iCell=1,nCellsSolve
 
+         iLevelSurface = minLevelCell(iCell)
 !        BGC_forcing%surfacePressure(column) = atmosphericPressure(iCell)*PascalsToAtmospheres
          BGC_forcing%surfacePressure(column) = 1.0_RKIND
          BGC_forcing%iceFraction(column) = iceFraction(iCell)
@@ -1188,6 +1190,7 @@ contains
          BGC_forcing%SST(column) = activeTracers(indexTemperature,iLevelSurface,iCell)
          BGC_forcing%SSS(column) = activeTracers(indexSalinity,iLevelSurface,iCell)
 
+         ! the 1 indices may need to be changed to iLevelSurface
          BGC_input%BGC_tracers(1,column,BGC_indices%dic_ind) = ecosysTracers(ecosysIndices%dic_ind,1,iCell)
          BGC_input%BGC_tracers(1,column,BGC_indices%dic_alt_co2_ind) = ecosysTracers(ecosysIndices%dic_alt_co2_ind,1,iCell)
          BGC_input%BGC_tracers(1,column,BGC_indices%alk_ind) = ecosysTracers(ecosysIndices%alk_ind,1,iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_ecosys.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_ecosys.F
@@ -1016,7 +1016,7 @@ contains
       type (mpas_pool_type), pointer :: ecosysAuxiliary,  &  ! additional forcing fields
                                         ecosysSeaIceCoupling
 
-      integer :: numColumns, column, iCell, iTracer, iLevelSurface
+      integer :: numColumns, column, iCell, iTracer, kSurface
 
 ! input flux components in forcing pool
       real (kind=RKIND), dimension(:), pointer :: &
@@ -1173,7 +1173,7 @@ contains
       !DWJ 08/05/2016: This loop needs OpenMP added to it.
       do iCell=1,nCellsSolve
 
-         iLevelSurface = minLevelCell(iCell)
+         kSurface = minLevelCell(iCell)
 !        BGC_forcing%surfacePressure(column) = atmosphericPressure(iCell)*PascalsToAtmospheres
          BGC_forcing%surfacePressure(column) = 1.0_RKIND
          BGC_forcing%iceFraction(column) = iceFraction(iCell)
@@ -1186,17 +1186,16 @@ contains
          BGC_forcing%atmCO2_ALT_CO2(column) = atmosphericCO2_ALT_CO2(iCell)
          BGC_forcing%surface_pH(column) = PH_PREV(iCell)
          BGC_forcing%surface_pH_alt_co2(column) = PH_PREV_ALT_CO2(iCell)
-         BGC_forcing%surfaceDepth(column) = -1.0_RKIND*zMid(iLevelSurface,iCell)
-         BGC_forcing%SST(column) = activeTracers(indexTemperature,iLevelSurface,iCell)
-         BGC_forcing%SSS(column) = activeTracers(indexSalinity,iLevelSurface,iCell)
+         BGC_forcing%surfaceDepth(column) = -1.0_RKIND*zMid(kSurface,iCell)
+         BGC_forcing%SST(column) = activeTracers(indexTemperature,kSurface,iCell)
+         BGC_forcing%SSS(column) = activeTracers(indexSalinity,kSurface,iCell)
 
-         ! the 1 indices may need to be changed to iLevelSurface
-         BGC_input%BGC_tracers(1,column,BGC_indices%dic_ind) = ecosysTracers(ecosysIndices%dic_ind,1,iCell)
-         BGC_input%BGC_tracers(1,column,BGC_indices%dic_alt_co2_ind) = ecosysTracers(ecosysIndices%dic_alt_co2_ind,1,iCell)
-         BGC_input%BGC_tracers(1,column,BGC_indices%alk_ind) = ecosysTracers(ecosysIndices%alk_ind,1,iCell)
-         BGC_input%BGC_tracers(1,column,BGC_indices%po4_ind) = ecosysTracers(ecosysIndices%po4_ind,1,iCell)
-         BGC_input%BGC_tracers(1,column,BGC_indices%sio3_ind) = ecosysTracers(ecosysIndices%sio3_ind,1,iCell)
-         BGC_input%BGC_tracers(1,column,BGC_indices%o2_ind) = ecosysTracers(ecosysIndices%o2_ind,1,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%dic_ind) = ecosysTracers(ecosysIndices%dic_ind,kSurface,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%dic_alt_co2_ind) = ecosysTracers(ecosysIndices%dic_alt_co2_ind,kSurface,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%alk_ind) = ecosysTracers(ecosysIndices%alk_ind,kSurface,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%po4_ind) = ecosysTracers(ecosysIndices%po4_ind,kSurface,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%sio3_ind) = ecosysTracers(ecosysIndices%sio3_ind,kSurface,iCell)
+         BGC_input%BGC_tracers(kSurface,column,BGC_indices%o2_ind) = ecosysTracers(ecosysIndices%o2_ind,kSurface,iCell)
 
 ! NOTE pass in total Fe and mult by parm_Fe_bioavail inside the flux routine
 !             divide river Fe by bioavail since it is already the available to make it total

--- a/src/core_ocean/shared/mpas_ocn_tracer_exponential_decay.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_exponential_decay.F
@@ -65,8 +65,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_exponential_decay_compute(nTracers, nCellsSolve, maxLevelCell, layerThickness, tracers, & !{{{
-                                                   tracersExponentialDecayRate, tracer_tend, err)
+   subroutine ocn_tracer_exponential_decay_compute(nTracers, nCellsSolve, minLevelCell, maxLevelCell, & !{{{
+                                                   layerThickness, tracers, tracersExponentialDecayRate, tracer_tend, err)
 
       !-----------------------------------------------------------------
       !
@@ -76,7 +76,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
 
       real (kind=RKIND), dimension(:), intent(in) :: &
          tracersExponentialDecayRate
@@ -122,7 +122,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
-         do iLevel=1,maxLevelCell(iCell)
+         do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
             do iTracer=1,nTracers
                tracer_tend(iTracer,iLevel,iCell) =   tracer_tend(iTracer,iLevel,iCell)   &
                                                     - (   layerThickness(iLevel,iCell)    &

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del2.F
@@ -119,7 +119,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: invAreaCell
@@ -137,6 +137,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       num_tracers = size(tracers, dim=1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
@@ -166,7 +167,7 @@ contains
 
           r_tmp = meshScalingDel2(iEdge) * eddyDiff2 * dvEdge(iEdge) / dcEdge(iEdge)
 
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             do iTracer = 1, num_tracers
               ! \kappa_2 \nabla \phi on edge
               tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_del4.F
@@ -120,7 +120,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, maxLevelCell, nEdgesOnCell
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: edgeMask, cellsOnEdge, edgesOnCell, edgeSignOnCell
 
       real (kind=RKIND) :: invAreaCell1, invAreaCell2, tracer_turb_flux, flux, invdcEdge, r_tmp1, r_tmp2
@@ -149,6 +149,8 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       num_tracers = size(tracers, dim=1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -181,7 +183,7 @@ contains
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
 
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             do iTracer = 1, num_tracers * edgeMask(k, iEdge)
 
               r_tmp1 = invdcEdge * layerThicknessEdge(k, iEdge) * tracers(iTracer, k, cell1)
@@ -211,7 +213,7 @@ contains
 
           invdcEdge = meshScalingDel4(iEdge) * dvEdge(iEdge) * eddyDiff4 / dcEdge(iEdge)
 
-          do k = 1, maxLevelEdgeTop(iEdge)
+          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             do iTracer = 1, num_tracers * edgeMask(k, iEdge)
               tracer_turb_flux = (delsq_tracer(iTracer, k, cell2) - delsq_tracer(iTracer, k, cell1))
 

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -133,7 +133,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop, nEdgesOnCell, maxLevelCell
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell, minLevelCell, maxLevelCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell, cellsOnCell
 
       real(kind=RKIND) :: tempTracer, invAreaCell1, invAreaCell2, invAreaCell, areaEdge
@@ -151,6 +151,8 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tracers, dim=1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -221,7 +223,7 @@ contains
             r_tmp = dvEdge(iEdge)/dcEdge(iEdge)
             coef = dvEdge(iEdge)
 
-            k = 1
+            k = minLevelEdgeBot(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
                                            RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
                                0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
@@ -239,12 +241,22 @@ contains
                              /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                              + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                              /(zMid(k, cell2) - zMid(k + 1, cell2)))
+               if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 1, iEdge)* &
+                               (tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1))/(zMid(k - 1, cell1) - zMid(k, cell1))
+               endif
+               if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
+                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 2, iEdge)* &
+                               (tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2))/(zMid(k - 1, cell2) - zMid(k, cell2))
+               endif
 
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
             end do
 
-            do k = 2, maxLevelEdgeTop(iEdge) - 1
+            do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
 
                kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
                                               RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))*0.25_RKIND* &
@@ -324,15 +336,15 @@ contains
          end do ! nEdgesOnCell(iCell)
 
          ! impose no-flux boundary conditions at top and bottom of column
-         fluxRediZTop(:, 1) = 0.0_RKIND
+         fluxRediZTop(:, 1:minLevelCell(iCell)) = 0.0_RKIND
          fluxRediZTop(:, maxLevelCell(iCell) + 1) = 0.0_RKIND
-         redi_term3_topOfCell(:, 1, iCell) = 0.0_RKIND
-         do k = 2, maxLevelCell(iCell)
+         redi_term3_topOfCell(:, 1:minLevelCell(iCell), iCell) = 0.0_RKIND
+         do k = minLevelCell(iCell) + 1, maxLevelCell(iCell)
             redi_term3_topOfCell(:, k, iCell) = fluxRediZTop(:, k) * invAreaCell
          end do
          redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
 
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, nTracers
                ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
                ! 2.0 in next line is because a dot product on a C-grid
@@ -367,7 +379,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k, iTr, tempTracer, iEdge)
       do iCell = 1, nCells
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tempTracer = tracers(iTr, k, iCell) + dt*(redi_term1(iTr, k, iCell) + redi_term2(iTr, k, iCell) + &
                                                          redi_term3(iTr, k, iCell))/layerThickness(k, iCell)
@@ -396,7 +408,7 @@ contains
       !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
          invAreaCell = 1.0_RKIND/areaCell(iCell)
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
@@ -409,7 +421,7 @@ contains
          do i = 1, nEdgesOnCell(iCell)
             if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
             iEdge = edgesOnCell(i, iCell)
-            do k = 1, maxLevelEdgeTop(iEdge)
+            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                do iTr = 1, ntracers
                   tend(iTr, k, iCell) = tend(iTr, k, iCell) + edgeSignOnCell(i, iCell)*invAreaCell*redi_term2_edge(iTr, k, iEdge)
                end do

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -248,13 +248,13 @@ contains
                              /(zMid(k, cell2) - zMid(k + 1, cell2)))
                if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 1, iEdge)* &
-                               (tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1))/(zMid(k - 1, cell1) - zMid(k, cell1))
+                               layerThicknessEdge(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 1, iEdge)* &
+                               (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell1) - tracers(iTr, minLevelEdgeBot(iEdge), cell1))/(zMid(minLevelEdgeBot(iEdge) - 1, cell1) - zMid(minLevelEdgeBot(iEdge), cell1))
                endif
                if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 2, iEdge)* &
-                               (tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2))/(zMid(k - 1, cell2) - zMid(k, cell2))
+                               layerThicknessEdge(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 2, iEdge)* &
+                               (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell

--- a/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_hmix_redi.F
@@ -228,6 +228,11 @@ contains
                                            RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
                                0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
                                            RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
+            k = 1
+            kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)

--- a/src/core_ocean/shared/mpas_ocn_tracer_ideal_age.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_ideal_age.F
@@ -65,7 +65,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_ideal_age_compute(nTracers, nCellsSolve, maxLevelCell, layerThickness, &
+   subroutine ocn_tracer_ideal_age_compute(nTracers, nCellsSolve, minLevelCell, maxLevelCell, layerThickness, &
                   idealAgeMask, tracers, tracer_tend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -76,7 +76,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
 
       ! two dimensional arrays
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -121,7 +121,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
-        do iLevel=1,maxLevelCell(iCell)
+        do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
           do iTracer=1,nTracers
              ! zero tracers at surface to zero where idealAgeMask == zero
              ! idealAgeMask should be equal to 1.0 elsewhere

--- a/src/core_ocean/shared/mpas_ocn_tracer_interior_restoring.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_interior_restoring.F
@@ -65,7 +65,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_interior_restoring_compute(nTracers, nCellsSolve, maxLevelCell, layerThickness, &
+   subroutine ocn_tracer_interior_restoring_compute(nTracers, nCellsSolve, minLevelCell, maxLevelCell, layerThickness, &
                   tracers, tracersInteriorRestoringRate, tracersInteriorRestoringValue, tracer_tend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -76,7 +76,7 @@ contains
 
       ! one dimensional arrays
       integer, dimension(:), intent(in) :: &
-         maxLevelCell
+         minLevelCell, maxLevelCell
 
       ! two dimensional arrays
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -121,7 +121,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(iLevel, iTracer)
       do iCell=1,nCellsSolve
-        do iLevel=1,maxLevelCell(iCell)
+        do iLevel=minLevelCell(iCell),maxLevelCell(iCell)
           do iTracer=1,nTracers
              tracer_tend(iTracer, iLevel, iCell) = tracer_tend(iTracer, iLevel, iCell)  - layerThickness(iLevel,iCell) &
                                                  * ( tracers(iTracer, iLevel, iCell) &

--- a/src/core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -112,7 +112,7 @@ contains
       integer :: iCell, k, iTracer, nTracers, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND) :: fluxTopOfCell, fluxBottomOfCell
 
       err = 0
@@ -125,6 +125,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tend, dim=1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       nCells = nCellsArray( 1 )
@@ -132,7 +133,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) private(k, iTracer, fluxTopOfCell, fluxBottomOfCell)
       do iCell = 1, nCells
-        do k = 2, maxLevelCell(iCell)-1
+        do k = minLevelCell(iCell)+1, maxLevelCell(iCell)-1
 
           ! NOTE: at the moment, all tracers are based on the flux-profile used for temperature, i.e. vertNonLocalFlux(1,:,:)
           do iTracer = 1, nTracers
@@ -151,7 +152,7 @@ contains
         end do
 
         ! enforce boundary conditions at top of column
-        k = 1
+        k = minLevelCell(iCell)
         do iTracer = 1, nTracers
           fluxTopOfCell = 0.0_RKIND
           fluxBottomOfCell = surfaceTracerFlux(iTracer, iCell) * vertNonLocalFlux(1, k+1, iCell)

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -128,7 +128,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real (kind=RKIND) :: depth, fluxRemaining
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth
@@ -139,6 +139,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
 
@@ -154,9 +155,9 @@ contains
       !$omp firstprivate(weights)
 #endif
       do iCell = 1, nCells
-         depth = 0.0_RKIND
+         depth = 0.0_RKIND ! depth relative to minLevelCell(iCell)
          fluxRemaining = 1.0_RKIND
-         do k = 1, maxLevelCell(iCell)
+         do k = minLevelCell(iCell), maxLevelCell(iCell)
             depth = depth + layerThickness(k, iCell)
 
             call ocn_get_jerlov_fraction(depth, weights(k+1))
@@ -174,13 +175,13 @@ contains
          end if
 
          depth = 0.0_RKIND
-         do k=1,maxLevelCell(iCell)
+         do k=minLevelCell(iCell),maxLevelCell(iCell)
            depth = depth + layerThickness(k,iCell)
            if(depth > abs(config_surface_buoyancy_depth)) exit
          enddo
 
-         if(k == maxLevelCell(iCell) .or. k == 1) then
-           depLev=2
+         if(k == maxLevelCell(iCell) .or. k == minLevelCell(iCell)) then
+           depLev=minLevelCell(iCell)+1
          else
            depLev=k
          endif

--- a/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_short_wave_absorption_variable.F
@@ -127,7 +127,7 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real (kind=RKIND) :: depth
       real (kind=RKIND), dimension(:), pointer :: refBottomDepth
@@ -141,12 +141,13 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'refBottomDepth', refBottomDepth)
 
       allocate(weights(nVertLevels+1))
       weights = 0.0_RKIND
-      weights(1) = 1.0_RKIND
+      weights(minLevelCell(iCell)) = 1.0_RKIND
       Avals(:)=0.0_RKIND
       Kvals(:)=0.0_RKIND
 
@@ -168,7 +169,7 @@ contains
 
         call ocn_get_os00_coeffs(chlorophyllA(iCell),zenithAngle(iCell),cloudRatio,Avals, Kvals)
 
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           depth = depth + layerThickness(k, iCell)
 
           call ocn_get_variable_sw_fraction(depth, weights(k+1), Avals, Kvals)
@@ -186,13 +187,13 @@ contains
         end if
 
         depth = 0.0_RKIND
-        do k=1,maxLevelCell(iCell)
+        do k=minLevelCell(iCell),maxLevelCell(iCell)
            depth = depth + layerThickness(k,iCell)
            if(depth > abs(config_surface_buoyancy_depth)) exit
         enddo
 
-        if(k == maxLevelCell(iCell) .or. k == 1) then
-           depLev=2
+        if(k == maxLevelCell(iCell) .or. k == minLevelCell(iCell)) then
+           depLev=minLevelCell(iCell)+1
         else
            depLev=k
         endif

--- a/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/src/core_ocean/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -123,7 +123,7 @@ contains
       integer :: iCell, k, iTracer, nTracers, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 
       real (kind=RKIND) :: remainingFlux
 
@@ -137,6 +137,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nTracers = size(tend, dim=1)
 
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
       nCells = nCellsArray( 1 )
@@ -145,7 +146,7 @@ contains
       !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
       do iCell = 1, nCells
         remainingFlux = 1.0_RKIND
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           remainingFlux = remainingFlux - fractionAbsorbed(k, iCell)
 
           do iTracer = 1, nTracers
@@ -174,7 +175,7 @@ contains
         !$omp do schedule(runtime) private(remainingFlux, k, iTracer)
         do iCell = 1, nCells
           remainingFlux = 1.0_RKIND
-          do k = 1, maxLevelCell(iCell)
+          do k = minLevelCell(iCell), maxLevelCell(iCell)
             remainingFlux = remainingFlux - fractionAbsorbedRunoff(k, iCell)
 
             do iTracer = 1, nTracers

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_del4.F
@@ -150,7 +150,7 @@ contains
       !Compute Laplacian of velocity
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, maxLevelEdgeTop, &
+      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
       !$acc            dvEdge, dcEdge, del2u, div, relVort) &
       !$acc    private(k, cell1, cell2, vertex1, vertex2, &
       !$acc            dcEdgeInv, dvEdgeInv)
@@ -171,7 +171,7 @@ contains
          dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
          dvEdgeInv = 1.0_RKIND / max(dvEdge(iEdge), 0.25_RKIND*dcEdge(iEdge))
 
-         do k=1,maxLevelEdgeTop(iEdge)
+         do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
             ! Compute \nabla^2 u = \nabla divergence + k \times \nabla relativeVorticity
             del2u(k,iEdge) = (div(k,cell2) - div(k,cell1))*dcEdgeInv &
                             -(relVort(k,vertex2) - relVort(k,vertex1))*&
@@ -188,7 +188,7 @@ contains
       ! Compute del2 of relative vorticity
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(edgesOnVertex, maxLevelVertexTop, dcEdge, &
+      !$acc    present(edgesOnVertex, minLevelVertexBot, maxLevelVertexTop, dcEdge, &
       !$acc            areaTriangle, edgeSignOnVertex, del2u, &
       !$acc            del2relVort) &
       !$acc    private(i, k, iEdge, areaTriInv)
@@ -201,7 +201,7 @@ contains
          areaTriInv = 1.0_RKIND/areaTriangle(iVertex)
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
-            do k = 1, maxLevelVertexTop(iVertex)
+            do k = minLevelVertexBot(iVertex), maxLevelVertexTop(iVertex)
                del2relVort(k,iVertex) = del2relVort(k,iVertex) &
                                       + edgeSignOnVertex(i,iVertex) &
                                        *dcEdge(iEdge)*del2u(k,iEdge)*areaTriInv
@@ -218,7 +218,7 @@ contains
       ! Compute del2 of divergence
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(nEdgesOnCell, edgesOnCell, maxLevelCell, dvEdge,&
+      !$acc    present(nEdgesOnCell, edgesOnCell, minLevelCell, maxLevelCell, dvEdge,&
       !$acc            edgeSignOnCell, areaCell, del2u, del2div) &
       !$acc    private(i, k, iEdge, areaCellInv)
 #else
@@ -230,7 +230,7 @@ contains
          areaCellInv = 1.0_RKIND / areaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                del2div(k,iCell) = del2div(k,iCell) - &
                                   edgeSignOnCell(i,iCell)*dvEdge(iEdge) &
                                  *del2u(k,iEdge)*areaCellInv
@@ -248,7 +248,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, maxLevelEdgeTop, &
+      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
       !$acc            dcEdge, dvEdge, meshScalingDel4, edgeMask, &
       !$acc            del2div, del2relVort, tend) &
       !$acc private(k, cell1, cell2, vertex1, vertex2, &
@@ -269,7 +269,7 @@ contains
          dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
          visc4 = viscDel4*meshScalingDel4(iEdge)
 
-         do k=1, maxLevelEdgeTop(iEdge)
+         do k=minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             uDiff = divFactor*(del2div(k,cell2) - del2div(k,cell1))* &
                                                           dcEdgeInv  &
                   - (del2relVort(k,vertex2) - del2relVort(k,vertex1))* &

--- a/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_hmix_leith.F
@@ -139,7 +139,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc    present(cellsOnEdge, verticesOnEdge, maxLevelEdgeTop, &
+      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
       !$acc            dcEdge, dvEdge, meshScalingDel2, div, relVort, &
       !$acc            tend, edgeMask) &
       !$acc    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
@@ -161,7 +161,7 @@ contains
 
          visc2tmp = (leithParam*dxLeith*meshScalingDel2(iEdge)/pii)**3
 
-         do k = 1, maxLevelEdgeTop(iEdge)
+         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
             ! Here -( relativeVorticity(k,vertex2) - 
             !         relativeVorticity(k,vertex1) ) / dvEdge(iEdge)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -1051,7 +1051,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
-      integer, dimension(:), pointer :: maxLevelCell, minLevelCell, maxLevelEdgeTop, minLevelEdgeTop
+      integer, dimension(:), pointer :: maxLevelCell, minLevelCell, maxLevelEdgeTop, minLevelEdgeBot
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       type (mpas_pool_iterator_type) :: groupItr
@@ -1078,7 +1078,7 @@ contains
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'minLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
@@ -1104,7 +1104,7 @@ contains
             vertViscTopOfEdge(:, iEdge) = 0.0_RKIND
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            do k=minLevelEdgeTop(iEdge),maxLevelEdgeTop(iEdge)
+            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
                vertViscTopOfEdge(k,iEdge) = 0.5_RKIND*(vertViscTopOfCell(k,cell2)+vertViscTopOfCell(k,cell1))
             end do
          end do

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -243,11 +243,11 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer :: iEdge, k, cell1, cell2, Nsurf, N, nEdges
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -261,18 +261,19 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
       nEdges = nEdgesArray( 1 )
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
-      A(1)=0.0_RKIND
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(N, cell1, cell2, edgeThicknessTotal, k, A, B, C, velTemp)
+      !$omp private(Nsurf, N, cell1, cell2, edgeThicknessTotal, k, A, B, C, velTemp)
       do iEdge = 1, nEdges
+        Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
@@ -282,30 +283,33 @@ contains
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          edgeThicknessTotal = 0.0_RKIND
-         do k = 1, N
+         do k = Nsurf, N
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
             edgeThicknessTotal = edgeThicknessTotal + layerThicknessEdge(k,iEdge)
          end do
 
          ! A is lower diagonal term
-         do k = 2, N
+         A(1:Nsurf)=0.0_RKIND
+         do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
                / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! C is upper diagonal term
-         do k = 1, N-1
+         C(1:Nsurf-1)=0.0_RKIND
+         do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
                / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! B is diagonal term
-         B(1) = 1.0_RKIND - C(1) &
+         B(1:Nsurf-1)=0.0_RKIND
+         B(Nsurf) = 1.0_RKIND - C(Nsurf) &
            ! added Rayleigh terms
            + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
-         do k = 2, N-1
+         do k = Nsurf, N-1
             B(k) = 1.0_RKIND - A(k) - C(k) &
               ! added Rayleigh terms
               + dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
@@ -319,9 +323,10 @@ contains
               + dt*(rayleighBottomDampingCoef + &
                     rayleighDampingCoef /((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
 
-         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+         call tridiagonal_solve(A(Nsurf+1:N),B(Nsurf:N),C(Nsurf:N-1),normalVelocity(Nsurf:N,iEdge),velTemp(Nsurf:N),N-Nsurf+1)
 
-         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(1:Nsurf-1,iEdge) = 0.0_RKIND
+         normalVelocity(Nsurf:N,iEdge) = velTemp(Nsurf:N)
          normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
 
         end if
@@ -424,7 +429,7 @@ contains
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
 
       !$omp parallel
-      !$omp do schedule(runtime) private(N, cell1, cell2, A, B, C, velTemp, k)
+      !$omp do schedule(runtime) private(Nsurf, N, cell1, cell2, A, B, C, velTemp, k)
       do iEdge = 1, nEdges
         N = maxLevelEdgeTop(iEdge)
         Nsurf = minLevelEdgeBot(iEdge)
@@ -554,12 +559,12 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer :: iEdge, k, cell1, cell2, N, Nsurf, nEdges
       integer, pointer :: nVertLevels
       real (kind=RKIND) :: implicitCd
       integer, dimension(:), pointer :: nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -572,16 +577,18 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
       nEdges = nEdgesArray( 1 )
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
-      A(1)=0.0_RKIND
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(Nsurf, N, cell1, cell2, A, B, C, velTemp, k)
       do iEdge = 1, nEdges
+        Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
@@ -590,7 +597,7 @@ contains
          ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = 1, N
+         do k = Nsurf, N
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
          end do
 
@@ -598,22 +605,25 @@ contains
          implicitCd = 0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2))
 
          ! A is lower diagonal term
-         do k = 2, N
+         A(1:Nsurf)=0.0_RKIND
+         do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
                / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! C is upper diagonal term
-         do k = 1, N-1
+         C(1:Nsurf-1)=0.0_RKIND
+         do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
                / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! B is diagonal term
-         B(1) = 1.0_RKIND - C(1)
-         do k = 2, N-1
+         B(1:Nsurf-1)=0.0_RKIND
+         B(Nsurf) = 1.0_RKIND - C(Nsurf)
+         do k = Nsurf+1, N-1
             B(k) = 1.0_RKIND - A(k) - C(k)
          enddo
 
@@ -623,9 +633,10 @@ contains
          B(N) = 1.0_RKIND - A(N) + dt*implicitCd &
               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge)
 
-         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+         call tridiagonal_solve(A(Nsurf+1:N),B(Nsurf:N),C(Nsurf:N-1),normalVelocity(Nsurf:N,iEdge),velTemp(Nsurf:N),N-Nsurf+1)
 
-         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(1:Nsurf-1,iEdge) = 0.0_RKIND
+         normalVelocity(Nsurf:N,iEdge) = velTemp(Nsurf:N)
          normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
 
         end if
@@ -717,12 +728,12 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer :: iEdge, k, cell1, cell2, N, Nsurf, nEdges
       integer, pointer :: nVertLevels
       real (kind=RKIND) :: implicitCd
       integer, dimension(:), pointer :: nEdgesArray
 
-      integer, dimension(:), pointer :: maxLevelEdgeTop
+      integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -748,6 +759,7 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
 
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
@@ -761,7 +773,6 @@ contains
       nCells = nCellsSolve
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
-      A(1)=0.0_RKIND
 
       ! Compute bottomDrag (Manning roughness) induced by vegetation
       if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
@@ -794,8 +805,10 @@ contains
         enddo
       endif
 
-      !$omp do schedule(runtime)
+      !$omp parallel
+      !$omp do schedule(runtime) private(Nsurf, N, A, B, C, rhs, velTemp, k)
       do iEdge = 1, nEdges
+        Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
@@ -804,7 +817,7 @@ contains
          ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = 1, N
+         do k = Nsurf, N
             layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
          end do
 
@@ -818,22 +831,25 @@ contains
          endif
 
          ! A is lower diagonal term
-         do k = 2, N
+         A(1:Nsurf)=0.0_RKIND
+         do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
                / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! C is upper diagonal term
-         do k = 1, N-1
+         C(1:Nsurf-1)=0.0_RKIND
+         do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
                / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
                / layerThicknessEdge(k,iEdge)
          enddo
 
          ! B is diagonal term
-         B(1) = 1.0_RKIND - C(1)
-         do k = 2, N-1
+         B(1:Nsurf-1)=0.0_RKIND
+         B(Nsurf) = 1.0_RKIND - C(Nsurf)
+         do k = Nsurf+1, N-1
             B(k) = 1.0_RKIND - A(k) - C(k)
          enddo
 
@@ -843,14 +859,16 @@ contains
          B(N) = 1.0_RKIND - A(N) + dt*implicitCd &
               * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge)
 
-         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+         call tridiagonal_solve(A(Nsurf+1:N),B(Nsurf:N),C(Nsurf:N-1),normalVelocity(Nsurf:N,iEdge),velTemp(Nsurf:N),N-Nsurf+1)
 
-         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(1:Nsurf-1,iEdge) = 0.0_RKIND
+         normalVelocity(Nsurf:N,iEdge) = velTemp(Nsurf:N)
          normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
 
         end if
       end do
       !$omp end do
+      !$omp end parallel
 
       deallocate(A,B,C,velTemp)
 
@@ -949,7 +967,7 @@ contains
 
       call mpas_timer_start('vmix tracers tend imp loop', .false.)
       !$omp parallel
-      !$omp do schedule(runtime) private(N, A, B, C, rhs, tracersTemp, k)
+      !$omp do schedule(runtime) private(Nsurf, N, A, B, C, rhs, tracersTemp, k)
       do iCell = 1, nCells
          ! Compute A(k), B(k), C(k) for tracers
          Nsurf = minLevelCell(iCell)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -307,9 +307,8 @@ contains
          ! B is diagonal term
          B(1:Nsurf-1)=0.0_RKIND
          B(Nsurf) = 1.0_RKIND - C(Nsurf) &
-           ! added Rayleigh terms
            + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
-         do k = Nsurf, N-1
+         do k = Nsurf+1, N-1
             B(k) = 1.0_RKIND - A(k) - C(k) &
               ! added Rayleigh terms
               + dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal))
@@ -585,8 +584,7 @@ contains
 
       allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
 
-      !$omp parallel
-      !$omp do schedule(runtime) private(Nsurf, N, cell1, cell2, A, B, C, velTemp, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
@@ -805,8 +803,7 @@ contains
         enddo
       endif
 
-      !$omp parallel
-      !$omp do schedule(runtime) private(Nsurf, N, A, B, C, rhs, velTemp, k)
+      !$omp do schedule(runtime)
       do iEdge = 1, nEdges
         Nsurf = minLevelEdgeBot(iEdge)
         N = maxLevelEdgeTop(iEdge)
@@ -868,7 +865,6 @@ contains
         end if
       end do
       !$omp end do
-      !$omp end parallel
 
       deallocate(A,B,C,velTemp)
 

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -975,9 +975,9 @@ contains
          enddo
 
          if ( config_cvmix_kpp_nonlocal_with_implicit_mix ) then
-            call ocn_compute_kpp_rhs(tracers(:,:,iCell), rhs(:,:), dt, N, num_tracers, &
+            call ocn_compute_kpp_rhs(tracers(:,:,iCell), rhs(:,:), dt, Nsurf, N, num_tracers, &
                              layerThickness(:,iCell), vertNonLocalFlux(:,:,iCell), &
-                             tracerGroupSurfaceFlux(:,iCell)) !mlc-arguments may need to be changed
+                             tracerGroupSurfaceFlux(:,iCell))
          else
             rhs(:,:) = tracers(:,:,iCell)
          endif
@@ -1376,24 +1376,26 @@ end subroutine tridiagonal_solve_mult!}}}
 !
 !-----------------------------------------------------------------------
 
-subroutine ocn_compute_kpp_rhs(tracers, rhs, dt, maxLevelCell, nTracers, &
+subroutine ocn_compute_kpp_rhs(tracers, rhs, dt, minLevelCell, maxLevelCell, nTracers, &
                          layerThickness, vertNonLocalFlux, tracerGroupSurfaceFlux)!{{{
 
   real (kind=RKIND), intent(in) :: dt
   real (kind=RKIND), dimension(:,:), intent(in) :: vertNonLocalFlux, tracers
   real (kind=RKIND), dimension(:), intent(in) :: layerThickness, tracerGroupSurfaceFlux
   real (kind=RKIND), dimension(:,:), intent(out) :: rhs
-  integer, intent(in) :: maxLevelCell, nTracers
+  integer, intent(in) :: minLevelCell, maxLevelCell, nTracers
   integer :: iTracer, k
 
-  do k=2,maxLevelCell-1
+  rhs(:,1:minLevelCell-1) = 0.0_RKIND
+  
+  do k=minLevelCell+1,maxLevelCell-1
      do iTracer=1,nTracers
         rhs(iTracer, k) = tracers(iTracer,k) + dt * tracerGroupSurfaceFlux(iTracer) *   &
                      (vertNonLocalFlux(1,k) - vertNonLocalFlux(1,k+1)) / layerThickness(k)
      enddo
   enddo
 
-  k=1
+  k=minLevelCell
   do iTracer=1,nTracers
      rhs(iTracer, k) = tracers(iTracer,k) + dt * tracerGroupSurfaceFlux(iTracer) *  &
                               (-vertNonLocalFlux(1,k+1) )/ layerThickness(k)

--- a/src/core_ocean/shared/mpas_ocn_vmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix.F
@@ -956,13 +956,14 @@ contains
          N = maxLevelCell(iCell)
 
          ! A is lower diagonal term
-         A(Nsurf)=0.0_RKIND
+         A(1:Nsurf)=0.0_RKIND
          do k = Nsurf+1, N
             A(k) = -2.0_RKIND*dt*vertDiffTopOfCell(k,iCell) &
                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) / layerThickness(k,iCell)
          enddo
 
          ! C is upper diagonal term
+         C(1:Nsurf-1)=0.0_RKIND
          do k = Nsurf, N-1
             C(k) = -2.0_RKIND*dt*vertDiffTopOfCell(k+1,iCell) &
                  / (layerThickness(k,iCell) + layerThickness(k+1,iCell)) / layerThickness(k,iCell)
@@ -970,6 +971,7 @@ contains
          C(N) = 0.0_RKIND
 
          ! B is diagonal term
+         B(1:Nsurf-1)=0.0_RKIND
          do k = Nsurf, N
             B(k) = 1.0_RKIND - A(k) - C(k)
          enddo

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -519,7 +519,7 @@ contains
               do i = 1, nEdgesOnCell(iCell)
                  iEdge = edgesOnCell(i, iCell)
 
-                 deltaVelocitySquared(minLevelCell(iCell):minLevelCell(iCell)) = 0.0_RKIND
+                 deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
 
                  normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
                                                           layerThickEdge(minLevelCell(iCell),iEdge)
@@ -662,8 +662,8 @@ contains
                           Snonlocal = cvmix_variables%kpp_Snonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                           surf_fric = cvmix_variables%SurfaceFriction,                      &
                           surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
-                          nlev = maxLevelCell(iCell),                                  &
-                          max_nlev = nVertLevels,                                      &
+                          nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 2,             &
+                          max_nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 2,         &
                           Langmuir_EFactor = langmuirEnhancementFactor )
 !           call mpas_timer_stop('cvmix coeffs kpp')
 
@@ -687,7 +687,7 @@ contains
          if ( kpp_stage == 2) then
          ! call convective mixing scheme
          if (config_use_cvmix_convection) then
-            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
+            do k = 1, maxLevelCell(iCell) + 1
                cvmix_variables % Mdiff_iface(k) = 0.0_RKIND
                cvmix_variables % Tdiff_iface(k) = 0.0_RKIND
             end do

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -364,7 +364,7 @@ contains
             ! https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/JC084iC05p02503
             ! The standard atan formulation is approximated following equation (13) of Girones et al (2012)
             ! https://doi.org/10.1109/MSP.2012.2219677
-            do k = 1,maxLevelCell(iCell)
+            do k = minLevelCell(iCell),maxLevelCell(iCell)
                x = (abs(cvmix_variables % zw_iface(k)) - config_cvmix_BryanLewis_transitionDepth) / &
                    config_cvmix_BryanLewis_transitionWidth
                vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + config_cvmix_BryanLewis_bl1 + &
@@ -375,11 +375,13 @@ contains
          endif
 
          ! fill Ri
-         RiSmoothed(1:maxLevelCell(iCell)) = RiTopOfCell(1:maxLevelCell(iCell),iCell)
+         RiSmoothed(1:minLevelCell(iCell)-1) = RiTopOfCell(minLevelCell(iCell),iCell)
+         RiSmoothed(minLevelCell(iCell):maxLevelCell(iCell)) = RiTopOfCell(minLevelCell(iCell):maxLevelCell(iCell),iCell)
          RiSmoothed(maxLevelCell(iCell)+1) = RiSmoothed(maxLevelCell(iCell))
          RiTemp(1:maxLevelCell(iCell)+1) = RiSmoothed(1:maxLevelCell(iCell)+1)
 
          ! Use a 1-2-1 filter to remove 2 dz noise in RiTopOfCell
+         ! Note: loop limits here must not be minLevelCell or non-bfb changes are introduced
          do nsmooth=1,config_cvmix_num_ri_smooth_loops
             do k=2,maxLevelCell(iCell)
                  RiSmoothed(k) = (RiTemp(k-1) + 2.0_RKIND*RiTemp(k) + RiTemp(k+1))  / 4.0_RKIND
@@ -387,7 +389,7 @@ contains
             RiTemp(1:maxLevelCell(iCell)) = RiSmoothed(1:maxLevelCell(iCell))
          enddo
 
-         cvmix_variables%ShearRichardson_iface => RiSmoothed(1:maxLevelCell(iCell)+1)
+         cvmix_variables%ShearRichardson_iface => RiSmoothed(minLevelCell(iCell):maxLevelCell(iCell)+1)
 
          endif
 
@@ -396,17 +398,17 @@ contains
                         BruntVaisalaFreqTop(minLevelCell(iCell):maxLevelCell(iCell),iCell))
          BVFSmoothed(1:minLevelCell(iCell)-1) = max(0.0_RKIND,BVFSmoothed(minLevelCell(iCell)))
          BVFSmoothed(maxLevelCell(iCell)+1) = max(0.0_RKIND,BVFSmoothed(maxLevelCell(iCell)))
-         cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed(1:maxLevelCell(iCell)+1)
+         cvmix_variables%SqrBuoyancyFreq_iface => BVFSmoothed(minLevelCell(iCell):maxLevelCell(iCell)+1)
 
          ! fill the intent(in) KPP
          cvmix_variables % SurfaceFriction = surfaceFrictionVelocity(iCell)
          cvmix_variables % SurfaceBuoyancyForcing = surfaceBuoyancyForcing(iCell)
-         cvmix_variables % BulkRichardson_cntr => bulkRichardsonNumber(1:maxLevelCell(iCell), iCell)
+         cvmix_variables % BulkRichardson_cntr => bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell), iCell)
 
          if (kpp_stage == 2) then
          if (config_use_cvmix_shear) then
 
-            do k = 1, maxLevelCell(iCell) + 1
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
                cvmix_variables % Mdiff_iface(k) = 0.0_RKIND
                cvmix_variables % Tdiff_iface(k) = 0.0_RKIND
             end do
@@ -418,13 +420,13 @@ contains
             ! accounted for seperately. so remove bac    kground from shear mixing values
 
             if(cvmixShearMixingChoice==cvmixShearMixingTypePP) then
-               do k = 1, maxLevelCell(iCell) + 1
+               do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
                   cvmix_variables % Mdiff_iface(k) = cvmix_variables % Mdiff_iface(k) - config_cvmix_background_viscosity
                   cvmix_variables % Tdiff_iface(k) = cvmix_variables % Tdiff_iface(k) - config_cvmix_background_diffusion
                end do
             endif
 
-            do k = 1, maxLevelCell(iCell)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + cvmix_variables % Mdiff_iface(k)
                vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + cvmix_variables % Tdiff_iface(k)
             end do
@@ -438,8 +440,8 @@ contains
             if (config_use_cvmix_fixed_boundary_layer) then
                cvmix_variables % BoundaryLayerDepth = config_cvmix_kpp_boundary_layer_depth
                cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = cvmix_variables % BoundaryLayerDepth )
 
             else
@@ -448,7 +450,7 @@ contains
               do k=minLevelCell(iCell),maxLevelCell(iCell)
                   Nsqr_iface(k) = BVFSmoothed(k)
               enddo
-              Nsqr_iface(1:minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
+              Nsqr_iface(minLevelCell(iCell):minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
               k=min(maxLevelCell(iCell)+1,nVertLevels)
               Nsqr_iface(k:maxLevelCell(iCell)+1) = Nsqr_iface(k-1)
 
@@ -507,17 +509,17 @@ contains
               ! compute the turbulent scales in order to compute the bulk Richardson number
               call cvmix_kpp_compute_turbulent_scales( &
                    sigma_coord = config_cvmix_kpp_surface_layer_extent, &
-                   OBL_depth = OBLDepths(1:maxLevelCell(iCell)), &
-                   surf_buoy_force = interfaceForcings(1:maxLevelCell(iCell)), &
+                   OBL_depth = OBLDepths(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   surf_buoy_force = interfaceForcings(minLevelCell(iCell):maxLevelCell(iCell)), &
                    surf_fric_vel = cvmix_variables % SurfaceFriction, &
-                   w_s = turbulentScalarVelocityScale(1:maxLevelCell(iCell)))
+                   w_s = turbulentScalarVelocityScale(minLevelCell(iCell):maxLevelCell(iCell)))
 
               ! averaging over a surface layer assuming that BLdepth is cell bottom
               ! Build deltaVelocitySquared
               do i = 1, nEdgesOnCell(iCell)
                  iEdge = edgesOnCell(i, iCell)
 
-                 deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
+                 deltaVelocitySquared(minLevelCell(iCell):minLevelCell(iCell)) = 0.0_RKIND
 
                  normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
                                                           layerThickEdge(minLevelCell(iCell),iEdge)
@@ -558,11 +560,11 @@ contains
 !             call mpas_timer_stop('Bulk Richardson kIndexOBL loops')
 
               cvmix_variables % bulkRichardson_cntr(:) = cvmix_kpp_compute_bulk_Richardson( &
-                   zt_cntr = cvmix_variables % zt_cntr(1:maxLevelCell(iCell)), &
-                   delta_buoy_cntr = bulkRichardsonNumberBuoy(1:maxLevelCell(iCell),iCell), &
-                   delta_Vsqr_cntr = bulkRichardsonNumberShear(1:maxLevelCell(iCell),iCell), &
+                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
+                   delta_buoy_cntr = bulkRichardsonNumberBuoy(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   delta_Vsqr_cntr = bulkRichardsonNumberShear(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
                    ws_cntr = turbulentScalarVelocityScale(:), &
-                   Nsqr_iface = Nsqr_iface(1:maxLevelCell(iCell)+1), &
+                   Nsqr_iface = Nsqr_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                    EFactor = langmuirEnhancementFactor, &
                    LaSL = langmuirNumber, &
                    bfsfc = cvmix_variables%SurfaceBuoyancyForcing, &
@@ -572,11 +574,11 @@ contains
               ! each level of bulk Richardson is computed as if OBL resided at bottom of that level
 
               call cvmix_kpp_compute_OBL_depth(  &
-                   Ri_bulk = bulkRichardsonNumber(1:maxLevelCell(iCell),iCell), &
-                   zw_iface = cvmix_variables % zw_iface(1:maxLevelCell(iCell)+1), &
+                   Ri_bulk = bulkRichardsonNumber(minLevelCell(iCell):maxLevelCell(iCell),iCell), &
+                   zw_iface = cvmix_variables % zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                    OBL_depth = cvmix_variables % BoundaryLayerDepth, &
                    kOBL_depth = cvmix_variables % kOBL_depth, &
-                   zt_cntr = cvmix_variables % zt_cntr(1:maxLevelCell(iCell)), &
+                   zt_cntr = cvmix_variables % zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)), &
                    surf_fric = cvmix_variables % SurfaceFriction, &
                    surf_buoy = cvmix_variables % SurfaceBuoyancyForcing, &
                    Coriolis = cvmix_variables % Coriolis)
@@ -587,8 +589,8 @@ contains
              if(cvmix_variables % BoundaryLayerDepth .lt. layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND) then
                 cvmix_variables % BoundaryLayerDepth = layerThickness(minLevelCell(iCell),iCell)/2.0_RKIND
                 cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1),&
-                          zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = cvmix_variables % BoundaryLayerDepth )
              endif
 
@@ -597,8 +599,8 @@ contains
              if(cvmix_variables % BoundaryLayerDepth .lt. configure_cvmix_kpp_minimum_OBL_under_sea_ice) then
                 cvmix_variables % BoundaryLayerDepth = configure_cvmix_kpp_minimum_OBL_under_sea_ice
                 cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1),&
-                          zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),&
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = cvmix_variables % BoundaryLayerDepth )
              endif
              endif
@@ -607,8 +609,8 @@ contains
              if(cvmix_variables % BoundaryLayerDepth .gt. abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))) then
                 cvmix_variables % BoundaryLayerDepth = abs(cvmix_variables%zt_cntr(maxLevelCell(iCell)))
                 cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = cvmix_variables % BoundaryLayerDepth )
 
              endif
@@ -618,7 +620,7 @@ contains
 
      if (kpp_stage == 2) then
             ! copy data into cvmix_variables
-            do k = 1, maxLevelCell(iCell) + 1
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
               cvmix_variables % Mdiff_iface(k) = vertViscTopOfCell(k, iCell)
               cvmix_variables % Tdiff_iface(k) = vertDiffTopOfCell(k, iCell)
             end do
@@ -628,8 +630,8 @@ contains
             boundaryLayerDepth(iCell) = min(blTemp, abs(cvmix_variables%zt_cntr(maxLevelCell(iCell))))
 
             cvmix_variables % kOBL_depth = cvmix_kpp_compute_kOBL_depth(  &
-                          zw_iface = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1), &
-                          zt_cntr = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),    &
+                          zw_iface = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          zt_cntr = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),    &
                           OBL_depth = boundaryLayerDepth(iCell) )
 
             ! update Langmuir enhancement factor
@@ -646,18 +648,18 @@ contains
 
 !           call mpas_timer_start('cvmix coeffs kpp', .false.)
             call cvmix_coeffs_kpp(                                              &
-                          Mdiff_out = cvmix_variables % Mdiff_iface(1:maxLevelCell(iCell)+1),       &
-                          Tdiff_out = cvmix_variables % Tdiff_iface(1:maxLevelCell(iCell)+1),       &
-                          Sdiff_out = cvmix_variables % Sdiff_iface(1:maxLevelCell(iCell)+1),       &
-                          zw = cvmix_variables%zw_iface(1:maxLevelCell(iCell)+1),            &
-                          zt = cvmix_variables%zt_cntr(1:maxLevelCell(iCell)),               &
-                          old_Mdiff = cvmix_variables%Mdiff_iface(1:maxLevelCell(iCell)+1),         &
-                          old_Tdiff = cvmix_variables%Tdiff_iface(1:maxLevelCell(iCell)+1),         &
-                          old_Sdiff = cvmix_variables%Sdiff_iface(1:maxLevelCell(iCell)+1),         &
+                          Mdiff_out = cvmix_variables % Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          Tdiff_out = cvmix_variables % Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          Sdiff_out = cvmix_variables % Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),       &
+                          zw = cvmix_variables%zw_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),            &
+                          zt = cvmix_variables%zt_cntr(minLevelCell(iCell):maxLevelCell(iCell)),               &
+                          old_Mdiff = cvmix_variables%Mdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
+                          old_Tdiff = cvmix_variables%Tdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
+                          old_Sdiff = cvmix_variables%Sdiff_iface(minLevelCell(iCell):maxLevelCell(iCell)+1),         &
                           OBL_depth = boundaryLayerDepth(iCell),                   &
                           kOBL_depth = cvmix_variables%kOBL_depth,                           &
-                          Tnonlocal = cvmix_variables%kpp_Tnonlocal_iface(1:maxLevelCell(iCell)+1), &
-                          Snonlocal = cvmix_variables%kpp_Snonlocal_iface(1:maxLevelCell(iCell)+1), &
+                          Tnonlocal = cvmix_variables%kpp_Tnonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
+                          Snonlocal = cvmix_variables%kpp_Snonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                           surf_fric = cvmix_variables%SurfaceFriction,                      &
                           surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
                           nlev = maxLevelCell(iCell),                                  &
@@ -668,7 +670,7 @@ contains
             ! intent out of BoundaryLayerDepth is boundary layer depth measured in meters and vertical index
             indexBoundaryLayerDepth(iCell) = cvmix_variables % kOBL_depth
 
-            do k = 1, maxLevelCell(iCell) + 1
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
                 vertViscTopOfCell(k, iCell) = cvmix_variables % Mdiff_iface(k)
                 vertDiffTopOfCell(k, iCell) = cvmix_variables % Tdiff_iface(k)
             end do
@@ -685,7 +687,7 @@ contains
          if ( kpp_stage == 2) then
          ! call convective mixing scheme
          if (config_use_cvmix_convection) then
-            do k = 1, maxLevelCell(iCell) + 1
+            do k = minLevelCell(iCell), maxLevelCell(iCell) + 1
                cvmix_variables % Mdiff_iface(k) = 0.0_RKIND
                cvmix_variables % Tdiff_iface(k) = 0.0_RKIND
             end do

--- a/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_cvmix.F
@@ -662,8 +662,8 @@ contains
                           Snonlocal = cvmix_variables%kpp_Snonlocal_iface(minLevelCell(iCell):maxLevelCell(iCell)+1), &
                           surf_fric = cvmix_variables%SurfaceFriction,                      &
                           surf_buoy = cvmix_variables%SurfaceBuoyancyForcing,               &
-                          nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 2,             &
-                          max_nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 2,         &
+                          nlev = maxLevelCell(iCell) - minLevelCell(iCell) + 1,             &
+                          max_nlev = nVertLevels,         &
                           Langmuir_EFactor = langmuirEnhancementFactor )
 !           call mpas_timer_stop('cvmix coeffs kpp')
 

--- a/src/core_ocean/shared/mpas_ocn_wetting_drying.F
+++ b/src/core_ocean/shared/mpas_ocn_wetting_drying.F
@@ -108,7 +108,7 @@ contains
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), pointer :: statePool, meshPool, tendPool
-      integer, dimension(:), pointer :: maxLevelCell
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
       real (kind=RKIND), dimension(:), pointer :: sshSubcycleNew
       real (kind=RKIND), dimension(:), pointer :: bottomDepth
       integer, pointer :: nCellsSolve
@@ -134,6 +134,7 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, timeLevel=1)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, timeLevel=2)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(tendPool, 'layerThickness', layerThicknessTend)
       call mpas_pool_get_array(statePool, 'sshSubcycle', sshSubcycleNew, 2)
@@ -148,7 +149,7 @@ contains
       ! check to make sure that there is no layer that is too dry
       minThickness = +1.0E34
       do iCell = 1, nCellsSolve
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           ! use ssh as a proxy too for baroclinic mode
           if (trim(config_time_integrator) == 'split_explicit' .or. trim(config_time_integrator) == 'semi_implicit') then
             layerThick = min(layerThicknessNew(k, iCell), (sshSubcycleNew(iCell)+bottomDepth(iCell))/maxLevelCell(iCell))
@@ -243,6 +244,7 @@ contains
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessProvis
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
 
+      integer, dimension(:), pointer :: minLevelEdgeTop
       integer, dimension(:), pointer :: maxLevelEdgeTop
       integer, dimension(:), pointer :: maxLevelEdgeBot
       integer, pointer :: nEdges
@@ -261,6 +263,7 @@ contains
      call mpas_pool_get_array(provisStatePool, 'layerThickness', layerThicknessProvis, 1)
 
      call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
+     call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
 
@@ -281,7 +284,7 @@ contains
      !$omp parallel
      !$omp do schedule(runtime) private(k)
      do iEdge = 1, nEdges
-       do k = 1, maxLevelEdgeBot(iEdge)
+       do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
          if (abs(normalTransportVelocity(k,iEdge) + wettingVelocity(k,iEdge)) < eps)  then
            ! prevent spurious flux for close to zero values
            normalTransportVelocity(k, iEdge) = 0.0_RKIND
@@ -370,8 +373,8 @@ contains
       integer :: iEdge, iCell, k, i
       integer, pointer :: nVertLevels, nCells
       integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:), pointer :: maxLevelCell
-      integer, dimension(:), pointer :: maxLevelEdgeBot
+      integer, dimension(:), pointer :: minLevelCell, maxLevelCell
+      integer, dimension(:), pointer :: minLevelEdgeTop, maxLevelEdgeBot
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:,:), pointer :: edgeSignOnCell
 
@@ -387,7 +390,9 @@ contains
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', maxLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -399,12 +404,12 @@ contains
       do iCell = 1, nCells
         invAreaCell = 1.0_RKIND / areaCell(iCell)
         ! can switch with maxLevelEdgeBot(iEdge)
-        do k = 1, maxLevelCell(iCell)
+        do k = minLevelCell(iCell), maxLevelCell(iCell)
           divOutFlux = 0.0_RKIND
           layerThickness = min(layerThicknessProvis(k, iCell), layerThicknessCur(k, iCell))
           do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            if (k <= maxLevelEdgeBot(iEdge)) then
+            if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
               ! only consider divergence flux leaving the cell
               if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) < 0.0_RKIND ) then
                 divOutFlux = divOutFlux + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) &
@@ -421,7 +426,7 @@ contains
 
             do i = 1, nEdgesOnCell(iCell)
               iEdge = edgesOnCell(i, iCell)
-              if (k <= maxLevelEdgeBot(iEdge)) then
+              if (k <= maxLevelEdgeBot(iEdge) .or. k >= minLevelEdgeTop(iEdge)) then
                 if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) <= 0.0_RKIND ) then
                   ! each outgoing velocity is penalized (but not the incoming, wetting velocities)
                   ! square the fractional term to make values near zero go to zero much quicker (to prevent threshold from being hit)


### PR DESCRIPTION
Here, we extend the capability for Inactive top cells introduced by https://github.com/MPAS-Dev/MPAS-Model/pull/825 to apply to additional model configurations besides those needed to run a basic ice shelf test case. More detail about the scope of this development is documented in https://github.com/MPAS-Dev/MPAS-Model/pull/811.

The variable `minLevelCell` and related `minLevelEdge*` and `minLevelVertex*` variables are added by analogy with `maxLevel*` variables. By default, there are no inactive top cells and `minLevel*` = 1. The main code changes are to k-loop limits and designating surface quantities as those at `minLevel*`. 