### PR TITLE
Remove pointer attribute from several PIO file descriptor dummy arguments

### DIFF
--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -85,7 +85,7 @@ module mpas_bootstrapping
       type (domain_type), pointer :: domain
       character(len=*), intent(in) :: mesh_filename
       integer, intent(in) :: mesh_iotype
-      type (file_desc_t), pointer, optional :: pio_file_desc
+      type (file_desc_t), intent(inout), optional :: pio_file_desc
 
       type (block_type), pointer :: readingBlock
 
@@ -450,7 +450,7 @@ module mpas_bootstrapping
       implicit none
 
       type (domain_type), pointer :: domain
-      type (file_desc_t), pointer, optional :: pio_file_desc
+      type (file_desc_t), intent(inout), optional :: pio_file_desc
 
       type (mpas_pool_type), pointer :: readableDimensions
       type (mpas_pool_type), pointer :: streamDimensions

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -223,7 +223,7 @@ module mpas_io
       type (mpas_io_context_type), pointer :: ioContext
       logical, intent(in), optional :: clobber_file
       logical, intent(in), optional :: truncate_file
-      type (file_desc_t), pointer, optional :: pio_file_desc
+      type (file_desc_t), intent(inout), optional :: pio_file_desc
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr, pio_iotype, pio_mode

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -91,7 +91,7 @@ module mpas_io_streams
       logical, intent(in), optional :: clobberRecords
       logical, intent(in), optional :: clobberFiles
       logical, intent(in), optional :: truncateFiles
-      type (file_desc_t), pointer, optional :: pio_file_desc
+      type (file_desc_t), intent(inout), optional :: pio_file_desc
       integer, intent(out), optional :: ierr
 
       integer :: io_err


### PR DESCRIPTION
This PR removes the `pointer` attribute from the optional PIO file descriptor
dummy argument in several framework routines:

  mpas_bootstrap_framework_phase1
  mpas_bootstrap_framework_phase2
  MPAS_createStream
  mpas_io_open

The dummy argument wasn't required to be a pointer, and external calls to these
routines may have a file descriptor to be passed that is not a pointer.