### PR TITLE
If 'make' is run with no target, extract list of available targets automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 dummy:
 	( $(MAKE) error )
 
-xlf:
+xlf:   # BUILDTARGET IBM XL compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpifort" \
 	"CC_PARALLEL = mpicc" \
@@ -34,7 +34,7 @@ xlf:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-xlf-summit-omp-offload:
+xlf-summit-omp-offload:   # BUILDTARGET IBM XL compilers w/OpenMP offloading on ORNL Summit
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -64,7 +64,7 @@ xlf-summit-omp-offload:
 	"OPENMP_OFFLOAD = $(OPENMP_OFFLOAD)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DFORTRAN_SAME -DCPRIBM -DLINUX" )
 
-ftn:
+ftn:   # BUILDTARGET Cray compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -86,7 +86,7 @@ ftn:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-titan-cray:
+titan-cray:   # BUILDTARGET (deprecated) Cray compilers with options for ORNL Titan
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -105,7 +105,7 @@ titan-cray:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-pgi:
+pgi:   # BUILDTARGET PGI compiler suite
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -132,7 +132,7 @@ pgi:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DCPRPGI" )
 
-pgi-summit:
+pgi-summit:   # BUILDTARGET PGI compiler suite w/OpenACC options for ORNL Summit
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -162,7 +162,7 @@ pgi-summit:
 	"OPENACC = $(OPENACC)" \
 	"CPPFLAGS = -DpgiFortran -D_MPI -DUNDERSCORE" )
 
-pgi-nersc:
+pgi-nersc:   # BUILDTARGET (deprecated) PGI compilers on NERSC machines
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -184,7 +184,7 @@ pgi-nersc:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DCPRPGI" )
 
-pgi-llnl:
+pgi-llnl:   # BUILDTARGET (deprecated) PGI compilers on LLNL machines
 	( $(MAKE) all \
 	"FC_PARALLEL = mpipgf90" \
 	"CC_PARALLEL = pgcc" \
@@ -206,7 +206,7 @@ pgi-llnl:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DCPRPGI" )
 
-ifort:
+ifort:   # BUILDTARGET Intel Fortran, C, and C++ compiler suite
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -233,7 +233,7 @@ ifort:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-ifort-scorep:
+ifort-scorep:   # BUILDTARGET Intel compiler suite with ScoreP profiling library
 	( $(MAKE) all \
 	"FC_PARALLEL = scorep --compiler mpif90" \
 	"CC_PARALLEL = scorep --compiler mpicc" \
@@ -259,7 +259,7 @@ ifort-scorep:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-ifort-gcc:
+ifort-gcc:   # BUILDTARGET Intel Fortran compiler and GNU C/C++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -285,7 +285,7 @@ ifort-gcc:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-intel-mpi:
+intel-mpi:   # BUILDTARGET Intel compiler suite with Intel MPI library
 	( $(MAKE) all \
 	"FC_PARALLEL = mpiifort" \
 	"CC_PARALLEL = mpiicc" \
@@ -312,7 +312,7 @@ intel-mpi:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-gfortran:
+gfortran:   # BUILDTARGET GNU Fortran, C, and C++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -339,7 +339,7 @@ gfortran:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-gfortran-clang:
+gfortran-clang:   # BUILDTARGET GNU Fortran compiler with LLVM clang/clang++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc -cc=clang" \
@@ -365,7 +365,7 @@ gfortran-clang:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-g95:
+g95:   # BUILDTARGET (deprecated) G95 Fortran compiler with GNU C/C++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpif90" \
 	"CC_PARALLEL = mpicc" \
@@ -387,7 +387,7 @@ g95:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-pathscale-nersc:
+pathscale-nersc:   # BUILDTARGET (deprecated) Pathscale compilers on NERSC machines
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -409,7 +409,7 @@ pathscale-nersc:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-cray-nersc:
+cray-nersc:   # BUILDTARGET (deprecated) Cray compilers on NERSC machines
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -431,7 +431,7 @@ cray-nersc:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-gnu-nersc:
+gnu-nersc:   # BUILDTARGET (deprecated) GNU compilers on NERSC machines
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -455,7 +455,7 @@ gnu-nersc:
 	"USE_PAPI = $(USE_PAPI)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI $(FILE_OFFSET) $(ZOLTAN_DEFINE)" )
 
-intel-nersc:
+intel-nersc:   # BUILDTARGET (deprecated) Intel compilers on NERSC machines
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
 	"CC_PARALLEL = cc" \
@@ -481,7 +481,7 @@ intel-nersc:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-bluegene:
+bluegene:   # BUILDTARGET (deprecated) IBM XL compilers on BlueGene/Q systems
 	( $(MAKE) all \
 	"FC_PARALLEL = mpixlf95_r" \
 	"CC_PARALLEL = mpixlc_r" \
@@ -507,7 +507,7 @@ bluegene:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-llvm:
+llvm:   # BUILDTARGET LLVM flang, clang, and clang++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpifort" \
 	"CC_PARALLEL = mpicc" \
@@ -534,7 +534,7 @@ llvm:
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
-nag:
+nag:   # BUILDTARGET NAG Fortran compiler and GNU C/C++ compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpifort" \
 	"CC_PARALLEL = mpicc" \
@@ -1080,11 +1080,8 @@ errmsg:
 	@echo ""
 	@echo "Usage: $(MAKE) target CORE=[core] [options]"
 	@echo ""
-	@echo "Example targets:"
-	@echo "    ifort"
-	@echo "    gfortran"
-	@echo "    xlf"
-	@echo "    pgi"
+	@echo "Available Targets:"
+	@grep BUILDTARGET Makefile | grep -v grep | sed -e 's/#[[:blank:]]*BUILDTARGET[[:blank:]]*/#/' | sed -e 's/:[[:blank:]]*#/:#/' | sed -e 's/://' | awk 'BEGIN {FS="#"}{printf ("    %-15s - %s\n", $$1, $$2)}'
 	@echo ""
 	@echo "Availabe Cores:"
 	@cd src; ls -d core_* | grep ".*" | sed "s/core_/    /g"


### PR DESCRIPTION
This PR enables the top-level Makefile to automatically extract a list of available
targets if 'make' is run with no specified target.

Previously, if 'make' was run with no target, the usage message included an
incomplete list of example targets. To be more helpful, running 'make' with no
options will now automatically extract a list of available build targets from
the Makefile itself.

Available build targets must be identified by adding a comment beginning with
BUILDTARGET on the line of that target; the BUILDTARGET keyword can be followed
by text to describe the applicability or other details of that target.