### PR TITLE
Remove unnecessary nullification of field members in atm_allocate_scalars [atmosphere/cam]

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -485,11 +485,6 @@ module atm_core_interface
          scalarsField(i) % isActive = .true.
          scalarsField(i) % isVarArray = .true.
          scalarsField(i) % isPersistent = .true.
-         nullify(scalarsField(i) % prev)
-         nullify(scalarsField(i) % next)
-         nullify(scalarsField(i) % sendList)
-         nullify(scalarsField(i) % recvList)
-         nullify(scalarsField(i) % copyList)
 
          allocate(scalarsField(i) % constituentNames(num_scalars))
 
@@ -535,11 +530,6 @@ module atm_core_interface
          scalarsField(i) % isActive = .true.
          scalarsField(i) % isVarArray = .true.
          scalarsField(i) % isPersistent = .true.
-         nullify(scalarsField(i) % prev)
-         nullify(scalarsField(i) % next)
-         nullify(scalarsField(i) % sendList)
-         nullify(scalarsField(i) % recvList)
-         nullify(scalarsField(i) % copyList)
 
          allocate(scalarsField(i) % constituentNames(num_scalars))
 


### PR DESCRIPTION
This PR removes unnecessary nullification of field members in the atm_allocate_scalars
routine.

The prev, next, sendList, recvList, and copyList members of all field derived
types are now nullified by default in mpas_field_types.inc, rendering the
nullification of these members in the atm_allocate_scalars routine redundant.