### PR TITLE
Include river runoff term in totalFreshWaterTemperatureFlux

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/src/core_ocean/shared/mpas_ocn_surface_bulk_forcing.F
@@ -567,6 +567,10 @@ contains
            tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
               + totalFreshWaterTemperatureFlux(iCell)
 
+           ! add runoff contribution for sending through coupler
+           totalFreshWaterTemperatureFlux(iCell) = totalFreshWaterTemperatureFlux(iCell) &
+              + tracersSurfaceFluxRunoff(index_temperature_flux,iCell)
+
            ! Fields with zero temperature are not accumulated. These include:
            !    snowFlux
            !    iceRunoffFlux


### PR DESCRIPTION
Adds the river runoff term to totalFreshWaterTemperatureFlux, which is passed to the coupler and atm in the E3SM driver.

