### PR TITLE
If MPAS-Atmosphere is run as a CAM dycore, don't zero-out physics tenencies

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -495,12 +495,14 @@ module atm_time_integration
       end do
       call mpas_timer_stop('physics_get_tend')
 #else
+#ifndef MPAS_CAM_DYCORE
       !
       ! If no physics are being used, simply zero-out the physics tendency fields
       !
       tend_ru_physics(:,:) = 0.0_RKIND
       tend_rtheta_physics(:,:) = 0.0_RKIND
       tend_rho_physics(:,:) = 0.0_RKIND
+#endif
 #endif
 
       !


### PR DESCRIPTION
This PR ensures that physics tendencies aren't zeroed-out when MPAS-Atmosphere
is run as a CAM dycore.

Previously, if the `DO_PHYSICS` macro was not defined, we assumed that
MPAS-Atmosphere was running without physics, in which case we set the physics
tendencies `tend_ru_physics`, `tend_rtheta_physics`, and `tend_rho_physics` to zero.

However, if MPAS-Atmosphere is running as a CAM dycore, the `DO_PHYSICS` macro
is not defined (since we don't want to activate any of the stand-alone MPAS-
Atmosphere physics), but we do not want to clear the physics tendency fields,
which are set in the CAM-MPAS dynamics-physics coupling interface.

If MPAS-Atmosphere is running as a CAM dycore, the `MPAS_CAM_DYCORE` will be
defined, so we now only clear physics tendencies if neither `DO_PHYSICS` nor
`MPAS_CAM_DYCORE` are defined.