### PR TITLE
Address unused variable and unused argument warnings in mpas_init_atm_cases.F

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -51,7 +51,6 @@ module init_atm_cases
       type (MPAS_streamManager_type), intent(inout) :: stream_manager
 
 
-      integer :: i
       integer :: ierr
       type (block_type), pointer :: block_ptr
 
@@ -380,7 +379,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: rdzw, dzu, rdzu, fzm, fzp
       real (kind=RKIND), dimension(:), pointer :: surface_pressure
       real (kind=RKIND), dimension(:,:), pointer :: zgrid, zxu, zz, hx
-      real (kind=RKIND), dimension(:,:), pointer :: pressure, ppb, pb, rho_zz, rb, rr, tb, rtb, p, pp, dss, t, rt
+      real (kind=RKIND), dimension(:,:), pointer :: ppb, pb, rho_zz, rb, rr, tb, rtb, p, pp, dss, t, rt
       real (kind=RKIND), dimension(:,:), pointer :: u, ru, w, rw, v
       real (kind=RKIND), dimension(:,:), pointer :: rho, theta
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3
@@ -398,29 +397,25 @@ module init_atm_cases
       integer, pointer :: nz1, nCellsSolve, nEdges, maxEdges, nVertices
 
       !This is temporary variable here. It just need when calculate tangential velocity v.
-      integer :: eoe, j
+      integer :: eoe
       integer, dimension(:), pointer :: nEdgesOnEdge, nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnEdge, cellsOnEdge, verticesOnEdge, cellsOnCell
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
 
-      real (kind=RKIND) :: flux, fluxk, lat1, lat2, eta_v, r_pert, u_pert, lat_pert, lon_pert, r
+      real (kind=RKIND) :: flux, fluxk, lat1, lat2, r_pert, u_pert, lat_pert, lon_pert
 
-      real (kind=RKIND) :: ptop, p0, phi
+      real (kind=RKIND) :: p0, phi
       real (kind=RKIND) :: lon_Edge
 
-      real (kind=RKIND) :: r_earth, etavs, ztemp, zd, zt, dz, gam, delt, str
+      real (kind=RKIND) :: r_earth, etavs, ztemp, zd, zt, dz, str
 
-      real (kind=RKIND) :: es, qvs, xnutr, znut, ptemp 
-      integer :: iter
-
-      real (kind=RKIND), dimension(nVertLevels + 1 ) :: hyai, hybi, znu, znw, znwc, znwv, hyam, hybm
-      real (kind=RKIND), dimension(nVertLevels + 1 ) :: znuc, znuv, bn, divh, dpn
+      real (kind=RKIND) :: es, xnutr, znut, ptemp
 
       real (kind=RKIND), dimension(nVertLevels + 1 ) :: sh, zw, ah
       real (kind=RKIND), dimension(nVertLevels ) :: zu, dzw, rdzwp, rdzwm
       real (kind=RKIND), dimension(nVertLevels ) :: eta, etav, teta, ppi, tt, temperature_1d
 
-      real (kind=RKIND) :: d1, d2, d3, cof1, cof2, psurf
+      real (kind=RKIND) :: cof1, cof2, psurf
       real (kind=RKIND), pointer :: cf1, cf2, cf3
 
       !  storage for (lat,z) arrays for zonal velocity calculation
@@ -1318,34 +1313,31 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3
 
       !This is temporary variable here. It just need when calculate tangential velocity v.
-      integer :: eoe, j
+      integer :: eoe
       integer, dimension(:), pointer :: nEdgesOnEdge 
       integer, dimension(:,:), pointer :: edgesOnEdge, cellsOnEdge
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
 
-      integer :: iCell, iCell1, iCell2 , iEdge, vtx1, vtx2, ivtx, i, k, nz, nz1, itr, cell1, cell2
+      integer :: iCell, iCell1, iCell2 , iEdge, ivtx, i, k, nz, nz1, itr, cell1, cell2
       integer, pointer :: nEdges, nVertices, maxEdges, nCellsSolve
       integer, pointer :: index_qv
