### PR TITLE
Modified driver_gwdo to run on CPUs during an OpenACC run.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
@@ -150,26 +150,29 @@
 !-----------------------------------------------------------------------------------------------------------------
 
  call mpas_pool_get_config(configs,'config_len_disp',len_disp)
- call mpas_pool_get_array(mesh,'meshDensity',meshDensity)
+ call mpas_pool_get_array_gpu(mesh,'meshDensity',meshDensity)
 
- call mpas_pool_get_array(sfc_input,'oa1'  ,oa1  )
- call mpas_pool_get_array(sfc_input,'oa2'  ,oa2  )
- call mpas_pool_get_array(sfc_input,'oa3'  ,oa3  )
- call mpas_pool_get_array(sfc_input,'oa4'  ,oa4  )
- call mpas_pool_get_array(sfc_input,'ol1'  ,ol1  )
- call mpas_pool_get_array(sfc_input,'ol2'  ,ol2  )
- call mpas_pool_get_array(sfc_input,'ol3'  ,ol3  )
- call mpas_pool_get_array(sfc_input,'ol4'  ,ol4  )
- call mpas_pool_get_array(sfc_input,'con'  ,con  )
- call mpas_pool_get_array(sfc_input,'var2d',var2d)
+ call mpas_pool_get_array_gpu(sfc_input,'oa1'  ,oa1  )
+ call mpas_pool_get_array_gpu(sfc_input,'oa2'  ,oa2  )
+ call mpas_pool_get_array_gpu(sfc_input,'oa3'  ,oa3  )
+ call mpas_pool_get_array_gpu(sfc_input,'oa4'  ,oa4  )
+ call mpas_pool_get_array_gpu(sfc_input,'ol1'  ,ol1  )
+ call mpas_pool_get_array_gpu(sfc_input,'ol2'  ,ol2  )
+ call mpas_pool_get_array_gpu(sfc_input,'ol3'  ,ol3  )
+ call mpas_pool_get_array_gpu(sfc_input,'ol4'  ,ol4  )
+ call mpas_pool_get_array_gpu(sfc_input,'con'  ,con  )
+ call mpas_pool_get_array_gpu(sfc_input,'var2d',var2d)
 
- call mpas_pool_get_array(diag_physics,'kpbl'    ,kpbl    )
- call mpas_pool_get_array(diag_physics,'dusfcg'  ,dusfcg  )
- call mpas_pool_get_array(diag_physics,'dvsfcg'  ,dvsfcg  )
- call mpas_pool_get_array(diag_physics,'dtaux3d' ,dtaux3d )
- call mpas_pool_get_array(diag_physics,'dtauy3d' ,dtauy3d )
- call mpas_pool_get_array(tend_physics,'rublten' ,rublten )
- call mpas_pool_get_array(tend_physics,'rvblten' ,rvblten )
+ call mpas_pool_get_array_gpu(diag_physics,'kpbl'    ,kpbl    )
+ call mpas_pool_get_array_gpu(diag_physics,'dusfcg'  ,dusfcg  )
+ call mpas_pool_get_array_gpu(diag_physics,'dvsfcg'  ,dvsfcg  )
+ call mpas_pool_get_array_gpu(diag_physics,'dtaux3d' ,dtaux3d )
+ call mpas_pool_get_array_gpu(diag_physics,'dtauy3d' ,dtauy3d )
+ call mpas_pool_get_array_gpu(tend_physics,'rublten' ,rublten )
+ call mpas_pool_get_array_gpu(tend_physics,'rvblten' ,rvblten )
+!$acc update host(meshDensity, oa1, oa2, oa3, oa4, ol1, ol2, ol3, ol4, &
+!$acc             con, var2d, kpbl, dusfcg, dvsfcg, dtaux3d, dtauy3d, &
+!$acc             rublten, rvblten)
 
  do j = jts,jte
  do i = its,ite
@@ -232,14 +235,14 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(diag_physics,'dusfcg'  ,dusfcg  )
- call mpas_pool_get_array(diag_physics,'dvsfcg'  ,dvsfcg  )
- call mpas_pool_get_array(diag_physics,'dtaux3d' ,dtaux3d )
- call mpas_pool_get_array(diag_physics,'dtauy3d' ,dtauy3d )
- call mpas_pool_get_array(diag_physics,'rubldiff',rubldiff)
- call mpas_pool_get_array(diag_physics,'rvbldiff',rvbldiff)
- call mpas_pool_get_array(tend_physics,'rublten' ,rublten )
- call mpas_pool_get_array(tend_physics,'rvblten' ,rvblten )
+ call mpas_pool_get_array_gpu(diag_physics,'dusfcg'  ,dusfcg  )
+ call mpas_pool_get_array_gpu(diag_physics,'dvsfcg'  ,dvsfcg  )
+ call mpas_pool_get_array_gpu(diag_physics,'dtaux3d' ,dtaux3d )
+ call mpas_pool_get_array_gpu(diag_physics,'dtauy3d' ,dtauy3d )
+ call mpas_pool_get_array_gpu(diag_physics,'rubldiff',rubldiff)
+ call mpas_pool_get_array_gpu(diag_physics,'rvbldiff',rvbldiff)
+ call mpas_pool_get_array_gpu(tend_physics,'rublten' ,rublten )
+ call mpas_pool_get_array_gpu(tend_physics,'rvblten' ,rvblten )
 
  do j = jts,jte
  do i = its,ite
@@ -260,6 +263,8 @@
  enddo
  enddo
  enddo
+!$acc update device(dusfcg, dvsfcg, dtaux3d, dtauy3d, rubldiff, &
+!$acc               rvbldiff, rublten, rvblten)
 
  end subroutine gwdo_to_MPAS
  


### PR DESCRIPTION

This is the 9th PR submitted in a pool of approximately 12 PRs.
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'driver_gwdo' subroutine to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. These temporary changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.

Code Execution Status:

1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.

