### PR TITLE
Adjusted loop-bounds in module_bl_gwdo.F to prevent illegal index operation.

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
@@ -135,7 +135,7 @@ contains
         if (znu(k).gt.0.6) kpblmax = k + 1
       enddo
    else
-      kpblmax = kte
+      kpblmax = kte - 1
    endif
 !
    do j = jts,jte


### PR DESCRIPTION
In the file
```
src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
```
contrast this loop between the 6.x & 7,x versions
```
569  do k = kts+1,kpblmax-1                               |  do k = kpblmin,kpblmax                                  539
570    do i = its,ite                                          do i = its,ite                                        540
571      if (k .lt. kbl(i)) then                                 if (k .lt. kbl(i)) then                             541
572        rdelks = (prsl(i,k)-prsl(i,k+1)) * delks1(i)            rdelks    = (prsl(i,k)-prsl(i,k+1)) * delks1(i)   542
573        bnv2(i,1) = bnv2(i,1) + bnv2(i,k) * rdelks              bnv2(i,1) = bnv2(i,1) + bnv2(i,k) * rdelks        543
574        usqj(i,1) = usqj(i,1) + usqj(i,k) * rdelks              usqj(i,1) = usqj(i,1) + usqj(i,k) * rdelks        544
575      endif                                                   endif                                               545
576    enddo                                                   enddo                                                 546
577  enddo                                                   enddo                                                   547
```
The `kpblmax` boundary is set here in the 7.x code
```
    133    if(present(p_top) .and. present(znu) .and. present(znw)) then
    134       do k = kts,kte
    135         if (znu(k).gt.0.6) kpblmax = k + 1
    136       enddo
    137    else
    138       kpblmax = kte
    139    endif
```
which could end up with a value of `kte` (or possibly `(kte+1)`).
The array `prsl` is only sized-out to `kte` in the second dimension in the subroutine declaration here
``` 
    280    real, dimension(its:ite,kts:kte)  , intent(in   ) :: prsl, del 
```
so the index operation `prsl(i,k+1)` here
```
    539    do k = kpblmin,kpblmax                                                
    540      do i = its,ite                                                    
    541        if (k .lt. kbl(i)) then
    542          rdelks    = (prsl(i,k)-prsl(i,k+1)) * delks1(i)
```
can be out-of-bounds.