### PR TITLE
Changed array-handling of u & v to GPU-compatible form in mpas_atm_time_integration.F

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -9305,8 +9305,8 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
 !call to mpas pool get array to get the pointer to the array that needs to be
 !updated on the host
-            call mpas_pool_get_array(state, 'w', w, 2)
-            call mpas_pool_get_array(state, 'u', u, 2)
+            call mpas_pool_get_array_gpu(state, 'w', w, 2)
+            call mpas_pool_get_array_gpu(state, 'u', u, 2)
 
 !add the variables in the "update host" clause below to update the data on host
         !$acc update host(w, &


### PR DESCRIPTION
In the file
```
src/core_atmosphere/dynamics/mpas_atm_time_integration.F
```
the `u` & `w` arrays are used on both the CPU & GPU and need to be handled using the convention
```
   9308             call mpas_pool_get_array_gpu(state, 'w', w, 2)
   9309             call mpas_pool_get_array_gpu(state, 'u', u, 2)
```
This was an oversight inherited from the` 6.x-openacc` branch
```
   8289 !call to mpas pool get array to get the pointer to the array that needs to be
   8290 !updated on the host
   8291             call mpas_pool_get_array(state, 'w', w, 2)
   8292             call mpas_pool_get_array(state, 'u', u, 2)
   8293 
   8294 !add the variables in the "update host" clause below to update the data on host
   8295         !$acc update host(w, &
   8296         !$acc u)
```
and needs to be fixed here. (Note that the line-numbers are different in these two versions of the file).