### PR TITLE
Switch tend_{ru,rtheta,rho}_physics from local variables to Registry scratch variables

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2896,13 +2896,16 @@
         <var_struct name="tend_physics" time_levs="1">
 
                 <var name="tend_ru_physics" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
-                     description="Total horizontal momentum tendency from physics"/>
+                     description="Total horizontal momentum tendency from physics"
+                     persistence="scratch" />
 
                 <var name="tend_rtheta_physics" type="real" dimensions="nVertLevels nCells Time" units="kg K m^{-3}"
-                     description="Total rho*theta/zz tendency from physics"/>
+                     description="Total rho*theta/zz tendency from physics"
+                     persistence="scratch" />
 
                 <var name="tend_rho_physics" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} s^{-1}"
-                     description="Total dry air tendency from physics"/>
+                     description="Total dry air tendency from physics"
+                     persistence="scratch" />
 
                 <!-- Scratch variables used when propagating cell-centered winds to edges -->
                 <var name="tend_uzonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2891,8 +2891,18 @@
                      description="ocean mixed layer integrated v (meridional velocity)"/>
 
         </var_struct>
+#endif
 
         <var_struct name="tend_physics" time_levs="1">
+
+                <var name="tend_ru_physics" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+                     description="Total horizontal momentum tendency from physics"/>
+
+                <var name="tend_rtheta_physics" type="real" dimensions="nVertLevels nCells Time" units="kg K m^{-3}"
+                     description="Total rho*theta/zz tendency from physics"/>
+
+                <var name="tend_rho_physics" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} s^{-1}"
+                     description="Total dry air tendency from physics"/>
 
                 <!-- Scratch variables used when propagating cell-centered winds to edges -->
                 <var name="tend_uzonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
@@ -2903,6 +2913,7 @@
                      description="Total cell-centered meridional wind tendency from physics"
                      persistence="scratch" />
  
+#ifdef DO_PHYSICS
                 <!-- ================================================================================================== -->
                 <!-- TENDENCIES FROM PARAMETERIZATION OF CONVECTION:                                                    -->
                 <!-- ================================================================================================== -->
@@ -3001,9 +3012,11 @@
 
                 <var name="rthratenlw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="tendency of potential temperature due to long wave radiation"/>
+#endif
         </var_struct>
 
 
+#ifdef DO_PHYSICS
         <var_struct name="atm_input" time_levs="1">
                 <!-- Monthly mean ozone climatology used in the CAM and RRTMG radiation codes -->
                 <var name="pin" type="real"  dimensions="nOznLevels" units="Pa"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -32,7 +32,7 @@ module atm_time_integration
    integer :: timerid, secs, u_secs
 
    ! Used to store physics tendencies for dynamics variables
-   real (kind=RKIND), allocatable, dimension(:,:) :: tend_ru_physics, tend_rtheta_physics, tend_rho_physics
+   real (kind=RKIND), dimension(:,:), pointer :: tend_ru_physics, tend_rtheta_physics, tend_rho_physics
    
    ! Used in compute_dyn_tend
    real (kind=RKIND), allocatable, dimension(:,:) :: qtot 
@@ -300,6 +300,7 @@ module atm_time_integration
       !
       call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'tend_physics', tend_physics)
 
       !
       ! Retrieve fields
@@ -318,11 +319,12 @@ module atm_time_integration
 
       allocate(qtot(nVertLevels,nCells+1))
       qtot(:,nCells+1) = 0.0_RKIND
-      allocate(tend_rtheta_physics(nVertLevels,nCells+1))
+
+      call mpas_pool_get_array(tend_physics, 'tend_rtheta_physics', tend_rtheta_physics)
       tend_rtheta_physics(:,nCells+1) = 0.0_RKIND
-      allocate(tend_rho_physics(nVertLevels,nCells+1))
+      call mpas_pool_get_array(tend_physics, 'tend_rho_physics', tend_rho_physics)
       tend_rho_physics(:,nCells+1) = 0.0_RKIND
-      allocate(tend_ru_physics(nVertLevels,nEdges+1))
+      call mpas_pool_get_array(tend_physics, 'tend_ru_physics', tend_ru_physics)
       tend_ru_physics(:,nEdges+1) = 0.0_RKIND
 
       !
@@ -1282,9 +1284,6 @@ module atm_time_integration
 
 
       deallocate(qtot)  !  we are finished with these now
-      deallocate(tend_rtheta_physics)
-      deallocate(tend_rho_physics)
-      deallocate(tend_ru_physics)
 
       !
       !  split transport, at present RK3

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -104,6 +104,27 @@ module atm_time_integration
 
       type (domain_type), intent(inout) :: domain
 
