### PR TITLE
Use RKIND kind type parameter for real constants defined in mpas_constants

### DIFF
--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -22,18 +22,18 @@ module mpas_constants
 
    use mpas_kind_types
 
-   real (kind=RKIND), parameter :: pii     = 3.141592653589793   !< Constant: Pi
-   real (kind=RKIND), parameter :: a       = 6371229.0           !< Constant: Spherical Earth radius [m]
-   real (kind=RKIND), parameter :: omega   = 7.29212e-5          !< Constant: Angular rotation rate of the Earth [s-1]
-   real (kind=RKIND), parameter :: gravity = 9.80616             !< Constant: Acceleration due to gravity [m s-2]
-   real (kind=RKIND), parameter :: rgas    = 287.0               !< Constant: Gas constant for dry air [J kg-1 K-1]
-   real (kind=RKIND), parameter :: rv      = 461.6               !< Constant: Gas constant for water vapor [J kg-1 K-1]
-   real (kind=RKIND), parameter :: rvord   = rv/rgas             !
-!  real (kind=RKIND), parameter :: cp      = 1003.0              !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
-   real (kind=RKIND), parameter :: cp      = 7.*rgas/2.          !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
-   real (kind=RKIND), parameter :: cv      = cp - rgas           !< Constant: Specific heat of dry air at constant volume [J kg-1 K-1]
-   real (kind=RKIND), parameter :: cvpm    = -cv/cp              !
-   real (kind=RKIND), parameter :: prandtl = 1.0                 !< Constant: Prandtl number
+   real (kind=RKIND), parameter :: pii     = 3.141592653589793_RKIND  !< Constant: Pi
+   real (kind=RKIND), parameter :: a       = 6371229.0_RKIND          !< Constant: Spherical Earth radius [m]
+   real (kind=RKIND), parameter :: omega   = 7.29212e-5_RKIND         !< Constant: Angular rotation rate of the Earth [s-1]
+   real (kind=RKIND), parameter :: gravity = 9.80616_RKIND            !< Constant: Acceleration due to gravity [m s-2]
+   real (kind=RKIND), parameter :: rgas    = 287.0_RKIND              !< Constant: Gas constant for dry air [J kg-1 K-1]
+   real (kind=RKIND), parameter :: rv      = 461.6_RKIND              !< Constant: Gas constant for water vapor [J kg-1 K-1]
+   real (kind=RKIND), parameter :: rvord   = rv / rgas                !
+!  real (kind=RKIND), parameter :: cp      = 1003.0_RKIND             !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
+   real (kind=RKIND), parameter :: cp      = 7.0_RKIND*rgas/2.0_RKIND !< Constant: Specific heat of dry air at constant pressure [J kg-1 K-1]
+   real (kind=RKIND), parameter :: cv      = cp - rgas                !< Constant: Specific heat of dry air at constant volume [J kg-1 K-1]
+   real (kind=RKIND), parameter :: cvpm    = -cv / cp                 !
+   real (kind=RKIND), parameter :: prandtl = 1.0_RKIND                !< Constant: Prandtl number
 
    contains
 


### PR DESCRIPTION
This PR ensures that all real-valued, literal constants defined in the mpas_constants
module have the RKIND kind.

The real-valued parameters in the mpas_constants module were previously set
to literal values without an explicit kind type parameter. This may lead to
differences in simulation results depending on whether MPAS is compiled with
flags to promote the default real kind (e.g, -fdefault-real-8 with the GNU
Fortran compiler).

For example, if RKIND is defined as 8, the 'gravity' constant defined below
will take on different values, depending on whether MPAS is compiled with,
e.g., -fdefault-real-8 (using the GNU compiler) or not:

    real (kind=RKIND), parameter :: gravity = 9.80616

The correct way to initialize real-valued parameters with kind-type RKIND
is to explicitly specify the kind type parameter for the literal value:

    real (kind=RKIND), parameter :: gravity = 9.80616_RKIND
