### PR TITLE
Fix intel e3sm errors

### DIFF
--- a/src/core_landice/landice.cmake
+++ b/src/core_landice/landice.cmake
@@ -69,6 +69,7 @@ list(APPEND RAW_SOURCES
   core_landice/mode_forward/mpas_li_velocity_simple.F
   core_landice/mode_forward/mpas_li_velocity_external.F
   core_landice/mode_forward/mpas_li_subglacial_hydro.F
+  core_landice/mode_forward/mpas_li_bedtopo.F
 )
 
 if (CPPDEFS MATCHES ".*MPAS_LI_BUILD_INTERFACE.*")

--- a/src/core_landice/mode_forward/mpas_li_calving.F
+++ b/src/core_landice/mode_forward/mpas_li_calving.F
@@ -2542,7 +2542,7 @@ module li_calving
            config_ice_density,            & ! ice density
            config_ocean_density             ! ocean density
 
-      real, dimension(:), pointer :: principalStrainRateRatio
+      real (kind=RKIND), dimension(:), pointer :: principalStrainRateRatio
 
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltat !< time step (s)

--- a/src/core_landice/mode_forward/mpas_li_velocity.F
+++ b/src/core_landice/mode_forward/mpas_li_velocity.F
@@ -910,7 +910,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: stiffnessFactor
 
       type (field1dReal), pointer :: meanFlowParamAVar
-      real, dimension(:), pointer :: meanFlowParamA
+      real (kind=RKIND), dimension(:), pointer :: meanFlowParamA
 
       integer, pointer :: nVertLevels
       integer, pointer :: nCells


### PR DESCRIPTION
This merge fixes a few intel build errors in E3SM:
* Adds missing RKIND specifications to variable declarations that Intel errs on
* Adds missing update to cmake build system for the bedtopo module 