### PR TITLE
Add empty mpas_atm_dynamics_init and mpas_atm_dynamics_finalize routines

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -83,6 +83,56 @@ module atm_time_integration
    contains
 
 
+   !----------------------------------------------------------------------------
+   !  routine MPAS_atm_dynamics_init
+   !
+   !> \brief Initialize the dynamics
+   !> \date  28 July 2021
+   !> \details
+   !>  Prepare the dynamics component of MPAS-Atmosphere for time integration.
+   !>  This may involve, for example, allocating dynamics-local storage or
+   !>  initializing data structures used throughout the dynamics. Since this
+   !>  routine is called once before the first integration step, the work done
+   !>  by this routine is generally persistent across all calls to the dynamical
+   !>  core, in contrast to work that is performed at the beginning of each call
+   !>  to the dynamical core.
+   !
+   !----------------------------------------------------------------------------
+   subroutine mpas_atm_dynamics_init(domain)
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+
+
+   end subroutine mpas_atm_dynamics_init
+
+
+   !----------------------------------------------------------------------------
+   !  routine MPAS_atm_dynamics_finalize
+   !
+   !> \brief Finalize the dynamics
+   !> \author Michael Duda
+   !> \date   28 July 2021
+   !> \details
+   !>  Finalizes the dynamics component of MPAS-Atmosphere by, for example,
+   !>  freeing up dynamics-local memory and shut down infrastructure used only
+   !>  in the dynamics component of MPAS-Atmosphere. This routine is called once
+   !>  after the last integration step, and the work done here is usually the
+   !>  inverse of that done in the mpas_atm_dynamics_init routine (e.g.,
+   !>  deallocating memory that was allocated by mpas_atm_dynamics_init).
+   !
+   !----------------------------------------------------------------------------
+   subroutine mpas_atm_dynamics_finalize(domain)
+
+      implicit none
+
+      type (domain_type), intent(inout) :: domain
+
+
+   end subroutine mpas_atm_dynamics_finalize
+
+
    subroutine atm_timestep(domain, dt, nowTime, itimestep)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -26,6 +26,7 @@ module atm_core
       use mpas_atm_dimensions, only : mpas_atm_set_dims
       use mpas_atm_diagnostics_manager, only : mpas_atm_diag_setup
       use mpas_atm_threading, only : mpas_atm_threading_init
+      use atm_time_integration, only : mpas_atm_dynamics_init
 
       implicit none
 
@@ -186,6 +187,11 @@ module atm_core
 
       call mpas_atm_diag_setup(domain % streamManager, domain % blocklist % configs, &
                                domain % blocklist % structs, domain % clock, domain % dminfo)
+
+      !
+      ! Prepare the dynamics for integration
+      !
+      call mpas_atm_dynamics_init(domain)
 
    end function atm_core_init
 
@@ -883,6 +889,7 @@ module atm_core
       use mpas_timekeeping
       use mpas_atm_diagnostics_manager, only : mpas_atm_diag_cleanup
       use mpas_atm_threading, only : mpas_atm_threading_finalize
+      use atm_time_integration, only : mpas_atm_dynamics_finalize
    
 #ifdef DO_PHYSICS
       use mpas_atmphys_finalize
@@ -898,6 +905,11 @@ module atm_core
 
       clock => domain % clock
       mpas_log_info => domain % logInfo
+
+      !
+      ! Finalize the dynamics
+      !
+      call mpas_atm_dynamics_finalize(domain)
 
       call mpas_atm_diag_cleanup()
 


### PR DESCRIPTION
This merge adds empty `mpas_atm_dynamics_init` and `mpas_atm_dynamics_finalize`
routines to the MPAS-Atmosphere core.

The `mpas_atm_dynamics_init` and `mpas_atm_dynamics_finalize` routines provide a way
for data structures and modules that are needed across all MPAS-Atmosphere
dynamics integration steps to be initialized and finalized. Currently these two
routines contain no executable code, but they serve as placeholders.

The `mpas_atm_dynamics_init` routine is called from the `atm_core_init` routine once
before the first dynamics step, and the `mpas_atm_dynamics_finalize` routine is
called from the `atm_core_finalize` routine after the last dynamics step.