### PR TITLE
Modified driver_radiation_sw to run on CPUs during an OpenACC run.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -395,14 +395,14 @@
  call mpas_pool_get_field(diag_physics,'m_hybi'    ,m_hybiField )
  call mpas_pool_get_field(diag_physics,'m_ps'      ,m_psField,time_lev)
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update host(latCell, lonCell, aerosols, skintemp, snow, &
     !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
     !$acc o3clim, m_hybi, m_ps)
  endif
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_includes(ROLE_RADIATION)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_is(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, latCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, lonCellField, ierr=ierr)
@@ -426,7 +426,7 @@
 
  end if
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
     !$acc update device(latCell, lonCell, aerosols, skintemp, snow, &
     !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
     !$acc o3clim, m_hybi, m_ps)
@@ -649,7 +649,7 @@
  end select radiation_sw_select
  end if
 
- if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
  !$acc update device(latCell, lonCell, aerosols, skintemp, snow, &
  !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
  !$acc o3clim, m_hybi, m_ps)
@@ -749,13 +749,13 @@
 
  if (transfer_fields) then
 
-    if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
        !$acc update host(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
        !$acc swupb, swupbc, swupt, swuptc, rthratensw)
     end if
 
-    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
-        mpas_cpl%role_includes(ROLE_RADIATION)) then
+    if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_is(ROLE_RADIATION)) then
 
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
@@ -772,7 +772,7 @@
 
     end if
 
-    if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    if (mpas_cpl%role_is(ROLE_INTEGRATE)) then
        !$acc update device(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
        !$acc swupb, swupbc, swupt, swuptc, rthratensw)
     end if

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -355,38 +355,38 @@
  call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme       )
  call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re    )
 
- call mpas_pool_get_array(mesh,'latCell',latCell)
- call mpas_pool_get_array(mesh,'lonCell',lonCell)
+ call mpas_pool_get_array_gpu(mesh,'latCell',latCell)
+ call mpas_pool_get_array_gpu(mesh,'lonCell',lonCell)
 
  call mpas_pool_get_field(mesh,'latCell',latCellField)
  call mpas_pool_get_field(mesh,'lonCell',lonCellField)
 
- call mpas_pool_get_array(state,'aerosols',aerosols,time_lev)
+ call mpas_pool_get_array_gpu(state,'aerosols',aerosols,time_lev)
 
  call mpas_pool_get_field(state,'aerosols',aerosolsField,time_lev)
 
- call mpas_pool_get_array(sfc_input,'skintemp',skintemp)
- call mpas_pool_get_array(sfc_input,'snow'    ,snow    )
- call mpas_pool_get_array(sfc_input,'xice'    ,xice    )
- call mpas_pool_get_array(sfc_input,'xland'   ,xland   )
+ call mpas_pool_get_array_gpu(sfc_input,'skintemp',skintemp)
+ call mpas_pool_get_array_gpu(sfc_input,'snow'    ,snow    )
+ call mpas_pool_get_array_gpu(sfc_input,'xice'    ,xice    )
+ call mpas_pool_get_array_gpu(sfc_input,'xland'   ,xland   )
 
  call mpas_pool_get_field(sfc_input,'skintemp',skintempField)
  call mpas_pool_get_field(sfc_input,'snow'    ,snowField    )
  call mpas_pool_get_field(sfc_input,'xice'    ,xiceField    )
  call mpas_pool_get_field(sfc_input,'xland'   ,xlandField   )
 
- call mpas_pool_get_array(atm_input,'pin'     ,pin     )
- call mpas_pool_get_array(atm_input,'ozmixm'  ,ozmixm  )
+ call mpas_pool_get_array_gpu(atm_input,'pin'     ,pin     )
+ call mpas_pool_get_array_gpu(atm_input,'ozmixm'  ,ozmixm  )
 
  call mpas_pool_get_field(atm_input,'pin'     ,pinField     )
  call mpas_pool_get_field(atm_input,'ozmixm'  ,ozmixmField  )
 
- call mpas_pool_get_array(diag_physics,'sfc_albedo',sfc_albedo)
- call mpas_pool_get_array(diag_physics,'sfc_emiss' ,sfc_emiss )
- call mpas_pool_get_array(diag_physics,'cldfrac'   ,cldfrac   )
- call mpas_pool_get_array(diag_physics,'o3clim'    ,o3clim    )
- call mpas_pool_get_array(diag_physics,'m_hybi'    ,m_hybi    )
- call mpas_pool_get_array(diag_physics,'m_ps'      ,m_ps      )
+ call mpas_pool_get_array_gpu(diag_physics,'sfc_albedo',sfc_albedo)
+ call mpas_pool_get_array_gpu(diag_physics,'sfc_emiss' ,sfc_emiss )
+ call mpas_pool_get_array_gpu(diag_physics,'cldfrac'   ,cldfrac   )
+ call mpas_pool_get_array_gpu(diag_physics,'o3clim'    ,o3clim    )
+ call mpas_pool_get_array_gpu(diag_physics,'m_hybi'    ,m_hybi    )
+ call mpas_pool_get_array_gpu(diag_physics,'m_ps'      ,m_ps      )
 
  call mpas_pool_get_field(diag_physics,'sfc_albedo',sfc_albedoField)
  call mpas_pool_get_field(diag_physics,'sfc_emiss' ,sfc_emissField )
