### PR TITLE
Added OpenACC directives to Surface Layer model, for GPU excecution. (Superceded by PR #928)

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -346,9 +346,11 @@
 
 !local pointers:
  logical,pointer:: config_frac_seaice
+ logical:: sconfig_frac_seaice
  character(len=StrKIND),pointer:: sfclayer_scheme
 
  real(kind=RKIND),pointer:: len_disp
+ real(kind=RKIND):: slen_disp
  real(kind=RKIND),dimension(:),pointer:: meshDensity
  real(kind=RKIND),dimension(:),pointer:: skintemp,sst,xice,xland
  real(kind=RKIND),dimension(:),pointer:: hpbl,mavail
@@ -369,42 +371,56 @@
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme   )
  call mpas_pool_get_config(configs,'config_len_disp'       ,len_disp          )
- call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
+ call mpas_pool_get_array_gpu(mesh,'meshDensity',meshDensity)
 
- call mpas_pool_get_array(diag_physics,'hpbl'    ,hpbl    )
- call mpas_pool_get_array(diag_physics,'mavail'  ,mavail  )
- call mpas_pool_get_array(sfc_input   ,'skintemp',skintemp)
- call mpas_pool_get_array(sfc_input   ,'xland'   ,xland   )
+ ! De-reference pointers-to-scalars to be immediate scalar values.
+ ! These are passed on the stack to the GPUs but also eliminate an indirect load in the CPU loops.
+ slen_disp = len_disp
+ sconfig_frac_seaice = config_frac_seaice
+
+ call mpas_pool_get_array_gpu(diag_physics,'hpbl'    ,hpbl    )
+ call mpas_pool_get_array_gpu(diag_physics,'mavail'  ,mavail  )
+ call mpas_pool_get_array_gpu(sfc_input   ,'skintemp',skintemp)
+ call mpas_pool_get_array_gpu(sfc_input   ,'xland'   ,xland   )
 
 !inout variables:
- call mpas_pool_get_array(diag_physics,'br'      ,br      )
- call mpas_pool_get_array(diag_physics,'cpm'     ,cpm     )
- call mpas_pool_get_array(diag_physics,'chs'     ,chs     )
- call mpas_pool_get_array(diag_physics,'chs2'    ,chs2    )
- call mpas_pool_get_array(diag_physics,'cqs2'    ,cqs2    )
- call mpas_pool_get_array(diag_physics,'flhc'    ,flhc    )
- call mpas_pool_get_array(diag_physics,'flqc'    ,flqc    )
- call mpas_pool_get_array(diag_physics,'gz1oz0'  ,gz1oz0  )
- call mpas_pool_get_array(diag_physics,'hfx'     ,hfx     )
- call mpas_pool_get_array(diag_physics,'qfx'     ,qfx     )
- call mpas_pool_get_array(diag_physics,'qgh'     ,qgh     )
- call mpas_pool_get_array(diag_physics,'qsfc'    ,qsfc    )
- call mpas_pool_get_array(diag_physics,'lh'      ,lh      )
- call mpas_pool_get_array(diag_physics,'mol'     ,mol     )
- call mpas_pool_get_array(diag_physics,'psih'    ,psih    )
- call mpas_pool_get_array(diag_physics,'psim'    ,psim    )
- call mpas_pool_get_array(diag_physics,'regime'  ,regime  )
- call mpas_pool_get_array(diag_physics,'rmol'    ,rmol    )
- call mpas_pool_get_array(diag_physics,'ust'     ,ust     )
- call mpas_pool_get_array(diag_physics,'ustm'    ,ustm    )
- call mpas_pool_get_array(diag_physics,'wspd'    ,wspd    )
- call mpas_pool_get_array(diag_physics,'znt'     ,znt     )
- call mpas_pool_get_array(diag_physics,'zol'     ,zol     )
+ call mpas_pool_get_array_gpu(diag_physics,'br'      ,br      )
+ call mpas_pool_get_array_gpu(diag_physics,'cpm'     ,cpm     )
+ call mpas_pool_get_array_gpu(diag_physics,'chs'     ,chs     )
+ call mpas_pool_get_array_gpu(diag_physics,'chs2'    ,chs2    )
+ call mpas_pool_get_array_gpu(diag_physics,'cqs2'    ,cqs2    )
+ call mpas_pool_get_array_gpu(diag_physics,'flhc'    ,flhc    )
+ call mpas_pool_get_array_gpu(diag_physics,'flqc'    ,flqc    )
+ call mpas_pool_get_array_gpu(diag_physics,'gz1oz0'  ,gz1oz0  )
+ call mpas_pool_get_array_gpu(diag_physics,'hfx'     ,hfx     )
+ call mpas_pool_get_array_gpu(diag_physics,'qfx'     ,qfx     )
+ call mpas_pool_get_array_gpu(diag_physics,'qgh'     ,qgh     )
+ call mpas_pool_get_array_gpu(diag_physics,'qsfc'    ,qsfc    )
+ call mpas_pool_get_array_gpu(diag_physics,'lh'      ,lh      )
+ call mpas_pool_get_array_gpu(diag_physics,'mol'     ,mol     )
+ call mpas_pool_get_array_gpu(diag_physics,'psih'    ,psih    )
+ call mpas_pool_get_array_gpu(diag_physics,'psim'    ,psim    )
+ call mpas_pool_get_array_gpu(diag_physics,'regime'  ,regime  )
+ call mpas_pool_get_array_gpu(diag_physics,'rmol'    ,rmol    )
+ call mpas_pool_get_array_gpu(diag_physics,'ust'     ,ust     )
+ call mpas_pool_get_array_gpu(diag_physics,'ustm'    ,ustm    )
+ call mpas_pool_get_array_gpu(diag_physics,'wspd'    ,wspd    )
+ call mpas_pool_get_array_gpu(diag_physics,'znt'     ,znt     )
+ call mpas_pool_get_array_gpu(diag_physics,'zol'     ,zol     )
 
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(hpbl, mavail, skintemp, xland, br, cpm, chs, &
+!$acc chs2, cqs2, flhc, flqc, gz1oz0, hfx, qfx, qgh, qsfc, lh, &
+!$acc mol, psih, psim, regime, rmol, ust, ustm, wspd, znt, zol)
+#endif
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     !input variables:
-    dx_p(i,j)     = len_disp / meshDensity(i)**0.25
+    dx_p(i,j)     = slen_disp / meshDensity(i)**0.25
     hpbl_p(i,j)   = hpbl(i)
     mavail_p(i,j) = mavail(i)
     tsk_p(i,j)    = skintemp(i)
