### PR TITLE
Ignore errors from PIO_enddef if a file uses an external file descriptor

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -2321,7 +2321,8 @@ module mpas_io
          ! new dimensions or variables, in which case PIO_enddef() will return
          ! an error under harmless circumstances; so, don't return only for
          ! pre-existing files.
-         if (pio_ierr /= PIO_noerr .and. (.not. handle % preexisting_file)) then
+         if (pio_ierr /= PIO_noerr .and. &
+             .not. (handle % external_file_desc .or. handle % preexisting_file)) then
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if


### PR DESCRIPTION
This PR adds logic to ignore errors from PIO_enddef if a file uses an externally
provided file descriptor.

In the MPAS_io_put_var_generic function, calls to PIO_enddef can fail under
harmless conditions; for example, PIO_enddef could fail if MPAS were writing
to an existing file, in which case no new variables or dimensions were defined.

This PR adds an additional condition under which errors from PIO_enddef
should be ignored: if the file uses an externally provided file descriptor, in
which case the file may have been taken out of define mode outside the context
of the mpas_io module.