### PR TITLE
Modified MPAS_to_physics to run on CPUs during an OpenACC run.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -226,7 +226,7 @@
     ! For all timesteps, we transfer MPAS state to physics
     !
 !$OMP PARALLEL DO
-    if (mpas_cpl%role_includes(ROLE_RADIATION)) then
+    if (mpas_cpl%role_is(ROLE_RADIATION)) then
     do thread=1,nThreads
        call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -226,11 +226,19 @@
     ! For all timesteps, we transfer MPAS state to physics
     !
 !$OMP PARALLEL DO
+    if (mpas_cpl%role_includes(ROLE_RADIATION)) then
     do thread=1,nThreads
        call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
     end do
+    else
+    do thread=1,nThreads
+       call MPAS_to_physics_gpu(block%configs,mesh,state,time_lev,diag,diag_physics, &
+                            mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
+                            cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+    end do
+    end if
 !$OMP END PARALLEL DO
 
     !call to cloud scheme:

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -316,8 +316,8 @@
  call mpas_pool_get_field(state,'scalars',scalarsField,time_lev)
 
  if (l_radtlw .or. l_radtsw) then
-    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-        mpas_cpl%role_includes(ROLE_RADIATION)) then
+    if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_is(ROLE_RADIATION)) then
 
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)
@@ -643,8 +643,8 @@
  if (l_radtlw .or. l_radtsw) then
 !$acc update host(exner, pressure_b, pressure_p, rtheta_b, rtheta_p, u, v, rho_zz, &
 !$acc             theta_m, w, scalars, surface_pressure, plrad)
-    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-        mpas_cpl%role_includes(ROLE_RADIATION)) then
+    if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_is(ROLE_RADIATION)) then
 
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -18,6 +18,7 @@
  public:: allocate_forall_physics,   &
           deallocate_forall_physics, &
           MPAS_to_physics,           &
+          MPAS_to_physics_gpu,       &
           microphysics_from_MPAS,    &
           microphysics_to_MPAS
 
@@ -315,8 +316,8 @@
  call mpas_pool_get_field(state,'scalars',scalarsField,time_lev)
 
  if (l_radtlw .or. l_radtsw) then
-    if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
-        mpas_cpl%role_is(ROLE_RADIATION)) then
+    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_includes(ROLE_RADIATION)) then
 
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)
@@ -517,6 +518,337 @@
  enddo
 
  end subroutine MPAS_to_physics
