### PR TITLE
Sea ice index allocation bug

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -4614,6 +4614,27 @@ contains
        ! set all indices for biogeochemistry including parent, ancestor and ancestor mask
        call init_column_tracer_object_for_biogeochemistry(domain, tracerObject)
 
+    else
+       allocate(tracerObject % index_algaeConc(1))
+       allocate(tracerObject % index_algalCarbon(1))
+       allocate(tracerObject % index_algalChlorophyll(1))
+       allocate(tracerObject % index_DOCConc(1))
+       allocate(tracerObject % index_DONConc(1))
+       allocate(tracerObject % index_DICConc(1))
+       allocate(tracerObject % index_dissolvedIronConc(1))
+       allocate(tracerObject % index_particulateIronConc(1))
+       allocate(tracerObject % index_verticalAerosolsConc(1))
+
+       allocate(tracerObject % index_algaeConcLayer(1))
+       allocate(tracerObject % index_algalCarbonLayer(1))
+       allocate(tracerObject % index_algalChlorophyllLayer(1))
+       allocate(tracerObject % index_DOCConcLayer(1))
+       allocate(tracerObject % index_DONConcLayer(1))
+       allocate(tracerObject % index_DICConcLayer(1))
+       allocate(tracerObject % index_dissolvedIronConcLayer(1))
+       allocate(tracerObject % index_particulateIronConcLayer(1))
+       allocate(tracerObject % index_verticalAerosolsConcLayer(1))
+       allocate(tracerObject % index_verticalAerosolsConcShortwave(1))
     endif
 
   end subroutine init_column_tracer_object

--- a/src/core_seaice/shared/mpas_seaice_column.F
+++ b/src/core_seaice/shared/mpas_seaice_column.F
@@ -4635,6 +4635,9 @@ contains
        allocate(tracerObject % index_particulateIronConcLayer(1))
        allocate(tracerObject % index_verticalAerosolsConcLayer(1))
        allocate(tracerObject % index_verticalAerosolsConcShortwave(1))
+
+       allocate(tracerObject % index_LayerIndexToDataArray(1))
+       allocate(tracerObject % index_LayerIndexToBioIndex(1))
     endif
 
   end subroutine init_column_tracer_object


### PR DESCRIPTION
Fix to issue https://github.com/MPAS-Dev/MPAS-Model/issues/344 for the e3sm/maint-1.0 branch.

Allocates bgc tracerObject indices to dimension 1 when not in use. Corrects a compile time error that appears with intel19 compiler versions. BFB with previous version compilers.