### PR TITLE
Fix parallel reproducibility error in 'smstav' field

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
@@ -666,12 +666,6 @@ CONTAINS
 !
 !  END FASDAS
 !
-  FLX4  = 0.0 !BSINGH - Initialized to 0.0
-  FVB   = 0.0 !BSINGH - Initialized to 0.0
-  FBUR  = 0.0 !BSINGH - Initialized to 0.0
-  FGSN  = 0.0 !BSINGH - Initialized to 0.0
-  SOILW = 0.0 !BSINGH - Initialized to 0.0
-
   sigma_sb=5.67e-08
 
 ! MEK MAY 2007
@@ -743,6 +737,12 @@ CONTAINS
         SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
 ! convert from mixing ratio to specific humidity
          Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+! initializing local variables
+        SOILW=0.
+        FLX4=0.
+        FVB=0.
+        FBUR=0.
+        FGSN=0.
 !
 !         Q2SAT=QGH(I,j)
          Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
@@ -2962,6 +2962,13 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 !-----------------------------------------------------------------------
       ILOOP : DO I=its,ite
       
+! initializing local variables
+         SOILW = 0.
+         FLX4  = 0.
+         FVB   = 0.
+         FBUR  = 0.
+         FGSN  = 0.
+
          IF (((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
                
                IVGTYP_dominant(I,J)=IVGTYP(I,J)                                   ! save this


### PR DESCRIPTION
This PR fixes reproducibility issues in several fields within the Noah LSM
over land-ice points when running with different MPI task counts; however, only
one of these fields -- smstav, the surface moisture availability field --
persists outside of the physics driver and is written to MPAS-Atmosphere restart
files.

Since the smstav field is a diagnostic, correcting this reproducibility error
has no other effect on model simulations.

The changes in this PR have also been committed to the WRF model
repository.