### PR TITLE
Enable more flexibility in PIO namelist settings

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -67,6 +67,9 @@ module mpas_framework
 !-----------------------------------------------------------------------
    subroutine mpas_framework_init_phase2(domain, io_system, calendar)!{{{
 
+      use mpas_log, only : mpas_log_write
+      use mpas_derived_types, only : MPAS_LOG_CRIT
+
       implicit none
 
       type (domain_type), pointer :: domain
@@ -103,14 +106,29 @@ module mpas_framework
          call mpas_pool_get_config(domain % configs, 'config_pio_stride', config_pio_stride)
          pio_num_iotasks = config_pio_num_iotasks
          pio_stride = config_pio_stride
+
+         !
+         ! If at most one of config_pio_num_iotasks and config_io_stride are zero, compute
+         ! a sensible value for the zero-valued option
+         !
+         if (pio_num_iotasks == 0 .and. pio_stride == 0) then
+            call mpas_log_write('Namelist options config_pio_num_iotasks and config_pio_stride cannot both be zero.', &
+                                messageType=MPAS_LOG_CRIT)
+         else if (pio_num_iotasks == 0) then
+            pio_num_iotasks = domain % dminfo % nprocs / pio_stride
+         else if (pio_stride == 0) then
+            pio_stride = domain % dminfo % nprocs / pio_num_iotasks
+         end if
+
+         call mpas_log_write('')
+         call mpas_log_write('----- I/O task configuration: -----')
+         call mpas_log_write('')
+         call mpas_log_write('    I/O task count  = $i', intArgs=[pio_num_iotasks])
+         call mpas_log_write('    I/O task stride = $i', intArgs=[pio_stride])
+         call mpas_log_write('')
       else
          pio_num_iotasks = -1    ! Not used when external io_system is provided
          pio_stride      = -1    ! Not used when external io_system is provided
-      end if
-
-      ! A value of 0 for pio_num_iotasks actually indicates that every task should be an I/O task
-      if (pio_num_iotasks == 0) then
-         pio_num_iotasks = domain % dminfo % nprocs
       end if
 
       domain % ioContext % dminfo => domain % dminfo


### PR DESCRIPTION
This PR adds flexibility in how I/O tasks are specified using the namelist
options `config_pio_num_iotasks` and `config_pio_stride`. Previously, it was
possible to set the number of I/O tasks to zero in the namelist, in which case
the actual number of I/O tasks used in the run was set to the total number of
MPI ranks (regardless of the setting of `config_pio_stride`).

Now, if `config_pio_num_iotasks` is zero in the namelist, the number of I/O tasks
is computed as the total number of MPI ranks divided by the specified value of
`config_pio_stride`. Additionally, if the I/O stride is zero in the namelist, the stride
is computed as the total number of MPI ranks dividied by the specified number of
I/O tasks.

Also included in this PR are log messages to inform users of the computed
I/O task configuration that will actually be used in a run; for example:
```
 ----- I/O task configuration: -----

     I/O task count  = 1
     I/O task stride = 72
```