### PR TITLE
Correct check on availability of dtheta_dt_mix when computing depv_dt_mix

### DIFF
--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -1457,7 +1457,7 @@ module pv_diagnostics
                depv_dt_mp(k,iCell) = 0.0_RKIND
             end if
             
-            if (associated(dtheta_dt_mp)) then
+            if (associated(dtheta_dt_mix)) then
                call calc_grad_cell(gradtheta, &
                                 iCell, k, nVertLevels, nEdgesOnCell(iCell), verticesOnCell, kiteAreasOnVertex, &
                                 cellsOnCell, edgesOnCell, cellsOnEdge, dvEdge, edgeNormalVectors, &


### PR DESCRIPTION
This PR corrects a check on the availability of the dtheta_dt_mix variable when
computing depv_dt_mix.

The code to compute depv_dt_mix in the calc_pvBudget routine previously checked
that the dtheta_dt_mp variable had been successfully been retrieved from the
diag pool, when instead the check should have been on the dtheta_dt_mix
variable.

Note that the fix in this PR isn't expected to have any impact in practice,
since both dtheta_dt_mp and dtheta_dt_mix should always be found in the diag
pool.