### PR TITLE
Extend Makefile support to include Ampere GPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ pgi:
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
-	"FFLAGS_ACC = -Mnofma -acc -ta=tesla:cc70 -Minfo=accel" \
+	"FFLAGS_ACC = -Mnofma -acc -ta=tesla:cc70,cc80 -Minfo=accel" \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \


### PR DESCRIPTION
Only a matter of adding 5 characters to one line:
```
    117 pgi:
                      ...
    136         "FFLAGS_ACC = -Mnofma -acc -ta=tesla:cc70,cc80 -Minfo=accel" \
```
This enables code-generation to support Ampere as well as Volta.
It will not break compatibility with previous use-cases.