### PR TITLE
Initialize qvb to zero before its first use in init_atm_case_squall_line

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -1652,6 +1652,8 @@ module init_atm_cases
 !
 !    for reference sounding 
 !
+     qvb(:) = 0.0_RKIND
+
      do itr=1,30
 
       pitop = 1.-.5*dzw(1)*gravity*(1.+scalars(index_qv,1,1))/(cp*t(1,1)*zz(1,1))


### PR DESCRIPTION
This PR initializes the qvb array to zero before its first use in the init_atm_case_squall_line
routine.

When computing the reference sounding in the squall line/supercell initialization,
the qvb array was used before it has been given an initial value. A simple zero
initial value for qvb is appropriate (and it's almost certainly what was assumed
by the code).