### PR TITLE
Create common variables across cloudiness and radiation on GPU.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -676,6 +676,7 @@
     qcrad_p,          &!cloud liquid water mixing ratio local to cloudiness and radiation                  [kg/kg]
     qirad_p,          &!cloud ice mixing ratio local to cloudiness and radiation                           [kg/kg]
     qsrad_p            !snow mixing ratio local to cloudiness and radiation                                [kg/kg]
+!$acc declare create(cldfrac_p,qvrad_p,qcrad_p,qirad_p,qsrad_p)
 
 !=================================================================================================================
 !.. variables and arrays related to land-surface parameterization:


### PR DESCRIPTION
In this PR few of the physics variables common to both Cloudiness and Radiation are created on GPU using `!$acc declare create().` 
These variables were missed out in the #912 submission as both cloudiness and radiation were not ported at that time. 
For any future PR layout, #912 and this PR can be used as a single PR.