@@ -449,10 +465,25 @@
     ustm_p(i,j)   = ustm(i)
  enddo
  enddo
+!$acc end parallel
 
- if(config_frac_seaice) then
-    call mpas_pool_get_array(sfc_input,'sst' ,sst)
-    call mpas_pool_get_array(sfc_input,'xice',xice)
+#ifdef OPENACC_SFCLAYER
+!$acc update host(dx_p, hpbl_p, mavail_p, tsk_p, xland_p, br_p, cpm_p, &
+!$acc chs_p, chs2_p, cqs2_p, flhc_p, flqc_p, gz1oz0_p, hfx_p, qfx_p, &
+!$acc qgh_p, qsfc_p, lh_p, mol_p, psim_p, psih_p, regime_p, rmol_p, &
+!$acc ust_p, wspd_p, znt_p, zol_p, q2_p, t2m_p, th2m_p, u10_p, v10_p, &
+!$acc cd_p, cda_p, ck_p, cka_p, ustm_p)
+#endif
+
+ if(sconfig_frac_seaice) then
+    call mpas_pool_get_array_gpu(sfc_input,'sst' ,sst)
+    call mpas_pool_get_array_gpu(sfc_input,'xice',xice)
+
+!!!
+! !$acc update host(sst, xice)
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        sst_p(i,j)      = sst(i)
@@ -512,36 +543,66 @@
        endif
     enddo
     enddo
+!$acc end parallel
+
+#ifdef OPENACC_SFCLAYER
+!$acc update host(sst_p, xice_p, mavail_sea, tsk_sea, xland_sea, br_sea, &
+!$acc cpm_sea, chs_sea, chs2_sea, cqs2_sea, flhc_sea, flqc_sea, gz1oz0_sea, &
+!$acc lh_sea, hfx_sea, qfx_sea, mol_sea, psim_sea, psih_sea, qgh_sea, rmol_sea, &
+!$acc regime_sea, ust_sea, ustm_sea, wspd_sea, zol_sea, znt_sea, regime_hold, &
+!$acc cd_sea, cda_sea, ck_sea, cka_sea, qsfc_sea, q2_sea, t2m_sea, th2m_sea, &
+!$acc u10_sea, v10_sea )
+#endif
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update device(sst, xice)
+#endif
  endif
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
     case("sf_monin_obukhov")
-       call mpas_pool_get_array(diag_physics,'fh',fh)
-       call mpas_pool_get_array(diag_physics,'fm',fm)
+       call mpas_pool_get_array_gpu(diag_physics,'fh',fh)
+       call mpas_pool_get_array_gpu(diag_physics,'fm',fm)
 
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(fh, fm)
+#endif
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
        do j = jts,jte
        do i = its,ite
           fh_p(i,j) = fh(i)
           fm_p(i,j) = fm(i)
-          if(config_frac_seaice) then
+          if(sconfig_frac_seaice) then
              fh_sea(i,j) = fh(i)
              fm_sea(i,j) = fm(i)
           endif
        enddo
        enddo
-
+!$acc end parallel
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(fh_p, fm_p, fh_sea, fm_sea)
+!$acc update device(fh, fm)
+#endif
     case("sf_mynn")
        !input variables:
-       call mpas_pool_get_array(diag_physics,'qcg'   ,qcg   )
-       call mpas_pool_get_array(sfc_input   ,'snowh' ,snowh )
-       call mpas_pool_get_array(diag_physics,'cov'   ,cov   )
-       call mpas_pool_get_array(diag_physics,'el_pbl',el_pbl)
-       call mpas_pool_get_array(diag_physics,'qsq'   ,qsq   )
-       call mpas_pool_get_array(diag_physics,'sh3d'  ,sh3d  )
-       call mpas_pool_get_array(diag_physics,'tsq'   ,tsq   )
+       call mpas_pool_get_array_gpu(diag_physics,'qcg'   ,qcg   )
+       call mpas_pool_get_array_gpu(sfc_input   ,'snowh' ,snowh )
+       call mpas_pool_get_array_gpu(diag_physics,'cov'   ,cov   )
+       call mpas_pool_get_array_gpu(diag_physics,'el_pbl',el_pbl)
+       call mpas_pool_get_array_gpu(diag_physics,'qsq'   ,qsq   )
+       call mpas_pool_get_array_gpu(diag_physics,'sh3d'  ,sh3d  )
+       call mpas_pool_get_array_gpu(diag_physics,'tsq'   ,tsq   )
        !inout variables:
-       call mpas_pool_get_array(diag_physics,'ch',ch        )
+       call mpas_pool_get_array_gpu(diag_physics,'ch',ch        )
+
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(qcg, snowh, cov, el_pbl, qsq, sh3d, tsq, ch)
+#endif
 
        do j = jts,jte
        do i = its,ite
@@ -568,11 +629,20 @@
        enddo
        enddo
        enddo
-
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update device(qcg, snowh, cov, el_pbl, qsq, sh3d, tsq, ch)
+#endif
     case default
 
  end select sfclayer_select
 
+!!!
+#ifdef OPENACC_SFCLAYER
+! !$acc update device(hpbl, mavail, skintemp, xland, br, cpm, chs, &
+! !$acc chs2, cqs2, flhc, flqc, gz1oz0, hfx, qfx, qgh, qsfc, lh, &
+! !$acc mol, psih, psim, regime, rmol, ust, ustm, wspd, znt, zol)
+#endif
  end subroutine sfclayer_from_MPAS
 
 !=================================================================================================================
@@ -592,6 +662,7 @@
 
 !local pointers:
  logical,pointer:: config_frac_seaice
