### PR TITLE
Added OpenACC directives and Role checks, to enable running on CPU with other Physics on GPUs.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -8,12 +8,15 @@
 !=================================================================================================================
  module mpas_atmphys_driver_cloudiness
  use mpas_kind_types
+ use mpas_derived_types
  use mpas_pool_routines
  use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 
  use mpas_atmphys_constants, only: ep_2
  use mpas_atmphys_vars
  use module_mp_thompson_cldfra3
+
+ use mpas_intracoupler, only : ROLE_INTEGRATE, ROLE_RADIATION
  
  implicit none
  private
@@ -106,15 +109,21 @@
  real(kind=RKIND),pointer:: len_disp
  real(kind=RKIND),dimension(:),pointer:: areaCell,meshDensity
  real(kind=RKIND),dimension(:),pointer:: xland
-
+ type(Field1DReal), pointer :: areaCellField
+ type(mpas_coupler_type), pointer :: coupler
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
 
- call mpas_pool_get_array(mesh,'areaCell'   ,areaCell   )
- call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
+ call mpas_pool_get_array_gpu(mesh,'areaCell'   ,areaCell   )
+ call mpas_pool_get_field(mesh,'areaCell'   ,areaCellField   )
+ call mpas_pool_get_array_gpu(mesh,'meshDensity',meshDensity)
 
- call mpas_pool_get_array(sfc_input,'xland',xland)
+ call mpas_pool_get_array_gpu(sfc_input,'xland',xland)
+ coupler => areaCellField%block%domain%mpas_cpl
+ if (coupler%role_includes(ROLE_INTEGRATE)) then
+        !$acc update host(areaCell, meshDensity, xland)
+ end if
 
  do j = jts,jte
     do i = its,ite
@@ -151,10 +160,12 @@
  integer:: i,j,k
 
  real(kind=RKIND),dimension(:,:),pointer:: cldfrac
-
+ type(Field2DReal), pointer :: cldfracField
+ type(mpas_coupler_type), pointer :: coupler
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(diag_physics,'cldfrac',cldfrac)
+ call mpas_pool_get_array_gpu(diag_physics,'cldfrac',cldfrac)
+ call mpas_pool_get_field(diag_physics,'cldfrac',cldfracField)
 
  do j = jts,jte
  do k = kts,kte
@@ -164,6 +175,10 @@
  enddo
  enddo
  
+ coupler => cldfracField%block%domain%mpas_cpl
+ if (coupler%role_includes(ROLE_INTEGRATE)) then
+        !$acc update device(cldfrac)
+ end if
  end subroutine cloudiness_to_MPAS
 
 !=================================================================================================================


### PR DESCRIPTION
Added OpenACC directives from 6.x-openacc version to manage Host <-> GPU memory movement, to work with some physics models running on the GPU.

This particular file, from my manual merge, came out the same as what was in mgduda's original 6.x -> develop merge.

I have successfully built & run the MPAS-A develop-openacc branch with this modifed file, with these two configurations:
1. CPU-only build, run with full physics simulation (including this modified file).
2. OpenACC build, but only the moist DyCore part of the simulation. This file is not tested in the run, but is show to compile OK with the changes.