### PR TITLE
Add scratch arrays in tend_physics pool for zonal and meridional wind tendencies

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2688,6 +2688,15 @@
         </var_struct>
 
         <var_struct name="tend_physics" time_levs="1">
+
+                <!-- Scratch variables used when propagating cell-centered winds to edges -->
+                <var name="tend_uzonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
+                     description="Total cell-centered zonal wind tendency from physics"
+                     persistence="scratch" />
+
+                <var name="tend_umerid" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
+                     description="Total cell-centered meridional wind tendency from physics"
+                     persistence="scratch" />
  
                 <!-- ================================================================================================== -->
                 <!-- TENDENCIES FROM PARAMETERIZATION OF CONVECTION:                                                    -->


### PR DESCRIPTION
This PR adds scratch arrays to the tend_physics pool for the tendencies of zonal
and meridional winds.

In order to allow code to avoid having to create ad hoc fields to udpate halos
of cell-centered wind tendencies as we currently do in tend_toEdges, this PR
adds two scratch arrays, tend_uzonal and tend_umerid, to the tend_physics pool.
At present, these scratch arrays are used in the p_d_coupling routine of
CAM-MPAS, though they are not used in stand-alone MPAS-Atmosphere.