### PR TITLE
Fix bug in vertical interp of relhum and spechum when levels are given top-to-bottom

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4563,7 +4563,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             relhum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                        sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
          end do
 
 
@@ -4581,7 +4580,6 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
-            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
          end do
 
 


### PR DESCRIPTION
This PR fixes a bug in the vertical extrapolation of relative humidity and
specific humidity to model levels below the lowest first-guess level when
first-guess levels are given in top-to-bottom order in the input intermediate
file.

Prior to the changes in this PR, if first-guess levels were given in
top-to-bottom order, the end result was that the vertically interpolated
relative humidity and specific humidity from the highest model level was copied
downward through all other model levels.