### PR TITLE
fEdge divide by zero fix in GM

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_gm.F
+++ b/src/core_ocean/shared/mpas_ocn_gm.F
@@ -636,7 +636,7 @@ contains
            do iEdge=1,nEdges
               cell1 = cellsOnEdge(1, iEdge)
               cell2 = cellsOnEdge(2, iEdge)
-              Lr = min(cGMphaseSpeed(iEdge) / abs(fEdge(iEdge)),          &
+              Lr = min(cGMphaseSpeed(iEdge) / (1.0E-15_RKIND + abs(fEdge(iEdge))), &
                        sqrt(cGMphaseSpeed(iEdge) / (2.0_RKIND*betaEdge(iEdge))))
 
               do k=minLevelEdgeBot(iEdge)+1,maxLevelEdgeTop(iEdge)


### PR DESCRIPTION
This bug creates a divide by zero error, but **only** if latEdge is very close to zero, so it is dependent on the mesh. The exact jigsaw output varies by compiler and machine, so we did not see this error until now.