### PR TITLE
Revert "update NF_ to NF90_ in mpas_io.F" [atmosphere/cam]

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -27,8 +27,8 @@ module mpas_io
    integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT
    character, parameter :: MPAS_CHAR_FILLVAL = achar(0)  ! TODO: To be replaced with PIO_FILL_CHAR once PIO2 provides this variable
 #else
-   integer, parameter :: MPAS_INT_FILLVAL = NF90_FILL_INT
-   character, parameter :: MPAS_CHAR_FILLVAL = NF90_FILL_CHAR
+   integer, parameter :: MPAS_INT_FILLVAL = NF_FILL_INT
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(NF_FILL_CHAR)
 #endif
 
 #ifdef USE_PIO2
@@ -39,9 +39,9 @@ module mpas_io
 #endif
 #else
 #ifdef SINGLE_PRECISION
-   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF90_FILL_FLOAT
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_FLOAT
 #else
-   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF90_FILL_DOUBLE
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_DOUBLE
 #endif
 #endif
 


### PR DESCRIPTION
This merge reverts changes from the use of `NF_FILL_` constants to `NF90_FILL_`
constants in `mpas_io.F`. The change from `NF_FILL_*` to `NF90_FILL_*` constants
in `mpas_io.F` was needed when building MPAS-Atmosphere as a CAM dycore in the
past, but since CAM/CESM has updated to using PIO2, these changes are no longer
needed (because the affected code is pre-processed out when `USE_PIO2` is defined).

Since the use of `NF_FILL_*` constants worked without apparent problem in stand-
alone MPAS, perhaps as a consequence of the way that PIO was installed by MPAS
users, it seems preferable to revert the `mpas_io.F` code to its former state.