+ logical:: sconfig_frac_seaice
  character(len=StrKIND),pointer:: sfclayer_scheme
 
  real(kind=RKIND),dimension(:),pointer:: br,cpm,chs,chs2,cqs2,flhc,flqc,gz1oz0,hfx,qfx,  &
@@ -613,50 +684,72 @@
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme   )
 
+ sconfig_frac_seaice = config_frac_seaice
+
 !inout variables:
- call mpas_pool_get_array(diag_physics,'br'    ,br    )
- call mpas_pool_get_array(diag_physics,'cpm'   ,cpm   )
- call mpas_pool_get_array(diag_physics,'chs'   ,chs   )
- call mpas_pool_get_array(diag_physics,'chs2'  ,chs2  )
- call mpas_pool_get_array(diag_physics,'cqs2'  ,cqs2  )
- call mpas_pool_get_array(diag_physics,'flhc'  ,flhc  )
- call mpas_pool_get_array(diag_physics,'flqc'  ,flqc  )
- call mpas_pool_get_array(diag_physics,'gz1oz0',gz1oz0)
- call mpas_pool_get_array(diag_physics,'hfx'   ,hfx   )
- call mpas_pool_get_array(diag_physics,'qfx'   ,qfx   )
- call mpas_pool_get_array(diag_physics,'qgh'   ,qgh   )
- call mpas_pool_get_array(diag_physics,'qsfc'  ,qsfc  )
- call mpas_pool_get_array(diag_physics,'lh'    ,lh    )
- call mpas_pool_get_array(diag_physics,'mol'   ,mol   )
- call mpas_pool_get_array(diag_physics,'psih'  ,psih  )
- call mpas_pool_get_array(diag_physics,'psim'  ,psim  )
- call mpas_pool_get_array(diag_physics,'regime',regime)
- call mpas_pool_get_array(diag_physics,'rmol'  ,rmol  )
- call mpas_pool_get_array(diag_physics,'ust'   ,ust   )
- call mpas_pool_get_array(diag_physics,'wspd'  ,wspd  )
- call mpas_pool_get_array(diag_physics,'znt'   ,znt   )
- call mpas_pool_get_array(diag_physics,'zol'   ,zol   )
+ call mpas_pool_get_array_gpu(diag_physics,'br'    ,br    )
+ call mpas_pool_get_array_gpu(diag_physics,'cpm'   ,cpm   )
+ call mpas_pool_get_array_gpu(diag_physics,'chs'   ,chs   )
+ call mpas_pool_get_array_gpu(diag_physics,'chs2'  ,chs2  )
+ call mpas_pool_get_array_gpu(diag_physics,'cqs2'  ,cqs2  )
+ call mpas_pool_get_array_gpu(diag_physics,'flhc'  ,flhc  )
+ call mpas_pool_get_array_gpu(diag_physics,'flqc'  ,flqc  )
+ call mpas_pool_get_array_gpu(diag_physics,'gz1oz0',gz1oz0)
+ call mpas_pool_get_array_gpu(diag_physics,'hfx'   ,hfx   )
+ call mpas_pool_get_array_gpu(diag_physics,'qfx'   ,qfx   )
+ call mpas_pool_get_array_gpu(diag_physics,'qgh'   ,qgh   )
+ call mpas_pool_get_array_gpu(diag_physics,'qsfc'  ,qsfc  )
+ call mpas_pool_get_array_gpu(diag_physics,'lh'    ,lh    )
+ call mpas_pool_get_array_gpu(diag_physics,'mol'   ,mol   )
+ call mpas_pool_get_array_gpu(diag_physics,'psih'  ,psih  )
+ call mpas_pool_get_array_gpu(diag_physics,'psim'  ,psim  )
+ call mpas_pool_get_array_gpu(diag_physics,'regime',regime)
+ call mpas_pool_get_array_gpu(diag_physics,'rmol'  ,rmol  )
+ call mpas_pool_get_array_gpu(diag_physics,'ust'   ,ust   )
+ call mpas_pool_get_array_gpu(diag_physics,'wspd'  ,wspd  )
+ call mpas_pool_get_array_gpu(diag_physics,'znt'   ,znt   )
+ call mpas_pool_get_array_gpu(diag_physics,'zol'   ,zol   )
 
 !output variables:
- call mpas_pool_get_array(diag_physics,'q2'    ,q2    )
- call mpas_pool_get_array(diag_physics,'t2m'   ,t2m   )
- call mpas_pool_get_array(diag_physics,'th2m'  ,th2m  )
- call mpas_pool_get_array(diag_physics,'u10'   ,u10   )
- call mpas_pool_get_array(diag_physics,'v10'   ,v10   )
+ call mpas_pool_get_array_gpu(diag_physics,'q2'    ,q2    )
+ call mpas_pool_get_array_gpu(diag_physics,'t2m'   ,t2m   )
+ call mpas_pool_get_array_gpu(diag_physics,'th2m'  ,th2m  )
+ call mpas_pool_get_array_gpu(diag_physics,'u10'   ,u10   )
+ call mpas_pool_get_array_gpu(diag_physics,'v10'   ,v10   )
 
 !output variables (optional):
- call mpas_pool_get_array(diag_physics,'cd'    ,cd    )
- call mpas_pool_get_array(diag_physics,'cda'   ,cda   )
- call mpas_pool_get_array(diag_physics,'ck'    ,ck    )
- call mpas_pool_get_array(diag_physics,'cka'   ,cka   )
- call mpas_pool_get_array(diag_physics,'ustm'  ,ustm  )
+ call mpas_pool_get_array_gpu(diag_physics,'cd'    ,cd    )
+ call mpas_pool_get_array_gpu(diag_physics,'cda'   ,cda   )
+ call mpas_pool_get_array_gpu(diag_physics,'ck'    ,ck    )
+ call mpas_pool_get_array_gpu(diag_physics,'cka'   ,cka   )
+ call mpas_pool_get_array_gpu(diag_physics,'ustm'  ,ustm  )
 
 !output variables (optional):