-
-      real (kind=RKIND), dimension(nVertLevels + 1 ) :: znu, znw, znwc, znwv
-      real (kind=RKIND), dimension(nVertLevels + 1 ) :: znuc, znuv
 
       real (kind=RKIND), dimension(nVertLevels + 1 ) :: zc, zw, ah
       real (kind=RKIND), dimension(nVertLevels ) :: zu, dzw, rdzwp, rdzwm
 
       real (kind=RKIND), dimension(nVertLevels, nCells) :: relhum, thi, tbi, cqwb
 
-      real (kind=RKIND) ::  r, xnutr
+      real (kind=RKIND) ::  xnutr
       real (kind=RKIND) ::  ztemp, zd, zt, dz, str
 
       real (kind=RKIND), dimension(nVertLevels ) :: qvb
       real (kind=RKIND), dimension(nVertLevels ) :: t_init_1d
 
-      real (kind=RKIND) :: d1, d2, d3, cof1, cof2
+      real (kind=RKIND) :: cof1, cof2
       real (kind=RKIND), pointer :: cf1, cf2, cf3
       real (kind=RKIND) :: ztr, thetar, ttr, thetas, um, us, zts, pitop, pibtop, ptopb, ptop, rcp, rcv, p0
       real (kind=RKIND) :: radx, radz, zcent, xmid, delt, xloc, rad, yloc, ymid, a_scale
-      real (kind=RKIND) :: pres, temp, es, qvs
+      real (kind=RKIND) :: pres, temp, qvs
 
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
       real (kind=RKIND), dimension(:), pointer :: xEdge, yEdge, zEdge
@@ -1905,12 +1897,12 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:,:), pointer :: scalars, deriv_two, zb, zb3
 
       !This is temporary variable here. It just need when calculate tangential velocity v.
-      integer :: eoe, j
+      integer :: eoe
       integer, dimension(:), pointer :: nEdgesOnEdge, nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnEdge, cellsOnEdge, cellsOnCell
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
 
-      integer :: iCell, iCell1, iCell2 , iEdge, vtx1, vtx2, ivtx, i, k, nz, itr, itrp, cell1, cell2, nz1
+      integer :: iCell, iCell1, iCell2 , iEdge, ivtx, i, k, nz, itr, cell1, cell2, nz1
       integer, pointer :: nEdges, maxEdges, nCellsSolve, nVertices
       integer, pointer :: index_qv
 
@@ -1919,20 +1911,18 @@ module init_atm_cases
       real (kind=RKIND) :: ztemp, zd, zt, dz, str
 
       real (kind=RKIND), dimension(nVertLevels, nCells) :: relhum
-      real (kind=RKIND) :: es, qvs, xnutr, ptemp
-      integer :: iter
+      real (kind=RKIND) :: qvs, xnutr
 
       real (kind=RKIND), dimension(nVertLevels + 1 ) :: zc, zw, ah
       real (kind=RKIND), dimension(nVertLevels ) :: zu, dzw, rdzwp, rdzwm
 
       real (kind=RKIND) :: d1, d2, d3, cof1, cof2
       real (kind=RKIND) :: um, vm,rcp, rcv
-      real (kind=RKIND) :: xmid, temp, pres, a_scale
+      real (kind=RKIND) :: temp, pres, a_scale
 
-      real (kind=RKIND) :: xi, xa, xc, xla, zinv, xn2, xn2m, xn2l, sm, dzh, dzht, dzmin, z_edge, z_edge3 
+      real (kind=RKIND) :: xi, xa, xc, xla, zinv, xn2, xn2m, xn2l, z_edge, z_edge3
 
       integer, dimension(nCells, 2) :: next_cell
-      real (kind=RKIND),  dimension(nCells) :: hxzt
       logical, parameter :: terrain_smooth = .false.
 
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
@@ -2567,7 +2557,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:,:), pointer :: deriv_two
 
       real (kind=RKIND) :: target_z