+
+!=================================================================================================================
+ subroutine MPAS_to_physics_gpu(configs,mesh,state,time_lev,diag,diag_physics,mpas_cpl,cells_to_rad_handle,cells_from_rad_handle,its,ite)
+!=================================================================================================================
+
+ use mpas_derived_types, only : mpas_coupler_type
+ use mpas_intracoupler, only : mpas_coupler_transfer_field
+ use mpas_intracoupler, only : ROLE_INTEGRATE, ROLE_RADIATION
+
+!input variables:
+ type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: state
+ type(mpas_pool_type),intent(in):: diag
+
+ type (mpas_coupler_type), pointer :: mpas_cpl
+ integer, intent(in) :: cells_to_rad_handle, cells_from_rad_handle
+
+ integer,intent(in):: its,ite
+ integer,intent(in):: time_lev
+
+!inout variables:
+ type(mpas_pool_type),intent(inout):: diag_physics
+
+!local pointers:
+ character(len=StrKIND),pointer:: pbl_scheme
+
+ integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
+ integer,pointer:: index_ni
+
+ real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
+ real(kind=RKIND),dimension(:),pointer    :: fzm,fzp,rdzw
+ real(kind=RKIND),dimension(:),pointer    :: surface_pressure,plrad
+ real(kind=RKIND),dimension(:,:),pointer  :: zgrid
+ real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b,rtheta_p,rtheta_b
+ real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p,u,v,w
+ real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
+ real(kind=RKIND),dimension(:,:),pointer  :: ni
+ real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+
+ type (field1DReal), pointer :: surface_pressureField, plradField
+ type (field2DReal), pointer :: exnerField, pressure_bField, rtheta_pField, rtheta_bField
+ type (field2DReal), pointer :: rho_zzField, theta_mField, pressure_pField, uField, vField, wField
+ type (field3DReal), pointer :: scalarsField
+
+!local variables:
+ integer:: i,k,j
+ integer :: iErr
+
+ real(kind=RKIND):: z0,z1,z2,w1,w2
+ real(kind=RKIND):: rho_a,rho1,rho2,tem1,tem2
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine MPAS_to_phys:')
+!call mpas_log_write('ims=$i ime=$i',intArgs=(/ims,ime/))
+!call mpas_log_write('jms=$i jme=$i',intArgs=(/jms,jme/))
+!call mpas_log_write('kms=$i kme=$i',intArgs=(/kms,kme/))
+!call mpas_log_write('')
+!call mpas_log_write('its=$i ite=$i',intArgs=(/its,ite/))
+!call mpas_log_write('jts=$i jte=$i',intArgs=(/jts,jte/))
+!call mpas_log_write('kts=$i kte=$i',intArgs=(/kts,kte/))
+
+!initialization:
+ call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+
+ call mpas_pool_get_array_gpu(mesh,'latCell',latCell)
+ call mpas_pool_get_array_gpu(mesh,'lonCell',lonCell)
+ call mpas_pool_get_array_gpu(mesh,'fzm'    ,fzm    )
+ call mpas_pool_get_array_gpu(mesh,'fzp'    ,fzp    )
+ call mpas_pool_get_array_gpu(mesh,'rdzw'   ,rdzw   )
+ call mpas_pool_get_array_gpu(mesh,'zgrid'  ,zgrid  )
+ call mpas_pool_get_array_gpu(mesh,'zz'     ,zz     )
+
+ call mpas_pool_get_array_gpu(diag,'surface_pressure'      ,surface_pressure)
+ call mpas_pool_get_array_gpu(diag,'exner'                 ,exner           )
+ call mpas_pool_get_array_gpu(diag,'pressure_base'         ,pressure_b      )
+ call mpas_pool_get_array_gpu(diag,'pressure_p'            ,pressure_p      )
+ call mpas_pool_get_array_gpu(diag,'rtheta_base'           ,rtheta_b        )
+ call mpas_pool_get_array_gpu(diag,'rtheta_p'              ,rtheta_p        )
+ call mpas_pool_get_array_gpu(diag,'uReconstructZonal'     ,u               )
+ call mpas_pool_get_array_gpu(diag,'uReconstructMeridional',v               )
+
+ call mpas_pool_get_field(diag,'surface_pressure'      ,surface_pressureField)
+ call mpas_pool_get_field(diag,'exner'                 ,exnerField           )
+ call mpas_pool_get_field(diag,'pressure_base'         ,pressure_bField      )
+ call mpas_pool_get_field(diag,'pressure_p'            ,pressure_pField      )
+ call mpas_pool_get_field(diag,'rtheta_base'           ,rtheta_bField        )
+ call mpas_pool_get_field(diag,'rtheta_p'              ,rtheta_pField        )
+ call mpas_pool_get_field(diag,'uReconstructZonal'     ,uField               )
+ call mpas_pool_get_field(diag,'uReconstructMeridional',vField               )
+
+ call mpas_pool_get_array_gpu(state,'rho_zz' ,rho_zz ,time_lev)
+ call mpas_pool_get_array_gpu(state,'theta_m',theta_m,time_lev)
+ call mpas_pool_get_array_gpu(state,'w'      ,w      ,time_lev)
+
+ call mpas_pool_get_field(state,'rho_zz' ,rho_zzField ,time_lev)
+ call mpas_pool_get_field(state,'theta_m',theta_mField,time_lev)
+ call mpas_pool_get_field(state,'w'      ,wField      ,time_lev)
+
+ call mpas_pool_get_dimension(state,'index_qv',index_qv)
+ call mpas_pool_get_dimension(state,'index_qc',index_qc)
+ call mpas_pool_get_dimension(state,'index_qr',index_qr)
+ call mpas_pool_get_dimension(state,'index_qi',index_qi)
+ call mpas_pool_get_dimension(state,'index_qs',index_qs)
+ call mpas_pool_get_dimension(state,'index_qg',index_qg)
+
+ call mpas_pool_get_array_gpu(diag_physics,'plrad',plrad)
+ call mpas_pool_get_array_gpu(state,'scalars',scalars,time_lev)
+!$acc update host(latCell, lonCell, fzm, fzp, rdzw, zgrid, zz, surface_pressure, &
+!$acc             exner, pressure_b, pressure_p, rtheta_b, rtheta_p, u, v, rho_zz, &
+!$acc             theta_m, w, plrad, scalars)
+ qv => scalars(index_qv,:,:)
+ qc => scalars(index_qc,:,:)
+ qr => scalars(index_qr,:,:)
+ qi => scalars(index_qi,:,:)
+ qs => scalars(index_qs,:,:)
+ qg => scalars(index_qg,:,:)
+
+ call mpas_pool_get_field(diag_physics,'plrad',plradField)
+ call mpas_pool_get_field(state,'scalars',scalarsField,time_lev)
+
+ if (l_radtlw .or. l_radtsw) then
+!$acc update host(exner, pressure_b, pressure_p, rtheta_b, rtheta_p, u, v, rho_zz, &
+!$acc             theta_m, w, scalars, surface_pressure, plrad)
+    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_includes(ROLE_RADIATION)) then
+
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_pField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, rtheta_bField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, rtheta_pField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, uField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, vField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, rho_zzField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, theta_mField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, wField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, scalarsField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, surface_pressureField, ierr=ierr)
+       call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, plradField, ierr=ierr)
+
+    end if
+!$acc update device(exner, pressure_b, pressure_p, rtheta_b, rtheta_p, u, v, rho_zz, &
+!$acc             theta_m, w, scalars, surface_pressure, plrad)
+ end if
+
+ do j = jts, jte
+ do k = kts, kte
+ do i = its, ite
+
+    !water vapor and moist arrays:
+    qv_p(i,k,j) = max(0.,qv(k,i))
+    qc_p(i,k,j) = max(0.,qc(k,i))
+    qr_p(i,k,j) = max(0.,qr(k,i))
+    qi_p(i,k,j) = max(0.,qi(k,i))
+    qs_p(i,k,j) = max(0.,qs(k,i))
+    qg_p(i,k,j) = max(0.,qg(k,i))
+
+    !arrays located at theta points:
+    u_p(i,k,j) = u(k,i)
+    v_p(i,k,j) = v(k,i)
+
+    zz_p(i,k,j)  = zz(k,i)
+    rho_p(i,k,j) = zz(k,i) * rho_zz(k,i)
+    rho_p(i,k,j) = rho_p(i,k,j)*(1._RKIND + qv_p(i,k,j))
+    th_p(i,k,j)  = theta_m(k,i) / (1._RKIND + R_v/R_d * qv_p(i,k,j))
+    t_p(i,k,j)   = th_p(i,k,j)*exner(k,i)
+
+    pi_p(i,k,j)   = exner(k,i)
+    pres_p(i,k,j) = pressure_p(k,i) + pressure_b(k,i)
+
+    zmid_p(i,k,j) = 0.5*(zgrid(k+1,i)+zgrid(k,i))
+    dz_p(i,k,j)   = zgrid(k+1,i)-zgrid(k,i)
+
+ enddo
+ enddo
+ enddo
+
+ pbl_select: select case (trim(pbl_scheme))
+    case("bl_mynn")
+       call mpas_pool_get_dimension(state,'index_ni',index_ni)
+       ni => scalars(index_ni,:,:)
+
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
+          ni_p(i,k,j) = max(0.,ni(k,i))
+       enddo
+       enddo
+       enddo
+
+    case default
+
+ end select pbl_select
+
+!calculation of the surface pressure using hydrostatic assumption down to the surface::
+ do j = jts,jte
+ do i = its,ite
+    tem1 = zgrid(2,i)-zgrid(1,i)
+    tem2 = zgrid(3,i)-zgrid(2,i)
+    rho1 = rho_zz(1,i) * zz(1,i) * (1. + qv_p(i,1,j))
+    rho2 = rho_zz(2,i) * zz(2,i) * (1. + qv_p(i,2,j))
+!   surface_pressure(i) = 0.5*gravity*(zgrid(2,i)-zgrid(1,i)) &
+!                   * (rho1 + 0.5*(rho2-rho1)*tem1/(tem1+tem2))
+    surface_pressure(i) = 0.5*gravity*(zgrid(2,i)-zgrid(1,i)) &
+                    * (rho1 - 0.5*(rho2-rho1)*tem1/(tem1+tem2))
+    surface_pressure(i) = surface_pressure(i) + pressure_p(1,i) + pressure_b(1,i)
+ enddo
+ 
+ do k = kts,kte
+ do i = its,ite
+    znu_p(i,k,j)  = pres_p(i,k,j) / surface_pressure(i)
+ enddo
+ enddo
+ enddo
+
+!arrays located at w points:
+ do j = jts, jte
+ do k = kts,kte+1
+ do i = its,ite
+    w_p(i,k,j) = w(k,i)
+    z_p(i,k,j) = zgrid(k,i)
+ enddo
+ enddo
+ enddo
+
+!check that the pressure in the layer above the surface is greater than that in the layer
+!above it:
+ do j = jts,jte
+ do i = its,ite
+    if(pres_p(i,1,j) .le. pres_p(i,2,j)) then
+       call mpas_log_write('')
+       call mpas_log_write('--- subroutine MPAS_to_phys - pressure(1) < pressure(2):')
+       call mpas_log_write('i      =$i', intArgs=(/i/))
+       call mpas_log_write('latCell=$r', realArgs=(/latCell(i)/degrad/))
+       call mpas_log_write('lonCell=$r', realArgs=(/lonCell(i)/degrad/))
+       do k = kts,kte
+          call mpas_log_write('$i $i $i $r $r $r $r $r $r $r $r', intArgs=(/j,i,k/),&
+             realArgs=(/dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
+                        rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)/))
+       enddo
+!      call mpas_log_write('pressure increasing with height', messageType=MPAS_LOG_CRIT)
+    endif
+ enddo
+ enddo
+
+!interpolation of pressure and temperature from theta points to w points:
+ do j = jts,jte
+ do k = kts+1,kte
+ do i = its,ite
+    tem1 = 1./(zgrid(k+1,i)-zgrid(k-1,i))
+    fzm_p(i,k,j) = (zgrid(k,i)-zgrid(k-1,i)) * tem1
+    fzp_p(i,k,j) = (zgrid(k+1,i)-zgrid(k,i)) * tem1
+    t2_p(i,k,j)    = fzm_p(i,k,j)*t_p(i,k,j) + fzp_p(i,k,j)*t_p(i,k-1,j)
+    pres2_p(i,k,j) = fzm_p(i,k,j)*pres_p(i,k,j) + fzp_p(i,k,j)*pres_p(i,k-1,j)
+ enddo
+ enddo
+ enddo
+
+!interpolation of pressure and temperature from theta points to the top-of-the-model: follows
+!the calculation of the top-of-the-model pressure and temperature in WRF (subroutine phy_prep
+!in ./dyn_em/module_big_step_utilities.F):
+ k = kte+1
+ do j = jts,jte
+ do i = its,ite
+    z0 = zgrid(k,i)
+    z1 = 0.5*(zgrid(k,i)+zgrid(k-1,i)) 
+    z2 = 0.5*(zgrid(k-1,i)+zgrid(k-2,i))
+    w1 = (z0-z2)/(z1-z2)
+    w2 = 1.-w1
+    t2_p(i,k,j) = w1*t_p(i,k-1,j) + w2*t_p(i,k-2,j)
+    !use log of pressure to avoid occurrences of negative top-of-the-model pressure.
+    pres2_p(i,k,j) = exp(w1*log(pres_p(i,k-1,j))+w2*log(pres_p(i,k-2,j)))
+ enddo
+ enddo
+
+!ldf (2012-06-22): recalculates the pressure at the surface as an extrapolation of the
+!pressures in the 2 layers above the surface, as was originally done:
+ k = kts
+ do j = jts,jte
+ do i = its,ite
+    z0 = zgrid(k,i)
+    z1 = 0.5*(zgrid(k,i)+zgrid(k+1,i)) 
+    z2 = 0.5*(zgrid(k+1,i)+zgrid(k+2,i))
+    w1 = (z0-z2)/(z1-z2)
+    w2 = 1.-w1
+    t2_p(i,k,j)    = w1*t_p(i,k,j)+w2*t_p(i,k+1,j)
+    pres2_p(i,k,j) = w1*pres_p(i,k,j)+w2*pres_p(i,k+1,j)
+!   psfc_p(i,j) = pres2_p(i,k,j)
+    psfc_p(i,j) = surface_pressure(i)
+ enddo
+ enddo
+
+!calculation of the hydrostatic pressure:
+ do j = jts,jte
+ do i = its,ite
+    !pressure at w-points:
+    k = kte+1
+    pres2_hyd_p(i,k,j)  = pres2_p(i,k,j)
+    pres2_hydd_p(i,k,j) = pres2_p(i,k,j)
+    do k = kte,1,-1
+       rho_a = rho_p(i,k,j) / (1.+qv_p(i,k,j))
+       pres2_hyd_p(i,k,j)  = pres2_hyd_p(i,k+1,j)  + gravity*rho_p(i,k,j)*dz_p(i,k,j)
+       pres2_hydd_p(i,k,j) = pres2_hydd_p(i,k+1,j) + gravity*rho_a*dz_p(i,k,j)
+    enddo
+    !pressure at theta-points:
+    do k = kte,1,-1
+       pres_hyd_p(i,k,j)  = 0.5*(pres2_hyd_p(i,k+1,j)+pres2_hyd_p(i,k,j))
+       pres_hydd_p(i,k,j) = 0.5*(pres2_hydd_p(i,k+1,j)+pres2_hydd_p(i,k,j))
+    enddo
+    !surface pressure:
+    psfc_hyd_p(i,j) = pres2_hyd_p(i,1,j)
+    psfc_hydd_p(i,j) = pres2_hydd_p(i,1,j)
+    !znu:
+    do k = kte,1,-1
+       znu_hyd_p(i,k,j) = pres_hyd_p(i,k,j) / psfc_hyd_p(i,j) 
+    enddo
+ enddo
+ enddo
+
+!save the model-top pressure:
+ do j = jts,jte
+ do i = its,ite
+    plrad(i) = pres2_p(i,kte+1,j) 
+ enddo
+ enddo
+
+!$acc update device(surface_pressure, plrad)
+
+ end subroutine MPAS_to_physics_gpu
 
 !=================================================================================================================
  subroutine microphysics_from_MPAS(configs,mesh,state,time_lev,diag,diag_physics,its,ite)


### PR DESCRIPTION

This is the 3rd PR submitted in a pool of approximately 12 PRs.
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'MPAS_to_physics' subroutine to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. 'MPAS_to_physics' is duplicated as 'MPAS_to_physics_gpu', where the former is used in radiation role execution and latter in dynamics role execution. These temporary data transfer changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.

Code Execution Status:

1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.