- call mpas_pool_get_array(diag_physics,'cd'    ,cd    )
- call mpas_pool_get_array(diag_physics,'cda'   ,cda   )
- call mpas_pool_get_array(diag_physics,'ck'    ,ck    )
- call mpas_pool_get_array(diag_physics,'cka'   ,cka   )
+ call mpas_pool_get_array_gpu(diag_physics,'cd'    ,cd    )
+ call mpas_pool_get_array_gpu(diag_physics,'cda'   ,cda   )
+ call mpas_pool_get_array_gpu(diag_physics,'ck'    ,ck    )
+ call mpas_pool_get_array_gpu(diag_physics,'cka'   ,cka   )
 
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(br, cpm, chs, chs2, cqs2, flhc, flqc, gz1oz0, &
+!$acc hfx, qfx, qgh, qsfc, lh, mol, psih, psim, regime, rmol, &
+!$acc ust, wspd, znt, zol, q2, t2m, th2m, u10, v10, cd, cda, &
+!$acc ck, cka, ustm)
+
+!$acc update device(br_p, cpm_p, chs_p, chs2_p, cqs2_p, flhc_p, flqc_p, &
+!$acc gz1oz0_p, hfx_p, lh_p, mol_p, qfx_p, qgh_p, qsfc_p, psim_p, psih_p, &
+!$acc regime_p, rmol_p, ust_p, wspd_p, zol_p, znt_p, q2_p, t2m_p, th2m_p, &
+!$acc u10_p, v10_p, cd_p, cda_p, ck_p, cka_p, ustm_p)
+
+!$acc update host(br_p, cpm_p, chs_p, chs2_p, cqs2_p, flhc_p, flqc_p, &
+!$acc gz1oz0_p, hfx_p, lh_p, mol_p, qfx_p, qgh_p, qsfc_p, psim_p, psih_p, &
+!$acc regime_p, rmol_p, ust_p, wspd_p, zol_p, znt_p, q2_p, t2m_p, th2m_p, &
+!$acc u10_p, v10_p, cd_p, cda_p, ck_p, cka_p, ustm_p)
+#endif
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     !inout variables:
@@ -696,9 +789,26 @@
     ustm(i)   = ustm_p(i,j)
  enddo
  enddo
+!$acc end parallel
 
  if(config_frac_seaice) then
-    call mpas_pool_get_array(sfc_input,'xice',xice)
+    call mpas_pool_get_array_gpu(sfc_input,'xice',xice)
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(xice)
+!$acc update device(br_sea, flhc_sea, flqc_sea, gz1oz0_sea, mol_sea, psih_sea, &
+!$acc psim_sea, rmol_sea, ust_sea, wspd_sea, zol_sea, regime_hold, q2_sea, &
+!$acc t2m_sea, th2m_sea, u10_sea, v10_sea, cd_sea, cda_sea, ck_sea, cka_sea, &
+!$acc ustm_sea)
+
+!$acc update host(br_sea, flhc_sea, flqc_sea, gz1oz0_sea, mol_sea, psih_sea,&
+!$acc psim_sea, rmol_sea, ust_sea, wspd_sea, zol_sea, regime_hold, q2_sea, &
+!$acc t2m_sea, th2m_sea, u10_sea, v10_sea, cd_sea, cda_sea, ck_sea, cka_sea, &
+!$acc ustm_sea)
+#endif
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        if(xice(i).ge.xice_threshold .and. xice(i).le.1._RKIND) then
@@ -729,22 +839,38 @@
        endif
     enddo
     enddo
+!$acc end parallel
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update device(xice)
+#endif
  endif
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
     case("sf_monin_obukhov")
-       call mpas_pool_get_array(diag_physics,'fh',fh)
-       call mpas_pool_get_array(diag_physics,'fm',fm)
+       call mpas_pool_get_array_gpu(diag_physics,'fh',fh)
+       call mpas_pool_get_array_gpu(diag_physics,'fm',fm)
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(fh, fm)
+!$acc update device(fh_p, fm_p, fh_sea, fm_sea)
+!$acc update host(fh_p, fm_p, fh_sea, fm_sea)
+#endif
 
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
        do j = jts,jte
        do i = its,ite
           fh(i) = fh_p(i,j)
           fm(i) = fm_p(i,j)
        enddo
        enddo
-       if(config_frac_seaice) then
-          call mpas_pool_get_array(sfc_input,'xice',xice)
+!$acc end parallel
+       if(sconfig_frac_seaice) then
+          call mpas_pool_get_array_gpu(sfc_input,'xice',xice)
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
           do j = jts,jte
           do i = its,ite
              if(xice(i).ge.xice_threshold .and. xice(i).le.1._RKIND) then
@@ -753,10 +879,19 @@
              endif
           enddo
           enddo
+!$acc end parallel
        endif
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update device(fh, fm)
+#endif
 
     case("sf_mynn")
-       call mpas_pool_get_array(diag_physics,'ch',ch)
+       call mpas_pool_get_array_gpu(diag_physics,'ch',ch)
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update host(ch)
+#endif
 
        do j = jts,jte
        do i = its,ite
@@ -773,11 +908,20 @@
           enddo
           enddo
        endif
+!!!
+! !$acc update device(ch)
 
     case default
 
  end select sfclayer_select
 
+!!!
+#ifdef OPENACC_SFCLAYER
+!$acc update device(br, cpm, chs, chs2, cqs2, flhc, flqc, gz1oz0, &
+!$acc hfx, qfx, qgh, qsfc, lh, mol, psih, psim, regime, rmol, &
+!$acc ust, wspd, znt, zol, q2, t2m, th2m, u10, v10, cd, cda, &
+!$acc ck, cka, ustm)
+#endif
  end subroutine sfclayer_to_MPAS
 
 !=================================================================================================================
@@ -837,11 +981,15 @@
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine driver_sfclayer:')
 
+ call mpas_timer_start('driver_sfclayer')
+
  call mpas_pool_get_config(configs,'config_do_restart'     ,config_do_restart )
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme   )
 
- call mpas_pool_get_array(mesh,'areaCell',areaCell)
+ call mpas_pool_get_array_gpu(mesh,'areaCell',areaCell)
+!!!
+!$acc update host(areaCell)
 
 !copy all MPAS arrays to rectanguler grid:
  call sfclayer_from_MPAS(configs,mesh,diag_physics,sfc_input,its,ite)
