### PR TITLE
Seaice variational basis operator refactor

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_mesh.F
+++ b/src/core_seaice/shared/mpas_seaice_mesh.F
@@ -631,25 +631,26 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine seaice_cell_vertices_at_vertex(&
-       mesh, &
-       cellVerticesAtVertex)!{{{
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+       cellVerticesAtVertex, &
+       nVertices, &
+       vertexDegree, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       cellsOnVertex)!{{{
 
     integer, dimension(:,:), intent(out) :: &
          cellVerticesAtVertex !< Output:
 
-    integer, pointer :: &
-         nVertices, &
-         vertexDegree
+    integer, intent(in) :: &
+         nVertices, & !< Input:
+         vertexDegree !< Input:
 
-    integer, dimension(:,:), pointer :: &
-         cellsOnVertex, &
-         verticesOnCell
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
 
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
+    integer, dimension(:,:), intent(in) :: &
+         cellsOnVertex, & !< Input:
+         verticesOnCell   !< Input:
 
     integer :: &
          iVertex, &
@@ -657,14 +658,6 @@ contains
          iCell, &
          iVertexOnCell, &
          jVertex
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
-    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
-
-    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
 
     do iVertex = 1, nVertices
 

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_pwl.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_pwl.F
@@ -71,7 +71,27 @@ contains
 
     integer, pointer :: &
          nCells, &
+         nVertices, &
+         vertexDegree, &
          maxEdges
+
+    integer, dimension(:), pointer :: &
+         nEdgesOnCell
+
+    integer, dimension(:,:), pointer :: &
+         verticesOnCell, &
+         cellsOnVertex, &
+         edgesOnCell
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell, &
+         dvEdge, &
+         areaCell
 
     real(kind=RKIND), dimension(:), pointer :: &
          tanLatVertexRotatedOverRadius
@@ -87,10 +107,31 @@ contains
          basisIntegralsU, &
          basisIntegralsV
 
-    integer :: iCell, i1, i2
+    logical, pointer :: &
+         on_a_sphere
+
+    real(kind=RKIND), pointer :: &
+         sphere_radius
+
+    call MPAS_pool_get_config(mesh, "on_a_sphere", on_a_sphere)
+    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
 
     call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
+    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
     call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
+    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
+    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
+    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
+    call MPAS_pool_get_array(mesh, "edgesOnCell", edgesOnCell)
+    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
+    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
+    call MPAS_pool_get_array(mesh, "zVertex", zVertex)
+    call MPAS_pool_get_array(mesh, "xCell", xCell)
+    call MPAS_pool_get_array(mesh, "yCell", yCell)
+    call MPAS_pool_get_array(mesh, "zCell", zCell)
+    call MPAS_pool_get_array(mesh, "dvEdge", dvEdge)
+    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
 
     call MPAS_pool_get_array(velocity_variational, "cellVerticesAtVertex", cellVerticesAtVertex)
     call MPAS_pool_get_array(velocity_variational, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
@@ -104,28 +145,51 @@ contains
     allocate(yLocal(maxEdges,nCells))
 
     call seaice_calc_local_coords(&
-         mesh, &
          xLocal, &
          yLocal, &
-         rotateCartesianGrid)
+         nCells, &
+         nEdgesOnCell, &
+         verticesOnCell, &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell, &
+         rotateCartesianGrid, &
+         on_a_sphere)
 
     call seaice_calc_variational_metric_terms(&
-         mesh, &
          tanLatVertexRotatedOverRadius, &
+         nVertices, &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         sphere_radius, &
          rotateCartesianGrid, &
          includeMetricTerms)
 
     call seaice_cell_vertices_at_vertex(&
-         mesh, &
-         cellVerticesAtVertex)
+         cellVerticesAtVertex, &
+         nVertices, &
+         vertexDegree, &
+         nEdgesOnCell, &
+         verticesOnCell, &
+         cellsOnVertex)
 
     call init_velocity_solver_pwl_basis(&
-         mesh, &
          basisGradientU, &
          basisGradientV, &
          basisIntegralsMetric, &
          basisIntegralsU, &
          basisIntegralsV, &
+         nCells, &
+         maxEdges, &
+         nEdgesOnCell, &
+         verticesOnCell, &
+         edgesOnCell, &
+         dvEdge, &
+         areaCell, &
          xLocal, &
          yLocal)
 
@@ -147,12 +211,18 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine init_velocity_solver_pwl_basis(&
-       mesh, &
        basisGradientU, &
        basisGradientV, &
        basisIntegralsMetric, &
        basisIntegralsU, &
        basisIntegralsV, &
+       nCells, &
+       maxEdges, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       edgesOnCell, &
+       dvEdge, &
+       areaCell, &
        xLocal, &
        yLocal)!{{{
 
@@ -161,9 +231,6 @@ contains
 
     use seaice_velocity_solver_variational_shared, only: &
          seaice_wrapped_index
-
-    type(MPAS_pool_type), pointer :: &
-         mesh !< Input:
 
     real(kind=RKIND), dimension(:,:,:), intent(out) :: &
          basisGradientU, &       !< Output:
@@ -175,6 +242,21 @@ contains
     real(kind=RKIND), dimension(:,:), intent(in) :: &
          xLocal, & !< Input:
          yLocal    !< Input:
+
+    integer, intent(in) :: &
+         nCells, & !< Input:
+         maxEdges  !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell, & !< Input:
+         edgesOnCell       !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         dvEdge, & !< Input:
+         areaCell  !< Input:
 
     real(kind=RKIND) :: &
          xPWLCentre, &
@@ -209,21 +291,6 @@ contains
          rightHandSide, &
          solutionVector
 
-    integer, pointer :: &
-         nCells, &
-         maxEdges
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), pointer :: &
-         verticesOnCell, &
-         edgesOnCell
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         dvEdge, &
-         areaCell
-
     real(kind=RKIND), dimension(:,:), allocatable :: &
          subBasisGradientU, &
          subBasisGradientV, &
@@ -233,16 +300,6 @@ contains
 
     real(kind=RKIND), dimension(:), allocatable :: &
          basisSubArea
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-    call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-    call MPAS_pool_get_array(mesh, "edgesOnCell", edgesOnCell)
-    call MPAS_pool_get_array(mesh, "dvEdge", dvEdge)
-    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
 
     allocate(subBasisGradientU(maxEdges,3))
     allocate(subBasisGradientV(maxEdges,3))

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_variational_shared.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_variational_shared.F
@@ -40,37 +40,72 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine seaice_calc_local_coords(&
-       mesh, &
        xLocal, &
        yLocal, &
-       rotateCartesianGrid)!{{{
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell, &
+       rotateCartesianGrid, &
+       onASphere)!{{{
 
     real(kind=RKIND), dimension(:,:), intent(out) :: &
          xLocal, & !< Output:
          yLocal    !< Output:
 
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
+
     logical, intent(in) :: &
-         rotateCartesianGrid !< Input:
+         rotateCartesianGrid, & !< Input:
+         onASphere              !< Input:
 
-    logical, pointer :: &
-         on_a_sphere
-
-    call MPAS_pool_get_config(mesh, "on_a_sphere", on_a_sphere)
-
-    if (on_a_sphere) then
+    if (onASphere) then
        call calc_local_coords_spherical(&
-            mesh, &
             xLocal, &
             yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell, &
             rotateCartesianGrid)
     else
        call calc_local_coords_planar(&
-            mesh, &
             xLocal, &
-            yLocal)
+            yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell)
     endif
 
   end subroutine seaice_calc_local_coords!}}}
@@ -88,45 +123,43 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine calc_local_coords_planar(&
-       mesh, &
        xLocal, &
-       yLocal)!{{{
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+       yLocal, &
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell)!{{{
 
     real(kind=RKIND), dimension(:,:), intent(out) :: &
          xLocal, & !< Output:
          yLocal    !< Output:
 
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
+
     integer :: &
          iCell, &
          iVertex, &
          iVertexOnCell
-
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), pointer :: &
-         verticesOnCell
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         xVertex, &
-         yVertex, &
-         xCell, &
-         yCell
-
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
-    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
-    call MPAS_pool_get_array(mesh, "xCell", xCell)
-    call MPAS_pool_get_array(mesh, "yCell", yCell)
 
     do iCell = 1, nCells
 
@@ -156,21 +189,43 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine calc_local_coords_spherical(&
-       mesh, &
        xLocal, &
        yLocal, &
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell, &
        rotateCartesianGrid)!{{{
 
     use seaice_mesh, only: &
          seaice_project_3D_vector_onto_local_2D, &
          seaice_grid_rotation_forward
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
     real(kind=RKIND), dimension(:,:), intent(out) :: &
          xLocal, & !< Output:
          yLocal    !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
 
     logical, intent(in) :: &
          rotateCartesianGrid !< Input:
@@ -186,38 +241,10 @@ contains
          iVertex, &
          iVertexOnCell
 
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), pointer :: &
-         verticesOnCell
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         xVertex, &
-         yVertex, &
-         zVertex, &
-         xCell, &
-         yCell, &
-         zCell
-
     real(kind=RKIND) :: &
          xCellRotated, &
          yCellRotated, &
          zCellRotated
-
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
-    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
-    call MPAS_pool_get_array(mesh, "zVertex", zVertex)
-    call MPAS_pool_get_array(mesh, "xCell", xCell)
-    call MPAS_pool_get_array(mesh, "yCell", yCell)
-    call MPAS_pool_get_array(mesh, "zCell", zCell)
 
     do iCell = 1, nCells
 
@@ -264,50 +291,44 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine seaice_calc_variational_metric_terms(&
-       mesh, &
        tanLatVertexRotatedOverRadius, &
+       nVertices, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       sphereRadius, &
        rotateCartesianGrid, &
        includeMetricTerms)
 
     use seaice_mesh, only: &
          seaice_grid_rotation_forward
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
     real(kind=RKIND), dimension(:), intent(out) :: &
          tanLatVertexRotatedOverRadius !< Output:
+
+    integer, intent(in) :: &
+         nVertices !< Input:
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex    !< Input:
+
+    real(kind=RKIND), pointer :: &
+         sphereRadius !< Input:
 
     logical, intent(in) :: &
          rotateCartesianGrid, & !< Input:
          includeMetricTerms     !< Input:
 
-    integer, pointer :: &
-         nVertices
-
     integer :: &
          iVertex
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         xVertex, &
-         yVertex, &
-         zVertex
-
-    real(kind=RKIND), pointer :: &
-         sphere_radius
 
     real(kind=RKIND) :: &
          xVertexRotated, &
          yVertexRotated, &
          zVertexRotated, &
          latVertexRotated
-
-    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
-    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
-
-    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
-    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
-    call MPAS_pool_get_array(mesh, "zVertex", zVertex)
 
     if (includeMetricTerms) then
 
@@ -318,9 +339,9 @@ contains
                xVertex(iVertex), yVertex(iVertex), zVertex(iVertex), &
                rotateCartesianGrid)
 
-          latVertexRotated = asin(zVertexRotated / sphere_radius)
+          latVertexRotated = asin(zVertexRotated / sphereRadius)
 
-          tanLatVertexRotatedOverRadius(iVertex) = tan(latVertexRotated) / sphere_radius
+          tanLatVertexRotatedOverRadius(iVertex) = tan(latVertexRotated) / sphereRadius
 
        enddo ! iVertex
 

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
@@ -117,7 +117,6 @@ contains
 
     call MPAS_pool_get_dimension(mesh, "nCells", nCells)
     call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
-
     call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
 
     call MPAS_pool_get_array(velocity_variational, "cellVerticesAtVertex", cellVerticesAtVertex)
@@ -152,19 +151,22 @@ contains
 
     call mpas_timer_start("wachpress calc_coefficients")
     call calc_wachspress_coefficients(&
-         mesh, &
          wachspressKappa, &
          wachspressA, &
          wachspressB, &
+         nCells, &
+         nEdgesOnCell, &
          xLocal, &
          yLocal)
     call mpas_timer_stop("wachpress calc_coefficients")
 
     call mpas_timer_start("wachpress calc_derivatives")
     call calculate_wachspress_derivatives(&
-         mesh, &
          basisGradientU, &
          basisGradientV, &
+         nCells, &
+         maxEdges, &
+         nEdgesOnCell, &
          xLocal, &
          yLocal, &
          wachspressA, &
@@ -174,10 +176,11 @@ contains
 
     call mpas_timer_start("wachpress integrate")
     call integrate_wachspress(&
-         mesh, &
          basisIntegralsU, &
          basisIntegralsV, &
          basisIntegralsMetric, &
+         nCells, &
+         nEdgesOnCell, &
          xLocal, &
          yLocal, &
          wachspressA, &
@@ -203,6 +206,366 @@ contains
 
   end subroutine seaice_init_velocity_solver_wachspress!}}}
 
+!-----------------------------------------------------------------------
+! Integration
+!-----------------------------------------------------------------------
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  integrate_wachspress
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine integrate_wachspress(&
+       basisIntegralsU, &
+       basisIntegralsV, &
+       basisIntegralsMetric, &
+       nCells, &
+       nEdgesOnCell, &
+       xLocal, &
+       yLocal, &
+       wachspressA, &
+       wachspressB, &
+       wachspressKappa, &
+       integrationType, &
+       integrationOrder)!{{{
+
+    ! basisIntegralsUV (iStressVertex,iVelocityVertex,iCell)
+    ! iCell         : cell integrals are performed on
+    ! iStressVertex : vertex number of Wachspress function
+    ! iVelocityVertex : vertex number of Wachspress derivative function
+    ! Sij
+
+    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
+         basisIntegralsU, &   !< Output:
+         basisIntegralsV, &   !< Output:
+         basisIntegralsMetric !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         xLocal, &      !< Input:
+         yLocal, &      !< Input:
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    real(kind=RKIND), dimension(:,:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    character(len=strKIND), intent(in) :: &
+         integrationType !< Input:
+
+    integer, intent(in) :: &
+         integrationOrder !< Input:
+
+    integer :: &
+         iCell, &
+         iStressVertex, &
+         iVelocityVertex
+
+    integer :: &
+         nIntegrationPoints
+
+    real(kind=RKIND), dimension(:), allocatable :: &
+         integrationU, &
+         integrationV, &
+         integrationWeights
+
+    real(kind=RKIND) :: &
+         normalizationFactor
+
+    ! Quadrature rules
+    call get_integration_factors(&
+         integrationType, &
+         integrationOrder, &
+         nIntegrationPoints, &
+         integrationU, &
+         integrationV, &
+         integrationWeights, &
+         normalizationFactor)
+
+    !$omp parallel do default(shared) private(iStressVertex, iVelocityVertex)
+    do iCell = 1, nCells
+
+       do iVelocityVertex = 1, nEdgesOnCell(iCell)
+
+          do iStressVertex = 1, nEdgesOnCell(iCell)
+
+             basisIntegralsU(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
+             basisIntegralsV(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
+             basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
+
+             call integrate_wachspress_polygon(&
+                  basisIntegralsU(iStressVertex,iVelocityVertex,iCell), &
+                  basisIntegralsV(iStressVertex,iVelocityVertex,iCell), &
+                  basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell), &
+                  nEdgesOnCell(iCell), &
+                  iStressVertex, &
+                  iVelocityVertex, &
+                  xLocal(:,iCell), &
+                  yLocal(:,iCell), &
+                  wachspressA(:,iCell), &
+                  wachspressB(:,iCell), &
+                  wachspressKappa(:,:,iCell), &
+                  nIntegrationPoints, &
+                  integrationU, &
+                  integrationV, &
+                  integrationWeights, &
+                  normalizationFactor)
+
+          enddo ! jVertex
+
+       enddo ! iVertex
+
+    enddo ! iCell
+
+    deallocate(integrationU)
+    deallocate(integrationV)
+    deallocate(integrationWeights)
+
+  end subroutine integrate_wachspress!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  integrate_wachspress_polygon
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine integrate_wachspress_polygon(&
+       basisIntegralsU, &
+       basisIntegralsV, &
+       basisIntegralsMetric, &
+       nEdgesOnCell, &
+       iStressVertex, &
+       iVelocityVertex, &
+       xLocal, &
+       yLocal, &
+       wachspressA, &
+       wachspressB, &
+       wachspressKappa, &
+       nIntegrationPoints, &
+       integrationU, &
+       integrationV, &
+       integrationWeights, &
+       normalizationFactor)!{{{
+
+    use seaice_velocity_solver_variational_shared, only: &
+         seaice_wrapped_index
+
+    real(kind=RKIND), intent(inout) :: &
+         basisIntegralsU, &   !< Input/Output:
+         basisIntegralsV, &   !< Input/Output:
+         basisIntegralsMetric !< Input/Output:
+
+    integer, intent(in) :: &
+         nEdgesOnCell, &  !< Input:
+         iStressVertex, & !< Input:
+         iVelocityVertex  !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xLocal, & !< Input:
+         yLocal    !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    integer, intent(in) :: &
+         nIntegrationPoints !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         integrationU, & !< Input:
+         integrationV, & !< Input:
+         integrationWeights !< Input:
+
+    real(kind=RKIND), intent(in) :: &
+         normalizationFactor !< Input:
+
+    integer, dimension(nEdgesOnCell) :: &
+         nEdgesOnCellSubset
+
+    integer, dimension(nEdgesOnCell,nEdgesOnCell) :: &
+         vertexIndexSubset
+
+    real(kind=RKIND) :: &
+         basisIntegralsSubTriangleTmp, &
+         basisIntegralsUSubTriangle, &
+         basisIntegralsVSubTriangle, &
+         basisIntegralsMetricSubTriangle
+
+    real(kind=RKIND), dimension(nIntegrationPoints) :: &
+         x, &
+         y, &
+         stressBasisFunction, &
+         velocityBasisFunction, &
+         velocityBasisDerivativeU, &
+         velocityBasisDerivativeV
+
+    real(kind=RKIND), dimension(2,2) :: &
+         mapping
+
+    real(kind=RKIND), dimension(nEdgesOnCell) :: &
+         jacobian
+
+    integer :: &
+         iIntegrationPoint, &
+         iSubTriangle, &
+         i1, &
+         i2
+
+    call wachspress_indexes(&
+         nEdgesOnCell, &
+         nEdgesOnCellSubset, &
+         vertexIndexSubset)
+
+    do iSubTriangle = 1, nEdgesOnCell
+
+       i1 = iSubTriangle
+       i2 = seaice_wrapped_index(iSubTriangle + 1, nEdgesOnCell)
+
+       call get_triangle_mapping(&
+            mapping, &
+            jacobian(iSubTriangle), &
+            1.0_RKIND, 0.0_RKIND, &
+            0.0_RKIND, 1.0_RKIND, &
+            xLocal(i1), yLocal(i1), &
+            xLocal(i2), yLocal(i2))
+
+       !in-lined use_triangle_mapping
+       do iIntegrationPoint = 1, nIntegrationPoints
+
+          x(iIntegrationPoint) = mapping(1,1) * integrationU(iIntegrationPoint) + &
+                                 mapping(1,2) * integrationV(iIntegrationPoint)
+          y(iIntegrationPoint) = mapping(2,1) * integrationU(iIntegrationPoint) + &
+                                 mapping(2,2) * integrationV(iIntegrationPoint)
+
+       enddo ! iIntegrationPoint
+
+       call wachspress_basis_function(&
+            nEdgesOnCell, iStressVertex, x, y, &
+            wachspressKappa, wachspressA, wachspressB, &
+            nEdgesOnCellSubset, vertexIndexSubset, &
+            stressBasisFunction)
+
+       call wachspress_basis_function(&
+            nEdgesOnCell, iVelocityVertex, x, y, &
+            wachspressKappa, wachspressA, wachspressB, &
+            nEdgesOnCellSubset, vertexIndexSubset, &
+            velocityBasisFunction)
+
+       call wachspress_basis_derivative(&
+            nEdgesOnCell, iVelocityVertex, x, y, &
+            wachspressKappa, wachspressA, wachspressB, &
+            nEdgesOnCellSubset, vertexIndexSubset, &
+            velocityBasisDerivativeU, &
+            velocityBasisDerivativeV)
+
+       basisIntegralsUSubTriangle      = 0.0_RKIND
+       basisIntegralsVSubTriangle      = 0.0_RKIND
+       basisIntegralsMetricSubTriangle = 0.0_RKIND
+
+       do iIntegrationPoint = 1, nIntegrationPoints
+
+          basisIntegralsSubTriangleTmp = &
+               jacobian(iSubTriangle) * &
+               integrationWeights(iIntegrationPoint) * &
+               stressBasisFunction(iIntegrationPoint)
+
+          basisIntegralsUSubTriangle = basisIntegralsUSubTriangle + &
+               basisIntegralsSubTriangleTmp * &
+               velocityBasisDerivativeU(iIntegrationPoint)
+
+          basisIntegralsVSubTriangle = basisIntegralsVSubTriangle + &
+               basisIntegralsSubTriangleTmp * &
+               velocityBasisDerivativeV(iIntegrationPoint)
+
+          basisIntegralsMetricSubTriangle = basisIntegralsMetricSubTriangle + &
+               basisIntegralsSubTriangleTmp * &
+               velocityBasisFunction(iIntegrationPoint)
+
+       enddo ! iIntegrationPoint
+
+       basisIntegralsU      = basisIntegralsU      + basisIntegralsUSubTriangle      / normalizationFactor
+       basisIntegralsV      = basisIntegralsV      + basisIntegralsVSubTriangle      / normalizationFactor
+       basisIntegralsMetric = basisIntegralsMetric + basisIntegralsMetricSubTriangle / normalizationFactor
+
+    enddo ! iSubTriangle
+
+  end subroutine integrate_wachspress_polygon!}}}
+
+!-----------------------------------------------------------------------
+! Remapping
+!-----------------------------------------------------------------------
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  get_triangle_mapping
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine get_triangle_mapping(&
+       mapping, &
+       jacobian, &
+       x1, y1, &
+       x2, y2, &
+       u1, v1, &
+       u2, v2)!{{{
+
+    real(kind=RKIND), dimension(2,2), intent(out) :: &
+         mapping !< Output:
+
+    real(kind=RKIND), intent(out) :: &
+         jacobian !< Output:
+
+    real(kind=RKIND), intent(in) :: &
+         x1, & !< Input:
+         y1, & !< Input:
+         x2, & !< Input:
+         y2, & !< Input:
+         u1, & !< Input:
+         v1, & !< Input:
+         u2, & !< Input:
+         v2    !< Input:
+
+    mapping(1,1) = (u2*y1 - u1*y2) / (x2*y1 - x1*y2)
+    mapping(1,2) = (u1*x2 - u2*x1) / (y1*x2 - y2*x1)
+
+    mapping(2,1) = (v2*y1 - v1*y2) / (x2*y1 - x1*y2)
+    mapping(2,2) = (v1*x2 - v2*x1) / (y1*x2 - y2*x1)
+
+    jacobian = mapping(1,1) * mapping(2,2) - mapping(1,2) * mapping(2,1)
+
+  end subroutine get_triangle_mapping!}}}
+
+!-----------------------------------------------------------------------
+! Wachspress function
+!-----------------------------------------------------------------------
+
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  calc_wachspress_coefficients
@@ -216,15 +579,13 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine calc_wachspress_coefficients(&
-       mesh, &
        wachspressKappa, &
        wachspressA, &
        wachspressB, &
+       nCells, &
+       nEdgesOnCell, &
        xLocal, &
        yLocal)!{{{
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
 
     real(kind=RKIND), dimension(:,:,:), intent(out) :: &
          wachspressKappa !< Output:
@@ -232,6 +593,12 @@ contains
     real(kind=RKIND), dimension(:,:), intent(out) :: &
          wachspressA, & !< Output:
          wachspressB    !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
 
     real(kind=RKIND), dimension(:,:), intent(in) :: &
          xLocal, & !< Input:
@@ -244,17 +611,6 @@ contains
          i1, &
          i2, &
          jVertex
-
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
 
     ! loop over cells
     do iCell = 1, nCells
@@ -324,13 +680,13 @@ contains
          seaice_wrapped_index
 
     integer, intent(in) :: &
-         nEdgesOnCell
+         nEdgesOnCell !< Input:
 
     integer, dimension(:), intent(out) :: &
-         nEdgesOnCellSubset
+         nEdgesOnCellSubset !< Output:
 
     integer, dimension(:,:), intent(out) :: &
-         vertexIndexSubset
+         vertexIndexSubset !< Output:
 
     integer :: &
          jVertex, &
@@ -400,10 +756,10 @@ contains
          wachspressB    !< Input:
 
     integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset
+         nEdgesOnCellSubset !< Input:
 
     integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset
+         vertexIndexSubset !< Input:
 
     real(kind=RKIND), dimension(:), intent(out) :: &
          wachpress !< Output:
@@ -479,10 +835,10 @@ contains
          wachspressB    !< Input:
 
     integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset
+         nEdgesOnCellSubset !< Input:
 
     integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset
+         vertexIndexSubset !< Input:
 
     real(kind=RKIND), dimension(:), intent(out) :: &
          wachspressU, & !< Output:
@@ -582,10 +938,10 @@ contains
          wachspressB    !< Input:
 
     integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset
+         nEdgesOnCellSubset !< Input:
 
     integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset
+         vertexIndexSubset !< Input:
 
     real(kind=RKIND), dimension(:), intent(inout) :: &
          edgeEquation
@@ -659,20 +1015,20 @@ contains
          wachspressB    !< Input:
 
     integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset
+         nEdgesOnCellSubset !< Input:
 
     integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset
+         vertexIndexSubset !< Input:
 
     real(kind=RKIND), dimension(:,:), intent(out) :: &
          derivative !< Output:
 
     real(kind=RKIND), dimension(:,:), intent(inout) :: &
-         sum_of_products, &
-         product
+         sum_of_products, & !< Input/Output:
+         product            !< Input/Output:
 
     real(kind=RKIND), dimension(:), intent(inout) :: &
-         edgeEquation
+         edgeEquation !< Input/Output:
 
     integer :: &
          kVertex, &
@@ -771,16 +1127,16 @@ contains
 !-----------------------------------------------------------------------
 
   subroutine calculate_wachspress_derivatives(&
-       mesh, &
        basisGradientU, &
        basisGradientV, &
+       nCells, &
+       maxEdges, &
+       nEdgesOnCell, &
        xLocal, &
        yLocal, &
        wachspressA, &
        wachspressB, &
        wachspressKappa)!{{{
-
-    use mpas_timer
 
     use seaice_velocity_solver_variational_shared, only: &
          seaice_wrapped_index
@@ -790,12 +1146,16 @@ contains
     ! iVertexOnCell : The vertex basis function the gradient is calculated from
     ! jVertexOnCell : The vertex location the gradients are calculated at
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
     real(kind=RKIND), dimension(:,:,:), intent(out) :: &
          basisGradientU, & !< Output:
          basisGradientV    !< Output:
+
+    integer, intent(in) :: &
+         nCells, & !< Input:
+         maxEdges  !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
 
     real(kind=RKIND), dimension(:,:), intent(in) :: &
          wachspressA, & !< Input:
@@ -811,16 +1171,6 @@ contains
          iBasisVertex, &
          iGradientVertex
 
-    integer, pointer :: &
-         nCells, &
-         maxEdges
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer, dimension(:,:), pointer :: &
-         verticesOnCell
-
     integer, dimension(:), allocatable :: &
          nEdgesOnCellSubset
 
@@ -829,13 +1179,6 @@ contains
 
     real(kind=RKIND), dimension(:), allocatable :: &
          x, y, derivativeU, derivativeV
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-    call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
 
     allocate(x(maxEdges))
     allocate(y(maxEdges))
@@ -908,183 +1251,9 @@ contains
 
   end subroutine calculate_wachspress_derivatives!}}}
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  get_triangle_mapping
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
 !-----------------------------------------------------------------------
-
-  subroutine get_triangle_mapping(&
-       mapping, &
-       jacobian, &
-       x1, y1, &
-       x2, y2, &
-       u1, v1, &
-       u2, v2)!{{{
-
-    real(kind=RKIND), dimension(2,2), intent(out) :: &
-         mapping !< Output:
-
-    real(kind=RKIND), intent(out) :: &
-         jacobian !< Output:
-
-    real(kind=RKIND), intent(in) :: &
-         x1, & !< Input:
-         y1, & !< Input:
-         x2, & !< Input:
-         y2, & !< Input:
-         u1, & !< Input:
-         v1, & !< Input:
-         u2, & !< Input:
-         v2    !< Input:
-
-    mapping(1,1) = (u2*y1 - u1*y2) / (x2*y1 - x1*y2)
-    mapping(1,2) = (u1*x2 - u2*x1) / (y1*x2 - y2*x1)
-
-    mapping(2,1) = (v2*y1 - v1*y2) / (x2*y1 - x1*y2)
-    mapping(2,2) = (v1*x2 - v2*x1) / (y1*x2 - y2*x1)
-
-    jacobian = mapping(1,1) * mapping(2,2) - mapping(1,2) * mapping(2,1)
-
-  end subroutine get_triangle_mapping!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  integrate_wachspress
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
+! Integration factors
 !-----------------------------------------------------------------------
-
-  subroutine integrate_wachspress(&
-       mesh, &
-       basisIntegralsU, &
-       basisIntegralsV, &
-       basisIntegralsMetric, &
-       xLocal, &
-       yLocal, &
-       wachspressA, &
-       wachspressB, &
-       wachspressKappa, &
-       integrationType, &
-       integrationOrder)!{{{
-
-    use mpas_timer
-
-    ! basisIntegralsUV (iStressVertex,iVelocityVertex,iCell)
-    ! iCell         : cell integrals are performed on
-    ! iStressVertex : vertex number of Wachspress function
-    ! iVelocityVertex : vertex number of Wachspress derivative function
-    ! Sij
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
-    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
-         basisIntegralsU, &   !< Output:
-         basisIntegralsV, &   !< Output:
-         basisIntegralsMetric !< Output:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         xLocal, &      !< Input:
-         yLocal, &      !< Input:
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    real(kind=RKIND), dimension(:,:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    character(len=strKIND), intent(in) :: &
-         integrationType !< Input:
-
-    integer, intent(in) :: &
-         integrationOrder !< Input:
-
-    integer :: &
-         iCell, &
-         iStressVertex, &
-         iVelocityVertex
-
-    integer, pointer :: &
-         nCells
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell
-
-    integer :: &
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), allocatable :: &
-         integrationU, &
-         integrationV, &
-         integrationWeights
-
-    real(kind=RKIND) :: &
-         normalizationFactor
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-
-    call get_integration_factors(&
-         integrationType, &
-         integrationOrder, &
-         nIntegrationPoints, &
-         integrationU, &
-         integrationV, &
-         integrationWeights, &
-         normalizationFactor)
-
-    !$omp parallel do default(shared) private(iStressVertex, iVelocityVertex)
-    do iCell = 1, nCells
-
-       do iVelocityVertex = 1, nEdgesOnCell(iCell)
-
-          do iStressVertex = 1, nEdgesOnCell(iCell)
-
-             basisIntegralsU(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
-             basisIntegralsV(iStressVertex,iVelocityVertex,iCell)      = 0.0_RKIND
-             basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
-
-             call integrate_wachspress_polygon(&
-                  basisIntegralsU(iStressVertex,iVelocityVertex,iCell), &
-                  basisIntegralsV(iStressVertex,iVelocityVertex,iCell), &
-                  basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell), &
-                  nEdgesOnCell(iCell), &
-                  iStressVertex, &
-                  iVelocityVertex, &
-                  xLocal(:,iCell), &
-                  yLocal(:,iCell), &
-                  wachspressA(:,iCell), &
-                  wachspressB(:,iCell), &
-                  wachspressKappa(:,:,iCell), &
-                  nIntegrationPoints, &
-                  integrationU, &
-                  integrationV, &
-                  integrationWeights, &
-                  normalizationFactor)
-
-          enddo ! jVertex
-
-       enddo ! iVertex
-
-    enddo ! iCell
-
-    deallocate(integrationU)
-    deallocate(integrationV)
-    deallocate(integrationWeights)
-
-  end subroutine integrate_wachspress!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1098,7 +1267,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine get_integration_factors(integrationType, integrationOrder, nIntegrationPoints, u, v, weights, normalizationFactor)
+  subroutine get_integration_factors(&
+       integrationType, &
+       integrationOrder, &
+       nIntegrationPoints, &
+       u, &
+       v, &
+       weights, &
+       normalizationFactor)
 
     character(len=strKIND), intent(in) :: &
          integrationType
@@ -1809,183 +1985,6 @@ contains
     end select
 
   end subroutine get_integration_factors_fekete
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  integrate_wachspress_polygon
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine integrate_wachspress_polygon(&
-       basisIntegralsU, &
-       basisIntegralsV, &
-       basisIntegralsMetric, &
-       nEdgesOnCell, &
-       iStressVertex, &
-       iVelocityVertex, &
-       xLocal, &
-       yLocal, &
-       wachspressA, &
-       wachspressB, &
-       wachspressKappa, &
-       nIntegrationPoints, &
-       integrationU, &
-       integrationV, &
-       integrationWeights, &
-       normalizationFactor)!{{{
-
-    use seaice_velocity_solver_variational_shared, only: &
-         seaice_wrapped_index
-
-    real(kind=RKIND), intent(inout) :: &
-         basisIntegralsU, &
-         basisIntegralsV, &
-         basisIntegralsMetric
-
-    integer, intent(in) :: &
-         nEdgesOnCell, &  !< Input:
-         iStressVertex, & !< Input:
-         iVelocityVertex  !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         xLocal, & !< Input:
-         yLocal    !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    integer, intent(in) :: & !< Input:
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         integrationU, & !< Input:
-         integrationV, & !< Input:
-         integrationWeights !< Input:
-
-    real(kind=RKIND), intent(in) :: &
-         normalizationFactor !< Input:
-
-    integer, dimension(nEdgesOnCell) :: &
-         nEdgesOnCellSubset
-
-    integer, dimension(nEdgesOnCell,nEdgesOnCell) :: &
-         vertexIndexSubset
-
-    real(kind=RKIND) :: &
-         basisIntegralsSubTriangleTmp, &
-         basisIntegralsUSubTriangle, &
-         basisIntegralsVSubTriangle, &
-         basisIntegralsMetricSubTriangle
-
-    real(kind=RKIND), dimension(nIntegrationPoints) :: &
-         x, &
-         y, &
-         stressBasisFunction, &
-         velocityBasisFunction, &
-         velocityBasisDerivativeU, &
-         velocityBasisDerivativeV
-
-    real(kind=RKIND), dimension(2,2) :: &
-         mapping
-
-    real(kind=RKIND), dimension(nEdgesOnCell) :: &
-         jacobian
-
-    integer :: &
-         iIntegrationPoint, &
-         iSubTriangle, &
-         i1, &
-         i2
-
-    call wachspress_indexes(&
-         nEdgesOnCell, &
-         nEdgesOnCellSubset, &
-         vertexIndexSubset)
-
-    do iSubTriangle = 1, nEdgesOnCell
-
-       i1 = iSubTriangle
-       i2 = seaice_wrapped_index(iSubTriangle + 1, nEdgesOnCell)
-
-       call get_triangle_mapping(&
-            mapping, &
-            jacobian(iSubTriangle), &
-            1.0_RKIND, 0.0_RKIND, &
-            0.0_RKIND, 1.0_RKIND, &
-            xLocal(i1), yLocal(i1), &
-            xLocal(i2), yLocal(i2))
-
-       !in-lined use_triangle_mapping
-       do iIntegrationPoint = 1, nIntegrationPoints
-
-          x(iIntegrationPoint) = mapping(1,1) * integrationU(iIntegrationPoint) + &
-                                 mapping(1,2) * integrationV(iIntegrationPoint)
-          y(iIntegrationPoint) = mapping(2,1) * integrationU(iIntegrationPoint) + &
-                                 mapping(2,2) * integrationV(iIntegrationPoint)
-
-       enddo ! iIntegrationPoint
-
-       call wachspress_basis_function(&
-            nEdgesOnCell, iStressVertex, x, y, &
-            wachspressKappa, wachspressA, wachspressB, &
-            nEdgesOnCellSubset, vertexIndexSubset, &
-            stressBasisFunction)
-
-       call wachspress_basis_function(&
-            nEdgesOnCell, iVelocityVertex, x, y, &
-            wachspressKappa, wachspressA, wachspressB, &
-            nEdgesOnCellSubset, vertexIndexSubset, &
-            velocityBasisFunction)
-
-       call wachspress_basis_derivative(&
-            nEdgesOnCell, iVelocityVertex, x, y, &
-            wachspressKappa, wachspressA, wachspressB, &
-            nEdgesOnCellSubset, vertexIndexSubset, &
-            velocityBasisDerivativeU, &
-            velocityBasisDerivativeV)
-
-       basisIntegralsUSubTriangle      = 0.0_RKIND
-       basisIntegralsVSubTriangle      = 0.0_RKIND
-       basisIntegralsMetricSubTriangle = 0.0_RKIND
-
-       do iIntegrationPoint = 1, nIntegrationPoints
-
-          basisIntegralsSubTriangleTmp = &
-               jacobian(iSubTriangle) * &
-               integrationWeights(iIntegrationPoint) * &
-               stressBasisFunction(iIntegrationPoint)
-
-          basisIntegralsUSubTriangle = basisIntegralsUSubTriangle + &
-               basisIntegralsSubTriangleTmp * &
-               velocityBasisDerivativeU(iIntegrationPoint)
-
-          basisIntegralsVSubTriangle = basisIntegralsVSubTriangle + &
-               basisIntegralsSubTriangleTmp * &
-               velocityBasisDerivativeV(iIntegrationPoint)
-
-          basisIntegralsMetricSubTriangle = basisIntegralsMetricSubTriangle + &
-               basisIntegralsSubTriangleTmp * &
-               velocityBasisFunction(iIntegrationPoint)
-
-       enddo ! iIntegrationPoint
-
-       basisIntegralsU      = basisIntegralsU      + basisIntegralsUSubTriangle      / normalizationFactor
-       basisIntegralsV      = basisIntegralsV      + basisIntegralsVSubTriangle      / normalizationFactor
-       basisIntegralsMetric = basisIntegralsMetric + basisIntegralsMetricSubTriangle / normalizationFactor
-
-    enddo ! iSubTriangle
-
-  end subroutine integrate_wachspress_polygon!}}}
 
 !-----------------------------------------------------------------------
 

--- a/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
+++ b/src/core_seaice/shared/mpas_seaice_velocity_solver_wachspress.F
@@ -84,13 +84,25 @@ contains
 
     integer, pointer :: &
          nCells, &
-         maxEdges, i1, i2
+         nVertices, &
+         vertexDegree, &
+         maxEdges
 
     integer, dimension(:), pointer :: &
          nEdgesOnCell
 
     integer, dimension(:,:), pointer :: &
+         verticesOnCell, &
+         cellsOnVertex, &
          cellVerticesAtVertex
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell
 
     real(kind=RKIND), dimension(:), pointer :: &
          tanLatVertexRotatedOverRadius
@@ -113,11 +125,30 @@ contains
          basisIntegralsV, &
          basisIntegralsMetric
 
+    logical, pointer :: &
+         on_a_sphere
+
+    real(kind=RKIND), pointer :: &
+         sphere_radius
+
     call mpas_timer_start("Velocity solver Wachpress init")
 
+    call MPAS_pool_get_config(mesh, "on_a_sphere", on_a_sphere)
+    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
+
     call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
+    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
     call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
     call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
+    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
+    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
+    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
+    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
+    call MPAS_pool_get_array(mesh, "zVertex", zVertex)
+    call MPAS_pool_get_array(mesh, "xCell", xCell)
+    call MPAS_pool_get_array(mesh, "yCell", yCell)
+    call MPAS_pool_get_array(mesh, "zCell", zCell)
 
     call MPAS_pool_get_array(velocity_variational, "cellVerticesAtVertex", cellVerticesAtVertex)
     call MPAS_pool_get_array(velocity_variational, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
@@ -135,16 +166,29 @@ contains
 
     call mpas_timer_start("wachpress calc_local_coords")
     call seaice_calc_local_coords(&
-         mesh, &
          xLocal, &
          yLocal, &
-         rotateCartesianGrid)
+         nCells, &
+         nEdgesOnCell, &
+         verticesOnCell, &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell, &
+         rotateCartesianGrid, &
+         on_a_sphere)
     call mpas_timer_stop("wachpress calc_local_coords")
 
     call mpas_timer_start("wachpress calc_metric_terms")
     call seaice_calc_variational_metric_terms(&
-         mesh, &
          tanLatVertexRotatedOverRadius, &
+         nVertices, &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         sphere_radius, &
          rotateCartesianGrid, &
          includeMetricTerms)
     call mpas_timer_stop("wachpress calc_metric_terms")
@@ -192,8 +236,12 @@ contains
 
     call mpas_timer_start("wachpress vertices_at_vertex")
     call seaice_cell_vertices_at_vertex(&
-         mesh, &
-         cellVerticesAtVertex)
+         cellVerticesAtVertex, &
+         nVertices, &
+         vertexDegree, &
+         nEdgesOnCell, &
+         verticesOnCell, &
+         cellsOnVertex)
     call mpas_timer_stop("wachpress vertices_at_vertex")
 
     deallocate(xLocal)


### PR DESCRIPTION
Refactors the initialization of the variational operator coefficient initialization to remove explicit calls to MPAS mesh. This allows other mesh definitions, other than the primary SCVT mesh to be used.

