### PR TITLE
Make several stream manager routines public: postread_reindex, prewrite_reindex, and postwrite_reindex

### DIFF
--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -47,6 +47,8 @@ module mpas_stream_manager
               MPAS_get_stream_filename, &
               MPAS_build_stream_filename
 
+    public :: postread_reindex
+
     private
 
     interface MPAS_stream_mgr_set_property

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -47,7 +47,9 @@ module mpas_stream_manager
               MPAS_get_stream_filename, &
               MPAS_build_stream_filename
 
-    public :: postread_reindex
+    public :: prewrite_reindex, &
+              postwrite_reindex, &
+              postread_reindex
 
     private
 

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -47,8 +47,21 @@ module mpas_stream_manager
               MPAS_get_stream_filename, &
               MPAS_build_stream_filename
 
-    public :: prewrite_reindex, &
-              postwrite_reindex, &
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !
+    !                  IMPORTANT NOTE for {pre,post}write_reindex
+    !
+    ! Caution is needed if calling the {pre,post}write_reindex routines directly
+    ! from outside of the stream manager. These two routines make use of module
+    ! state to save and retrieve pointers to the original indexing arrays. Problems
+    ! can arise, for example, if external code calls prewrite_reindex, then makes
+    ! a call to write output streams via the stream manager: in this case, pointers
+    ! set by the external call to prewrite_reindex will be overwritten by the
+    ! internal call to prewrite_reindex within mpas_stream_mgr_write.
+    !
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    public :: prewrite_reindex, &    ! Please see note above...
+              postwrite_reindex, &   ! Please see note above...
               postread_reindex
 
     private
@@ -4785,6 +4798,10 @@ module mpas_stream_manager
     !>  indexed fields in module variables *_save, and allocate new arrays for
     !>  the fields, which are set to contain global indices.
     !>  This routine should be called immediately before a write of a stream.
+    !>
+    !>  IMPORTANT NOTE: Before calling this routine from outside of the stream
+    !>                  manager module, please read the "IMPORTANT NOTE" near
+    !>                  the top of this module where this routine is made public.
     !
     !-----------------------------------------------------------------------
     subroutine prewrite_reindex(allFields, streamFields) !{{{
@@ -5080,6 +5097,10 @@ module mpas_stream_manager
     !> 
     !>  NB: Even if the write of a stream fails, it is important to stil call
     !>      this routine to reset the connectivity fields to contain local indices.
+    !>
+    !>  IMPORTANT NOTE: Before calling this routine from outside of the stream
+    !>                  manager module, please read the "IMPORTANT NOTE" near
+    !>                  the top of this module where this routine is made public.
     !
     !-----------------------------------------------------------------------
     subroutine postwrite_reindex(allFields, streamFields) !{{{


### PR DESCRIPTION
The postread_reindex, prewrite_reindex, and postwrite_reindex routines in
the mpas_stream_manager module were previously private. However, code that
builds ad hoc output streams at the mpas_io_streams level that contain
indexing fields could benefit from the use of these routine to reindex
indexing fields (e.g., cellsOnCell).
    
The use of prewrite_reindex and postwrite_reindex requires some care, since
they set module variables within the mpas_stream_manager module to save and
retrieve pointers to the original indexing arrays. Problems can arise, for
example, if external code calls prewrite_reindex, then makes a call to write
output streams via the stream manager: in this case, pointers set by the
external call to prewrite_reindex will be overwritten by the internal call to
prewrite_reindex within mpas_stream_mgr_write.

Unlike the prewrite_reindex and postwrite_reindex routines, which rely on
module state, the postread_reindex routine does not rely on any module
variables in the mpas_stream_manager module, and can therefore be safely used
by external code.