### PR TITLE
Modified lagged_radiation_sw to run on CPUs during an OpenACC run.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -813,13 +813,13 @@
  call mpas_pool_get_field(diag_physics,'swuptc'    ,swuptcField    )
  call mpas_pool_get_field(tend_physics,'rthratensw',rthratenswField)
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update host(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
     !$acc swupb, swupbc, swupt, swuptc, rthratensw)
  endif
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_includes(ROLE_RADIATION)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_is(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
@@ -836,7 +836,7 @@
 
  end if
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update device(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
     !$acc swupb, swupbc, swupt, swuptc, rthratensw)
  endif

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -788,18 +788,18 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(diag_physics,'coszr'     ,coszr     )
- call mpas_pool_get_array(diag_physics,'gsw'       ,gsw       )
- call mpas_pool_get_array(diag_physics,'swcf'      ,swcf      )
- call mpas_pool_get_array(diag_physics,'swdnb'     ,swdnb     )
- call mpas_pool_get_array(diag_physics,'swdnbc'    ,swdnbc    )
- call mpas_pool_get_array(diag_physics,'swdnt'     ,swdnt     )
- call mpas_pool_get_array(diag_physics,'swdntc'    ,swdntc    )
- call mpas_pool_get_array(diag_physics,'swupb'     ,swupb     )
- call mpas_pool_get_array(diag_physics,'swupbc'    ,swupbc    )
- call mpas_pool_get_array(diag_physics,'swupt'     ,swupt     )
- call mpas_pool_get_array(diag_physics,'swuptc'    ,swuptc    )
- call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
+ call mpas_pool_get_array_gpu(diag_physics,'coszr'     ,coszr     )
+ call mpas_pool_get_array_gpu(diag_physics,'gsw'       ,gsw       )
+ call mpas_pool_get_array_gpu(diag_physics,'swcf'      ,swcf      )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnb'     ,swdnb     )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnbc'    ,swdnbc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnt'     ,swdnt     )
+ call mpas_pool_get_array_gpu(diag_physics,'swdntc'    ,swdntc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swupb'     ,swupb     )
+ call mpas_pool_get_array_gpu(diag_physics,'swupbc'    ,swupbc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swupt'     ,swupt     )
+ call mpas_pool_get_array_gpu(diag_physics,'swuptc'    ,swuptc    )
+ call mpas_pool_get_array_gpu(tend_physics,'rthratensw',rthratensw)
  call mpas_pool_get_field(diag_physics,'coszr'     ,coszrField     )
  call mpas_pool_get_field(diag_physics,'gsw'       ,gswField       )
  call mpas_pool_get_field(diag_physics,'swcf'      ,swcfField      )
@@ -813,8 +813,13 @@
  call mpas_pool_get_field(diag_physics,'swuptc'    ,swuptcField    )
  call mpas_pool_get_field(tend_physics,'rthratensw',rthratenswField)
 
- if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_is(ROLE_RADIATION)) then
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update host(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
+    !$acc swupb, swupbc, swupt, swuptc, rthratensw)
+ endif
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_includes(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
@@ -830,6 +835,11 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenswField, ierr=ierr)
 
  end if
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update device(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
+    !$acc swupb, swupbc, swupt, swuptc, rthratensw)
+ endif
 
  end subroutine lagged_radiation_sw_to_MPAS
 


### PR DESCRIPTION
This is the 1st PR submitted in a pool of approximately 12 PRs. 
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'lagged_radiation_sw_to_MPAS' subroutine to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. These temporary changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.
Code Execution Status:
1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.
