### PR TITLE
Create Physics variables on the GPU.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -149,15 +149,18 @@
     ht_p,             &!
     psfc_p,           &!surface pressure                                                       [Pa]
     ptop_p             !model-top pressure                                                     [Pa]
+!$acc declare create(psfc_p,ptop_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     fzm_p,            &!weight for interpolation to w points                                    [-]
     fzp_p              !weight for interpolation to w points                                    [-]
+!$acc declare create(fzm_p, fzp_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
 !... arrays related to u- and v-velocities interpolated to theta points:
     u_p,              &!u-velocity interpolated to theta points                               [m/s]
     v_p                !v-velocity interpolated to theta points                               [m/s]
+!$acc declare create(u_p, v_p)
     
 !... arrays related to vertical sounding:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
@@ -172,6 +175,8 @@
     al_p,             &!inverse of air density                                              [m3/kg]
     rho_p,            &!air density                                                         [kg/m3]
     rh_p               !relative humidity                                                       [-]
+!$acc declare create(zz_p, rho_p, th_p, t_p, pi_p, pres_p, z_p, dz_p, &
+!$acc zmid_p,al_p,rh_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     qv_p,             &!water vapor mixing ratio                                            [kg/kg]
@@ -180,17 +185,20 @@
     qi_p,             &!cloud ice mixing ratio                                              [kg/kg]
     qs_p,             &!snow mixing ratio                                                   [kg/kg]
     qg_p               !graupel mixing ratio                                                [kg/kg]
+!$acc declare create(qv_p, qc_p, qr_p, qi_p, qs_p, qg_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     nc_p,             &!
     ni_p,             &!
     nr_p               !
+!$acc declare create(nc_p, ni_p, nr_p)
 
 !... arrays located at w (vertical velocity) points, or at interface between layers:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     w_p,              &!vertical velocity                                                     [m/s]
     pres2_p,          &!pressure                                                               [Pa]
     t2_p               !temperature                                                             [K]
+!$acc declare create(w_p, t2_p, pres2_p)
 
 !... arrays used for calculating the hydrostatic pressure and exner function:
  real(kind=RKIND),dimension(:,:),allocatable:: &
@@ -202,6 +210,8 @@
     pres2_hyd_p,      &!pressure located at w-velocity levels                                  [Pa]
     pres2_hydd_p,     &!"dry" pressure located at w-velocity levels                            [Pa]
     znu_hyd_p          !(pres_hyd_p / P0) needed in the Tiedtke convection scheme              [Pa]
+!$acc declare create(pres2_hyd_p, pres2_hydd_p, pres_hyd_p, pres_hydd_p, &
+!$acc psfc_hyd_p, psfc_hydd_p, znu_hyd_p)
 
 !=================================================================================================================
 !... variables related to ozone climatlogy:
@@ -250,6 +260,8 @@
     graupelnc_p,      &!
     graupelncv_p,     &!
     sr_p
+!$acc declare create(rainnc_p, rainncv_p, snownc_p, snowncv_p, &
+!$acc graupelnc_p, graupelncv_p, sr_p)
 
 !... added for the thompson and wsm6 cloud microphysics:
  integer:: & 
@@ -260,6 +272,7 @@
  real(kind=RKIND),dimension(:,:),allocatable:: &
     ntc_p,            &!
     muc_p              !
+!$acc declare create(muc_p, ntc_p)
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rainprod_p,       &!
     evapprod_p,       &!
@@ -267,6 +280,7 @@
     reice_p,          &!
     resnow_p,         &!
     refl10cm_p         !
+!$acc declare create(rainprod_p, evapprod_p, recloud_p, reice_p, resnow_p)
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of convection:
@@ -286,6 +300,8 @@
     rqvcuten_p,       &!
     rqccuten_p,       &!
     rqicuten_p         !
+!$acc declare create(cu_act_flag,rthcuten_p,rqvcuten_p,rqccuten_p, &
+!$acc rqicuten_p,pratec_p,raincv_p)
 
 !... kain fritsch specific arrays:
  real(kind=RKIND),dimension(:,:),allocatable::   &
@@ -298,14 +314,17 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rqrcuten_p,       &!
     rqscuten_p         !
+!$acc declare create(cubot_p,cutop_p)
 
 !... tiedtke specific arrays:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     znu_p              !
+!$acc declare create(znu_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rucuten_p,        &!
     rvcuten_p          !
+!$acc declare create(rucuten_p,rvcuten_p)
 
 !... grell-freitas specific parameters and arrays:
     integer, parameter:: ishallow  = 1 !shallow convection used with grell scheme.
@@ -328,6 +347,7 @@
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rthraten_p         !
+!$acc declare create(rthraten_p)
 
 !... grell and tiedkte specific arrays:
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
@@ -339,15 +359,18 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rqvften_p,        &!
     rthften_p          !
+!$acc declare create(rqvften_p,rthften_p)
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of pbl:
 !=================================================================================================================
 
  integer:: ysu_pblmix
+!$acc declare create(ysu_pblmix)
 
  integer,dimension(:,:),allocatable:: &
     kpbl_p             !index of PBL top                                                                       [-]
+!$acc declare create(kpbl_p)
 
  real(kind=RKIND),public:: dt_pbl
 
@@ -359,9 +382,12 @@
     wstar_p,          &!
     uoce_p,           &!
     voce_p             !
+!$acc declare create(hpbl_p, delta_p, wstar_p, uoce_p, voce_p, &
+!$acc ctopo_p, ctopo2_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     exch_p             !exchange coefficient                                                                   [-]
+!$acc declare create(exch_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rublten_p,        &!
@@ -370,11 +396,14 @@
     rqvblten_p,       &!
     rqcblten_p,       &!
     rqiblten_p         !
+!$acc declare create(rublten_p, rvblten_p, rthblten_p, rqvblten_p, rqcblten_p, &
+!$acc rqiblten_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     kzh_p,            &!
     kzm_p,            &!
     kzq_p              !
+!$acc declare create(kzh_p, kzm_p, kzq_p)
 
 !... MYNN PBL scheme (module_bl_mynn.F):
  integer,parameter:: grav_settling = 0
@@ -395,6 +424,7 @@
     qshear_p,         &!
     qwt_p,            &!
     tkepbl_p           !
+!$acc declare create(tkepbl_p)
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rniblten_p         !
@@ -406,6 +436,7 @@
  real(kind=RKIND),dimension(:,:),allocatable:: &
     cosa_p,           &!cosine of map rotation                                                                 [-]
     sina_p             !sine of map rotation                                                                   [-]
+!$acc declare create(cosa_p, sina_p)
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
     var2d_p,          &!orographic variance                                                                   [m2]
@@ -418,6 +449,8 @@
     ol2_p,            &!orographic direction asymmetry function                                                [-]
     ol3_p,            &!orographic direction asymmetry function                                                [-]
     ol4_p              !orographic direction asymmetry function                                                [-]
+!$acc declare create(oa1_p,oa2_p,oa3_p,oa4_p,ol1_p,ol2_p, &
+!$acc ol3_p,ol4_p,var2d_p,con_p)
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
     dx_p               !mean distance between cell centers                                                     [m]
@@ -429,6 +462,7 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     dtaux3d_p,        &!gravity wave drag over orography u-stress                                          [m s-1]
     dtauy3d_p          !gravity wave drag over orography u-stress                                          [m s-1]
+!$acc declare create(dx_p,dusfcg_p,dvsfcg_p,dtaux3d_p,dtauy3d_p)
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of surface layer:
@@ -469,11 +503,18 @@
     wspd_p,           &!wind speed                                                                           [m/s]
     znt_p,            &!time-varying roughness length                                                          [m]
     zol_p              !
+!$acc declare create(hfx_p, qfx_p, ust_p, wspd_p, znt_p, &
+!$acc br_p, psih_p, psim_p, regime_p, u10_p, v10_p, cd_p, &
+!$acc cda_p, chs_p, chs2_p, ck_p, cka_p, cpm_p, cqs2_p, &
+!$acc gz1oz0_p, flhc_p, flqc_p, lh_p, mavail_p, &
+!$acc mol_p, q2_p, qgh_p, qsfc_p, rmol_p, t2m_p, th2m_p, &
+!$acc ustm_p, zol_p)
 
 !... arrays only in monin_obukohv (module_sf_sfclay.F):
  real(kind=RKIND),dimension(:,:),allocatable:: &
     fh_p,             &!integrated stability function for heat                                                 [-]
     fm_p               !integrated stability function for momentum                                             [-]
+!$acc declare create(fh_p, fm_p)
 
 !... arrays only in mynn surface layer scheme (module_sf_mynn.F):
  real(kind=RKIND),dimension(:,:),allocatable:: &
@@ -710,6 +751,7 @@
     fvbsnow_p,        &!fraction of vegetation with snow beneath when ua_phys=true                             [-]
     fbursnow_p,       &!fraction of canopy buried when ua_phys=true                                            [-]
     fgsnsnow_p         !fraction of ground snow cover when ua_phys=true                                        [-]
+!$acc declare create(flxsnow_p,fvbsnow_p,fbursnow_p, fgsnsnow_p)
 
 !.. arrays needed in the argument list in the call to the Noah LSM urban parameterization: note that these arrays
 !.. are initialized to zero since we do not run an urban model:
@@ -746,6 +788,7 @@
     sst_p,            &!sea-surface temperature                                                                [K]
     xice_p,           &!ice mask                                                                               [-]
     xland_p            !land mask    (1 for land; 2 for water)                                                 [-]
+!$acc declare create(xland_p, tsk_p, sst_p, xice_p)
 
 !=================================================================================================================
 !.. variables needed for the surface layer scheme and land surface scheme when config_frac_seaice
@@ -761,7 +804,12 @@
 
  real(kind=RKIND),dimension(:,:),allocatable:: regime_hold
  real(kind=RKIND),dimension(:,:),allocatable:: tsk_ice
-
+!$acc declare create(br_sea, chs_sea, chs2_sea, cqs2_sea, cpm_sea, flhc_sea, &
+!$acc flqc_sea, gz1oz0_sea, hfx_sea, qfx_sea, mavail_sea, mol_sea, lh_sea, &
+!$acc psih_sea, psim_sea, qgh_sea, qsfc_sea, regime_sea, rmol_sea, tsk_sea, &
+!$acc ust_sea, ustm_sea, wspd_sea, xland_sea, zol_sea, znt_sea, cd_sea, &
+!$acc cda_sea, ck_sea, cka_sea, t2m_sea, th2m_sea, q2_sea, u10_sea, v10_sea, &
+!$acc regime_hold, fh_sea, fm_sea)
 
  contains
 


### PR DESCRIPTION
This PR includes changes to the 'mpas_atmphys_vars' module in the 'mpas_atmphys_vars.F' file. The common variables used across the physics schemes are declared/created on the GPU using '!$acc declare create'. This is the first step in the process of porting the Physics schemes. 
These changes will allow the GPU code in the Physics schemes to access the Physics global variables. As the physics porting efforts progress, additional variables in the 'mpas_atmphys_vars' module might be declared/created on the GPU.
