### PR TITLE
Add comment explaining default initialization choice for att_list_type % attType

### DIFF
--- a/src/framework/mpas_attlist_types.inc
+++ b/src/framework/mpas_attlist_types.inc
@@ -11,7 +11,7 @@
    ! Derived type for holding field attributes
    type att_list_type
       character (len=StrKIND) :: attName = ''
-      integer :: attType = -1
+      integer :: attType = -1     ! Should not match any of MPAS_ATT_INT, MPAS_ATT_REAL, etc.
       integer :: attValueInt
       integer, dimension(:), pointer :: attValueIntA => null()
       real (kind=RKIND) :: attValueReal


### PR DESCRIPTION
This merge adds a comment to explain the choice of default initialization for
the `attType` member of `att_list_type`.

The `attType` member of the `att_list_type` derived type was given a default value
of -1, but there was no explanation in the code as to how this default value was
chosen. This merge adds a comment explaining that the key consideration in the
choice of the default value for `attType` is that it must not match a valid type
(e.g., `MPAS_ATT_INT`, `MPAS_ATT_REAL`, etc.) so that new instances of the
`att_list_type` that haven't been explicitly initialized or otherwise set cannot
be mistaken for valid attributes.