@@ -988,6 +1136,7 @@
 !copy local arrays to MPAS grid:
  call sfclayer_to_MPAS(configs,sfc_input,diag_physics,its,ite)
 
+ call mpas_timer_stop('driver_sfclayer')
 !call mpas_log_write('--- end subroutine driver_sfclayer.')
 
  end subroutine driver_sfclayer

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
@@ -7,6 +7,7 @@ MODULE module_sf_sfclay
  REAL    , PARAMETER ::  OZO=1.59E-5
 
  REAL,   DIMENSION(0:1000 ),SAVE          :: PSIMTB,PSIHTB
+!$acc declare create(PSIMTB,PSIHTB)
 
 CONTAINS
 
@@ -211,16 +212,20 @@ CONTAINS
 
       INTEGER ::  I,J
 
+!$acc data create(dz8w1d,U1D,V1D,QV1D,P1D,T1D)
       DO J=jts,jte
-
+!$acc parallel vector_length(32)
+!$acc loop gang vector
         DO i=its,ite
            DX2D(i)=DX(i,j)
         ENDDO
-
+!$acc parallel vector_length(32)
+!$acc loop gang vector
         DO i=its,ite
           dz8w1d(I) = dz8w(i,1,j)
         ENDDO
-   
+!$acc parallel vector_length(32)
+!$acc loop gang vector
         DO i=its,ite
            U1D(i) =U3D(i,1,j)
            V1D(i) =V3D(i,1,j)
@@ -228,6 +233,8 @@ CONTAINS
            P1D(i) =P3D(i,1,j)
            T1D(i) =T3D(i,1,j)
         ENDDO
+!$acc end parallel
+!-!-!$acc update host(dz8w1d,U1D,V1D,QV1D,P1D,T1D)
 
         !  Sending array starting locations of optional variables may cause
         !  troubles, so we explicitly change the call.
@@ -255,7 +262,7 @@ CONTAINS
 #endif
                                                                    )
       ENDDO
-
+!$acc end data
  
    END SUBROUTINE SFCLAY
 
@@ -388,9 +395,14 @@ CONTAINS
       REAL    ::  FLUXC,VSGD,Z0Q,VISC,RESTAR,CZIL,GZ0OZQ,GZ0OZT
       REAL    ::  ZW, ZN1, ZN2
       REAL    ::  Z0T, CZC
+!$acc data create(PSFC,TGDSA,THGB,SCR3,THX,SCR4,THVX,QX,ZQKLP1, &
+!$acc ZQKL,ZA,GOVRTH,RHOX,GZ2OZ0,GZ10OZ0,PSIM10,PSIH10,PSIM2, &
+!$acc PSIH2,WSPDI,DENOMQ,DENOMQ2,DENOMT2)
 !-------------------------------------------------------------------
       KL=kte
 
+!$acc parallel vector_length(32)
+!$acc loop gang vector
       DO i=its,ite
 ! PSFC cb
          PSFC(I)=PSFCPA(I)/1000.
@@ -398,12 +410,17 @@ CONTAINS
 !                                                      
 !----CONVERT GROUND TEMPERATURE TO POTENTIAL TEMPERATURE:  
 !                                                            
-      DO 5 I=its,ite                                   
+!!!   DO 5 I=its,ite                                   
+!$acc loop gang vector
+      DO I=its,ite                                   
         TGDSA(I)=TSK(I)                                    
 ! PSFC cb
 !        THGB(I)=TSK(I)*(100./PSFC(I))**ROVCP                
         THGB(I)=TSK(I)*(P1000mb/PSFCPA(I))**ROVCP   
-    5 CONTINUE                                               
+      END DO
+!$acc end parallel
+!-!-!$acc update host(PSFC,TGDSA,THGB)
+!!!i   5 CONTINUE                                               
 !                                                            
 !-----DECOUPLE FLUX-FORM VARIABLES TO GIVE U,V,T,THETA,THETA-VIR.,
 !     T-VIR., QV, AND QC AT CROSS POINTS AND AT KTAU-1.  
@@ -413,19 +430,22 @@ CONTAINS
 !         SO USE ONLY INTERIOR VALUES OF UX AND VX TO CALCULATE 
 !         TENDENCIES.                             
 !                                                           
-   10 CONTINUE                                                     
+!!!   10 CONTINUE                                                     
 
 !     DO 24 I=its,ite
 !        UX(I)=U1D(I)
 !        VX(I)=V1D(I)
 !  24 CONTINUE                                             
                                                              
-   26 CONTINUE                                               
+!!!   26 CONTINUE                                               
                                                    
 !.....SCR3(I,K) STORE TEMPERATURE,                           
 !     SCR4(I,K) STORE VIRTUAL TEMPERATURE.                                       
                                                                                  
-      DO 30 I=its,ite
+!!!       DO 30 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(PL,THCON)
+      DO I=its,ite
 ! PL cb
          PL=P1D(I)/1000.
          SCR3(I)=T1D(I)                                                   
@@ -435,8 +455,10 @@ CONTAINS
          SCR4(I)=SCR3(I)                                                    
          THVX(I)=THX(I)                                                     
          QX(I)=0.                                                             
-   30 CONTINUE                                                                 
-!                                                                                
+      END DO
+!!!   30 CONTINUE                                                                 
+!      
+!$acc loop gang vector
       DO I=its,ite
          QGH(I)=0.                                                                
          FLHC(I)=0.                                                               
@@ -445,14 +467,23 @@ CONTAINS
       ENDDO
 !                                                                                
 !     IF(IDRY.EQ.1)GOTO 80                                                   
-      DO 50 I=its,ite
+!!!      DO 50 I=its,ite
+!$acc loop gang vector private(TVCON)
+      DO I=its,ite
          QX(I)=QV1D(I)                                                    
          TVCON=(1.+EP1*QX(I))                                      
          THVX(I)=THX(I)*TVCON                                               
          SCR4(I)=SCR3(I)*TVCON                                              
-   50 CONTINUE                                                                 
+      END DO
+!$acc end parallel
+!-!-!$acc update host(SCR3,THX,SCR4,THVX,QX)
+!$acc update host(QGH,FLHC,FLQC,CPM)
+!!!   50 CONTINUE                                                                 
 !                                                                                
