### PR TITLE
Fixes nonlocal temp flux for KPP

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2020,6 +2020,10 @@ contains
                               -100.0_RKIND) )
          ! Store the total tracer flux below in nonLocalSurfaceTemperatureFlux for use in the CVMix nonlocal
          ! transport code.  This includes tracer forcing due to thickness
+         ! Note: rainFlux, evaporationFlux, seaIceFreshWaterFlux, icebergFreshWaterFlux 
+         !       all have units of kg m^{-2} s^{-1}, so require division by rho_sw.
+         !       surfaceThicknessFlux, surfaceThicknessFluxRunoff have units of m s^{-1},
+         !       so has no division by rho_sw is needed.
 
          nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = activeTracersSurfaceFlux(indexTempFlux,iCell) &
                  + penetrativeTemperatureFlux(iCell) - penetrativeTemperatureFluxOBL(iCell)  &

--- a/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -2024,7 +2024,7 @@ contains
          nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = activeTracersSurfaceFlux(indexTempFlux,iCell) &
                  + penetrativeTemperatureFlux(iCell) - penetrativeTemperatureFluxOBL(iCell)  &
                  - fracAbsorbed * (rainFlux(iCell) + evaporationFlux(iCell)) * activeTracers(indexTempFlux,1,iCell)/rho_sw &
-                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell)* min(activeTracers(indexTempFlux,1,iCell),0.0_RKIND)/rho_sw &
+                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell)* min(activeTracers(indexTempFlux,1,iCell),0.0_RKIND) &
                  - fracAbsorbed * (seaIceFreshWaterFlux(iCell) + icebergFreshWaterFlux(iCell)) * &
                  ocn_freezing_temperature( activeTracers(indexSaltFlux, 1, iCell), pressure=0.0_RKIND, inLandIceCavity=.false.)&
                   / rho_sw


### PR DESCRIPTION
Currently the nonLocalTemperatureFlux includes the river flux as 
```
surfaceThicknessFluxRunoff*max(0,SST)/rho_sw
```
however `surfaceThicknessFluxRunoff` is already divided by rho_sw in `mpas_ocn_surface_bulk_forcing.F` so this second division is incorrect and does not yield units of m C /s. The extra `rho_sw` is removed in this PR.

The effect should be small but the PR will be nonBFB