@@ -395,8 +395,14 @@
  call mpas_pool_get_field(diag_physics,'m_hybi'    ,m_hybiField )
  call mpas_pool_get_field(diag_physics,'m_ps'      ,m_psField,time_lev)
 
- if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
-     mpas_cpl%role_is(ROLE_RADIATION)) then
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update host(latCell, lonCell, aerosols, skintemp, snow, &
+    !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
+    !$acc o3clim, m_hybi, m_ps)
+ endif
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+     mpas_cpl%role_includes(ROLE_RADIATION)) then
 
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, latCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, lonCellField, ierr=ierr)
@@ -419,6 +425,12 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, o3climField, ierr=ierr)
 
  end if
+
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+    !$acc update device(latCell, lonCell, aerosols, skintemp, snow, &
+    !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
+    !$acc o3clim, m_hybi, m_ps)
+ endif
 
  if (mpas_cpl%role_includes(ROLE_RADIATION)) then
  do j = jts,jte
@@ -637,6 +649,11 @@
  end select radiation_sw_select
  end if
 
+ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+ !$acc update device(latCell, lonCell, aerosols, skintemp, snow, &
+ !$acc xice, xland, pin, ozmixm, sfc_albedo, sfc_emiss, cldfrac, &
+ !$acc o3clim, m_hybi, m_ps)
+ end if
  end subroutine radiation_sw_from_MPAS
 
 !=================================================================================================================
@@ -678,18 +695,18 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(diag_physics,'coszr'     ,coszr     )
- call mpas_pool_get_array(diag_physics,'gsw'       ,gsw       )
- call mpas_pool_get_array(diag_physics,'swcf'      ,swcf      )
- call mpas_pool_get_array(diag_physics,'swdnb'     ,swdnb     )
- call mpas_pool_get_array(diag_physics,'swdnbc'    ,swdnbc    )
- call mpas_pool_get_array(diag_physics,'swdnt'     ,swdnt     )
- call mpas_pool_get_array(diag_physics,'swdntc'    ,swdntc    )
- call mpas_pool_get_array(diag_physics,'swupb'     ,swupb     )
- call mpas_pool_get_array(diag_physics,'swupbc'    ,swupbc    )
- call mpas_pool_get_array(diag_physics,'swupt'     ,swupt     )
- call mpas_pool_get_array(diag_physics,'swuptc'    ,swuptc    )
- call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
+ call mpas_pool_get_array_gpu(diag_physics,'coszr'     ,coszr     )
+ call mpas_pool_get_array_gpu(diag_physics,'gsw'       ,gsw       )
+ call mpas_pool_get_array_gpu(diag_physics,'swcf'      ,swcf      )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnb'     ,swdnb     )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnbc'    ,swdnbc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swdnt'     ,swdnt     )
+ call mpas_pool_get_array_gpu(diag_physics,'swdntc'    ,swdntc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swupb'     ,swupb     )
+ call mpas_pool_get_array_gpu(diag_physics,'swupbc'    ,swupbc    )
+ call mpas_pool_get_array_gpu(diag_physics,'swupt'     ,swupt     )
+ call mpas_pool_get_array_gpu(diag_physics,'swuptc'    ,swuptc    )
+ call mpas_pool_get_array_gpu(tend_physics,'rthratensw',rthratensw)
 
  call mpas_pool_get_field(diag_physics,'coszr'     ,coszrField     )
  call mpas_pool_get_field(diag_physics,'gsw'       ,gswField       )
@@ -732,8 +749,13 @@
 
  if (transfer_fields) then
 
-    if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
-        mpas_cpl%role_is(ROLE_RADIATION)) then
+    if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+       !$acc update host(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
+       !$acc swupb, swupbc, swupt, swuptc, rthratensw)
+    end if
+
+    if (mpas_cpl%role_includes(ROLE_INTEGRATE) .or. &
+        mpas_cpl%role_includes(ROLE_RADIATION)) then
 
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
@@ -748,6 +770,11 @@
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swuptcField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenswField, ierr=ierr)
 
+    end if
+
+    if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
+       !$acc update device(coszr, gsw, swcf, swdnb, swdnbc, swdnt, swdntc, &
+       !$acc swupb, swupbc, swupt, swuptc, rthratensw)
     end if
 
  end if


### PR DESCRIPTION

This is the 4th PR submitted in a pool of approximately 12 PRs.
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'driver_radiation_sw' subroutine to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. These temporary changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.

Code Execution Status:

1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.