-      integer :: iCell, iCell1, iCell2 , iEdge, vtx1, vtx2, ivtx, i, k, nz, itr, itrp, cell1, cell2
+      integer :: iCell, iCell1, iCell2 , iEdge, i, k, nz, cell1, cell2
       integer, pointer :: nCellsSolve, nz1
       integer :: nInterpPoints, ndims
 
@@ -2581,11 +2571,10 @@ module init_atm_cases
       integer :: masked
 
       !This is temporary variable here. It just need when calculate tangential velocity v.
-      integer :: eoe, j
+      integer :: j
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnEdge, cellsOnEdge, edgesOnCell, cellsOnCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge, dcEdge, areaCell 
-      real (kind=RKIND), dimension(:,:), pointer :: v
       real (kind=RKIND), dimension(:,:), pointer :: sorted_arr
       integer, dimension(:), pointer :: bdyMaskCell
 
@@ -2594,7 +2583,7 @@ module init_atm_cases
       type (field1DReal), target :: tempFieldTarget
 
       real(kind=RKIND), dimension(:), pointer :: hs, hs1, sm0
-      real(kind=RKIND) :: hm, hm_global, zh, dzmin, dzmina, dzmina_global, dzminf, dzminf_global, sm
+      real(kind=RKIND) :: hm, hm_global, zh, dzmin, dzmina, dzminf, dzminf_global, sm
       real(kind=RKIND) :: dcsum
       integer :: nsmterrain, kz, sfc_k
       logical :: hybrid, smooth
@@ -2603,46 +2592,31 @@ module init_atm_cases
       real (kind=RKIND) :: p_check
 
       ! For interpolating terrain and land use
-      integer :: nx, ny
       integer :: istatus
 
       real (kind=RKIND), allocatable, dimension(:,:) :: rslab, maskslab
       integer, dimension(:), pointer :: mask_array
       integer, dimension(nEdges), target :: edge_mask
-      character (len=StrKIND) :: fname
       logical :: is_sfc_field
 
-      real (kind=RKIND) :: flux, fluxk, lat1, lat2, eta_v, r_pert, u_pert, lat_pert, lon_pert, r
+      real (kind=RKIND) :: flux
       real (kind=RKIND) :: lat, lon, x, y
 
-      real (kind=RKIND) :: ptop, p0, phi
-      real (kind=RKIND) :: lon_Edge
+      real (kind=RKIND) :: p0
 
-      real (kind=RKIND) :: r_earth, etavs, ztemp, zd, zt, dz, gam, delt, str
+      real (kind=RKIND) :: etavs, ztemp, zd, zt, dz, str
 
-      real (kind=RKIND), dimension(nVertLevels, nCells) :: rel_hum, temperature, qv
-      real (kind=RKIND) :: ptmp, es, rs, rgas_moist, qvs, xnutr, znut, ptemp, rcv
-      integer :: iter
-
-      real (kind=RKIND), dimension(nVertLevels + 1) :: hyai, hybi, znu, znw, znwc, znwv, hyam, hybm
-      real (kind=RKIND), dimension(nVertLevels + 1) :: znuc, znuv, bn, divh, dpn
+      real (kind=RKIND) :: es, rs, xnutr, znut, rcv
 
       real (kind=RKIND), dimension(:), pointer :: specified_zw
-      real (kind=RKIND), dimension(nVertLevels + 1) :: sh, zw, ah
+      real (kind=RKIND), dimension(nVertLevels + 1) :: zw, ah
       real (kind=RKIND), dimension(nVertLevels) :: zu, dzw, rdzwp, rdzwm
-      real (kind=RKIND), dimension(nVertLevels) :: eta, etav, teta, ppi, tt
 
-      real (kind=RKIND) :: d1, d2, d3, cof1, cof2, psurf
+      real (kind=RKIND) :: cof1, cof2
 
       !  storage for (lat,z) arrays for zonal velocity calculation
 
       integer, parameter :: nlat=361
