### PR TITLE
Fix lagged radiation time

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -914,6 +914,7 @@ end if
       type (MPAS_TimeInterval_Type) :: xtimeTime
       integer :: s, s_n, s_d
       real (kind=RKIND) :: xtime_s
+      logical :: is_lagged
       integer :: ierr
 
       clock => domain % clock
@@ -930,7 +931,8 @@ end if
 #ifdef DO_PHYSICS
       !proceed with physics if moist_physics is set to true:
       if (moist_physics) then
-         call physics_timetracker(domain, dt, clock, itimestep, xtime_s)
+         is_lagged = (mpas_cpl%role_is(ROLE_INTEGRATE) .or. mpas_cpl%role_is(ROLE_RADIATION))
+         call physics_timetracker(domain, dt, clock, itimestep, xtime_s, is_lagged)
          call physics_driver(domain, itimestep, xtime_s, mpas_cpl, cells_to_rad_handle, cells_from_rad_handle)
       endif
 #endif

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -201,7 +201,7 @@
     !
     ! For timesteps other than the first, we transfer previous radiation tendencies back to integration tasks
     !
-    if ((itimestep > 1) .and. (l_radtsw .or. l_radtlw)) then
+    if ((itimestep > 2) .and. (l_radtsw .or. l_radtlw)) then
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call lagged_driver_radiation_sw(itimestep,block%configs,mesh,state,time_lev,diag_physics, &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -939,9 +939,11 @@
 !local pointers:
  logical,pointer:: config_o3climatology
  character(len=StrKIND),pointer:: radt_sw_scheme
+ real(kind=RKIND),pointer:: dt
 
 !local variables:
  integer:: o3input
+ logical:: is_lagged
  real(kind=RKIND):: radt,xtime_m
 
 !-----------------------------------------------------------------------------------------------------------------
@@ -949,13 +951,37 @@
 
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme      )
+ call mpas_pool_get_config(configs,'config_dt'            ,dt                  )
 
  xtime_m = xtime_s/60.
+
+ is_lagged = (mpas_cpl%role_is(ROLE_INTEGRATE) .or. mpas_cpl%role_is(ROLE_RADIATION))
+
+ if (itimestep == 1 .and. dt_radtsw == dt .and. is_lagged) then
+     ! When running lagged radiation with dt == radt, the 2nd and 3rd timesteps would receive
+     ! SW radiation computed at 1 radt behind.
+     call mpas_log_write('')
+     call mpas_log_write('Lagged radiation with dt==radt is not fully supported.', messageType=MPAS_LOG_WARN)
+     call mpas_log_write('')
+ end if
 
  if (mpas_cpl%role_includes(ROLE_RADIATION)) then
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
 !$OMP SINGLE
+
+!... convert the radiation time_step to minutes:
+ radt = dt_radtsw/60.
+
+!... Adjust effective solar time for lagged radiation
+ if (is_lagged) then
+    if (itimestep == 2) then
+       xtime_m = xtime_m - dt/60. + radt ! Special radiation step after init
+    elseif (itimestep > 2) then
+       xtime_m = xtime_m + radt
+    end if
+ end if
+
 !... calculates solar declination:
 !call radconst(declin,solcon,julday,degrad,dpd)
  call radconst(declin,solcon,curr_julday,degrad,dpd)
@@ -969,10 +995,7 @@
 !call mpas_log_write('     DECLIN      = $r', realArgs=(/declin/))
 !$OMP END SINGLE
 
-!... convert the radiation time_step to minutes:
- radt = dt_radtsw/60.
-
- call mpas_log_write('RUNNING SW RADIATION SCHEME')
+ call mpas_log_write('RUNNING SW RADIATION SCHEME FOR XTIME_M = $r', realArgs=(/xtime_m/))
     
 !call to shortwave radiation scheme:
  radiation_sw_select: select case (trim(radt_sw_scheme))

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -130,13 +130,14 @@
 
 
 !=================================================================================================================
- subroutine physics_timetracker(domain,dt,clock,itimestep,xtime_s)
+ subroutine physics_timetracker(domain,dt,clock,itimestep,xtime_s,radiation_is_lagged)
 !=================================================================================================================
 
 !input arguments:
  integer,intent(in):: itimestep
  real(kind=RKIND),intent(in):: dt
  real(kind=RKIND),intent(in) :: xtime_s
+ logical,intent(in):: radiation_is_lagged
 
 !inout arguments:
  type(MPAS_Clock_type),intent(inout):: clock
@@ -260,6 +261,8 @@
        if(mpas_is_alarm_ringing(clock,radtlwAlarmID,ierr=ierr)) then
           call mpas_reset_clock_alarm(clock,radtlwAlarmID,ierr=ierr)
           l_radtlw = .true.
+       elseif(radiation_is_lagged .and. itimestep==2) then
+          l_radtlw = .true.
        endif
     elseif(config_radtlw_interval == "none") then
        l_radtlw = .true.
@@ -273,6 +276,8 @@
     if(config_radtsw_interval /= "none") then
        if(mpas_is_alarm_ringing(clock,radtswAlarmID,ierr=ierr)) then
           call mpas_reset_clock_alarm(clock,radtswAlarmID,ierr=ierr)
+          l_radtsw = .true.
+       elseif(radiation_is_lagged .and. itimestep==2) then
           l_radtsw = .true.
        endif
     elseif(config_radtsw_interval == "none") then


### PR DESCRIPTION
The original implementation is missing an entire radiation step, and solar zenith angle is a whole 1 radt behind after the first radt. This PR corrects the solar zenith angles by offsetting the xtime going into shortwave radiation driver forward by 1 radt, while adding an extra condition to perform an additional radiation step at +1 dynamic dt.

A shortcoming of this implementation is that when dt and radt are the same, the 2nd and 3rd timesteps would still have the wrong solar zenith angles. Since this use case is extremely rare, a warning message is thrown instead.

![Screen Shot 2021-08-30 at 10 56 11 AM](https://user-images.githubusercontent.com/4195515/131359393-acb829ec-4f1e-4de7-957a-2bc88e5d09e9.png)
