### PR TITLE
Modified update_convection_step1/step2 to run on CPUs during an OpenA…

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -1002,18 +1002,20 @@
  convection_select: select case(convection_scheme)
 
     case ("cu_kain_fritsch")
-      call mpas_pool_get_array(diag_physics,'nca'   ,nca   )
-      call mpas_pool_get_array(diag_physics,'cubot' ,cubot )
-      call mpas_pool_get_array(diag_physics,'cutop' ,cutop )
-      call mpas_pool_get_array(diag_physics,'cuprec',cuprec)
-      call mpas_pool_get_array(diag_physics,'raincv',raincv)
+      call mpas_pool_get_array_gpu(diag_physics,'nca'   ,nca   )
+      call mpas_pool_get_array_gpu(diag_physics,'cubot' ,cubot )
+      call mpas_pool_get_array_gpu(diag_physics,'cutop' ,cutop )
+      call mpas_pool_get_array_gpu(diag_physics,'cuprec',cuprec)
+      call mpas_pool_get_array_gpu(diag_physics,'raincv',raincv)
 
-      call mpas_pool_get_array(tend_physics,'rthcuten',rthcuten)
-      call mpas_pool_get_array(tend_physics,'rqvcuten',rqvcuten)
-      call mpas_pool_get_array(tend_physics,'rqccuten',rqccuten)
-      call mpas_pool_get_array(tend_physics,'rqicuten',rqicuten)
-      call mpas_pool_get_array(tend_physics,'rqrcuten',rqrcuten)
-      call mpas_pool_get_array(tend_physics,'rqscuten',rqscuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rthcuten',rthcuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rqvcuten',rqvcuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rqccuten',rqccuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rqicuten',rqicuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rqrcuten',rqrcuten)
+      call mpas_pool_get_array_gpu(tend_physics,'rqscuten',rqscuten)
+!$acc update host(nca, cubot, cutop, cuprec, raincv, rthcuten, rqvcuten, &
+!$acc             rqccuten, rqicuten, rqrcuten, rqscuten)
 
        do i = its, ite
           !decreases the characteristic time period that convection remains active. When nca_p
@@ -1038,6 +1040,8 @@
              endif
           endif
        enddo
+!$acc update device(nca, cubot, cutop, cuprec, raincv, rthcuten, rqvcuten, &
+!$acc             rqccuten, rqicuten, rqrcuten, rqscuten)
 
     case default
 
@@ -1069,9 +1073,10 @@
 
  call mpas_pool_get_config(configs,'config_bucket_rainc',bucket_rainc)
 
- call mpas_pool_get_array(diag_physics,'i_rainc',i_rainc)
- call mpas_pool_get_array(diag_physics,'cuprec' ,cuprec )
- call mpas_pool_get_array(diag_physics,'rainc'  ,rainc  )
+ call mpas_pool_get_array_gpu(diag_physics,'i_rainc',i_rainc)
+ call mpas_pool_get_array_gpu(diag_physics,'cuprec' ,cuprec )
+ call mpas_pool_get_array_gpu(diag_physics,'rainc'  ,rainc  )
+!$acc update host(i_rainc, cuprec, rainc)
 
 !update the accumulated precipitation at the end of each dynamic time-step:
  do i = its, ite
@@ -1084,6 +1089,7 @@
     endif
  enddo
 
+!$acc update device(i_rainc, cuprec, rainc)
  end subroutine update_convection_step2
 
 !=================================================================================================================


### PR DESCRIPTION
…CC run.

This is the 11th PR submitted in a pool of approximately 12 PRs.
The code changes include appropriate role checks and data transfers to/from CPU and GPU. The code changes allow the 'update_convection_step1' and 'update_convection_step2' subroutines to execute on the CPU while any other dynamics/physics schemes are executing on the GPU. These temporary changes are required to keep track of any intermediate bugs originating as part of the Physics porting efforts. As the physics porting efforts progress, these changes will be removed if the data transfers become redundant.

Code Execution Status:

1. The code compiles and executes successfully on CPU.
2. Code compiles successfully with Dynamics on GPU and Physics on CPU. Code is not executed as the arrays/variables are not yet updated appropriately (will result in NaNs or incorrect answers) in the Physics. The code should be working by the end of all the PRs.