-      DO 60 I=its,ite
+!!!      DO 60 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(E1,PL)
+      DO I=its,ite
         E1=SVP1*EXP(SVP2*(TGDSA(I)-SVPT0)/(TGDSA(I)-SVP3))                       
 !  for land points QSFC can come from previous time step
         if(xland(i).gt.1.5.or.qsfc(i).le.0.0)QSFC(I)=EP2*E1/(PSFC(I)-E1)                                                 
@@ -462,33 +493,53 @@ CONTAINS
         PL=P1D(I)/1000.
         QGH(I)=EP2*E1/(PL-E1)                                                 
         CPM(I)=CP*(1.+0.8*QX(I))                                   
-   60 CONTINUE                                                                   
-   80 CONTINUE
+      END DO                                                                  
+!!!   60 CONTINUE                                                                   
+!!!   80 CONTINUE
                                                                                  
 !-----COMPUTE THE HEIGHT OF FULL- AND HALF-SIGMA LEVELS ABOVE GROUND             
 !     LEVEL, AND THE LAYER THICKNESSES.                                          
                                                                                  
-      DO 90 I=its,ite
+!!!      DO 90 I=its,ite
+!$acc loop gang vector
+      DO I=its,ite
         ZQKLP1(I)=0.
         RHOX(I)=PSFC(I)*1000./(R*SCR4(I))                                       
-   90 CONTINUE                                                                   
+      END DO
+!!!   90 CONTINUE                                                                   
 !                                                                                
-      DO 110 I=its,ite                                                   
+!!!      DO 110 I=its,ite                                                   
+!$acc loop gang vector
+      DO I=its,ite                                                   
            ZQKL(I)=dz8w1d(I)+ZQKLP1(I)
-  110 CONTINUE                                                                 
+      END DO                                                              
+!!!  110 CONTINUE                                                                 
 !                                                                                
-      DO 120 I=its,ite
+!!!      DO 120 I=its,ite
+!$acc loop gang vector
+      DO I=its,ite
          ZA(I)=0.5*(ZQKL(I)+ZQKLP1(I))                                        
-  120 CONTINUE                                                                 
+      END DO
+!!!  120 CONTINUE                                                                 
 !                                                                                
-      DO 160 I=its,ite
+!!!      DO 160 I=its,ite
+!$acc loop gang vector
+      DO I=its,ite
         GOVRTH(I)=G/THX(I)                                                    
-  160 CONTINUE                                                                   
+      END DO
+!$acc end parallel
+!$acc update host(QGH,CPM,QSFC)
+!-!-!$acc update host(ZQKLP1,RHOX,ZQKL,ZA,GOVRTH)
+!!!  160 CONTINUE                                                                   
                                                                                  
 !-----CALCULATE BULK RICHARDSON NO. OF SURFACE LAYER, ACCORDING TO               
 !     AKB(1976), EQ(12).                                                         
                    
-      DO 260 I=its,ite
+!!!    DO 260 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(ZL,TSKV,DTHVDZ,fluxc,VCONV,DTHVM, &
+!$acc VSGD)
+      DO I=its,ite
         GZ1OZ0(I)=ALOG(ZA(I)/ZNT(I))                                        
         GZ2OZ0(I)=ALOG(2./ZNT(I))                                        
         GZ10OZ0(I)=ALOG(10./ZNT(I))                                        
@@ -532,7 +583,11 @@ CONTAINS
         RMOL(I)=-GOVRTH(I)*DTHVDZ*ZA(I)*KARMAN
 !jdf
 
-  260 CONTINUE                                                                   
+     END DO                                                                 
+!$acc end parallel
+!$acc update host(GZ1OZ0,WSPD,BR,RMOL)
+!-!-!$acc update host(GZ2OZ0,GZ10OZ0)
+!!!  260 CONTINUE                                                                   
 
 !                                                                                
 !-----DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATED STABILITY CLASS:            
@@ -558,15 +613,19 @@ CONTAINS
 !                                                                                
 !CCCCC                                                                           
 
-      DO 320 I=its,ite
+!!!      DO 320 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(ZOL10,ZOL2,NZOL,RZOL,NZOL10,RZOL10,NZOL2,RZOL2)
+      DO I=its,ite
 !CCCCC                                                                           
 !CC     REMOVE REGIME 3 DEPENDENCE ON PBL HEIGHT                                 
 !CC          IF(BR(I).LT.0..AND.HOL(I,J).GT.1.5)GOTO 310                         
-        IF(BR(I).LT.0.)GOTO 310                                                  
+!!!        IF(BR(I).LT.0.)GOTO 310                                                  
 !                                                                                
 !-----CLASS 1; STABLE (NIGHTTIME) CONDITIONS:                                    
 !                                                                                
-        IF(BR(I).LT.0.2)GOTO 270                                                 
+!!!          IF(BR(I).LT.0.2)GOTO 270                                                 
+      IF(BR(I) .GE. 0.2) THEN
         REGIME(I)=1.                                                           
         PSIM(I)=-10.*GZ1OZ0(I)                                                   
 !    LOWER LIMIT ON PSI IN STABLE CONDITIONS                                     
@@ -587,12 +646,13 @@ CONTAINS
         ENDIF
         RMOL(I)=AMIN1(RMOL(I),9.999) ! ZA/L
         RMOL(I) = RMOL(I)/ZA(I) !1.0/L
-
-        GOTO 320                                                                 
+      ENDIF
+!!!        GOTO 320                                                                 
 !                                                                                
 !-----CLASS 2; DAMPED MECHANICAL TURBULENCE:                                     
 !                                                                                
-  270   IF(BR(I).EQ.0.0)GOTO 280                                                 
+!!!  270   IF(BR(I).EQ.0.0)GOTO 280                                                 
+      IF((BR(I) .LT. 0.2) .AND. (BR(I) .GT. 0.0)) THEN
         REGIME(I)=2.                                                           
         PSIM(I)=-5.0*BR(I)*GZ1OZ0(I)/(1.1-5.0*BR(I))                             
 !    LOWER LIMIT ON PSI IN STABLE CONDITIONS                                     