-      real (kind=RKIND), dimension(nVertLevels + 1) :: zz_1d, zgrid_1d, hx_1d
-      real (kind=RKIND), dimension(nVertLevels) :: flux_zonal
-      real (kind=RKIND), dimension(nlat, nVertLevels) :: u_2d, etavs_2d
-      real (kind=RKIND), dimension(nVertLevels + 1) :: fsum
-      real (kind=RKIND), dimension(nlat) :: lat_2d
-      real (kind=RKIND) :: dlat
       real (kind=RKIND) :: z_edge, z_edge3, d2fdx2_cell1, d2fdx2_cell2
       real (kind=RKIND) :: alt, als, zetal, zl
 
@@ -2718,8 +2692,6 @@ module init_atm_cases
       integer :: level_value
 
       ! For outputting surface fields u10, v10, q2, rh2, and t2m from first-guess data
-      real (kind=RKIND), dimension(:), pointer :: u10
-      real (kind=RKIND), dimension(:), pointer :: v10
       real (kind=RKIND), dimension(:), pointer :: q2
       real (kind=RKIND), dimension(:), pointer :: rh2
       real (kind=RKIND), dimension(:), pointer :: t2m
@@ -4995,8 +4967,6 @@ call mpas_log_write('Done with soil consistency check')
 
       real (kind=RKIND) :: rs, rcv
 
-      real (kind=RKIND), dimension(nVertLevels + 1) :: sh
-
       !  calculation of the water vapor mixing ratio:
       real (kind=RKIND) :: sh_max,sh_min,global_sh_max,global_sh_min
 
@@ -5864,7 +5834,7 @@ call mpas_log_write('Done with soil consistency check')
    real (kind=RKIND) function env_qv( z, temperature, pressure, rh_max )
 
       implicit none
-      real (kind=RKIND) :: z, temperature, pressure, ztr, es, qvs, p0, rh_max
+      real (kind=RKIND) :: z, temperature, pressure, es, qvs, p0, rh_max
 
       p0 = 100000.
 
@@ -6011,7 +5981,7 @@ call mpas_log_write('Done with soil consistency check')
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: diag
 
-      integer :: iCell, iEdge, k
+      integer :: iCell, k
 
       integer, dimension(:,:), pointer :: cellsOnEdge
       real (kind=RKIND), dimension(:), pointer :: rdzw

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2687,7 +2687,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: sm_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
 
-      type (hashtable) :: level_hash
+      type (hashtable), allocatable :: level_hash
       logical :: too_many_fg_levs
       integer :: level_value
 
@@ -3337,6 +3337,7 @@ module init_atm_cases
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_CRIT)
       end if
 
+      allocate(level_hash)
       call mpas_hash_init(level_hash)
       too_many_fg_levs = .false.
 
@@ -4141,6 +4142,7 @@ module init_atm_cases
       call read_met_close()
       level_value = mpas_hash_size(level_hash)
       call mpas_hash_destroy(level_hash)
+      deallocate(level_hash)
 
       if (too_many_fg_levs) then
          write(errstring,'(a,i4)') '       Please increase config_nfglevels to at least ', level_value
@@ -5001,7 +5003,7 @@ call mpas_log_write('Done with soil consistency check')
       real (kind=RKIND), dimension(:,:), pointer :: p_fg
       real (kind=RKIND), dimension(:), pointer :: soilz
 
-      type (hashtable) :: level_hash
+      type (hashtable), allocatable :: level_hash
       logical :: too_many_fg_levs
       integer :: level_value
 
@@ -5131,6 +5133,7 @@ call mpas_log_write('Done with soil consistency check')
                              messageType=MPAS_LOG_CRIT)
       end if
 
+      allocate(level_hash)
       call mpas_hash_init(level_hash)
       too_many_fg_levs = .false.
 
@@ -5318,6 +5321,7 @@ call mpas_log_write('Done with soil consistency check')
       call read_met_close()
       level_value = mpas_hash_size(level_hash)
       call mpas_hash_destroy(level_hash)
