### PR TITLE
Enable bootstrapping from an externally provided PIO file descriptor

### DIFF
--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -441,14 +441,16 @@ module mpas_bootstrapping
    !>  and allocating all fields and structs.
    !
    !-----------------------------------------------------------------------
-   subroutine mpas_bootstrap_framework_phase2(domain) !{{{
+   subroutine mpas_bootstrap_framework_phase2(domain, pio_file_desc) !{{{
 
       use mpas_stream_manager
       use mpas_stream_list
+      use pio, only : file_desc_t
 
       implicit none
 
       type (domain_type), pointer :: domain
+      type (file_desc_t), pointer, optional :: pio_file_desc
 
       type (mpas_pool_type), pointer :: readableDimensions
       type (mpas_pool_type), pointer :: streamDimensions
@@ -478,105 +480,173 @@ module mpas_bootstrapping
       call mpas_log_write(' ')
       call mpas_log_write(' ')
 
-      ! Reading dimensions from streams
-      call mpas_log_write('Reading dimensions from input streams ...')
-      call mpas_stream_mgr_begin_iteration(domain % streamManager)
-      do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID = streamName, directionProperty = streamDirection, &
-                                                 activeProperty = streamActive) )
+      if (present(pio_file_desc)) then
+         call mpas_log_write('Reading dimensions from external PIO file handle ...')
 
-         if ( streamActive .and. ( streamDirection == MPAS_STREAM_INPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+         ! Build stream dimension pool from the list of fields
+         call mpas_pool_create_pool(streamDimensions)
 
-            call mpas_stream_mgr_begin_iteration(domain % streamManager, streamID=streamName)
-
-            ! Build stream dimension pool from the list of fields
-            call mpas_pool_create_pool(streamDimensions)
-
-            do while ( mpas_stream_mgr_get_next_field(domain % streamManager, streamName, fieldName, isActive=fieldActive) )
-
-               if (fieldActive) then
-                  call get_dimlist_for_field(domain % blocklist % allFields, fieldName, dimNames)
-
-                  do i=1,size(dimNames)
-                     call mpas_pool_get_dimension(streamDimensions, dimNames(i), dimValue)
-                     if ( .not. associated(dimValue) ) then
-                        call mpas_pool_add_dimension(streamDimensions, dimNames(i), MPAS_MISSING_DIM)
-                     end if
-                  end do
-                  deallocate(dimNames)
-               end if
-
-            end do
-
-            ! Determine stream filename
-            call mpas_get_stream_filename(domain % streamManager, streamID = streamName, filename = streamFilename, ierr = err_local)
-
-            ! Determine stream io_type
-            call MPAS_stream_mgr_get_property(domain % streamManager, streamName, &
-                                              MPAS_STREAM_PROPERTY_IOTYPE, ioType, ierr = err_local)
-
-            ! Try to open file
-            inputHandle = MPAS_io_open(trim(streamFilename), MPAS_IO_READ, ioType, domain % ioContext, ierr = err_local)
-
-            ! If to determine if file was opened or not.
-            if ( err_local == MPAS_IO_NOERR ) then
-
-               call mpas_log_write(' ')
-               call mpas_log_write('----- reading dimensions from stream '''//trim(streamName)//''' using file ' &
-                                    //trim(streamFilename) )
-
-               ! Iterate over list of dimensions we determined we need from the above loop
-               call mpas_pool_begin_iteration(streamDimensions)
-               do while ( mpas_pool_get_next_member(streamDimensions, poolItr) )
-                  if ( poolItr % memberType == MPAS_POOL_DIMENSION ) then
-                     ! Try to read the dimension
-                     call mpas_io_inq_dim(inputHandle, trim(poolItr % memberName), tempDim, ierr = err_local)
-
-                     ! Check to see if the dimension has already been defined
-                     call mpas_pool_get_dimension(readableDimensions, poolItr % memberName, dimValue)
-
-                     ! If to see if dimension was read or not
-                     if ( err_local == MPAS_IO_NOERR ) then
-                        call mpas_log_write('       ' // trim(poolItr % memberName) // ' = $i', intArgs=(/tempDim/) )
-
-                        if ( .not. associated(dimValue) ) then
-                           call mpas_pool_add_dimension(readableDimensions, poolItr % memberName, tempDim)
-                        else if ( dimValue /= tempDim .and. dimValue == MPAS_MISSING_DIM ) then
-                           dimValue = tempDim
-                        else if ( dimValue /= tempDim ) then
-                           call mpas_log_write('Dimension ' // trim(poolItr % membername) &
-                                                // ' was read with an inconsistent value.', MPAS_LOG_CRIT)
-                        end if
-                     else
-                        call mpas_log_write('       ' // trim(poolItr % memberName) // ' *** not found in stream ***')
-                     end if
-
+         call mpas_pool_begin_iteration(domain % blocklist % allFields)
+         do while ( mpas_pool_get_next_member(domain % blocklist % allFields, poolItr) )
+            if ( poolItr % memberType == MPAS_POOL_FIELD ) then
+               call get_dimlist_for_field(domain % blocklist % allFields, poolItr % memberName, dimNames)
+               do i=1,size(dimNames)
+                  call mpas_pool_get_dimension(streamDimensions, dimNames(i), dimValue)
+                  if ( .not. associated(dimValue) ) then
+                     call mpas_pool_add_dimension(streamDimensions, dimNames(i), MPAS_MISSING_DIM)
                   end if
                end do
-
-               ! Close file
-               call mpas_io_close(inputHandle)
-            else
-               call mpas_log_write(' ')
-               call mpas_log_write('  *** unable to open input file '//trim(streamFilename)//' for stream ''' &
-                                    //trim(streamName)//'''')
             end if
+         end do
 
-            ! Destroy pool that contains list of streams dimensions
-            call mpas_pool_destroy_pool(streamDimensions)
+         ioType = MPAS_IO_NETCDF  ! ioType is not actually used when an external PIO file_desc_t is provided to MPAS_io_open
+         inputHandle = MPAS_io_open('FILENAME_NOT_USED', MPAS_IO_READ, ioType, domain % ioContext, pio_file_desc = pio_file_desc, ierr = err_local)
 
-         else if ( .not. streamActive .and. ( streamDirection == MPAS_STREAM_INPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+         ! If to determine if file was opened or not.
+         if ( err_local == MPAS_IO_NOERR ) then
 
             call mpas_log_write(' ')
-            call mpas_log_write('----- skipping inactive stream '''//trim(streamName)//'''')
-            
+
+            ! Iterate over list of dimensions we determined we need from the above loop
+            call mpas_pool_begin_iteration(streamDimensions)
+            do while ( mpas_pool_get_next_member(streamDimensions, poolItr) )
+               if ( poolItr % memberType == MPAS_POOL_DIMENSION ) then
+                  ! Try to read the dimension
+                  call mpas_io_inq_dim(inputHandle, trim(poolItr % memberName), tempDim, ierr = err_local)
+
+                  ! Check to see if the dimension has already been defined
+                  call mpas_pool_get_dimension(readableDimensions, poolItr % memberName, dimValue)
+
+                  ! If to see if dimension was read or not
+                  if ( err_local == MPAS_IO_NOERR ) then
+                     call mpas_log_write('       ' // trim(poolItr % memberName) // ' = $i', intArgs=(/tempDim/) )
+
+                     if ( .not. associated(dimValue) ) then
+                        call mpas_pool_add_dimension(readableDimensions, poolItr % memberName, tempDim)
+                     else if ( dimValue /= tempDim .and. dimValue == MPAS_MISSING_DIM ) then
+                        dimValue = tempDim
+                     else if ( dimValue /= tempDim ) then
+                        call mpas_log_write('Dimension ' // trim(poolItr % membername) &
+                                             // ' was read with an inconsistent value.', MPAS_LOG_CRIT)
+                     end if
+                  else
+                     call mpas_log_write('       ' // trim(poolItr % memberName) // ' *** not found in stream ***')
+                  end if
+
+               end if
+            end do
+
+            ! Close file
+            call MPAS_io_close(inputHandle)
+
          end if
 
-      end do
+         ! Destroy pool that contains list of streams dimensions
+         call mpas_pool_destroy_pool(streamDimensions)
 
-      call mpas_log_write(' ')
-      call mpas_log_write('----- done reading dimensions from input streams -----')
-      call mpas_log_write(' ')
-      call mpas_log_write(' ')
+      else
+
+         ! Reading dimensions from streams
+         call mpas_log_write('Reading dimensions from input streams ...')
+         call mpas_stream_mgr_begin_iteration(domain % streamManager)
+         do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID = streamName, directionProperty = streamDirection, &
+                                                    activeProperty = streamActive) )
+
+            if ( streamActive .and. ( streamDirection == MPAS_STREAM_INPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+
+               call mpas_stream_mgr_begin_iteration(domain % streamManager, streamID=streamName)
+
+               ! Build stream dimension pool from the list of fields
+               call mpas_pool_create_pool(streamDimensions)
+
+               do while ( mpas_stream_mgr_get_next_field(domain % streamManager, streamName, fieldName, isActive=fieldActive) )
+
+                  if (fieldActive) then
+                     call get_dimlist_for_field(domain % blocklist % allFields, fieldName, dimNames)
+
+                     do i=1,size(dimNames)
+                        call mpas_pool_get_dimension(streamDimensions, dimNames(i), dimValue)
+                        if ( .not. associated(dimValue) ) then
+                           call mpas_pool_add_dimension(streamDimensions, dimNames(i), MPAS_MISSING_DIM)
+                        end if
+                     end do
+                     deallocate(dimNames)
+                  end if
+
+               end do
+
+               ! Determine stream filename
+               call mpas_get_stream_filename(domain % streamManager, streamID = streamName, filename = streamFilename, ierr = err_local)
+
+               ! Determine stream io_type
+               call MPAS_stream_mgr_get_property(domain % streamManager, streamName, &
+                                              MPAS_STREAM_PROPERTY_IOTYPE, ioType, ierr = err_local)
+
+               ! Try to open file
+               inputHandle = MPAS_io_open(trim(streamFilename), MPAS_IO_READ, ioType, domain % ioContext, ierr = err_local)
+
+               ! If to determine if file was opened or not.
+               if ( err_local == MPAS_IO_NOERR ) then
+
+                  call mpas_log_write(' ')
+                  call mpas_log_write('----- reading dimensions from stream '''//trim(streamName)//''' using file ' &
+                                       //trim(streamFilename) )
+
+                  ! Iterate over list of dimensions we determined we need from the above loop
+                  call mpas_pool_begin_iteration(streamDimensions)
+                  do while ( mpas_pool_get_next_member(streamDimensions, poolItr) )
+                     if ( poolItr % memberType == MPAS_POOL_DIMENSION ) then
+                        ! Try to read the dimension
+                        call mpas_io_inq_dim(inputHandle, trim(poolItr % memberName), tempDim, ierr = err_local)
+
+                        ! Check to see if the dimension has already been defined
+                        call mpas_pool_get_dimension(readableDimensions, poolItr % memberName, dimValue)
+
+                        ! If to see if dimension was read or not
+                        if ( err_local == MPAS_IO_NOERR ) then
+                           call mpas_log_write('       ' // trim(poolItr % memberName) // ' = $i', intArgs=(/tempDim/) )
+
+                           if ( .not. associated(dimValue) ) then
+                              call mpas_pool_add_dimension(readableDimensions, poolItr % memberName, tempDim)
+                           else if ( dimValue /= tempDim .and. dimValue == MPAS_MISSING_DIM ) then
+                              dimValue = tempDim
+                           else if ( dimValue /= tempDim ) then
+                              call mpas_log_write('Dimension ' // trim(poolItr % membername) &
+                                                   // ' was read with an inconsistent value.', MPAS_LOG_CRIT)
+                           end if
+                        else
+                           call mpas_log_write('       ' // trim(poolItr % memberName) // ' *** not found in stream ***')
+                        end if
+
+                     end if
+                  end do
+
+                  ! Close file
+                  call mpas_io_close(inputHandle)
+               else
+                  call mpas_log_write(' ')
+                  call mpas_log_write('  *** unable to open input file '//trim(streamFilename)//' for stream ''' &
+                                       //trim(streamName)//'''')
+               end if
+
+               ! Destroy pool that contains list of streams dimensions
+               call mpas_pool_destroy_pool(streamDimensions)
+
+            else if ( .not. streamActive .and. ( streamDirection == MPAS_STREAM_INPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+
+               call mpas_log_write(' ')
+               call mpas_log_write('----- skipping inactive stream '''//trim(streamName)//'''')
+            
+            end if
+
+         end do
+
+         call mpas_log_write(' ')
+         call mpas_log_write('----- done reading dimensions from input streams -----')
+         call mpas_log_write(' ')
+         call mpas_log_write(' ')
+
+      end if
 
       call mpas_pool_set_error_level(err_level)
 

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -76,13 +76,16 @@ module mpas_bootstrapping
    !>            mpas_initialize_vectors()
    !
    !-----------------------------------------------------------------------
-   subroutine mpas_bootstrap_framework_phase1(domain, mesh_filename, mesh_iotype) !{{{
+   subroutine mpas_bootstrap_framework_phase1(domain, mesh_filename, mesh_iotype, pio_file_desc) !{{{
+
+      use pio, only : file_desc_t
 
       implicit none
 
       type (domain_type), pointer :: domain
       character(len=*), intent(in) :: mesh_filename
       integer, intent(in) :: mesh_iotype
+      type (file_desc_t), pointer, optional :: pio_file_desc
 
       type (block_type), pointer :: readingBlock
 
@@ -147,7 +150,8 @@ module mpas_bootstrapping
       nHalos = config_num_halos
 
 
-      inputHandle = MPAS_io_open(trim(mesh_filename), MPAS_IO_READ, mesh_iotype, domain % ioContext, ierr=ierr)
+      inputHandle = MPAS_io_open(trim(mesh_filename), MPAS_IO_READ, mesh_iotype, domain % ioContext, &
+                                 pio_file_desc=pio_file_desc, ierr=ierr)
       if (ierr /= MPAS_IO_NOERR) then
          call mpas_log_write('Could not open input file '''//trim(mesh_filename)//''' to read mesh fields', MPAS_LOG_CRIT)
       else

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -212,7 +212,8 @@ module mpas_io
    end subroutine MPAS_io_unset_iotype
 
    
-   type (MPAS_IO_Handle_type) function MPAS_io_open(filename, mode, ioformat, ioContext, clobber_file, truncate_file, ierr)
+   type (MPAS_IO_Handle_type) function MPAS_io_open(filename, mode, ioformat, ioContext, &
+                                                    clobber_file, truncate_file, pio_file_desc, ierr)
 
       implicit none
 
@@ -222,6 +223,7 @@ module mpas_io
       type (mpas_io_context_type), pointer :: ioContext
       logical, intent(in), optional :: clobber_file
       logical, intent(in), optional :: truncate_file
+      type (file_desc_t), pointer, optional :: pio_file_desc
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr, pio_iotype, pio_mode
@@ -289,44 +291,49 @@ module mpas_io
          end if
       end if
 
-      if (mode == MPAS_IO_WRITE) then
-!call mpas_log_write('MGD PIO_createfile')
-         if (ioContext % dminfo % my_proc_id == 0) then
-            inquire(file=trim(filename), exist=exists)
-         end if
-         call mpas_dmpar_bcast_logical(ioContext % dminfo, exists)
-
-         ! If the file exists and we are not allowed to clobber it, return an
-         !    appropriate error code
-         if (exists .and. (.not. local_clobber)) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_WOULD_CLOBBER
-            return
-         end if
- 
-         if (exists .and. (.not. local_truncate)) then
-            pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_write)
-            MPAS_io_open % preexisting_file = .true.
-         else
-            pio_ierr = PIO_createfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), pio_mode)
-#ifdef MPAS_DEBUG
-            if (exists) then
-               call mpas_log_write('MPAS I/O: Truncating existing data in output file '//trim(filename), MPAS_LOG_WARN)
-            end if
-#endif
-         end if
+      if (present(pio_file_desc)) then
+call mpas_log_write('Using externally provided PIO file descriptor')
+         MPAS_io_open % pio_file = pio_file_desc
       else
-         inquire(file=trim(filename), exist=exists)
+         if (mode == MPAS_IO_WRITE) then
+!call mpas_log_write('MGD PIO_createfile')
+            if (ioContext % dminfo % my_proc_id == 0) then
+               inquire(file=trim(filename), exist=exists)
+            end if
+            call mpas_dmpar_bcast_logical(ioContext % dminfo, exists)
 
-         if (.not. exists) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_NOEXIST_READ
+            ! If the file exists and we are not allowed to clobber it, return an
+            !    appropriate error code
+            if (exists .and. (.not. local_clobber)) then
+               if (present(ierr)) ierr = MPAS_IO_ERR_WOULD_CLOBBER
+               return
+            end if
+ 
+            if (exists .and. (.not. local_truncate)) then
+               pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_write)
+               MPAS_io_open % preexisting_file = .true.
+            else
+               pio_ierr = PIO_createfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), pio_mode)
+#ifdef MPAS_DEBUG
+               if (exists) then
+                  call mpas_log_write('MPAS I/O: Truncating existing data in output file '//trim(filename), MPAS_LOG_WARN)
+               end if
+#endif
+            end if
+         else
+            inquire(file=trim(filename), exist=exists)
+
+            if (.not. exists) then
+               if (present(ierr)) ierr = MPAS_IO_ERR_NOEXIST_READ
+               return
+            end if
+!call mpas_log_write('MGD PIO_openfile')
+            pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
+         endif
+         if (pio_ierr /= PIO_noerr) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
-!call mpas_log_write('MGD PIO_openfile')
-         pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
-      endif
-      if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
-         return
       end if
 
       if (mode == MPAS_IO_READ .or. MPAS_io_open % preexisting_file) then

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -292,8 +292,8 @@ module mpas_io
       end if
 
       if (present(pio_file_desc)) then
-call mpas_log_write('Using externally provided PIO file descriptor')
          MPAS_io_open % pio_file = pio_file_desc
+         MPAS_io_open % external_file_desc = .true.
       else
          if (mode == MPAS_IO_WRITE) then
 !call mpas_log_write('MGD PIO_createfile')
@@ -334,6 +334,7 @@ call mpas_log_write('Using externally provided PIO file descriptor')
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
+         MPAS_io_open % external_file_desc = .false.
       end if
 
       if (mode == MPAS_IO_READ .or. MPAS_io_open % preexisting_file) then
@@ -4883,7 +4884,9 @@ call mpas_log_write('Using externally provided PIO file descriptor')
       handle % initialized = .false.
 
 !call mpas_log_write('MGD PIO_closefile')
-      call PIO_closefile(handle % pio_file)
+      if (.not. handle % external_file_desc) then
+         call PIO_closefile(handle % pio_file)
+      end if
 
    end subroutine MPAS_io_close
 

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -61,6 +61,7 @@
       logical :: initialized = .false.
       logical :: preexisting_file = .false.
       logical :: data_mode = .false.
+      logical :: external_file_desc = .false.
       type (file_desc_t) :: pio_file
       character (len=StrKIND) :: filename
       integer :: iomode


### PR DESCRIPTION
This PR adds the ability for both phase1 and phase2 of the boostrapping process
to use an externally provided PIO file descriptor.

When MPAS is a component in a larger system, it may be necessary to "bootstrap"
the MPAS infrastructure from an externally provided file descriptor. This PR
adds an optional PIO file_desc_t argument to mpas_bootstrap_framework_phase1
and to mpas_bootstrap_framework_phase2.

The MPAS_io_open routine now uses the optional PIO file_desc_t if provided, and
opens the file indicated by the filename argument as before if no PIO
file_desc_t argument is provided.

In order to avoid closing a PIO file_desc_t that was not opened by MPAS_io_open
(because this external file_desc_t was provided as an optional argument in
the call to MPAS_io_open), this PR also adds a new member, external_file_desc,
to the MPAS_IO_Handle_type type. This member is set to .true. if an external
PIO file_desc_t was provided, and if .true. in the call to MPAS_io_close,
PIO_closefile is not called.

In the second bootstrapping phase, when a PIO file descriptor is provided,
rather than scanning through all input streams from the streams.<core> file
to find definitions of dimensions, the routine searches for dimensions only in
the file corresponding to the externally provided PIO file descriptor.