@@ -623,12 +683,14 @@ CONTAINS
 
         ! 1.0 over Monin-Obukhov length
         RMOL(I)= ZOL(I)/ZA(I)
-
-        GOTO 320                                                                 
+      ENDIF
+!!!        GOTO 320                                                                 
 !                                                                                
 !-----CLASS 3; FORCED CONVECTION:                                                
 !                                                                                
-  280   REGIME(I)=3.                                                           
+!!!  280   REGIME(I)=3.                                                           
+      IF(BR(I).EQ.0.0) THEN
+	        REGIME(I)=3.
         PSIM(I)=0.0                                                              
         PSIH(I)=PSIM(I)                                                          
         PSIM10(I)=0.                                                   
@@ -644,12 +706,13 @@ CONTAINS
         ENDIF                                                                    
 
         RMOL(I) = ZOL(I)/ZA(I)  
-
-        GOTO 320                                                                 
+      ENDIF
+!!!        GOTO 320                                                                 
 !                                                                                
 !-----CLASS 4; FREE CONVECTION:                                                  
 !                                                                                
-  310   CONTINUE                                                                 
+!!!  310   CONTINUE                                                                 
+      IF(BR(I).LT.0.) THEN
         REGIME(I)=4.                                                           
         IF(UST(I).LT.0.01)THEN                                                 
           ZOL(I)=BR(I)*GZ1OZ0(I)                                               
@@ -689,13 +752,21 @@ CONTAINS
         PSIH10(I)=AMIN1(PSIH10(I),0.9*GZ10OZ0(I))
 
         RMOL(I) = ZOL(I)/ZA(I)  
-
-  320 CONTINUE                                                                   
+      ENDIF
+      ENDDO
+!$acc end parallel
+!$acc update host(REGIME,PSIM,PSIH,RMOL,ZOL)
+!-!-!$acc update host(PSIM10,PSIH10,PSIM2,PSIH2)
+!!!  320 CONTINUE                                                                   
 !                                                                                
 !-----COMPUTE THE FRICTIONAL VELOCITY:                                           
 !     ZA(1982) EQS(2.60),(2.61).                                                 
 !                                                                                
-      DO 330 I=its,ite
+!!!      DO 330 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(DTG,PSIX,PSIX10,PSIT,ZL,PSIQ,PSIT2, &
+!$acc PSIQ2,PSIQ10,VISC,RESTAR,Z0T,Z0Q,GZ0OZT,GZ0OZQ,CZIL)
+      DO I=its,ite
         DTG=THX(I)-THGB(I)                                                   
         PSIX=GZ1OZ0(I)-PSIM(I)                                                   
         PSIX10=GZ10OZ0(I)-PSIM10(I)
@@ -821,25 +892,40 @@ CONTAINS
         DENOMT2(I)=PSIT2
         FM(I)=PSIX
         FH(I)=PSIT
-  330 CONTINUE                                                                   
+      END DO
+!$acc end parallel
+!$acc update host(Ck,Cd,Cka,Cda,UST,USTM,U10,V10,TH2,&
+!$acc Q2,T2,MOL,FM,FH)
+!-!-!$acc update host(WSPDI,DENOMQ,DENOMQ2,DENOMT2)
+!!!  330 CONTINUE                                                                   
 !                                                                                
-  335 CONTINUE                                                                   
+!!!  335 CONTINUE                                                                   
                                                                                   
 !-----COMPUTE THE SURFACE SENSIBLE AND LATENT HEAT FLUXES:                       
-      IF ( PRESENT(SCM_FORCE_FLUX) ) THEN
-         IF (SCM_FORCE_FLUX.EQ.1) GOTO 350              
-      ENDIF
+!!!   IF ( PRESENT(SCM_FORCE_FLUX) ) THEN
+!!!       IF (SCM_FORCE_FLUX.EQ.1) GOTO 350              
+!!!   ENDIF
+      IF ( .NOT. ( PRESENT(SCM_FORCE_FLUX) .AND. SCM_FORCE_FLUX.EQ.1 ) ) THEN
+!$acc parallel vector_length(32)
+!$acc loop gang vector
       DO i=its,ite
         QFX(i)=0.                                                              
         HFX(i)=0.                                                              
       ENDDO
-  350 CONTINUE
+!$acc end parallel
+      ENDIF
+!$acc update host(QFX,HFX)
+!!!  350 CONTINUE
 
-      IF (ISFFLX.EQ.0) GOTO 410                                                
+!!!      IF (ISFFLX.EQ.0) GOTO 410                                                
+    IF (ISFFLX.NE.0) THEN
                                                                                  
 !-----OVER WATER, ALTER ROUGHNESS LENGTH (ZNT) ACCORDING TO WIND (UST).
                                                                                  
-      DO 360 I=its,ite
+!!!      DO 360 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(ZW,ZN1,ZN2,ZL,DTTHX)
+      DO I=its,ite
         IF((XLAND(I)-1.5).GE.0)THEN                                            
 !         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
 ! Since V3.7 (ref: EC Physics document for Cy36r1)
@@ -879,62 +965,75 @@ CONTAINS
         IF(DTTHX.GT.1.E-5)THEN                                                   
           FLHC(I)=CPM(I)*RHOX(I)*UST(I)*MOL(I)/(THX(I)-THGB(I))          
 !         write(*,1001)FLHC(I),CPM(I),RHOX(I),UST(I),MOL(I),THX(I),THGB(I),I
- 1001   format(f8.5,2x,f12.7,2x,f12.10,2x,f12.10,2x,f13.10,2x,f12.8,f12.8,2x,i3)
+! 1001   format(f8.5,2x,f12.7,2x,f12.10,2x,f12.10,2x,f13.10,2x,f12.8,f12.8,2x,i3)
         ELSE                                                                     
           FLHC(I)=0.                                                             
         ENDIF                                                                    
-  360 CONTINUE
+     END DO
+!$acc end parallel
+!$acc update host(ZNT,FLQC,FLHC)
+!!!  360 CONTINUE
 
 !                                                                                
 !-----COMPUTE SURFACE MOIST FLUX:                                               
 !
 !     IF(IDRY.EQ.1)GOTO 390