+      deallocate(level_hash)
 
       if (too_many_fg_levs) then
          write(errstring,'(a,i4)') '       Please increase config_nfglevels to at least ', level_value

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -977,7 +977,7 @@ module init_atm_cases
 
          if (rebalance) then
 
-           call init_atm_calc_flux_zonal(u_2d,etavs_2d,lat_2d,flux_zonal,lat1,lat2,dvEdge(iEdge),sphere_radius,u0,nz1,nlat)
+           call init_atm_calc_flux_zonal(u_2d,lat_2d,flux_zonal,lat1,lat2,dvEdge(iEdge),sphere_radius,u0,nz1,nlat)
            do k=1,nVertLevels
              fluxk = u0*flux_zonal(k)/(0.5*(rb(k,iCell1)+rb(k,iCell2)+rr(k,iCell1)+rr(k,iCell2)))
              u(k,iEdge) = fluxk + u_pert
@@ -1141,12 +1141,12 @@ module init_atm_cases
    end subroutine init_atm_case_jw
 
 
-   subroutine init_atm_calc_flux_zonal(u_2d,etavs_2d,lat_2d,flux_zonal,lat1_in,lat2_in,dvEdge,a,u0,nz1,nlat)
+   subroutine init_atm_calc_flux_zonal(u_2d,lat_2d,flux_zonal,lat1_in,lat2_in,dvEdge,a,u0,nz1,nlat)
 
       implicit none
    
       integer, intent(in) :: nz1,nlat
-      real (kind=RKIND), dimension(nz1,nlat), intent(in) :: u_2d,etavs_2d
+      real (kind=RKIND), dimension(nz1,nlat), intent(in) :: u_2d
       real (kind=RKIND), dimension(nlat), intent(in) :: lat_2d
       real (kind=RKIND), dimension(nz1), intent(out) :: flux_zonal
       real (kind=RKIND), intent(in) :: lat1_in, lat2_in, dvEdge, a, u0

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -237,7 +237,7 @@ module init_atm_cases
             end if
 
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
-                                   diag, diag_physics, config_init_case, block_ptr % dimensions, block_ptr % configs)
+                                   diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
             
             if (config_met_interp) then
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
@@ -2499,7 +2499,7 @@ module init_atm_cases
    end subroutine init_atm_case_mtn_wave
 
 
-   subroutine init_atm_case_gfs(block, mesh, nCells, nEdges, nVertLevels, fg, state, diag, diag_physics, init_case, dims, configs)
+   subroutine init_atm_case_gfs(block, mesh, nCells, nEdges, nVertLevels, fg, state, diag, diag_physics, dims, configs)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Real-data test case using GFS data
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2522,7 +2522,6 @@ module init_atm_cases
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: diag
       type (mpas_pool_type), intent(inout):: diag_physics
-      integer, intent(in) :: init_case
       type (mpas_pool_type), intent(inout):: dims
       type (mpas_pool_type), intent(inout):: configs
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -759,7 +759,7 @@ module init_atm_cases
 
             !get moisture 
             if (moisture) then
-              qv_2d(k,i) = env_qv( ztemp, temperature_1d(k), ptemp, rh_max )
+              qv_2d(k,i) = env_qv( temperature_1d(k), ptemp, rh_max )
             end if
 
             tt(k) = temperature_1d(k)*(1.+1.61*qv_2d(k,i))
@@ -867,7 +867,7 @@ module init_atm_cases
             !get moisture 
             if (moisture) then
  
-                !scalars(index_qv,k,i) = env_qv( ztemp, temperature_1d(k), ptemp, rh_max )
+                !scalars(index_qv,k,i) = env_qv( temperature_1d(k), ptemp, rh_max )
 
                if(ptemp < 50000.) then
                   relhum(k,i) = 0.0
@@ -5835,24 +5835,12 @@ call mpas_log_write('Done with soil consistency check')
 
 !----------------------------------------------------------------------------------------------------------
 