+#ifdef MPAS_CAM_DYCORE
+      ! Used in allocating scratch fields for physics tendencies
+      type (mpas_pool_type), pointer :: tend_physics
+      type (field2DReal), pointer :: tend_ru_physicsField, tend_rtheta_physicsField, tend_rho_physicsField
+#endif
+
+
+#ifdef MPAS_CAM_DYCORE
+      nullify(tend_physics)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'tend_physics', tend_physics)
+
+      call mpas_pool_get_field(tend_physics, 'tend_rtheta_physics', tend_rtheta_physicsField)
+      call mpas_allocate_scratch_field(tend_rtheta_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_rho_physics', tend_rho_physicsField)
+      call mpas_allocate_scratch_field(tend_rho_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_ru_physics', tend_ru_physicsField)
+      call mpas_allocate_scratch_field(tend_ru_physicsField)
+#endif
+
 
    end subroutine mpas_atm_dynamics_init
 
@@ -129,6 +150,26 @@ module atm_time_integration
 
       type (domain_type), intent(inout) :: domain
 
+#ifdef MPAS_CAM_DYCORE
+      ! Used in allocating scratch fields for physics tendencies
+      type (mpas_pool_type), pointer :: tend_physics
+      type (field2DReal), pointer :: tend_ru_physicsField, tend_rtheta_physicsField, tend_rho_physicsField
+#endif
+
+
+#ifdef MPAS_CAM_DYCORE
+      nullify(tend_physics)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'tend_physics', tend_physics)
+
+      call mpas_pool_get_field(tend_physics, 'tend_rtheta_physics', tend_rtheta_physicsField)
+      call mpas_deallocate_scratch_field(tend_rtheta_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_rho_physics', tend_rho_physicsField)
+      call mpas_deallocate_scratch_field(tend_rho_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_ru_physics', tend_ru_physicsField)
+      call mpas_deallocate_scratch_field(tend_ru_physicsField)
+#endif
 
    end subroutine mpas_atm_dynamics_finalize
 
@@ -276,6 +317,11 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(:,:), pointer :: rqvdynten
 
+#ifndef MPAS_CAM_DYCORE
+      ! Used in allocating scratch fields for physics tendencies
+      type (field2DReal), pointer :: tend_ru_physicsField, tend_rtheta_physicsField, tend_rho_physicsField
+#endif
+
       real (kind=RKIND)  :: time_dyn_step
       logical, parameter :: debug = .false.
 
@@ -319,6 +365,17 @@ module atm_time_integration
 
       allocate(qtot(nVertLevels,nCells+1))
       qtot(:,nCells+1) = 0.0_RKIND
+
+#ifndef MPAS_CAM_DYCORE
+      call mpas_pool_get_field(tend_physics, 'tend_rtheta_physics', tend_rtheta_physicsField)
+      call mpas_allocate_scratch_field(tend_rtheta_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_rho_physics', tend_rho_physicsField)
+      call mpas_allocate_scratch_field(tend_rho_physicsField)
+
+      call mpas_pool_get_field(tend_physics, 'tend_ru_physics', tend_ru_physicsField)
+      call mpas_allocate_scratch_field(tend_ru_physicsField)
+#endif
 
       call mpas_pool_get_array(tend_physics, 'tend_rtheta_physics', tend_rtheta_physics)
       tend_rtheta_physics(:,nCells+1) = 0.0_RKIND
@@ -1284,6 +1341,13 @@ module atm_time_integration
 
 
       deallocate(qtot)  !  we are finished with these now
+
+#ifndef MPAS_CAM_DYCORE
+      call mpas_deallocate_scratch_field(tend_rtheta_physicsField)
+      call mpas_deallocate_scratch_field(tend_rho_physicsField)
+      call mpas_deallocate_scratch_field(tend_ru_physicsField)
+#endif
+
 
       !
       !  split transport, at present RK3


### PR DESCRIPTION
This PR changes the `tend_{ru,rtheta,rho}_physics` variables from local variables
to Registry-defined scratch variables.

The `tend_ru_physics`, `tend_rtheta_physics`, and `tend_rho_physics` variables were
formerly allocatable module variables in the `atm_time_integration` module. When
MPAS-Atmosphere is run as a dycore in CAM, setting these physics tendencies
and having the ability to read/write them from/to restart files would be better
facilitated by having them be defined as Registry variables (and therefore,
having them be accessible from pools).
    
This PR rearranges the preprocessing directives in the `Registry.xml` file
so that the `tend_physics` pool (var_struct) is always defined with the fields
`tend_ru_physics`, `tend_rtheta_physics`, and `tend_rho_physics` (and also `tend_uzonal`
and `tend_umerid`, which were already part of tend_physics and are used by
CAM-MPAS).

In order to allow stand-alone MPAS-Atmosphere to allocate the `tend_ru_physics`,
`tend_rtheta_physics`, and `tend_rho_physics` fields only for the duration of a call
to `atm_srk3` (as was done when these fields were allocatable arrays), the allocation
and deallocation of these fields in the `atm_srk3` routine happens when
`MPAS_CAM_DYCORE` is not defined.
    
When MPAS-Atmosphere is run as a dycore in CAM, the `tend_{ru,rtheta,rho}_physics`
fields need to persist between calls to the dycore, since these fields are set 
in the CAM physics-dynamics coupling layer. When `MPAS_CAM_DYCORE` is defined,
these scratch fields are allocated and deallocated once per run in the 
`mpas_atm_dynamics_init` and `mpas_atm_dynamics_finalize` routines.
    
Note that CAM-MPAS will need to ensure that calls to `mpas_atm_dynamics_init` and 
`mpas_atm_dynamics_finalize` are made at appropriate points in the CAM-MPAS run 
sequence.