### PR TITLE
Modified lagged_radiation_lw to run on CPUs during an OpenACC run.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -877,22 +877,27 @@
  call mpas_pool_get_field(diag_physics,'lwuptc',lwuptcField)
  call mpas_pool_get_field(diag_physics,'olrtoa',olrtoaField)
  call mpas_pool_get_field(tend_physics,'rthratenlw',rthratenlwField)
- call mpas_pool_get_array(diag_physics,'glw'   ,glw   )
- call mpas_pool_get_array(diag_physics,'lwcf'  ,lwcf  )
- call mpas_pool_get_array(diag_physics,'lwdnb' ,lwdnb )
- call mpas_pool_get_array(diag_physics,'lwdnbc',lwdnbc)
- call mpas_pool_get_array(diag_physics,'lwdnt' ,lwdnt )
- call mpas_pool_get_array(diag_physics,'lwdntc',lwdntc)
- call mpas_pool_get_array(diag_physics,'lwupb' ,lwupb )
- call mpas_pool_get_array(diag_physics,'lwupbc',lwupbc)
- call mpas_pool_get_array(diag_physics,'lwupt' ,lwupt )
- call mpas_pool_get_array(diag_physics,'lwuptc',lwuptc)
- call mpas_pool_get_array(diag_physics,'olrtoa',olrtoa)
+ call mpas_pool_get_array_gpu(diag_physics,'glw'   ,glw   )
+ call mpas_pool_get_array_gpu(diag_physics,'lwcf'  ,lwcf  )
+ call mpas_pool_get_array_gpu(diag_physics,'lwdnb' ,lwdnb )
+ call mpas_pool_get_array_gpu(diag_physics,'lwdnbc',lwdnbc)
+ call mpas_pool_get_array_gpu(diag_physics,'lwdnt' ,lwdnt )
+ call mpas_pool_get_array_gpu(diag_physics,'lwdntc',lwdntc)
+ call mpas_pool_get_array_gpu(diag_physics,'lwupb' ,lwupb )
+ call mpas_pool_get_array_gpu(diag_physics,'lwupbc',lwupbc)
+ call mpas_pool_get_array_gpu(diag_physics,'lwupt' ,lwupt )
+ call mpas_pool_get_array_gpu(diag_physics,'lwuptc',lwuptc)
+ call mpas_pool_get_array_gpu(diag_physics,'olrtoa',olrtoa)
 
- call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
+ call mpas_pool_get_array_gpu(tend_physics,'rthratenlw',rthratenlw)
 
- if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_is(ROLE_RADIATION)) then
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update host(glw, lwcf, lwdnb, lwdnbc, lwdnt, lwdntc, lwupb, &
+    !$acc lwupbc, lwupt, lwuptc, olrtoa, rthratenlw)
+ end if
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_includes(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, glwField   , ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwcfField  , ierr=ierr)
@@ -907,6 +912,11 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, olrtoaField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenlwField, ierr=ierr)
 
+ end if
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update device(glw, lwcf, lwdnb, lwdnbc, lwdnt, lwdntc, lwupb, &
+    !$acc lwupbc, lwupt, lwuptc, olrtoa, rthratenlw)
  end if
 
  end subroutine lagged_radiation_lw_to_MPAS

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -891,13 +891,13 @@
 
  call mpas_pool_get_array_gpu(tend_physics,'rthratenlw',rthratenlw)
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update host(glw, lwcf, lwdnb, lwdnbc, lwdnt, lwdntc, lwupb, &
     !$acc lwupbc, lwupt, lwuptc, olrtoa, rthratenlw)
  end if
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_includes(ROLE_RADIATION)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_is(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, glwField   , ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwcfField  , ierr=ierr)
@@ -914,7 +914,7 @@
 
  end if
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update device(glw, lwcf, lwdnb, lwdnbc, lwdnt, lwdntc, lwupb, &
     !$acc lwupbc, lwupt, lwuptc, olrtoa, rthratenlw)
  end if


### PR DESCRIPTION
This is the 2nd PR submitted in a pool of approximately 12 PRs.
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'lagged_radiation_lw_to_MPAS' subroutine to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. These temporary changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.

Code Execution Status:
1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.