### PR TITLE
Update MPAS Frazil to match E3SM conservation

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -3660,6 +3660,7 @@
 		<var name="seaSurfaceSalinity"			type="real"	dimensions="nCells Time"		name_in_code="seaSurfaceSalinity"		default_value="34.0"/>
 		<var name="seaFreezingTemperature"		type="real"	dimensions="nCells Time"		name_in_code="seaFreezingTemperature"/>
 		<var name="freezingMeltingPotential"		type="real"	dimensions="nCells Time"		name_in_code="freezingMeltingPotential"/>
+		<var name="frazilMassAdjust"		        type="real"	dimensions="nCells Time"		name_in_code="frazilMassAdjust"/>
 		<var name="uOceanVelocity"			type="real"	dimensions="nCells Time"		name_in_code="uOceanVelocity"/>
 		<var name="vOceanVelocity"			type="real"	dimensions="nCells Time"		name_in_code="vOceanVelocity"/>
 		<var name="seaSurfaceTiltU"			type="real"	dimensions="nCells Time"		name_in_code="seaSurfaceTiltU"/>

--- a/src/core_seaice/column/ice_therm_itd.F90
+++ b/src/core_seaice/column/ice_therm_itd.F90
@@ -1237,7 +1237,7 @@
          do k = 1, nilyr
             Sprofile(k) = Si0new
          enddo
-         Ti = min(liquidus_temperature_mush(Si0new/phi_init), -p1)
+         Ti = liquidus_temperature_mush(Si0new/phi_init)
          qi0new = enthalpy_mush(Ti, Si0new)
       else
          do k = 1, nilyr


### PR DESCRIPTION
Adds a frazil mass flux correction to the ocean coupling pool in MPAS-SeaIce, and removes an artificial limit on enthalpy of new sea ice created from frazil. These changes are provided in concert with updates to E3SM PR https://github.com/E3SM-Project/E3SM/pull/4295 to conserver mass and heat in frazil coupling. Testing has taken place via a B-case E3SM simulation on Chrysalis.