-     IF ( PRESENT(SCM_FORCE_FLUX) ) THEN
-        IF (SCM_FORCE_FLUX.EQ.1) GOTO 405                                     
-     ENDIF
+!!!  IF ( PRESENT(SCM_FORCE_FLUX) ) THEN
+!!!       IF (SCM_FORCE_FLUX.EQ.1) GOTO 405                                     
+!!!  ENDIF
+     IF ( .NOT. ( PRESENT(SCM_FORCE_FLUX) .AND. (SCM_FORCE_FLUX.EQ.1) ) ) THEN
 !                                                                               
-      DO 370 I=its,ite
-        QFX(I)=FLQC(I)*(QSFC(I)-QX(I))                                     
-        QFX(I)=AMAX1(QFX(I),0.)                                            
-        LH(I)=XLV*QFX(I)
-  370 CONTINUE                                                                 
+!!!      DO 370 I=its,ite
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+        DO I=its,ite
+          QFX(I)=FLQC(I)*(QSFC(I)-QX(I))                                     
+          QFX(I)=AMAX1(QFX(I),0.)                                            
+          LH(I)=XLV*QFX(I)
+        END DO                                                               
+!!!  370 CONTINUE                                                                 
                                                                                 
 !-----COMPUTE SURFACE HEAT FLUX:                                                 
 !                                                                                
-  390 CONTINUE                                                                 
-      DO 400 I=its,ite
-        IF(XLAND(I)-1.5.GT.0.)THEN                                           
-          HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
+!!!  390 CONTINUE                                                                 
+!!!      DO 400 I=its,ite
+!$acc loop gang vector
+        DO I=its,ite
+          IF(XLAND(I)-1.5.GT.0.)THEN                                           
+            HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
 !         IF ( PRESENT(ISFTCFLX) ) THEN
 !            IF ( ISFTCFLX.NE.0 ) THEN
 ! AHW: add dissipative heating term (commented out in 3.6.1)
 !               HFX(I)=HFX(I)+RHOX(I)*USTM(I)*USTM(I)*WSPDI(I)
 !            ENDIF
 !         ENDIF
-        ELSEIF(XLAND(I)-1.5.LT.0.)THEN                                       
-          HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
-          HFX(I)=AMAX1(HFX(I),-250.)                                       
-        ENDIF                                                                  
-  400 CONTINUE                                                                 
-
-  405 CONTINUE                                                                 
-         
-      DO I=its,ite
-         IF((XLAND(I)-1.5).GE.0)THEN
-           ZL=ZNT(I)
-         ELSE
-           ZL=0.01
-         ENDIF
-         CHS(I)=UST(I)*KARMAN/DENOMQ(I)
-!        GZ2OZ0(I)=ALOG(2./ZNT(I))
-!        PSIM2(I)=-10.*GZ2OZ0(I)
-!        PSIM2(I)=AMAX1(PSIM2(I),-10.)
-!        PSIH2(I)=PSIM2(I)
-         CQS2(I)=UST(I)*KARMAN/DENOMQ2(I)
-         CHS2(I)=UST(I)*KARMAN/DENOMT2(I)
-      ENDDO
-                                                                        
-  410 CONTINUE                                                                   
+          ELSEIF(XLAND(I)-1.5.LT.0.)THEN                                       
+            HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
+            HFX(I)=AMAX1(HFX(I),-250.)                                       
+          ENDIF                                                                  
+       END DO                                                                 
+!!!  400 CONTINUE                                                                 
+    END IF
+!!!  405 CONTINUE                                                                 
+!$acc loop gang vector private(ZL)         
+        DO I=its,ite
+          IF((XLAND(I)-1.5).GE.0)THEN
+            ZL=ZNT(I)
+          ELSE
+            ZL=0.01
+          ENDIF
+          CHS(I)=UST(I)*KARMAN/DENOMQ(I)
+!         GZ2OZ0(I)=ALOG(2./ZNT(I))
+!         PSIM2(I)=-10.*GZ2OZ0(I)
+!         PSIM2(I)=AMAX1(PSIM2(I),-10.)
+!         PSIH2(I)=PSIM2(I)
+          CQS2(I)=UST(I)*KARMAN/DENOMQ2(I)
+          CHS2(I)=UST(I)*KARMAN/DENOMT2(I)
+        ENDDO
+!$acc end parallel
+!$acc update host(QFX,LH,HFX,CHS,CQS2,CHS2)
+   ENDIF
+!!!  410 CONTINUE                                                                   
 !jdf
 !     DO I=its,ite
 !       IF(UST(I).GE.0.1) THEN
@@ -944,7 +1043,7 @@ CONTAINS
 !       ENDIF
 !     ENDDO
 !jdf
-
+!$acc end data
 !                                                                                
    END SUBROUTINE SFCLAY1D
 
@@ -963,6 +1062,7 @@ CONTAINS
       Y=(1-16*ZOLN)**0.5
       PSIHTB(N)=2*ALOG(0.5*(1+Y))
    ENDDO
+!$acc update device(PSIMTB,PSIHTB)
 
    END SUBROUTINE sfclayinit
 

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
@@ -219,12 +219,10 @@ CONTAINS
         DO i=its,ite
            DX2D(i)=DX(i,j)
         ENDDO
-!$acc parallel vector_length(32)
 !$acc loop gang vector
         DO i=its,ite
           dz8w1d(I) = dz8w(i,1,j)
         ENDDO
-!$acc parallel vector_length(32)
 !$acc loop gang vector
         DO i=its,ite
            U1D(i) =U3D(i,1,j)
@@ -1012,9 +1010,11 @@ CONTAINS
             HFX(I)=AMAX1(HFX(I),-250.)                                       
           ENDIF                                                                  
        END DO                                                                 
+!$acc end parallel
 !!!  400 CONTINUE                                                                 
     END IF
 !!!  405 CONTINUE                                                                 
+!$acc parallel vector_length(32)
 !$acc loop gang vector private(ZL)         
         DO I=its,ite
           IF((XLAND(I)-1.5).GE.0)THEN


### PR DESCRIPTION
Added OpenACC directives from 6.x-openacc version to manage Host <-> GPU memory movement, to enable surface-layer model to run on the GPU.