-   real (kind=RKIND) function env_qv( z, temperature, pressure, rh_max )
+   real (kind=RKIND) function env_qv( temperature, pressure, rh_max )
 
       implicit none
-      real (kind=RKIND) :: z, temperature, pressure, es, qvs, p0, rh_max
+      real (kind=RKIND) :: temperature, pressure, es, qvs, p0, rh_max
 
       p0 = 100000.
-
-!      ztr = 5000.
-!
-!      if(z .gt. ztr) then
-!         env_qv = 0.
-!      else
-!         if(z.lt.2000.) then
-!            env_qv = .5
-!         else
-!            env_qv = .5*(1.-(z-2000.)/(ztr-2000.))
-!         end if
-!      end if
 
        if (pressure .lt. 50000. ) then
            env_qv = 0.0

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -111,7 +111,7 @@ module init_atm_cases
             call mpas_pool_get_dimension(block_ptr % dimensions, 'nVertLevels', nVertLevels)
 
             call mpas_log_write(' calling test case setup ')
-            call init_atm_case_jw(mesh, nCells, nVertLevels, state, diag, block_ptr % configs, config_init_case)
+            call init_atm_case_jw(mesh, nCells, nVertLevels, state, diag, block_ptr % configs)
             call decouple_variables(mesh, nCells, nVertLevels, state, diag)
             call mpas_log_write(' returned from test case setup ')
             block_ptr => block_ptr % next
@@ -349,7 +349,7 @@ module init_atm_cases
 
 !----------------------------------------------------------------------------------------------------------
 
-   subroutine init_atm_case_jw(mesh, nCells, nVertLevels, state, diag, configs, test_case)
+   subroutine init_atm_case_jw(mesh, nCells, nVertLevels, state, diag, configs)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Setup baroclinic wave test case from Jablonowski and Williamson 2008 (QJRMS)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -362,7 +362,6 @@ module init_atm_cases
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: diag
       type (mpas_pool_type), intent(in) :: configs
-      integer, intent(in) :: test_case
 
       real (kind=RKIND), parameter :: u0 = 35.0
       real (kind=RKIND), parameter :: alpha_grid = 0.  ! no grid rotation

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -153,7 +153,7 @@ module init_atm_cases
             call mpas_pool_get_subpool(block_ptr % structs, 'diag', diag)
 
             call mpas_log_write(' calling test case setup ')
-            call init_atm_case_mtn_wave(domain % dminfo, mesh, nCells, nVertLevels, state, diag, block_ptr % configs, config_init_case)
+            call init_atm_case_mtn_wave(mesh, nCells, nVertLevels, state, diag, block_ptr % configs)
             call decouple_variables(mesh, nCells, nVertLevels, state, diag)
             call mpas_log_write(' returned from test case setup ')
             block_ptr => block_ptr % next
@@ -1873,21 +1873,19 @@ module init_atm_cases
 !----------------------------------------------------------------------------------------------------------
 
 
-   subroutine init_atm_case_mtn_wave(dminfo, mesh, nCells, nVertLevels, state, diag, configs, init_case)
+   subroutine init_atm_case_mtn_wave(mesh, nCells, nVertLevels, state, diag, configs)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Setup baroclinic wave test case from Jablonowski and Williamson 2008 (QJRMS)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       implicit none
 
-      type (dm_info), intent(in) :: dminfo
       type (mpas_pool_type), intent(inout) :: mesh
       integer, intent(in) :: nCells
       integer, intent(in) :: nVertLevels
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: diag
       type (mpas_pool_type), intent(inout) :: configs
-      integer, intent(in) :: init_case
 
       real (kind=RKIND), parameter :: t0=288., hm=250.
 


### PR DESCRIPTION
This PR addresses unused variable and unused argument warnings in
the mpas_init_atm_cases.F file when building with the GNU compilers and
with the addition of the -Wall flag. Also addressed in this PR are
warnings in the mpas_init_atm_cases.F file about the level_hash automatic
variable, which has been converted to an ALLOCATABLE variable.