### PR TITLE
Port of NOAH LSM onto GPUs using OpenACC.

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -389,19 +389,24 @@
  call mpas_pool_get_array_gpu(sfc_input,'smois'     ,smois     )
  call mpas_pool_get_array_gpu(sfc_input,'tslb'      ,tslb      )
 
-!$acc update host(acsnom, acsnow, canwat, chs, chs2, chklowq, cpm, cqs2, glw, grdflx, &
-!$acc             gsw, hfx, lai, lh, noahres, potevp, qfx, qgh, qsfc, br, sfc_albedo, &
-!$acc             sfc_albedo_seaice, sfc_emibck, sfc_emiss, sfcrunoff, smstav, smstot, &
-!$acc             snotime, snopcx, udrunoff, z0, znt, t2m, th2m, q2, isltyp, ivgtyp,  &
-!$acc             shdmin, shdmax, snoalb, sfc_albbck, snow, snowc, snowh, tmn, skintemp, &
-!$acc             vegfra, xice, xland, dzs, sh2o, smcrel, smois, tslb)
+!!!$acc update host(acsnom, acsnow, canwat, chs, chs2, chklowq, cpm, cqs2, glw, grdflx, &
+!!!$acc             gsw, hfx, lai, lh, noahres, potevp, qfx, qgh, qsfc, br, sfc_albedo, &
+!!!$acc             sfc_albedo_seaice, sfc_emibck, sfc_emiss, sfcrunoff, smstav, smstot, &
+!!!$acc             snotime, snopcx, udrunoff, z0, znt, t2m, th2m, q2, isltyp, ivgtyp,  &
+!!!$acc             shdmin, shdmax, snoalb, sfc_albbck, snow, snowc, snowh, tmn, skintemp, &
+!!!$acc             vegfra, xice, xland, dzs, sh2o, smcrel, smois, tslb)
 
 !In Registry.xml, dzs is a function of nCells. In the Noah lsm scheme, dzs is independent
 !of cell locations:
+!$acc parallel vector_length(128)
+!$acc loop gang vector
  do n = 1,num_soils
     dzs_p(n) = dzs(n,its)
  enddo
+!$acc end parallel
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(3)
  do j = jts,jte
  do n = 1,num_soils
  do i = its,ite
@@ -412,7 +417,10 @@
  enddo
  enddo
  enddo
+!$acc end parallel
 
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     acsnom_p(i,j)     = acsnom(i)
@@ -485,8 +493,11 @@
     soldrain_p(i,j)   = 0._RKIND
  enddo
  enddo
+!$acc end parallel
 
  if(config_frac_seaice) then
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        !modify the surface albedo and surface emissivity, and surface temperatures over sea-ice points:
@@ -499,19 +510,25 @@
        endif
     enddo
     enddo
+!$acc end parallel
 
     !calculate sea-surface and sea-ice temperatures over sea-ice grid cells:
     call correct_tsk_over_seaice(ims,ime,jms,jme,its,ite,jts,jte,xice_threshold,xice_p, &
                                  tsk_p,tsk_sea,tsk_ice)
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        tsk_p(i,j) = tsk_ice(i,j)
     enddo
     enddo
+!$acc end parallel
 
     !initialize the surface albedo, the surface albedo over snow-covered seaice, and the
     !seaice thickness.
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        albsi_p(i,j)    = sfc_albedo_seaice(i)
@@ -519,43 +536,57 @@
        snowsi_p(i,j)   = seaice_snowdepth_min
     enddo
     enddo
+!$acc end parallel
  endif
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     sr_p(i,j)     = 0._RKIND
     rainbl_p(i,j) = 0._RKIND
  enddo
  enddo
+!$acc end parallel
 
  if(config_microp_scheme .ne. 'off') then
     call mpas_pool_get_array_gpu(diag_physics,'sr'     ,sr     ) 
     call mpas_pool_get_array_gpu(diag_physics,'rainncv',rainncv)
-!$acc update host(sr, rainncv)
+!!!$acc update host(sr, rainncv)
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        sr_p(i,j) = sr(i)
        rainbl_p(i,j) = rainbl_p(i,j) + rainncv(i)
     enddo
     enddo
+!$acc end parallel
  endif
  if(config_convection_scheme .ne. 'off') then
     call mpas_pool_get_array_gpu(diag_physics,'raincv',raincv)
-!$acc update host(raincv)
+!!!$acc update host(raincv)
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
     do j = jts,jte
     do i = its,ite
        rainbl_p(i,j) = rainbl_p(i,j) + raincv(i)
     enddo
     enddo
+!$acc end parallel
  endif
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     swdown_p(i,j) = gsw(i) / (1._RKIND - sfc_albedo(i))
  enddo
  enddo
+!$acc end parallel
+
 
  end subroutine lsm_from_MPAS
  
@@ -653,6 +684,8 @@
  call mpas_pool_get_array_gpu(sfc_input,'smois'        ,smois     )
  call mpas_pool_get_array_gpu(sfc_input,'tslb'         ,tslb      )
 
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(3)
  do j = jts,jte
  do n = 1,num_soils
  do i = its,ite
@@ -663,7 +696,10 @@
  enddo
  enddo
  enddo
+!$acc end parallel
 
+!$acc parallel vector_length(2)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     acsnom(i)     = acsnom_p(i,j)
@@ -713,9 +749,14 @@
     xland(i)      = xland_p(i,j)
  enddo
  enddo
+!$acc end parallel
 
  if(config_frac_seaice) then
+!$acc update device(chs_sea,chs2_sea,cqs2_sea,cpm_sea,      &
+!$acc        hfx_sea,lh_sea,qfx_sea,qgh_sea,qsfc_sea)
     do j = jts,jte
+!$acc parallel vector_length(128)
+!$acc loop gang vector
     do i = its,ite
        if(xice_p(i,j).ge.xice_threshold .and. xice_p(i,j).le.1._RKIND) then
           chs(i)        = xice_p(i,j)*chs_p(i,j)  + (1._RKIND-xice_p(i,j))*chs_sea(i,j)
@@ -732,6 +773,7 @@
           sfc_emiss(i)  = xice_p(i,j)*sfc_emiss_p(i,j)  + (1._RKIND-xice_p(i,j))*0.98_RKIND
        endif
     enddo
+!$acc end parallel
     enddo
  endif
 
@@ -739,18 +781,21 @@
     call mpas_pool_get_array_gpu(diag_physics,'sr',sr) 
 
     do j = jts,jte
+!$acc parallel vector_length(128)
+!$acc loop gang vector 
     do i = its,ite
        sr(i) = sr_p(i,j)
     enddo
+!$acc end parallel
     enddo
-!$acc update device(sr)
+!!!$acc update device(sr)
  endif
 
-!$acc update device(acsnom, acsnow, canwat, chs, chs2, chklowq, cpm, cqs2, glw, grdflx, gsw, &
-!$acc               hfx, lai, lh, noahres, potevp, qfx, qgh, qsfc, br, raincv, rainncv, sfc_albedo, &
-!$acc               sfc_emibck, sfc_emiss, sfcrunoff, smstav, smstot, snotime, snopcx, udrunoff, z0, &
-!$acc               znt, t2m, th2m, q2, isltyp, ivgtyp, shdmin, shdmax, snoalb, sfc_albbck, snow, &
-!$acc               snowc, snowh, tmn, skintemp, vegfra, xice, xland, sh2o, smcrel, smois, tslb)
+!!!$acc update device(acsnom, acsnow, canwat, chs, chs2, chklowq, cpm, cqs2, glw, grdflx, gsw, &
+!!!$acc               hfx, lai, lh, noahres, potevp, qfx, qgh, qsfc, br, raincv, rainncv, sfc_albedo, &
+!!!$acc               sfc_emibck, sfc_emiss, sfcrunoff, smstav, smstot, snotime, snopcx, udrunoff, z0, &
+!!!$acc               znt, t2m, th2m, q2, isltyp, ivgtyp, shdmin, shdmax, snoalb, sfc_albbck, snow, &
+!!!$acc               snowc, snowh, tmn, skintemp, vegfra, xice, xland, sh2o, smcrel, smois, tslb)
 
  end subroutine lsm_to_MPAS
  
@@ -826,7 +871,7 @@
 
     case("noah")
        call mpas_timer_start('Noah')
-       call lsm( &
+       call lsm_gpu( &
                 dz8w        = dz_p        , p8w3d       = pres2_hyd_p  , t3d       = t_p          , &
                 qv3d        = qv_p        , xland       = xland_p      , xice      = xice_p       , &
                 ivgtyp      = ivgtyp_p    , isltyp      = isltyp_p     , tmn       = tmn_p        , &
@@ -870,7 +915,7 @@
                )
 
        if(config_frac_seaice) then
-          call seaice_noah( &
+          call seaice_noah_gpu( &
                 dz8w      = dz_p        , p8w3d   = pres2_hyd_p  , t3d      = t_p      , &
                 qv3d      = qv_p        , xice    = xice_p       , snoalb2d = snoalb_p , &
                 glw       = glw_p       , swdown  = swdown_p     , rainbl   = rainbl_p , &
@@ -901,7 +946,7 @@
                           )
        endif
 
-       call sfcdiags( &
+       call sfcdiags_gpu( &
                 hfx   = hfx_p  , qfx     = qfx_p   , tsk  = tsk_p , qsfc = qsfc_p , chs = chs_p , &
                 chs2  = chs2_p , cqs2    = cqs2_p  , t2   = t2m_p , th2  = th2m_p , q2  = q2_p  , &
                 psfc  = psfc_p , t3d     = t_p     , qv3d = qv_p  , cp   = cp     , R_d = R_d   , &
@@ -943,6 +988,8 @@
 
 !initialize the local sea-surface temperature and local sea-ice temperature to the local surface
 !temperature:
+!$acc parallel vector_length(128)
+!$acc loop gang vector collapse(2)
  do j = jts,jte
  do i = its,ite
     tsk_sea(i,j) = tsk(i,j)
@@ -959,6 +1006,7 @@
     endif
  enddo
  enddo
+!$acc end parallel
 
  end subroutine correct_tsk_over_seaice
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -752,8 +752,8 @@
 !$acc end parallel
 
  if(config_frac_seaice) then
-!$acc update device(chs_sea,chs2_sea,cqs2_sea,cpm_sea,      &
-!$acc        hfx_sea,lh_sea,qfx_sea,qgh_sea,qsfc_sea)
+!!!$acc update device(chs_sea,chs2_sea,cqs2_sea,cpm_sea,      &
+!!!$acc        hfx_sea,lh_sea,qfx_sea,qgh_sea,qsfc_sea)
     do j = jts,jte
 !$acc parallel vector_length(128)
 !$acc loop gang vector

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
@@ -109,7 +109,7 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(sfc_input,'mminlu'              ,mminlu          )
+ call mpas_pool_get_array_gpu(sfc_input,'mminlu'              ,mminlu          )
  call mpas_pool_get_config(configs,'input_soil_data'      ,mminsl          )
  call mpas_pool_get_config(configs,'config_sfc_snowalbedo',input_sfc_albedo)
  call mpas_pool_get_config(configs,'config_do_restart'    ,restart         )
@@ -117,14 +117,16 @@
  call mpas_pool_get_dimension(mesh,'nCells'     ,nCells     )
  call mpas_pool_get_dimension(mesh,'nSoilLevels',nSoilLevels)
 
- call mpas_pool_get_array(sfc_input,'isltyp', isltyp)
- call mpas_pool_get_array(sfc_input,'ivgtyp', ivgtyp)
- call mpas_pool_get_array(sfc_input,'sh2o'  , sh2o  )
- call mpas_pool_get_array(sfc_input,'smois' , smois )
- call mpas_pool_get_array(sfc_input,'tslb'  , tslb  )
- call mpas_pool_get_array(sfc_input,'snoalb', snoalb)
- call mpas_pool_get_array(sfc_input,'snow'  , snow  )
- call mpas_pool_get_array(sfc_input,'snowh' , snowh )
+ call mpas_pool_get_array_gpu(sfc_input,'isltyp', isltyp)
+ call mpas_pool_get_array_gpu(sfc_input,'ivgtyp', ivgtyp)
+ call mpas_pool_get_array_gpu(sfc_input,'sh2o'  , sh2o  )
+ call mpas_pool_get_array_gpu(sfc_input,'smois' , smois )
+ call mpas_pool_get_array_gpu(sfc_input,'tslb'  , tslb  )
+ call mpas_pool_get_array_gpu(sfc_input,'snoalb', snoalb)
+ call mpas_pool_get_array_gpu(sfc_input,'snow'  , snow  )
+ call mpas_pool_get_array_gpu(sfc_input,'snowh' , snowh )
+
+!$acc update host(mminlu,isltyp,ivgtyp,sh2o,smois,tslb,snoalb,snow,snowh)
 
 !reads the NOAH LSM tables:
  call mpas_log_write('')
@@ -203,6 +205,8 @@
     110 continue
 
  endif
+
+!$acc update device(mminlu,isltyp,ivgtyp,sh2o,smois,tslb,snoalb,snow,snowh)
 
  end subroutine lsminit
 
@@ -548,6 +552,15 @@
 !enddo
 !call mpas_log_write('       end subroutine soil_veg_gen_parm:')
  call mpas_log_write('    end read GENPARM.TBL')
+
+!$acc update device(LUTYPE,LUCATS,SHDTBL,NROTBL,RSTBL,RGLTBL,HSTBL,SNUPTBL,MAXALB, &
+!$acc         LAIMINTBL,LAIMAXTBL,EMISSMINTBL,EMISSMAXTBL,ALBEDOMINTBL,ALBEDOMAXTBL,&
+!$acc         Z0MINTBL,Z0MAXTBL,ZTOPVTBL,ZBOTVTBL,TOPT_DATA,CMCMAX_DATA,CFACTR_DATA,&
+!$acc         RSMAX_DATA,BARE,NATURAL,LOW_DENSITY_RESIDENTIAL,                      &
+!$acc         HIGH_DENSITY_RESIDENTIAL,HIGH_INTENSITY_INDUSTRIAL,SLTYPE,SLCATS,BB,  &
+!$acc         DRYSMC,F11,MAXSMC,REFSMC,SATPSI,SATDK,SATDW,WLTSMC,QTZ,SLPCATS,       &
+!$acc         SLOPE_DATA,SBETA_DATA,FXEXP_DATA,CSOIL_DATA,SALP_DATA,REFDK_DATA,     &
+!$acc         REFKDT_DATA,FRZK_DATA,ZBOT_DATA,CZIL_DATA,SMLOW_DATA,SMHIGH_DATA,LVCOEF_DATA)
 
  end subroutine soil_veg_gen_parm
 

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
@@ -9,9 +9,10 @@ use module_wrf_error
 #define FATAL_ERROR(M) call wrf_error_fatal( M )
 #endif
   use module_sf_noahlsm, only : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, &
-       &                        HSTEP
+       &                        HSTEP, HSTEP_gpu
 
   PUBLIC  SFLX_SEAICE
+  PUBLIC  SFLX_SEAICE_gpu
   PRIVATE CSNOW
   PRIVATE HRTICE
   PRIVATE PENMAN
@@ -541,6 +542,587 @@ CONTAINS
     END SUBROUTINE SFLX_SEAICE
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE SFLX_SEAICE_gpu (ims,ime,its,ite,XICE,XICE_THRESHOLD,         &
+       &                  IILOC, JJLOC, SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, &    !C
+       &                  SEAICE_SNOWDEPTH_OPT, SEAICE_SNOWDEPTH_MAX,      &    !C
+       &                  SEAICE_SNOWDEPTH_MIN,                            &    !C
+       &                  FFROZP,DT,ZLVL,NSOIL,                            &    !C
+       &                  SITHICK,                                         &
+       &                  LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2,               &    !F
+       &                  TH2,Q2SAT,DQSDT2,                                &    !I
+       &                  SNOALB,TBOT, Z0BRD, Z0, EMISSI,                  &    !S
+       &                  T1,STC,SNOWH,SNEQV,ALBEDO, CH,                   &    !H
+       &                  ALBEDOSI, SNOWONSI,                              &
+       &                  ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+       &                  ESNOW,DEW,ETP,SSOIL,FLX1,FLX2,FLX3,              &    !O
+       &                  SNOMLT,SNCOVR,                                   &    !O
+       &                  RUNOFF1,Q1,RIBB)
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SFLX_SEAICE
+! ----------------------------------------------------------------------
+! SUB-DRIVER FOR "Noah LSM" FAMILY OF PHYSICS SUBROUTINES FOR A SEA-ICE
+! LAND-SURFACE MODEL TO UPDATE ICE TEMPERATURE, SKIN TEMPERATURE,
+! SNOWPACK WATER CONTENT, SNOWDEPTH, AND ALL TERMS OF THE SURFACE ENERGY
+! BALANCE (EXCLUDING INPUT ATMOSPHERIC FORCINGS OF DOWNWARD RADIATION
+! AND PRECIP)
+! ----------------------------------------------------------------------
+! SFLX_SEAICE ARGUMENT LIST KEY:
+! ----------------------------------------------------------------------
+!  C  CONFIGURATION INFORMATION
+!  F  FORCING DATA
+!  I  OTHER (INPUT) FORCING DATA
+!  S  SURFACE CHARACTERISTICS
+!  H  HISTORY (STATE) VARIABLES
+!  O  OUTPUT VARIABLES
+!  D  DIAGNOSTIC OUTPUT
+! ----------------------------------------------------------------------
+! 1. CONFIGURATION INFORMATION (C):
+! ----------------------------------------------------------------------
+!   DT         TIMESTEP (SEC) (DT SHOULD NOT EXCEED 3600 SECS, RECOMMEND
+!                1800 SECS OR LESS)
+!   ZLVL       HEIGHT (M) ABOVE GROUND OF ATMOSPHERIC FORCING VARIABLES
+!   NSOIL      NUMBER OF SOIL LAYERS (AT LEAST 2, AND NOT GREATER THAN
+!                PARAMETER NSOLD SET BELOW)
+! ----------------------------------------------------------------------
+! 3. FORCING DATA (F):
+! ----------------------------------------------------------------------
+!   LWDN       LW DOWNWARD RADIATION (W M-2; POSITIVE, NOT NET LONGWAVE)
+!   SOLNET     NET DOWNWARD SOLAR RADIATION ((W M-2; POSITIVE)
+!   SFCPRS     PRESSURE AT HEIGHT ZLVL ABOVE GROUND (PASCALS)
+!   PRCP       PRECIP RATE (KG M-2 S-1) (NOTE, THIS IS A RATE)
+!   SFCTMP     AIR TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   TH2        AIR POTENTIAL TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   Q2         MIXING RATIO AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   FFROZP     FRACTION OF FROZEN PRECIPITATION
+! ----------------------------------------------------------------------
+! 4. OTHER FORCING (INPUT) DATA (I):
+! ----------------------------------------------------------------------
+!   Q2SAT      SAT SPECIFIC HUMIDITY AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   DQSDT2     SLOPE OF SAT SPECIFIC HUMIDITY CURVE AT T=SFCTMP
+!                (KG KG-1 K-1)
+! ----------------------------------------------------------------------
+! 5. CANOPY/SOIL CHARACTERISTICS (S):
+! ----------------------------------------------------------------------
+!   SNOALB     UPPER BOUND ON MAXIMUM ALBEDO OVER DEEP SNOW (E.G. FROM
+!                ROBINSON AND KUKLA, 1985, J. CLIM. & APPL. METEOR.)
+!   TBOT       BOTTOM SOIL TEMPERATURE (LOCAL YEARLY-MEAN SFC AIR
+!                TEMPERATURE)
+!   Z0BRD      Background fixed roughness length (M)
+!   Z0         Time varying roughness length (M) as function of snow depth
+!
+!   EMISSI     Surface emissivity (between 0 and 1)
+! ----------------------------------------------------------------------
+! 6. HISTORY (STATE) VARIABLES (H):
+! ----------------------------------------------------------------------
+!  T1          GROUND/CANOPY/SNOWPACK) EFFECTIVE SKIN TEMPERATURE (K)
+!  STC(NSOIL)  SOIL TEMP (K)
+!  SNOWH       ACTUAL SNOW DEPTH (M)
+!  SNEQV       LIQUID WATER-EQUIVALENT SNOW DEPTH (M)
+!                NOTE: SNOW DENSITY = SNEQV/SNOWH
+!  ALBEDO      SURFACE ALBEDO
+!  CH          SURFACE EXCHANGE COEFFICIENT FOR HEAT AND MOISTURE
+!                (M S-1); NOTE: CH IS TECHNICALLY A CONDUCTANCE SINCE
+!                IT HAS BEEN MULTIPLIED BY WIND SPEED.
+! ----------------------------------------------------------------------
+! 7. OUTPUT (O):
+! ----------------------------------------------------------------------
+! OUTPUT VARIABLES NECESSARY FOR A COUPLED NWP MODEL.  FOR THIS APPLICATION,
+! THE REMAINING OUTPUT/DIAGNOSTIC/PARAMETER BLOCKS BELOW ARE NOT
+! NECESSARY.  OTHER APPLICATIONS MAY REQUIRE DIFFERENT OUTPUT VARIABLES.
+!   ETA        ACTUAL LATENT HEAT FLUX (W m-2: NEGATIVE, IF UP FROM
+!              SURFACE)
+!  ETA_KINEMATIC actual latent heat flux in Kg m-2 s-1
+!   SHEAT      SENSIBLE HEAT FLUX (W M-2: NEGATIVE, IF UPWARD FROM
+!              SURFACE)
+!   FDOWN      Radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+! ----------------------------------------------------------------------
+!   ESNOW      SUBLIMATION FROM (OR DEPOSITION TO IF <0) SNOWPACK (W m-2)
+!   DEW        DEWFALL (OR FROSTFALL FOR T<273.15) (M)
+! ----------------------------------------------------------------------
+!   ETP        POTENTIAL EVAPORATION (W m-2)
+!   SSOIL      SOIL HEAT FLUX (W M-2: NEGATIVE IF DOWNWARD FROM SURFACE)
+! ----------------------------------------------------------------------
+!   FLX1       PRECIP-SNOW SFC (W M-2)
+!   FLX2       FREEZING RAIN LATENT HEAT FLUX (W M-2)
+!   FLX3       PHASE-CHANGE HEAT FLUX FROM SNOWMELT (W M-2)
+! ----------------------------------------------------------------------
+!   SNOMLT     SNOW MELT (M) (WATER EQUIVALENT)
+!   SNCOVR     FRACTIONAL SNOW COVER (UNITLESS FRACTION, 0-1)
+! ----------------------------------------------------------------------
+!   RUNOFF1    SURFACE RUNOFF (M S-1), NOT INFILTRATING THE SURFACE
+! ----------------------------------------------------------------------
+! 8. DIAGNOSTIC OUTPUT (D):
+! ----------------------------------------------------------------------
+!   Q1         Effective mixing ratio at surface (kg kg-1), used for
+!              diagnosing the mixing ratio at 2 meter for coupled model
+!  Documentation SNOABL2 ?????
+!  What categories of arguments do these variables fall into ????
+!  Documentation for RIBB ?????
+!  What category of argument does RIBB fall into ?????
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+! ----------------------------------------------------------------------
+      integer, intent(in) :: ims,ime,IILOC,JJLOC,ITS,ITE
+      REAL, DIMENSION ( ims:ime ), INTENT(IN) :: XICE
+      REAL   , INTENT (IN)      :: XICE_THRESHOLD
+      INTEGER, INTENT(IN) :: SEAICE_ALBEDO_OPT
+      REAL,    INTENT(IN) :: SEAICE_ALBEDO_DEFAULT
+      INTEGER, INTENT(IN) :: SEAICE_SNOWDEPTH_OPT
+      REAL,    INTENT(IN) :: SEAICE_SNOWDEPTH_MAX
+      REAL,    INTENT(IN) :: SEAICE_SNOWDEPTH_MIN
+
+      LOGICAL, DIMENSION( ims:ime )  ::  FRZGRA, SNOWNG
+
+      INTEGER,INTENT(IN) ::  NSOIL
+
+      REAL, INTENT(IN)   :: DT,                   &
+                            TBOT
+      REAL, DIMENSION( ims:ime ), INTENT(IN) :: FFROZP,ZLVL,LWDN,SOLNET,   &
+                            SFCPRS,PRCP,SFCTMP,Q2,TH2,Q2SAT,DQSDT2,SNOALB, &
+                            ALBEDOSI
+      REAL, DIMENSION( ims:ime ), INTENT(OUT)  :: ALBEDO
+      REAL, DIMENSION( ims:ime ), INTENT(INOUT):: SNCOVR
+      REAL, DIMENSION( ims:ime ), INTENT(INOUT) :: Z0BRD,EMISSI,T1,SNOWH,  &
+                            SNEQV,CH
+      REAL, DIMENSION( ims:ime ), INTENT(IN)   :: SNOWONSI
+      REAL, DIMENSION( ims:ime ), INTENT(IN)   :: SITHICK
+      REAL, DIMENSION( ims:ime ), INTENT(INOUT):: RIBB
+      REAL, DIMENSION(1:NSOIL, ims:ime ), INTENT(INOUT) ::  STC
+      REAL, DIMENSION(1:NSOIL, ims:ime )::   ZSOIL
+
+      REAL, DIMENSION( ims:ime ), INTENT(OUT) :: Z0,ETA,SHEAT,ETA_KINEMATIC,&
+                            FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,FLX2,FLX3,SNOMLT,&
+                            RUNOFF1,Q1
+      REAL :: TH2V,TSNOW
+      REAL, DIMENSION( ims:ime ) :: SNDENS,SNCOND,SN_NEW,DF1,DSOIL,DTOT,    &
+              FRCSNO,FRCSOI,DF1A,T2V,T24,RCH,RR
+
+      REAL :: RHO
+      INTEGER  :: KZ, K, I
+
+      REAL :: ALB_SNOW
+      REAL :: ALB_ICE
+      REAL :: Z0N
+      REAL :: SNCOVRR
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - PARAMETERS
+! ----------------------------------------------------------------------
+
+      REAL, PARAMETER :: LVH2O = 2.501E+6
+      REAL, PARAMETER :: LSUBS = 2.83E+6
+      REAL, PARAMETER :: R = 287.04
+
+      ILOC = IILOC
+      JLOC = JJLOC
+
+!!!$acc update device(XICE,FFROZP,ZLVL,LWDN,SOLNET,SFCPRS,PRCP,      &
+!!!$acc               SFCTMP,Q2,TH2,Q2SAT,DQSDT2,SNOALB,ALBEDOSI,    &
+!!!$acc               ALBEDO,SNCOVR,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,  &
+!!!$acc               SNOWONSI,SITHICK,RIBB,STC,Z0,ETA,SHEAT,        &
+!!!$acc               ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,  &
+!!!$acc               FLX2,FLX3,SNOMLT,RUNOFF1,Q1)
+
+!$acc data present(XICE,FFROZP,ZLVL,LWDN,SOLNET,SFCPRS,PRCP,       &
+!$acc               SFCTMP,Q2,TH2,Q2SAT,DQSDT2,SNOALB,ALBEDOSI,    &
+!$acc               ALBEDO,SNCOVR,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,  &
+!$acc               SNOWONSI,SITHICK,RIBB,STC,Z0,ETA,SHEAT,        &
+!$acc               ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,  &
+!$acc               FLX2,FLX3,SNOMLT,RUNOFF1,Q1) &
+!$acc      create(SNDENS,SNCOND,SN_NEW,DF1,DSOIL,DTOT,FRZGRA,SNOWNG, &
+!$acc             FRCSNO,FRCSOI,DF1A,T2V,T24,RCH,RR,ZSOIL)
+
+! ----------------------------------------------------------------------
+!   INITIALIZATION
+! ----------------------------------------------------------------------
+
+!!!      RUNOFF1 = 0.0
+!!!      SNOMLT = 0.0
+
+! ----------------------------------------------------------------------
+! SEA-ICE LAYERS ARE EQUAL THICKNESS AND SUM TO <SITHICK> METERS
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+      DO I = ITS,ITE
+         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            RUNOFF1(I) = 0.0
+            SNOMLT(I) = 0.0
+            DO KZ = 1,NSOIL
+               ZSOIL (KZ,I) = -SITHICK(I) * FLOAT (KZ) / FLOAT (NSOIL)
+            END DO
+
+! ----------------------------------------------------------------------
+
+            Z0BRD(I) = 0.001 
+!      ALB = 0.82  ! Arctic pre-melt spring and post-melt autumn
+!      ALB = 0.80  ! Antarctica
+!      ALB = 0.50  ! Arctic mid-summer (ice and melt ponds)
+!      ALB = 0.65  ! Arctic bare ice with no snow and no melt ponds
+
+! ----------------------------------------------------------------------
+!  INITIALIZE PRECIPITATION LOGICALS.
+! ----------------------------------------------------------------------
+
+            SNOWNG(I) = .FALSE.
+            FRZGRA(I) = .FALSE.
+
+! ----------------------------------------------------------------------
+! OVER SEA-ICE, IF S.W.E. (SNEQV) BELOW THRESHOLD LOWER
+! BOUND (0.01 M FOR SEA-ICE, 0.10 M FOR GLACIAL-ICE), THEN SET AT LOWER
+! BOUND
+! ----------------------------------------------------------------------
+! FOR SEA-ICE CASE, ASSIGN DEFAULT WATER-EQUIV SNOW ON TOP
+! ----------------------------------------------------------------------
+
+            SELECT CASE ( SEAICE_ALBEDO_OPT )
+
+            CASE DEFAULT
+
+               IF ( SNEQV(I) < 0.01 ) THEN
+                  SNEQV(I) = 0.01
+                  SNOWH(I) = 0.05
+               ENDIF
+
+            CASE ( 1 ) ! Arctic sea-ice albedo from Mills (2011)
+
+               IF ( SNEQV(I) < 0.0001 ) THEN
+                  SNEQV(I) = 0.0001
+                  SNOWH(I) = 0.0005
+               ENDIF
+
+            END SELECT
+
+
+            IF ( SEAICE_SNOWDEPTH_OPT == 0 ) THEN
+
+          !
+          ! Enforce bounds on snow depth, maintaining original snow density.
+          !
+
+               SNDENS(I) = SNEQV(I) / SNOWH(I)
+               SNOWH(I) = MAX ( SEAICE_SNOWDEPTH_MIN , MIN ( SNOWH(I) , SEAICE_SNOWDEPTH_MAX ) )
+               SNEQV(I) = SNOWH(I) * SNDENS(I)
+
+            ELSEIF ( SEAICE_SNOWDEPTH_OPT == 1 ) THEN
+
+          !
+          ! Regardless of the assignments above, we want to enforce
+          ! a specified snow depth and density on sea ice.
+          !
+
+               SNDENS(I) = 0.3
+               SNOWH(I) = SNOWONSI(I)
+               SNEQV(I) = SNOWH(I) * SNDENS(I)
+            ENDIF
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! IF INPUT SNOWPACK IS NONZERO, THEN COMPUTE SNOW DENSITY "SNDENS" AND
+! SNOW THERMAL CONDUCTIVITY "SNCOND"
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            SNDENS(I) = SNEQV(I) / SNOWH(I)
+            IF(SNDENS(I) > 1.0) THEN
+!!!               FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
+            ENDIF
+            CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+
+! ----------------------------------------------------------------------
+! DETERMINE IF IT'S PRECIPITATING AND WHAT KIND OF PRECIP IT IS.
+! IF IT'S PRCPING AND THE AIR TEMP IS COLDER THAN 0 C, IT'S SNOWING!
+! IF IT'S PRCPING AND THE AIR TEMP IS WARMER THAN 0 C, BUT THE GRND
+! TEMP IS COLDER THAN 0 C, FREEZING RAIN IS PRESUMED TO BE FALLING.
+! ----------------------------------------------------------------------
+
+            IF (PRCP(I) > 0.0) THEN
+! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+! passed in from model microphysics.
+               IF (FFROZP(I) .GT. 0.5) THEN
+                  SNOWNG(I) = .TRUE.
+               ELSE
+                  IF (T1(I) <= TFREEZ) FRZGRA(I) = .TRUE.
+               END IF
+            END IF
+
+! ----------------------------------------------------------------------
+! IF EITHER PRCP FLAG IS SET, DETERMINE NEW SNOWFALL (CONVERTING PRCP
+! RATE FROM KG M-2 S-1 TO A LIQUID EQUIV SNOW DEPTH IN METERS) AND ADD
+! IT TO THE EXISTING SNOWPACK.
+! ----------------------------------------------------------------------
+
+            IF ( SNOWNG(I) .OR. FRZGRA(I) ) THEN
+               SN_NEW(I) = PRCP(I) * DT * 0.001
+               SNEQV(I) = SNEQV(I) + SN_NEW(I)
+
+! ----------------------------------------------------------------------
+! UPDATE SNOW DENSITY BASED ON NEW SNOWFALL, USING OLD AND NEW SNOW.
+! UPDATE SNOW THERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+
+               CALL SNOW_NEW_gpu ( SFCTMP(I) , SN_NEW(I) , SNOWH(I) , SNDENS(I) )
+         !
+         ! kmh 09/04/2006 set Snow Density at 0.2 g/cm**3
+         ! for "cold permanent ice" or new "dry" snow
+         !
+               IF ( SNCOVR(I) .GT. 0.99 ) THEN
+            !
+            !  if soil temperature less than 268.15 K, treat as typical 
+            !  Antarctic/Greenland snow firn
+            !
+                  IF ( STC(1,I) .LT. (TFREEZ - 5.) ) SNDENS(I) = 0.2
+                  IF ( SNOWNG(I) .AND. (T1(I).LT.273.) .AND. (SFCTMP(I).LT.273.) ) SNDENS(I)=0.2
+               ENDIF
+
+               CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+
+            END IF
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! ALBEDO OF SEA ICE
+! ----------------------------------------------------------------------
+ 
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector private(ALB_SNOW,ALB_ICE,Z0N,SNCOVRR)     
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            SELECT CASE ( SEAICE_ALBEDO_OPT )
+
+            CASE DEFAULT
+ 
+               SNCOVR(I) = 1.0
+               EMISSI(I) = 0.98
+               ALBEDO(I) = SEAICE_ALBEDO_DEFAULT
+!        ALBEDO = 0.82  ! Arctic pre-melt spring and post-melt autumn
+!        ALBEDO = 0.80  ! Antarctica
+!        ALBEDO = 0.50  ! Arctic mid-summer (ice and melt ponds)
+!        ALBEDO = 0.65  ! Arctic bare ice with no snow and no melt ponds
+
+            CASE ( 1 ) ! Arctic sea-ice albedo from Mills (2011)
+
+         !
+         ! Make albedo of snow on sea-ice a function of skin temperature:
+         !
+               IF (T1(I) < 268.15) THEN
+                  ALB_SNOW = 0.8
+               ELSEIF ( ( T1(I) >= 268.15 ) .AND. ( T1(I) < 273.15 ) ) then
+                  ALB_SNOW = 0.65 - ( 0.03 * (T1(I) - 273.15) )
+               ELSE
+                  ALB_SNOW = 0.65
+               ENDIF
+
+         !
+         ! Make albedo of snow-free sea-ice a function of air temperature
+         !
+               IF ( SFCTMP(I) <= 273.15 ) THEN
+                  ALB_ICE = 0.65
+               ELSEIF ( ( SFCTMP(I) > 273.15 ) .and. ( SFCTMP(I) < 278.15 ) ) THEN
+                  ALB_ICE = 0.65 - ( 0.04 * (SFCTMP(I) - 273.15) )
+               ELSE
+                  ALB_ICE = 0.45
+               ENDIF
+
+         !
+         ! Define a snow-cover fraction for use only with Mills sea-ice albedo
+         !
+               Z0N = 0.10 ! Approximate roughness length of snow-covered surface
+               SNCOVRR = SNOWH(I) / ( SNOWH(I) + Z0N )
+
+         !
+         ! Final albedo over sea-ice point is a combination of the snow 
+         ! albedo and the snow-free ice albedo, weighted by the snow cover.
+         !
+               ALBEDO(I) = (SNCOVRR * ALB_SNOW ) + ( ( 1.0 - SNCOVRR) * ALB_ICE )
+
+            CASE ( 2 ) ! Seaice albedo from 2d field
+
+               SNCOVR(I) = 1.0
+               EMISSI(I) = 0.98
+               ALBEDO(I) = ALBEDOSI(I)
+
+            END SELECT
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! THERMAL CONDUCTIVITY FOR SEA-ICE CASE
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector private(RHO)
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            DF1(I) = 2.2
+ 
+            DSOIL(I) = - (0.5 * ZSOIL (1,I))
+
+            DTOT(I) = SNOWH(I) + DSOIL(I)
+            FRCSNO(I) = SNOWH(I) / DTOT(I)
+
+! 1. HARMONIC MEAN (SERIES FLOW)
+!        DF1(I) = (SNCOND(I)*DF1(I))/(FRCSOI(I)*SNCOND(I)+FRCSNO(I)*DF1(I))
+            FRCSOI(I) = DSOIL(I) / DTOT(I)
+! 2. ARITHMETIC MEAN (PARALLEL FLOW)
+!        DF1(I) = FRCSNO(I)*SNCOND(I) + FRCSOI(I)*DF1(I)
+
+! 3. GEOMETRIC MEAN (INTERMEDIATE BETWEEN HARMONIC AND ARITHMETIC MEAN)
+!        DF1(I) = (SNCOND(I)**FRCSNO(I))*(DF1(I)**FRCSOI(I))
+! weigh DF by snow fraction
+            DF1A(I) = FRCSNO(I) * SNCOND(I) + FRCSOI(I) * DF1(I)
+
+! ----------------------------------------------------------------------
+! CALCULATE SUBSURFACE HEAT FLUX, SSOIL, FROM FINAL THERMAL DIFFUSIVITY
+! OF SURFACE MEDIUMS, DF1 ABOVE, AND SKIN TEMPERATURE AND TOP
+! MID-LAYER SOIL TEMPERATURE
+! ----------------------------------------------------------------------
+            DF1(I) = DF1A(I) * SNCOVR(I) + DF1(I) * ( 1.0 - SNCOVR(I) )
+      
+            SSOIL(I) = DF1(I) * ( T1(I) - STC(1,I) ) / DTOT(I)
+
+! ----------------------------------------------------------------------
+! DETERMINE SURFACE ROUGHNESS OVER SNOWPACK USING SNOW CONDITION FROM
+! THE PREVIOUS TIMESTEP.
+! ----------------------------------------------------------------------
+
+            CALL SNOWZ0_gpu (SNCOVR(I),Z0(I),Z0BRD(I),SNOWH(I))
+
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL DOWNWARD RADIATION (SOLAR PLUS LONGWAVE) NEEDED IN
+! PENMAN EP SUBROUTINE THAT FOLLOWS
+! ----------------------------------------------------------------------
+            FDOWN(I) =  SOLNET(I) + LWDN(I)
+! ----------------------------------------------------------------------
+! CALC VIRTUAL TEMPS AND VIRTUAL POTENTIAL TEMPS NEEDED BY SUBROUTINES
+! PENMAN.
+! ----------------------------------------------------------------------
+            T2V(I) = SFCTMP(I) * (1.0+ 0.61 * Q2(I) )
+            T24(I) = SFCTMP(I) * SFCTMP(I) * SFCTMP(I) * SFCTMP(I)
+            RHO = SFCPRS(I) / ( RD * T2V(I) )
+      ! RCH = RHO * CP * CH
+            RCH(I) = RHO * 1004.6 * CH(I)  ! CP is defined different in subroutine PENMAN.
+                               ! Pulling this computation out of PENMAN changed
+                               ! the results.  So I'm hard-coding the PENMAN
+                               ! value here, but perhaps this should go back
+                               ! into PENMAN for now.
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! CALL PENMAN SUBROUTINE TO CALCULATE POTENTIAL EVAPORATION (ETP), AND
+! OTHER PARTIAL PRODUCTS AND SUMS FOR LATER CALCULATIONS.
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector 
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            CALL PENMAN_gpu (SFCTMP(I),SFCPRS(I),CH(I),TH2(I),PRCP(I),FDOWN(I),T24(I),SSOIL(I),     &
+                 Q2(I),Q2SAT(I),ETP(I),RCH(I),RR(I),SNOWNG(I),FRZGRA(I),                     &
+                 DQSDT2(I),FLX2(I),EMISSI(I),T1(I))
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            ESNOW(I) = 0.0
+            CALL SNOPAC_gpu (ETP(I),ETA(I),PRCP(I),SNOWNG(I),                    &
+                 NSOIL,DT,DF1(I),                                   &
+                 Q2(I),T1(I),SFCTMP(I),T24(I),TH2(I),FDOWN(I),SSOIL(I),STC(1:NSOIL,I),           &
+                 SFCPRS(I),RCH(I),RR(I),SNCOVR(I),SNEQV(I),SNDENS(I),              &
+                 SNOWH(I),ZSOIL(1:NSOIL,I),TBOT,                               &
+                 SNOMLT(I),DEW(I),FLX1(I),FLX2(I),FLX3(I),ESNOW(I),EMISSI(I),RIBB(I),    &
+                 SEAICE_ALBEDO_OPT)
+!     ETA_KINEMATIC(I) =  ESNOW(I)
+            ETA_KINEMATIC(I) =  ETP(I)
+!!!         ENDIF
+!!!      ENDDO
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!      DO I = ITS,ITE
+!!!         IF ( XICE(I) >= XICE_THRESHOLD ) THEN
+            IF ( SEAICE_SNOWDEPTH_OPT == 0 ) THEN
+
+          !
+          ! Set bounds on snow depth, maintaining snow density.
+          !
+               SNDENS(I) = SNEQV(I) / SNOWH(I)
+               SNOWH(I) = MAX ( SEAICE_SNOWDEPTH_MIN , MIN ( SNOWH(I) , SEAICE_SNOWDEPTH_MAX ) )
+               SNEQV(I) = SNOWH(I) * SNDENS(I)
+
+            ELSEIF ( SEAICE_SNOWDEPTH_OPT == 1 ) THEN
+
+          !
+          ! Regardless of the results of snopac, we want to enforce
+          ! a specified snow depth and density on sea ice.
+          !
+               SNDENS(I) = 0.3
+               SNOWH(I) = SNOWONSI(I)
+               SNEQV(I) = SNOWH(I) * SNDENS(I)
+            ENDIF
+
+!     Calculate effective mixing ratio at ground level (skin)
+            Q1(I)=Q2(I)+ETA_KINEMATIC(I)*CP/RCH(I)
+!
+! ----------------------------------------------------------------------
+! DETERMINE SENSIBLE HEAT (H) IN ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+
+            SHEAT(I) = - (CH(I) * CP * SFCPRS(I))/ (R * T2V(I)) * ( TH2(I)- T1(I) )
+
+! ----------------------------------------------------------------------
+! CONVERT EVAP TERMS FROM KINEMATIC (KG M-2 S-1) TO ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+
+            ESNOW(I) = ESNOW(I) * LSUBS
+            ETP(I) = ETP(I)*((1.-SNCOVR(I))*LVH2O + SNCOVR(I)*LSUBS)
+            IF (ETP(I) .GT. 0.) THEN
+               ETA(I) = ESNOW(I)
+            ELSE
+               ETA(I) = ETP(I)
+            ENDIF
+
+! ----------------------------------------------------------------------
+! CONVERT THE SIGN OF SOIL HEAT FLUX SO THAT:
+!   SSOIL>0: WARM THE SURFACE  (NIGHT TIME)
+!   SSOIL<0: COOL THE SURFACE  (DAY TIME)
+! ----------------------------------------------------------------------
+
+            SSOIL(I) = -1.0* SSOIL(I)
+
+! ----------------------------------------------------------------------
+! FOR THE CASE OF SEA-ICE, ADD ANY
+! SNOWMELT DIRECTLY TO SURFACE RUNOFF (RUNOFF1) SINCE THERE IS NO
+! SOIL MEDIUM, AND THUS NO CALL TO SUBROUTINE SMFLX (FOR SOIL MOISTURE
+! TENDENCY).
+! ----------------------------------------------------------------------
+            RUNOFF1(I) = SNOMLT(I)/DT
+         ENDIF
+      ENDDO
+!$acc end parallel
+
+!$acc end data
+
+!!!$acc update host(ALBEDO,SNCOVR,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,RIBB,STC,Z0, &
+!!!$acc             ETA,SHEAT,ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,   &
+!!!$acc             FLX2,FLX3,SNOMLT,RUNOFF1,Q1)
+! ----------------------------------------------------------------------
+    END SUBROUTINE SFLX_SEAICE_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE CSNOW (SNCOND,DSNOW)
 
 ! ----------------------------------------------------------------------
@@ -581,6 +1163,47 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE CSNOW
+
+      SUBROUTINE CSNOW_gpu (SNCOND,DSNOW)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE CSNOW
+! FUNCTION CSNOW
+! ----------------------------------------------------------------------
+! CALCULATE SNOW TERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: DSNOW
+      REAL, INTENT(OUT):: SNCOND
+      REAL             :: C
+      REAL, PARAMETER  :: UNIT = 0.11631
+
+! ----------------------------------------------------------------------
+! SNCOND IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! CSNOW IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! BASIC VERSION IS DYACHKOVA EQUATION (1960), FOR RANGE 0.1-0.4
+! ----------------------------------------------------------------------
+      C = 0.328*10** (2.25* DSNOW)
+!      CSNOW=UNIT*C
+
+! ----------------------------------------------------------------------
+! DE VAUX EQUATION (1933), IN RANGE 0.1-0.6
+! ----------------------------------------------------------------------
+!      SNCOND=0.0293*(1.+100.*DSNOW**2)
+!      CSNOW=0.0293*(1.+100.*DSNOW**2)
+
+! ----------------------------------------------------------------------
+! E. ANDERSEN FROM FLERCHINGER
+! ----------------------------------------------------------------------
+!      SNCOND=0.021+2.51*DSNOW**2
+!      CSNOW=0.021+2.51*DSNOW**2
+
+!      SNCOND = UNIT * C
+! double snow thermal conductivity
+      SNCOND = 2.0 * UNIT * C
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE CSNOW_gpu
 ! ----------------------------------------------------------------------
   SUBROUTINE HRTICE (RHSTS,STC,TBOT,NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
 ! ----------------------------------------------------------------------
@@ -701,6 +1324,127 @@ CONTAINS
       END DO
 ! ----------------------------------------------------------------------
   END SUBROUTINE HRTICE
+
+  SUBROUTINE HRTICE_gpu (RHSTS,STC,TBOT,NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE THE RIGHT HAND SIDE OF THE TIME TENDENCY TERM OF THE SOIL
+! THERMAL DIFFUSION EQUATION IN THE CASE OF SEA-ICE (ICE=1) OR GLACIAL
+! ICE (ICE=-1). COMPUTE (PREPARE) THE MATRIX COEFFICIENTS FOR THE
+! TRI-DIAGONAL MATRIX OF THE IMPLICIT TIME SCHEME.
+!
+! (NOTE:  THIS SUBROUTINE ONLY CALLED FOR SEA-ICE OR GLACIAL ICE, BUT
+! NOT FOR NON-GLACIAL LAND (ICE = 0).
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+
+      INTEGER, INTENT(IN)    :: NSOIL
+      INTEGER                :: K
+
+      REAL,    INTENT(IN)    :: DF1,YY,ZZ1
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT):: AI, BI,CI
+      REAL, DIMENSION(1:NSOIL), INTENT(IN) :: STC, ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT):: RHSTS
+      REAL,                     INTENT(IN) :: TBOT
+      REAL                   :: DDZ,DDZ2,DENOM,DTSDZ,DTSDZ2,SSOIL,       &
+                                ZBOT
+      REAL                   :: HCPCT
+      REAL :: DF1K
+      REAL :: DF1N
+      REAL :: ZMD
+
+! ----------------------------------------------------------------------
+! SET A NOMINAL UNIVERSAL VALUE OF THE SEA-ICE SPECIFIC HEAT CAPACITY,
+! HCPCT = 1880.0*917.0.
+! ----------------------------------------------------------------------
+      ! Sea-ice values
+      HCPCT = 1.72396E+6
+
+! ----------------------------------------------------------------------
+! THE INPUT ARGUMENT DF1 IS A UNIVERSALLY CONSTANT VALUE OF SEA-ICE
+! THERMAL DIFFUSIVITY, SET IN ROUTINE SNOPAC AS DF1 = 2.2.
+! ----------------------------------------------------------------------
+! SET ICE PACK DEPTH.  USE TBOT AS ICE PACK LOWER BOUNDARY TEMPERATURE
+! (THAT OF UNFROZEN SEA WATER AT BOTTOM OF SEA ICE PACK).  ASSUME ICE
+! PACK IS OF N=NSOIL LAYERS SPANNING A UNIFORM CONSTANT ICE PACK
+! THICKNESS AS DEFINED BY ZSOIL(NSOIL) IN ROUTINE SFLX.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEFFICIENTS AI, BI, AND CI FOR THE TOP LAYER
+! ----------------------------------------------------------------------
+      ZBOT = ZSOIL (NSOIL)
+      DDZ = 1.0 / ( -0.5 * ZSOIL (2) )
+      AI (1) = 0.0
+      CI (1) = (DF1 * DDZ) / (ZSOIL (1) * HCPCT)
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT BTWN THE TOP AND 2ND SOIL LAYERS.
+! RECALC/ADJUST THE SOIL HEAT FLUX.  USE THE GRADIENT AND FLUX TO CALC
+! RHSTS FOR THE TOP SOIL LAYER.
+! ----------------------------------------------------------------------
+      BI (1) = - CI (1) + DF1/ (0.5 * ZSOIL (1) * ZSOIL (1) * HCPCT *    &
+       ZZ1)
+      DTSDZ = ( STC (1) - STC (2) ) / ( -0.5 * ZSOIL (2) )
+      SSOIL = DF1 * ( STC (1) - YY ) / ( 0.5 * ZSOIL (1) * ZZ1 )
+
+! ----------------------------------------------------------------------
+! INITIALIZE DDZ2
+! ----------------------------------------------------------------------
+      RHSTS (1) = ( DF1 * DTSDZ - SSOIL ) / ( ZSOIL (1) * HCPCT )
+
+! ----------------------------------------------------------------------
+! LOOP THRU THE REMAINING SOIL LAYERS, REPEATING THE ABOVE PROCESS
+! ----------------------------------------------------------------------
+      DDZ2 = 0.0
+      DF1K = DF1
+      DF1N = DF1
+      DO K = 2,NSOIL
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU THIS LAYER.
+! ----------------------------------------------------------------------
+         IF (K /= NSOIL) THEN
+            DENOM = 0.5 * ( ZSOIL (K -1) - ZSOIL (K +1) )
+
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEF, CI, AFTER CALC'NG ITS PARTIAL PRODUCT.
+! ----------------------------------------------------------------------
+            DTSDZ2 = ( STC (K) - STC (K +1) ) / DENOM
+            DDZ2 = 2. / (ZSOIL (K -1) - ZSOIL (K +1))
+            CI (K) = - DF1N * DDZ2 / ( (ZSOIL (K -1) - ZSOIL (K))*HCPCT)
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU THE LOWEST LAYER.
+! ----------------------------------------------------------------------
+         ELSE
+
+! ----------------------------------------------------------------------
+! SET MATRIX COEF, CI TO ZERO.
+! ----------------------------------------------------------------------
+            DTSDZ2 = (STC (K) - TBOT)/ (.5 * (ZSOIL (K -1) + ZSOIL (K)) &
+                     - ZBOT)
+            CI (K) = 0.
+         END IF
+! ----------------------------------------------------------------------
+! CALC RHSTS FOR THIS LAYER AFTER CALC'NG A PARTIAL PRODUCT.
+! ----------------------------------------------------------------------
+         DENOM = ( ZSOIL (K) - ZSOIL (K -1) ) * HCPCT
+! ----------------------------------------------------------------------
+! CALC MATRIX COEFS, AI, AND BI FOR THIS LAYER.
+! ----------------------------------------------------------------------
+         RHSTS (K) = ( DF1N * DTSDZ2- DF1K * DTSDZ ) / DENOM
+         AI (K) = - DF1K * DDZ / ( (ZSOIL (K -1) - ZSOIL (K)) * HCPCT)
+         BI (K) = - (AI (K) + CI (K))
+! ----------------------------------------------------------------------
+! RESET VALUES OF DTSDZ AND DDZ FOR LOOP TO NEXT SOIL LYR.
+! ----------------------------------------------------------------------
+         DF1K = DF1N
+         DTSDZ = DTSDZ2
+         DDZ = DDZ2
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE HRTICE_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE PENMAN (SFCTMP,SFCPRS,CH,TH2,PRCP,FDOWN,T24,SSOIL, &
@@ -778,6 +1522,81 @@ CONTAINS
   END SUBROUTINE PENMAN
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE PENMAN_gpu (SFCTMP,SFCPRS,CH,TH2,PRCP,FDOWN,T24,SSOIL, &
+       &             Q2,Q2SAT,ETP,RCH,RR,SNOWNG,FRZGRA,       &
+       &             DQSDT2,FLX2,EMISSI,T1)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE POTENTIAL EVAPORATION FOR THE CURRENT POINT.  VARIOUS
+! PARTIAL SUMS/PRODUCTS ARE ALSO CALCULATED AND PASSED BACK TO THE
+! CALLING ROUTINE FOR LATER USE.
+! ----------------------------------------------------------------------
+
+    IMPLICIT NONE
+    LOGICAL, INTENT(IN)     :: SNOWNG, FRZGRA
+    REAL, INTENT(IN)        :: CH, DQSDT2, FDOWN, PRCP,           &
+         &                     Q2, Q2SAT, SSOIL, SFCPRS, SFCTMP,  &
+         &                     TH2,EMISSI
+    REAL, INTENT(IN)        :: T1, T24, RCH
+    REAL, INTENT(OUT)       :: ETP,FLX2,RR
+    REAL                    :: ELCP1, LVS, EPSCA, A, DELTA, FNET, RAD
+
+    REAL, PARAMETER      :: ELCP = 2.4888E+3, LSUBC = 2.501000E+6,CP = 1004.6
+    REAL, PARAMETER      :: LSUBS = 2.83E+6
+
+! ----------------------------------------------------------------------
+! PREPARE PARTIAL QUANTITIES FOR PENMAN EQUATION.
+! ----------------------------------------------------------------------
+
+    IF ( T1 > 273.15 ) THEN
+       ELCP1=ELCP
+       LVS=LSUBC
+    ELSE
+       ELCP1  = ELCP*LSUBS/LSUBC
+       LVS    = LSUBS
+    ENDIF
+
+    FLX2 = 0.0
+    DELTA = ELCP1 * DQSDT2
+    RR = EMISSI * T24 * 6.48E-8 / (SFCPRS * CH) + 1.0
+
+! ----------------------------------------------------------------------
+! ADJUST THE PARTIAL SUMS / PRODUCTS WITH THE LATENT HEAT
+! EFFECTS CAUSED BY FALLING PRECIPITATION.
+! ----------------------------------------------------------------------
+
+    IF ( PRCP > 0.0 ) THEN
+       IF (.NOT. SNOWNG) THEN
+          RR = RR + CPH2O * PRCP / RCH
+       ELSE
+          RR = RR + CPICE * PRCP / RCH
+       ENDIF
+    ENDIF
+
+! ----------------------------------------------------------------------
+! INCLUDE THE LATENT HEAT EFFECTS OF FREEZING RAIN CONVERTING TO ICE ON
+! IMPACT IN THE CALCULATION OF FLX2 AND FNET.
+! ----------------------------------------------------------------------
+
+    FNET = FDOWN - EMISSI * SIGMA * T24 - SSOIL
+    IF (FRZGRA) THEN
+       FLX2 = - LSUBF * PRCP
+       FNET = FNET - FLX2
+    END IF
+
+! ----------------------------------------------------------------------
+! FINISH PENMAN EQUATION CALCULATIONS.
+! ----------------------------------------------------------------------
+
+    RAD = FNET / RCH + TH2 - SFCTMP
+    A = ELCP1 * (Q2SAT - Q2)
+    EPSCA = (A * RR + RAD * DELTA) / (DELTA + RR)
+    ETP = EPSCA * RCH / LVS
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE PENMAN_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE SHFLX (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
 ! ----------------------------------------------------------------------
 ! UPDATE THE TEMPERATURE STATE OF THE SOIL COLUMN BASED ON THE THERMAL
@@ -806,6 +1625,37 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SHFLX
+! ----------------------------------------------------------------------
+
+  SUBROUTINE SHFLX_gpu (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! UPDATE THE TEMPERATURE STATE OF THE SOIL COLUMN BASED ON THE THERMAL
+! DIFFUSION EQUATION.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER,                  INTENT(IN)    :: NSOIL
+      REAL,                     INTENT(IN)    :: DF1,DT,TBOT,YY, ZZ1
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)    :: ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
+      REAL, DIMENSION(1:NSOIL)                :: AI, BI, CI, STCF,RHSTS
+      INTEGER                                 :: I
+      REAL, PARAMETER                         :: T0 = 273.15
+
+! ----------------------------------------------------------------------
+! HRTICE ROUTINE CALCS THE RIGHT HAND SIDE OF THE SOIL TEMP DIF EQN
+! ----------------------------------------------------------------------
+
+      CALL HRTICE_gpu (RHSTS,STC,TBOT,NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
+      CALL HSTEP_gpu (STCF,STC,RHSTS,DT,NSOIL,AI,BI,CI)
+
+      DO I = 1,NSOIL
+         STC (I) = STCF (I)
+      END DO
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SHFLX_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE SNOPAC (ETP,ETA,PRCP,SNOWNG,            &
@@ -1075,6 +1925,273 @@ CONTAINS
   END SUBROUTINE SNOPAC
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE SNOPAC_gpu (ETP,ETA,PRCP,SNOWNG,            &
+       NSOIL,DT,DF1,                                 &
+       Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,STC,         &
+       SFCPRS,RCH,RR,SNCOVR,ESD,SNDENS,              &
+       SNOWH,ZSOIL,TBOT,                             &
+       SNOMLT,DEW,FLX1,FLX2,FLX3,ESNOW,EMISSI,       &
+       RIBB, SEAICE_ALBEDO_OPT)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOPAC
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE AND HEAT FLUX VALUES & UPDATE SOIL MOISTURE
+! CONTENT AND SOIL HEAT CONTENT VALUES FOR THE CASE WHEN A SNOW PACK IS
+! PRESENT.
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: NSOIL
+    INTEGER               :: K
+    LOGICAL, INTENT(IN)   :: SNOWNG
+    REAL, INTENT(IN)      :: DF1,                                     &
+         &                   DT,FDOWN,                                &
+         &                   PRCP,Q2,                                 &
+         &                   RCH,RR,SFCPRS, SFCTMP,                   &
+         &                   T24,                                     &
+         &                   TBOT,TH2,EMISSI
+    REAL, INTENT(INOUT)   :: ESD,FLX2,SNOWH,SNCOVR,                   &
+         &                   SNDENS, T1, RIBB, ETP
+    REAL, INTENT(OUT)     :: DEW,ESNOW,                               &
+         &                   FLX1,FLX3, SSOIL,SNOMLT
+    REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: ZSOIL
+    REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
+    REAL                  :: DENOM,DSOIL,DTOT,ETA,                    &
+         &                   ESNOW1, ESNOW2, ETA1,ETP1,ETP2,          &
+         &                   ETANRG, EX, SEH,                         &
+         &                   SNCOND,T12, T12A,                        &
+         &                   T12B, T14, YY, ZZ1
+    INTEGER, INTENT(IN)   :: SEAICE_ALBEDO_OPT
+    REAL, PARAMETER       :: ESDMIN = 1.E-6, LSUBC = 2.501000E+6,     &
+         LSUBS = 2.83E+6, SNOEXP = 2.0
+
+! ----------------------------------------------------------------------
+! SNOWCOVER FRACTION = 1.0, AND SUBLIMATION IS AT THE POTENTIAL RATE.
+! ----------------------------------------------------------------------
+! INITIALIZE EVAP TERMS.
+! ----------------------------------------------------------------------
+! conversions:
+! ESNOW [KG M-2 S-1]
+! ESNOW1 [M S-1]
+! ESNOW2 [M]
+! ETP [KG M-2 S-1]
+! ETP1 [M S-1]
+! ETP2 [M]
+! ----------------------------------------------------------------------
+    DEW = 0.
+    ESNOW = 0.
+    ESNOW1 = 0.
+    ESNOW2 = 0.
+
+! ----------------------------------------------------------------------
+! CONVERT POTENTIAL EVAP (ETP) FROM KG M-2 S-1 TO ETP1 IN M S-1
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! IF ETP<0 (DOWNWARD) THEN DEWFALL (=FROSTFALL IN THIS CASE).
+! ----------------------------------------------------------------------
+    IF (ETP <= 0.0) THEN
+       IF ( ( RIBB >= 0.1 ) .AND. ( FDOWN > 150.0 ) ) THEN
+          ETP=(MIN(ETP*(1.0-RIBB),0.)*SNCOVR/0.980 + ETP*(0.980-SNCOVR))/0.980
+       ENDIF
+       ETP1 = ETP * 0.001
+       DEW = -ETP1
+       ESNOW2 = ETP1*DT
+       ETANRG = ETP*((1.-SNCOVR)*LSUBC + SNCOVR*LSUBS)
+    ELSE
+       ETP1 = ETP * 0.001
+       ESNOW  = ETP
+       ESNOW1 = ESNOW*0.001
+       ESNOW2 = ESNOW1*DT
+       ETANRG = ESNOW*LSUBS
+       ESNOW  = ETP*SNCOVR
+       ESNOW1 = ESNOW*0.001
+       ESNOW2 = ESNOW1*DT
+       ETANRG = ESNOW*LSUBS
+    END IF
+
+! ----------------------------------------------------------------------
+! IF PRECIP IS FALLING, CALCULATE HEAT FLUX FROM SNOW SFC TO NEWLY
+! ACCUMULATING PRECIP.  NOTE THAT THIS REFLECTS THE FLUX APPROPRIATE FOR
+! THE NOT-YET-UPDATED SKIN TEMPERATURE (T1).  ASSUMES TEMPERATURE OF THE
+! SNOWFALL STRIKING THE GROUND IS =SFCTMP (LOWEST MODEL LEVEL AIR TEMP).
+! ----------------------------------------------------------------------
+    FLX1 = 0.0
+    IF (SNOWNG) THEN
+       FLX1 = CPICE * PRCP * (T1- SFCTMP)
+    ELSE
+       IF (PRCP >  0.0) FLX1 = CPH2O * PRCP * (T1- SFCTMP)
+! ----------------------------------------------------------------------
+! CALCULATE AN 'EFFECTIVE SNOW-GRND SFC TEMP' (T12) BASED ON HEAT FLUXES
+! BETWEEN THE SNOW PACK AND THE SOIL AND ON NET RADIATION.
+! INCLUDE FLX1 (PRECIP-SNOW SFC) AND FLX2 (FREEZING RAIN LATENT HEAT)
+! FLUXES.  FLX1 FROM ABOVE, FLX2 BROUGHT IN VIA COMMOM BLOCK RITE.
+! FLX2 REFLECTS FREEZING RAIN LATENT HEAT FLUX USING T1 CALCULATED IN
+! PENMAN.
+! ----------------------------------------------------------------------
+    END IF
+    DSOIL = - (0.5 * ZSOIL (1))
+    DTOT = SNOWH + DSOIL
+    DENOM = 1.0+ DF1 / (DTOT * RR * RCH)
+! surface emissivity weighted by snow cover fraction
+!      T12A = ( (FDOWN - FLX1 - FLX2 -                                   &
+!     &       ((SNCOVR*EMISSI_S)+EMISSI*(1.0-SNCOVR))*SIGMA *T24)/RCH    &
+!     &       + TH2 - SFCTMP - ETANRG/RCH ) / RR
+    T12A = ( (FDOWN - FLX1 - FLX2 - EMISSI * SIGMA * T24)/ RCH                    &
+         + TH2 - SFCTMP - ETANRG / RCH ) / RR
+
+    T12B = DF1 * STC (1) / (DTOT * RR * RCH)
+
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS AT OR BELOW FREEZING, NO SNOW
+! MELT WILL OCCUR.  SET THE SKIN TEMP TO THIS EFFECTIVE TEMP.  REDUCE
+! (BY SUBLIMINATION ) OR INCREASE (BY FROST) THE DEPTH OF THE SNOWPACK,
+! DEPENDING ON SIGN OF ETP.
+! UPDATE SOIL HEAT FLUX (SSOIL) USING NEW SKIN TEMPERATURE (T1)
+! SINCE NO SNOWMELT, SET ACCUMULATED SNOWMELT TO ZERO, SET 'EFFECTIVE'
+! PRECIP FROM SNOWMELT TO ZERO, SET PHASE-CHANGE HEAT FLUX FROM SNOWMELT
+! TO ZERO.
+! ----------------------------------------------------------------------
+! SUB-FREEZING BLOCK
+! ----------------------------------------------------------------------
+    T12 = (SFCTMP + T12A + T12B) / DENOM
+    IF (T12 <=  TFREEZ) THEN
+       T1 = T12
+       SSOIL = DF1 * (T1- STC (1)) / DTOT
+!        ESD = MAX (0.0, ESD- ETP2)
+       ESD = MAX(0.0, ESD-ESNOW2)
+       FLX3 = 0.0
+       EX = 0.0
+
+       SNOMLT = 0.0
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS ABOVE FREEZING, SNOW MELT
+! WILL OCCUR.  CALL THE SNOW MELT RATE,EX AND AMT, SNOMLT.  REVISE THE
+! EFFECTIVE SNOW DEPTH.  REVISE THE SKIN TEMP BECAUSE IT WOULD HAVE CHGD
+! DUE TO THE LATENT HEAT RELEASED BY THE MELTING. CALC THE LATENT HEAT
+! RELEASED, FLX3.  ADJUSTMENT TO T1 TO ACCOUNT FOR SNOW PATCHES.
+! CALCULATE QSAT VALID AT FREEZING POINT.  NOTE THAT ESAT (SATURATION
+! VAPOR PRESSURE) VALUE OF 6.11E+2 USED HERE IS THAT VALID AT FRZZING
+! POINT.  NOTE THAT ETP FROM CALL PENMAN IN SFLX IS IGNORED HERE IN
+! FAVOR OF BULK ETP OVER 'OPEN WATER' AT FREEZING TEMP.
+! UPDATE SOIL HEAT FLUX (S) USING NEW SKIN TEMPERATURE (T1)
+! ----------------------------------------------------------------------
+! ABOVE FREEZING BLOCK
+! ----------------------------------------------------------------------
+    ELSE
+       T1 = TFREEZ 
+       SSOIL = DF1 * (T1- STC (1)) / DTOT
+
+! ----------------------------------------------------------------------
+! IF POTENTIAL EVAP (SUBLIMATION) GREATER THAN DEPTH OF SNOWPACK.
+! SNOWPACK HAS SUBLIMATED AWAY, SET DEPTH TO ZERO.
+! ----------------------------------------------------------------------
+
+       IF (ESD-ESNOW2 <= ESDMIN) THEN
+          ESD = 0.0
+          EX = 0.0
+          SNOMLT = 0.0
+          FLX3 = 0.0
+! ----------------------------------------------------------------------
+! SUBLIMATION LESS THAN DEPTH OF SNOWPACK
+! SNOWPACK (ESD) REDUCED BY ESNOW2 (DEPTH OF SUBLIMATED SNOW)
+! ----------------------------------------------------------------------
+       ELSE
+          ESD = ESD-ESNOW2
+          SEH = RCH * (T1- TH2)
+          T14 = ( T1 * T1 ) * ( T1 * T1 )
+          FLX3 = FDOWN - FLX1- FLX2- EMISSI*SIGMA * T14- SSOIL - SEH - ETANRG
+          IF (FLX3 <= 0.0) FLX3 = 0.0
+! ----------------------------------------------------------------------
+! SNOWMELT REDUCTION DEPENDING ON SNOW COVER
+! ----------------------------------------------------------------------
+          EX = FLX3*0.001/ LSUBF
+
+! ----------------------------------------------------------------------
+! ESDMIN REPRESENTS A SNOWPACK DEPTH THRESHOLD VALUE BELOW WHICH WE
+! CHOOSE NOT TO RETAIN ANY SNOWPACK, AND INSTEAD INCLUDE IT IN SNOWMELT.
+! ----------------------------------------------------------------------
+          SNOMLT = EX * DT
+          IF (ESD- SNOMLT >=  ESDMIN) THEN
+             ESD = ESD- SNOMLT
+          ELSE
+             !
+             ! SNOWMELT EXCEEDS SNOW DEPTH
+             !
+             EX = ESD / DT
+             FLX3 = EX *1000.0* LSUBF
+             SNOMLT = ESD
+
+             ESD = 0.0
+          ENDIF
+       ENDIF
+
+! ----------------------------------------------------------------------
+! END OF 'T12 .LE. TFREEZ' IF-BLOCK
+! ----------------------------------------------------------------------
+
+    ENDIF
+
+! ----------------------------------------------------------------------
+! FOR SEA-ICE, THE SNOWMELT WILL BE ADDED TO SUBSURFACE
+! RUNOFF/BASEFLOW LATER NEAR THE END OF SFLX (AFTER RETURN FROM CALL TO
+! SUBROUTINE SNOPAC)
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! SET THE EFFECTIVE POTNL EVAPOTRANSP (ETP1) TO ZERO SINCE THIS IS SNOW
+! CASE, SO SURFACE EVAP NOT CALCULATED FROM EDIR IN SMFLX (BELOW).
+! IF SEAICE (ICE==1) SKIP CALL TO SMFLX, SINCE NO SOIL MEDIUM FOR SEA-ICE
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! BEFORE CALL SHFLX IN THIS SNOWPACK CASE, SET ZZ1 AND YY ARGUMENTS TO
+! SPECIAL VALUES THAT ENSURE THAT GROUND HEAT FLUX CALCULATED IN SHFLX
+! MATCHES THAT ALREADY COMPUTED FOR BELOW THE SNOWPACK, THUS THE SFC
+! HEAT FLUX TO BE COMPUTED IN SHFLX WILL EFFECTIVELY BE THE FLUX AT THE
+! SNOW TOP SURFACE.
+! ----------------------------------------------------------------------
+
+    ZZ1 = 1.0
+    YY = STC (1) -0.5* SSOIL * ZSOIL (1)* ZZ1/ DF1
+
+! ----------------------------------------------------------------------
+! SHFLX WILL CALC/UPDATE THE ICE TEMPS.
+! ----------------------------------------------------------------------
+
+    CALL SHFLX_gpu (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
+
+! ----------------------------------------------------------------------
+! SNOW DEPTH AND DENSITY ADJUSTMENT BASED ON SNOW COMPACTION.  YY IS
+! ASSUMED TO BE THE SOIL TEMPERTURE AT THE TOP OF THE SOIL COLUMN.
+! ----------------------------------------------------------------------
+    SELECT CASE ( SEAICE_ALBEDO_OPT )
+
+    CASE DEFAULT
+
+       IF (ESD .GE. 0.01) THEN
+          CALL SNOWPACK_gpu (ESD,DT,SNOWH,SNDENS,T1,YY)
+       ELSE
+          ESD = 0.01
+          SNOWH = 0.05
+!KWM???? SNDENS =
+!KWM???? SNCOND =
+          SNCOVR = 1.0
+       ENDIF
+
+    CASE ( 1 ) ! Arctic sea-ice albedo from Mills (2011)
+
+       IF ( ESD >= 0.0001 ) THEN
+          CALL SNOWPACK_gpu (ESD,DT,SNOWH,SNDENS,T1,YY)
+       ELSE
+          ESD    = 0.0001
+          SNOWH  = 0.0005
+          SNCOVR = 0.005
+       ENDIF
+
+    END SELECT
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOPAC_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE SNOWPACK (ESD,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL)
 
 ! ----------------------------------------------------------------------
@@ -1203,6 +2320,134 @@ CONTAINS
   END SUBROUTINE SNOWPACK
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNOWPACK_gpu (ESD,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOWPACK
+! ----------------------------------------------------------------------
+! CALCULATE COMPACTION OF SNOWPACK UNDER CONDITIONS OF INCREASING SNOW
+! DENSITY, AS OBTAINED FROM AN APPROXIMATE SOLUTION OF E. ANDERSON'S
+! DIFFERENTIAL EQUATION (3.29), NOAA TECHNICAL REPORT NWS 19, BY VICTOR
+! KOREN, 03/25/95.
+! ----------------------------------------------------------------------
+! ESD     WATER EQUIVALENT OF SNOW (M)
+! DTSEC   TIME STEP (SEC)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! TSNOW   SNOW SURFACE TEMPERATURE (K)
+! TSOIL   SOIL SURFACE TEMPERATURE (K)
+
+! SUBROUTINE WILL RETURN NEW VALUES OF SNOWH AND SNDENS
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER                :: IPOL, J
+      REAL, INTENT(IN)       :: ESD, DTSEC,TSNOW,TSOIL
+      REAL, INTENT(INOUT)    :: SNOWH, SNDENS
+      REAL                   :: BFAC,DSX,DTHR,DW,SNOWHC,PEXP,           &
+                                TAVGC,TSNOWC,TSOILC,ESDC,ESDCX
+      REAL, PARAMETER        :: C1 = 0.01, C2 = 21.0, G = 9.81,         &
+                                KN = 4000.0
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+      SNOWHC = SNOWH *100.
+      ESDC = ESD *100.
+      DTHR = DTSEC /3600.
+      TSNOWC = TSNOW -273.15
+      TSOILC = TSOIL -273.15
+
+! ----------------------------------------------------------------------
+! CALCULATING OF AVERAGE TEMPERATURE OF SNOW PACK
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALCULATING OF SNOW DEPTH AND DENSITY AS A RESULT OF COMPACTION
+!  SNDENS=DS0*(EXP(BFAC*ESD)-1.)/(BFAC*ESD)
+!  BFAC=DTHR*C1*EXP(0.08*TAVGC-C2*DS0)
+! NOTE: BFAC*ESD IN SNDENS EQN ABOVE HAS TO BE CAREFULLY TREATED
+! NUMERICALLY BELOW:
+!   C1 IS THE FRACTIONAL INCREASE IN DENSITY (1/(CM*HR))
+!   C2 IS A CONSTANT (CM3/G) KOJIMA ESTIMATED AS 21 CMS/G
+! ----------------------------------------------------------------------
+      TAVGC = 0.5* (TSNOWC + TSOILC)
+      IF (ESDC >  1.E-2) THEN
+         ESDCX = ESDC
+      ELSE
+         ESDCX = 1.E-2
+      END IF
+
+!      DSX = SNDENS*((DEXP(BFAC*ESDC)-1.)/(BFAC*ESDC))
+! ----------------------------------------------------------------------
+! THE FUNCTION OF THE FORM (e**x-1)/x EMBEDDED IN ABOVE EXPRESSION
+! FOR DSX WAS CAUSING NUMERICAL DIFFICULTIES WHEN THE DENOMINATOR "x"
+! (I.E. BFAC*ESDC) BECAME ZERO OR APPROACHED ZERO (DESPITE THE FACT THAT
+! THE ANALYTICAL FUNCTION (e**x-1)/x HAS A WELL DEFINED LIMIT AS
+! "x" APPROACHES ZERO), HENCE BELOW WE REPLACE THE (e**x-1)/x
+! EXPRESSION WITH AN EQUIVALENT, NUMERICALLY WELL-BEHAVED
+! POLYNOMIAL EXPANSION.
+
+! NUMBER OF TERMS OF POLYNOMIAL EXPANSION, AND HENCE ITS ACCURACY,
+! IS GOVERNED BY ITERATION LIMIT "IPOL".
+!      IPOL GREATER THAN 9 ONLY MAKES A DIFFERENCE ON DOUBLE
+!            PRECISION (RELATIVE ERRORS GIVEN IN PERCENT %).
+!       IPOL=9, FOR REL.ERROR <~ 1.6 E-6 % (8 SIGNIFICANT DIGITS)
+!       IPOL=8, FOR REL.ERROR <~ 1.8 E-5 % (7 SIGNIFICANT DIGITS)
+!       IPOL=7, FOR REL.ERROR <~ 1.8 E-4 % ...
+! ----------------------------------------------------------------------
+      BFAC = DTHR * C1* EXP (0.08* TAVGC - C2* SNDENS)
+      IPOL = 4
+      PEXP = 0.
+!        PEXP = (1. + PEXP)*BFAC*ESDC/REAL(J+1)
+      DO J = IPOL,1, -1
+         PEXP = (1. + PEXP)* BFAC * ESDCX / REAL (J +1)
+      END DO
+
+      PEXP = PEXP + 1.
+! ----------------------------------------------------------------------
+! ABOVE LINE ENDS POLYNOMIAL SUBSTITUTION
+! ----------------------------------------------------------------------
+!     END OF KOREAN FORMULATION
+
+!     BASE FORMULATION (COGLEY ET AL., 1990)
+!     CONVERT DENSITY FROM G/CM3 TO KG/M3
+!       DSM=SNDENS*1000.0
+
+!       DSX=DSM+DTSEC*0.5*DSM*G*ESD/
+!    &      (1E7*EXP(-0.02*DSM+KN/(TAVGC+273.16)-14.643))
+
+!  &   CONVERT DENSITY FROM KG/M3 TO G/CM3
+!       DSX=DSX/1000.0
+
+!     END OF COGLEY ET AL. FORMULATION
+
+! ----------------------------------------------------------------------
+! SET UPPER/LOWER LIMIT ON SNOW DENSITY
+! ----------------------------------------------------------------------
+      DSX = SNDENS * (PEXP)
+      IF (DSX > 0.40) DSX = 0.40
+      IF (DSX < 0.05) DSX = 0.05
+! ----------------------------------------------------------------------
+! UPDATE OF SNOW DEPTH AND DENSITY DEPENDING ON LIQUID WATER DURING
+! SNOWMELT.  ASSUMED THAT 13% OF LIQUID WATER CAN BE STORED IN SNOW PER
+! DAY DURING SNOWMELT TILL SNOW DENSITY 0.40.
+! ----------------------------------------------------------------------
+      SNDENS = DSX
+      IF (TSNOWC >=  0.) THEN
+         DW = 0.13* DTHR /24.
+         SNDENS = SNDENS * (1. - DW) + DW
+         IF (SNDENS >=  0.40) SNDENS = 0.40
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH (CM) FROM SNOW WATER EQUIVALENT AND SNOW DENSITY.
+! CHANGE SNOW DEPTH UNITS TO METERS
+! ----------------------------------------------------------------------
+      END IF
+      SNOWHC = ESDC / SNDENS
+      SNOWH = SNOWHC *0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWPACK_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE SNOWZ0 (SNCOVR,Z0, Z0BRD, SNOWH)
 
 ! ----------------------------------------------------------------------
@@ -1235,6 +2480,37 @@ CONTAINS
   END SUBROUTINE SNOWZ0
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNOWZ0_gpu (SNCOVR,Z0, Z0BRD, SNOWH)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOWZ0
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL ROUGHNESS LENGTH OVER SNOW
+! SNCOVR  FRACTIONAL SNOW COVER
+! Z0      ROUGHNESS LENGTH (m)
+! Z0S     SNOW ROUGHNESS LENGTH:=0.001 (m)
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN)        :: SNCOVR, Z0BRD
+      REAL, INTENT(OUT)       :: Z0
+      REAL, PARAMETER         :: Z0S=0.001
+      REAL, INTENT(IN)        :: SNOWH
+      REAL                    :: BURIAL
+      REAL                    :: Z0EFF
+
+!m      Z0 = (1.- SNCOVR)* Z0BRD + SNCOVR * Z0S
+      BURIAL = 7.0*Z0BRD - SNOWH
+      IF(BURIAL.LE.0.0007) THEN
+        Z0EFF = Z0S
+      ELSE      
+        Z0EFF = BURIAL/7.0
+      ENDIF
+      
+      Z0 = (1.- SNCOVR)* Z0BRD + SNCOVR * Z0EFF
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWZ0_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE SNOW_NEW (TEMP,NEWSN,SNOWH,SNDENS)
 
@@ -1286,6 +2562,58 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SNOW_NEW
+! ----------------------------------------------------------------------
+
+      SUBROUTINE SNOW_NEW_gpu (TEMP,NEWSN,SNOWH,SNDENS)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOW_NEW
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH AND DENSITY TO ACCOUNT FOR THE NEW SNOWFALL.
+! NEW VALUES OF SNOW DEPTH & DENSITY RETURNED.
+
+! TEMP    AIR TEMPERATURE (K)
+! NEWSN   NEW SNOWFALL (M)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN)        :: NEWSN, TEMP
+      REAL, INTENT(INOUT)     :: SNDENS, SNOWH
+      REAL                    :: DSNEW, HNEWC, SNOWHC,NEWSNC,TEMPC
+
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+      SNOWHC = SNOWH *100.
+      NEWSNC = NEWSN *100.
+
+! ----------------------------------------------------------------------
+! CALCULATING NEW SNOWFALL DENSITY DEPENDING ON TEMPERATURE
+! EQUATION FROM GOTTLIB L. 'A GENERAL RUNOFF MODEL FOR SNOWCOVERED
+! AND GLACIERIZED BASIN', 6TH NORDIC HYDROLOGICAL CONFERENCE,
+! VEMADOLEN, SWEDEN, 1980, 172-177PP.
+!-----------------------------------------------------------------------
+      TEMPC = TEMP -273.15
+      IF (TEMPC <=  -15.) THEN
+         DSNEW = 0.05
+      ELSE
+         DSNEW = 0.05+0.0017* (TEMPC +15.)**1.5
+      END IF
+! ----------------------------------------------------------------------
+! ADJUSTMENT OF SNOW DENSITY DEPENDING ON NEW SNOWFALL
+! ----------------------------------------------------------------------
+      HNEWC = NEWSNC / DSNEW
+      IF (SNOWHC + HNEWC .LT. 1.0E-3) THEN
+         SNDENS = MAX(DSNEW,SNDENS)
+      ELSE
+         SNDENS = (SNOWHC * SNDENS + HNEWC * DSNEW)/ (SNOWHC + HNEWC)
+      ENDIF
+      SNOWHC = SNOWHC + HNEWC
+      SNOWH = SNOWHC *0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOW_NEW_gpu
 ! ----------------------------------------------------------------------
 
 END MODULE module_sf_noah_seaice

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice_drv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice_drv.F
@@ -499,4 +499,560 @@ contains
 
   end subroutine seaice_noah
 
+  subroutine seaice_noah_gpu( SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT, SEAICE_THICKNESS_OPT, &
+       &                  SEAICE_THICKNESS_DEFAULT, SEAICE_SNOWDEPTH_OPT,               &
+       &                  SEAICE_SNOWDEPTH_MAX, SEAICE_SNOWDEPTH_MIN,                   &
+       &                  T3D, QV3D, P8W3D, DZ8W, NUM_SOIL_LAYERS, DT, FRPCPN, SR,      &
+       &                  GLW, SWDOWN, RAINBL, SNOALB2D, QGH, XICE, XICE_THRESHOLD,     &
+       &                  ALBSI, ICEDEPTH, SNOWSI,                                      &
+       &                  TSLB, EMISS, ALBEDO, Z02D, TSK, SNOW, SNOWC, SNOWH2D, &
+       &                  CHS, CHS2, CQS2,                                              &
+       &                  RIB, ZNT, LH, HFX, QFX, POTEVP, GRDFLX, QSFC, ACSNOW,         &
+       &                  ACSNOM, SNOPCX, SFCRUNOFF, NOAHRES,                           &
+       &                  SF_URBAN_PHYSICS, B_T_BEP, B_Q_BEP, RHO,                      &
+       &                  IDS, IDE, JDS, JDE, KDS, KDE,                                 &
+       &                  IMS, IME, JMS, JME, KMS, KME,                                 &
+       &                  ITS, ITE, JTS, JTE, KTS, KTE  )
+#if defined(wrfmodel)
+#if (NMM_CORE != 1)
+    USE module_state_description, ONLY : NOAHUCMSCHEME
+    USE module_state_description, ONLY : BEPSCHEME
+    USE module_state_description, ONLY : BEP_BEMSCHEME
+#endif
+#endif
+    implicit none
+
+    INTEGER, INTENT(IN)       ::               SEAICE_ALBEDO_OPT
+    REAL   , INTENT(IN)       ::               SEAICE_ALBEDO_DEFAULT
+    INTEGER, INTENT(IN)       ::               SEAICE_THICKNESS_OPT
+    REAL,    INTENT(IN)       ::               SEAICE_THICKNESS_DEFAULT
+    INTEGER, INTENT(IN)       ::               SEAICE_SNOWDEPTH_OPT
+    REAL,    INTENT(IN)       ::               SEAICE_SNOWDEPTH_MAX
+    REAL,    INTENT(IN)       ::               SEAICE_SNOWDEPTH_MIN
+
+    INTEGER, INTENT(IN)       ::                            IDS, &
+         &                                                  IDE, &
+         &                                                  JDS, &
+         &                                                  JDE, &
+         &                                                  KDS, &
+         &                                                  KDE
+
+    INTEGER, INTENT(IN)       ::                            IMS, &
+         &                                                  IME, &
+         &                                                  JMS, &
+         &                                                  JME, &
+         &                                                  KMS, &
+         &                                                  KME
+
+    INTEGER, INTENT(IN)       ::                            ITS, &
+         &                                                  ITE, &
+         &                                                  JTS, &
+         &                                                  JTE, &
+         &                                                  KTS, &
+         &                                                  KTE
+
+    REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+         &   INTENT (IN)      ::                            T3D, &
+         &                                                 QV3D, &
+         &                                                P8W3D, &
+         &                                                 DZ8W
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+         &   INTENT (IN)      ::                             SR, &
+         &                                                  GLW, &
+         &                                                  QGH, &
+         &                                               SWDOWN, &
+         &                                               RAINBL, &
+         &                                             SNOALB2D, &
+         &                                                 XICE, &
+         &                                                  RIB
+
+    LOGICAL, INTENT (IN)      :: FRPCPN
+    REAL   , INTENT (IN)      :: DT
+    INTEGER, INTENT (IN)      :: NUM_SOIL_LAYERS
+    REAL   , INTENT (IN)      :: XICE_THRESHOLD
+
+    REAL,     DIMENSION( ims:ime , 1:NUM_SOIL_LAYERS, jms:jme ), &
+         INTENT(INOUT)   ::                            TSLB
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+         &   INTENT (INOUT)   ::                          EMISS, &
+         &                                               ALBEDO, &
+         &                                                ALBSI, &
+         &                                                 Z02D, &
+         &                                                 SNOW, &
+         &                                                  TSK, &
+         &                                                SNOWC, &
+         &                                              SNOWH2D, &
+         &                                                  CHS, &
+         &                                                 CQS2
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+         &   INTENT (OUT)     ::                            HFX, &
+         &                                                   LH, &
+         &                                                  QFX, &
+         &                                                  ZNT, &
+         &                                               POTEVP, &
+         &                                               GRDFLX, &
+         &                                                 QSFC, &
+         &                                               ACSNOW, &
+         &                                               ACSNOM, &
+         &                                               SNOPCX, &
+         &                                            SFCRUNOFF, &
+         &                                              NOAHRES, &
+         &                                                 CHS2
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                      ,&
+         &   INTENT(INOUT)    ::                         SNOWSI
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+         &   INTENT (INOUT)   ::                        ICEDEPTH
+
+    INTEGER, INTENT (IN)      ::               SF_URBAN_PHYSICS
+    REAL,    OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme )  , &
+         &   INTENT (INOUT)   ::                        B_Q_BEP, &
+         &                                              B_T_BEP
+    REAL,    OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme )  , &
+         &   INTENT (IN)      ::                            RHO
+
+    INTEGER :: I
+    INTEGER :: J
+    INTEGER :: NSOIL
+    REAL    :: TBOT
+
+    REAL, DIMENSION(1:NUM_SOIL_LAYERS, ims:ime )::  STC
+
+    INTEGER :: NS
+    REAL    :: FDTW
+    REAL    :: FDTLIW
+    REAL, DIMENSION( ims:ime ) :: SFCTMP,T1,SNOALB,ALBEDOK,ALBBRD,ALBEDOSI, &
+               ZLVL,EMISSI,LWDN,SNEQV,SNOWH,SNCOVR,SOLNET,SFCPRS,PSFC,Q2, &
+               APES,APELM,TH2,Q2SAT,DQSDT2,SNOWONSI,SFCTSNO,E2SAT,Q2SATI, &
+               PRCP,FFROZP,Z0BRD,CH,RIBB,Z0,ETA,SHEAT,ETA_KINEMATIC,FDOWN, &
+               ESNOW,DEW,ETP,SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,Q1, &
+               SITHICK
+
+    REAL, PARAMETER  :: CAPA   = R_D / CP
+    REAL, PARAMETER  :: A2     = 17.67
+    REAL, PARAMETER  :: A3     = 273.15
+    REAL, PARAMETER  :: A4     = 29.65
+    REAL, PARAMETER  :: A23M4  = A2 * ( A3 - A4 )
+    REAL, PARAMETER  :: ROW    = 1.E3
+    REAL, PARAMETER  :: ELIW   = XLF
+    REAL, PARAMETER  :: ROWLIW = ROW * ELIW
+
+    CHARACTER(len=80) :: message
+
+!!!$acc update device(T3D,QV3D,P8W3D,DZ8W,SR,GLW,QGH,SWDOWN,RAINBL,SNOALB2D,XICE,RIB, &
+!!!$acc               TSLB,EMISS,ALBEDO,ALBSI,Z02D,SNOW,TSK,SNOWC,SNOWH2D,CHS,CQS2,   &
+!!!$acc               HFX,LH,QFX,ZNT,POTEVP,GRDFLX,QSFC,ACSNOW,ACSNOM,SNOPCX,SFCRUNOFF,&
+!!!$acc               NOAHRES,CHS2,SNOWSI,ICEDEPTH,B_Q_BEP,B_T_BEP,RHO)
+
+!$acc data present(T3D,QV3D,P8W3D,DZ8W,SR,GLW,QGH,SWDOWN,RAINBL,SNOALB2D,XICE,RIB, &
+!$acc               TSLB,EMISS,ALBEDO,ALBSI,Z02D,SNOW,TSK,SNOWC,SNOWH2D,CHS,CQS2,   &
+!$acc               HFX,LH,QFX,ZNT,POTEVP,GRDFLX,QSFC,ACSNOW,ACSNOM,SNOPCX,SFCRUNOFF,&
+!$acc               NOAHRES,CHS2,SNOWSI,ICEDEPTH,B_Q_BEP,B_T_BEP,RHO) &
+!$acc      create(SFCTMP,T1,SNOALB,ALBEDOK,ALBBRD,ALBEDOSI,ZLVL,EMISSI,LWDN, &
+!$acc             SNEQV,SNOWH,SNCOVR,SOLNET,SFCPRS,PSFC,Q2,APES,APELM,TH2,   &
+!$acc             Q2SAT,DQSDT2,SNOWONSI,SFCTSNO,E2SAT,Q2SATI,PRCP,FFROZP,    &
+!$acc             Z0BRD,CH,RIBB,Z0,ETA,SHEAT,ETA_KINEMATIC,FDOWN,ESNOW,DEW,  &
+!$acc             ETP,SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,Q1,SITHICK,STC)
+
+    FDTLIW = DT / ROWLIW
+    FDTW   = DT / ( XLV * RHOWATER )
+
+    NSOIL  = NUM_SOIL_LAYERS
+    TBOT = 271.36
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
+    SEAICE_JLOOP1 : do J = JTS, JTE
+       SEAICE_ILOOP1 : do I = ITS, ITE
+
+          ! Skip the points that are not sea-ice points.
+          IF ( XICE(I,J) < XICE_THRESHOLD ) THEN
+             IF ( SEAICE_THICKNESS_OPT == 1 ) THEN
+                ICEDEPTH(I,J) = 0.0
+             ENDIF
+             IF ( SEAICE_SNOWDEPTH_OPT == 1 ) THEN
+                SNOWSI(I,J) = 0.0
+             ENDIF
+!!!             CYCLE SEAICE_ILOOP
+          ENDIF
+       ENDDO SEAICE_ILOOP1
+    ENDDO SEAICE_JLOOP1
+!$acc end parallel
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
+    SEAICE_JLOOP21 : do J = JTS, JTE
+       SEAICE_ILOOP21 : do I = ITS, ITE
+          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             SELECT CASE ( SEAICE_THICKNESS_OPT )
+             CASE DEFAULT
+!!!                WRITE(message,'("Namelist value for SEAICE_THICKNESS_OPT not recognized: ",I6)') SEAICE_THICKNESS_OPT
+!!!                FATAL_ERROR(message)
+             CASE (0)
+                ! Use uniform sea-ice thickness.
+                SITHICK(I) = SEAICE_THICKNESS_DEFAULT
+             CASE (1)
+                ! Use the sea-ice as read in from the input files.
+                ! Limit the to between 0.10 and 10.0 m.
+                IF ( ICEDEPTH(I,J) < -1.E6 ) THEN
+!!!                   WRITE_MESSAGE("Field ICEDEPTH not found in input files.")
+!!!                   WRITE_MESSAGE(".... Namelist SEAICE_THICKNESS_OPT=1 requires ICEDEPTH field.")
+!!!                   WRITE_MESSAGE(".... Try namelist option SEAICE_THICKNESS_OPT=0.")
+!!!                   FATAL_ERROR("SEAICE_THICKNESS_OPT")
+                ENDIF
+                SITHICK(I) = MIN ( MAX ( 0.10 , ICEDEPTH(I,J) ) , 10.0 )
+                ICEDEPTH(I,J) = SITHICK(I)
+             END SELECT
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP21
+!!!    ENDDO SEAICE_JLOOP21
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP22 : do J = JTS, JTE
+!!!       SEAICE_ILOOP22 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             SFCTMP(I) = T3D(I,1,J)
+             T1(I)     = TSK(I,J)
+             IF ( SEAICE_ALBEDO_OPT == 2 ) THEN
+                IF ( ALBSI(I,J) < -1.E6 ) THEN
+!!!                   FATAL_ERROR("Field ALBSI not found in input.  Field ALBSI is required if SEAICE_ALBEDO_OPT=2")
+                ENDIF
+                SNOALB(I) = ALBSI(I,J)
+                ALBEDO(I,J) = ALBSI(I,J)
+                ALBEDOK(I) = ALBSI(I,J)
+                ALBBRD(I) = ALBSI(I,J)
+                ALBEDOSI(I) = ALBSI(I,J)
+             ELSE
+                SNOALB(I) = SNOALB2D(I,J)
+             ENDIF
+             ZLVL(I)   = 0.5 * DZ8W(I,1,J)
+             EMISSI(I) = EMISS(I,J)               ! But EMISSI might change in SFLX_SEAICE
+             LWDN(I)   = GLW(I,J) * EMISSI(I)        ! But EMISSI might change in SFLX_SEAICE
+
+             ! convert snow water equivalent from mm to meter
+             SNEQV(I) = SNOW(I,J) * 0.001
+
+             ! snow depth in meters
+             SNOWH(I) = SNOWH2D(I,J)
+             SNCOVR(I) = SNOWC(I,J)
+   
+             ! Use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+             SOLNET(I) = SWDOWN(I,J) * (1.-ALBEDO(I,J))   ! But ALBEDO might change after SFLX_SEAICE
+
+             ! Pressure in middle of lowest layer.  Why don't we use the true surface pressure?
+             ! Are there places where we would need to use the true surface pressure?
+             SFCPRS(I) = ( P8W3D(I,KTS+1,J) + P8W3D(I,KTS,J) ) * 0.5
+ 
+             ! surface pressure
+             PSFC(I)   = P8W3D(I,1,J)
+  
+             ! Convert lowest model level humidity from mixing ratio to specific humidity
+             Q2(I)     = QV3D(I,1,J) / ( 1.0 + QV3D(I,1,J) )
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP22
+!!!    ENDDO SEAICE_JLOOP22
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP22_1 : do J = JTS, JTE
+!!!       SEAICE_ILOOP22_1 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             ! Calculate TH2 via Exner function
+             APES(I)   = ( 1.E5 / PSFC(I) )   ** CAPA
+             APELM(I)  = ( 1.E5 / SFCPRS(I) ) ** CAPA
+             TH2(I)    = ( SFCTMP(I) * APELM(I) ) / APES(I)
+   
+             ! Q2SAT is specific humidity
+             Q2SAT(I)  = QGH(I,J) / ( 1.0 + QGH(I,J) )
+             DQSDT2(I) = Q2SAT(I) * A23M4 / ( SFCTMP(I) - A4 ) ** 2
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP22_1
+!!!    ENDDO SEAICE_JLOOP22_1
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP23 : do J = JTS, JTE
+!!!       SEAICE_ILOOP23 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             SELECT CASE ( SEAICE_SNOWDEPTH_OPT )
+             CASE DEFAULT
+              
+!!!                WRITE(message,'("Namelist value for SEAICE_SNOWDEPTH_OPT not recognized: ",I6)') SEAICE_SNOWDEPTH_OPT
+!!!                FATAL_ERROR(message)
+
+             CASE ( 0 )
+   
+                ! Minimum and maximum bounds on snow depth are enforced in SFLX_SEAICE
+   
+             CASE ( 1 ) 
+
+                ! Snow depth on sea ice comes from a 2D array, SNOWSI, bounded by user-specified
+                ! minimum and maximum values.  No matter what anybody else says about snow 
+                ! accumulation and melt, we want the snow depth on sea ice to be specified
+                ! as SNOWSI (bounded by SEAICE_SNOWDEPTH_MIN and SEAICE_SNOWDEPTH_MAX).
+                SNOWONSI(I) = MAX ( SEAICE_SNOWDEPTH_MIN , MIN ( SNOWSI(I,J) , SEAICE_SNOWDEPTH_MAX ) )
+                SNEQV(I) = SNOWONSI(I) * 0.3
+                SNOWH2D(I,J) = SNOWONSI(I)
+ 
+             END SELECT
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP23
+!!!    ENDDO SEAICE_JLOOP23
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP24_1 : do J = JTS, JTE
+!!!       SEAICE_ILOOP24_1 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             IF ( SNOW(I,J) .GT. 0.0 ) THEN
+                ! If snow on surface, use ice saturation properties
+                SFCTSNO(I) = SFCTMP(I) ! Lowest model Air temperature
+                E2SAT(I) = 611.2 * EXP ( 6174. * ( 1./273.15 - 1./SFCTSNO(I) ) )
+                Q2SATI(I) = 0.622 * E2SAT(I) / ( SFCPRS(I) - E2SAT(I) )
+                Q2SATI(I) = Q2SATI(I) / ( 1.0 + Q2SATI(I) )    ! Convert to specific humidity
+                ! T1 is skin temperature
+             ENDIF
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP24_1
+!!!    ENDDO SEAICE_JLOOP24_1
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP24_2 : do J = JTS, JTE
+!!!       SEAICE_ILOOP24_2 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             IF ( SNOW(I,J) .GT. 0.0 ) THEN
+                IF (T1(I) .GT. 273.14) THEN
+                   ! Warm ground temps, weight the saturation between ice and water according to SNOWC
+                   Q2SAT(I) = Q2SAT(I) * (1.-SNOWC(I,J)) + Q2SATI(I) * SNOWC(I,J)
+                   DQSDT2(I) = DQSDT2(I) * (1.-SNOWC(I,J)) + Q2SATI(I) * 6174. / (SFCTSNO(I)**2) * SNOWC(I,J)
+                ELSE
+                   ! Cold ground temps, use ice saturation only
+                   Q2SAT(I) = Q2SATI(I)
+                   DQSDT2(I) = Q2SATI(I) * 6174. / (SFCTSNO(I)**2)
+                ENDIF
+                IF ( ( T1(I) .GT. 273. ) .AND. ( SNOWC(I,J) .GT. 0.0 ) ) THEN   
+                   ! If (SNOW > 0) can we have (SNOWC <= 0) ?  Perhaps not, so the check on 
+                   ! SNOWC here might be superfluous.
+                   DQSDT2(I) = DQSDT2(I) * ( 1. - SNOWC(I,J) )
+                ENDIF
+             ENDIF
+!!!         ENDIF
+!!!       ENDDO SEAICE_ILOOP24_2
+!!!    ENDDO SEAICE_JLOOP24_2
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP24 : do J = JTS, JTE
+!!!       SEAICE_ILOOP24 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             PRCP(I) = RAINBL(I,J) / DT
+
+             ! If "SR" is present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+             ! SR from e.g. Ferrier microphysics
+             ! otherwise define from 1st atmos level temperature
+
+             IF (FRPCPN) THEN
+                FFROZP(I) = SR(I,J)
+             ELSE
+                IF (SFCTMP(I) <=  273.15) THEN
+                   FFROZP(I) = 1.0
+                ELSE
+                   FFROZP(I) = 0.0
+                ENDIF
+             ENDIF
+!!!          ENDIF
+!!!       ENDDO SEAICE_ILOOP24
+!!!    ENDDO SEAICE_JLOOP24
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector collapse(2)
+!!!    SEAICE_JLOOP25 : do J = JTS, JTE
+!!!       SEAICE_ILOOP25 : do I = ITS, ITE
+!!!          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             ! Sea-ice point has deep-level temperature of about -1.8 C
+!!!             TBOT = 271.36
+             ! TBOT=273.15  ! appropriate value for lake ice.
+
+             ! INTENT(IN) for SFLX_SEAICE, values unchanged by SFLX_SEAICE
+             !       I           --
+             !       J           --
+             !       FFROZP      --
+             !       DT          --
+             !       ZLVL        --
+             !       NSOIL       --
+             !       LWDN        --
+             !       SOLNET      --
+             !       SFCPRS      --
+             !       PRCP        --
+             !       SFCTMP      --
+             !       Q2          --
+             !       TH2         --
+             !       Q2SAT       --
+             !       DQSDT2      --
+             !       SNOALB      --
+             !       TBOT        --
+   
+             Z0BRD(I)  = Z02D(I,J)
+  
+             DO NS = 1, NSOIL
+                STC(NS,I) = TSLB(I,NS,J)
+             ENDDO
+
+             CH(I) = CHS(I,J)
+             RIBB(I) = RIB(I,J)
+  
+             ! INTENT(INOUT) for SFLX_SEAICE, values updated by SFLX_SEAICE
+             !       Z0BRD       --
+             !       EMISSI      --
+             !       T1          --
+             !       STC         --
+             !       SNOWH       --
+             !       SNEQV       --
+             !       SNCOVR      --
+             !       CH          -- but the result isn't used for anything.
+             !                      Might as well be intent in to SFLX_SEAICE and changed locally in 
+             !                      that routine?
+             !       RIBB        -- but the result isn't used for anything.  
+             !                      Might as well be intent in to SFLX_SEAICE and changed locally in 
+             !                      that routine?
+ 
+             ! INTENT(OUT) for SFLX_SEAICE.  Input value should not matter.
+             Z0(I)               = -1.E36
+             ETA(I)              = -1.E36
+             SHEAT(I)            = -1.E36
+             ETA_KINEMATIC(I)    = -1.E36
+             FDOWN(I)            = -1.E36  ! Returned value unused.  Might as well be local to SFLX_SEAICE ?
+             ESNOW(I)            = -1.E36  ! Returned value unused.  Might as well be local to SFLX_SEAICE ?
+             DEW(I)              = -1.E36  ! Returned value unused.  Might as well be local to SFLX_SEAICE ?
+             ETP(I)              = -1.E36
+             SSOIL(I)            = -1.E36
+             FLX1(I)             = -1.E36
+             FLX2(I)             = -1.E36
+             FLX3(I)             = -1.E36
+             SNOMLT(I)           = -1.E36
+             RUNOFF1(I)          = -1.E36
+             Q1(I)               = -1.E36
+          ENDIF
+       ENDDO SEAICE_ILOOP21
+    ENDDO SEAICE_JLOOP21
+!$acc end parallel
+
+    call sflx_seaice_gpu(ims,ime,its,ite,XICE,XICE_THRESHOLD,                 &
+                  &           I, J, SEAICE_ALBEDO_OPT, SEAICE_ALBEDO_DEFAULT,  &    !C
+                  &           SEAICE_SNOWDEPTH_OPT, SEAICE_SNOWDEPTH_MAX,      &    !C
+                  &           SEAICE_SNOWDEPTH_MIN,                            &    !C
+                  &           FFROZP, DT, ZLVL, NSOIL,                         &    !C
+                  &           SITHICK,                                         &
+                  &           LWDN, SOLNET, SFCPRS, PRCP, SFCTMP, Q2,          &    !F
+                  &           TH2, Q2SAT, DQSDT2,                              &    !I
+                  &           SNOALB, TBOT, Z0BRD, Z0, EMISSI,                 &    !S
+                  &           T1, STC, SNOWH, SNEQV, ALBEDOK, CH,              &    !H
+                  &           ALBEDOSI, SNOWONSI,                              &
+                  &           ETA, SHEAT, ETA_KINEMATIC, FDOWN,                &    !O
+                  &           ESNOW, DEW, ETP, SSOIL, FLX1, FLX2, FLX3,        &    !O
+                  &           SNOMLT, SNCOVR,                                  &    !O
+                  &           RUNOFF1, Q1, RIBB)
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2)
+    SEAICE_JLOOP4 : do J = JTS, JTE
+       SEAICE_ILOOP4 : do I = ITS, ITE
+          IF ( XICE(I,J) >= XICE_THRESHOLD ) THEN
+             ! Update our 2d arrays with results from SFLX_SEAICE
+             ALBEDO(I,J)  = ALBEDOK(I)
+             EMISS(I,J)   = EMISSI(I)
+             TSK(I,J)     = T1(I)
+             Z02D(I,J)    = Z0BRD(I)
+             SNOWH2D(I,J) = SNOWH(I)
+             SNOWC(I,J)   = SNCOVR(I)
+  
+             ! Convert snow water equivalent from (m) back to (mm)
+             SNOW(I,J)    = SNEQV(I) * 1000.
+  
+             ! Update our ice temperature array with results from SFLX_SEAICE
+             DO NS = 1,NSOIL
+                TSLB(I,NS,J) = STC(NS,I)
+             ENDDO
+
+             ! Intent (OUT) from SFLX_SEAICE
+             ZNT(I,J)    = Z0(I)
+             LH(I,J)     = ETA(I)
+             HFX(I,J)    = SHEAT(I)
+             QFX(I,J)    = ETA_KINEMATIC(I)
+             POTEVP(I,J) = POTEVP(I,J) + ETP(I)*FDTW
+             GRDFLX(I,J) = SSOIL(I)
+  
+             ! Exchange Coefficients
+             CHS2(I,J) = CQS2(I,J)
+             IF (Q1(I) .GT. QSFC(I,J)) THEN
+                CQS2(I,J) = CHS(I,J)
+             ENDIF
+
+             ! Convert QSFC term back to Mixing Ratio.
+             QSFC(I,J)   = Q1(I) / ( 1.0 - Q1(I) )
+ 
+             IF ( SEAICE_SNOWDEPTH_OPT == 1 ) THEN
+                SNOWSI(I,J) = SNOWONSI(I)
+             ENDIF
+
+             ! Accumulated snow precipitation.
+             IF ( FFROZP(I) .GT. 0.5 ) THEN
+                ACSNOW(I,J) = ACSNOW(I,J) + PRCP(I) * DT
+             ENDIF
+
+             ! Accumulated snow melt.
+             ACSNOM(I,J) = ACSNOM(I,J) + SNOMLT(I) * 1000.
+  
+             ! Accumulated snow-melt energy.
+             SNOPCX(I,J) = SNOPCX(I,J) - SNOMLT(I)/FDTLIW
+ 
+             ! Surface runoff
+             SFCRUNOFF(I,J) = SFCRUNOFF(I,J) + RUNOFF1(I) * DT * 1000.0
+ 
+             !
+             ! Residual of surface energy balance terms
+             !
+             NOAHRES(I,J) = ( SOLNET(I) + LWDN(I) ) &
+                  &         - SHEAT(I) + SSOIL(I) - ETA(I) &
+                  &         - ( EMISSI(I) * STBOLT * (T1(I)**4) ) &
+                  &         - FLX1(I) - FLX2(I) - FLX3(I)
+#if defined(wrfmodel)
+#if (NMM_CORE != 1)
+             IF ( ( SF_URBAN_PHYSICS == NOAHUCMSCHEME ) .OR. &
+                  (SF_URBAN_PHYSICS == BEPSCHEME )      .OR. &
+                  ( SF_URBAN_PHYSICS == BEP_BEMSCHEME ) ) THEN
+                if ( PRESENT (B_T_BEP) ) then
+                   B_T_BEP(I,1,J)=HFX(i,j)/DZ8W(i,1,j)/RHO(i,1,j)/CP
+                endif
+                if ( PRESENT (B_Q_BEP) ) then
+                   B_Q_BEP(I,1,J)=QFX(i,j)/DZ8W(i,1,j)/RHO(i,1,j)
+                endif
+             ENDIF
+#endif
+#endif
+          ENDIF
+       ENDDO SEAICE_ILOOP4
+    ENDDO SEAICE_JLOOP4
+!$acc end parallel
+
+!$acc end data
+
+!!!$acc update host(TSLB,EMISS,ALBEDO,ALBSI,Z02D,SNOW,TSK,SNOWC,SNOWH2D,CHS,CQS2,HFX,LH, &
+!!!$acc             QFX,ZNT,POTEVP,GRDFLX,QSFC,ACSNOW,ACSNOM,SNOPCX,SFCRUNOFF,NOAHRES,   &
+!!!$acc             CHS2,SNOWSI,ICEDEPTH,B_Q_BEP,B_T_BEP)
+  end subroutine seaice_noah_gpu
+
 end module module_sf_noah_seaice_drv

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
@@ -1,7 +1,7 @@
 MODULE module_sf_noahdrv
 
 !-------------------------------
-  USE module_sf_noahlsm,  only: SFLX, XLF, XLV, CP, R_D, RHOWATER, NATURAL, SHDTBL, LUTYPE, SLTYPE, STBOLT, &
+  USE module_sf_noahlsm,  only: SFLX, SFLX_gpu, XLF, XLV, CP, R_D, RHOWATER, NATURAL, SHDTBL, LUTYPE, SLTYPE, STBOLT, &
       &                         KARMAN, LUCATS, NROTBL, RSTBL, RGLTBL, HSTBL, SNUPTBL, MAXALB, LAIMINTBL,   &
       &                         LAIMAXTBL, Z0MINTBL, Z0MAXTBL, ALBEDOMINTBL, ALBEDOMAXTBL, EMISSMINTBL,     &
       &                         EMISSMAXTBL, TOPT_DATA, CMCMAX_DATA, CFACTR_DATA, RSMAX_DATA, BARE, NLUS,   &
@@ -13,7 +13,7 @@ MODULE module_sf_noahdrv
       &                         LOW_DENSITY_RESIDENTIAL, HIGH_DENSITY_RESIDENTIAL, HIGH_INTENSITY_INDUSTRIAL
 
   USE module_sf_urban,    only: urban, oasis, IRI_SCHEME
-  USE module_sf_noahlsm_glacial_only, only: sflx_glacial
+  USE module_sf_noahlsm_glacial_only, only: sflx_glacial, SFLX_GLACIAL_gpu
   USE module_sf_bep,      only: bep
   USE module_sf_bep_bem,  only: bep_bem
 #if defined(mpas)
@@ -1684,6 +1684,1271 @@ CONTAINS
 !------------------------------------------------------
    END SUBROUTINE lsm
 !------------------------------------------------------
+
+!
+!----------------------------------------------------------------
+! Urban related variable are added to arguments - urban
+!----------------------------------------------------------------
+   SUBROUTINE lsm_gpu(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
+                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,GLW,SMSTAV,SMSTOT, &
+                  SFCRUNOFF, UDRUNOFF,IVGTYP,ISLTYP,ISURBAN,ISICE,VEGFRA,    &
+                  ALBEDO,ALBBCK,ZNT,Z0,TMN,XLAND,XICE,EMISS,EMBCK,   &
+                  SNOWC,QSFC,RAINBL,MMINLU,                     &
+                  NUM_SOIL_LAYERS,DT,DZS,ITIMESTEP,             &
+                  SMOIS,TSLB,SNOW,CANWAT,                       &
+                  CHS,CHS2,CQS2,CPM,ROVCP,SR,CHKLOWQ,LAI,QZ0,   & !H
+                  MYJ,FRPCPN,                                   &
+                  SH2O,SNOWH,                                   & !H
+                  U_PHY,V_PHY,                                  & !I
+                  SNOALB,SHDMIN,SHDMAX,                         & !I
+                  SNOTIME,                                      & !?
+                  ACSNOM,ACSNOW,                                & !O
+                  SNOPCX,                                       & !O
+                  POTEVP,                                       & !O
+                  SMCREL,                                       & !O
+                  XICE_THRESHOLD,                               &
+                  RDLAI2D,USEMONALB,                            &
+                  RIB,                                          & !?
+                  NOAHRES,OPT_THCND,                            &
+! Noah UA changes
+                  UA_PHYS,FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D,       &
+                  ids,ide, jds,jde, kds,kde,                    &
+                  ims,ime, jms,jme, kms,kme,                    &
+                  its,ite, jts,jte, kts,kte,                    &
+                  SF_URBAN_PHYSICS,                             &
+                  CMR_SFCDIF,CHR_SFCDIF,CMC_SFCDIF,CHC_SFCDIF,  &
+                  CMGR_SFCDIF,CHGR_SFCDIF,                      &
+!Optional Urban
+                  TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
+                  UC_URB2D,                                     & !H urban
+                  XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
+                  TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
+                  SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
+                  PSIM_URB2D,PSIH_URB2D,U10_URB2D,V10_URB2D,    & !O urban
+                  GZ1OZ0_URB2D,  AKMS_URB2D,                    & !O urban
+                  TH2_URB2D,Q2_URB2D, UST_URB2D,                & !O urban
+                  DECLIN_URB,COSZ_URB2D,OMG_URB2D,              & !I urban
+                  XLAT_URB2D,                                   & !I urban
+                  NUM_ROOF_LAYERS,NUM_WALL_LAYERS,             & !I urban
+                  NUM_ROAD_LAYERS, DZR, DZB, DZG,               & !I urban
+                  CMCR_URB2D,TGR_URB2D,TGRL_URB3D,SMR_URB3D,    & !H urban
+                  DRELR_URB2D,DRELB_URB2D,DRELG_URB2D,          & !H urban
+                  FLXHUMR_URB2D,FLXHUMB_URB2D,FLXHUMG_URB2D,    & !H urban
+                  JULIAN, JULYR,                                & !H urban
+                  FRC_URB2D,UTYPE_URB2D,                        & !O
+                  NUM_URBAN_LAYERS,                             & !I multi-layer urban
+                  NUM_URBAN_HI,                                 & !I multi-layer urban
+                  TSK_RURAL_BEP,                                & !H multi-layer urban
+                  TRB_URB4D,TW1_URB4D,TW2_URB4D,TGB_URB4D,      & !H multi-layer urban
+                  TLEV_URB3D,QLEV_URB3D,                        & !H multi-layer urban
+                  TW1LEV_URB3D,TW2LEV_URB3D,                    & !H multi-layer urban
+                  TGLEV_URB3D,TFLEV_URB3D,                      & !H multi-layer urban
+                  SF_AC_URB3D,LF_AC_URB3D,CM_AC_URB3D,          & !H multi-layer urban
+                  SFVENT_URB3D,LFVENT_URB3D,                    & !H multi-layer urban
+                  SFWIN1_URB3D,SFWIN2_URB3D,                    & !H multi-layer urban
+                  SFW1_URB3D,SFW2_URB3D,SFR_URB3D,SFG_URB3D,    & !H multi-layer urban
+                  LP_URB2D,HI_URB2D,LB_URB2D,HGT_URB2D,         & !H multi-layer urban
+                  MH_URB2D,STDH_URB2D,LF_URB2D,                 & !SLUCM
+                  TH_PHY,RHO,P_PHY,UST,                         & !I multi-layer urban
+                  GMT,JULDAY,XLONG,XLAT,                        & !I multi-layer urban
+                  A_U_BEP,A_V_BEP,A_T_BEP,A_Q_BEP,              & !O multi-layer urban
+                  A_E_BEP,B_U_BEP,B_V_BEP,                      & !O multi-layer urban
+                  B_T_BEP,B_Q_BEP,B_E_BEP,DLG_BEP,              & !O multi-layer urban
+                  DL_U_BEP,SF_BEP,VL_BEP,SFCHEADRT,INFXSRT,SOLDRAIN,      &   !O multi-layer urban         
+                  SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM, FASDAS,     &   !fasdas
+                  RC2,XLAI2                                               &
+                  )
+
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!----------------------------------------------------------------
+! --- atmospheric (WRF generic) variables
+!-- DT          time step (seconds)
+!-- DZ8W        thickness of layers (m)
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- FLHC        exchange coefficient for heat (m/s)
+!-- FLQC        exchange coefficient for moisture (m/s)
+!-- PSFC        surface pressure (Pa)
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- QGH         saturated mixing ratio at 2 meter
+!-- GSW         downward short wave flux at ground surface (W/m^2)
+!-- GLW         downward long wave flux at ground surface (W/m^2)
+!-- History variables
+!-- CANWAT      canopy moisture content (mm)
+!-- TSK         surface temperature (K)
+!-- TSLB        soil temp (k)
+!-- SMOIS       total soil moisture content (volumetric fraction)
+!-- SH2O        unfrozen soil moisture content (volumetric fraction)
+!                note: frozen soil moisture (i.e., soil ice) = SMOIS - SH2O
+!-- SNOWH       actual snow depth (m)
+!-- SNOW        liquid water-equivalent snow depth (m)
+!-- ALBEDO      time-varying surface albedo including snow effect (unitless fraction)
+!-- ALBBCK      background surface albedo (unitless fraction)
+!-- CHS          surface exchange coefficient for heat and moisture (m s-1);
+!-- CHS2        2m surface exchange coefficient for heat  (m s-1);
+!-- CQS2        2m surface exchange coefficient for moisture (m s-1);
+! --- soil variables
+!-- NUM_SOIL_LAYERS   the number of soil layers
+!-- ZS          depths of centers of soil layers   (m)
+!-- DZS         thicknesses of soil layers (m)
+!-- SLDPTH      thickness of each soil layer (m, same as DZS)
+!-- TMN         soil temperature at lower boundary (K)
+!-- SMCWLT      wilting point (volumetric)
+!-- SMCDRY      dry soil moisture threshold where direct evap from
+!               top soil layer ends (volumetric)
+!-- SMCREF      soil moisture threshold below which transpiration begins to
+!                   stress (volumetric)
+!-- SMCMAX      porosity, i.e. saturated value of soil moisture (volumetric)
+!-- NROOT       number of root layers, a function of veg type, determined
+!               in subroutine redprm.
+!-- SMSTAV      Soil moisture availability for evapotranspiration (
+!                   fraction between SMCWLT and SMCMXA)
+!-- SMSTOT      Total soil moisture content frozen+unfrozen) in the soil column (mm)
+! --- snow variables
+!-- SNOWC       fraction snow coverage (0-1.0)
+! --- vegetation variables
+!-- SNOALB      upper bound on maximum albedo over deep snow
+!-- SHDMIN      minimum areal fractional coverage of annual green vegetation
+!-- SHDMAX      maximum areal fractional coverage of annual green vegetation
+!-- XLAI        leaf area index (dimensionless)
+!-- XLAI2       leaf area index (same as XLAI) passed to output (dimensionless)
+!-- Z0BRD       Background fixed roughness length (M)
+!-- Z0          Background vroughness length (M) as function
+!-- ZNT         Time varying roughness length (M) as function
+!-- ALBD(IVGTPK,ISN) background albedo reading from a table
+! --- LSM output
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          upward moisture flux at the surface (W m-2)
+!-- GRDFLX(I,J) ground heat flux (W m-2)
+!-- FDOWN       radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+!----------------------------------------------------------------------------
+!-- EC          canopy water evaporation ((W m-2)
+!-- EDIR        direct soil evaporation (W m-2)
+!-- ET          plant transpiration from a particular root layer (W m-2)
+!-- ETT         total plant transpiration (W m-2)
+!-- ESNOW       sublimation from (or deposition to if <0) snowpack (W m-2)
+!-- DRIP        through-fall of precip and/or dew in excess of canopy
+!                 water-holding capacity (m)
+!-- DEW         dewfall (or frostfall for t<273.15) (M)
+!-- SMAV        Soil Moisture Availability for each layer, as a fraction
+!                 between SMCWLT and SMCMAX (dimensionless fraction)
+! ----------------------------------------------------------------------
+!-- BETA        ratio of actual/potential evap (dimensionless)
+!-- ETP         potential evaporation (W m-2)
+! ----------------------------------------------------------------------
+!-- FLX1        precip-snow sfc (W m-2)
+!-- FLX2        freezing rain latent heat flux (W m-2)
+!-- FLX3        phase-change heat flux from snowmelt (W m-2)
+! ----------------------------------------------------------------------
+!-- ACSNOM      snow melt (mm) (water equivalent)
+!-- ACSNOW      accumulated snow fall (mm) (water equivalent)
+!-- SNOPCX      snow phase change heat flux (W/m^2)
+!-- POTEVP      accumulated potential evaporation (m)
+!-- RIB         Documentation needed!!!
+! ----------------------------------------------------------------------
+!-- RUNOFF1     surface runoff (m s-1), not infiltrating the surface
+!-- RUNOFF2     subsurface runoff (m s-1), drainage out bottom of last
+!                  soil layer (baseflow)
+!  important note: here RUNOFF2 is actually the sum of RUNOFF2 and RUNOFF3
+!-- RUNOFF3     numerical trunctation in excess of porosity (smcmax)
+!                  for a given soil layer at the end of a time step (m s-1).
+!SFCRUNOFF     Surface Runoff (mm)
+!UDRUNOFF      Total Underground Runoff (mm), which is the sum of RUNOFF2 and RUNOFF3
+! ----------------------------------------------------------------------
+!-- RC          canopy resistance (s m-1)
+!-- RC2         canopy resistance (same as RC) passed to output
+!-- PC          plant coefficient (unitless fraction, 0-1) where PC*ETP = actual transp
+!-- RSMIN       minimum canopy resistance (s m-1)
+!-- RCS         incoming solar rc factor (dimensionless)
+!-- RCT         air temperature rc factor (dimensionless)
+!-- RCQ         atmos vapor pressure deficit rc factor (dimensionless)
+!-- RCSOIL      soil moisture rc factor (dimensionless)
+
+!-- EMISS       surface emissivity (between 0 and 1)
+!-- EMBCK       Background surface emissivity (between 0 and 1)
+
+!-- ROVCP       R/CP
+!               (R_d/R_v) (dimensionless)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!
+!-- SR          fraction of frozen precip (0.0 to 1.0)
+!----------------------------------------------------------------
+
+! IN only
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER,  INTENT(IN   )   ::  SF_URBAN_PHYSICS               !urban
+   INTEGER,  INTENT(IN   )   ::  ISURBAN
+   INTEGER,  INTENT(IN   )   ::  ISICE
+   INTEGER,  INTENT(IN   )   ::  JULIAN, JULYR                  !urban
+
+!added by Wei Yu  for routing
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+             INTENT(INOUT)  :: SFCHEADRT,INFXSRT,SOLDRAIN
+    REAL,    DIMENSION( ims:ime) :: ETPND1
+!end added
+
+
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                            TMN, &
+                                                         XLAND, &
+                                                          XICE, &
+                                                        VEGFRA, &
+                                                        SHDMIN, &
+                                                        SHDMAX, &
+                                                        SNOALB, &
+                                                           GSW, &
+                                                        SWDOWN, & !added 10 jan 2007
+                                                           GLW, &
+                                                        RAINBL, &
+                                                        EMBCK,  &
+                                                        SR
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                         ALBBCK, &
+                                                            Z0
+   CHARACTER(LEN=*), INTENT(IN   )    ::                 MMINLU
+
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                         P8W3D, &
+                                                          DZ8W, &
+                                                          T3D
+   REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+             INTENT(IN   )               ::               QGH,  &
+                                                          CPM
+
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                         IVGTYP, &
+                                                        ISLTYP
+
+   INTEGER, INTENT(IN)       ::     NUM_SOIL_LAYERS,ITIMESTEP
+
+   REAL,     INTENT(IN   )   ::     DT,ROVCP
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::DZS
+
+! IN and OUT
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)   ::                          SMOIS, & ! total soil moisture
+                                                         SH2O,  & ! new soil liquid
+                                                         TSLB     ! TSLB     STEMP
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(OUT)     ::                         SMCREL
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                            TSK, & !was TGB (temperature)
+                                                           HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                        GRDFLX, &
+                                                          QSFC,&
+                                                          CQS2,&
+                                                          CHS,   &
+                                                          CHS2,&
+                                                          SNOW, &
+                                                         SNOWC, &
+                                                         SNOWH, & !new
+                                                        CANWAT, &
+                                                        SMSTAV, &
+                                                        SMSTOT, &
+                                                     SFCRUNOFF, &
+                                                      UDRUNOFF, &
+                                                        ACSNOM, &
+                                                        ACSNOW, &
+                                                       SNOTIME, &
+                                                        SNOPCX, &
+                                                        EMISS,  &
+                                                          RIB,  &
+                                                        POTEVP, &
+                                                        ALBEDO, &
+                                                           ZNT
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(OUT)      ::                         NOAHRES
+   INTEGER, INTENT(IN)       ::                         OPT_THCND
+
+! Noah UA changes
+   LOGICAL,                                INTENT(IN)  :: UA_PHYS
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D
+   REAL,    DIMENSION( ims:ime) :: FLX4,FVB,FBUR,FGSN
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+               INTENT(OUT)    ::                        CHKLOWQ
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LAI
+   REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) ::        QZ0
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) ::  RC2, XLAI2
+
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMC_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHC_SFCDIF
+! Local variables (moved here from driver to make routine thread safe, 20031007 jm)
+
+      REAL, DIMENSION(1:num_soil_layers,ims:ime) ::  ET
+
+      REAL, DIMENSION(1:num_soil_layers,ims:ime) ::  SMAV
+
+    REAL, DIMENSION(ims:ime) :: FFROZP,XLAI,FDOWN,EC,EDIR,ETT,ESNOW, &
+                DRIP,DEW,BETA,ETP,SSOIL,FLX1,FLX2,FLX3,RC,PC,RSMIN,  &
+                RCS,RCT,RCQ,RCSOIL
+
+    LOGICAL,    INTENT(IN   )    ::     MYJ,FRPCPN
+
+! DECLARATIONS - LOGICAL
+! ----------------------------------------------------------------------
+      LOGICAL, PARAMETER :: LOCAL=.false.
+      LOGICAL :: FRZGRA, SNOWNG
+
+      LOGICAL :: IPRINT
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - INTEGER
+! ----------------------------------------------------------------------
+      INTEGER :: I,J, NSOIL,SLOPETYP
+      INTEGER, DIMENSION( ims:ime ) :: VEGTYP,SOILTYP,ICE
+      INTEGER, DIMENSION( ims:ime ) :: NROOT
+      INTEGER :: KZ ,K
+      INTEGER :: NS
+! ----------------------------------------------------------------------
+! DECLARATIONS - REAL
+! ----------------------------------------------------------------------
+
+      REAL  :: PRCPRAIN,                    &
+               SFCSPD,         &
+! mek, WRF testing, expanded diagnostics
+               SOLUP,LWUP,RNET,RES,Q1SFC,TAIRV,SATFLG
+      REAL, DIMENSION(ims:ime) :: SFCPRS,Q2K,Q2SAT,SFCTMP,ZLVL,LWDN,     &
+               SOLDN,SOLNET,PRCP,SHDFAC,SHMIN,SHMAX,DQSDT2,SFCTSNO,      &
+               E2SAT,Q2SATI,TBOT,SNOALB1,ALBBRD,EMBRD,Z0K,ALBEDOK,       &
+               ETA,SHEAT,ETA_KINEMATIC,RUNOFF1,RUNOFF2,RUNOFF3
+! MEK MAY 2007
+      REAL ::  FDTLIW
+! MEK JUL2007 for pot. evap.
+      REAL, DIMENSION(ims:ime) :: RIBB
+      REAL ::  FDTW
+
+      REAL, DIMENSION(ims:ime) :: EMISSI
+
+      REAL, DIMENSION(ims:ime) :: TH2,CHK,SNEQV,SNCOVR,SNOWHK,CMC
+
+      REAL, DIMENSION(ims:ime) :: T1,SNOMLT,SOILM,SOILW,Q1,SMCDRY,SMCMAX,SMCREF,SMCWLT
+      REAL, DIMENSION(ims:ime) :: SNOTIME1    ! LSTSNW1 INITIAL NUMBER OF TIMESTEPS SINCE LAST SNOWFALL
+
+      REAL, DIMENSION(ims:ime) :: DUMMY
+      REAL, DIMENSION(ims:ime) :: Z0BRD
+!
+      REAL  :: COSZ, SOLARDIRECT
+!
+      REAL, DIMENSION(1:NUM_SOIL_LAYERS, ims:ime):: SMC,STC,SWC,SLDPTH
+!
+      REAL, DIMENSION(1:NUM_SOIL_LAYERS) ::     ZSOIL, RTDIS
+      REAL, PARAMETER  :: TRESH=.95E0, A2=17.67,A3=273.15,A4=29.65,   &
+                          T0=273.16E0, ELWV=2.50E6,  A23M4=A2*(A3-A4)
+! MEK MAY 2007
+      REAL, PARAMETER  :: ROW=1.E3,ELIW=XLF,ROWLIW=ROW*ELIW
+
+! ----------------------------------------------------------------------
+! DECLARATIONS START - urban
+! ----------------------------------------------------------------------
+
+! input variables surface_driver --> lsm
+     INTEGER, INTENT(IN) :: NUM_ROOF_LAYERS
+     INTEGER, INTENT(IN) :: NUM_WALL_LAYERS
+     INTEGER, INTENT(IN) :: NUM_ROAD_LAYERS
+     REAL, OPTIONAL, DIMENSION(1:NUM_ROOF_LAYERS), INTENT(IN) :: DZR
+     REAL, OPTIONAL, DIMENSION(1:NUM_WALL_LAYERS), INTENT(IN) :: DZB
+     REAL, OPTIONAL, DIMENSION(1:NUM_ROAD_LAYERS), INTENT(IN) :: DZG
+     REAL, OPTIONAL, INTENT(IN) :: DECLIN_URB
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: XLAT_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: U_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: V_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: TH_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: P_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: RHO
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST
+
+     LOGICAL, intent(in) :: RDLAI2D
+     LOGICAL, intent(in) :: USEMONALB
+
+! input variables lsm --> urban
+     INTEGER :: UTYPE_URB ! urban type [urban=1, suburban=2, rural=3]
+     REAL :: TA_URB       ! potential temp at 1st atmospheric level [K]
+     REAL :: QA_URB       ! mixing ratio at 1st atmospheric level  [kg/kg]
+     REAL :: UA_URB       ! wind speed at 1st atmospheric level    [m/s]
+     REAL :: U1_URB       ! u at 1st atmospheric level             [m/s]
+     REAL :: V1_URB       ! v at 1st atmospheric level             [m/s]
+     REAL :: SSG_URB      ! downward total short wave radiation    [W/m/m]
+     REAL :: LLG_URB      ! downward long wave radiation           [W/m/m]
+     REAL :: RAIN_URB     ! precipitation                          [mm/h]
+     REAL :: RHOO_URB     ! air density                            [kg/m^3]
+     REAL :: ZA_URB       ! first atmospheric level                [m]
+     REAL :: DELT_URB     ! time step                              [s]
+     REAL :: SSGD_URB     ! downward direct short wave radiation   [W/m/m]
+     REAL :: SSGQ_URB     ! downward diffuse short wave radiation  [W/m/m]
+     REAL :: XLAT_URB     ! latitude                               [deg]
+     REAL :: COSZ_URB     ! cosz
+     REAL :: OMG_URB      ! hour angle
+     REAL :: ZNT_URB      ! roughness length                       [m]
+     REAL :: TR_URB
+     REAL :: TB_URB
+     REAL :: TG_URB
+     REAL :: TC_URB
+     REAL :: QC_URB
+     REAL :: UC_URB
+     REAL :: XXXR_URB
+     REAL :: XXXB_URB
+     REAL :: XXXG_URB
+     REAL :: XXXC_URB
+     REAL, DIMENSION(1:NUM_ROOF_LAYERS) :: TRL_URB  ! roof layer temp [K]
+     REAL, DIMENSION(1:NUM_WALL_LAYERS) :: TBL_URB  ! wall layer temp [K]
+     REAL, DIMENSION(1:NUM_ROAD_LAYERS) :: TGL_URB  ! road layer temp [K]
+     LOGICAL  :: LSOLAR_URB
+
+!===Yang,2014/10/08,hydrological variable for single layer UCM===
+     INTEGER :: JMONTH, JDAY, TLOC
+     INTEGER :: IRIOPTION, USOIL, DSOIL
+     REAL :: AOASIS, OMG
+     REAL :: DRELR_URB
+     REAL :: DRELB_URB
+     REAL :: DRELG_URB
+     REAL :: FLXHUMR_URB
+     REAL :: FLXHUMB_URB
+     REAL :: FLXHUMG_URB
+     REAL :: CMCR_URB
+     REAL :: TGR_URB
+     REAL, DIMENSION(1:NUM_ROOF_LAYERS) :: SMR_URB  ! green roof layer moisture
+     REAL, DIMENSION(1:NUM_ROOF_LAYERS) :: TGRL_URB ! green roof layer temp [K]
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMCR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TGR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_ROOF_LAYERS, jms:jme ), INTENT(INOUT) :: TGRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_ROOF_LAYERS, jms:jme ), INTENT(INOUT) :: SMR_URB3D
+
+
+! state variable surface_driver <--> lsm <--> urban
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: QC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: G_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: RN_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TS_URB2D
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_ROOF_LAYERS, jms:jme ), INTENT(INOUT) :: TRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_WALL_LAYERS, jms:jme ), INTENT(INOUT) :: TBL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_ROAD_LAYERS, jms:jme ), INTENT(INOUT) :: TGL_URB3D
+
+! output variable lsm --> surface_driver
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIM_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: GZ1OZ0_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: U10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: V10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: TH2_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: Q2_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: AKMS_URB2D
+!
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: UST_URB2D
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: FRC_URB2D
+     INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
+
+
+! output variables urban --> lsm
+     REAL :: TS_URB     ! surface radiative temperature    [K]
+     REAL :: QS_URB     ! surface humidity                 [-]
+     REAL :: SH_URB     ! sensible heat flux               [W/m/m]
+     REAL :: LH_URB     ! latent heat flux                 [W/m/m]
+     REAL :: LH_KINEMATIC_URB ! latent heat flux, kinetic  [kg/m/m/s]
+     REAL :: SW_URB     ! upward short wave radiation flux [W/m/m]
+     REAL :: ALB_URB    ! time-varying albedo            [fraction]
+     REAL :: LW_URB     ! upward long wave radiation flux  [W/m/m]
+     REAL :: G_URB      ! heat flux into the ground        [W/m/m]
+     REAL :: RN_URB     ! net radiation                    [W/m/m]
+     REAL :: PSIM_URB   ! shear f for momentum             [-]
+     REAL :: PSIH_URB   ! shear f for heat                 [-]
+     REAL :: GZ1OZ0_URB   ! shear f for heat                 [-]
+     REAL :: U10_URB    ! wind u component at 10 m         [m/s]
+     REAL :: V10_URB    ! wind v component at 10 m         [m/s]
+     REAL :: TH2_URB    ! potential temperature at 2 m     [K]
+     REAL :: Q2_URB     ! humidity at 2 m                  [-]
+     REAL :: CHS_URB
+     REAL :: CHS2_URB
+     REAL :: UST_URB
+! NUDAPT Parameters urban --> lam
+     REAL :: MH_URB
+     REAL :: STDH_URB
+     REAL :: LP_URB
+     REAL :: HGT_URB
+     REAL, DIMENSION(4) :: LF_URB
+! Variables for multi-layer UCM (Martilli et al. 2002)
+   REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
+   INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
+   REAL, OPTIONAL, DIMENSION( ims:ime,                     jms:jme ), INTENT(INOUT) :: TSK_RURAL_BEP
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TRB_URB4D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TW1_URB4D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TW2_URB4D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TGB_URB4D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TLEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: QLEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TW1LEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TW2LEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TGLEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: TFLEV_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LF_AC_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SF_AC_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CM_AC_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SFVENT_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LFVENT_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFWIN1_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFWIN2_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFW1_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFW2_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFR_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_LAYERS, jms:jme ), INTENT(INOUT) :: SFG_URB3D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:NUM_URBAN_HI, jms:jme ), INTENT(IN) :: HI_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: LP_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: LB_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: HGT_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: MH_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: STDH_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, 4, jms:jme ), INTENT(IN) :: LF_URB2D
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::A_U_BEP   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::A_V_BEP   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::A_T_BEP   !Implicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::A_Q_BEP   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::A_E_BEP   !Implicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::B_U_BEP   !Explicit momentum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::B_V_BEP   !Explicit momentum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::B_T_BEP   !Explicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::B_Q_BEP   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::B_E_BEP   !Explicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::VL_BEP    !Fraction air volume in grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::DLG_BEP   !Height above ground
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::SF_BEP  !Fraction air at the face of grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::DL_U_BEP  !Length scale
+
+! Local variables for multi-layer UCM (Martilli et al. 2002)
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_RURAL,LH_RURAL,GRDFLX_RURAL ! ,RN_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_RURAL ! ,QSFC_RURAL,UMOM_RURAL,VMOM_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: ALB_RURAL,EMISS_RURAL,TSK_RURAL ! ,UST_RURAL
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: QSFC_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_URB,UMOM_URB,VMOM_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_URB
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: ALBEDO_URB,EMISS_URB,UMOM,VMOM,UST
+   REAL, DIMENSION(its:ite,jts:jte) ::EMISS_URB
+   REAL, DIMENSION(its:ite,jts:jte) :: RL_UP_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::RS_ABS_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::GRDFLX_URB
+   REAL :: SIGMA_SB,RL_UP_RURAL,RL_UP_TOT,RS_ABS_TOT,UMOM,VMOM
+   REAL :: CMR_URB, CHR_URB, CMC_URB, CHC_URB, CMGR_URB, CHGR_URB
+   REAL :: frc_urb,lb_urb
+   REAL :: check 
+! ----------------------------------------------------------------------
+! DECLARATIONS END - urban
+! ----------------------------------------------------------------------
+
+  REAL, PARAMETER  :: CAPA=R_D/CP
+  REAL :: APELM,APES,SFCTH2,PSFC
+  real, intent(in) :: XICE_THRESHOLD
+  character(len=80) :: message_text
+!
+!  FASDAS
+!
+   REAL,    DIMENSION( ims:ime, jms:jme ),  OPTIONAL,                     &
+            INTENT(INOUT)  ::   SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM
+   INTEGER, INTENT(IN   )  ::  FASDAS
+!  local vars
+   REAL, DIMENSION( ims:ime ) :: XSDA_HFX, XSDA_QFX, XQNORM,HFX_PHY,QFX_PHY,HCPCT_FASDAS
+   REAL                    ::  DZQ
+
+!!!$acc update device(DZ8W,P8W3D,T3D,QV3D,XLAND,XICE,IVGTYP,ISLTYP,TMN,VEGFRA,SHDMIN,SHDMAX, &
+!!!$acc               SNOALB,GLW,GSW,SWDOWN,RAINBL,EMBCK,SR,QGH,CPM,QZ0,TSK,HFX,QFX,LH,      &
+!!!$acc               GRDFLX,QSFC,CQS2,CHS,CHS2,SNOW,SNOWC,SNOWH,CANWAT,SMSTAV,SMSTOT,       &
+!!!$acc               SFCRUNOFF,UDRUNOFF,ACSNOM,ACSNOW,SNOTIME,SNOPCX,EMISS,RIB,POTEVP,      &
+!!!$acc               ALBEDO,ALBBCK,Z0,ZNT,LAI,NOAHRES,CHKLOWQ,SH2O,SMOIS,TSLB,SMCREL,DZS,   &
+!!!$acc               FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D,UTYPE_URB2D,FRC_URB2D,UST_URB2D,INFXSRT,&
+!!!$acc               SFCHEADRT,SOLDRAIN)
+
+!$acc data create(HFX_PHY,QFX_PHY,XQNORM,XSDA_HFX,XSDA_QFX,FLX4,FVB,FBUR,FGSN,SOILW, &
+!$acc             SLDPTH,SFCPRS,Q2K,Q2SAT,SFCTMP,ZLVL,LWDN,SOLDN,SOLNET,PRCP,SHDFAC, &
+!$acc             SHMIN,SHMAX,DQSDT2,SFCTSNO,E2SAT,Q2SATI,TBOT,SNOALB1,ALBBRD,EMBRD, &
+!$acc             Z0K,ALBEDOK,ETA,SHEAT,ETA_KINEMATIC,RUNOFF1,RUNOFF2,RUNOFF3,TH2,   &
+!$acc             EMISSI,VEGTYP,SOILTYP,T1,CHK,SNEQV,SNCOVR,SNOWHK,CMC,FFROZP,XLAI,  &
+!$acc             FDOWN,EC,EDIR,ETT,ESNOW,DRIP,DEW,BETA,ETP,SSOIL,FLX1,FLX2,FLX3,RC, &
+!$acc             PC,RSMIN,RCS,RCT,RCQ,RCSOIL,TSK_RURAL,HFX_RURAL,QFX_RURAL,LH_RURAL,&
+!$acc             GRDFLX_RURAL,EMISS_RURAL,Z0BRD,SNOTIME1,RIBB,SMC,STC,SWC,ICE,SOILM,&
+!$acc             SMAV,ALB_RURAL,HCPCT_FASDAS,Q1,SNOMLT,SMCMAX,SMCREF,SMCDRY,SMCWLT, &
+!$acc             ETPND1,ET,NROOT,DUMMY)
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+   DO I=its,ite
+      HFX_PHY(I) = 0.0   ! initialize
+      QFX_PHY(I) = 0.0
+      XQNORM(I)  = 0.0
+      XSDA_HFX(I) = 0.0
+      XSDA_QFX(I) = 0.0
+!
+!  END FASDAS
+!
+      FLX4(I)  = 0.0 !BSINGH - Initialized to 0.0
+      FVB(I)   = 0.0 !BSINGH - Initialized to 0.0
+      FBUR(I)  = 0.0 !BSINGH - Initialized to 0.0
+      FGSN(I)  = 0.0 !BSINGH - Initialized to 0.0
+      SOILW(I) = 0.0 !BSINGH - Initialized to 0.0
+   ENDDO
+!$acc end parallel
+
+  SIGMA_SB=5.67e-08
+
+! MEK MAY 2007
+      FDTLIW=DT/ROWLIW
+! MEK JUL2007
+      FDTW=DT/(XLV*RHOWATER)
+! debug printout
+         IPRINT=.false.
+
+!      SLOPETYP=2
+      SLOPETYP=1
+!      SHDMIN=0.00
+
+
+      NSOIL=NUM_SOIL_LAYERS
+
+
+     JLOOP : DO J=jts,jte
+
+      IF(ITIMESTEP.EQ.1)THEN
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+        DO 50 I=its,ite
+!*** initialize soil conditions for IHOP 31 May case
+!         IF((XLAND(I,J)-1.5) < 0.)THEN
+!            if (I==108.and.j==85) then
+!                  DO NS=1,NSOIL
+!                      SMOIS(I,NS,J)=0.10
+!                      SH2O(I,NS,J)=0.10
+!                  enddo
+!             endif
+!         ENDIF
+
+!*** SET ZERO-VALUE FOR SOME OUTPUT DIAGNOSTIC ARRAYS
+          IF((XLAND(I,J)-1.5).GE.0.)THEN
+! check sea-ice point
+#if 0
+            IF( XICE(I,J).GE. XICE_THRESHOLD .and. IPRINT ) PRINT*, ' sea-ice at water point, I=',I,'J=',J
+#endif
+!***   Open Water Case
+            SMSTAV(I,J)=1.0
+            SMSTOT(I,J)=1.0
+            DO NS=1,NSOIL
+              SMOIS(I,NS,J)=1.0
+              TSLB(I,NS,J)=273.16                                          !STEMP
+              SMCREL(I,NS,J)=1.0
+            ENDDO
+          ELSE
+            IF ( XICE(I,J) .GE. XICE_THRESHOLD ) THEN
+!***        SEA-ICE CASE
+              SMSTAV(I,J)=1.0
+              SMSTOT(I,J)=1.0
+              DO NS=1,NSOIL
+                SMOIS(I,NS,J)=1.0
+                SMCREL(I,NS,J)=1.0
+              ENDDO
+            ENDIF
+          ENDIF
+!
+   50   CONTINUE
+!$acc end parallel
+      ENDIF                                                               ! end of initialization over ocean
+
+!-----------------------------------------------------------------------
+!$acc parallel vector_length(32)
+!$acc loop gang vector private(PSFC,SATFLG,APES,APELM,SFCTH2)
+      ILOOP1 : DO I=its,ite
+
+        DO NS=1,NSOIL
+          SLDPTH(NS,I)=DZS(NS)
+        ENDDO
+
+! surface pressure
+        PSFC=P8W3D(i,1,j)
+! pressure in middle of lowest layer
+        SFCPRS(I)=(P8W3D(I,KTS+1,J)+P8W3D(I,KTS,j))*0.5
+! convert from mixing ratio to specific humidity
+         Q2K(I)=QV3D(I,1,J)/(1.0+QV3D(I,1,J))
+!
+!         Q2SAT(I)=QGH(I,j)
+         Q2SAT(I)=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+! add check on myj=.true.
+!        IF((Q2K(I).GE.Q2SAT(I)*TRESH).AND.Q2K(I).LT.QZ0(I,J))THEN
+        IF((MYJ).AND.(Q2K(I).GE.Q2SAT(I)*TRESH).AND.Q2K(I).LT.QZ0(I,J))THEN
+          SATFLG=0.
+          CHKLOWQ(I,J)=0.
+        ELSE
+          SATFLG=1.0
+          CHKLOWQ(I,J)=1.
+        ENDIF
+
+        SFCTMP(I)=T3D(i,1,j)
+        ZLVL(I)=0.5*DZ8W(i,1,j)
+
+!        TH2(I)=SFCTMP(I)+(0.0097545*ZLVL(I))
+! calculate SFCTH2 via Exner function vs lapse-rate (above)
+         APES=(1.E5/PSFC)**CAPA
+         APELM=(1.E5/SFCPRS(I))**CAPA
+         SFCTH2=SFCTMP(I)*APELM
+         TH2(I)=SFCTH2/APES
+!
+         EMISSI(I) = EMISS(I,J)
+         LWDN(I)=GLW(I,J)*EMISSI(I)
+! SOLDN is total incoming solar
+        SOLDN(I)=SWDOWN(I,J)
+! GSW is net downward solar
+!        SOLNET(I)=GSW(I,J)
+! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+        SOLNET(I)=SOLDN(I)*(1.-ALBEDO(I,J))
+        PRCP(I)=RAINBL(i,j)/DT
+        VEGTYP(I)=IVGTYP(I,J)
+        SOILTYP(I)=ISLTYP(I,J)
+        SHDFAC(I)=VEGFRA(I,J)/100.
+        T1(I)=TSK(I,J)
+        CHK(I)=CHS(I,J)
+        SHMIN(I)=SHDMIN(I,J)/100. !NEW
+        SHMAX(I)=SHDMAX(I,J)/100. !NEW
+! convert snow water equivalent from mm to meter
+        SNEQV(I)=SNOW(I,J)*0.001
+! snow depth in meters
+        SNOWHK(I)=SNOWH(I,J)
+        SNCOVR(I)=SNOWC(I,J)
+
+! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+! SR from e.g. Ferrier microphysics
+! otherwise define from 1st atmos level temperature
+       IF(FRPCPN) THEN
+          FFROZP(I)=SR(I,J)
+        ELSE
+          IF (SFCTMP(I) <=  273.15) THEN
+            FFROZP(I) = 1.0
+          ELSE
+            FFROZP(I) = 0.0
+          ENDIF
+        ENDIF
+
+      ENDDO ILOOP1
+!$acc end parallel
+!***
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector 
+      ILOOP2 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+! Open water points
+          TSK_RURAL(I,J)=TSK(I,J)
+          HFX_RURAL(I,J)=HFX(I,J)
+          QFX_RURAL(I,J)=QFX(I,J)
+          LH_RURAL(I,J)=LH(I,J)
+          EMISS_RURAL(I,J)=EMISS(I,J)
+          GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+        ENDIF
+      ENDDO ILOOP2
+!$acc end parallel
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
+          AOASIS = 1.0
+          USOIL = 1
+          DSOIL = 2
+          IRIOPTION=IRI_SCHEME
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+      ILOOP31 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0.)THEN
+! Land or sea-ice case
+
+          IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+             ! Sea-ice point
+             ICE(I) = 1
+          ELSE IF ( VEGTYP(I) == ISICE ) THEN
+             ! Land-ice point
+             ICE(I) = -1
+          ELSE
+             ! Neither sea ice or land ice.
+             ICE(I) = 0
+          ENDIF
+          DQSDT2(I)=Q2SAT(I)*A23M4/(SFCTMP(I)-A4)**2
+
+          IF(SNOW(I,J).GT.0.0)THEN
+! snow on surface (use ice saturation properties)
+            SFCTSNO(I)=SFCTMP(I)
+            E2SAT(I)=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO(I)))
+            Q2SATI(I)=0.622*E2SAT(I)/(SFCPRS(I)-E2SAT(I))
+            Q2SATI(I)=Q2SATI(I)/(1.0+Q2SATI(I))    ! spec. hum.
+            IF (T1(I) .GT. 273.14) THEN
+! warm ground temps, weight the saturation between ice and water according to SNOWC
+              Q2SAT(I)=Q2SAT(I)*(1.-SNOWC(I,J)) + Q2SATI(I)*SNOWC(I,J)
+              DQSDT2(I)=DQSDT2(I)*(1.-SNOWC(I,J)) + Q2SATI(I)*6174./(SFCTSNO(I)**2)*SNOWC(I,J)
+            ELSE
+! cold ground temps, use ice saturation only
+              Q2SAT(I)=Q2SATI(I)
+              DQSDT2(I)=Q2SATI(I)*6174./(SFCTSNO(I)**2)
+            ENDIF
+! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+! V3.8 add condition for SWDOWN to restrict condition to positive forcing (JD)
+            IF(T1(I) .GT. 273. .AND. SNOWC(I,J) .GT. 0. .AND. SWDOWN(I,J) .GT. 10.)DQSDT2(I)=DQSDT2(I)*(1.-SNOWC(I,J))
+          ENDIF
+        ENDIF
+      ENDDO ILOOP31
+!$acc end parallel
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector 
+      ILOOP32 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0.)THEN
+          ! Land-ice or land points use the usual deep-soil temperature.
+          TBOT(I)=TMN(I,J)
+
+          IF(ISURBAN.EQ.1) THEN
+! assumes these only need to be set for USGS land data
+            IF(VEGTYP(I).EQ.25) SHDFAC(I)=0.0000
+            IF(VEGTYP(I).EQ.26) SHDFAC(I)=0.0000
+            IF(VEGTYP(I).EQ.27) SHDFAC(I)=0.0000
+          ENDIF
+          IF(SOILTYP(I).EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+         IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+         IF(IPRINT)PRINT*,I,J,'RESET SOIL in surfce.F'
+#endif
+            SOILTYP(I)=7
+          ENDIF
+          SNOALB1(I) = SNOALB(I,J)
+! converts canwat in mm to CMC in meters
+          CMC(I)=CANWAT(I,J)/1000.
+
+!-------------------------------------------
+!*** convert snow depth from mm to meter
+!
+!          IF(RDMAXALB) THEN
+!           SNOALB=ALBMAX(I,J)*0.01
+!         ELSE
+!           SNOALB=MAXALB(IVGTPK)*0.01
+!         ENDIF
+
+!        SNOALB1(I)=0.80
+!        SHMIN(I)=0.00
+          ALBBRD(I)=ALBBCK(I,J)
+          Z0BRD(I)=Z0(I,J)
+          EMBRD(I)=EMBCK(I,J)
+          SNOTIME1(I) = SNOTIME(I,J)
+          RIBB(I)=RIB(I,J)
+!FEI: temporaray arrays above need to be changed later by using SI
+
+          DO NS=1,NSOIL
+            SMC(NS,I)=SMOIS(I,NS,J)
+            STC(NS,I)=TSLB(I,NS,J)                                          !STEMP
+            SWC(NS,I)=SH2O(I,NS,J)
+          ENDDO
+!
+          IF ( (SNEQV(I).ne.0..AND.SNOWHK(I).eq.0.).or.(SNOWHK(I).le.SNEQV(I)) )THEN
+            SNOWHK(I)= 5.*SNEQV(I)
+          ENDIF
+!
+
+
+#if 0
+          IF(IPRINT) THEN
+!
+       print*, 'BEFORE SFLX, in Noahlsm_driver'
+       print*, 'ICE', ICE(I), 'DT',DT, 'ZLVL',ZLVL(I), 'NSOIL', NSOIL,   &
+       'SLDPTH', SLDPTH(1:NSOIL,I), 'LOCAL',LOCAL, 'LUTYPE',&
+        LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN(I), 'SOLDN',SOLDN(I),      &
+        'SFCPRS',SFCPRS(I), 'PRCP',PRCP(I),'SFCTMP',SFCTMP(I),'Q2K',Q2K(I),   &
+         'TH2',TH2(I),'Q2SAT',Q2SAT(I),'DQSDT2',DQSDT2(I),'VEGTYP', VEGTYP(I),&
+         'SOILTYP',SOILTYP(I), 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC(I),&
+         'SHMIN',SHMIN(I), 'ALBBRD',ALBBRD(I),'SNOALB1',SNOALB1(I),'TBOT',&
+          TBOT(I), 'Z0BRD',Z0BRD(I), 'Z0K',Z0K(I), 'CMC',CMC(I), 'T1',T1(I),'STC',&
+          STC(1:NSOIL,I), 'SMC',SMC(1:NSOIL,I), 'SWC',SWC(1:NSOIL,I),'SNOWHK',SNOWHK(I),'SNEQV',SNEQV(I),&
+          'ALBEDOK',ALBEDOK(I),'CHK',CHK(I),'ETA',ETA(I),'SHEAT',SHEAT(I),      &
+          'ETA_KINEMATIC',ETA_KINEMATIC(I), 'FDOWN',FDOWN(I),'EC',EC(I),   &
+          'EDIR',EDIR(I),'ET',ET(1:NSOIL,I),'ETT',ETT(I),'ESNOW',ESNOW(I),'DRIP',DRIP(I),&
+          'DEW',DEW(I),'BETA',BETA(I),'ETP',ETP(I),'SSOIL',SSOIL(I),'FLX1',FLX1(I),&
+          'FLX2',FLX2(I),'FLX3',FLX3(I),'SNOMLT',SNOMLT(I),'SNCOVR',SNCOVR(I),&
+          'RUNOFF1',RUNOFF1(I),'RUNOFF2',RUNOFF2(I),'RUNOFF3',RUNOFF3(I), &
+          'RC',RC(I), 'PC',PC(I),'RSMIN',RSMIN(I),'XLAI',XLAI,'RCS',RCS(I),  &
+          'RCT',RCT(I),'RCQ',RCQ(I),'RCSOIL',RCSOIL(I),'SOILW',SOILW(I),     &
+          'SOILM',SOILM(I),'Q1',Q1(I),'SMCWLT',SMCWLT(I),'SMCDRY',SMCDRY(I),&
+          'SMCREF',SMCREF(I),'SMCMAX',SMCMAX(I),'NROOT',NROOT(I)
+          endif
+#endif
+
+          IF (RDLAI2D) THEN
+             IF (SHDFAC(I) > 0.0 .AND. LAI(I,J) <= 0.0) LAI(I,J) = 0.01
+             XLAI(I) = LAI(i,j)
+          ENDIF
+        ENDIF
+      ENDDO ILOOP32
+!$acc end parallel
+
+      ! Non-glacial land
+!
+!  FASDAS
+!
+      IF( FASDAS == 1 ) THEN
+!!!$acc update device(SDA_HFX,RHO,SDA_QFX,QNORM)
+!$acc parallel vector_length(128)
+!$acc loop gang vector private(DZQ)
+        ILOOP41 : DO I=its,ite
+          IF((XLAND(I,J)-1.5).LT.0.)THEN
+            IF (ICE(I) == 0) THEN
+              DZQ = DZ8W(I,1,J)
+              XSDA_HFX(I)= SDA_HFX(I,J)*RHO(I,1,J)*CPM(I,J)*DZQ  ! W/m^2
+            ! TWG2015 Bugfix remove factor of 1000.0 for correct units
+              XSDA_QFX(I)= SDA_QFX(I,J)*RHO(I,1,J)*DZQ          ! Kg/m2/s of water
+              XQNORM(I) = QNORM(I,J)
+            ENDIF
+          ENDIF
+        ENDDO ILOOP41
+!$acc end parallel
+      ENDIF
+!
+!  END FASDAS
+!
+!!!$acc update device(LUTYPE,SLTYPE)
+            CALL SFLX_gpu (ims,ime,its,ite,XLAND,ICE,              &
+                 I,J,FFROZP, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                 LOCAL,                                            &    !L
+                 LUTYPE, SLTYPE,                                   &    !CL
+                 LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                 DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                 TH2,Q2SAT,DQSDT2,                                 &    !I
+                 VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                 ALBBRD, SNOALB1,TBOT,Z0BRD,Z0K,EMISSI,EMBRD,  &    !S
+                 CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,DUMMY,&    !H
+                 ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+                 EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                 BETA,ETP,SSOIL,                                   &    !O
+                 FLX1,FLX2,FLX3,                                   &    !O
+                 FLX4,FVB,FBUR,FGSN,UA_PHYS,                       &    !UA 
+                 SNOMLT,SNCOVR,                                    &    !O
+                 RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                 RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                 SOILW,SOILM,Q1,SMAV,                              &    !D
+                 RDLAI2D,USEMONALB,                                &
+                 SNOTIME1,                                         &
+                 RIBB,                                             &
+                 SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
+                 SFCHEADRT,                                   &    !I
+                 INFXSRT,ETPND1,OPT_THCND,AOASIS              &    !O
+                ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, FASDAS, HCPCT_FASDAS    &   ! fasdas
+                 )
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+      ILOOP43 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0.)THEN
+          IF (ICE(I) == 0) THEN
+#ifdef WRF_HYDRO
+            SOLDRAIN(I,J) = RUNOFF2(I)*DT*1000.0
+#endif
+          ENDIF
+        ENDIF
+      ENDDO ILOOP43
+!$acc end parallel
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+      ILOOP51 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0.)THEN
+          IF (ICE(I) == -1) THEN
+       !
+       ! Set values that the LSM is expected to update,
+       ! but don't get updated for glacial points.
+       !
+            SOILM(I) = 0.0 !BSINGH(PNNL)- SOILM is undefined for this case, it is used for diagnostics so setting it to zero
+            XLAI(I) = 0.01 ! KWM Should this be Zero over land ice?  Does this value matter?
+            RUNOFF2(I) = 0.0
+            RUNOFF3(I) = 0.0
+            DO NS = 1, NSOIL
+              SWC(NS,I) = 1.0
+              SMC(NS,I) = 1.0
+              SMAV(NS,I) = 1.0
+            ENDDO
+          ENDIF
+        ENDIF
+      ENDDO ILOOP51
+!$acc end parallel
+!
+!  FASDAS
+! 
+      IF( FASDAS == 1 ) THEN
+!!!$acc update device(SDA_HFX,RHO)
+!$acc parallel vector_length(128)
+!$acc loop gang vector private(DZQ)
+        ILOOP52 : DO I=its,ite
+          IF((XLAND(I,J)-1.5).LT.0.)THEN
+            IF (ICE(I) == -1) THEN
+
+              DZQ = DZ8W(I,1,J)
+              XSDA_HFX(I)= SDA_HFX(I,J)*RHO(I,1,J)*CPM(I,J)*DZQ  ! W/m^2
+              XSDA_QFX(I)= 0.0          ! Kg/m2/s of water
+              XQNORM(I) = 0.0
+            ENDIF
+          ENDIF
+        ENDDO ILOOP52
+!$acc end parallel
+      ENDIF
+!
+!  END FASDAS
+!
+
+            CALL SFLX_GLACIAL_gpu(ims,ime,its,ite,XLAND,ICE,         &
+                 I,J,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,           &    !C
+            &    LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,              &    !F
+            &    TH2,Q2SAT,DQSDT2,                                &    !I
+            &    ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD, &    !S
+            &    T1,STC,SNOWHK,SNEQV,ALBEDOK,CHK,        &    !H
+            &    ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+            &    ESNOW,DEW,                                       &    !O
+            &    ETP,SSOIL,                                       &    !O
+            &    FLX1,FLX2,FLX3,                                  &    !O
+            &    SNOMLT,SNCOVR,                                   &    !O
+            &    RUNOFF1,                                         &    !O
+            &    Q1,                                              &    !D
+            &    SNOTIME1,                                        &
+            &    RIBB)
+
+!!!$acc update device(RC2,XLAI2)
+!$acc parallel vector_length(32)
+!$acc loop gang vector 
+      ILOOP6 : DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0.)THEN
+          IF ( ICE(I) == 1 ) THEN
+          ! Sea-ice case
+
+            DO NS = 1, NSOIL
+              SH2O(I,NS,J) = 1.0
+            ENDDO
+            LAI(I,J) = 0.01
+
+!!!            CYCLE ILOOP3
+
+          ELSE
+
+            LAI(i,j) = XLAI(I)
+            if (present(RC2) .and. present(XLAI2)) then
+              RC2(I,J) = RC(I)                                             ! for output
+              XLAI2(I,J) = XLAI(I)
+            endif
+
+#if 0
+            IF(IPRINT) THEN
+
+       print*, 'AFTER SFLX, in Noahlsm_driver'
+       print*, 'ICE', ICE(I), 'DT',DT, 'ZLVL',ZLVL(I), 'NSOIL', NSOIL,   &
+       'SLDPTH', SLDPTH(1:NSOIL,I), 'LOCAL',LOCAL, 'LUTYPE',&
+        LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN(I), 'SOLDN',SOLDN(I),      &
+        'SFCPRS',SFCPRS(I), 'PRCP',PRCP(I),'SFCTMP',SFCTMP(I),'Q2K',Q2K(I),   &
+         'TH2',TH2(I),'Q2SAT',Q2SAT(I),'DQSDT2',DQSDT2(I),'VEGTYP', VEGTYP(I),&
+          'SOILTYP',SOILTYP(I), 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC(I),&
+         'SHDMIN',SHMIN(I), 'ALBBRD',ALBBRD(I),'SNOALB',SNOALB1(I),'TBOT',&
+          TBOT(I), 'Z0BRD',Z0BRD(I), 'Z0K',Z0K(I), 'CMC',CMC(I), 'T1',T1(I),'STC',&
+          STC(1:NSOIL,I), 'SMC',SMC(1:NSOIL,I), 'SWc',SWC(1:NSOIL,I),'SNOWHK',SNOWHK(I),'SNEQV',SNEQV(I),&
+          'ALBEDOK',ALBEDOK(I),'CHK',CHK(I),'ETA',ETA(I),'SHEAT',SHEAT(I),      &
+          'ETA_KINEMATIC',ETA_KINEMATIC(I), 'FDOWN',FDOWN(I),'EC',EC(I),   &
+          'EDIR',EDIR(I),'ET',ET(1:NSOIL,I),'ETT',ETT(I),'ESNOW',ESNOW(I),'DRIP',DRIP(I),&
+          'DEW',DEW(I),'BETA',BETA(I),'ETP',ETP(I),'SSOIL',SSOIL(I),'FLX1',FLX1(I),&
+          'FLX2',FLX2(I),'FLX3',FLX3(I),'SNOMLT',SNOMLT(I),'SNCOVR',SNCOVR(I),&
+          'RUNOFF1',RUNOFF1(I),'RUNOFF2',RUNOFF2(I),'RUNOFF3',RUNOFF3(I), &
+          'RC',RC(I), 'PC',PC(I),'RSMIN',RSMIN(I),'XLAI',XLAI(I),'RCS',RCS(I),  &
+          'RCT',RCT(I),'RCQ',RCQ(I),'RCSOIL',RCSOIL(I),'SOILW',SOILW(I),     &
+          'SOILM',SOILM(I),'Q1',Q1(I),'SMCWLT',SMCWLT(I),'SMCDRY',SMCDRY(I),&
+          'SMCREF',SMCREF(I),'SMCMAX',SMCMAX(I),'NROOT',NROOT(I)
+            endif
+#endif
+
+!***  UPDATE STATE VARIABLES
+            CANWAT(I,J)=CMC(I)*1000.
+            SNOW(I,J)=SNEQV(I)*1000.
+!          SNOWH(I,J)=SNOWHK(I)*1000.
+            SNOWH(I,J)=SNOWHK(I)                   ! SNOWHK in meters
+            ALBEDO(I,J)=ALBEDOK(I)
+            ALB_RURAL(I,J)=ALBEDOK(I)
+            ALBBCK(I,J)=ALBBRD(I)
+            Z0(I,J)=Z0BRD(I)
+            EMISS(I,J) = EMISSI(I)
+            EMISS_RURAL(I,J) = EMISSI(I)
+! Noah: activate time-varying roughness length (V3.3 Feb 2011)
+            ZNT(I,J)=Z0K(I)
+!
+! FASDAS
+!
+! Update Skin Temperature
+            IF( FASDAS == 1 ) THEN
+              XSDA_QFX(I)= XSDA_QFX(I)*ELWV*XQNORM(I)
+
+        !TWG2015 Bugfix to multiply Heat Capacity by Soil Depth for correct
+        !units 
+
+              T1(I) = T1(I) + (XSDA_HFX(I)-XSDA_QFX(I))*DT/(HCPCT_FASDAS(I)*DZS(1))
+
+            END IF
+!
+! END FASDAS
+!
+            TSK(I,J)=T1(I)
+            TSK_RURAL(I,J)=T1(I)
+            HFX(I,J)=SHEAT(I)
+            HFX_RURAL(I,J)=SHEAT(I)
+! MEk Jul07 add potential evap accum
+            POTEVP(I,J)=POTEVP(I,J)+ETP(I)*FDTW
+            QFX(I,J)=ETA_KINEMATIC(I)
+            QFX_RURAL(I,J)=ETA_KINEMATIC(I)
+
+#ifdef WRF_HYDRO
+!added by Wei Yu
+!         QFX(I,J) = QFX(I,J) + ETPND1(I)
+!         ETA(I) = ETA(I) + ETPND1(I)/2.501E6*dt
+!end added by Wei Yu
+#endif
+
+
+            LH(I,J)=ETA(I)
+            LH_RURAL(I,J)=ETA(I)
+            GRDFLX(I,J)=SSOIL(I)
+            GRDFLX_RURAL(I,J)=SSOIL(I)
+            SNOWC(I,J)=SNCOVR(I)
+            CHS2(I,J)=CQS2(I,J)
+            SNOTIME(I,J) = SNOTIME1(I)
+!      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+!      as happens over snow cover where the cqs2 value also becomes irrelevant
+!      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+! ww: comment out this change to avoid Q2 drop due to change of radiative flux
+!         IF (Q1(I) .GT. QSFC(I,J)) THEN
+!           CQS2(I,J) = CHS(I,J)
+!         ENDIF
+!          QSFC(I,J)=Q1(I)
+! Convert QSFC back to mixing ratio
+             QSFC(I,J)= Q1(I)/(1.0-Q1(I))
+!
+           ! QSFC_RURAL(I,J)= Q1(I)/(1.0-Q1(I))
+! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+
+            DO 80 NS=1,NSOIL
+              SMOIS(I,NS,J)=SMC(NS,I)
+              TSLB(I,NS,J)=STC(NS,I)                                        !  STEMP
+              SH2O(I,NS,J)=SWC(NS,I)
+     80     CONTINUE
+!       ENDIF
+
+            FLX4_2D(I,J)  = FLX4(I)
+            FVB_2D(I,J)   = FVB(I)
+            FBUR_2D(I,J)  = FBUR(I)
+            FGSN_2D(I,J)  = FGSN(I)
+
+     !
+     ! Residual of surface energy balance equation terms
+     !
+
+            IF ( UA_PHYS ) THEN
+              NOAHRES(I,J) = ( SOLNET(I) + LWDN(I) ) - SHEAT(I) + SSOIL(I) - ETA(I) &
+                - ( EMISSI(I) * STBOLT * (T1(I)**4) ) - FLX1(I) - FLX2(I) - FLX3(I) - FLX4(I)
+            ELSE
+              NOAHRES(I,J) = ( SOLNET(I) + LWDN(I) ) - SHEAT(I) + SSOIL(I) - ETA(I) &
+                - ( EMISSI(I) * STBOLT * (T1(I)**4) ) - FLX1(I) - FLX2(I) - FLX3(I)
+            ENDIF
+
+
+!***  DIAGNOSTICS
+            SMSTAV(I,J)=SOILW(I)
+            SMSTOT(I,J)=SOILM(I)*1000.
+            DO NS=1,NSOIL
+              SMCREL(I,NS,J)=SMAV(NS,I)
+            ENDDO
+
+
+!         Convert the water unit into mm
+            SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1(I)*DT*1000.0
+            UDRUNOFF(I,J)=UDRUNOFF(I,J)+RUNOFF2(I)*DT*1000.0
+! snow defined when fraction of frozen precip (FFROZP(I)) > 0.5,
+            IF(FFROZP(I).GT.0.5)THEN
+              ACSNOW(I,J)=ACSNOW(I,J)+PRCP(I)*DT
+            ENDIF
+            IF(SNOW(I,J).GT.0.)THEN
+              ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT(I)*1000.
+! accumulated snow-melt energy
+              SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT(I)/FDTLIW
+            ENDIF
+
+          ENDIF
+        ENDIF                                                           ! endif of land-sea test
+      ENDDO ILOOP6                                                       ! of I loop
+!$acc end parallel
+!!!$acc update host(RC2,XLAI2)
+   ENDDO JLOOP                                                          ! of J loop
+
+!$acc end data
+
+!!!$acc update host(TSK,HFX,QFX,LH,      &
+!!!$acc               GRDFLX,QSFC,CQS2,CHS,CHS2,SNOW,SNOWC,SNOWH,CANWAT,SMSTAV,SMSTOT,       &
+!!!$acc               SFCRUNOFF,UDRUNOFF,ACSNOM,ACSNOW,SNOTIME,SNOPCX,EMISS,RIB,POTEVP,      &
+!!!$acc               ALBEDO,ALBBCK,Z0,ZNT,LAI,NOAHRES,CHKLOWQ,SH2O,SMOIS,TSLB,SMCREL,   &
+!!!$acc               FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D,UST_URB2D,INFXSRT,&
+!!!$acc               SFCHEADRT,SOLDRAIN)
+
+!------------------------------------------------------
+   END SUBROUTINE lsm_gpu
+!------------------------------------------------------
+
 
 !For MPAS, the below section of the module is moved to module_physics_lsm_noahinit.F in
 !./../core_physics to accomodate differences in the mpi calls between WRF and MPAS.I thought

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
@@ -61,6 +61,16 @@ use module_wrf_error
         CHARACTER*256  :: err_message
 
         integer, private :: iloc, jloc
+
+!$acc declare create(LUTYPE,LUCATS,SHDTBL,NROTBL,RSTBL,RGLTBL,HSTBL,SNUPTBL,MAXALB, &
+!$acc         LAIMINTBL,LAIMAXTBL,EMISSMINTBL,EMISSMAXTBL,ALBEDOMINTBL,ALBEDOMAXTBL,&
+!$acc         Z0MINTBL,Z0MAXTBL,ZTOPVTBL,ZBOTVTBL,TOPT_DATA,CMCMAX_DATA,CFACTR_DATA,&
+!$acc         RSMAX_DATA,BARE,NATURAL,LOW_DENSITY_RESIDENTIAL,                      &
+!$acc         HIGH_DENSITY_RESIDENTIAL,HIGH_INTENSITY_INDUSTRIAL,SLTYPE,SLCATS,BB,  &
+!$acc         DRYSMC,F11,MAXSMC,REFSMC,SATPSI,SATDK,SATDW,WLTSMC,QTZ,SLPCATS,       &
+!$acc         SLOPE_DATA,SBETA_DATA,FXEXP_DATA,CSOIL_DATA,SALP_DATA,REFDK_DATA,     &
+!$acc         REFKDT_DATA,FRZK_DATA,ZBOT_DATA,CZIL_DATA,SMLOW_DATA,SMHIGH_DATA,LVCOEF_DATA)
+
 !$omp threadprivate(iloc, jloc)
 !
 CONTAINS
@@ -884,6 +894,1014 @@ CONTAINS
   END SUBROUTINE SFLX
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SFLX_gpu (ims,ime,its,ite,XLAND,ICE,                   &
+                       IILOC,JJLOC,FFROZP,ISURBAN,DT,ZLVL,NSOIL,SLDPTH, &    !C
+                       LOCAL,                                           &    !L
+                       LLANDUSE, LSOIL,                                 &    !CL
+                       LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2,SFCSPD,  &    !F
+                       COSZ,PRCPRAIN, SOLARDIRECT,                      &    !F
+                       TH2,Q2SAT,DQSDT2,                                &    !I
+                       VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHDMIN,SHDMAX,    &    !I
+                       ALB, SNOALB,TBOT, Z0BRD, Z0, EMISSI, EMBRD,      &    !S
+                       CMC,T1,STC,SMC,SH2O,SNOWH,SNEQV,ALBEDO,CH,CM,    &    !H
+! ----------------------------------------------------------------------
+! OUTPUTS, DIAGNOSTICS, PARAMETERS BELOW GENERALLY NOT NECESSARY WHEN
+! COUPLED WITH E.G. A NWP MODEL (SUCH AS THE NOAA/NWS/NCEP MESOSCALE ETA
+! MODEL).  OTHER APPLICATIONS MAY REQUIRE DIFFERENT OUTPUT VARIABLES.
+! ----------------------------------------------------------------------
+                       ETA,SHEAT, ETA_KINEMATIC,FDOWN,                  &    !O
+                       EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                   &    !O
+                       BETA,ETP,SSOIL,                                  &    !O
+                       FLX1,FLX2,FLX3,                                  &    !O
+		       FLX4,FVB,FBUR,FGSN,UA_PHYS,                      &    !UA 
+                       SNOMLT,SNCOVR,                                   &    !O
+                       RUNOFF1,RUNOFF2,RUNOFF3,                         &    !O
+                       RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,             &    !O
+                       SOILW,SOILM,Q1,SMAV,                             &    !D
+                       RDLAI2D,USEMONALB,                               &
+                       SNOTIME1,                                        &
+                       RIBB,                                            &
+                       SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,   &
+                       SFHEAD1RT,                                       &    !I
+                       INFXS1RT,ETPND1,OPT_THCND,AOASIS                 &    !P
+                      ,XSDA_QFX,HFX_PHY,QFX_PHY,XQNORM                  &    !fasdas
+                      ,FASDAS,HCPCT_FASDAS                              )    !fasdas
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SFLX - UNIFIED NOAHLSM VERSION 1.0 JULY 2007
+! ----------------------------------------------------------------------
+! SUB-DRIVER FOR "Noah LSM" FAMILY OF PHYSICS SUBROUTINES FOR A
+! SOIL/VEG/SNOWPACK LAND-SURFACE MODEL TO UPDATE SOIL MOISTURE, SOIL
+! ICE, SOIL TEMPERATURE, SKIN TEMPERATURE, SNOWPACK WATER CONTENT,
+! SNOWDEPTH, AND ALL TERMS OF THE SURFACE ENERGY BALANCE AND SURFACE
+! WATER BALANCE (EXCLUDING INPUT ATMOSPHERIC FORCINGS OF DOWNWARD
+! RADIATION AND PRECIP)
+! ----------------------------------------------------------------------
+! SFLX ARGUMENT LIST KEY:
+! ----------------------------------------------------------------------
+!  C  CONFIGURATION INFORMATION
+!  L  LOGICAL
+! CL  4-string character bearing logical meaning
+!  F  FORCING DATA
+!  I  OTHER (INPUT) FORCING DATA
+!  S  SURFACE CHARACTERISTICS
+!  H  HISTORY (STATE) VARIABLES
+!  O  OUTPUT VARIABLES
+!  D  DIAGNOSTIC OUTPUT
+!  P  Parameters
+!  Msic Miscellaneous terms passed from gridded driver
+! ----------------------------------------------------------------------
+! 1. CONFIGURATION INFORMATION (C):
+! ----------------------------------------------------------------------
+!   DT         TIMESTEP (SEC) (DT SHOULD NOT EXCEED 3600 SECS, RECOMMEND
+!                1800 SECS OR LESS)
+!   ZLVL       HEIGHT (M) ABOVE GROUND OF ATMOSPHERIC FORCING VARIABLES
+!   NSOIL      NUMBER OF SOIL LAYERS (AT LEAST 2, AND NOT GREATER THAN
+!                PARAMETER NSOLD SET BELOW)
+!   SLDPTH     THE THICKNESS OF EACH SOIL LAYER (M)
+! ----------------------------------------------------------------------
+! 2. LOGICAL:
+! ----------------------------------------------------------------------
+!   LCH       Exchange coefficient (Ch) calculation flag (false: using
+!                ch-routine SFCDIF; true: Ch is brought in)
+!   LOCAL      Flag for local-site simulation (where there is no
+!              maps for albedo, veg fraction, and roughness
+!             true:  all LSM parameters (inluding albedo, veg fraction and
+!                    roughness length) will be defined by three tables
+!   LLANDUSE  (=USGS, using USGS landuse classification)
+!   LSOIL     (=STAS, using FAO/STATSGO soil texture classification)
+!   OPT_THCND option for how to treat thermal conductivity
+! ----------------------------------------------------------------------
+! 3. FORCING DATA (F):
+! ----------------------------------------------------------------------
+!   LWDN       LW DOWNWARD RADIATION (W M-2; POSITIVE, NOT NET LONGWAVE)
+!   SOLDN      SOLAR DOWNWARD RADIATION (W M-2; POSITIVE, NOT NET SOLAR)
+!   SOLNET     NET DOWNWARD SOLAR RADIATION ((W M-2; POSITIVE)
+!   SFCPRS     PRESSURE AT HEIGHT ZLVL ABOVE GROUND (PASCALS)
+!   PRCP       PRECIP RATE (KG M-2 S-1) (NOTE, THIS IS A RATE)
+!   SFCTMP     AIR TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   TH2        AIR POTENTIAL TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   Q2         MIXING RATIO AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   COSZ       Solar zenith angle (not used for now)
+!   PRCPRAIN   Liquid-precipitation rate (KG M-2 S-1) (not used)
+! SOLARDIRECT  Direct component of downward solar radiation (W M-2) (not used)
+!   FFROZP     FRACTION OF FROZEN PRECIPITATION
+! ----------------------------------------------------------------------
+! 4. OTHER FORCING (INPUT) DATA (I):
+! ----------------------------------------------------------------------
+!   SFCSPD     WIND SPEED (M S-1) AT HEIGHT ZLVL ABOVE GROUND
+!   Q2SAT      SAT SPECIFIC HUMIDITY AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   DQSDT2     SLOPE OF SAT SPECIFIC HUMIDITY CURVE AT T=SFCTMP
+!                (KG KG-1 K-1)
+! ----------------------------------------------------------------------
+! 5. CANOPY/SOIL CHARACTERISTICS (S):
+! ----------------------------------------------------------------------
+!   VEGTYP     VEGETATION TYPE (INTEGER INDEX)
+!   SOILTYP    SOIL TYPE (INTEGER INDEX)
+!   SLOPETYP   CLASS OF SFC SLOPE (INTEGER INDEX)
+!   SHDFAC     AREAL FRACTIONAL COVERAGE OF GREEN VEGETATION
+!                (FRACTION= 0.0-1.0)
+!   SHDMIN     MINIMUM AREAL FRACTIONAL COVERAGE OF GREEN VEGETATION
+!                (FRACTION= 0.0-1.0) <= SHDFAC
+!   PTU        PHOTO THERMAL UNIT (PLANT PHENOLOGY FOR ANNUALS/CROPS)
+!                (NOT YET USED, BUT PASSED TO REDPRM FOR FUTURE USE IN
+!                VEG PARMS)
+!   ALB        BACKROUND SNOW-FREE SURFACE ALBEDO (FRACTION), FOR JULIAN
+!                DAY OF YEAR (USUALLY FROM TEMPORAL INTERPOLATION OF
+!                MONTHLY MEAN VALUES' CALLING PROG MAY OR MAY NOT
+!                INCLUDE DIURNAL SUN ANGLE EFFECT)
+!   SNOALB     UPPER BOUND ON MAXIMUM ALBEDO OVER DEEP SNOW (E.G. FROM
+!                ROBINSON AND KUKLA, 1985, J. CLIM. & APPL. METEOR.)
+!   TBOT       BOTTOM SOIL TEMPERATURE (LOCAL YEARLY-MEAN SFC AIR
+!                TEMPERATURE)
+!   Z0BRD      Background fixed roughness length (M)
+!   Z0         Time varying roughness length (M) as function of snow depth
+!
+!   EMBRD      Background surface emissivity (between 0 and 1)
+!   EMISSI     Surface emissivity (between 0 and 1)
+! ----------------------------------------------------------------------
+! 6. HISTORY (STATE) VARIABLES (H):
+! ----------------------------------------------------------------------
+!  CMC         CANOPY MOISTURE CONTENT (M)
+!  T1          GROUND/CANOPY/SNOWPACK) EFFECTIVE SKIN TEMPERATURE (K)
+!  STC(NSOIL)  SOIL TEMP (K)
+!  SMC(NSOIL)  TOTAL SOIL MOISTURE CONTENT (VOLUMETRIC FRACTION)
+!  SH2O(NSOIL) UNFROZEN SOIL MOISTURE CONTENT (VOLUMETRIC FRACTION)
+!                NOTE: FROZEN SOIL MOISTURE = SMC - SH2O
+!  SNOWH       ACTUAL SNOW DEPTH (M)
+!  SNEQV       LIQUID WATER-EQUIVALENT SNOW DEPTH (M)
+!                NOTE: SNOW DENSITY = SNEQV/SNOWH
+!  ALBEDO      SURFACE ALBEDO INCLUDING SNOW EFFECT (UNITLESS FRACTION)
+!                =SNOW-FREE ALBEDO (ALB) WHEN SNEQV=0, OR
+!                =FCT(MSNOALB,ALB,VEGTYP,SHDFAC,SHDMIN) WHEN SNEQV>0
+!  CH          SURFACE EXCHANGE COEFFICIENT FOR HEAT AND MOISTURE
+!                (M S-1); NOTE: CH IS TECHNICALLY A CONDUCTANCE SINCE
+!                IT HAS BEEN MULTIPLIED BY WIND SPEED.
+!  CM          SURFACE EXCHANGE COEFFICIENT FOR MOMENTUM (M S-1); NOTE:
+!                CM IS TECHNICALLY A CONDUCTANCE SINCE IT HAS BEEN
+!                MULTIPLIED BY WIND SPEED.
+! ----------------------------------------------------------------------
+! 7. OUTPUT (O):
+! ----------------------------------------------------------------------
+! OUTPUT VARIABLES NECESSARY FOR A COUPLED NUMERICAL WEATHER PREDICTION
+! MODEL, E.G. NOAA/NWS/NCEP MESOSCALE ETA MODEL.  FOR THIS APPLICATION,
+! THE REMAINING OUTPUT/DIAGNOSTIC/PARAMETER BLOCKS BELOW ARE NOT
+! NECESSARY.  OTHER APPLICATIONS MAY REQUIRE DIFFERENT OUTPUT VARIABLES.
+!   ETA        ACTUAL LATENT HEAT FLUX (W m-2: NEGATIVE, IF UP FROM
+!              SURFACE)
+!  ETA_KINEMATIC atctual latent heat flux in Kg m-2 s-1
+!   SHEAT      SENSIBLE HEAT FLUX (W M-2: POSITIVE, IF UPWARD FROM
+!              SURFACE)
+!   FDOWN      Radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+! ----------------------------------------------------------------------
+!   EC         CANOPY WATER EVAPORATION (W m-2)
+!   EDIR       DIRECT SOIL EVAPORATION (W m-2)
+!   ET(NSOIL)  PLANT TRANSPIRATION FROM A PARTICULAR ROOT (SOIL) LAYER
+!                 (W m-2)
+!   ETT        TOTAL PLANT TRANSPIRATION (W m-2)
+!   ESNOW      SUBLIMATION FROM (OR DEPOSITION TO IF <0) SNOWPACK
+!                (W m-2)
+!   DRIP       THROUGH-FALL OF PRECIP AND/OR DEW IN EXCESS OF CANOPY
+!                WATER-HOLDING CAPACITY (M)
+!   DEW        DEWFALL (OR FROSTFALL FOR T<273.15) (M)
+! ----------------------------------------------------------------------
+!   BETA       RATIO OF ACTUAL/POTENTIAL EVAP (DIMENSIONLESS)
+!   ETP        POTENTIAL EVAPORATION (W m-2)
+!   SSOIL      SOIL HEAT FLUX (W M-2: NEGATIVE IF DOWNWARD FROM SURFACE)
+! ----------------------------------------------------------------------
+!   FLX1       PRECIP-SNOW SFC (W M-2)
+!   FLX2       FREEZING RAIN LATENT HEAT FLUX (W M-2)
+!   FLX3       PHASE-CHANGE HEAT FLUX FROM SNOWMELT (W M-2)
+! ----------------------------------------------------------------------
+!   SNOMLT     SNOW MELT (M) (WATER EQUIVALENT)
+!   SNCOVR     FRACTIONAL SNOW COVER (UNITLESS FRACTION, 0-1)
+! ----------------------------------------------------------------------
+!   RUNOFF1    SURFACE RUNOFF (M S-1), NOT INFILTRATING THE SURFACE
+!   RUNOFF2    SUBSURFACE RUNOFF (M S-1), DRAINAGE OUT BOTTOM OF LAST
+!                SOIL LAYER (BASEFLOW)
+!   RUNOFF3    NUMERICAL TRUNCTATION IN EXCESS OF POROSITY (SMCMAX)
+!                FOR A GIVEN SOIL LAYER AT THE END OF A TIME STEP (M S-1).
+! Note: the above RUNOFF2 is actually the sum of RUNOFF2 and RUNOFF3
+! ----------------------------------------------------------------------
+!   RC         CANOPY RESISTANCE (S M-1)
+!   PC         PLANT COEFFICIENT (UNITLESS FRACTION, 0-1) WHERE PC*ETP
+!                = ACTUAL TRANSP
+!   XLAI       LEAF AREA INDEX (DIMENSIONLESS)
+!   RSMIN      MINIMUM CANOPY RESISTANCE (S M-1)
+!   RCS        INCOMING SOLAR RC FACTOR (DIMENSIONLESS)
+!   RCT        AIR TEMPERATURE RC FACTOR (DIMENSIONLESS)
+!   RCQ        ATMOS VAPOR PRESSURE DEFICIT RC FACTOR (DIMENSIONLESS)
+!   RCSOIL     SOIL MOISTURE RC FACTOR (DIMENSIONLESS)
+! ----------------------------------------------------------------------
+! 8. DIAGNOSTIC OUTPUT (D):
+! ----------------------------------------------------------------------
+!   SOILW      AVAILABLE SOIL MOISTURE IN ROOT ZONE (UNITLESS FRACTION
+!              BETWEEN SMCWLT AND SMCMAX)
+!   SOILM      TOTAL SOIL COLUMN MOISTURE CONTENT (FROZEN+UNFROZEN) (M)
+!   Q1         Effective mixing ratio at surface (kg kg-1), used for
+!              diagnosing the mixing ratio at 2 meter for coupled model
+!   SMAV       Soil Moisture Availability for each layer, as a fraction
+!              between SMCWLT and SMCMAX.
+!  Documentation for SNOTIME1 and SNOABL2 ?????
+!  What categories of arguments do these variables fall into ????
+!  Documentation for RIBB ?????
+!  What category of argument does RIBB fall into ?????
+! ----------------------------------------------------------------------
+! 9. PARAMETERS (P):
+! ----------------------------------------------------------------------
+!   SMCWLT     WILTING POINT (VOLUMETRIC)
+!   SMCDRY     DRY SOIL MOISTURE THRESHOLD WHERE DIRECT EVAP FRM TOP
+!                LAYER ENDS (VOLUMETRIC)
+!   SMCREF     SOIL MOISTURE THRESHOLD WHERE TRANSPIRATION BEGINS TO
+!                STRESS (VOLUMETRIC)
+!   SMCMAX     POROSITY, I.E. SATURATED VALUE OF SOIL MOISTURE
+!                (VOLUMETRIC)
+!   NROOT      NUMBER OF ROOT LAYERS, A FUNCTION OF VEG TYPE, DETERMINED
+!              IN SUBROUTINE REDPRM.
+! ----------------------------------------------------------------------
+
+
+      IMPLICIT NONE
+! ----------------------------------------------------------------------
+
+! DECLARATIONS - LOGICAL AND CHARACTERS
+! ----------------------------------------------------------------------
+
+      INTEGER, INTENT(IN) :: ims,ime,its,ite
+      REAL,    DIMENSION( ims:ime ), INTENT(IN) :: XLAND
+      INTEGER, DIMENSION( ims:ime ), INTENT(IN) :: ICE
+      INTEGER, INTENT(IN) :: IILOC, JJLOC
+      LOGICAL, INTENT(IN)::  LOCAL
+      LOGICAL, DIMENSION(ims:ime)            ::  FRZGRA, SNOWNG
+      CHARACTER (LEN=256), INTENT(IN)::  LLANDUSE, LSOIL
+
+! ----------------------------------------------------------------------
+! 1. CONFIGURATION INFORMATION (C):
+! ----------------------------------------------------------------------
+      INTEGER,INTENT(IN) ::  NSOIL
+      INTEGER,DIMENSION(ims:ime), INTENT(IN) :: VEGTYP,SOILTYP
+      INTEGER, INTENT(IN) :: SLOPETYP
+      INTEGER, INTENT(IN) :: ISURBAN
+      INTEGER,DIMENSION(ims:ime),INTENT(OUT)::  NROOT
+      INTEGER  KZ, K, IOUT
+
+! ----------------------------------------------------------------------
+! 2. LOGICAL:
+! ----------------------------------------------------------------------
+      LOGICAL, INTENT(IN) :: RDLAI2D
+      LOGICAL, INTENT(IN) :: USEMONALB
+      INTEGER, INTENT(IN) :: OPT_THCND
+
+      REAL, DIMENSION(ims:ime), INTENT(INOUT) :: SFHEAD1RT,INFXS1RT,ETPND1
+
+      REAL, INTENT(IN)    :: DT,AOASIS
+      REAL, DIMENSION(ims:ime), INTENT(IN) :: FFROZP,ZLVL,LWDN,SOLDN,SOLNET,   &
+                            SFCPRS,PRCP,SFCTMP,Q2,SFCSPD,PRCPRAIN,TH2,         &
+                            Q2SAT,DQSDT2,SHDMIN,SHDMAX,SNOALB,TBOT
+
+      REAL, DIMENSION(ims:ime), INTENT(OUT)  :: EMBRD
+      REAL, DIMENSION(ims:ime), INTENT(OUT)  :: ALBEDO
+      REAL, DIMENSION(ims:ime), INTENT(INOUT):: XLAI
+      REAL, DIMENSION(ims:ime), INTENT(INOUT) :: CH,CM,SNCOVR
+      REAL, DIMENSION(ims:ime), INTENT(INOUT) :: COSZ,SOLARDIRECT,SHDFAC,   &
+                            ALB,Z0BRD,EMISSI,CMC,T1,SNOWH,SNEQV
+
+      REAL, DIMENSION(ims:ime), INTENT(INOUT):: SNOTIME1
+      REAL, DIMENSION(ims:ime), INTENT(INOUT):: RIBB
+      REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(IN) :: SLDPTH
+      REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(OUT):: ET
+      REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(OUT):: SMAV
+      REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(INOUT) :: STC, SMC, SH2O
+      REAL, DIMENSION(1:NSOIL,ims:ime) ::   RTDIS, ZSOIL
+
+      REAL, DIMENSION(ims:ime), INTENT(OUT) :: ETA,SHEAT,ETA_KINEMATIC,   &
+                            FDOWN,EC,EDIR,ESNOW,DRIP,DEW,BETA,ETP,SSOIL,  &
+                            FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,RUNOFF2,RUNOFF3, &
+                            RC,PC,RSMIN,RCS,RCT,RCQ,RCSOIL,SOILW,SOILM,Q1, &
+                            SMCWLT,SMCDRY,SMCREF,SMCMAX
+      LOGICAL, INTENT(IN) :: UA_PHYS   ! UA: flag for UA option
+      REAL, DIMENSION(ims:ime), INTENT(OUT)    :: FLX4      ! UA: energy added to sensible heat
+      REAL, DIMENSION(ims:ime), INTENT(OUT)    :: FVB       ! UA: frac. veg. w/snow beneath
+      REAL, DIMENSION(ims:ime), INTENT(OUT)    :: FBUR      ! UA: fraction of canopy buried
+      REAL, DIMENSION(ims:ime), INTENT(OUT)    :: FGSN      ! UA: ground snow cover fraction
+      REAL, DIMENSION(ims:ime)                 :: ZTOPV     ! UA: height of canopy top
+      REAL, DIMENSION(ims:ime)                 :: ZBOTV     ! UA: height of canopy bottom
+      REAL, DIMENSION(ims:ime)                 :: GAMA      ! UA: = EXP(-1.* XLAI)
+      REAL                :: FNET      ! UA:
+      REAL, DIMENSION(ims:ime)                 :: ETPN      ! UA:
+      REAL, DIMENSION(ims:ime)                 :: RU        ! UA:
+
+      REAL :: LVH2O,PRCP1,R,            &
+              RSNOW,      &
+              T1V,TH2V,TFREEZ,TSNOW,      &
+              LSUBS
+      REAL, DIMENSION(ims:ime) :: CFACTR,CMCMAX,RSMAX,TOPT,REFKDT,  &
+              KDT,SBETA,RGL,HS,ZBOT,FRZX,PSISAT,SLOPE,SNUP,SALP,    &
+              BEXP,DKSAT,DWSAT,F1,QUARTZ,FXEXP,CZIL,CSOIL,PTU,      &
+              SNDENS,SNCOND,SN_NEW,PRCPF,DF1,DSOIL,DTOT,FRCSNO,     &
+              FRCSOI,DF1H,DF1A,T2V,T24,RCH,EPSCA,RR,ETNS,SOILWM,    &
+              SOILWW
+      REAL, DIMENSION(ims:ime) :: Z0,ETT
+      REAL, DIMENSION(ims:ime) ::  LVCOEF
+      REAL, DIMENSION(ims:ime) :: INTERP_FRACTION
+      REAL, DIMENSION(ims:ime) :: LAIMIN,    LAIMAX
+      REAL, DIMENSION(ims:ime) :: ALBEDOMIN, ALBEDOMAX
+      REAL, DIMENSION(ims:ime) :: EMISSMIN,  EMISSMAX
+      REAL, DIMENSION(ims:ime) :: Z0MIN,     Z0MAX
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - PARAMETERS
+! ----------------------------------------------------------------------
+      PARAMETER (TFREEZ = 273.15)
+      PARAMETER (LVH2O = 2.501E+6)
+      PARAMETER (LSUBS = 2.83E+6)
+      PARAMETER (R = 287.04)
+!
+!  FASDAS
+!
+   INTEGER, INTENT(IN   )  ::  FASDAS
+   REAL, DIMENSION(ims:ime), INTENT(INOUT)  ::  XSDA_QFX, XQNORM
+   REAL, DIMENSION(ims:ime), INTENT(INOUT)  ::  HFX_PHY, QFX_PHY
+   REAL, DIMENSION(ims:ime), INTENT(  OUT)  ::  HCPCT_FASDAS
+!
+!  END FASDAS
+!
+   INTEGER :: I
+! ----------------------------------------------------------------------
+!   INITIALIZATION
+! ----------------------------------------------------------------------
+      ILOC = IILOC
+      JLOC = JJLOC
+
+!!!$acc update device(XLAND,ICE,FFROZP,ZLVL,SLDPTH,LLANDUSE,LSOIL,LWDN,SOLDN, &
+!!!$acc               SOLNET,SFCPRS,PRCP,SFCTMP,Q2,SFCSPD,COSZ,PRCPRAIN,SOLARDIRECT, &
+!!!$acc               TH2,Q2SAT,DQSDT2,VEGTYP,SOILTYP,SHDFAC,SHDMIN,SHDMAX,ALB,      &
+!!!$acc               SNOALB,TBOT,Z0BRD,Z0,EMISSI,EMBRD,CMC,T1,STC,SMC,SH2O,SNOWH,   &
+!!!$acc               SNEQV,ALBEDO,CH,CM,ETA,SHEAT,ETA_KINEMATIC,FDOWN,EC,EDIR,ET,   &
+!!!$acc               ETT,ESNOW,DRIP,DEW,BETA,ETP,SSOIL,FLX1,FLX2,FLX3,FLX4,FVB,FBUR,&
+!!!$acc               FGSN,SNOMLT,SNCOVR,RUNOFF1,RUNOFF2,RUNOFF3,RC,PC,RSMIN,XLAI,   &
+!!!$acc               RCS,RCT,RCQ,RCSOIL,SOILW,SOILM,Q1,SMAV,SNOTIME1,RIBB,SMCWLT,   &
+!!!$acc               SMCDRY,SMCREF,SMCMAX,NROOT,SFHEAD1RT,INFXS1RT,ETPND1,XSDA_QFX, &
+!!!$acc               HFX_PHY,QFX_PHY,XQNORM,HCPCT_FASDAS)
+
+!$acc data present(XLAND,ICE,FFROZP,ZLVL,SLDPTH,LLANDUSE,LSOIL,LWDN,SOLDN, &
+!$acc               SOLNET,SFCPRS,PRCP,SFCTMP,Q2,SFCSPD,COSZ,PRCPRAIN,SOLARDIRECT, &
+!$acc               TH2,Q2SAT,DQSDT2,VEGTYP,SOILTYP,SHDFAC,SHDMIN,SHDMAX,ALB,      &
+!$acc               SNOALB,TBOT,Z0BRD,Z0,EMISSI,EMBRD,CMC,T1,STC,SMC,SH2O,SNOWH,   &
+!$acc               SNEQV,ALBEDO,CH,CM,ETA,SHEAT,ETA_KINEMATIC,FDOWN,EC,EDIR,ET,   &
+!$acc               ETT,ESNOW,DRIP,DEW,BETA,ETP,SSOIL,FLX1,FLX2,FLX3,FLX4,FVB,FBUR,&
+!$acc               FGSN,SNOMLT,SNCOVR,RUNOFF1,RUNOFF2,RUNOFF3,RC,PC,RSMIN,XLAI,   &
+!$acc               RCS,RCT,RCQ,RCSOIL,SOILW,SOILM,Q1,SMAV,SNOTIME1,RIBB,SMCWLT,   &
+!$acc               SMCDRY,SMCREF,SMCMAX,NROOT,SFHEAD1RT,INFXS1RT,ETPND1,XSDA_QFX, &
+!$acc               HFX_PHY,QFX_PHY,XQNORM,HCPCT_FASDAS) &
+!$acc      create(FRZGRA,SNOWNG,RTDIS,ZSOIL,ZTOPV,ZBOTV,GAMA,ETPN,RU, &
+!$acc             CFACTR,CMCMAX,RSMAX,TOPT,REFKDT,KDT,SBETA,RGL,HS,ZBOT, &
+!$acc             FRZX,PSISAT,SLOPE,SNUP,SALP,BEXP,DKSAT,DWSAT,F1,QUARTZ,&
+!$acc             FXEXP,CZIL,CSOIL,PTU,SNDENS,SNCOND,SN_NEW,PRCPF,DF1,   &
+!$acc             DSOIL,DTOT,FRCSNO,FRCSOI,DF1H,DF1A,T2V,T24,RCH,EPSCA,  &
+!$acc             RR,ETNS,SOILWM,SOILWW,LVCOEF,INTERP_FRACTION,   &
+!$acc             LAIMIN,LAIMAX,ALBEDOMIN,ALBEDOMAX,EMISSMIN,EMISSMAX,   &
+!$acc             Z0MIN,Z0MAX)
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+! ----------------------------------------------------------------------
+! CALCULATE DEPTH (NEGATIVE) BELOW GROUND FROM TOP SKIN SFC TO BOTTOM OF
+!   EACH SOIL LAYER.  NOTE:  SIGN OF ZSOIL IS NEGATIVE (DENOTING BELOW
+!   GROUND)
+! ----------------------------------------------------------------------
+      RUNOFF1(I) = 0.0
+      RUNOFF2(I) = 0.0
+      RUNOFF3(I) = 0.0
+      SNOMLT(I) = 0.0
+
+      IF ( .NOT. UA_PHYS ) THEN
+          FLX4(I) = 0.0
+          FVB(I)  = 0.0
+          FBUR(I) = 0.0
+          FGSN(I) = 0.0
+      ENDIF
+
+      ZSOIL (1,I) = - SLDPTH (1,I)
+      DO KZ = 2,NSOIL
+         ZSOIL (KZ,I) = - SLDPTH (KZ,I) + ZSOIL (KZ -1,I)
+      END DO
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+! ----------------------------------------------------------------------
+! NEXT IS CRUCIAL CALL TO SET THE LAND-SURFACE PARAMETERS, INCLUDING
+! SOIL-TYPE AND VEG-TYPE DEPENDENT PARAMETERS.
+! ----------------------------------------------------------------------
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+      CALL REDPRM_gpu (VEGTYP(I),SOILTYP(I),SLOPETYP,CFACTR(I),CMCMAX(I),RSMAX(I),TOPT(I),   &
+                       REFKDT(I),KDT(I),SBETA(I), SHDFAC(I),RSMIN(I),RGL(I),HS(I),ZBOT(I),FRZX(I),    &
+                       PSISAT(I),SLOPE(I),SNUP(I),SALP(I),BEXP(I),DKSAT(I),DWSAT(I),          &
+                       SMCMAX(I),SMCWLT(I),SMCREF(I),SMCDRY(I),F1(I),QUARTZ(I),FXEXP(I),      &
+                       RTDIS(1:NSOIL,I),SLDPTH(1:NSOIL,I),ZSOIL(1:NSOIL,I),NROOT(I),NSOIL,CZIL(I),              &
+                       LAIMIN(I), LAIMAX(I), EMISSMIN(I), EMISSMAX(I), ALBEDOMIN(I),    &
+                       ALBEDOMAX(I), Z0MIN(I), Z0MAX(I), CSOIL(I), PTU(I), LLANDUSE,    &
+                       LSOIL,LOCAL,LVCOEF(I),ZTOPV(I),ZBOTV(I))
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+!urban
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF(VEGTYP(I)==ISURBAN)THEN
+              SHDFAC(I)=0.05
+              RSMIN(I)=400.0
+              SMCMAX(I) = 0.45
+              SMCREF(I) = 0.42
+              SMCWLT(I) = 0.40
+              SMCDRY(I) = 0.40
+         ENDIF
+
+         IF ( SHDFAC(I) >= SHDMAX(I) ) THEN
+            EMBRD(I) = EMISSMAX(I)
+            IF (.NOT. RDLAI2D) THEN
+               XLAI(I)  = LAIMAX(I)
+            ENDIF
+            IF (.NOT. USEMONALB) THEN
+               ALB(I)   = ALBEDOMIN(I)
+            ENDIF
+            Z0BRD(I) = Z0MAX(I)
+         ELSE IF ( SHDFAC(I) <= SHDMIN(I) ) THEN
+            EMBRD(I) = EMISSMIN(I)
+            IF(.NOT. RDLAI2D) THEN
+               XLAI(I)  = LAIMIN(I)
+            ENDIF
+            IF(.NOT. USEMONALB) then
+               ALB(I)   = ALBEDOMAX(I)
+            ENDIF
+            Z0BRD(I) = Z0MIN(I)
+         ELSE
+
+            IF ( SHDMAX(I) > SHDMIN(I) ) THEN
+
+               INTERP_FRACTION(I) = ( SHDFAC(I) - SHDMIN(I) ) / ( SHDMAX(I) - SHDMIN(I) )
+               ! Bound INTERP_FRACTION between 0 and 1
+               INTERP_FRACTION(I) = MIN ( INTERP_FRACTION(I), 1.0 )
+               INTERP_FRACTION(I) = MAX ( INTERP_FRACTION(I), 0.0 )
+               ! Scale Emissivity and LAI between EMISSMIN and EMISSMAX by INTERP_FRACTION
+               EMBRD(I) = ( ( 1.0 - INTERP_FRACTION(I) ) * EMISSMIN(I)  ) + ( INTERP_FRACTION(I) * EMISSMAX(I)  )
+               IF (.NOT. RDLAI2D) THEN
+                  XLAI(I)  = ( ( 1.0 - INTERP_FRACTION(I) ) * LAIMIN(I)    ) + ( INTERP_FRACTION(I) * LAIMAX(I)    )
+               ENDIF
+               if (.not. USEMONALB) then
+                  ALB(I)   = ( ( 1.0 - INTERP_FRACTION(I) ) * ALBEDOMAX(I) ) + ( INTERP_FRACTION(I) * ALBEDOMIN(I) )
+               endif
+               Z0BRD(I) = ( ( 1.0 - INTERP_FRACTION(I) ) * Z0MIN(I)     ) + ( INTERP_FRACTION(I) * Z0MAX(I)     )
+
+            ELSE
+
+               EMBRD(I) = 0.5 * EMISSMIN(I)  + 0.5 * EMISSMAX(I)
+               IF (.NOT. RDLAI2D) THEN
+                  XLAI(I)  = 0.5 * LAIMIN(I)    + 0.5 * LAIMAX(I)
+               ENDIF
+               if (.not. USEMONALB) then
+                  ALB(I)   = 0.5 * ALBEDOMIN(I) + 0.5 * ALBEDOMAX(I)
+               endif
+               Z0BRD(I) = 0.5 * Z0MIN(I)     + 0.5 * Z0MAX(I)
+
+            ENDIF
+
+         ENDIF
+! ----------------------------------------------------------------------
+!  INITIALIZE PRECIPITATION LOGICALS.
+! ----------------------------------------------------------------------
+         SNOWNG(I) = .FALSE.
+         FRZGRA(I) = .FALSE.
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+! ----------------------------------------------------------------------
+! IF INPUT SNOWPACK IS NONZERO, THEN COMPUTE SNOW DENSITY "SNDENS" AND
+!   SNOW THERMAL CONDUCTIVITY "SNCOND" (NOTE THAT CSNOW IS A FUNCTION
+!   SUBROUTINE)
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF ( SNEQV(I) <= 1.E-7 ) THEN ! safer IF	kmh (2008/03/25)
+            SNEQV(I) = 0.0
+            SNDENS(I) = 0.0
+            SNOWH(I) = 0.0
+            SNCOND(I) = 1.0
+         ELSE
+            SNDENS(I) = SNEQV(I) / SNOWH(I)
+            IF(SNDENS(I) > 1.0) THEN
+!!!             FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
+            ENDIF
+            CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! DETERMINE IF IT'S PRECIPITATING AND WHAT KIND OF PRECIP IT IS.
+! IF IT'S PRCPING AND THE AIR TEMP IS COLDER THAN 0 C, IT'S SNOWING!
+! IF IT'S PRCPING AND THE AIR TEMP IS WARMER THAN 0 C, BUT THE GRND
+! TEMP IS COLDER THAN 0 C, FREEZING RAIN IS PRESUMED TO BE FALLING.
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF (PRCP(I) > 0.0) THEN
+! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+! passed in from model microphysics.
+            IF (FFROZP(I) .GT. 0.5) THEN
+               SNOWNG(I) = .TRUE.
+            ELSE
+               IF (T1(I) <= TFREEZ) FRZGRA(I) = .TRUE.
+            END IF
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! IF EITHER PRCP FLAG IS SET, DETERMINE NEW SNOWFALL (CONVERTING PRCP
+! RATE FROM KG M-2 S-1 TO A LIQUID EQUIV SNOW DEPTH IN METERS) AND ADD
+! IT TO THE EXISTING SNOWPACK.
+! NOTE THAT SINCE ALL PRECIP IS ADDED TO SNOWPACK, NO PRECIP INFILTRATES
+! INTO THE SOIL SO THAT PRCP1 IS SET TO ZERO.
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF ( (SNOWNG(I)) .OR. (FRZGRA(I)) ) THEN
+            SN_NEW(I) = PRCP(I) * DT * 0.001
+            SNEQV(I) = SNEQV(I) + SN_NEW(I)
+            PRCPF(I) = 0.0
+
+! ----------------------------------------------------------------------
+! UPDATE SNOW DENSITY BASED ON NEW SNOWFALL, USING OLD AND NEW SNOW.
+! UPDATE SNOW THERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+            CALL SNOW_NEW_gpu (SFCTMP(I),SN_NEW(I),SNOWH(I),SNDENS(I))
+            CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+
+! ----------------------------------------------------------------------
+! PRECIP IS LIQUID (RAIN), HENCE SAVE IN THE PRECIP VARIABLE THAT
+! LATER CAN WHOLELY OR PARTIALLY INFILTRATE THE SOIL (ALONG WITH
+! ANY CANOPY "DRIP" ADDED TO THIS LATER)
+! ----------------------------------------------------------------------
+         ELSE
+            PRCPF(I) = PRCP(I)
+         ENDIF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! DETERMINE SNOWCOVER AND ALBEDO OVER LAND.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! IF SNOW DEPTH=0, SET SNOW FRACTION=0, ALBEDO=SNOW FREE ALBEDO.
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF (SNEQV(I)  == 0.0) THEN
+            SNCOVR(I) = 0.0
+            ALBEDO(I) = ALB(I)
+            EMISSI(I) = EMBRD(I)
+	    IF(UA_PHYS) FGSN(I) = 0.0
+	    IF(UA_PHYS) FVB(I) = 0.0
+	    IF(UA_PHYS) FBUR(I) = 0.0
+         ELSE
+! ----------------------------------------------------------------------
+! DETERMINE SNOW FRACTIONAL COVERAGE.
+! DETERMINE SURFACE ALBEDO MODIFICATION DUE TO SNOWDEPTH STATE.
+! ----------------------------------------------------------------------
+            CALL SNFRAC_gpu (SNEQV(I),SNUP(I),SALP(I),SNOWH(I),SNCOVR(I), &
+                         XLAI(I),SHDFAC(I),FVB(I),GAMA(I),FBUR(I),    &
+                         FGSN(I),ZTOPV(I),ZBOTV(I),UA_PHYS)
+
+            IF ( UA_PHYS ) then
+              IF(SFCTMP(I) <= T1(I)) THEN
+                RU(I) = 0.
+              ELSE
+                RU(I) = 100.*SHDFAC(I)*FGSN(I)*MIN((SFCTMP(I)-T1(I))/5., 1.)*(1.-EXP(-XLAI(I)))
+              ENDIF
+              CH(I) = CH(I)/(1.+RU(I)*CH(I))
+            ENDIF
+
+            SNCOVR(I) = MIN(SNCOVR(I),0.98) 
+
+            CALL ALCALC_gpu (ALB(I),SNOALB(I),EMBRD(I),SHDFAC(I),SHDMIN(I),SNCOVR(I),T1(I), &
+                 ALBEDO(I),EMISSI(I),DT,SNOWNG(I),SNOTIME1(I),LVCOEF(I))
+         ENDIF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! NEXT CALCULATE THE SUBSURFACE HEAT FLUX, WHICH FIRST REQUIRES
+! CALCULATION OF THE THERMAL DIFFUSIVITY.  TREATMENT OF THE
+! LATTER FOLLOWS THAT ON PAGES 148-149 FROM "HEAT TRANSFER IN
+! COLD CLIMATES", BY V. J. LUNARDINI (PUBLISHED IN 1981
+! BY VAN NOSTRAND REINHOLD CO.) I.E. TREATMENT OF TWO CONTIGUOUS
+! "PLANE PARALLEL" MEDIUMS (NAMELY HERE THE FIRST SOIL LAYER
+! AND THE SNOWPACK LAYER, IF ANY). THIS DIFFUSIVITY TREATMENT
+! BEHAVES WELL FOR BOTH ZERO AND NONZERO SNOWPACK, INCLUDING THE
+! LIMIT OF VERY THIN SNOWPACK.  THIS TREATMENT ALSO ELIMINATES
+! THE NEED TO IMPOSE AN ARBITRARY UPPER BOUND ON SUBSURFACE
+! HEAT FLUX WHEN THE SNOWPACK BECOMES EXTREMELY THIN.
+! ----------------------------------------------------------------------
+! FIRST CALCULATE THERMAL DIFFUSIVITY OF TOP SOIL LAYER, USING
+! BOTH THE FROZEN AND LIQUID SOIL MOISTURE, FOLLOWING THE
+! SOIL THERMAL DIFFUSIVITY FUNCTION OF PETERS-LIDARD ET AL.
+! (1998,JAS, VOL 55, 1209-1224), WHICH REQUIRES THE SPECIFYING
+! THE QUARTZ CONTENT OF THE GIVEN SOIL CLASS (SEE ROUTINE REDPRM)
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! NEXT ADD SUBSURFACE HEAT FLUX REDUCTION EFFECT FROM THE
+! OVERLYING GREEN CANOPY, ADAPTED FROM SECTION 2.1.2 OF
+! PETERS-LIDARD ET AL. (1997, JGR, VOL 102(D4))
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+            CALL TDFCND_gpu (DF1(I),SMC (1,I),QUARTZ(I),SMCMAX(I),SH2O (1,I),BEXP(I), PSISAT(I), SOILTYP(I), OPT_THCND)
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+!urban
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+            IF ( VEGTYP(I) == ISURBAN ) DF1(I)=3.24
+
+            DF1(I) = DF1(I) * EXP (SBETA(I) * SHDFAC(I))
+!
+! kmh 09/03/2006
+! kmh 03/25/2008  change SNCOVR threshold to 0.97
+!
+            IF (  SNCOVR(I) .GT. 0.97 ) THEN
+               DF1(I) = SNCOND(I)
+            ENDIF
+!
+! ----------------------------------------------------------------------
+! FINALLY "PLANE PARALLEL" SNOWPACK EFFECT FOLLOWING
+! V.J. LINARDINI REFERENCE CITED ABOVE. NOTE THAT DTOT IS
+! COMBINED DEPTH OF SNOWDEPTH AND THICKNESS OF FIRST SOIL LAYER
+! ----------------------------------------------------------------------
+
+         DSOIL(I) = - (0.5 * ZSOIL (1,I))
+         IF (SNEQV(I) == 0.) THEN
+            SSOIL(I) = DF1(I) * (T1(I)- STC (1,I) ) / DSOIL(I)
+         ELSE
+            DTOT(I) = SNOWH(I) + DSOIL(I)
+            FRCSNO(I) = SNOWH(I) / DTOT(I)
+
+! 1. HARMONIC MEAN (SERIES FLOW)
+!        DF1(I) = (SNCOND(I)*DF1(I))/(FRCSOI(I)*SNCOND(I)+FRCSNO(I)*DF1(I))
+            FRCSOI(I) = DSOIL(I) / DTOT(I)
+! 2. ARITHMETIC MEAN (PARALLEL FLOW)
+!        DF1(I) = FRCSNO(I)*SNCOND(I) + FRCSOI(I)*DF1(I)
+            DF1H(I) = (SNCOND(I) * DF1(I))/ (FRCSOI(I) * SNCOND(I)+ FRCSNO(I) * DF1(I))
+
+! 3. GEOMETRIC MEAN (INTERMEDIATE BETWEEN HARMONIC AND ARITHMETIC MEAN)
+!        DF1(I) = (SNCOND(I)**FRCSNO(I))*(DF1(I)**FRCSOI(I))
+! weigh DF by snow fraction
+!        DF1(I) = DF1H(I)*SNCOVR(I) + DF1A(I)*(1.0-SNCOVR(I))
+!        DF1(I) = DF1H(I)*SNCOVR(I) + DF1(I)*(1.0-SNCOVR(I))
+            DF1A(I) = FRCSNO(I) * SNCOND(I)+ FRCSOI(I) * DF1(I)
+
+! ----------------------------------------------------------------------
+! CALCULATE SUBSURFACE HEAT FLUX, SSOIL, FROM FINAL THERMAL DIFFUSIVITY
+! OF SURFACE MEDIUMS, DF1 ABOVE, AND SKIN TEMPERATURE AND TOP
+! MID-LAYER SOIL TEMPERATURE
+! ----------------------------------------------------------------------
+            DF1(I) = DF1A(I) * SNCOVR(I) + DF1(I)* (1.0- SNCOVR(I))
+            SSOIL(I) = DF1(I) * (T1(I)- STC (1,I) ) / DTOT(I)
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! DETERMINE SURFACE ROUGHNESS OVER SNOWPACK USING SNOW CONDITION FROM
+! THE PREVIOUS TIMESTEP.
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF (SNCOVR (I) > 0. ) THEN
+            CALL SNOWZ0_gpu (SNCOVR(I),Z0(I),Z0BRD(I),SNOWH(I),FBUR(I),FGSN(I),SHDMAX(I),UA_PHYS)
+         ELSE
+            Z0(I)=Z0BRD(I)
+            IF(UA_PHYS) CALL SNOWZ0_gpu (SNCOVR(I),Z0(I),Z0BRD(I),SNOWH(I),FBUR(I),FGSN(I), &
+	                             SHDMAX(I),UA_PHYS)
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! NEXT CALL ROUTINE SFCDIF TO CALCULATE THE SFC EXCHANGE COEF (CH) FOR
+! HEAT AND MOISTURE.
+
+! NOTE !!!
+! DO NOT CALL SFCDIF UNTIL AFTER ABOVE CALL TO REDPRM, IN CASE
+! ALTERNATIVE VALUES OF ROUGHNESS LENGTH (Z0) AND ZILINTINKEVICH COEF
+! (CZIL) ARE SET THERE VIA NAMELIST I/O.
+
+! NOTE !!!
+! ROUTINE SFCDIF RETURNS A CH THAT REPRESENTS THE WIND SPD TIMES THE
+! "ORIGINAL" NONDIMENSIONAL "Ch" TYPICAL IN LITERATURE.  HENCE THE CH
+! RETURNED FROM SFCDIF HAS UNITS OF M/S.  THE IMPORTANT COMPANION
+! COEFFICIENT OF CH, CARRIED HERE AS "RCH", IS THE CH FROM SFCDIF TIMES
+! AIR DENSITY AND PARAMETER "CP".  "RCH" IS COMPUTED IN "CALL PENMAN".
+! RCH RATHER THAN CH IS THE COEFF USUALLY INVOKED LATER IN EQNS.
+
+! NOTE !!!
+! ----------------------------------------------------------------------
+! SFCDIF ALSO RETURNS THE SURFACE EXCHANGE COEFFICIENT FOR MOMENTUM, CM,
+! ALSO KNOWN AS THE SURFACE DRAGE COEFFICIENT. Needed as a state variable
+! for iterative/implicit solution of CH in SFCDIF
+! ----------------------------------------------------------------------
+!        IF(.NOT.LCH) THEN
+!          T1V = T1(I) * (1.0+ 0.61 * Q2(I))
+!          TH2V = TH2(I) * (1.0+ 0.61 * Q2(I))
+!          CALL SFCDIF_off (ZLVL,Z0,T1V,TH2V,SFCSPD,CZIL,CM,CH)
+!        ENDIF
+
+! ----------------------------------------------------------------------
+! CALL PENMAN SUBROUTINE TO CALCULATE POTENTIAL EVAPORATION (ETP), AND
+! OTHER PARTIAL PRODUCTS AND SUMS SAVE IN COMMON/RITE FOR LATER
+! CALCULATIONS.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL DOWNWARD RADIATION (SOLAR PLUS LONGWAVE) NEEDED IN
+! PENMAN EP SUBROUTINE THAT FOLLOWS
+! ----------------------------------------------------------------------
+!         FDOWN(I) = SOLDN(I) * (1.0- ALBEDO(I)) + LWDN(I)
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         FDOWN(I) =  SOLNET(I) + LWDN(I)
+! ----------------------------------------------------------------------
+! CALC VIRTUAL TEMPS AND VIRTUAL POTENTIAL TEMPS NEEDED BY SUBROUTINES
+! PENMAN.
+         T2V(I) = SFCTMP(I) * (1.0+ 0.61 * Q2(I) )
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+         IOUT=0
+         if(IOUT.eq.1) then
+         print*,'before penman'
+         print*,' SFCTMP',SFCTMP(I),'SFCPRS',SFCPRS(I),'CH',CH(I),'T2V',T2V(I),      &
+       'TH2',TH2(I),'PRCP',PRCP(I),'FDOWN',FDOWN(I),'T24',T24(I),'SSOIL',SSOIL(I),      &
+        'Q2',Q2(I),'Q2SAT',Q2SAT(I),'ETP',ETP(I),'RCH',RCH(I),                       &
+        'EPSCA',EPSCA(I),'RR',RR(I)  ,'SNOWNG',SNOWNG(I),'FRZGRA',FRZGRA(I),           &
+        'DQSDT2',DQSDT2(I),'FLX2',FLX2(I),'SNOWH',SNOWH(I),'SNEQV',SNEQV(I),         &
+        ' DSOIL',DSOIL(I),' FRCSNO',FRCSNO(I),' SNCOVR',SNCOVR(I),' DTOT',DTOT(I),   &
+       ' ZSOIL (1)',ZSOIL(1,I),' DF1',DF1(I),'T1',T1(I),' STC1',STC(1,I),          &
+        'ALBEDO',ALBEDO(I),'SMC',SMC(1:NSOIL,I),'STC',STC(1:NSOIL,I),'SH2O',SH2O(1:NSOIL,I)
+         endif
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector 
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         CALL PENMAN_gpu (SFCTMP(I),SFCPRS(I),CH(I),T2V(I),TH2(I),PRCP(I),FDOWN(I),T24(I),SSOIL(I),     &
+                       Q2(I),Q2SAT(I),ETP(I),RCH(I),EPSCA(I),RR(I),SNOWNG(I),FRZGRA(I),          &
+                       DQSDT2(I),FLX2(I),EMISSI(I),SNEQV(I),T1(I),SNCOVR(I),AOASIS,        &
+		       ALBEDO(I),SOLDN(I),FVB(I),GAMA(I),STC(1,I),ETPN(I),FLX4(I),UA_PHYS)
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+!
+! ----------------------------------------------------------------------
+! CALL CANRES TO CALCULATE THE CANOPY RESISTANCE AND CONVERT IT INTO PC
+! IF NONZERO GREENNESS FRACTION
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+!  FROZEN GROUND EXTENSION: TOTAL SOIL WATER "SMC" WAS REPLACED
+!  BY UNFROZEN SOIL WATER "SH2O" IN CALL TO CANRES BELOW
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         IF ( (SHDFAC(I) > 0.) .AND. (XLAI(I) > 0.) ) THEN
+            CALL CANRES_gpu (SOLDN(I),CH(I),SFCTMP(I),Q2(I),SFCPRS(I),SH2O(1:NSOIL,I),ZSOIL(1:NSOIL,I),NSOIL,     &
+                          SMCWLT(I),SMCREF(I),RSMIN(I),RC(I),PC(I),NROOT(I),Q2SAT(I),DQSDT2(I),  &
+                          TOPT(I),RSMAX(I),RGL(I),HS(I),XLAI(I),                        &
+                          RCS(I),RCT(I),RCQ(I),RCSOIL(I),EMISSI(I))
+         ELSE
+            RC(I) = 0.0
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+! ----------------------------------------------------------------------
+! NOW DECIDE MAJOR PATHWAY BRANCH TO TAKE DEPENDING ON WHETHER SNOWPACK
+! EXISTS OR NOT:
+! ----------------------------------------------------------------------
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+         ESNOW(I) = 0.0
+         IF (SNEQV(I)  == 0.0) THEN
+            CALL NOPAC_gpu (ETP(I),ETA(I),PRCP(I),SMC(1:NSOIL,I),SMCMAX(I),SMCWLT(I),                  &
+                            SMCREF(I),SMCDRY(I),CMC(I),CMCMAX(I),NSOIL,DT,           &
+                            SHDFAC(I),                                      &
+                            SBETA(I),Q2(I),T1(I),SFCTMP(I),T24(I),TH2(I),FDOWN(I),F1(I),EMISSI(I),  &
+                            SSOIL(I),                                       &
+                            STC(1:NSOIL,I),EPSCA(I),BEXP(I),PC(I),RCH(I),RR(I),CFACTR(I),             &
+                            SH2O(1:NSOIL,I),SLOPE(I),KDT(I),FRZX(I),PSISAT(I),ZSOIL(1:NSOIL,I),            &
+                            DKSAT(I),DWSAT(I),TBOT(I),ZBOT(I),RUNOFF1(I),RUNOFF2(I),       &
+                            RUNOFF3(I),EDIR(I),EC(I),ET(1:NSOIL,I),ETT(I),NROOT(I),RTDIS(1:NSOIL,I),          &
+                            QUARTZ(I),FXEXP(I),CSOIL(I),                          &
+                            BETA(I),DRIP(I),DEW(I),FLX1(I),FLX3(I),VEGTYP(I),ISURBAN,      &
+                            SFHEAD1RT(I),INFXS1RT(I),ETPND1(I),SOILTYP(I),OPT_THCND  &
+                           ,XSDA_QFX(I),QFX_PHY(I),XQNORM(I),FASDAS,HCPCT_FASDAS(I)  ) !fasdas
+            ETA_KINEMATIC(I) = ETA(I)
+         ELSE
+            CALL SNOPAC_gpu (ETP(I),ETA(I),PRCP(I),PRCPF(I),SNOWNG(I),SMC(1:NSOIL,I),SMCMAX(I),SMCWLT(I),    &
+                         SMCREF(I),SMCDRY(I),CMC(I),CMCMAX(I),NSOIL,DT,              &
+                         SBETA(I),DF1(I),                                      &
+                         Q2(I),T1(I),SFCTMP(I),T24(I),TH2(I),FDOWN(I),F1(I),SSOIL(I),STC(1:NSOIL,I),EPSCA(I),  &
+                         SFCPRS(I),BEXP(I),PC(I),RCH(I),RR(I),CFACTR(I),SNCOVR(I),SNEQV(I),SNDENS(I),&
+                         SNOWH(I),SH2O(1:NSOIL,I),SLOPE(I),KDT(I),FRZX(I),PSISAT(I),               &
+                         ZSOIL(1:NSOIL,I),DWSAT(I),DKSAT(I),TBOT(I),ZBOT(I),SHDFAC(I),RUNOFF1(I),     &
+                         RUNOFF2(I),RUNOFF3(I),EDIR(I),EC(I),ET(1:NSOIL,I),ETT(I),NROOT(I),SNOMLT(I),    &
+                         RTDIS(1:NSOIL,I),QUARTZ(I),FXEXP(I),CSOIL(I),                       &
+                         BETA(I),DRIP(I),DEW(I),FLX1(I),FLX2(I),FLX3(I),ESNOW(I),ETNS(I),EMISSI(I), &
+                         RIBB(I),SOLDN(I),                                     &
+                         ISURBAN,                                        &
+                         VEGTYP(I),                                         &
+                         ETPN(I),FLX4(I),UA_PHYS,                              &
+                         SFHEAD1RT(I),INFXS1RT(I),ETPND1(I),SOILTYP(I),OPT_THCND     &
+                        ,QFX_PHY(I),FASDAS,HCPCT_FASDAS(I)                     ) !fasdas
+            ETA_KINEMATIC(I) =  ESNOW(I) + ETNS(I) - 1000.0*DEW(I)
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+!$acc parallel vector_length(128)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == 0) THEN
+!     Calculate effective mixing ratio at grnd level (skin)
+!
+!     Q1(I)=Q2(I)+ETA(I)*CP/RCH(I)
+     Q1(I)=Q2(I)+ETA_KINEMATIC(I)*CP/RCH(I)
+!
+! ----------------------------------------------------------------------
+! DETERMINE SENSIBLE HEAT (H) IN ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+
+         SHEAT(I) = - (CH(I) * CP * SFCPRS(I))/ (R * T2V(I)) * ( TH2(I)- T1(I) )
+         IF(UA_PHYS) SHEAT(I) = SHEAT(I) + FLX4(I)
+!
+! FASDAS
+!
+      IF ( FASDAS == 1 ) THEN
+        HFX_PHY(I) = SHEAT(I)
+      ENDIF
+!
+! END FASDAS
+!
+! ----------------------------------------------------------------------
+! CONVERT EVAP TERMS FROM KINEMATIC (KG M-2 S-1) TO ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+      EDIR(I) = EDIR(I) * LVH2O
+      EC(I) = EC(I) * LVH2O
+      DO K=1,4
+      ET(K,I) = ET(K,I) * LVH2O
+      ENDDO
+      ETT(I) = ETT(I) * LVH2O
+      
+      ETPND1(I)=ETPND1(I) * LVH2O
+
+      ESNOW(I) = ESNOW(I) * LSUBS
+      ETP(I) = ETP(I)*((1.-SNCOVR(I))*LVH2O + SNCOVR(I)*LSUBS)
+      IF(UA_PHYS) ETPN(I) = ETPN(I)*((1.-SNCOVR(I))*LVH2O + SNCOVR(I)*LSUBS)
+      IF (ETP(I) .GT. 0.) THEN
+         ETA(I) = EDIR(I) + EC(I) + ETT(I) + ESNOW(I)
+      ELSE
+        ETA(I) = ETP(I)
+      ENDIF
+! ----------------------------------------------------------------------
+! DETERMINE BETA (RATIO OF ACTUAL TO POTENTIAL EVAP)
+! ----------------------------------------------------------------------
+      IF (ETP(I) == 0.0) THEN
+        BETA(I) = 0.0
+      ELSE
+        BETA(I) = ETA(I)/ETP(I)
+      ENDIF
+
+! ----------------------------------------------------------------------
+! CONVERT THE SIGN OF SOIL HEAT FLUX SO THAT:
+!   SSOIL>0: WARM THE SURFACE  (NIGHT TIME)
+!   SSOIL<0: COOL THE SURFACE  (DAY TIME)
+! ----------------------------------------------------------------------
+         SSOIL(I) = -1.0* SSOIL(I)
+
+! ----------------------------------------------------------------------
+!  FOR THE CASE OF LAND:
+!  CONVERT RUNOFF3 (INTERNAL LAYER RUNOFF FROM SUPERSAT) FROM M TO M S-1
+!  AND ADD TO SUBSURFACE RUNOFF/DRAINAGE/BASEFLOW.  RUNOFF2 IS ALREADY
+!  A RATE AT THIS POINT
+! ----------------------------------------------------------------------
+         RUNOFF3(I) = RUNOFF3(I)/ DT
+         RUNOFF2(I) = RUNOFF2(I)+ RUNOFF3(I)
+         SOILM(I) = -1.0* SMC (1,I)* ZSOIL (1,I)
+         DO K = 2,NSOIL
+            SOILM(I) = SOILM(I) + SMC (K,I)* (ZSOIL (K -1,I) - ZSOIL (K,I))
+         END DO
+         SOILWM(I) = -1.0* (SMCMAX(I) - SMCWLT(I))* ZSOIL (1,I)
+         SOILWW(I) = -1.0* (SMC (1,I) - SMCWLT(I))* ZSOIL (1,I)
+
+         DO K = 1,NSOIL
+            SMAV(K,I)=(SMC(K,I) - SMCWLT(I))/(SMCMAX(I) - SMCWLT(I))
+         END DO
+
+         IF (NROOT(I) >= 2) THEN
+            DO K = 2,NROOT(I)
+                SOILWM(I) = SOILWM(I) + (SMCMAX(I) - SMCWLT(I))* (ZSOIL (K -1,I) - ZSOIL (K,I))
+                SOILWW(I) = SOILWW(I) + (SMC(K,I) - SMCWLT(I))* (ZSOIL (K -1,I) - ZSOIL (K,I))
+            END DO
+         END IF
+         IF (SOILWM(I) .LT. 1.E-6) THEN
+           SOILWM(I) = 0.0
+           SOILW(I)  = 0.0
+           SOILM(I)  = 0.0
+         ELSE
+           SOILW(I) = SOILWW(I) / SOILWM(I)
+         END IF
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+!$acc end data
+
+!!!$acc update host(NROOT,SFHEAD1RT,INFXS1RT,ETPND1,EMBRD,ALBEDO,XLAI,CH,CM,SNCOVR,COSZ, &
+!!!$acc             SOLARDIRECT,SHDFAC,ALB,Z0BRD,EMISSI,CMC,T1,SNOWH,SNEQV,SNOTIME1,RIBB,&
+!!!$acc             ET,SMAV,STC,SMC,SH2O,ETA,SHEAT,ETA_KINEMATIC,FDOWN,EC,EDIR,ESNOW,    &
+!!!$acc             DRIP,DEW,BETA,ETP,SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,RUNOFF2,       &
+!!!$acc             RUNOFF3,RC,PC,RSMIN,RCS,RCT,RCQ,RCSOIL,SOILW,SOILM,Q1,SMCWLT,SMCDRY, &
+!!!$acc             SMCREF,SMCMAX,FLX4,FVB,FBUR,FGSN,Z0,ETT,XSDA_QFX,XQNORM,HFX_PHY,     &
+!!!$acc             QFX_PHY,HCPCT_FASDAS)
+! ----------------------------------------------------------------------
+  END SUBROUTINE SFLX_gpu
+! ----------------------------------------------------------------------
+
+
       SUBROUTINE ALCALC (ALB,SNOALB,EMBRD,SHDFAC,SHDMIN,SNCOVR,TSNOW,ALBEDO,EMISSI,   &
                          DT,SNOWNG,SNOTIME1,LVCOEF)
 
@@ -1000,6 +2018,125 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE ALCALC
+! ----------------------------------------------------------------------
+
+      SUBROUTINE ALCALC_gpu (ALB,SNOALB,EMBRD,SHDFAC,SHDMIN,SNCOVR,TSNOW,ALBEDO,EMISSI,   &
+                         DT,SNOWNG,SNOTIME1,LVCOEF)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! CALCULATE ALBEDO INCLUDING SNOW EFFECT (0 -> 1)
+!   ALB     SNOWFREE ALBEDO
+!   SNOALB  MAXIMUM (DEEP) SNOW ALBEDO
+!   SHDFAC    AREAL FRACTIONAL COVERAGE OF GREEN VEGETATION
+!   SHDMIN    MINIMUM AREAL FRACTIONAL COVERAGE OF GREEN VEGETATION
+!   SNCOVR  FRACTIONAL SNOW COVER
+!   ALBEDO  SURFACE ALBEDO INCLUDING SNOW EFFECT
+!   TSNOW   SNOW SURFACE TEMPERATURE (K)
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+! ----------------------------------------------------------------------
+! SNOALB IS ARGUMENT REPRESENTING MAXIMUM ALBEDO OVER DEEP SNOW,
+! AS PASSED INTO SFLX, AND ADAPTED FROM THE SATELLITE-BASED MAXIMUM
+! SNOW ALBEDO FIELDS PROVIDED BY D. ROBINSON AND G. KUKLA
+! (1985, JCAM, VOL 24, 402-411)
+! ----------------------------------------------------------------------
+      REAL, INTENT(IN)  ::  ALB, SNOALB, EMBRD, SHDFAC, SHDMIN, SNCOVR, TSNOW
+      REAL, INTENT(IN)  :: DT
+      LOGICAL, INTENT(IN) :: SNOWNG
+      REAL, INTENT(INOUT):: SNOTIME1
+      REAL, INTENT(OUT) ::  ALBEDO, EMISSI
+      REAL              :: SNOALB2
+      REAL              :: TM,SNOALB1
+      REAL, INTENT(IN)  :: LVCOEF
+      REAL, PARAMETER   :: SNACCA=0.94,SNACCB=0.58,SNTHWA=0.82,SNTHWB=0.46
+! turn of vegetation effect
+!      ALBEDO = ALB + (1.0- (SHDFAC - SHDMIN))* SNCOVR * (SNOALB - ALB)
+!      ALBEDO = (1.0-SNCOVR)*ALB + SNCOVR*SNOALB !this is equivalent to below
+      ALBEDO = ALB + SNCOVR*(SNOALB-ALB)
+      EMISSI = EMBRD + SNCOVR*(EMISSI_S - EMBRD)
+
+!     BASE FORMULATION (DICKINSON ET AL., 1986, COGLEY ET AL., 1990)
+!          IF (TSNOW.LE.263.16) THEN
+!            ALBEDO=SNOALB
+!          ELSE
+!            IF (TSNOW.LT.273.16) THEN
+!              TM=0.1*(TSNOW-263.16)
+!              SNOALB1=0.5*((0.9-0.2*(TM**3))+(0.8-0.16*(TM**3)))
+!            ELSE
+!              SNOALB1=0.67
+!             IF(SNCOVR.GT.0.95) SNOALB1= 0.6
+!             SNOALB1 = ALB + SNCOVR*(SNOALB-ALB)
+!            ENDIF
+!          ENDIF
+!            ALBEDO = ALB + SNCOVR*(SNOALB1-ALB)
+
+!     ISBA FORMULATION (VERSEGHY, 1991; BAKER ET AL., 1990)
+!          SNOALB1 = SNOALB+COEF*(0.85-SNOALB)
+!          SNOALB2=SNOALB1
+!!m          LSTSNW=LSTSNW+1
+!          SNOTIME1 = SNOTIME1 + DT
+!          IF (SNOWNG) THEN
+!             SNOALB2=SNOALB
+!!m             LSTSNW=0
+!             SNOTIME1 = 0.0
+!          ELSE
+!            IF (TSNOW.LT.273.16) THEN
+!!              SNOALB2=SNOALB-0.008*LSTSNW*DT/86400
+!!m              SNOALB2=SNOALB-0.008*SNOTIME1/86400
+!              SNOALB2=(SNOALB2-0.65)*EXP(-0.05*DT/3600)+0.65
+!!              SNOALB2=(ALBEDO-0.65)*EXP(-0.01*DT/3600)+0.65
+!            ELSE
+!              SNOALB2=(SNOALB2-0.5)*EXP(-0.0005*DT/3600)+0.5
+!!              SNOALB2=(SNOALB-0.5)*EXP(-0.24*LSTSNW*DT/86400)+0.5
+!!m              SNOALB2=(SNOALB-0.5)*EXP(-0.24*SNOTIME1/86400)+0.5
+!            ENDIF
+!          ENDIF
+!
+!!               print*,'SNOALB2',SNOALB2,'ALBEDO',ALBEDO,'DT',DT
+!          ALBEDO = ALB + SNCOVR*(SNOALB2-ALB)
+!          IF (ALBEDO .GT. SNOALB2) ALBEDO=SNOALB2
+!!m          LSTSNW1=LSTSNW
+!!          SNOTIME = SNOTIME1
+
+! formulation by Livneh
+! ----------------------------------------------------------------------
+! SNOALB IS CONSIDERED AS THE MAXIMUM SNOW ALBEDO FOR NEW SNOW, AT
+! A VALUE OF 85%. SNOW ALBEDO CURVE DEFAULTS ARE FROM BRAS P.263. SHOULD
+! NOT BE CHANGED EXCEPT FOR SERIOUS PROBLEMS WITH SNOW MELT.
+! TO IMPLEMENT ACCUMULATIN PARAMETERS, SNACCA AND SNACCB, ASSERT THAT IT
+! IS INDEED ACCUMULATION SEASON. I.E. THAT SNOW SURFACE TEMP IS BELOW
+! ZERO AND THE DATE FALLS BETWEEN OCTOBER AND FEBRUARY
+! ----------------------------------------------------------------------
+         SNOALB1 = SNOALB+LVCOEF*(0.85-SNOALB)
+         SNOALB2=SNOALB1
+! ---------------- Initial LSTSNW --------------------------------------
+          IF (SNOWNG) THEN
+             SNOTIME1 = 0.
+          ELSE
+           SNOTIME1=SNOTIME1+DT
+!               IF (TSNOW.LT.273.16) THEN
+                   SNOALB2=SNOALB1*(SNACCA**((SNOTIME1/86400.0)**SNACCB))
+!               ELSE
+!                  SNOALB2 =SNOALB1*(SNTHWA**((SNOTIME1/86400.0)**SNTHWB))
+!               ENDIF
+          ENDIF
+!
+           SNOALB2 = MAX ( SNOALB2, ALB )
+           ALBEDO = ALB + SNCOVR*(SNOALB2-ALB)
+           IF (ALBEDO .GT. SNOALB2) ALBEDO=SNOALB2
+
+!          IF (TSNOW.LT.273.16) THEN
+!            ALBEDO=SNOALB-0.008*DT/86400
+!          ELSE
+!            ALBEDO=(SNOALB-0.5)*EXP(-0.24*DT/86400)+0.5
+!          ENDIF
+
+!      IF (ALBEDO > SNOALB) ALBEDO = SNOALB
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE ALCALC_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE CANRES (SOLAR,CH,SFCTMP,Q2,SFCPRS,SMC,ZSOIL,NSOIL,       &
@@ -1141,6 +2278,146 @@ CONTAINS
   END SUBROUTINE CANRES
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE CANRES_gpu (SOLAR,CH,SFCTMP,Q2,SFCPRS,SMC,ZSOIL,NSOIL,       &
+                         SMCWLT,SMCREF,RSMIN,RC,PC,NROOT,Q2SAT,DQSDT2,    &
+                         TOPT,RSMAX,RGL,HS,XLAI,                          &
+                         RCS,RCT,RCQ,RCSOIL,EMISSI)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE CANRES
+! ----------------------------------------------------------------------
+! CALCULATE CANOPY RESISTANCE WHICH DEPENDS ON INCOMING SOLAR RADIATION,
+! AIR TEMPERATURE, ATMOSPHERIC WATER VAPOR PRESSURE DEFICIT AT THE
+! LOWEST MODEL LEVEL, AND SOIL MOISTURE (PREFERABLY UNFROZEN SOIL
+! MOISTURE RATHER THAN TOTAL)
+! ----------------------------------------------------------------------
+! SOURCE:  JARVIS (1976), NOILHAN AND PLANTON (1989, MWR), JACQUEMIN AND
+! NOILHAN (1990, BLM)
+! SEE ALSO:  CHEN ET AL (1996, JGR, VOL 101(D3), 7251-7268), EQNS 12-14
+! AND TABLE 2 OF SEC. 3.1.2
+! ----------------------------------------------------------------------
+! INPUT:
+!   SOLAR   INCOMING SOLAR RADIATION
+!   CH      SURFACE EXCHANGE COEFFICIENT FOR HEAT AND MOISTURE
+!   SFCTMP  AIR TEMPERATURE AT 1ST LEVEL ABOVE GROUND
+!   Q2      AIR HUMIDITY AT 1ST LEVEL ABOVE GROUND
+!   Q2SAT   SATURATION AIR HUMIDITY AT 1ST LEVEL ABOVE GROUND
+!   DQSDT2  SLOPE OF SATURATION HUMIDITY FUNCTION WRT TEMP
+!   SFCPRS  SURFACE PRESSURE
+!   SMC     VOLUMETRIC SOIL MOISTURE
+!   ZSOIL   SOIL DEPTH (NEGATIVE SIGN, AS IT IS BELOW GROUND)
+!   NSOIL   NO. OF SOIL LAYERS
+!   NROOT   NO. OF SOIL LAYERS IN ROOT ZONE (1.LE.NROOT.LE.NSOIL)
+!   XLAI    LEAF AREA INDEX
+!   SMCWLT  WILTING POINT
+!   SMCREF  REFERENCE SOIL MOISTURE (WHERE SOIL WATER DEFICIT STRESS
+!             SETS IN)
+! RSMIN, RSMAX, TOPT, RGL, HS ARE CANOPY STRESS PARAMETERS SET IN
+!   SURBOUTINE REDPRM
+! OUTPUT:
+!   PC  PLANT COEFFICIENT
+!   RC  CANOPY RESISTANCE
+! ----------------------------------------------------------------------
+
+      IMPLICIT NONE
+      INTEGER, INTENT(IN) :: NROOT,NSOIL
+      INTEGER  K
+      REAL,    INTENT(IN) :: CH,DQSDT2,HS,Q2,Q2SAT,RSMIN,RGL,RSMAX,        &
+                             SFCPRS,SFCTMP,SMCREF,SMCWLT, SOLAR,TOPT,XLAI, &
+                             EMISSI
+      REAL,DIMENSION(1:NSOIL), INTENT(IN) :: SMC,ZSOIL
+      REAL,    INTENT(OUT):: PC,RC,RCQ,RCS,RCSOIL,RCT
+      REAL                :: DELTA,FF,GX,P,RR
+      REAL, DIMENSION(1:NSOIL) ::  PART
+      REAL, PARAMETER     :: SLV = 2.501000E6
+
+
+! ----------------------------------------------------------------------
+! INITIALIZE CANOPY RESISTANCE MULTIPLIER TERMS.
+! ----------------------------------------------------------------------
+      RCS = 0.0
+      RCT = 0.0
+      RCQ = 0.0
+      RCSOIL = 0.0
+
+! ----------------------------------------------------------------------
+! CONTRIBUTION DUE TO INCOMING SOLAR RADIATION
+! ----------------------------------------------------------------------
+      RC = 0.0
+      FF = 0.55*2.0* SOLAR / (RGL * XLAI)
+      RCS = (FF + RSMIN / RSMAX) / (1.0+ FF)
+
+! ----------------------------------------------------------------------
+! CONTRIBUTION DUE TO AIR TEMPERATURE AT FIRST MODEL LEVEL ABOVE GROUND
+! RCT EXPRESSION FROM NOILHAN AND PLANTON (1989, MWR).
+! ----------------------------------------------------------------------
+      RCS = MAX (RCS,0.0001)
+      RCT = 1.0- 0.0016* ( (TOPT - SFCTMP)**2.0)
+
+! ----------------------------------------------------------------------
+! CONTRIBUTION DUE TO VAPOR PRESSURE DEFICIT AT FIRST MODEL LEVEL.
+! RCQ EXPRESSION FROM SSIB
+! ----------------------------------------------------------------------
+      RCT = MAX (RCT,0.0001)
+      RCQ = 1.0/ (1.0+ HS * (Q2SAT - Q2))
+
+! ----------------------------------------------------------------------
+! CONTRIBUTION DUE TO SOIL MOISTURE AVAILABILITY.
+! DETERMINE CONTRIBUTION FROM EACH SOIL LAYER, THEN ADD THEM UP.
+! ----------------------------------------------------------------------
+      RCQ = MAX (RCQ,0.01)
+      GX = (SMC (1) - SMCWLT) / (SMCREF - SMCWLT)
+      IF (GX  >  1.) GX = 1.
+      IF (GX  <  0.) GX = 0.
+
+! ----------------------------------------------------------------------
+! USE SOIL DEPTH AS WEIGHTING FACTOR
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! USE ROOT DISTRIBUTION AS WEIGHTING FACTOR
+!      PART(1) = RTDIS(1) * GX
+! ----------------------------------------------------------------------
+      PART (1) = (ZSOIL (1)/ ZSOIL (NROOT)) * GX
+      DO K = 2,NROOT
+         GX = (SMC (K) - SMCWLT) / (SMCREF - SMCWLT)
+         IF (GX >  1.) GX = 1.
+         IF (GX <  0.) GX = 0.
+! ----------------------------------------------------------------------
+! USE SOIL DEPTH AS WEIGHTING FACTOR
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! USE ROOT DISTRIBUTION AS WEIGHTING FACTOR
+!        PART(K) = RTDIS(K) * GX
+! ----------------------------------------------------------------------
+         PART (K) = ( (ZSOIL (K) - ZSOIL (K -1))/ ZSOIL (NROOT)) * GX
+      END DO
+      DO K = 1,NROOT
+         RCSOIL = RCSOIL + PART (K)
+      END DO
+
+! ----------------------------------------------------------------------
+! DETERMINE CANOPY RESISTANCE DUE TO ALL FACTORS.  CONVERT CANOPY
+! RESISTANCE (RC) TO PLANT COEFFICIENT (PC) TO BE USED WITH POTENTIAL
+! EVAP IN DETERMINING ACTUAL EVAP.  PC IS DETERMINED BY:
+!   PC * LINERIZED PENMAN POTENTIAL EVAP =
+!   PENMAN-MONTEITH ACTUAL EVAPORATION (CONTAINING RC TERM).
+! ----------------------------------------------------------------------
+      RCSOIL = MAX (RCSOIL,0.0001)
+
+      RC = RSMIN / (XLAI * RCS * RCT * RCQ * RCSOIL)
+!      RR = (4.* SIGMA * RD / CP)* (SFCTMP **4.)/ (SFCPRS * CH) + 1.0
+      RR = (4.* EMISSI *SIGMA * RD / CP)* (SFCTMP **4.)/ (SFCPRS * CH) &
+             + 1.0
+
+      DELTA = (SLV / CP)* DQSDT2
+
+      PC = (RR + DELTA)/ (RR * (1. + RC * CH) + DELTA)
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE CANRES_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE CSNOW (SNCOND,DSNOW)
 
 ! ----------------------------------------------------------------------
@@ -1181,7 +2458,50 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE CSNOW
+! ---------------------------------------------------------------------
+
+      SUBROUTINE CSNOW_gpu (SNCOND,DSNOW)
+!$acc routine seq
 ! ----------------------------------------------------------------------
+! SUBROUTINE CSNOW
+! FUNCTION CSNOW
+! ----------------------------------------------------------------------
+! CALCULATE SNOW TERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: DSNOW
+      REAL, INTENT(OUT):: SNCOND
+      REAL             :: C
+      REAL, PARAMETER  :: UNIT = 0.11631
+
+! ----------------------------------------------------------------------
+! SNCOND IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! CSNOW IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! BASIC VERSION IS DYACHKOVA EQUATION (1960), FOR RANGE 0.1-0.4
+! ----------------------------------------------------------------------
+      C = 0.328*10** (2.25* DSNOW)
+!      CSNOW=UNIT*C
+
+! ----------------------------------------------------------------------
+! DE VAUX EQUATION (1933), IN RANGE 0.1-0.6
+! ----------------------------------------------------------------------
+!      SNCOND=0.0293*(1.+100.*DSNOW**2)
+!      CSNOW=0.0293*(1.+100.*DSNOW**2)
+
+! ----------------------------------------------------------------------
+! E. ANDERSEN FROM FLERCHINGER
+! ----------------------------------------------------------------------
+!      SNCOND=0.021+2.51*DSNOW**2
+!      CSNOW=0.021+2.51*DSNOW**2
+
+!      SNCOND = UNIT * C
+! double snow thermal conductivity
+      SNCOND = 2.0 * UNIT * C
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE CSNOW_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE DEVAP (EDIR,ETP1,SMC,ZSOIL,SHDFAC,SMCMAX,BEXP,         &
                         DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP)
 
@@ -1222,6 +2542,48 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE DEVAP
+
+      SUBROUTINE DEVAP_gpu (EDIR,ETP1,SMC,ZSOIL,SHDFAC,SMCMAX,BEXP,         &
+                        DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE DEVAP
+! FUNCTION DEVAP
+! ----------------------------------------------------------------------
+! CALCULATE DIRECT SOIL EVAPORATION
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: ETP1,SMC,BEXP,DKSAT,DWSAT,FXEXP,              &
+                          SHDFAC,SMCDRY,SMCMAX,ZSOIL,SMCREF,SMCWLT
+      REAL, INTENT(OUT):: EDIR
+      REAL             :: FX, SRATIO
+
+
+! ----------------------------------------------------------------------
+! DIRECT EVAP A FUNCTION OF RELATIVE SOIL MOISTURE AVAILABILITY, LINEAR
+! WHEN FXEXP=1.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! FX > 1 REPRESENTS DEMAND CONTROL
+! FX < 1 REPRESENTS FLUX CONTROL
+! ----------------------------------------------------------------------
+
+      SRATIO = (SMC - SMCDRY) / (SMCMAX - SMCDRY)
+      IF (SRATIO > 0.) THEN
+        FX = SRATIO**FXEXP
+        FX = MAX ( MIN ( FX, 1. ) ,0. )
+      ELSE
+        FX = 0.
+      ENDIF
+
+! ----------------------------------------------------------------------
+! ALLOW FOR THE DIRECT-EVAP-REDUCING EFFECT OF SHADE
+! ----------------------------------------------------------------------
+      EDIR = FX * ( 1.0- SHDFAC ) * ETP1
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE DEVAP_gpu
 
       SUBROUTINE DEVAP_hydro (EDIR,ETP1,SMC,ZSOIL,SHDFAC,SMCMAX,BEXP,         &
                         DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP,         &
@@ -1314,6 +2676,100 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE DEVAP_hydro
+! ----------------------------------------------------------------------
+
+      SUBROUTINE DEVAP_hydro_gpu (EDIR,ETP1,SMC,ZSOIL,SHDFAC,SMCMAX,BEXP,         &
+                        DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP,         &
+                        SFHEAD1RT,ETPND1,DT)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE DEVAP
+! FUNCTION DEVAP
+! ----------------------------------------------------------------------
+! CALCULATE DIRECT SOIL EVAPORATION
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN) :: ETP1,SMC,BEXP,DKSAT,DWSAT,FXEXP,              &
+                          SHDFAC,SMCDRY,SMCMAX,ZSOIL,SMCREF,SMCWLT
+      REAL, INTENT(OUT):: EDIR
+      REAL             :: FX, SRATIO
+
+      REAL, INTENT(INOUT) :: SFHEAD1RT,ETPND1
+      REAL, INTENT(IN   ) :: DT
+       REAL             :: EDIRTMP
+
+
+
+! ----------------------------------------------------------------------
+! DIRECT EVAP A FUNCTION OF RELATIVE SOIL MOISTURE AVAILABILITY, LINEAR
+! WHEN FXEXP=1.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! FX > 1 REPRESENTS DEMAND CONTROL
+! FX < 1 REPRESENTS FLUX CONTROL
+! ----------------------------------------------------------------------
+
+      SRATIO = (SMC - SMCDRY) / (SMCMAX - SMCDRY)
+      IF (SRATIO > 0.) THEN
+        FX = SRATIO**FXEXP
+        FX = MAX ( MIN ( FX, 1. ) ,0. )
+      ELSE
+        FX = 0.
+      ENDIF
+
+!DJG NDHMS/WRF-Hydro edits... Adjustment for ponded surface water : Reduce ETP1
+      EDIRTMP = 0.
+      ETPND1 = 0.
+
+!DJG NDHMS/WRF-Hydro edits...  Calc Max Potential Dir Evap. (ETP1 units: }=m/s)
+
+!DJG NDHMS/WRF-Hydro...currently set ponded water evap to 0.0 until further notice...11/5/2012
+!EDIRTMP = ( 1.0- SHDFAC ) * ETP1
+
+! Convert all units to (m)
+! Convert EDIRTMP  from (kg m{-2} s{-1}=m/s) to (m) ...
+      EDIRTMP = EDIRTMP * DT
+
+!DJG NDHMS/WRF-Hydro edits... Convert SFHEAD from (mm) to (m) ...
+      SFHEAD1RT=SFHEAD1RT * 0.001
+
+
+
+!DJG NDHMS/WRF-Hydro edits... Calculate ETPND as reduction in EDIR(TMP)...
+      IF (EDIRTMP > 0.) THEN
+       IF ( EDIRTMP > SFHEAD1RT ) THEN
+         ETPND1 = SFHEAD1RT
+         SFHEAD1RT=0.
+         EDIRTMP = EDIRTMP - ETPND1
+       ELSE
+         ETPND1 = EDIRTMP
+         EDIRTMP = 0.
+         SFHEAD1RT = SFHEAD1RT - ETPND1
+       END IF
+      END IF
+
+!DJG NDHMS/WRF-Hydro edits... Convert SFHEAD units back to (mm)
+      IF ( SFHEAD1RT /= 0.) SFHEAD1RT=SFHEAD1RT * 1000.
+
+!DJG NDHMS/WRF-Hydro edits...Convert ETPND and EDIRTMP back to (mm/s=kg m{-2} s{-1})
+      ETPND1 = ETPND1 / DT
+      EDIRTMP = EDIRTMP / DT
+!DEBUG    print *, "After DEVAP...SFCHEAD+ETPND1",SFHEAD1RT+ETPND1*DT
+
+
+! ----------------------------------------------------------------------
+! ALLOW FOR THE DIRECT-EVAP-REDUCING EFFECT OF SHADE
+! ----------------------------------------------------------------------
+!DJG NDHMS/WRF-Hydro edits...
+!       EDIR = FX * ( 1.0- SHDFAC ) * ETP1
+       EDIR = FX * EDIRTMP
+
+
+
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE DEVAP_hydro_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE EVAPO (ETA1,SMC,NSOIL,CMC,ETP1,DT,ZSOIL,               &
@@ -1417,6 +2873,108 @@ CONTAINS
   END SUBROUTINE EVAPO
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE EVAPO_gpu (ETA1,SMC,NSOIL,CMC,ETP1,DT,ZSOIL,               &
+                         SH2O,                                          &
+                         SMCMAX,BEXP,PC,SMCWLT,DKSAT,DWSAT,             &
+                         SMCREF,SHDFAC,CMCMAX,                          &
+                         SMCDRY,CFACTR,                                 &
+                         EDIR,EC,ET,ETT,SFCTMP,Q2,NROOT,RTDIS,FXEXP,    &
+                         SFHEAD1RT,ETPND1)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE EVAPO
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE FLUX.  THE SOIL MOISTURE CONTENT (SMC - A PER
+! UNIT VOLUME MEASUREMENT) IS A DEPENDENT VARIABLE THAT IS UPDATED WITH
+! PROGNOSTIC EQNS. THE CANOPY MOISTURE CONTENT (CMC) IS ALSO UPDATED.
+! FROZEN GROUND VERSION:  NEW STATES ADDED: SH2O, AND FROZEN GROUND
+! CORRECTION FACTOR, FRZFACT AND PARAMETER SLOPE.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)   :: NSOIL, NROOT
+      INTEGER               :: I,K
+      REAL,    INTENT(IN)   :: BEXP, CFACTR,CMC,CMCMAX,DKSAT,           &
+                                 DT,DWSAT,ETP1,FXEXP,PC,Q2,SFCTMP,           &
+                                 SHDFAC,SMCDRY,SMCMAX,SMCREF,SMCWLT
+      REAL,    INTENT(OUT)  :: EC,EDIR,ETA1,ETT
+      REAL                  :: CMC2MS
+      REAL,DIMENSION(1:NSOIL), INTENT(IN) :: RTDIS, SMC, SH2O, ZSOIL
+      REAL,DIMENSION(1:NSOIL), INTENT(OUT) :: ET
+
+      REAL,   INTENT(INOUT) :: SFHEAD1RT,ETPND1
+
+! ----------------------------------------------------------------------
+! EXECUTABLE CODE BEGINS HERE IF THE POTENTIAL EVAPOTRANSPIRATION IS
+! GREATER THAN ZERO.
+! ----------------------------------------------------------------------
+      EDIR = 0.
+      EC = 0.
+      ETT = 0.
+      DO K = 1,NSOIL
+         ET (K) = 0.
+      END DO
+
+! ----------------------------------------------------------------------
+! RETRIEVE DIRECT EVAPORATION FROM SOIL SURFACE.  CALL THIS FUNCTION
+! ONLY IF VEG COVER NOT COMPLETE.
+! FROZEN GROUND VERSION:  SH2O STATES REPLACE SMC STATES.
+! ----------------------------------------------------------------------
+      IF (ETP1 > 0.0) THEN
+         IF (SHDFAC <  1.) THEN
+#ifdef WRF_HYDRO
+!            CALL DEVAP_hydro (EDIR,ETP1,SMC (1),ZSOIL (1),SHDFAC,SMCMAX,      &
+!                        BEXP,DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP,    &
+!                         SFHEAD1RT,ETPND1,DT)
+!DJG Reduce ETP1 by EDIR & ETPND1...
+!                ETP1=ETP1-EDIR-ETPND1
+
+! following is the temparay setting ...
+             CALL DEVAP_gpu (EDIR,ETP1,SMC (1),ZSOIL (1),SHDFAC,SMCMAX,      &
+                         BEXP,DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP)
+!            ETP1=ETP1-EDIR
+#else
+             CALL DEVAP_gpu (EDIR,ETP1,SMC (1),ZSOIL (1),SHDFAC,SMCMAX,      &
+                         BEXP,DKSAT,DWSAT,SMCDRY,SMCREF,SMCWLT,FXEXP)
+#endif
+         END IF
+! ----------------------------------------------------------------------
+! INITIALIZE PLANT TOTAL TRANSPIRATION, RETRIEVE PLANT TRANSPIRATION,
+! AND ACCUMULATE IT FOR ALL SOIL LAYERS.
+! ----------------------------------------------------------------------
+
+         IF (SHDFAC > 0.0) THEN
+            CALL TRANSP_gpu (ET,NSOIL,ETP1,SH2O,CMC,ZSOIL,SHDFAC,SMCWLT,     &
+                          CMCMAX,PC,CFACTR,SMCREF,SFCTMP,Q2,NROOT,RTDIS)
+            DO K = 1,NSOIL
+               ETT = ETT + ET ( K )
+            END DO
+! ----------------------------------------------------------------------
+! CALCULATE CANOPY EVAPORATION.
+! IF STATEMENTS TO AVOID TANGENT LINEAR PROBLEMS NEAR CMC=0.0.
+! ----------------------------------------------------------------------
+            IF (CMC > 0.0) THEN
+               EC = SHDFAC * ( ( CMC / CMCMAX ) ** CFACTR ) * ETP1
+            ELSE
+               EC = 0.0
+            END IF
+! ----------------------------------------------------------------------
+! EC SHOULD BE LIMITED BY THE TOTAL AMOUNT OF AVAILABLE WATER ON THE
+! CANOPY.  -F.CHEN, 18-OCT-1994
+! ----------------------------------------------------------------------
+            CMC2MS = CMC / DT
+            EC = MIN ( CMC2MS, EC )
+         END IF
+      END IF
+! ----------------------------------------------------------------------
+! TOTAL UP EVAP AND TRANSP TYPES TO OBTAIN ACTUAL EVAPOTRANSP
+! ----------------------------------------------------------------------
+      ETA1 = EDIR + ETT + EC
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE EVAPO_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE FAC2MIT(SMCMAX,FLIMIT)
     IMPLICIT NONE		
     REAL, INTENT(IN)  :: SMCMAX
@@ -1438,6 +2996,30 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE FAC2MIT
+! ----------------------------------------------------------------------
+
+  SUBROUTINE FAC2MIT_gpu(SMCMAX,FLIMIT)
+!$acc routine seq
+    IMPLICIT NONE		
+    REAL, INTENT(IN)  :: SMCMAX
+    REAL, INTENT(OUT) :: FLIMIT
+
+    FLIMIT = 0.90
+
+    IF ( SMCMAX == 0.395 ) THEN
+       FLIMIT = 0.59
+    ELSE IF ( ( SMCMAX == 0.434 ) .OR. ( SMCMAX == 0.404 ) ) THEN
+       FLIMIT = 0.85
+    ELSE IF ( ( SMCMAX == 0.465 ) .OR. ( SMCMAX == 0.406 ) ) THEN
+       FLIMIT = 0.86
+    ELSE IF ( ( SMCMAX == 0.476 ) .OR. ( SMCMAX == 0.439 ) ) THEN
+       FLIMIT = 0.74
+    ELSE IF ( ( SMCMAX == 0.200 ) .OR. ( SMCMAX == 0.464 ) ) THEN
+       FLIMIT = 0.80
+    ENDIF
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE FAC2MIT_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE FRH2O (FREE,TKELV,SMC,SH2O,SMCMAX,BEXP,PSIS)
@@ -1579,6 +3161,148 @@ CONTAINS
       END IF
 ! ----------------------------------------------------------------------
   END SUBROUTINE FRH2O
+! ----------------------------------------------------------------------
+
+      SUBROUTINE FRH2O_gpu (FREE,TKELV,SMC,SH2O,SMCMAX,BEXP,PSIS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE FRH2O
+! ----------------------------------------------------------------------
+! CALCULATE AMOUNT OF SUPERCOOLED LIQUID SOIL WATER CONTENT IF
+! TEMPERATURE IS BELOW 273.15K (T0).  REQUIRES NEWTON-TYPE ITERATION TO
+! SOLVE THE NONLINEAR IMPLICIT EQUATION GIVEN IN EQN 17 OF KOREN ET AL
+! (1999, JGR, VOL 104(D16), 19569-19585).
+! ----------------------------------------------------------------------
+! NEW VERSION (JUNE 2001): MUCH FASTER AND MORE ACCURATE NEWTON
+! ITERATION ACHIEVED BY FIRST TAKING LOG OF EQN CITED ABOVE -- LESS THAN
+! 4 (TYPICALLY 1 OR 2) ITERATIONS ACHIEVES CONVERGENCE.  ALSO, EXPLICIT
+! 1-STEP SOLUTION OPTION FOR SPECIAL CASE OF PARAMETER CK=0, WHICH
+! REDUCES THE ORIGINAL IMPLICIT EQUATION TO A SIMPLER EXPLICIT FORM,
+! KNOWN AS THE "FLERCHINGER EQN". IMPROVED HANDLING OF SOLUTION IN THE
+! LIMIT OF FREEZING POINT TEMPERATURE T0.
+! ----------------------------------------------------------------------
+! INPUT:
+
+!   TKELV.........TEMPERATURE (Kelvin)
+!   SMC...........TOTAL SOIL MOISTURE CONTENT (VOLUMETRIC)
+!   SH2O..........LIQUID SOIL MOISTURE CONTENT (VOLUMETRIC)
+!   SMCMAX........SATURATION SOIL MOISTURE CONTENT (FROM REDPRM)
+!   B.............SOIL TYPE "B" PARAMETER (FROM REDPRM)
+!   PSIS..........SATURATED SOIL MATRIC POTENTIAL (FROM REDPRM)
+
+! OUTPUT:
+!   FRH2O.........SUPERCOOLED LIQUID WATER CONTENT
+!   FREE..........SUPERCOOLED LIQUID WATER CONTENT
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN)     :: BEXP,PSIS,SH2O,SMC,SMCMAX,TKELV
+      REAL, INTENT(OUT)    :: FREE
+      REAL                 :: BX,DENOM,DF,DSWL,FK,SWL,SWLK
+      INTEGER              :: NLOG,KCOUNT
+!      PARAMETER(CK = 0.0)
+      REAL, PARAMETER      :: CK = 8.0, BLIM = 5.5, ERROR = 0.005,       &
+                              HLICE = 3.335E5, GS = 9.81,DICE = 920.0,   &
+                              DH2O = 1000.0, T0 = 273.15
+
+! ----------------------------------------------------------------------
+! LIMITS ON PARAMETER B: B < 5.5  (use parameter BLIM)
+! SIMULATIONS SHOWED IF B > 5.5 UNFROZEN WATER CONTENT IS
+! NON-REALISTICALLY HIGH AT VERY LOW TEMPERATURES.
+! ----------------------------------------------------------------------
+      BX = BEXP
+
+! ----------------------------------------------------------------------
+! INITIALIZING ITERATIONS COUNTER AND ITERATIVE SOLUTION FLAG.
+! ----------------------------------------------------------------------
+      IF (BEXP >  BLIM) BX = BLIM
+      NLOG = 0
+
+! ----------------------------------------------------------------------
+!  IF TEMPERATURE NOT SIGNIFICANTLY BELOW FREEZING (T0), SH2O = SMC
+! ----------------------------------------------------------------------
+      KCOUNT = 0
+!      FRH2O = SMC
+      IF (TKELV > (T0- 1.E-3)) THEN
+          FREE = SMC
+      ELSE
+
+! ----------------------------------------------------------------------
+! OPTION 1: ITERATED SOLUTION FOR NONZERO CK
+! IN KOREN ET AL, JGR, 1999, EQN 17
+! ----------------------------------------------------------------------
+! INITIAL GUESS FOR SWL (frozen content)
+! ----------------------------------------------------------------------
+         IF (CK /= 0.0) THEN
+            SWL = SMC - SH2O
+! ----------------------------------------------------------------------
+! KEEP WITHIN BOUNDS.
+! ----------------------------------------------------------------------
+            IF (SWL > (SMC -0.02)) SWL = SMC -0.02
+
+! ----------------------------------------------------------------------
+!  START OF ITERATIONS
+! ----------------------------------------------------------------------
+            IF (SWL < 0.) SWL = 0.
+ 1001       Continue
+              IF (.NOT.( (NLOG < 10) .AND. (KCOUNT == 0)))   goto 1002
+              NLOG = NLOG +1
+              DF = ALOG ( ( PSIS * GS / HLICE ) * ( ( 1. + CK * SWL )**2.) * &
+                   ( SMCMAX / (SMC - SWL) )** BX) - ALOG ( - (               &
+                   TKELV - T0)/ TKELV)
+              DENOM = 2. * CK / ( 1. + CK * SWL ) + BX / ( SMC - SWL )
+              SWLK = SWL - DF / DENOM
+! ----------------------------------------------------------------------
+! BOUNDS USEFUL FOR MATHEMATICAL SOLUTION.
+! ----------------------------------------------------------------------
+              IF (SWLK > (SMC -0.02)) SWLK = SMC - 0.02
+              IF (SWLK < 0.) SWLK = 0.
+
+! ----------------------------------------------------------------------
+! MATHEMATICAL SOLUTION BOUNDS APPLIED.
+! ----------------------------------------------------------------------
+              DSWL = ABS (SWLK - SWL)
+
+! ----------------------------------------------------------------------
+! IF MORE THAN 10 ITERATIONS, USE EXPLICIT METHOD (CK=0 APPROX.)
+! WHEN DSWL LESS OR EQ. ERROR, NO MORE ITERATIONS REQUIRED.
+! ----------------------------------------------------------------------
+              SWL = SWLK
+              IF ( DSWL <= ERROR ) THEN
+                    KCOUNT = KCOUNT +1
+              END IF
+! ----------------------------------------------------------------------
+!  END OF ITERATIONS
+! ----------------------------------------------------------------------
+! BOUNDS APPLIED WITHIN DO-BLOCK ARE VALID FOR PHYSICAL SOLUTION.
+! ----------------------------------------------------------------------
+!          FRH2O = SMC - SWL
+           goto 1001
+ 1002   continue
+           FREE = SMC - SWL
+         END IF
+! ----------------------------------------------------------------------
+! END OPTION 1
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! OPTION 2: EXPLICIT SOLUTION FOR FLERCHINGER EQ. i.e. CK=0
+! IN KOREN ET AL., JGR, 1999, EQN 17
+! APPLY PHYSICAL BOUNDS TO FLERCHINGER SOLUTION
+! ----------------------------------------------------------------------
+         IF (KCOUNT == 0) THEN
+             PRINT *,'Flerchinger USEd in NEW version. Iterations=',NLOG
+                  FK = ( ( (HLICE / (GS * ( - PSIS)))*                    &
+                       ( (TKELV - T0)/ TKELV))** ( -1/ BX))* SMCMAX
+!            FRH2O = MIN (FK, SMC)
+             IF (FK < 0.02) FK = 0.02
+             FREE = MIN (FK, SMC)
+! ----------------------------------------------------------------------
+! END OPTION 2
+! ----------------------------------------------------------------------
+         END IF
+      END IF
+! ----------------------------------------------------------------------
+  END SUBROUTINE FRH2O_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE HRT (RHSTS,STC,SMC,SMCMAX,NSOIL,ZSOIL,YY,ZZ1,          &
@@ -1846,6 +3570,272 @@ CONTAINS
   END SUBROUTINE HRT
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE HRT_gpu (RHSTS,STC,SMC,SMCMAX,NSOIL,ZSOIL,YY,ZZ1,          &
+                       TBOT,ZBOT,PSISAT,SH2O,DT,BEXP,SOILTYP,OPT_THCND, &
+                       F1,DF1,QUARTZ,CSOIL,AI,BI,CI,VEGTYP,ISURBAN      &
+                      ,HCPCT_FASDAS                                     ) !fasdas
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE HRT
+! ----------------------------------------------------------------------
+! CALCULATE THE RIGHT HAND SIDE OF THE TIME TENDENCY TERM OF THE SOIL
+! THERMAL DIFFUSION EQUATION.  ALSO TO COMPUTE ( PREPARE ) THE MATRIX
+! COEFFICIENTS FOR THE TRI-DIAGONAL MATRIX OF THE IMPLICIT TIME SCHEME.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      LOGICAL              :: ITAVG
+      INTEGER, INTENT(IN)  :: OPT_THCND
+      INTEGER, INTENT(IN)  :: NSOIL, VEGTYP, SOILTYP
+      INTEGER, INTENT(IN)  :: ISURBAN
+      INTEGER              :: I, K
+
+      REAL, INTENT(IN)     :: BEXP, CSOIL, DF1, DT,F1,PSISAT,QUARTZ,     &
+                              SMCMAX ,TBOT,YY,ZZ1, ZBOT
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: SMC,STC,ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: SH2O
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT)  :: RHSTS
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT)  :: AI, BI,CI
+      REAL                 :: DDZ, DDZ2, DENOM, DF1N, DF1K, DTSDZ,       &
+                              DTSDZ2,HCPCT,QTOT,SSOIL,SICE,TAVG,TBK,     &
+                              TBK1,TSNSR,TSURF,CSOIL_LOC
+      REAL, PARAMETER      :: T0 = 273.15, CAIR = 1004.0, CICE = 2.106E6,&
+                              CH2O = 4.2E6
+
+!
+! FASDAS
+!
+      REAL, INTENT(  OUT)       :: HCPCT_FASDAS
+!
+! END FASDAS
+!
+
+!urban
+        IF( VEGTYP == ISURBAN ) then
+            CSOIL_LOC=3.0E6
+        ELSE
+            CSOIL_LOC=CSOIL
+        ENDIF
+
+! ----------------------------------------------------------------------
+! INITIALIZE LOGICAL FOR SOIL LAYER TEMPERATURE AVERAGING.
+! ----------------------------------------------------------------------
+       ITAVG = .TRUE.
+! ----------------------------------------------------------------------
+! BEGIN SECTION FOR TOP SOIL LAYER
+! ----------------------------------------------------------------------
+! CALC THE HEAT CAPACITY OF THE TOP SOIL LAYER
+! ----------------------------------------------------------------------
+      HCPCT = SH2O (1)* CH2O + (1.0- SMCMAX)* CSOIL_LOC + (SMCMAX - SMC (1))&
+       * CAIR                                                           &
+              + ( SMC (1) - SH2O (1) )* CICE
+!
+! FASDAS
+!
+      HCPCT_FASDAS = HCPCT
+!
+! END FASDAS
+!
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEFFICIENTS AI, BI, AND CI FOR THE TOP LAYER
+! ----------------------------------------------------------------------
+      DDZ = 1.0 / ( -0.5 * ZSOIL (2) )
+      AI (1) = 0.0
+      CI (1) = (DF1 * DDZ) / (ZSOIL (1) * HCPCT)
+
+! ----------------------------------------------------------------------
+! CALCULATE THE VERTICAL SOIL TEMP GRADIENT BTWN THE 1ST AND 2ND SOIL
+! LAYERS.  THEN CALCULATE THE SUBSURFACE HEAT FLUX. USE THE TEMP
+! GRADIENT AND SUBSFC HEAT FLUX TO CALC "RIGHT-HAND SIDE TENDENCY
+! TERMS", OR "RHSTS", FOR TOP SOIL LAYER.
+! ----------------------------------------------------------------------
+      BI (1) = - CI (1) + DF1 / (0.5 * ZSOIL (1) * ZSOIL (1)* HCPCT *    &
+       ZZ1)
+      DTSDZ = (STC (1) - STC (2)) / ( -0.5 * ZSOIL (2))
+      SSOIL = DF1 * (STC (1) - YY) / (0.5 * ZSOIL (1) * ZZ1)
+!      RHSTS(1) = (DF1 * DTSDZ - SSOIL) / (ZSOIL(1) * HCPCT)
+      DENOM = (ZSOIL (1) * HCPCT)
+
+! ----------------------------------------------------------------------
+! NEXT CAPTURE THE VERTICAL DIFFERENCE OF THE HEAT FLUX AT TOP AND
+! BOTTOM OF FIRST SOIL LAYER FOR USE IN HEAT FLUX CONSTRAINT APPLIED TO
+! POTENTIAL SOIL FREEZING/THAWING IN ROUTINE SNKSRC.
+! ----------------------------------------------------------------------
+!      QTOT = SSOIL - DF1*DTSDZ
+      RHSTS (1) = (DF1 * DTSDZ - SSOIL) / DENOM
+
+! ----------------------------------------------------------------------
+! CALCULATE FROZEN WATER CONTENT IN 1ST SOIL LAYER.
+! ----------------------------------------------------------------------
+      QTOT = -1.0* RHSTS (1)* DENOM
+
+! ----------------------------------------------------------------------
+! IF TEMPERATURE AVERAGING INVOKED (ITAVG=TRUE; ELSE SKIP):
+! SET TEMP "TSURF" AT TOP OF SOIL COLUMN (FOR USE IN FREEZING SOIL
+! PHYSICS LATER IN FUNCTION SUBROUTINE SNKSRC).  IF SNOWPACK CONTENT IS
+! ZERO, THEN TSURF EXPRESSION BELOW GIVES TSURF = SKIN TEMP.  IF
+! SNOWPACK IS NONZERO (HENCE ARGUMENT ZZ1=1), THEN TSURF EXPRESSION
+! BELOW YIELDS SOIL COLUMN TOP TEMPERATURE UNDER SNOWPACK.  THEN
+! CALCULATE TEMPERATURE AT BOTTOM INTERFACE OF 1ST SOIL LAYER FOR USE
+! LATER IN FUNCTION SUBROUTINE SNKSRC
+! ----------------------------------------------------------------------
+      SICE = SMC (1) - SH2O (1)
+      IF (ITAVG) THEN
+         TSURF = (YY + (ZZ1-1) * STC (1)) / ZZ1
+! ----------------------------------------------------------------------
+! IF FROZEN WATER PRESENT OR ANY OF LAYER-1 MID-POINT OR BOUNDING
+! INTERFACE TEMPERATURES BELOW FREEZING, THEN CALL SNKSRC TO
+! COMPUTE HEAT SOURCE/SINK (AND CHANGE IN FROZEN WATER CONTENT)
+! DUE TO POSSIBLE SOIL WATER PHASE CHANGE
+! ----------------------------------------------------------------------
+         CALL TBND_gpu (STC (1),STC (2),ZSOIL,ZBOT,1,NSOIL,TBK)
+         IF ( (SICE > 0.) .OR. (STC (1) < T0) .OR.                         &
+            (TSURF < T0) .OR. (TBK < T0) ) THEN
+!          TSNSR = SNKSRC (TAVG,SMC(1),SH2O(1),
+            CALL TMPAVG_gpu (TAVG,TSURF,STC (1),TBK,ZSOIL,NSOIL,1)
+            CALL SNKSRC_gpu (TSNSR,TAVG,SMC (1),SH2O (1),                      &
+                          ZSOIL,NSOIL,SMCMAX,PSISAT,BEXP,DT,1,QTOT)
+!          RHSTS(1) = RHSTS(1) - TSNSR / ( ZSOIL(1) * HCPCT )
+            RHSTS (1) = RHSTS (1) - TSNSR / DENOM
+         END IF
+      ELSE
+!          TSNSR = SNKSRC (STC(1),SMC(1),SH2O(1),
+         IF ( (SICE > 0.) .OR. (STC (1) < T0) ) THEN
+            CALL SNKSRC_gpu (TSNSR,STC (1),SMC (1),SH2O (1),                   &
+                          ZSOIL,NSOIL,SMCMAX,PSISAT,BEXP,DT,1,QTOT)
+!          RHSTS(1) = RHSTS(1) - TSNSR / ( ZSOIL(1) * HCPCT )
+            RHSTS (1) = RHSTS (1) - TSNSR / DENOM
+         END IF
+! ----------------------------------------------------------------------
+! THIS ENDS SECTION FOR TOP SOIL LAYER.
+! ----------------------------------------------------------------------
+      END IF
+
+! INITIALIZE DDZ2
+! ----------------------------------------------------------------------
+
+      DDZ2 = 0.0
+      DF1K = DF1
+
+! ----------------------------------------------------------------------
+! LOOP THRU THE REMAINING SOIL LAYERS, REPEATING THE ABOVE PROCESS
+! (EXCEPT SUBSFC OR "GROUND" HEAT FLUX NOT REPEATED IN LOWER LAYERS)
+! ----------------------------------------------------------------------
+! CALCULATE HEAT CAPACITY FOR THIS SOIL LAYER.
+! ----------------------------------------------------------------------
+      DO K = 2,NSOIL
+         HCPCT = SH2O (K)* CH2O + (1.0- SMCMAX)* CSOIL_LOC + (SMCMAX - SMC (  &
+                K))* CAIR + ( SMC (K) - SH2O (K) )* CICE
+! ----------------------------------------------------------------------
+! THIS SECTION FOR LAYER 2 OR GREATER, BUT NOT LAST LAYER.
+! ----------------------------------------------------------------------
+! CALCULATE THERMAL DIFFUSIVITY FOR THIS LAYER.
+! ----------------------------------------------------------------------
+         IF (K /= NSOIL) THEN
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU THIS LAYER
+! ----------------------------------------------------------------------
+            CALL TDFCND_gpu (DF1N,SMC (K),QUARTZ,SMCMAX,SH2O (K),BEXP, PSISAT, SOILTYP, OPT_THCND)
+
+!urban
+       IF ( VEGTYP == ISURBAN ) DF1N = 3.24
+
+            DENOM = 0.5 * ( ZSOIL (K -1) - ZSOIL (K +1) )
+
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEF, CI, AFTER CALC'NG ITS PARTIAL PRODUCT
+! ----------------------------------------------------------------------
+            DTSDZ2 = ( STC (K) - STC (K +1) ) / DENOM
+            DDZ2 = 2. / (ZSOIL (K -1) - ZSOIL (K +1))
+
+! ----------------------------------------------------------------------
+! IF TEMPERATURE AVERAGING INVOKED (ITAVG=TRUE; ELSE SKIP):  CALCULATE
+! TEMP AT BOTTOM OF LAYER.
+! ----------------------------------------------------------------------
+            CI (K) = - DF1N * DDZ2 / ( (ZSOIL (K -1) - ZSOIL (K)) *      &
+       HCPCT)
+            IF (ITAVG) THEN
+               CALL TBND_gpu (STC (K),STC (K +1),ZSOIL,ZBOT,K,NSOIL,TBK1)
+            END IF
+
+         ELSE
+! ----------------------------------------------------------------------
+! SPECIAL CASE OF BOTTOM SOIL LAYER:  CALCULATE THERMAL DIFFUSIVITY FOR
+! BOTTOM LAYER.
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU BOTTOM LAYER.
+! ----------------------------------------------------------------------
+            CALL TDFCND_gpu (DF1N,SMC (K),QUARTZ,SMCMAX,SH2O (K),BEXP, PSISAT, SOILTYP, OPT_THCND)
+
+
+!urban
+       IF ( VEGTYP == ISURBAN ) DF1N = 3.24
+
+            DENOM = .5 * (ZSOIL (K -1) + ZSOIL (K)) - ZBOT
+
+! ----------------------------------------------------------------------
+! SET MATRIX COEF, CI TO ZERO IF BOTTOM LAYER.
+! ----------------------------------------------------------------------
+            DTSDZ2 = (STC (K) - TBOT) / DENOM
+
+! ----------------------------------------------------------------------
+! IF TEMPERATURE AVERAGING INVOKED (ITAVG=TRUE; ELSE SKIP):  CALCULATE
+! TEMP AT BOTTOM OF LAST LAYER.
+! ----------------------------------------------------------------------
+            CI (K) = 0.
+            IF (ITAVG) THEN
+               CALL TBND_gpu (STC (K),TBOT,ZSOIL,ZBOT,K,NSOIL,TBK1)
+            END IF
+! ----------------------------------------------------------------------
+! THIS ENDS SPECIAL LOOP FOR BOTTOM LAYER.
+         END IF
+! ----------------------------------------------------------------------
+! CALCULATE RHSTS FOR THIS LAYER AFTER CALC'NG A PARTIAL PRODUCT.
+! ----------------------------------------------------------------------
+         DENOM = ( ZSOIL (K) - ZSOIL (K -1) ) * HCPCT
+         RHSTS (K) = ( DF1N * DTSDZ2- DF1K * DTSDZ ) / DENOM
+         QTOT = -1.0* DENOM * RHSTS (K)
+
+         SICE = SMC (K) - SH2O (K)
+         IF (ITAVG) THEN
+            CALL TMPAVG_gpu (TAVG,TBK,STC (K),TBK1,ZSOIL,NSOIL,K)
+!            TSNSR = SNKSRC(TAVG,SMC(K),SH2O(K),ZSOIL,NSOIL,
+            IF ( (SICE > 0.) .OR. (STC (K) < T0) .OR.                   &
+               (TBK .lt. T0) .OR. (TBK1 .lt. T0) ) THEN
+               CALL SNKSRC_gpu (TSNSR,TAVG,SMC (K),SH2O (K),ZSOIL,NSOIL,    &
+                             SMCMAX,PSISAT,BEXP,DT,K,QTOT)
+               RHSTS (K) = RHSTS (K) - TSNSR / DENOM
+            END IF
+         ELSE
+!            TSNSR = SNKSRC(STC(K),SMC(K),SH2O(K),ZSOIL,NSOIL,
+            IF ( (SICE > 0.) .OR. (STC (K) < T0) ) THEN
+               CALL SNKSRC_gpu (TSNSR,STC (K),SMC (K),SH2O (K),ZSOIL,NSOIL, &
+                             SMCMAX,PSISAT,BEXP,DT,K,QTOT)
+               RHSTS (K) = RHSTS (K) - TSNSR / DENOM
+            END IF
+         END IF
+
+! ----------------------------------------------------------------------
+! CALC MATRIX COEFS, AI, AND BI FOR THIS LAYER.
+! ----------------------------------------------------------------------
+         AI (K) = - DF1K * DDZ / ( (ZSOIL (K -1) - ZSOIL (K)) * HCPCT)
+
+! ----------------------------------------------------------------------
+! RESET VALUES OF DF1, DTSDZ, DDZ, AND TBK FOR LOOP TO NEXT SOIL LAYER.
+! ----------------------------------------------------------------------
+         BI (K) = - (AI (K) + CI (K))
+         TBK = TBK1
+         DF1K = DF1N
+         DTSDZ = DTSDZ2
+         DDZ = DDZ2
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE HRT_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE HSTEP (STCOUT,STCIN,RHSTS,DT,NSOIL,AI,BI,CI)
 
 ! ----------------------------------------------------------------------
@@ -1895,6 +3885,57 @@ CONTAINS
       END DO
 ! ----------------------------------------------------------------------
   END SUBROUTINE HSTEP
+! ----------------------------------------------------------------------
+
+      SUBROUTINE HSTEP_gpu (STCOUT,STCIN,RHSTS,DT,NSOIL,AI,BI,CI)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE HSTEP
+! ----------------------------------------------------------------------
+! CALCULATE/UPDATE THE SOIL TEMPERATURE FIELD.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)  :: NSOIL
+      INTEGER              :: K
+
+      REAL, DIMENSION(1:NSOIL), INTENT(IN):: STCIN
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT):: STCOUT
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: RHSTS
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: AI,BI,CI
+      REAL, DIMENSION(1:NSOIL) :: RHSTSIN
+      REAL, DIMENSION(1:NSOIL) :: CIIN
+      REAL                 :: DT
+
+! ----------------------------------------------------------------------
+! CREATE FINITE DIFFERENCE VALUES FOR USE IN ROSR12 ROUTINE
+! ----------------------------------------------------------------------
+      DO K = 1,NSOIL
+         RHSTS (K) = RHSTS (K) * DT
+         AI (K) = AI (K) * DT
+         BI (K) = 1. + BI (K) * DT
+         CI (K) = CI (K) * DT
+      END DO
+! ----------------------------------------------------------------------
+! COPY VALUES FOR INPUT VARIABLES BEFORE CALL TO ROSR12
+! ----------------------------------------------------------------------
+      DO K = 1,NSOIL
+         RHSTSIN (K) = RHSTS (K)
+      END DO
+      DO K = 1,NSOIL
+         CIIN (K) = CI (K)
+      END DO
+! ----------------------------------------------------------------------
+! SOLVE THE TRI-DIAGONAL MATRIX EQUATION
+! ----------------------------------------------------------------------
+      CALL ROSR12_gpu (CI,AI,BI,CIIN,RHSTSIN,RHSTS,NSOIL)
+! ----------------------------------------------------------------------
+! CALC/UPDATE THE SOIL TEMPS USING MATRIX SOLUTION
+! ----------------------------------------------------------------------
+      DO K = 1,NSOIL
+         STCOUT (K) = STCIN (K) + CI (K)
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE HSTEP_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE NOPAC (ETP,ETA,PRCP,SMC,SMCMAX,SMCWLT,                 &
@@ -2186,6 +4227,296 @@ CONTAINS
   END SUBROUTINE NOPAC
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE NOPAC_gpu (ETP,ETA,PRCP,SMC,SMCMAX,SMCWLT,                 &
+                         SMCREF,SMCDRY,CMC,CMCMAX,NSOIL,DT,SHDFAC,      &
+                         SBETA,Q2,T1,SFCTMP,T24,TH2,FDOWN,F1,EMISSI,    &
+                         SSOIL,                                         &
+                         STC,EPSCA,BEXP,PC,RCH,RR,CFACTR,               &
+                         SH2O,SLOPE,KDT,FRZFACT,PSISAT,ZSOIL,           &
+                         DKSAT,DWSAT,TBOT,ZBOT,RUNOFF1,RUNOFF2,         &
+                         RUNOFF3,EDIR,EC,ET,ETT,NROOT,RTDIS,            &
+                         QUARTZ,FXEXP,CSOIL,                            &
+                         BETA,DRIP,DEW,FLX1,FLX3,VEGTYP,ISURBAN,        &
+                         SFHEAD1RT,INFXS1RT,ETPND1,SOILTYP,OPT_THCND    &
+                        ,XSDA_QFX,QFX_PHY,XQNORM,FASDAS,HCPCT_FASDAS    ) !fasdas
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE NOPAC
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE AND HEAT FLUX VALUES AND UPDATE SOIL MOISTURE
+! CONTENT AND SOIL HEAT CONTENT VALUES FOR THE CASE WHEN NO SNOW PACK IS
+! PRESENT.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)  :: OPT_THCND
+      INTEGER, INTENT(IN)  :: NROOT,NSOIL,VEGTYP,SOILTYP
+      INTEGER, INTENT(IN)  :: ISURBAN
+      INTEGER              :: K
+
+      REAL, INTENT(IN)     :: BEXP,CFACTR, CMCMAX,CSOIL,DKSAT,DT,DWSAT, &
+                              EPSCA,ETP,FDOWN,F1,FXEXP,FRZFACT,KDT,PC,  &
+                              PRCP,PSISAT,Q2,QUARTZ,RCH,RR,SBETA,SFCTMP,&
+                              SHDFAC,SLOPE,SMCDRY,SMCMAX,SMCREF,SMCWLT, &
+                              T24,TBOT,TH2,ZBOT,EMISSI
+      REAL, INTENT(INOUT)  :: CMC,BETA,T1
+      REAL, INTENT(OUT)    :: DEW,DRIP,EC,EDIR,ETA,ETT,FLX1,FLX3,       &
+                              RUNOFF1,RUNOFF2,RUNOFF3,SSOIL
+!DJG NDHMS/WRF-Hydro edit...
+      REAL, INTENT(INOUT)  :: SFHEAD1RT,INFXS1RT,ETPND1
+
+      REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: RTDIS,ZSOIL
+      REAL, DIMENSION(1:NSOIL),INTENT(OUT)    :: ET
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: SMC,SH2O,STC
+      REAL, DIMENSION(1:NSOIL) :: ET1
+      REAL                 :: EC1,EDIR1,ETT1,DF1,ETA1,ETP1,PRCP1,YY,    &
+                              YYNUM,ZZ1
+!
+! FASDAS
+!
+      REAL                       ::  XSDA_QFX, QFX_PHY, XQNORM
+      INTEGER                    ::  FASDAS
+      REAL , DIMENSION(1:NSOIL)  ::  EFT(NSOIL), WETTY(1:NSOIL)
+      REAL                       ::  EFDIR, EFC, EALL_NOW
+      REAL, INTENT(  OUT)        ::  HCPCT_FASDAS
+!
+! END FASDAS
+!
+! ----------------------------------------------------------------------
+! EXECUTABLE CODE BEGINS HERE:
+! CONVERT ETP Fnd PRCP FROM KG M-2 S-1 TO M S-1 AND INITIALIZE DEW.
+! ----------------------------------------------------------------------
+      PRCP1 = PRCP * 0.001
+      ETP1 = ETP * 0.001
+      DEW = 0.0
+! ----------------------------------------------------------------------
+! INITIALIZE EVAP TERMS.
+! ----------------------------------------------------------------------
+!
+! FASDAS
+!
+      QFX_PHY = 0.0
+!
+! END FASDAS
+!
+      EDIR = 0.
+      EDIR1 = 0.
+      EC1 = 0.
+      EC = 0.
+      DO K = 1,NSOIL
+        ET(K) = 0.
+        ET1(K) = 0.
+!
+! FASDAS
+!
+        WETTY(K) = 1.0
+!
+! END FASDAS
+!
+      END DO
+      ETT = 0.
+      ETT1 = 0.
+
+!DJG NDHMS/WRF-Hydro edit...
+      ETPND1 = 0.
+
+
+      IF (ETP > 0.0) THEN
+         CALL EVAPO_gpu (ETA1,SMC,NSOIL,CMC,ETP1,DT,ZSOIL,                  &
+                      SH2O,                                             &
+                      SMCMAX,BEXP,PC,SMCWLT,DKSAT,DWSAT,                &
+                      SMCREF,SHDFAC,CMCMAX,                             &
+                      SMCDRY,CFACTR,                                    &
+                       EDIR1,EC1,ET1,ETT1,SFCTMP,Q2,NROOT,RTDIS,FXEXP,  &
+                      SFHEAD1RT,ETPND1 )
+!
+! FASDAS
+!
+      IF( FASDAS == 1 ) THEN
+        DO K=1,NSOIL
+        QFX_PHY = QFX_PHY + ET1(K)   ! m/s
+! dont add moisture fluxes if soil moisture is = or > smcref
+        IF(SMC(K).GE.SMCREF.and.XSDA_QFX.gt.0.0) WETTY(K)=0.0
+        END DO
+       QFX_PHY = EDIR1+EC1+QFX_PHY    ! m/s
+       EALL_NOW = QFX_PHY           ! m/s
+       QFX_PHY = QFX_PHY*1000.0     ! Kg/m2/s
+
+       if(EALL_NOW.ne.0.0) then
+       EFDIR = (EDIR1/EALL_NOw)*XSDA_QFX*1.0E-03*XQNORM
+       EFDIR = EFDIR * WETTY(1)
+          !TWG2015 Bugfix Flip Sign to conform to Net upward Flux
+           EDIR1 = EDIR1 + EFDIR    ! new value
+       
+       EFC = (EC1/EALL_NOW)*XSDA_QFX*1.0E-03*XQNORM
+       !TWG2015 Bugfix Flip Sign to conform to Net upward Flux
+       EC1 = EC1 + EFC         ! new value
+
+
+       DO K=1,NSOIL
+        EFT(K) = (ET1(K)/EALL_NOW)*XSDA_QFX*1.0E-03*XQNORM
+        EFT(K) =  EFT(K) * WETTY(K)
+        !TWG2015 Bugfix Flip Sign to conform to Net upward Flux
+        ET1(K) = ET1(K) + EFT(K) ! new value
+       END DO
+
+
+       END IF ! for non-zero eall_now
+      ELSE
+        QFX_PHY = 0.0
+      ENDIF
+!
+! END FASDAS
+!
+         CALL SMFLX_gpu (SMC,NSOIL,CMC,DT,PRCP1,ZSOIL,                      &
+                      SH2O,SLOPE,KDT,FRZFACT,                           &
+                      SMCMAX,BEXP,SMCWLT,DKSAT,DWSAT,                   &
+                      SHDFAC,CMCMAX,                                    &
+                      RUNOFF1,RUNOFF2,RUNOFF3,                          &
+                      EDIR1,EC1,ET1,                                    &
+                      DRIP, SFHEAD1RT,INFXS1RT)
+
+! ----------------------------------------------------------------------
+! CONVERT MODELED EVAPOTRANSPIRATION FROM  M S-1  TO  KG M-2 S-1.
+! ----------------------------------------------------------------------
+
+         ETA = ETA1 * 1000.0
+
+! ----------------------------------------------------------------------
+! IF ETP < 0, ASSUME DEW FORMS (TRANSFORM ETP1 INTO DEW AND REINITIALIZE
+! ETP1 TO ZERO).
+! ----------------------------------------------------------------------
+      ELSE
+         DEW = - ETP1
+
+! ----------------------------------------------------------------------
+! CONVERT PRCP FROM 'KG M-2 S-1' TO 'M S-1' AND ADD DEW AMOUNT.
+! ----------------------------------------------------------------------
+
+         PRCP1 = PRCP1+ DEW
+!
+! FASDAS
+!
+     IF( FASDAS == 1 ) THEN
+       DO K=1,NSOIL
+        QFX_PHY = QFX_PHY + ET1(K)   ! m/s
+! dont add moisture fluxes if soil moisture is = or > smcref
+        IF(SMC(K).GE.SMCREF.and.XSDA_QFX.gt.0.0) WETTY(K)=0.0
+       END DO
+       QFX_PHY = EDIR1+EC1+QFX_PHY    ! m/s
+        EALL_NOW = QFX_PHY     ! m/s
+       QFX_PHY = QFX_PHY*1000.0    ! Kg/m2/s
+
+       IF(EALL_NOW.ne.0.0) then
+       EFDIR = (EDIR1/EALL_NOW)*XSDA_QFX*1.0E-03*XQNORM
+        EFDIR =  EFDIR * WETTY(1)
+          !TWG2015 Bugfix Flip Sign to conform to Net Upward Flux
+           EDIR1 = EDIR1 + EFDIR    ! new value
+
+        EFC = (EC1/EALL_NOW)*XSDA_QFX*1.0E-03*XQNORM
+        !TWG2015 Bugfix Flip Sign to conform to Net Upward Flux
+        EC1 = EC1+ EFC         ! new value
+
+       DO K=1,NSOIL
+        EFT(K) = (ET1(K)/EALL_NOW)*XSDA_QFX*1.0E-03*XQNORM
+        EFT(K) = EFT(K) * WETTY(K)
+        !TWG2015 Bugfix Flip Sign to conform to Net Upward Flux
+        ET1(K) = ET1(K) + EFT(K)   ! new value
+       END DO
+
+        END IF ! for non-zero eall_now
+      ELSE
+        QFX_PHY = 0.0
+      ENDIF
+!
+! END FASDAS
+!
+         CALL SMFLX_gpu (SMC,NSOIL,CMC,DT,PRCP1,ZSOIL,                      &
+                      SH2O,SLOPE,KDT,FRZFACT,                           &
+                      SMCMAX,BEXP,SMCWLT,DKSAT,DWSAT,                   &
+                      SHDFAC,CMCMAX,                                    &
+                      RUNOFF1,RUNOFF2,RUNOFF3,                          &
+                      EDIR1,EC1,ET1,                                    &
+                      DRIP, SFHEAD1RT,INFXS1RT)
+
+! ----------------------------------------------------------------------
+! CONVERT MODELED EVAPOTRANSPIRATION FROM 'M S-1' TO 'KG M-2 S-1'.
+! ----------------------------------------------------------------------
+!         ETA = ETA1 * 1000.0
+      END IF
+
+! ----------------------------------------------------------------------
+! BASED ON ETP AND E VALUES, DETERMINE BETA
+! ----------------------------------------------------------------------
+
+      IF ( ETP <= 0.0 ) THEN
+         BETA = 0.0
+         ETA = ETP
+         IF ( ETP < 0.0 ) THEN
+            BETA = 1.0
+         END IF
+      ELSE
+         BETA = ETA / ETP
+      END IF
+
+! ----------------------------------------------------------------------
+! CONVERT MODELED EVAPOTRANSPIRATION COMPONENTS 'M S-1' TO 'KG M-2 S-1'.
+! ----------------------------------------------------------------------
+      EDIR = EDIR1*1000.
+      EC = EC1*1000.
+      DO K = 1,NSOIL
+        ET(K) = ET1(K)*1000.
+      END DO
+      ETT = ETT1*1000.
+
+! ----------------------------------------------------------------------
+! GET SOIL THERMAL DIFFUXIVITY/CONDUCTIVITY FOR TOP SOIL LYR,
+! CALC. ADJUSTED TOP LYR SOIL TEMP AND ADJUSTED SOIL FLUX, THEN
+! CALL SHFLX TO COMPUTE/UPDATE SOIL HEAT FLUX AND SOIL TEMPS.
+! ----------------------------------------------------------------------
+
+      CALL TDFCND_gpu (DF1,SMC (1),QUARTZ,SMCMAX,SH2O (1),BEXP, PSISAT, SOILTYP, OPT_THCND)
+
+!urban
+      IF ( VEGTYP == ISURBAN ) DF1=3.24
+!
+
+! ----------------------------------------------------------------------
+! VEGETATION GREENNESS FRACTION REDUCTION IN SUBSURFACE HEAT FLUX
+! VIA REDUCTION FACTOR, WHICH IS CONVENIENT TO APPLY HERE TO THERMAL
+! DIFFUSIVITY THAT IS LATER USED IN HRT TO COMPUTE SUB SFC HEAT FLUX
+! (SEE ADDITIONAL COMMENTS ON VEG EFFECT SUB-SFC HEAT FLX IN
+! ROUTINE SFLX)
+! ----------------------------------------------------------------------
+      DF1 = DF1 * EXP (SBETA * SHDFAC)
+! ----------------------------------------------------------------------
+! COMPUTE INTERMEDIATE TERMS PASSED TO ROUTINE HRT (VIA ROUTINE
+! SHFLX BELOW) FOR USE IN COMPUTING SUBSURFACE HEAT FLUX IN HRT
+! ----------------------------------------------------------------------
+      YYNUM = FDOWN - EMISSI*SIGMA * T24
+      YY = SFCTMP + (YYNUM / RCH + TH2- SFCTMP - BETA * EPSCA) / RR
+
+      ZZ1 = DF1 / ( -0.5 * ZSOIL (1) * RCH * RR ) + 1.0
+
+!urban
+      CALL SHFLX_gpu (SSOIL,STC,SMC,SMCMAX,NSOIL,T1,DT,YY,ZZ1,ZSOIL,       &
+                  TBOT,ZBOT,SMCWLT,PSISAT,SH2O,BEXP,F1,DF1,            &
+                  QUARTZ,CSOIL,VEGTYP,ISURBAN,SOILTYP,OPT_THCND        &
+                 ,HCPCT_FASDAS                                         ) !fasdas
+
+! ----------------------------------------------------------------------
+! SET FLX1 AND FLX3 (SNOPACK PHASE CHANGE HEAT FLUXES) TO ZERO SINCE
+! THEY ARE NOT USED HERE IN SNOPAC.  FLX2 (FREEZING RAIN HEAT FLUX) WAS
+! SIMILARLY INITIALIZED IN THE PENMAN ROUTINE.
+! ----------------------------------------------------------------------
+      FLX1 = CPH2O * PRCP * (T1- SFCTMP)
+      FLX3 = 0.0
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE NOPAC_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE PENMAN (SFCTMP,SFCPRS,CH,T2V,TH2,PRCP,FDOWN,T24,SSOIL, &
      &                   Q2,Q2SAT,ETP,RCH,EPSCA,RR,SNOWNG,FRZGRA,       &
      &                   DQSDT2,FLX2,EMISSI_IN,SNEQV,T1,SNCOVR,AOASIS,  &
@@ -2304,6 +4635,127 @@ CONTAINS
       END IF
 ! ----------------------------------------------------------------------
   END SUBROUTINE PENMAN
+! ----------------------------------------------------------------------
+
+      SUBROUTINE PENMAN_gpu (SFCTMP,SFCPRS,CH,T2V,TH2,PRCP,FDOWN,T24,SSOIL, &
+     &                   Q2,Q2SAT,ETP,RCH,EPSCA,RR,SNOWNG,FRZGRA,       &
+     &                   DQSDT2,FLX2,EMISSI_IN,SNEQV,T1,SNCOVR,AOASIS,  &
+		         ALBEDO,SOLDN,FVB,GAMA,STC1,ETPN,FLX4,UA_PHYS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE PENMAN
+! ----------------------------------------------------------------------
+! CALCULATE POTENTIAL EVAPORATION FOR THE CURRENT POINT.  VARIOUS
+! PARTIAL SUMS/PRODUCTS ARE ALSO CALCULATED AND PASSED BACK TO THE
+! CALLING ROUTINE FOR LATER USE.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      LOGICAL, INTENT(IN)     :: SNOWNG, FRZGRA
+      REAL, INTENT(IN)        :: CH, DQSDT2,FDOWN,PRCP,                 &
+                                 Q2, Q2SAT,SSOIL, SFCPRS, SFCTMP,       &
+                                 T2V, TH2,EMISSI_IN,SNEQV,AOASIS
+      REAL, INTENT(IN)        :: T1 , SNCOVR
+      REAL, INTENT(IN)        :: ALBEDO,SOLDN,FVB,GAMA,STC1
+      LOGICAL, INTENT(IN)     :: UA_PHYS
+!
+      REAL, INTENT(OUT)       :: EPSCA,ETP,FLX2,RCH,RR,T24
+      REAL, INTENT(OUT)       :: FLX4,ETPN
+      REAL                    :: A, DELTA, FNET,RAD,RHO,EMISSI,ELCP1,LVS
+      REAL                    :: TOTABS,UCABS,SIGNCK,FNETN,RADN,EPSCAN
+
+      REAL, PARAMETER      :: ELCP = 2.4888E+3, LSUBC = 2.501000E+6,CP = 1004.6
+      REAL, PARAMETER      :: LSUBS = 2.83E+6
+      REAL, PARAMETER      :: ALGDSN = 0.5, ALVGSN = 0.13
+
+! ----------------------------------------------------------------------
+! EXECUTABLE CODE BEGINS HERE:
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! PREPARE PARTIAL QUANTITIES FOR PENMAN EQUATION.
+! ----------------------------------------------------------------------
+        EMISSI=EMISSI_IN
+        ELCP1  = (1.0-SNCOVR)*ELCP  + SNCOVR*ELCP*LSUBS/LSUBC
+        LVS    = (1.0-SNCOVR)*LSUBC + SNCOVR*LSUBS
+
+      FLX2 = 0.0
+!      DELTA = ELCP * DQSDT2
+      DELTA = ELCP1 * DQSDT2
+      T24 = SFCTMP * SFCTMP * SFCTMP * SFCTMP
+!      RR = T24 * 6.48E-8 / (SFCPRS * CH) + 1.0
+      RR = EMISSI*T24 * 6.48E-8 / (SFCPRS * CH) + 1.0
+      RHO = SFCPRS / (RD * T2V)
+
+! ----------------------------------------------------------------------
+! ADJUST THE PARTIAL SUMS / PRODUCTS WITH THE LATENT HEAT
+! EFFECTS CAUSED BY FALLING PRECIPITATION.
+! ----------------------------------------------------------------------
+      RCH = RHO * CP * CH
+      IF (.NOT. SNOWNG) THEN
+         IF (PRCP >  0.0) RR = RR + CPH2O * PRCP / RCH
+      ELSE
+         RR = RR + CPICE * PRCP / RCH
+      END IF
+
+! ----------------------------------------------------------------------
+! INCLUDE THE LATENT HEAT EFFECTS OF FRZNG RAIN CONVERTING TO ICE ON
+! IMPACT IN THE CALCULATION OF FLX2 AND FNET.
+! ----------------------------------------------------------------------
+!      FNET = FDOWN - SIGMA * T24- SSOIL
+      FNET = FDOWN -  EMISSI*SIGMA * T24- SSOIL
+
+      FLX4 = 0.0
+      IF(UA_PHYS) THEN
+        IF(SNEQV > 0. .AND. FNET > 0. .AND. SOLDN > 0. ) THEN
+         TOTABS = (1.-ALBEDO)*SOLDN*FVB           ! solar radiation absorbed 
+                                                  ! by vegetated fraction
+         UCABS = MIN(TOTABS,((1.0-ALGDSN)*(1.0-ALVGSN)*SOLDN*GAMA)*FVB)
+!         print*,'penman',UCABS,TOTABS,SOLDN,GAMA,FVB
+!         UCABS = MIN(TOTABS,(0.44*SOLDN*GAMA)*FVB)  
+                                                  ! UCABS -> solar radiation
+						  ! absorbed under canopy
+         FLX4 = MIN(TOTABS - UCABS, MIN(250., 0.5*(1.-ALBEDO)*SOLDN))
+        ENDIF
+
+        SIGNCK = (STC1-273.15)*(SFCTMP-273.15)
+
+        IF(FLX4 > 0. .AND. (SIGNCK <= 0. .OR. STC1 < 273.15)) THEN
+          IF(FNET >= FLX4) THEN
+           FNETN = FNET - FLX4
+          ELSE
+           FLX4 = FNET
+           FNETN = 0.
+          ENDIF
+        ELSE
+          FLX4 = 0.0
+          FNETN = 0.
+        ENDIF
+      ENDIF
+
+      IF (FRZGRA) THEN
+         FLX2 = - LSUBF * PRCP
+         FNET = FNET - FLX2
+         IF(UA_PHYS) FNETN = FNETN - FLX2
+! ----------------------------------------------------------------------
+! FINISH PENMAN EQUATION CALCULATIONS.
+! ----------------------------------------------------------------------
+      END IF
+      RAD = FNET / RCH + TH2- SFCTMP
+!      A = ELCP * (Q2SAT - Q2)
+      A = ELCP1 * (Q2SAT - Q2)
+      EPSCA = (A * RR + RAD * DELTA) / (DELTA + RR)
+! Fei-Mike
+      IF (EPSCA>0.) EPSCA = EPSCA * AOASIS
+!      ETP = EPSCA * RCH / LSUBC
+      ETP = EPSCA * RCH / LVS
+
+      IF(UA_PHYS) THEN
+        RADN = FNETN / RCH + TH2- SFCTMP
+        EPSCAN = (A * RR + RADN * DELTA) / (DELTA + RR)
+        ETPN = EPSCAN * RCH / LVS
+      END IF
+! ----------------------------------------------------------------------
+  END SUBROUTINE PENMAN_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE REDPRM (VEGTYP,SOILTYP,SLOPETYP,CFACTR,CMCMAX,RSMAX,      &
@@ -2528,6 +4980,229 @@ CONTAINS
 
       END  SUBROUTINE REDPRM
 
+      SUBROUTINE REDPRM_gpu (VEGTYP,SOILTYP,SLOPETYP,CFACTR,CMCMAX,RSMAX,      &
+                         TOPT,                                             &
+                         REFKDT,KDT,SBETA, SHDFAC,RSMIN,RGL,HS,ZBOT,FRZX,  &
+                         PSISAT,SLOPE,SNUP,SALP,BEXP,DKSAT,DWSAT,          &
+                         SMCMAX,SMCWLT,SMCREF,SMCDRY,F1,QUARTZ,FXEXP,      &
+                         RTDIS,SLDPTH,ZSOIL, NROOT,NSOIL,CZIL,             &
+                         LAIMIN, LAIMAX, EMISSMIN, EMISSMAX, ALBEDOMIN,    &
+                         ALBEDOMAX, Z0MIN, Z0MAX, CSOIL, PTU, LLANDUSE,    &
+                         LSOIL, LOCAL,LVCOEF,ZTOPV,ZBOTV)
+!$acc routine seq
+
+      IMPLICIT NONE
+! ----------------------------------------------------------------------
+! Internally set (default valuess)
+! all soil and vegetation parameters required for the execusion oF
+! the Noah lsm are defined in VEGPARM.TBL, SOILPARM.TB, and GENPARM.TBL.
+! ----------------------------------------------------------------------
+!     Vegetation parameters:
+!             ALBBRD: SFC background snow-free albedo
+!             CMXTBL: MAX CNPY Capacity
+!              Z0BRD: Background roughness length
+!             SHDFAC: Green vegetation fraction
+!              NROOT: Rooting depth
+!              RSMIN: Mimimum stomatal resistance
+!              RSMAX: Max. stomatal resistance
+!                RGL: Parameters used in radiation stress function
+!                 HS: Parameter used in vapor pressure deficit functio
+!               TOPT: Optimum transpiration air temperature.
+!             CMCMAX: Maximum canopy water capacity
+!             CFACTR: Parameter used in the canopy inteception calculation
+!               SNUP: Threshold snow depth (in water equivalent m) that
+!                     implies 100 percent snow cover
+!                LAI: Leaf area index
+!
+! ----------------------------------------------------------------------
+!      Soil parameters:
+!        SMCMAX: MAX soil moisture content (porosity)
+!        SMCREF: Reference soil moisture  (field capacity)
+!        SMCWLT: Wilting point soil moisture
+!        SMCWLT: Air dry soil moist content limits
+!       SSATPSI: SAT (saturation) soil potential
+!         DKSAT: SAT soil conductivity
+!          BEXP: B parameter
+!        SSATDW: SAT soil diffusivity
+!           F1: Soil thermal diffusivity/conductivity coef.
+!        QUARTZ: Soil quartz content
+!  Modified by F. Chen (12/22/97)  to use the STATSGO soil map
+!  Modified By F. Chen (01/22/00)  to include PLaya, Lava, and White San
+!  Modified By F. Chen (08/05/02)  to include additional parameters for the Noah
+! NOTE: SATDW = BB*SATDK*(SATPSI/MAXSMC)
+!         F11 = ALOG10(SATPSI) + BB*ALOG10(MAXSMC) + 2.0
+!       REFSMC1=MAXSMC*(5.79E-9/SATDK)**(1/(2*BB+3)) 5.79E-9 m/s= 0.5 mm
+!       REFSMC=REFSMC1+1./3.(MAXSMC-REFSMC1)
+!       WLTSMC1=MAXSMC*(200./SATPSI)**(-1./BB)    (Wetzel and Chang, 198
+!       WLTSMC=WLTSMC1-0.5*WLTSMC1
+! Note: the values for playa is set for it to have a thermal conductivit
+! as sand and to have a hydrulic conductivity as clay
+!
+! ----------------------------------------------------------------------
+! Class parameter 'SLOPETYP' was included to estimate linear reservoir
+! coefficient 'SLOPE' to the baseflow runoff out of the bottom layer.
+! lowest class (slopetyp=0) means highest slope parameter = 1.
+! definition of slopetyp from 'zobler' slope type:
+! slope class  percent slope
+! 1            0-8
+! 2            8-30
+! 3            > 30
+! 4            0-30
+! 5            0-8 & > 30
+! 6            8-30 & > 30
+! 7            0-8, 8-30, > 30
+! 9            GLACIAL ICE
+! BLANK        OCEAN/SEA
+!       SLOPE_DATA: linear reservoir coefficient
+!       SBETA_DATA: parameter used to caluculate vegetation effect on soil heat
+!       FXEXP_DAT:  soil evaporation exponent used in DEVAP
+!       CSOIL_DATA: soil heat capacity [J M-3 K-1]
+!       SALP_DATA: shape parameter of  distribution function of snow cover
+!       REFDK_DATA and REFKDT_DATA: parameters in the surface runoff parameteriz
+!       FRZK_DATA: frozen ground parameter
+!       ZBOT_DATA: depth[M] of lower boundary soil temperature
+!       CZIL_DATA: calculate roughness length of heat
+!       SMLOW_DATA and MHIGH_DATA: two soil moisture wilt, soil moisture referen
+!                 parameters
+! Set maximum number of soil-, veg-, and slopetyp in data statement.
+! ----------------------------------------------------------------------
+      INTEGER, PARAMETER     :: MAX_SLOPETYP=30,MAX_SOILTYP=30,MAX_VEGTYP=30
+      LOGICAL                :: LOCAL
+      CHARACTER (LEN=256), INTENT(IN)::  LLANDUSE, LSOIL
+
+! Veg parameters
+      INTEGER, INTENT(IN)    :: VEGTYP
+      INTEGER, INTENT(OUT)   :: NROOT
+      REAL, INTENT(INOUT)    :: SHDFAC
+      REAL, INTENT(OUT)      :: HS,RSMIN,RGL,SNUP,                          &
+                                CMCMAX,RSMAX,TOPT,                          &
+                                EMISSMIN,  EMISSMAX,                        &
+                                LAIMIN,    LAIMAX,                          &
+                                Z0MIN,     Z0MAX,                           &
+                                ALBEDOMIN, ALBEDOMAX, ZTOPV, ZBOTV
+! Soil parameters
+      INTEGER, INTENT(IN)    :: SOILTYP
+      REAL, INTENT(OUT)      :: BEXP,DKSAT,DWSAT,F1,QUARTZ,SMCDRY,          &
+                                SMCMAX,SMCREF,SMCWLT,PSISAT
+! General parameters
+      INTEGER, INTENT(IN)    :: SLOPETYP,NSOIL
+      INTEGER                :: I
+
+      REAL,    INTENT(OUT)   :: SLOPE,CZIL,SBETA,FXEXP,                     &
+                                CSOIL,SALP,FRZX,KDT,CFACTR,      &
+                                ZBOT,REFKDT,PTU
+      REAL,    INTENT(OUT)   :: LVCOEF
+      REAL,DIMENSION(1:NSOIL),INTENT(IN) :: SLDPTH,ZSOIL
+      REAL,DIMENSION(1:NSOIL),INTENT(OUT):: RTDIS
+      REAL                   :: FRZFACT,FRZK,REFDK
+
+!      SAVE
+! ----------------------------------------------------------------------
+!
+               IF (SOILTYP .gt. SLCATS) THEN
+!!!                        FATAL_ERROR( 'Warning: too many input soil types' )
+               END IF
+               IF (VEGTYP .gt. LUCATS) THEN
+!!!                     FATAL_ERROR( 'Warning: too many input landuse types' )
+               END IF
+               IF (SLOPETYP .gt. SLPCATS) THEN
+!!!                     FATAL_ERROR( 'Warning: too many input slope types' )
+               END IF
+
+! ----------------------------------------------------------------------
+!  SET-UP SOIL PARAMETERS
+! ----------------------------------------------------------------------
+      CSOIL = CSOIL_DATA
+      BEXP = BB (SOILTYP)
+      DKSAT = SATDK (SOILTYP)
+      DWSAT = SATDW (SOILTYP)
+      F1 = F11 (SOILTYP)
+      PSISAT = SATPSI (SOILTYP)
+      QUARTZ = QTZ (SOILTYP)
+      SMCDRY = DRYSMC (SOILTYP)
+      SMCMAX = MAXSMC (SOILTYP)
+      SMCREF = REFSMC (SOILTYP)
+      SMCWLT = WLTSMC (SOILTYP)
+! ----------------------------------------------------------------------
+! Set-up universal parameters (not dependent on SOILTYP, VEGTYP or
+! SLOPETYP)
+! ----------------------------------------------------------------------
+      ZBOT = ZBOT_DATA
+      SALP = SALP_DATA
+      SBETA = SBETA_DATA
+      REFDK = REFDK_DATA
+      FRZK = FRZK_DATA
+      FXEXP = FXEXP_DATA
+      REFKDT = REFKDT_DATA
+      PTU = 0.    ! (not used yet) to satisify intent(out)
+      KDT = REFKDT * DKSAT / REFDK
+      CZIL = CZIL_DATA
+      SLOPE = SLOPE_DATA (SLOPETYP)
+      LVCOEF = LVCOEF_DATA
+
+! ----------------------------------------------------------------------
+! TO ADJUST FRZK PARAMETER TO ACTUAL SOIL TYPE: FRZK * FRZFACT
+! ----------------------------------------------------------------------
+      FRZFACT = (SMCMAX / SMCREF) * (0.412 / 0.468)
+      FRZX = FRZK * FRZFACT
+
+! ----------------------------------------------------------------------
+! SET-UP VEGETATION PARAMETERS
+! ----------------------------------------------------------------------
+      TOPT = TOPT_DATA
+      CMCMAX = CMCMAX_DATA
+      CFACTR = CFACTR_DATA
+      RSMAX = RSMAX_DATA
+      NROOT = NROTBL (VEGTYP)
+      SNUP = SNUPTBL (VEGTYP)
+      RSMIN = RSTBL (VEGTYP)
+      RGL = RGLTBL (VEGTYP)
+      HS = HSTBL (VEGTYP)
+      EMISSMIN  = EMISSMINTBL  (VEGTYP)
+      EMISSMAX  = EMISSMAXTBL  (VEGTYP)
+      LAIMIN    = LAIMINTBL    (VEGTYP)
+      LAIMAX    = LAIMAXTBL    (VEGTYP)
+      Z0MIN     = Z0MINTBL     (VEGTYP)
+      Z0MAX     = Z0MAXTBL     (VEGTYP)
+      ALBEDOMIN = ALBEDOMINTBL (VEGTYP)
+      ALBEDOMAX = ALBEDOMAXTBL (VEGTYP)
+      ZTOPV     = ZTOPVTBL     (VEGTYP)
+      ZBOTV     = ZBOTVTBL     (VEGTYP)
+
+               IF (VEGTYP .eq. BARE) SHDFAC = 0.0
+               IF (NROOT .gt. NSOIL) THEN
+!!!                  WRITE (err_message,*) 'Error: too many root layers ',  &
+!!!                                                 NSOIL,NROOT
+!!!                  FATAL_ERROR( err_message )
+! ----------------------------------------------------------------------
+! CALCULATE ROOT DISTRIBUTION.  PRESENT VERSION ASSUMES UNIFORM
+! DISTRIBUTION BASED ON SOIL LAYER DEPTHS.
+! ----------------------------------------------------------------------
+               END IF
+               DO I = 1,NROOT
+                  RTDIS (I) = - SLDPTH (I)/ ZSOIL (NROOT)
+! ----------------------------------------------------------------------
+!  SET-UP SLOPE PARAMETER
+! ----------------------------------------------------------------------
+               END DO
+
+!        print*,'end of PRMRED'
+!       print*,'VEGTYP',VEGTYP,'SOILTYP',SOILTYP,'SLOPETYP',SLOPETYP,    &
+!    & 'CFACTR',CFACTR,'CMCMAX',CMCMAX,'RSMAX',RSMAX,'TOPT',TOPT,        &
+!    & 'REFKDT',REFKDT,'KDT',KDT,'SBETA',SBETA, 'SHDFAC',SHDFAC,         &
+!    &  'RSMIN',RSMIN,'RGL',RGL,'HS',HS,'ZBOT',ZBOT,'FRZX',FRZX,         &
+!    &  'PSISAT',PSISAT,'SLOPE',SLOPE,'SNUP',SNUP,'SALP',SALP,'BEXP',    &
+!    &   BEXP,                                                           &
+!    &  'DKSAT',DKSAT,'DWSAT',DWSAT,                                     &
+!    &  'SMCMAX',SMCMAX,'SMCWLT',SMCWLT,'SMCREF',SMCREF,'SMCDRY',SMCDRY, &
+!    &  'F1',F1,'QUARTZ',QUARTZ,'FXEXP',FXEXP,                           &
+!    &  'RTDIS',RTDIS,'SLDPTH',SLDPTH,'ZSOIL',ZSOIL, 'NROOT',NROOT,      &
+!    &  'NSOIL',NSOIL,'Z0',Z0,'CZIL',CZIL,'LAI',LAI,                     &
+!    &  'CSOIL',CSOIL,'PTU',PTU,                                         &
+!    &  'LOCAL', LOCAL
+
+      END  SUBROUTINE REDPRM_gpu
+
       SUBROUTINE ROSR12 (P,A,B,C,D,DELTA,NSOIL)
 
 ! ----------------------------------------------------------------------
@@ -2590,6 +5265,67 @@ CONTAINS
   END SUBROUTINE ROSR12
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE ROSR12_gpu (P,A,B,C,D,DELTA,NSOIL)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE ROSR12
+! ----------------------------------------------------------------------
+! INVERT (SOLVE) THE TRI-DIAGONAL MATRIX PROBLEM SHOWN BELOW:
+! ###                                            ### ###  ###   ###  ###
+! #B(1), C(1),  0  ,  0  ,  0  ,   . . .  ,    0   # #      #   #      #
+! #A(2), B(2), C(2),  0  ,  0  ,   . . .  ,    0   # #      #   #      #
+! # 0  , A(3), B(3), C(3),  0  ,   . . .  ,    0   # #      #   # D(3) #
+! # 0  ,  0  , A(4), B(4), C(4),   . . .  ,    0   # # P(4) #   # D(4) #
+! # 0  ,  0  ,  0  , A(5), B(5),   . . .  ,    0   # # P(5) #   # D(5) #
+! # .                                          .   # #  .   # = #   .  #
+! # .                                          .   # #  .   #   #   .  #
+! # .                                          .   # #  .   #   #   .  #
+! # 0  , . . . , 0 , A(M-2), B(M-2), C(M-2),   0   # #P(M-2)#   #D(M-2)#
+! # 0  , . . . , 0 ,   0   , A(M-1), B(M-1), C(M-1)# #P(M-1)#   #D(M-1)#
+! # 0  , . . . , 0 ,   0   ,   0   ,  A(M) ,  B(M) # # P(M) #   # D(M) #
+! ###                                            ### ###  ###   ###  ###
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)   :: NSOIL
+      INTEGER               :: K, KK
+
+      REAL, DIMENSION(1:NSOIL), INTENT(IN):: A, B, D
+      REAL, DIMENSION(1:NSOIL),INTENT(INOUT):: C,P,DELTA
+
+! ----------------------------------------------------------------------
+! INITIALIZE EQN COEF C FOR THE LOWEST SOIL LAYER
+! ----------------------------------------------------------------------
+      C (NSOIL) = 0.0
+      P (1) = - C (1) / B (1)
+! ----------------------------------------------------------------------
+! SOLVE THE COEFS FOR THE 1ST SOIL LAYER
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+! SOLVE THE COEFS FOR SOIL LAYERS 2 THRU NSOIL
+! ----------------------------------------------------------------------
+      DELTA (1) = D (1) / B (1)
+      DO K = 2,NSOIL
+         P (K) = - C (K) * ( 1.0 / (B (K) + A (K) * P (K -1)) )
+         DELTA (K) = (D (K) - A (K)* DELTA (K -1))* (1.0/ (B (K) + A (K)&
+                    * P (K -1)))
+      END DO
+! ----------------------------------------------------------------------
+! SET P TO DELTA FOR LOWEST SOIL LAYER
+! ----------------------------------------------------------------------
+      P (NSOIL) = DELTA (NSOIL)
+
+! ----------------------------------------------------------------------
+! ADJUST P FOR SOIL LAYERS 2 THRU NSOIL
+! ----------------------------------------------------------------------
+      DO K = 2,NSOIL
+         KK = NSOIL - K + 1
+         P (KK) = P (KK) * P (KK +1) + DELTA (KK)
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE ROSR12_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE SHFLX (SSOIL,STC,SMC,SMCMAX,NSOIL,T1,DT,YY,ZZ1,ZSOIL, &
                          TBOT,ZBOT,SMCWLT,PSISAT,SH2O,BEXP,F1,DF1,     &
@@ -2658,6 +5394,76 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SHFLX
+! ----------------------------------------------------------------------
+
+      SUBROUTINE SHFLX_gpu (SSOIL,STC,SMC,SMCMAX,NSOIL,T1,DT,YY,ZZ1,ZSOIL, &
+                         TBOT,ZBOT,SMCWLT,PSISAT,SH2O,BEXP,F1,DF1,     &
+                         QUARTZ,CSOIL,VEGTYP,ISURBAN,SOILTYP,OPT_THCND &
+                        ,HCPCT_FASDAS                                  ) ! fasdas
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SHFLX
+! ----------------------------------------------------------------------
+! UPDATE THE TEMPERATURE STATE OF THE SOIL COLUMN BASED ON THE THERMAL
+! DIFFUSION EQUATION AND UPDATE THE FROZEN SOIL MOISTURE CONTENT BASED
+! ON THE TEMPERATURE.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)   :: OPT_THCND
+      INTEGER, INTENT(IN)   :: NSOIL, VEGTYP, ISURBAN, SOILTYP
+      INTEGER               :: I
+
+      REAL, INTENT(IN)      :: BEXP,CSOIL,DF1,DT,F1,PSISAT,QUARTZ,     &
+                               SMCMAX, SMCWLT, TBOT,YY, ZBOT,ZZ1
+      REAL, INTENT(INOUT)   :: T1
+      REAL, INTENT(OUT)     :: SSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)    :: SMC,ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: SH2O
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
+      REAL, DIMENSION(1:NSOIL)             :: AI, BI, CI, STCF,RHSTS
+      REAL, PARAMETER       :: T0 = 273.15
+
+!
+! FASDAS
+!
+      REAL, INTENT(  OUT)     :: HCPCT_FASDAS
+!
+! END FASDAS
+!
+! ----------------------------------------------------------------------
+! HRT ROUTINE CALCS THE RIGHT HAND SIDE OF THE SOIL TEMP DIF EQN
+! ----------------------------------------------------------------------
+
+      ! Land case
+
+      CALL HRT_gpu (RHSTS,STC,SMC,SMCMAX,NSOIL,ZSOIL,YY,ZZ1,TBOT,     &
+                ZBOT,PSISAT,SH2O,DT,BEXP,SOILTYP,OPT_THCND,       &
+                F1,DF1,QUARTZ,CSOIL,AI,BI,CI,VEGTYP,ISURBAN       &
+               ,HCPCT_FASDAS                                      ) !fasdas
+
+      CALL HSTEP_gpu (STCF,STC,RHSTS,DT,NSOIL,AI,BI,CI)
+
+      DO I = 1,NSOIL
+         STC (I) = STCF (I)
+      ENDDO
+
+! ----------------------------------------------------------------------
+! IN THE NO SNOWPACK CASE (VIA ROUTINE NOPAC BRANCH,) UPDATE THE GRND
+! (SKIN) TEMPERATURE HERE IN RESPONSE TO THE UPDATED SOIL TEMPERATURE
+! PROFILE ABOVE.  (NOTE: INSPECTION OF ROUTINE SNOPAC SHOWS THAT T1
+! BELOW IS A DUMMY VARIABLE ONLY, AS SKIN TEMPERATURE IS UPDATED
+! DIFFERENTLY IN ROUTINE SNOPAC)
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALCULATE SURFACE SOIL HEAT FLUX
+! ----------------------------------------------------------------------
+      T1 = (YY + (ZZ1- 1.0) * STC (1)) / ZZ1
+      SSOIL = DF1 * (STC (1) - T1) / (0.5 * ZSOIL (1))
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SHFLX_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE SMFLX (SMC,NSOIL,CMC,DT,PRCP1,ZSOIL,                   &
@@ -2802,6 +5608,148 @@ CONTAINS
   END SUBROUTINE SMFLX
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SMFLX_gpu (SMC,NSOIL,CMC,DT,PRCP1,ZSOIL,                   &
+     &                   SH2O,SLOPE,KDT,FRZFACT,                        &
+     &                   SMCMAX,BEXP,SMCWLT,DKSAT,DWSAT,                &
+     &                   SHDFAC,CMCMAX,                                 &
+     &                   RUNOFF1,RUNOFF2,RUNOFF3,                       &
+     &                   EDIR,EC,ET,                                    &
+     &                   DRIP, SFHEAD1RT,INFXS1RT)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SMFLX
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE FLUX.  THE SOIL MOISTURE CONTENT (SMC - A PER
+! UNIT VOLUME MEASUREMENT) IS A DEPENDENT VARIABLE THAT IS UPDATED WITH
+! PROGNOSTIC EQNS. THE CANOPY MOISTURE CONTENT (CMC) IS ALSO UPDATED.
+! FROZEN GROUND VERSION:  NEW STATES ADDED: SH2O, AND FROZEN GROUND
+! CORRECTION FACTOR, FRZFACT AND PARAMETER SLOPE.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)   :: NSOIL
+      INTEGER               :: I,K
+
+      REAL, INTENT(IN)      :: BEXP, CMCMAX, DKSAT,DWSAT, DT, EC, EDIR,  &
+                               KDT, PRCP1, SHDFAC, SLOPE, SMCMAX, SMCWLT
+      REAL, INTENT(OUT)                      :: DRIP, RUNOFF1, RUNOFF2, RUNOFF3
+      REAL, INTENT(INOUT)   :: CMC
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: ET,ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: SMC, SH2O
+      REAL, DIMENSION(1:NSOIL)             :: AI, BI, CI, STCF,RHSTS, RHSTT, &
+                                              SICE, SH2OA, SH2OFG
+      REAL                  :: DUMMY, EXCESS,FRZFACT,PCPDRP,RHSCT,TRHSCT
+      REAL :: FAC2
+      REAL :: FLIMIT
+
+      REAL,    INTENT(INOUT)                 :: SFHEAD1RT,INFXS1RT
+
+! ----------------------------------------------------------------------
+! EXECUTABLE CODE BEGINS HERE.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! COMPUTE THE RIGHT HAND SIDE OF THE CANOPY EQN TERM ( RHSCT )
+! ----------------------------------------------------------------------
+      DUMMY = 0.
+
+! ----------------------------------------------------------------------
+! CONVERT RHSCT (A RATE) TO TRHSCT (AN AMOUNT) AND ADD IT TO EXISTING
+! CMC.  IF RESULTING AMT EXCEEDS MAX CAPACITY, IT BECOMES DRIP AND WILL
+! FALL TO THE GRND.
+! ----------------------------------------------------------------------
+      RHSCT = SHDFAC * PRCP1- EC
+      DRIP = 0.
+      TRHSCT = DT * RHSCT
+      EXCESS = CMC + TRHSCT
+
+! ----------------------------------------------------------------------
+! PCPDRP IS THE COMBINED PRCP1 AND DRIP (FROM CMC) THAT GOES INTO THE
+! SOIL
+! ----------------------------------------------------------------------
+      IF (EXCESS > CMCMAX) DRIP = EXCESS - CMCMAX
+      PCPDRP = (1. - SHDFAC) * PRCP1+ DRIP / DT
+
+! ----------------------------------------------------------------------
+! STORE ICE CONTENT AT EACH SOIL LAYER BEFORE CALLING SRT and SSTEP
+!
+      DO I = 1,NSOIL
+         SICE (I) = SMC (I) - SH2O (I)
+      END DO
+! ----------------------------------------------------------------------
+! CALL SUBROUTINES SRT AND SSTEP TO SOLVE THE SOIL MOISTURE
+! TENDENCY EQUATIONS.
+! IF THE INFILTRATING PRECIP RATE IS NONTRIVIAL,
+!   (WE CONSIDER NONTRIVIAL TO BE A PRECIP TOTAL OVER THE TIME STEP
+!    EXCEEDING ONE ONE-THOUSANDTH OF THE WATER HOLDING CAPACITY OF
+!    THE FIRST SOIL LAYER)
+! THEN CALL THE SRT/SSTEP SUBROUTINE PAIR TWICE IN THE MANNER OF
+!   TIME SCHEME "F" (IMPLICIT STATE, AVERAGED COEFFICIENT)
+!   OF SECTION 2 OF KALNAY AND KANAMITSU (1988, MWR, VOL 116,
+!   PAGES 1945-1958)TO MINIMIZE 2-DELTA-T OSCILLATIONS IN THE
+!   SOIL MOISTURE VALUE OF THE TOP SOIL LAYER THAT CAN ARISE BECAUSE
+!   OF THE EXTREME NONLINEAR DEPENDENCE OF THE SOIL HYDRAULIC
+!   DIFFUSIVITY COEFFICIENT AND THE HYDRAULIC CONDUCTIVITY ON THE
+!   SOIL MOISTURE STATE
+! OTHERWISE CALL THE SRT/SSTEP SUBROUTINE PAIR ONCE IN THE MANNER OF
+!   TIME SCHEME "D" (IMPLICIT STATE, EXPLICIT COEFFICIENT)
+!   OF SECTION 2 OF KALNAY AND KANAMITSU
+! PCPDRP IS UNITS OF KG/M**2/S OR MM/S, ZSOIL IS NEGATIVE DEPTH IN M
+! ----------------------------------------------------------------------
+!  According to Dr. Ken Mitchell's suggestion, add the second contraint
+!  to remove numerical instability of runoff and soil moisture
+!  FLIMIT is a limit value for FAC2
+      FAC2=0.0
+      DO I=1,NSOIL
+         FAC2=MAX(FAC2,SH2O(I)/SMCMAX)
+      ENDDO
+      CALL FAC2MIT_gpu(SMCMAX,FLIMIT)
+
+! ----------------------------------------------------------------------
+! FROZEN GROUND VERSION:
+! SMC STATES REPLACED BY SH2O STATES IN SRT SUBR.  SH2O & SICE STATES
+! INC&UDED IN SSTEP SUBR.  FROZEN GROUND CORRECTION FACTOR, FRZFACT
+! ADDED.  ALL WATER BALANCE CALCULATIONS USING UNFROZEN WATER
+! ----------------------------------------------------------------------
+
+#ifdef WRF_HYDRO
+!DJG NDHMS/WRF-Hydro edit... Add previous ponded water to new precip drip...
+    PCPDRP = PCPDRP + SFHEAD1RT/1000./DT   ! convert SFHEAD1RT to (m/s)
+#endif
+
+
+      IF ( ( (PCPDRP * DT) > (0.0001*1000.0* (- ZSOIL (1))* SMCMAX) )   &
+           .OR. (FAC2 > FLIMIT) ) THEN
+         CALL SRT_gpu (RHSTT,EDIR,ET,SH2O,SH2O,NSOIL,PCPDRP,ZSOIL,          &
+                    DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
+                    RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
+                    SFHEAD1RT,INFXS1RT)
+         CALL SSTEP_gpu (SH2OFG,SH2O,DUMMY,RHSTT,RHSCT,DT,NSOIL,SMCMAX,     &
+                        CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
+         DO K = 1,NSOIL
+            SH2OA (K) = (SH2O (K) + SH2OFG (K)) * 0.5
+         END DO
+         CALL SRT_gpu (RHSTT,EDIR,ET,SH2O,SH2OA,NSOIL,PCPDRP,ZSOIL,         &
+                    DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
+                    RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
+                    SFHEAD1RT,INFXS1RT)
+         CALL SSTEP_gpu (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+                        CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
+
+      ELSE
+         CALL SRT_gpu (RHSTT,EDIR,ET,SH2O,SH2O,NSOIL,PCPDRP,ZSOIL,          &
+                    DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
+                    RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
+                   SFHEAD1RT,INFXS1RT)
+         CALL SSTEP_gpu (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+                     CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
+!      RUNOF = RUNOFF
+
+      END IF
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SMFLX_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE SNFRAC (SNEQV,SNUP,SALP,SNOWH,SNCOVR, &
                          XLAI,SHDFAC,FVB,GAMA,FBUR,    &
@@ -2908,6 +5856,111 @@ CONTAINS
   END SUBROUTINE SNFRAC
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNFRAC_gpu (SNEQV,SNUP,SALP,SNOWH,SNCOVR, &
+                         XLAI,SHDFAC,FVB,GAMA,FBUR,    &
+                         FGSN,ZTOPV,ZBOTV,UA_PHYS)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNFRAC
+! ----------------------------------------------------------------------
+! CALCULATE SNOW FRACTION (0 -> 1)
+! SNEQV   SNOW WATER EQUIVALENT (M)
+! SNUP    THRESHOLD SNEQV DEPTH ABOVE WHICH SNCOVR=1
+! SALP    TUNING PARAMETER
+! SNCOVR  FRACTIONAL SNOW COVER
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      REAL, INTENT(IN)     :: SNEQV,SNUP,SALP,SNOWH
+      REAL, INTENT(OUT)    :: SNCOVR
+      REAL                 :: RSNOW, Z0N
+      LOGICAL, INTENT(IN)  :: UA_PHYS  ! UA: flag for UA option
+      REAL, INTENT(IN)     :: ZTOPV    ! UA: height of canopy top
+      REAL, INTENT(IN)     :: ZBOTV    ! UA: height of canopy bottom
+      REAL, INTENT(IN)     :: SHDFAC   ! UA: vegetation fraction
+      REAL, INTENT(INOUT)  :: XLAI     ! UA: LAI modified by snow
+      REAL, INTENT(OUT)    :: FVB      ! UA: frac. veg. w/snow beneath
+      REAL, INTENT(OUT)    :: GAMA     ! UA: = EXP(-1.* XLAI)
+      REAL, INTENT(OUT)    :: FBUR     ! UA: fraction of canopy buried
+      REAL, INTENT(OUT)    :: FGSN     ! UA: ground snow cover fraction
+
+      REAL ::  SNUPGRD = 0.02          ! UA: SWE limit for ground cover
+
+! ----------------------------------------------------------------------
+! SNUP IS VEG-CLASS DEPENDENT SNOWDEPTH THRESHHOLD (SET IN ROUTINE
+! REDPRM) ABOVE WHICH SNOCVR=1.
+! ----------------------------------------------------------------------
+      IF (SNEQV < SNUP) THEN
+         RSNOW = SNEQV / SNUP
+         SNCOVR = 1. - ( EXP ( - SALP * RSNOW) - RSNOW * EXP ( - SALP))
+      ELSE
+         SNCOVR = 1.0
+      END IF
+
+!     FORMULATION OF DICKINSON ET AL. 1986
+!     Z0N = 0.035
+
+!        SNCOVR=SNOWH/(SNOWH + 5*Z0N)
+
+!     FORMULATION OF MARSHALL ET AL. 1994
+!        SNCOVR=SNEQV/(SNEQV + 2*Z0N)
+
+      IF(UA_PHYS) THEN
+
+!---------------------------------------------------------------------
+! FGSN: FRACTION OF SOIL COVERED WITH SNOW
+!---------------------------------------------------------------------
+        IF (SNEQV < SNUPGRD) THEN
+         FGSN = SNEQV / SNUPGRD
+        ELSE
+         FGSN = 1.0
+        END IF
+!------------------------------------------------------------------
+! FBUR: VERTICAL FRACTION OF VEGETATION COVERED BY SNOW
+! GRASS, CROP, AND SHRUB: MULTIPLY 0.4 BY ZTOPV AND ZBOTV BECAUSE 
+! THEY WILL BE PRESSED DOWN BY THE SNOW.
+! FOREST: DON'T NEED TO CHANGE ZTOPV AND ZBOTV.
+
+        IF(ZBOTV > 0. .AND. SNOWH > ZBOTV) THEN
+          IF(ZBOTV <= 0.5) THEN
+            FBUR = (SNOWH - 0.4*ZBOTV) / (0.4*(ZTOPV-ZBOTV)) ! short veg.
+          ELSE
+            FBUR = (SNOWH - ZBOTV) / (ZTOPV-ZBOTV)           !  tall veg.
+          ENDIF
+        ELSE
+          FBUR = 0.
+        ENDIF
+
+        FBUR = MIN(MAX(FBUR,0.0),1.0)
+
+! XLAI IS ADJUSTED FOR VERTICAL BURYING BY SNOW
+        XLAI = XLAI * (1.0 - FBUR)
+! ----------------------------------------------------------------------
+! SNOW-COVERED SOIL: (1-SHDFAC)*FGSN
+! VEGETATION WITH SNOW ABOVE DUE TO BURIAL FVEG_SN_AB = SHDFAC*FBUR
+! SNOW ON THE GROUND THAT CAN BE "SEEN" BY SATELLITE
+! (IF XLAI GOES TO ZERO): GAMA*FVB
+! Where GAMA = exp(-XLAI)
+! ----------------------------------------------------------------------
+
+! VEGETATION WITH SNOW BELOW
+        FVB = SHDFAC * FGSN * (1.0 - FBUR)
+
+! GAMA IS USED TO DIVIDE FVB INTO TWO PARTS:
+! GAMA=1 FOR XLAI=0 AND GAMA=0 FOR XLAI=6
+        GAMA = EXP(-1.* XLAI)
+      ELSE
+        ! Define intent(out) terms for .NOT. UA_PHYS case
+        FVB  = 0.0
+        GAMA = 0.0
+        FBUR = 0.0
+        FGSN = 0.0
+      END IF    ! UA_PHYS
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNFRAC_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE SNKSRC (TSNSR,TAVG,SMC,SH2O,ZSOIL,NSOIL,               &
      &                      SMCMAX,PSISAT,BEXP,DT,K,QTOT)
 ! ----------------------------------------------------------------------
@@ -2994,6 +6047,95 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SNKSRC
+! ----------------------------------------------------------------------
+
+      SUBROUTINE SNKSRC_gpu (TSNSR,TAVG,SMC,SH2O,ZSOIL,NSOIL,               &
+     &                      SMCMAX,PSISAT,BEXP,DT,K,QTOT)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNKSRC
+! ----------------------------------------------------------------------
+! CALCULATE SINK/SOURCE TERM OF THE TERMAL DIFFUSION EQUATION. (SH2O) IS
+! AVAILABLE LIQUED WATER.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)   :: K,NSOIL
+      REAL, INTENT(IN)      :: BEXP, DT, PSISAT, QTOT, SMC, SMCMAX,    &
+                               TAVG
+      REAL, INTENT(INOUT)   :: SH2O
+
+      REAL, DIMENSION(1:NSOIL), INTENT(IN):: ZSOIL
+
+      REAL                  :: DF, DZ, DZH, FREE, TSNSR,               &
+                               TDN, TM, TUP, TZ, X0, XDN, XH2O, XUP
+
+      REAL, PARAMETER       :: DH2O = 1.0000E3, HLICE = 3.3350E5,      &
+                               T0 = 2.7315E2
+
+      IF (K == 1) THEN
+         DZ = - ZSOIL (1)
+      ELSE
+         DZ = ZSOIL (K -1) - ZSOIL (K)
+      END IF
+! ----------------------------------------------------------------------
+! VIA FUNCTION FRH2O, COMPUTE POTENTIAL OR 'EQUILIBRIUM' UNFROZEN
+! SUPERCOOLED FREE WATER FOR GIVEN SOIL TYPE AND SOIL LAYER TEMPERATURE.
+! FUNCTION FRH20 INVOKES EQN (17) FROM V. KOREN ET AL (1999, JGR, VOL.
+! 104, PG 19573).  (ASIDE:  LATTER EQN IN JOURNAL IN CENTIGRADE UNITS.
+! ROUTINE FRH2O USE FORM OF EQN IN KELVIN UNITS.)
+! ----------------------------------------------------------------------
+!      FREE = FRH2O(TAVG,SMC,SH2O,SMCMAX,BEXP,PSISAT)
+
+! ----------------------------------------------------------------------
+! IN NEXT BLOCK OF CODE, INVOKE EQN 18 OF V. KOREN ET AL (1999, JGR,
+! VOL. 104, PG 19573.)  THAT IS, FIRST ESTIMATE THE NEW AMOUNTOF LIQUID
+! WATER, 'XH2O', IMPLIED BY THE SUM OF (1) THE LIQUID WATER AT THE BEGIN
+! OF CURRENT TIME STEP, AND (2) THE FREEZE OF THAW CHANGE IN LIQUID
+! WATER IMPLIED BY THE HEAT FLUX 'QTOT' PASSED IN FROM ROUTINE HRT.
+! SECOND, DETERMINE IF XH2O NEEDS TO BE BOUNDED BY 'FREE' (EQUIL AMT) OR
+! IF 'FREE' NEEDS TO BE BOUNDED BY XH2O.
+! ----------------------------------------------------------------------
+      CALL FRH2O_gpu (FREE,TAVG,SMC,SH2O,SMCMAX,BEXP,PSISAT)
+
+! ----------------------------------------------------------------------
+! FIRST, IF FREEZING AND REMAINING LIQUID LESS THAN LOWER BOUND, THEN
+! REDUCE EXTENT OF FREEZING, THEREBY LETTING SOME OR ALL OF HEAT FLUX
+! QTOT COOL THE SOIL TEMP LATER IN ROUTINE HRT.
+! ----------------------------------------------------------------------
+      XH2O = SH2O + QTOT * DT / (DH2O * HLICE * DZ)
+      IF ( XH2O < SH2O .AND. XH2O < FREE) THEN
+         IF ( FREE > SH2O ) THEN
+            XH2O = SH2O
+         ELSE
+            XH2O = FREE
+         END IF
+      END IF
+! ----------------------------------------------------------------------
+! SECOND, IF THAWING AND THE INCREASE IN LIQUID WATER GREATER THAN UPPER
+! BOUND, THEN REDUCE EXTENT OF THAW, THEREBY LETTING SOME OR ALL OF HEAT
+! FLUX QTOT WARM THE SOIL TEMP LATER IN ROUTINE HRT.
+! ----------------------------------------------------------------------
+      IF ( XH2O > SH2O .AND. XH2O > FREE ) THEN
+         IF ( FREE < SH2O ) THEN
+            XH2O = SH2O
+         ELSE
+            XH2O = FREE
+         END IF
+      END IF
+
+! ----------------------------------------------------------------------
+! CALCULATE PHASE-CHANGE HEAT SOURCE/SINK TERM FOR USE IN ROUTINE HRT
+! AND UPDATE LIQUID WATER TO REFLCET FINAL FREEZE/THAW INCREMENT.
+! ----------------------------------------------------------------------
+!      SNKSRC = -DH2O*HLICE*DZ*(XH2O-SH2O)/DT
+      IF (XH2O < 0.) XH2O = 0.
+      IF (XH2O > SMC) XH2O = SMC
+      TSNSR = - DH2O * HLICE * DZ * (XH2O - SH2O)/ DT
+      SH2O = XH2O
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNKSRC_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE SNOPAC (ETP,ETA,PRCP,PRCPF,SNOWNG,SMC,SMCMAX,SMCWLT,   &
@@ -3402,6 +6544,412 @@ CONTAINS
   END SUBROUTINE SNOPAC
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNOPAC_gpu (ETP,ETA,PRCP,PRCPF,SNOWNG,SMC,SMCMAX,SMCWLT,   &
+                          SMCREF,SMCDRY,CMC,CMCMAX,NSOIL,DT,            &
+                          SBETA,DF1,                                    &
+                          Q2,T1,SFCTMP,T24,TH2,FDOWN,F1,SSOIL,STC,EPSCA,&
+                         SFCPRS,BEXP,PC,RCH,RR,CFACTR,SNCOVR,ESD,SNDENS,&
+                          SNOWH,SH2O,SLOPE,KDT,FRZFACT,PSISAT,          &
+                          ZSOIL,DWSAT,DKSAT,TBOT,ZBOT,SHDFAC,RUNOFF1,   &
+                          RUNOFF2,RUNOFF3,EDIR,EC,ET,ETT,NROOT,SNOMLT,  &
+                          RTDIS,QUARTZ,FXEXP,CSOIL,                     &
+                          BETA,DRIP,DEW,FLX1,FLX2,FLX3,ESNOW,ETNS,EMISSI,&
+                          RIBB,SOLDN,                                   &
+                          ISURBAN,                                      &
+                          VEGTYP,                                       &
+                          ETPN,FLX4,UA_PHYS,                            &
+                          SFHEAD1RT,INFXS1RT,ETPND1,SOILTYP,OPT_THCND   &
+                         ,QFX_PHY,fasdas,HCPCT_FASDAS                   ) !fasdas
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOPAC
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE AND HEAT FLUX VALUES & UPDATE SOIL MOISTURE
+! CONTENT AND SOIL HEAT CONTENT VALUES FOR THE CASE WHEN A SNOW PACK IS
+! PRESENT.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN)   :: OPT_THCND
+      INTEGER, INTENT(IN)   :: NROOT, NSOIL,VEGTYP,SOILTYP
+      INTEGER, INTENT(IN)   :: ISURBAN
+      INTEGER               :: K
+!
+! kmh 09/03/2006 add IT16 for surface temperature iteration
+!
+      INTEGER               :: IT16
+      LOGICAL, INTENT(IN)   :: SNOWNG
+
+!DJG NDHMS/WRF-Hydro edit...
+       REAL, INTENT(INOUT)    ::  SFHEAD1RT,INFXS1RT,ETPND1
+
+      REAL, INTENT(IN)      :: BEXP,CFACTR, CMCMAX,CSOIL,DF1,DKSAT,     &
+                               DT,DWSAT, EPSCA,FDOWN,F1,FXEXP,          &
+                               FRZFACT,KDT,PC, PRCP,PSISAT,Q2,QUARTZ,   &
+                               RCH,RR,SBETA,SFCPRS, SFCTMP, SHDFAC,     &
+                               SLOPE,SMCDRY,SMCMAX,SMCREF,SMCWLT, T24,  &
+                               TBOT,TH2,ZBOT,EMISSI,SOLDN
+      REAL, INTENT(INOUT)   :: CMC, BETA, ESD,FLX2,PRCPF,SNOWH,SNCOVR,  &
+                               SNDENS, T1, RIBB, ETP
+      REAL, INTENT(OUT)     :: DEW,DRIP,EC,EDIR, ETNS, ESNOW,ETT,       &
+                               FLX1,FLX3, RUNOFF1,RUNOFF2,RUNOFF3,      &
+                               SSOIL,SNOMLT
+      REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: RTDIS,ZSOIL
+      REAL, DIMENSION(1:NSOIL),INTENT(OUT)    :: ET
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: SMC,SH2O,STC
+      REAL, DIMENSION(1:NSOIL) :: ET1
+      REAL                  :: DENOM,DSOIL,DTOT,EC1,EDIR1,ESDFLX,ETA,   &
+                               ETT1, ESNOW1, ESNOW2, ETA1,ETP1,ETP2,    &
+                               ETP3, ETNS1, ETANRG, ETAX, EX, FLX3X,    &
+                               FRCSNO,FRCSOI, PRCP1, QSAT,RSNOW, SEH,   &
+                               SNCOND,SSOIL1, T11,T12, T12A, T12AX,     &
+                               T12B, T14, YY, ZZ1
+!                               T12B, T14, YY, ZZ1,EMISSI_S
+!
+! kmh 01/11/2007 add T15, T16, and DTOT2 for SFC T iteration and snow heat flux
+!
+      REAL                  :: T15, T16, DTOT2
+      REAL, PARAMETER       :: ESDMIN = 1.E-6, LSUBC = 2.501000E+6,     &
+                               LSUBS = 2.83E+6, TFREEZ = 273.15,        &
+                               SNOEXP = 2.0
+      LOGICAL, INTENT(IN)   :: UA_PHYS  ! UA: flag for UA option
+      REAL, INTENT(INOUT)   :: FLX4     ! UA: energy removed by canopy
+      REAL, INTENT(IN)      :: ETPN     ! UA: adjusted pot. evap. [mm/s]
+      REAL                  :: ETP1N    ! UA: adjusted pot. evap. [m/s]
+
+!
+!  FASDAS
+!
+      REAL                  :: QFX_PHY
+      INTEGER               :: FASDAS
+      REAL, INTENT(  OUT)   :: HCPCT_FASDAS
+!
+!  END FASDAS
+!
+! ----------------------------------------------------------------------
+! EXECUTABLE CODE BEGINS HERE:
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! INITIALIZE EVAP TERMS.
+! ----------------------------------------------------------------------
+! conversions:
+! ESNOW [KG M-2 S-1]
+! ESDFLX [KG M-2 S-1] .le. ESNOW
+! ESNOW1 [M S-1]
+! ESNOW2 [M]
+! ETP [KG M-2 S-1]
+! ETP1 [M S-1]
+! ETP2 [M]
+! ----------------------------------------------------------------------
+      DEW = 0.
+      EDIR = 0.
+      EDIR1 = 0.
+      EC1 = 0.
+      EC = 0.
+!      EMISSI_S=0.95    ! For snow
+
+      DO K = 1,NSOIL
+         ET (K) = 0.
+         ET1 (K) = 0.
+      END DO
+      ETT = 0.
+      ETT1 = 0.
+
+!DJG NDHMS/WRF-Hydro edit...
+      ETPND1 = 0.
+
+
+      ETNS = 0.
+      ETNS1 = 0.
+      ESNOW = 0.
+      ESNOW1 = 0.
+      ESNOW2 = 0.
+
+! ----------------------------------------------------------------------
+! CONVERT POTENTIAL EVAP (ETP) FROM KG M-2 S-1 TO ETP1 IN M S-1
+! ----------------------------------------------------------------------
+      PRCP1 = PRCPF *0.001
+! ----------------------------------------------------------------------
+! IF ETP<0 (DOWNWARD) THEN DEWFALL (=FROSTFALL IN THIS CASE).
+! ----------------------------------------------------------------------
+      BETA = 1.0
+      IF (ETP <= 0.0) THEN
+         IF ( ( RIBB >= 0.1 ) .AND. ( FDOWN > 150.0 ) ) THEN
+            ETP=(MIN(ETP*(1.0-RIBB),0.)*SNCOVR/0.980 + ETP*(0.980-SNCOVR))/0.980
+         ENDIF
+         IF(ETP == 0.) BETA = 0.0
+         ETP1 = ETP * 0.001
+         IF(UA_PHYS) ETP1N = ETPN * 0.001
+         DEW = -ETP1
+         ESNOW2 = ETP1*DT
+         ETANRG = ETP*((1.-SNCOVR)*LSUBC + SNCOVR*LSUBS)
+      ELSE
+         ETP1 = ETP * 0.001
+         IF(UA_PHYS) ETP1N = ETPN * 0.001
+         !  LAND CASE
+         IF (SNCOVR <  1.) THEN
+            CALL EVAPO_gpu (ETNS1,SMC,NSOIL,CMC,ETP1,DT,ZSOIL,           &
+                         SH2O,                                       &
+                         SMCMAX,BEXP,PC,SMCWLT,DKSAT,DWSAT,          &
+                         SMCREF,SHDFAC,CMCMAX,                       &
+                         SMCDRY,CFACTR,                              &
+                         EDIR1,EC1,ET1,ETT1,SFCTMP,Q2,NROOT,RTDIS,   &
+                         FXEXP, SFHEAD1RT,ETPND1)
+! ----------------------------------------------------------------------------
+            EDIR1 = EDIR1* (1. - SNCOVR)
+            EC1 = EC1* (1. - SNCOVR)
+            DO K = 1,NSOIL
+               ET1 (K) = ET1 (K)* (1. - SNCOVR)
+            END DO
+            ETT1 = ETT1*(1.-SNCOVR)
+!            ETNS1 = EDIR1+ EC1+ ETT1
+            ETNS1 = ETNS1*(1.-SNCOVR)
+! ----------------------------------------------------------------------------
+            EDIR = EDIR1*1000.
+            EC = EC1*1000.
+            DO K = 1,NSOIL
+               ET (K) = ET1 (K)*1000.
+            END DO
+!
+! FASDAS
+!
+            if( FASDAS ==  1 ) then
+              QFX_PHY = EDIR + EC
+              DO K=1,NSOIL
+                 QFX_PHY = QFX_PHY + ET(K)
+              END DO
+            endif
+!
+! END FASDAS
+!
+            ETT = ETT1*1000.
+            ETNS = ETNS1*1000.
+
+
+!DJG NDHMS/WRF-Hydro edit...
+               ETPND1 = ETPND1*1000.
+
+
+! ----------------------------------------------------------------------
+
+         ENDIF
+         ESNOW = ETP*SNCOVR
+         IF(UA_PHYS) ESNOW = ETPN*SNCOVR   ! USE ADJUSTED ETP
+         ESNOW1 = ESNOW*0.001
+         ESNOW2 = ESNOW1*DT
+         ETANRG = ESNOW*LSUBS + ETNS*LSUBC
+      ENDIF
+
+! ----------------------------------------------------------------------
+! IF PRECIP IS FALLING, CALCULATE HEAT FLUX FROM SNOW SFC TO NEWLY
+! ACCUMULATING PRECIP.  NOTE THAT THIS REFLECTS THE FLUX APPROPRIATE FOR
+! THE NOT-YET-UPDATED SKIN TEMPERATURE (T1).  ASSUMES TEMPERATURE OF THE
+! SNOWFALL STRIKING THE GROUND IS =SFCTMP (LOWEST MODEL LEVEL AIR TEMP).
+! ----------------------------------------------------------------------
+      FLX1 = 0.0
+      IF (SNOWNG) THEN
+         FLX1 = CPICE * PRCP * (T1- SFCTMP)
+      ELSE
+         IF (PRCP >  0.0) FLX1 = CPH2O * PRCP * (T1- SFCTMP)
+! ----------------------------------------------------------------------
+! CALCULATE AN 'EFFECTIVE SNOW-GRND SFC TEMP' (T12) BASED ON HEAT FLUXES
+! BETWEEN THE SNOW PACK AND THE SOIL AND ON NET RADIATION.
+! INCLUDE FLX1 (PRECIP-SNOW SFC) AND FLX2 (FREEZING RAIN LATENT HEAT)
+! FLUXES.  FLX1 FROM ABOVE, FLX2 BROUGHT IN VIA COMMOM BLOCK RITE.
+! FLX2 REFLECTS FREEZING RAIN LATENT HEAT FLUX USING T1 CALCULATED IN
+! PENMAN.
+! ----------------------------------------------------------------------
+      END IF
+      DSOIL = - (0.5 * ZSOIL (1))
+      DTOT = SNOWH + DSOIL
+      DENOM = 1.0+ DF1 / (DTOT * RR * RCH)
+! surface emissivity weighted by snow cover fraction
+!      T12A = ( (FDOWN - FLX1 - FLX2 -                                   &
+!     &       ((SNCOVR*EMISSI_S)+EMISSI*(1.0-SNCOVR))*SIGMA *T24)/RCH    &
+!     &       + TH2 - SFCTMP - ETANRG/RCH ) / RR
+      T12A = ( (FDOWN - FLX1- FLX2- EMISSI * SIGMA * T24)/ RCH                    &
+                + TH2- SFCTMP - ETANRG / RCH ) / RR
+
+      T12B = DF1 * STC (1) / (DTOT * RR * RCH)
+
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS AT OR BELOW FREEZING, NO SNOW
+! MELT WILL OCCUR.  SET THE SKIN TEMP TO THIS EFFECTIVE TEMP.  REDUCE
+! (BY SUBLIMINATION ) OR INCREASE (BY FROST) THE DEPTH OF THE SNOWPACK,
+! DEPENDING ON SIGN OF ETP.
+! UPDATE SOIL HEAT FLUX (SSOIL) USING NEW SKIN TEMPERATURE (T1)
+! SINCE NO SNOWMELT, SET ACCUMULATED SNOWMELT TO ZERO, SET 'EFFECTIVE'
+! PRECIP FROM SNOWMELT TO ZERO, SET PHASE-CHANGE HEAT FLUX FROM SNOWMELT
+! TO ZERO.
+! ----------------------------------------------------------------------
+! SUB-FREEZING BLOCK
+! ----------------------------------------------------------------------
+      T12 = (SFCTMP + T12A + T12B) / DENOM
+      IF (T12 <=  TFREEZ) THEN
+         T1 = T12
+         SSOIL = DF1 * (T1- STC (1)) / DTOT
+!        ESD = MAX (0.0, ESD- ETP2)
+         ESD = MAX(0.0, ESD-ESNOW2)
+         FLX3 = 0.0
+         EX = 0.0
+
+         SNOMLT = 0.0
+         IF(UA_PHYS) FLX4 = 0.0
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS ABOVE FREEZING, SNOW MELT
+! WILL OCCUR.  CALL THE SNOW MELT RATE,EX AND AMT, SNOMLT.  REVISE THE
+! EFFECTIVE SNOW DEPTH.  REVISE THE SKIN TEMP BECAUSE IT WOULD HAVE CHGD
+! DUE TO THE LATENT HEAT RELEASED BY THE MELTING. CALC THE LATENT HEAT
+! RELEASED, FLX3. SET THE EFFECTIVE PRECIP, PRCP1 TO THE SNOW MELT RATE,
+! EX FOR USE IN SMFLX.  ADJUSTMENT TO T1 TO ACCOUNT FOR SNOW PATCHES.
+! CALCULATE QSAT VALID AT FREEZING POINT.  NOTE THAT ESAT (SATURATION
+! VAPOR PRESSURE) VALUE OF 6.11E+2 USED HERE IS THAT VALID AT FRZZING
+! POINT.  NOTE THAT ETP FROM CALL PENMAN IN SFLX IS IGNORED HERE IN
+! FAVOR OF BULK ETP OVER 'OPEN WATER' AT FREEZING TEMP.
+! UPDATE SOIL HEAT FLUX (S) USING NEW SKIN TEMPERATURE (T1)
+! ----------------------------------------------------------------------
+! ABOVE FREEZING BLOCK
+! ----------------------------------------------------------------------
+      ELSE
+!     From V3.9 original code (commented) replaced to allow complete melting of small snow amounts
+!        T1 = TFREEZ * SNCOVR ** SNOEXP + T12 * (1.0- SNCOVR ** SNOEXP)
+         T1 = TFREEZ * max(0.01,SNCOVR ** SNOEXP) + T12 * (1.0- max(0.01,SNCOVR ** SNOEXP))
+         BETA = 1.0
+
+! ----------------------------------------------------------------------
+! IF POTENTIAL EVAP (SUBLIMATION) GREATER THAN DEPTH OF SNOWPACK.
+! BETA<1
+! SNOWPACK HAS SUBLIMATED AWAY, SET DEPTH TO ZERO.
+! ----------------------------------------------------------------------
+         SSOIL = DF1 * (T1- STC (1)) / DTOT
+         IF (ESD-ESNOW2 <= ESDMIN) THEN
+            ESD = 0.0
+            EX = 0.0
+            SNOMLT = 0.0
+            FLX3 = 0.0
+            IF(UA_PHYS) FLX4 = 0.0
+! ----------------------------------------------------------------------
+! SUBLIMATION LESS THAN DEPTH OF SNOWPACK
+! SNOWPACK (ESD) REDUCED BY ESNOW2 (DEPTH OF SUBLIMATED SNOW)
+! ----------------------------------------------------------------------
+         ELSE
+            ESD = ESD-ESNOW2
+            ETP3 = ETP * LSUBC
+            SEH = RCH * (T1- TH2)
+            T14 = T1* T1
+            T14 = T14* T14
+!           FLX3 = FDOWN - FLX1 - FLX2 -                                 &
+!                  ((SNCOVR*EMISSI_S)+EMISSI*(1-SNCOVR))*SIGMA*T14 -     &
+!                    SSOIL - SEH - ETANRG
+            FLX3 = FDOWN - FLX1- FLX2- EMISSI*SIGMA * T14- SSOIL - SEH - ETANRG
+            IF (FLX3 <= 0.0) FLX3 = 0.0
+
+            IF(UA_PHYS .AND. FLX4 > 0. .AND. FLX3 > 0.) THEN
+              IF(FLX3 >= FLX4) THEN
+                FLX3 = FLX3 - FLX4
+              ELSE
+                FLX4 = FLX3
+                FLX3 = 0.
+              ENDIF
+            ELSE
+              FLX4 = 0.0
+            ENDIF
+
+! ----------------------------------------------------------------------
+! SNOWMELT REDUCTION DEPENDING ON SNOW COVER
+! ----------------------------------------------------------------------
+            EX = FLX3*0.001/ LSUBF
+
+! ----------------------------------------------------------------------
+! ESDMIN REPRESENTS A SNOWPACK DEPTH THRESHOLD VALUE BELOW WHICH WE
+! CHOOSE NOT TO RETAIN ANY SNOWPACK, AND INSTEAD INCLUDE IT IN SNOWMELT.
+! ----------------------------------------------------------------------
+            SNOMLT = EX * DT
+            IF (ESD- SNOMLT >=  ESDMIN) THEN
+               ESD = ESD- SNOMLT
+! ----------------------------------------------------------------------
+! SNOWMELT EXCEEDS SNOW DEPTH
+! ----------------------------------------------------------------------
+            ELSE
+               EX = ESD / DT
+               FLX3 = EX *1000.0* LSUBF
+               SNOMLT = ESD
+
+               ESD = 0.0
+! ----------------------------------------------------------------------
+! END OF 'ESD .LE. ETP2' IF-BLOCK
+! ----------------------------------------------------------------------
+            END IF
+         END IF
+
+! ----------------------------------------------------------------------
+! END OF 'T12 .LE. TFREEZ' IF-BLOCK
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! IF NON-GLACIAL LAND, ADD SNOWMELT RATE (EX) TO PRECIP RATE TO BE USED
+! IN SUBROUTINE SMFLX (SOIL MOISTURE EVOLUTION) VIA INFILTRATION.
+!
+! RUNOFF/BASEFLOW LATER NEAR THE END OF SFLX (AFTER RETURN FROM CALL TO
+! SUBROUTINE SNOPAC)
+! ----------------------------------------------------------------------
+         PRCP1 = PRCP1+ EX
+
+! ----------------------------------------------------------------------
+! SET THE EFFECTIVE POTNL EVAPOTRANSP (ETP1) TO ZERO SINCE THIS IS SNOW
+! CASE, SO SURFACE EVAP NOT CALCULATED FROM EDIR, EC, OR ETT IN SMFLX
+! (BELOW).
+! SMFLX RETURNS UPDATED SOIL MOISTURE VALUES FOR NON-GLACIAL LAND.
+! ----------------------------------------------------------------------
+      END IF
+      CALL SMFLX_gpu (SMC,NSOIL,CMC,DT,PRCP1,ZSOIL,                      &
+                   SH2O,SLOPE,KDT,FRZFACT,                           &
+                   SMCMAX,BEXP,SMCWLT,DKSAT,DWSAT,                   &
+                   SHDFAC,CMCMAX,                                    &
+                   RUNOFF1,RUNOFF2,RUNOFF3,                          &
+                   EDIR1,EC1,ET1,                                    &
+                   DRIP, SFHEAD1RT,INFXS1RT)
+! ----------------------------------------------------------------------
+! BEFORE CALL SHFLX IN THIS SNOWPACK CASE, SET ZZ1 AND YY ARGUMENTS TO
+! SPECIAL VALUES THAT ENSURE THAT GROUND HEAT FLUX CALCULATED IN SHFLX
+! MATCHES THAT ALREADY COMPUTER FOR BELOW THE SNOWPACK, THUS THE SFC
+! HEAT FLUX TO BE COMPUTED IN SHFLX WILL EFFECTIVELY BE THE FLUX AT THE
+! SNOW TOP SURFACE.  T11 IS A DUMMY ARGUEMENT SO WE WILL NOT USE THE
+! SKIN TEMP VALUE AS REVISED BY SHFLX.
+! ----------------------------------------------------------------------
+      ZZ1 = 1.0
+      YY = STC (1) -0.5* SSOIL * ZSOIL (1)* ZZ1/ DF1
+
+! ----------------------------------------------------------------------
+! SHFLX WILL CALC/UPDATE THE SOIL TEMPS.  NOTE:  THE SUB-SFC HEAT FLUX
+! (SSOIL1) AND THE SKIN TEMP (T11) OUTPUT FROM THIS SHFLX CALL ARE NOT
+! USED  IN ANY SUBSEQUENT CALCULATIONS. RATHER, THEY ARE DUMMY VARIABLES
+! HERE IN THE SNOPAC CASE, SINCE THE SKIN TEMP AND SUB-SFC HEAT FLUX ARE
+! UPDATED INSTEAD NEAR THE BEGINNING OF THE CALL TO SNOPAC.
+! ----------------------------------------------------------------------
+      T11 = T1
+      CALL SHFLX_gpu (SSOIL1,STC,SMC,SMCMAX,NSOIL,T11,DT,YY,ZZ1,ZSOIL,     &
+                   TBOT,ZBOT,SMCWLT,PSISAT,SH2O,BEXP,F1,DF1,           &
+                   QUARTZ,CSOIL,VEGTYP,ISURBAN,SOILTYP,OPT_THCND       &
+                  ,HCPCT_FASDAS                                        ) !fasdas
+
+! ----------------------------------------------------------------------
+! SNOW DEPTH AND DENSITY ADJUSTMENT BASED ON SNOW COMPACTION.  YY IS
+! ASSUMED TO BE THE SOIL TEMPERTURE AT THE TOP OF THE SOIL COLUMN.
+! ----------------------------------------------------------------------
+      ! LAND
+      IF (ESD >  0.) THEN
+         CALL SNOWPACK_gpu (ESD,DT,SNOWH,SNDENS,T1,YY,SNOMLT,UA_PHYS)
+      ELSE
+         ESD = 0.
+         SNOWH = 0.
+         SNDENS = 0.
+         SNCOND = 1.
+         SNCOVR = 0.
+      END IF
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOPAC_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE SNOWPACK (ESD,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL,SNOMLT,UA_PHYS)
 
@@ -3538,6 +7086,142 @@ CONTAINS
   END SUBROUTINE SNOWPACK
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNOWPACK_gpu (ESD,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL,SNOMLT,UA_PHYS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOWPACK
+! ----------------------------------------------------------------------
+! CALCULATE COMPACTION OF SNOWPACK UNDER CONDITIONS OF INCREASING SNOW
+! DENSITY, AS OBTAINED FROM AN APPROXIMATE SOLUTION OF E. ANDERSON'S
+! DIFFERENTIAL EQUATION (3.29), NOAA TECHNICAL REPORT NWS 19, BY VICTOR
+! KOREN, 03/25/95.
+! ----------------------------------------------------------------------
+! ESD     WATER EQUIVALENT OF SNOW (M)
+! DTSEC   TIME STEP (SEC)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! TSNOW   SNOW SURFACE TEMPERATURE (K)
+! TSOIL   SOIL SURFACE TEMPERATURE (K)
+
+! SUBROUTINE WILL RETURN NEW VALUES OF SNOWH AND SNDENS
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER                :: IPOL, J
+      REAL, INTENT(IN)       :: ESD, DTSEC,TSNOW,TSOIL
+      REAL, INTENT(INOUT)    :: SNOWH, SNDENS
+      REAL                   :: BFAC,DSX,DTHR,DW,SNOWHC,PEXP,           &
+                                TAVGC,TSNOWC,TSOILC,ESDC,ESDCX
+      REAL, PARAMETER        :: C1 = 0.01, C2 = 21.0, G = 9.81,         &
+                                KN = 4000.0
+      LOGICAL, INTENT(IN)    :: UA_PHYS  ! UA: flag for UA option
+      REAL, INTENT(IN)       :: SNOMLT   ! UA: snow melt [m]
+      REAL                   :: SNOMLTC  ! UA: snow melt [cm]
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+      SNOWHC = SNOWH *100.
+      ESDC = ESD *100.
+      IF(UA_PHYS) SNOMLTC = SNOMLT *100.
+      DTHR = DTSEC /3600.
+      TSNOWC = TSNOW -273.15
+      TSOILC = TSOIL -273.15
+
+! ----------------------------------------------------------------------
+! CALCULATING OF AVERAGE TEMPERATURE OF SNOW PACK
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALCULATING OF SNOW DEPTH AND DENSITY AS A RESULT OF COMPACTION
+!  SNDENS=DS0*(EXP(BFAC*ESD)-1.)/(BFAC*ESD)
+!  BFAC=DTHR*C1*EXP(0.08*TAVGC-C2*DS0)
+! NOTE: BFAC*ESD IN SNDENS EQN ABOVE HAS TO BE CAREFULLY TREATED
+! NUMERICALLY BELOW:
+!   C1 IS THE FRACTIONAL INCREASE IN DENSITY (1/(CM*HR))
+!   C2 IS A CONSTANT (CM3/G) KOJIMA ESTIMATED AS 21 CMS/G
+! ----------------------------------------------------------------------
+      TAVGC = 0.5* (TSNOWC + TSOILC)
+      IF (ESDC >  1.E-2) THEN
+         ESDCX = ESDC
+      ELSE
+         ESDCX = 1.E-2
+      END IF
+
+!      DSX = SNDENS*((DEXP(BFAC*ESDC)-1.)/(BFAC*ESDC))
+! ----------------------------------------------------------------------
+! THE FUNCTION OF THE FORM (e**x-1)/x EMBEDDED IN ABOVE EXPRESSION
+! FOR DSX WAS CAUSING NUMERICAL DIFFICULTIES WHEN THE DENOMINATOR "x"
+! (I.E. BFAC*ESDC) BECAME ZERO OR APPROACHED ZERO (DESPITE THE FACT THAT
+! THE ANALYTICAL FUNCTION (e**x-1)/x HAS A WELL DEFINED LIMIT AS
+! "x" APPROACHES ZERO), HENCE BELOW WE REPLACE THE (e**x-1)/x
+! EXPRESSION WITH AN EQUIVALENT, NUMERICALLY WELL-BEHAVED
+! POLYNOMIAL EXPANSION.
+
+! NUMBER OF TERMS OF POLYNOMIAL EXPANSION, AND HENCE ITS ACCURACY,
+! IS GOVERNED BY ITERATION LIMIT "IPOL".
+!      IPOL GREATER THAN 9 ONLY MAKES A DIFFERENCE ON DOUBLE
+!            PRECISION (RELATIVE ERRORS GIVEN IN PERCENT %).
+!       IPOL=9, FOR REL.ERROR <~ 1.6 E-6 % (8 SIGNIFICANT DIGITS)
+!       IPOL=8, FOR REL.ERROR <~ 1.8 E-5 % (7 SIGNIFICANT DIGITS)
+!       IPOL=7, FOR REL.ERROR <~ 1.8 E-4 % ...
+! ----------------------------------------------------------------------
+      BFAC = DTHR * C1* EXP (0.08* TAVGC - C2* SNDENS)
+      IPOL = 4
+      PEXP = 0.
+!        PEXP = (1. + PEXP)*BFAC*ESDC/REAL(J+1)
+      DO J = IPOL,1, -1
+         PEXP = (1. + PEXP)* BFAC * ESDCX / REAL (J +1)
+      END DO
+
+      PEXP = PEXP + 1.
+! ----------------------------------------------------------------------
+! ABOVE LINE ENDS POLYNOMIAL SUBSTITUTION
+! ----------------------------------------------------------------------
+!     END OF KOREAN FORMULATION
+
+!     BASE FORMULATION (COGLEY ET AL., 1990)
+!     CONVERT DENSITY FROM G/CM3 TO KG/M3
+!       DSM=SNDENS*1000.0
+
+!       DSX=DSM+DTSEC*0.5*DSM*G*ESD/
+!    &      (1E7*EXP(-0.02*DSM+KN/(TAVGC+273.16)-14.643))
+
+!  &   CONVERT DENSITY FROM KG/M3 TO G/CM3
+!       DSX=DSX/1000.0
+
+!     END OF COGLEY ET AL. FORMULATION
+
+! ----------------------------------------------------------------------
+! SET UPPER/LOWER LIMIT ON SNOW DENSITY
+! ----------------------------------------------------------------------
+      DSX = SNDENS * (PEXP)
+      IF (DSX > 0.40) DSX = 0.40
+      IF (DSX < 0.05) DSX = 0.05
+! ----------------------------------------------------------------------
+! UPDATE OF SNOW DEPTH AND DENSITY DEPENDING ON LIQUID WATER DURING
+! SNOWMELT.  ASSUMED THAT 13% OF LIQUID WATER CAN BE STORED IN SNOW PER
+! DAY DURING SNOWMELT TILL SNOW DENSITY 0.40.
+! ----------------------------------------------------------------------
+      SNDENS = DSX
+      IF (TSNOWC >=  0.) THEN
+         DW = 0.13* DTHR /24.
+         IF ( UA_PHYS .AND. TSOILC >= 0.) THEN
+             DW = MIN (DW, 0.13*SNOMLTC/(ESDCX+0.13*SNOMLTC))
+         ENDIF
+         SNDENS = SNDENS * (1. - DW) + DW
+         IF (SNDENS >=  0.40) SNDENS = 0.40
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH (CM) FROM SNOW WATER EQUIVALENT AND SNOW DENSITY.
+! CHANGE SNOW DEPTH UNITS TO METERS
+! ----------------------------------------------------------------------
+      END IF
+      SNOWHC = ESDC / SNDENS
+      SNOWH = SNOWHC *0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWPACK_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE SNOWZ0 (SNCOVR,Z0, Z0BRD, SNOWH,FBUR,FGSN,SHDMAX,UA_PHYS)
 
 ! ----------------------------------------------------------------------
@@ -3586,6 +7270,54 @@ CONTAINS
   END SUBROUTINE SNOWZ0
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SNOWZ0_gpu (SNCOVR,Z0, Z0BRD, SNOWH,FBUR,FGSN,SHDMAX,UA_PHYS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOWZ0
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL ROUGHNESS LENGTH OVER SNOW
+! SNCOVR  FRACTIONAL SNOW COVER
+! Z0      ROUGHNESS LENGTH (m)
+! Z0S     SNOW ROUGHNESS LENGTH:=0.001 (m)
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN)        :: SNCOVR, Z0BRD
+      REAL, INTENT(OUT)       :: Z0
+      REAL, PARAMETER         :: Z0S=0.001
+      REAL, INTENT(IN)        :: SNOWH
+      REAL                    :: BURIAL
+      REAL                    :: Z0EFF
+      LOGICAL, INTENT(IN)     :: UA_PHYS   ! UA: flag for UA option
+      REAL, INTENT(IN)        :: FBUR      ! UA: fraction of canopy buried
+      REAL, INTENT(IN)        :: FGSN      ! UA: ground snow cover fraction
+      REAL, INTENT(IN)        :: SHDMAX    ! UA: maximum vegetation fraction
+      REAL, PARAMETER         :: Z0G=0.01  ! UA: soil roughness
+      REAL                    :: FV,A1,A2
+
+      IF(UA_PHYS) THEN
+
+          FV = SHDMAX * (1.-FBUR)
+          A1 = (1.-FV)**2*((1.-FGSN**2)*LOG(Z0G) + (FGSN**2)*LOG(Z0S))
+          A2 = (1.-(1.-FV)**2)*LOG(Z0BRD)
+          Z0 = EXP(A1+A2)
+
+      ELSE
+
+!m        Z0 = (1.- SNCOVR)* Z0BRD + SNCOVR * Z0S
+          BURIAL = 7.0*Z0BRD - SNOWH
+          IF(BURIAL.LE.0.0007) THEN
+              Z0EFF = Z0S
+          ELSE      
+              Z0EFF = BURIAL/7.0
+          ENDIF
+      
+          Z0 = (1.- SNCOVR)* Z0BRD + SNCOVR * Z0EFF
+
+      ENDIF
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWZ0_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE SNOW_NEW (TEMP,NEWSN,SNOWH,SNDENS)
 
@@ -3637,6 +7369,58 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SNOW_NEW
+! ----------------------------------------------------------------------
+
+      SUBROUTINE SNOW_NEW_gpu (TEMP,NEWSN,SNOWH,SNDENS)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! SUBROUTINE SNOW_NEW
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH AND DENSITY TO ACCOUNT FOR THE NEW SNOWFALL.
+! NEW VALUES OF SNOW DEPTH & DENSITY RETURNED.
+
+! TEMP    AIR TEMPERATURE (K)
+! NEWSN   NEW SNOWFALL (M)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL, INTENT(IN)        :: NEWSN, TEMP
+      REAL, INTENT(INOUT)     :: SNDENS, SNOWH
+      REAL                    :: DSNEW, HNEWC, SNOWHC,NEWSNC,TEMPC
+
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+      SNOWHC = SNOWH *100.
+      NEWSNC = NEWSN *100.
+
+! ----------------------------------------------------------------------
+! CALCULATING NEW SNOWFALL DENSITY DEPENDING ON TEMPERATURE
+! EQUATION FROM GOTTLIB L. 'A GENERAL RUNOFF MODEL FOR SNOWCOVERED
+! AND GLACIERIZED BASIN', 6TH NORDIC HYDROLOGICAL CONFERENCE,
+! VEMADOLEN, SWEDEN, 1980, 172-177PP.
+!-----------------------------------------------------------------------
+      TEMPC = TEMP -273.15
+      IF (TEMPC <=  -15.) THEN
+         DSNEW = 0.05
+      ELSE
+         DSNEW = 0.05+0.0017* (TEMPC +15.)**1.5
+      END IF
+! ----------------------------------------------------------------------
+! ADJUSTMENT OF SNOW DENSITY DEPENDING ON NEW SNOWFALL
+! ----------------------------------------------------------------------
+      HNEWC = NEWSNC / DSNEW
+      IF (SNOWHC + HNEWC .LT. 1.0E-3) THEN
+         SNDENS = MAX(DSNEW,SNDENS)
+      ELSE
+         SNDENS = (SNOWHC * SNDENS + HNEWC * DSNEW)/ (SNOWHC + HNEWC)
+      ENDIF
+      SNOWHC = SNOWHC + HNEWC
+      SNOWH = SNOWHC *0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOW_NEW_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE SRT (RHSTT,EDIR,ET,SH2O,SH2OA,NSOIL,PCPDRP,            &
@@ -3936,6 +7720,304 @@ CONTAINS
   END SUBROUTINE SRT
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SRT_gpu (RHSTT,EDIR,ET,SH2O,SH2OA,NSOIL,PCPDRP,            &
+                       ZSOIL,DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,           &
+                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZX,SICE,AI,BI,CI,  &
+                     SFHEAD1RT,INFXS1RT )
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SRT
+! ----------------------------------------------------------------------
+! CALCULATE THE RIGHT HAND SIDE OF THE TIME TENDENCY TERM OF THE SOIL
+! WATER DIFFUSION EQUATION.  ALSO TO COMPUTE ( PREPARE ) THE MATRIX
+! COEFFICIENTS FOR THE TRI-DIAGONAL MATRIX OF THE IMPLICIT TIME SCHEME.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)       :: NSOIL
+      INTEGER                   :: IALP1, IOHINF, J, JJ,  K, KS
+
+!DJG NDHMS/WRF-Hydro edit... Variables used in OV routing infiltration calcs
+       REAL, INTENT(INOUT)     :: SFHEAD1RT, INFXS1RT
+       REAL                    :: SFCWATR,CHCKSM
+
+
+
+      REAL, INTENT(IN)          :: BEXP, DKSAT, DT, DWSAT, EDIR, FRZX,  &
+                                   KDT, PCPDRP, SLOPE, SMCMAX, SMCWLT
+      REAL, INTENT(OUT)         :: RUNOFF1, RUNOFF2
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: ET, SH2O, SH2OA, SICE,  &
+                                                ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT)  :: RHSTT
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT)  :: AI, BI, CI
+      REAL, DIMENSION(1:NSOIL)  :: DMAX
+      REAL                      :: ACRT, DD, DDT, DDZ, DDZ2, DENOM,     &
+                                   DENOM2,DICE, DSMDZ, DSMDZ2, DT1,     &
+                                   FCR,INFMAX,MXSMC,MXSMC2,NUMER,PDDUM, &
+                                   PX, SICEMAX,SLOPX, SMCAV, SSTT,      &
+                                   SUM, VAL, WCND, WCND2, WDF, WDF2
+      INTEGER, PARAMETER        :: CVFRZ = 3
+
+! ----------------------------------------------------------------------
+! FROZEN GROUND VERSION:
+! REFERENCE FROZEN GROUND PARAMETER, CVFRZ, IS A SHAPE PARAMETER OF
+! AREAL DISTRIBUTION FUNCTION OF SOIL ICE CONTENT WHICH EQUALS 1/CV.
+! CV IS A COEFFICIENT OF SPATIAL VARIATION OF SOIL ICE CONTENT.  BASED
+! ON FIELD DATA CV DEPENDS ON AREAL MEAN OF FROZEN DEPTH, AND IT CLOSE
+! TO CONSTANT = 0.6 IF AREAL MEAN FROZEN DEPTH IS ABOVE 20 CM.  THAT IS
+! WHY PARAMETER CVFRZ = 3 (INT{1/0.6*0.6}).
+! CURRENT LOGIC DOESN'T ALLOW CVFRZ BE BIGGER THAN 3
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+! DETERMINE RAINFALL INFILTRATION RATE AND RUNOFF.  INCLUDE THE
+! INFILTRATION FORMULE FROM SCHAAKE AND KOREN MODEL.
+! MODIFIED BY Q DUAN
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! LET SICEMAX BE THE GREATEST, IF ANY, FROZEN WATER CONTENT WITHIN SOIL
+! LAYERS.
+! ----------------------------------------------------------------------
+      IOHINF = 1
+      SICEMAX = 0.0
+      DO KS = 1,NSOIL
+         IF (SICE (KS) >  SICEMAX) SICEMAX = SICE (KS)
+! ----------------------------------------------------------------------
+! DETERMINE RAINFALL INFILTRATION RATE AND RUNOFF
+! ----------------------------------------------------------------------
+      END DO
+
+#ifdef WRF_HYDRO
+!DJG NDHMS/WRF-Hydro edit...
+!DJG Use previously merged Precip and Sfchead for infil. cap. calc.
+      SFCWATR = PCPDRP
+      PDDUM = SFCWATR
+!DJG original   PDDUM = PCPDRP
+      RUNOFF1 = 0.0
+      INFXS1RT = 0.0
+#else
+      PDDUM = PCPDRP
+      RUNOFF1 = 0.0
+#endif
+
+
+
+! ----------------------------------------------------------------------
+! MODIFIED BY Q. DUAN, 5/16/94
+! ----------------------------------------------------------------------
+!        IF (IOHINF == 1) THEN
+
+#ifdef WRF_HYDRO
+!DJG NDHMS/WRF-Hydro edit...
+!DJG IF (PCPDRP /=  0.0) THEN
+      IF (SFCWATR /=  0.0) THEN
+#else
+     IF (PCPDRP /=  0.0) THEN
+#endif
+         DT1 = DT /86400.
+         SMCAV = SMCMAX - SMCWLT
+
+! ----------------------------------------------------------------------
+! FROZEN GROUND VERSION:
+! ----------------------------------------------------------------------
+         DMAX (1)= - ZSOIL (1)* SMCAV
+
+         DICE = - ZSOIL (1) * SICE (1)
+         DMAX (1)= DMAX (1)* (1.0- (SH2OA (1) + SICE (1) - SMCWLT)/      &
+                    SMCAV)
+
+         DD = DMAX (1)
+
+! ----------------------------------------------------------------------
+! FROZEN GROUND VERSION:
+! ----------------------------------------------------------------------
+         DO KS = 2,NSOIL
+
+            DICE = DICE+ ( ZSOIL (KS -1) - ZSOIL (KS) ) * SICE (KS)
+            DMAX (KS) = (ZSOIL (KS -1) - ZSOIL (KS))* SMCAV
+            DMAX (KS) = DMAX (KS)* (1.0- (SH2OA (KS) + SICE (KS)        &
+                        - SMCWLT)/ SMCAV)
+            DD = DD+ DMAX (KS)
+! ----------------------------------------------------------------------
+! VAL = (1.-EXP(-KDT*SQRT(DT1)))
+! IN BELOW, REMOVE THE SQRT IN ABOVE
+! ----------------------------------------------------------------------
+         END DO
+         VAL = (1. - EXP ( - KDT * DT1))
+         DDT = DD * VAL
+#ifdef WRF_HYDRO
+!DJG NDHMS/WRF-Hydro edit...
+!DJG        PX = PCPDRP * DT
+         PX = SFCWATR * DT
+#else
+         PX = PCPDRP * DT
+#endif
+         IF (PX <  0.0) PX = 0.0
+
+
+
+! ----------------------------------------------------------------------
+! FROZEN GROUND VERSION:
+! REDUCTION OF INFILTRATION BASED ON FROZEN GROUND PARAMETERS
+! ----------------------------------------------------------------------
+         INFMAX = (PX * (DDT / (PX + DDT)))/ DT
+         FCR = 1.
+         IF (DICE >  1.E-2) THEN
+            ACRT = CVFRZ * FRZX / DICE
+            SUM = 1.
+            IALP1 = CVFRZ - 1
+            DO J = 1,IALP1
+               K = 1
+               DO JJ = J +1,IALP1
+                  K = K * JJ
+               END DO
+               SUM = SUM + (ACRT ** ( CVFRZ - J)) / FLOAT (K)
+            END DO
+            FCR = 1. - EXP ( - ACRT) * SUM
+         END IF
+
+! ----------------------------------------------------------------------
+! CORRECTION OF INFILTRATION LIMITATION:
+! IF INFMAX .LE. HYDROLIC CONDUCTIVITY ASSIGN INFMAX THE VALUE OF
+! HYDROLIC CONDUCTIVITY
+! ----------------------------------------------------------------------
+!         MXSMC = MAX ( SH2OA(1), SH2OA(2) )
+         INFMAX = INFMAX * FCR
+
+         MXSMC = SH2OA (1)
+         CALL WDFCND_gpu (WDF,WCND,MXSMC,SMCMAX,BEXP,DKSAT,DWSAT,           &
+                         SICEMAX)
+         INFMAX = MAX (INFMAX,WCND)
+
+         INFMAX = MIN (INFMAX,PX/DT)
+#ifdef WRF_HYDRO 
+!DJG NDHMS/WRF-Hydro edit...
+!DJG       IF (PCPDRP >  INFMAX) THEN
+         IF (SFCWATR > INFMAX) THEN
+!DJG          RUNOFF1 = PCPDRP - INFMAX
+          RUNOFF1 = SFCWATR - INFMAX
+#else
+         IF (PCPDRP >  INFMAX) THEN
+            RUNOFF1 = PCPDRP - INFMAX
+#endif
+          INFXS1RT = RUNOFF1*DT*1000.
+          PDDUM = INFMAX
+         END IF
+
+! ----------------------------------------------------------------------
+! TO AVOID SPURIOUS DRAINAGE BEHAVIOR, 'UPSTREAM DIFFERENCING' IN LINE
+! BELOW REPLACED WITH NEW APPROACH IN 2ND LINE:
+! 'MXSMC = MAX(SH2OA(1), SH2OA(2))'
+! ----------------------------------------------------------------------
+      END IF
+
+      MXSMC = SH2OA (1)
+      CALL WDFCND_gpu (WDF,WCND,MXSMC,SMCMAX,BEXP,DKSAT,DWSAT,              &
+                    SICEMAX)
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEFFICIENTS AI, BI, AND CI FOR THE TOP LAYER
+! ----------------------------------------------------------------------
+      DDZ = 1. / ( - .5 * ZSOIL (2) )
+      AI (1) = 0.0
+      BI (1) = WDF * DDZ / ( - ZSOIL (1) )
+
+! ----------------------------------------------------------------------
+! CALC RHSTT FOR THE TOP LAYER AFTER CALC'NG THE VERTICAL SOIL MOISTURE
+! GRADIENT BTWN THE TOP AND NEXT TO TOP LAYERS.
+! ----------------------------------------------------------------------
+      CI (1) = - BI (1)
+      DSMDZ = ( SH2O (1) - SH2O (2) ) / ( - .5 * ZSOIL (2) )
+      RHSTT (1) = (WDF * DSMDZ + WCND- PDDUM + EDIR + ET (1))/ ZSOIL (1)
+
+! ----------------------------------------------------------------------
+! INITIALIZE DDZ2
+! ----------------------------------------------------------------------
+      SSTT = WDF * DSMDZ + WCND+ EDIR + ET (1)
+
+! ----------------------------------------------------------------------
+! LOOP THRU THE REMAINING SOIL LAYERS, REPEATING THE ABV PROCESS
+! ----------------------------------------------------------------------
+      DDZ2 = 0.0
+      DO K = 2,NSOIL
+         DENOM2 = (ZSOIL (K -1) - ZSOIL (K))
+         IF (K /= NSOIL) THEN
+
+! ----------------------------------------------------------------------
+! AGAIN, TO AVOID SPURIOUS DRAINAGE BEHAVIOR, 'UPSTREAM DIFFERENCING' IN
+! LINE BELOW REPLACED WITH NEW APPROACH IN 2ND LINE:
+! 'MXSMC2 = MAX (SH2OA(K), SH2OA(K+1))'
+! ----------------------------------------------------------------------
+            SLOPX = 1.
+
+            MXSMC2 = SH2OA (K)
+            CALL WDFCND_gpu (WDF2,WCND2,MXSMC2,SMCMAX,BEXP,DKSAT,DWSAT,     &
+                          SICEMAX)
+! -----------------------------------------------------------------------
+! CALC SOME PARTIAL PRODUCTS FOR LATER USE IN CALC'NG RHSTT
+! ----------------------------------------------------------------------
+            DENOM = (ZSOIL (K -1) - ZSOIL (K +1))
+
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEF, CI, AFTER CALC'NG ITS PARTIAL PRODUCT
+! ----------------------------------------------------------------------
+            DSMDZ2 = (SH2O (K) - SH2O (K +1)) / (DENOM * 0.5)
+            DDZ2 = 2.0 / DENOM
+            CI (K) = - WDF2 * DDZ2 / DENOM2
+
+         ELSE
+! ----------------------------------------------------------------------
+! SLOPE OF BOTTOM LAYER IS INTRODUCED
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+! RETRIEVE THE SOIL WATER DIFFUSIVITY AND HYDRAULIC CONDUCTIVITY FOR
+! THIS LAYER
+! ----------------------------------------------------------------------
+            SLOPX = SLOPE
+          CALL WDFCND_gpu (WDF2,WCND2,SH2OA (NSOIL),SMCMAX,BEXP,DKSAT,DWSAT,     &
+                            SICEMAX)
+
+! ----------------------------------------------------------------------
+! CALC A PARTIAL PRODUCT FOR LATER USE IN CALC'NG RHSTT
+! ----------------------------------------------------------------------
+
+! ----------------------------------------------------------------------
+! SET MATRIX COEF CI TO ZERO
+! ----------------------------------------------------------------------
+            DSMDZ2 = 0.0
+            CI (K) = 0.0
+! ----------------------------------------------------------------------
+! CALC RHSTT FOR THIS LAYER AFTER CALC'NG ITS NUMERATOR
+! ----------------------------------------------------------------------
+         END IF
+         NUMER = (WDF2 * DSMDZ2) + SLOPX * WCND2- (WDF * DSMDZ)         &
+                 - WCND+ ET (K)
+
+! ----------------------------------------------------------------------
+! CALC MATRIX COEFS, AI, AND BI FOR THIS LAYER
+! ----------------------------------------------------------------------
+         RHSTT (K) = NUMER / ( - DENOM2)
+         AI (K) = - WDF * DDZ / DENOM2
+
+! ----------------------------------------------------------------------
+! RESET VALUES OF WDF, WCND, DSMDZ, AND DDZ FOR LOOP TO NEXT LYR
+! RUNOFF2:  SUB-SURFACE OR BASEFLOW RUNOFF
+! ----------------------------------------------------------------------
+         BI (K) = - ( AI (K) + CI (K) )
+         IF (K .eq. NSOIL) THEN
+            RUNOFF2 = SLOPX * WCND2
+         END IF
+         IF (K .ne. NSOIL) THEN
+            WDF = WDF2
+            WCND = WCND2
+            DSMDZ = DSMDZ2
+            DDZ = DDZ2
+         END IF
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE SRT_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE SSTEP (SH2OOUT,SH2OIN,CMC,RHSTT,RHSCT,DT,              &
                         NSOIL,SMCMAX,CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,     &
                         AI,BI,CI, INFXS1RT)
@@ -4066,6 +8148,137 @@ CONTAINS
   END SUBROUTINE SSTEP
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE SSTEP_gpu (SH2OOUT,SH2OIN,CMC,RHSTT,RHSCT,DT,              &
+                        NSOIL,SMCMAX,CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,     &
+                        AI,BI,CI, INFXS1RT)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SSTEP
+! ----------------------------------------------------------------------
+! CALCULATE/UPDATE SOIL MOISTURE CONTENT VALUES AND CANOPY MOISTURE
+! CONTENT VALUES.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)       :: NSOIL
+      INTEGER                   :: I, K, KK11
+
+!!DJG NDHMS/WRF-Hydro edit...
+      REAL, INTENT(INOUT)       :: INFXS1RT
+      REAL                      :: AVAIL
+
+      REAL, INTENT(IN)          :: CMCMAX, DT, SMCMAX
+      REAL, INTENT(OUT)         :: RUNOFF3
+      REAL, INTENT(INOUT)       :: CMC
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)     :: SH2OIN, SICE, ZSOIL
+      REAL, DIMENSION(1:NSOIL), INTENT(OUT)    :: SH2OOUT
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT)  :: RHSTT, SMC
+      REAL, DIMENSION(1:NSOIL), INTENT(INOUT)  :: AI, BI, CI
+      REAL, DIMENSION(1:NSOIL)  :: RHSTTIN
+      REAL, DIMENSION(1:NSOIL)  :: CIIN
+      REAL                      :: DDZ, RHSCT, STOT, WPLUS
+
+! ----------------------------------------------------------------------
+! CREATE 'AMOUNT' VALUES OF VARIABLES TO BE INPUT TO THE
+! TRI-DIAGONAL MATRIX ROUTINE.
+! ----------------------------------------------------------------------
+      DO K = 1,NSOIL
+         RHSTT (K) = RHSTT (K) * DT
+         AI (K) = AI (K) * DT
+         BI (K) = 1. + BI (K) * DT
+         CI (K) = CI (K) * DT
+      END DO
+! ----------------------------------------------------------------------
+! COPY VALUES FOR INPUT VARIABLES BEFORE CALL TO ROSR12
+! ----------------------------------------------------------------------
+      DO K = 1,NSOIL
+         RHSTTIN (K) = RHSTT (K)
+      END DO
+      DO K = 1,NSOIL
+         CIIN (K) = CI (K)
+      END DO
+! ----------------------------------------------------------------------
+! CALL ROSR12 TO SOLVE THE TRI-DIAGONAL MATRIX
+! ----------------------------------------------------------------------
+      CALL ROSR12_gpu (CI,AI,BI,CIIN,RHSTTIN,RHSTT,NSOIL)
+! ----------------------------------------------------------------------
+! SUM THE PREVIOUS SMC VALUE AND THE MATRIX SOLUTION TO GET A
+! NEW VALUE.  MIN ALLOWABLE VALUE OF SMC WILL BE 0.02.
+! RUNOFF3: RUNOFF WITHIN SOIL LAYERS
+! ----------------------------------------------------------------------
+      WPLUS = 0.0
+      RUNOFF3 = 0.
+
+      DDZ = - ZSOIL (1)
+      DO K = 1,NSOIL
+         IF (K /= 1) DDZ = ZSOIL (K - 1) - ZSOIL (K)
+         SH2OOUT (K) = SH2OIN (K) + CI (K) + WPLUS / DDZ
+         STOT = SH2OOUT (K) + SICE (K)
+         IF (STOT > SMCMAX) THEN
+            IF (K .eq. 1) THEN
+               DDZ = - ZSOIL (1)
+            ELSE
+               KK11 = K - 1
+               DDZ = - ZSOIL (K) + ZSOIL (KK11)
+            END IF
+            WPLUS = (STOT - SMCMAX) * DDZ
+         ELSE
+            WPLUS = 0.
+         END IF
+         SMC (K) = MAX ( MIN (STOT,SMCMAX),0.02 )
+         SH2OOUT (K) = MAX ( (SMC (K) - SICE (K)),0.0)
+      END DO
+#ifdef WRF_HYDRO
+!DJG NDHMS/WRF-Hydro edit...
+!DJG Modifications to redstribute WPLUS/RUNOFF3 (soil moisture closure error) to soil profile
+!DJG beginning at bottom layer (NSOIL)
+         IF (WPLUS > 0.) THEN
+           DO K=NSOIL,2,-1
+
+               IF (K .eq. 2) THEN     !Assign soil depths
+                 DDZ = -ZSOIL(1)
+               ELSE
+                 DDZ = ZSOIL(K-2)-ZSOIL(K-1)
+               END IF
+
+               AVAIL = (SMCMAX - SMC(K-1)) * DDZ    !Det. Avail. Stor.
+
+!               print *, "ZZZZZ", K,DDZ,AVAIL,WPLUS,SMC(K),SMC(K-1),SMCMAX
+
+               IF (WPLUS <= AVAIL) THEN
+                 SMC(K-1) = SMC(K-1) + WPLUS/DDZ
+                 WPLUS = 0.
+               ELSE
+                 SMC(K-1) = SMCMAX
+                 WPLUS = WPLUS - AVAIL
+                 IF (K-1 .eq. 1) THEN
+                   INFXS1RT = INFXS1RT + WPLUS*1000
+                   WPLUS = 0.
+                 END IF
+               END IF
+
+!             SMC (K) = MAX ( MIN (STOT,SMCMAX),0.02 )
+             SH2OOUT (K) = MAX ( (SMC (K) - SICE (K)),0.0)
+
+           END DO
+         END IF
+!DJG NDHMS/WRF-Hydro edit...End of modification
+#endif
+
+
+! ----------------------------------------------------------------------
+! UPDATE CANOPY WATER CONTENT/INTERCEPTION (CMC).  CONVERT RHSCT TO
+! AN 'AMOUNT' VALUE AND ADD TO PREVIOUS CMC VALUE TO GET NEW CMC.
+! ----------------------------------------------------------------------
+      RUNOFF3 = WPLUS
+      CMC = CMC + DT * RHSCT
+      IF (CMC < 1.E-20) CMC = 0.0
+      CMC = MIN (CMC,CMCMAX)
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SSTEP_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE TBND (TU,TB,ZSOIL,ZBOT,K,NSOIL,TBND1)
 
 ! ----------------------------------------------------------------------
@@ -4109,6 +8322,49 @@ CONTAINS
   END SUBROUTINE TBND
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE TBND_gpu (TU,TB,ZSOIL,ZBOT,K,NSOIL,TBND1)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE TBND
+! ----------------------------------------------------------------------
+! CALCULATE TEMPERATURE ON THE BOUNDARY OF THE LAYER BY INTERPOLATION OF
+! THE MIDDLE LAYER TEMPERATURES
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)       :: NSOIL
+      INTEGER                   :: K
+      REAL, INTENT(IN)          :: TB, TU, ZBOT
+      REAL, INTENT(OUT)         :: TBND1
+      REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: ZSOIL
+      REAL                      :: ZB, ZUP
+      REAL, PARAMETER           :: T0 = 273.15
+
+! ----------------------------------------------------------------------
+! USE SURFACE TEMPERATURE ON THE TOP OF THE FIRST LAYER
+! ----------------------------------------------------------------------
+     IF (K == 1) THEN
+         ZUP = 0.
+      ELSE
+         ZUP = ZSOIL (K -1)
+      END IF
+! ----------------------------------------------------------------------
+! USE DEPTH OF THE CONSTANT BOTTOM TEMPERATURE WHEN INTERPOLATE
+! TEMPERATURE INTO THE LAST LAYER BOUNDARY
+! ----------------------------------------------------------------------
+      IF (K ==  NSOIL) THEN
+         ZB = 2.* ZBOT - ZSOIL (K)
+      ELSE
+         ZB = ZSOIL (K +1)
+      END IF
+! ----------------------------------------------------------------------
+! LINEAR INTERPOLATION BETWEEN THE AVERAGE LAYER TEMPERATURES
+! ----------------------------------------------------------------------
+
+      TBND1 = TU + (TB - TU)* (ZUP - ZSOIL (K))/ (ZUP - ZB)
+! ----------------------------------------------------------------------
+  END SUBROUTINE TBND_gpu
+! ----------------------------------------------------------------------
 
       SUBROUTINE TDFCND ( DF, SMC, QZ, SMCMAX, SH2O, BEXP, PSISAT, SOILTYP, OPT_THCND)
 
@@ -4236,6 +8492,133 @@ IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3
   END SUBROUTINE TDFCND
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE TDFCND_gpu ( DF, SMC, QZ, SMCMAX, SH2O, BEXP, PSISAT, SOILTYP, OPT_THCND)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE TDFCND
+! ----------------------------------------------------------------------
+! CALCULATE THERMAL DIFFUSIVITY AND CONDUCTIVITY OF THE SOIL FOR A GIVEN
+! POINT AND TIME.
+! ----------------------------------------------------------------------
+! PETERS-LIDARD APPROACH (PETERS-LIDARD et al., 1998)
+! June 2001 CHANGES: FROZEN SOIL CONDITION.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER, INTENT(IN)       :: SOILTYP, OPT_THCND  
+      REAL, INTENT(IN)          :: QZ,  SMC, SMCMAX, SH2O, BEXP, PSISAT
+      REAL, INTENT(OUT)         :: DF
+      REAL                      :: AKE, GAMMD, THKDRY, THKICE, THKO,    &
+                                   THKQTZ,THKSAT,THKS,THKW,SATRATIO,XU, &
+                                   XUNFROZ,AKEI,AKEL,PSIF,PF  
+
+! ----------------------------------------------------------------------
+! WE NOW GET QUARTZ AS AN INPUT ARGUMENT (SET IN ROUTINE REDPRM):
+!      DATA QUARTZ /0.82, 0.10, 0.25, 0.60, 0.52,
+!     &             0.35, 0.60, 0.40, 0.82/
+! ----------------------------------------------------------------------
+! IF THE SOIL HAS ANY MOISTURE CONTENT COMPUTE A PARTIAL SUM/PRODUCT
+! OTHERWISE USE A CONSTANT VALUE WHICH WORKS WELL WITH MOST SOILS
+! ----------------------------------------------------------------------
+!  THKW ......WATER THERMAL CONDUCTIVITY
+!  THKQTZ ....THERMAL CONDUCTIVITY FOR QUARTZ
+!  THKO ......THERMAL CONDUCTIVITY FOR OTHER SOIL COMPONENTS
+!  THKS ......THERMAL CONDUCTIVITY FOR THE SOLIDS COMBINED(QUARTZ+OTHER)
+!  THKICE ....ICE THERMAL CONDUCTIVITY
+!  SMCMAX ....POROSITY (= SMCMAX)
+!  QZ .........QUARTZ CONTENT (SOIL TYPE DEPENDENT)
+! ----------------------------------------------------------------------
+! USE AS IN PETERS-LIDARD, 1998 (MODIF. FROM JOHANSEN, 1975).
+
+!                                  PABLO GRUNMANN, 08/17/98
+! REFS.:
+!      FAROUKI, O.T.,1986: THERMAL PROPERTIES OF SOILS. SERIES ON ROCK
+!              AND SOIL MECHANICS, VOL. 11, TRANS TECH, 136 PP.
+!      JOHANSEN, O., 1975: THERMAL CONDUCTIVITY OF SOILS. PH.D. THESIS,
+!              UNIVERSITY OF TRONDHEIM,
+!      PETERS-LIDARD, C. D., ET AL., 1998: THE EFFECT OF SOIL THERMAL
+!              CONDUCTIVITY PARAMETERIZATION ON SURFACE ENERGY FLUXES
+!              AND TEMPERATURES. JOURNAL OF THE ATMOSPHERIC SCIENCES,
+!              VOL. 55, PP. 1209-1224.
+! ----------------------------------------------------------------------
+
+IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3)) )THEN
+
+! NEEDS PARAMETERS
+! POROSITY(SOIL TYPE):
+!      POROS = SMCMAX
+! SATURATION RATIO:
+! PARAMETERS  W/(M.K)
+      SATRATIO = SMC / SMCMAX
+! ICE CONDUCTIVITY:
+      THKICE = 2.2
+! WATER CONDUCTIVITY:
+      THKW = 0.57
+! THERMAL CONDUCTIVITY OF "OTHER" SOIL COMPONENTS
+!      IF (QZ .LE. 0.2) THKO = 3.0
+      THKO = 2.0
+! QUARTZ' CONDUCTIVITY
+      THKQTZ = 7.7
+! SOLIDS' CONDUCTIVITY
+      THKS = (THKQTZ ** QZ)* (THKO ** (1. - QZ))
+
+! UNFROZEN FRACTION (FROM 1., i.e., 100%LIQUID, TO 0. (100% FROZEN))
+      XUNFROZ = SH2O / SMC
+! UNFROZEN VOLUME FOR SATURATION (POROSITY*XUNFROZ)
+      XU = XUNFROZ * SMCMAX
+
+! SATURATED THERMAL CONDUCTIVITY
+      THKSAT = THKS ** (1. - SMCMAX)* THKICE ** (SMCMAX - XU)* THKW **   &
+         (XU)
+
+! DRY DENSITY IN KG/M3
+      GAMMD = (1. - SMCMAX)*2700.
+
+! DRY THERMAL CONDUCTIVITY IN W.M-1.K-1
+      THKDRY = (0.135* GAMMD+ 64.7)/ (2700. - 0.947* GAMMD)
+! FROZEN
+         AKEI = SATRATIO
+! UNFROZEN
+! RANGE OF VALIDITY FOR THE KERSTEN NUMBER (AKE)
+
+! KERSTEN NUMBER (USING "FINE" FORMULA, VALID FOR SOILS CONTAINING AT
+! LEAST 5% OF PARTICLES WITH DIAMETER LESS THAN 2.E-6 METERS.)
+! (FOR "COARSE" FORMULA, SEE PETERS-LIDARD ET AL., 1998).
+
+         IF ( SATRATIO >  0.1 ) THEN
+
+            AKEL = LOG10 (SATRATIO) + 1.0
+
+! USE K = KDRY
+         ELSE
+
+            AKEL = 0.0
+         END IF
+      AKE = ((SMC-SH2O)*AKEI + SH2O*AKEL)/SMC
+!  THERMAL CONDUCTIVITY
+
+
+      DF = AKE * (THKSAT - THKDRY) + THKDRY
+
+    ELSE
+ 
+! use the Mccumber and Pielke approach for silt loam (4), sandy loam (3)
+
+         PSIF = PSISAT*100.*(SMCMAX/(SMC))**BEXP
+!--- PSIF should be in [CM] to compute PF
+           PF=log10(abs(PSIF))
+!--- HK is for McCumber thermal conductivity
+         IF(PF.LE.5.1) THEN
+           DF=420.*EXP(-(PF+2.7))
+         ELSE
+           DF=.1744
+         END IF
+
+    ENDIF  ! for OPT_THCND OPTIONS             
+! ----------------------------------------------------------------------
+  END SUBROUTINE TDFCND_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE TMPAVG (TAVG,TUP,TM,TDN,ZSOIL,NSOIL,K)
 
 ! ----------------------------------------------------------------------
@@ -4339,6 +8722,112 @@ IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3
       END IF
 ! ----------------------------------------------------------------------
   END SUBROUTINE TMPAVG
+! ----------------------------------------------------------------------
+
+      SUBROUTINE TMPAVG_gpu (TAVG,TUP,TM,TDN,ZSOIL,NSOIL,K)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE TMPAVG
+! ----------------------------------------------------------------------
+! CALCULATE SOIL LAYER AVERAGE TEMPERATURE (TAVG) IN FREEZING/THAWING
+! LAYER USING UP, DOWN, AND MIDDLE LAYER TEMPERATURES (TUP, TDN, TM),
+! WHERE TUP IS AT TOP BOUNDARY OF LAYER, TDN IS AT BOTTOM BOUNDARY OF
+! LAYER.  TM IS LAYER PROGNOSTIC STATE TEMPERATURE.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER  K
+
+      INTEGER  NSOIL
+      REAL     DZ
+      REAL     DZH
+      REAL     T0
+      REAL     TAVG
+      REAL     TDN
+      REAL     TM
+      REAL     TUP
+      REAL     X0
+      REAL     XDN
+      REAL     XUP
+
+      REAL     ZSOIL (NSOIL)
+
+! ----------------------------------------------------------------------
+      PARAMETER (T0 = 2.7315E2)
+      IF (K .eq. 1) THEN
+         DZ = - ZSOIL (1)
+      ELSE
+         DZ = ZSOIL (K -1) - ZSOIL (K)
+      END IF
+
+      DZH = DZ *0.5
+      IF (TUP .lt. T0) THEN
+         IF (TM .lt. T0) THEN
+! ----------------------------------------------------------------------
+! TUP, TM, TDN < T0
+! ----------------------------------------------------------------------
+            IF (TDN .lt. T0) THEN
+               TAVG = (TUP + 2.0* TM + TDN)/ 4.0
+! ----------------------------------------------------------------------
+! TUP & TM < T0,  TDN .ge. T0
+! ----------------------------------------------------------------------
+            ELSE
+               X0 = (T0- TM) * DZH / (TDN - TM)
+               TAVG = 0.5 * (TUP * DZH + TM * (DZH + X0) + T0* (        &
+     &               2.* DZH - X0)) / DZ
+            END IF
+         ELSE
+! ----------------------------------------------------------------------
+! TUP < T0, TM .ge. T0, TDN < T0
+! ----------------------------------------------------------------------
+            IF (TDN .lt. T0) THEN
+               XUP = (T0- TUP) * DZH / (TM - TUP)
+               XDN = DZH - (T0- TM) * DZH / (TDN - TM)
+               TAVG = 0.5 * (TUP * XUP + T0* (2.* DZ - XUP - XDN)       &
+     &                + TDN * XDN) / DZ
+! ----------------------------------------------------------------------
+! TUP < T0, TM .ge. T0, TDN .ge. T0
+! ----------------------------------------------------------------------
+            ELSE
+               XUP = (T0- TUP) * DZH / (TM - TUP)
+               TAVG = 0.5 * (TUP * XUP + T0* (2.* DZ - XUP)) / DZ
+            END IF
+         END IF
+      ELSE
+         IF (TM .lt. T0) THEN
+! ----------------------------------------------------------------------
+! TUP .ge. T0, TM < T0, TDN < T0
+! ----------------------------------------------------------------------
+            IF (TDN .lt. T0) THEN
+               XUP = DZH - (T0- TUP) * DZH / (TM - TUP)
+               TAVG = 0.5 * (T0* (DZ - XUP) + TM * (DZH + XUP)          &
+     &                + TDN * DZH) / DZ
+! ----------------------------------------------------------------------
+! TUP .ge. T0, TM < T0, TDN .ge. T0
+! ----------------------------------------------------------------------
+            ELSE
+               XUP = DZH - (T0- TUP) * DZH / (TM - TUP)
+               XDN = (T0- TM) * DZH / (TDN - TM)
+               TAVG = 0.5 * (T0* (2.* DZ - XUP - XDN) + TM *            &
+     & (XUP + XDN)) / DZ
+            END IF
+         ELSE
+! ----------------------------------------------------------------------
+! TUP .ge. T0, TM .ge. T0, TDN < T0
+! ----------------------------------------------------------------------
+            IF (TDN .lt. T0) THEN
+               XDN = DZH - (T0- TM) * DZH / (TDN - TM)
+               TAVG = (T0* (DZ - XDN) +0.5* (T0+ TDN)* XDN) / DZ
+! ----------------------------------------------------------------------
+! TUP .ge. T0, TM .ge. T0, TDN .ge. T0
+! ----------------------------------------------------------------------
+            ELSE
+               TAVG = (TUP + 2.0* TM + TDN) / 4.0
+            END IF
+         END IF
+      END IF
+! ----------------------------------------------------------------------
+  END SUBROUTINE TMPAVG_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE TRANSP (ET,NSOIL,ETP1,SMC,CMC,ZSOIL,SHDFAC,SMCWLT,     &
@@ -4447,6 +8936,113 @@ IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3
   END SUBROUTINE TRANSP
 ! ----------------------------------------------------------------------
 
+      SUBROUTINE TRANSP_gpu (ET,NSOIL,ETP1,SMC,CMC,ZSOIL,SHDFAC,SMCWLT,     &
+     &                      CMCMAX,PC,CFACTR,SMCREF,SFCTMP,Q2,NROOT,    &
+     &                      RTDIS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE TRANSP
+! ----------------------------------------------------------------------
+! CALCULATE TRANSPIRATION FOR THE VEG CLASS.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER  I
+      INTEGER  K
+      INTEGER  NSOIL
+
+      INTEGER  NROOT
+      REAL     CFACTR
+      REAL     CMC
+      REAL     CMCMAX
+      REAL     DENOM
+      REAL     ET (NSOIL)
+      REAL     ETP1
+      REAL     ETP1A
+!.....REAL PART(NSOIL)
+      REAL     GX (NROOT)
+      REAL     PC
+      REAL     Q2
+      REAL     RTDIS (NSOIL)
+      REAL     RTX
+      REAL     SFCTMP
+      REAL     SGX
+      REAL     SHDFAC
+      REAL     SMC (NSOIL)
+      REAL     SMCREF
+      REAL     SMCWLT
+
+! ----------------------------------------------------------------------
+! INITIALIZE PLANT TRANSP TO ZERO FOR ALL SOIL LAYERS.
+! ----------------------------------------------------------------------
+      REAL     ZSOIL (NSOIL)
+      DO K = 1,NSOIL
+         ET (K) = 0.
+! ----------------------------------------------------------------------
+! CALCULATE AN 'ADJUSTED' POTENTIAL TRANSPIRATION
+! IF STATEMENT BELOW TO AVOID TANGENT LINEAR PROBLEMS NEAR ZERO
+! NOTE: GX AND OTHER TERMS BELOW REDISTRIBUTE TRANSPIRATION BY LAYER,
+! ET(K), AS A FUNCTION OF SOIL MOISTURE AVAILABILITY, WHILE PRESERVING
+! TOTAL ETP1A.
+! ----------------------------------------------------------------------
+      END DO
+      IF (CMC .ne. 0.0) THEN
+         ETP1A = SHDFAC * PC * ETP1 * (1.0- (CMC / CMCMAX) ** CFACTR)
+      ELSE
+         ETP1A = SHDFAC * PC * ETP1
+      END IF
+      SGX = 0.0
+      DO I = 1,NROOT
+         GX (I) = ( SMC (I) - SMCWLT ) / ( SMCREF - SMCWLT )
+         GX (I) = MAX ( MIN ( GX (I), 1. ), 0. )
+         SGX = SGX + GX (I)
+      END DO
+
+      SGX = SGX / NROOT
+      DENOM = 0.
+      DO I = 1,NROOT
+         RTX = RTDIS (I) + GX (I) - SGX
+         GX (I) = GX (I) * MAX ( RTX, 0. )
+         DENOM = DENOM + GX (I)
+      END DO
+
+      IF (DENOM .le. 0.0) DENOM = 1.
+      DO I = 1,NROOT
+         ET (I) = ETP1A * GX (I) / DENOM
+! ----------------------------------------------------------------------
+! ABOVE CODE ASSUMES A VERTICALLY UNIFORM ROOT DISTRIBUTION
+! CODE BELOW TESTS A VARIABLE ROOT DISTRIBUTION
+! ----------------------------------------------------------------------
+!      ET(1) = ( ZSOIL(1) / ZSOIL(NROOT) ) * GX * ETP1A
+!      ET(1) = ( ZSOIL(1) / ZSOIL(NROOT) ) * ETP1A
+! ----------------------------------------------------------------------
+! USING ROOT DISTRIBUTION AS WEIGHTING FACTOR
+! ----------------------------------------------------------------------
+!      ET(1) = RTDIS(1) * ETP1A
+!      ET(1) = ETP1A * PART(1)
+! ----------------------------------------------------------------------
+! LOOP DOWN THRU THE SOIL LAYERS REPEATING THE OPERATION ABOVE,
+! BUT USING THE THICKNESS OF THE SOIL LAYER (RATHER THAN THE
+! ABSOLUTE DEPTH OF EACH LAYER) IN THE FINAL CALCULATION.
+! ----------------------------------------------------------------------
+!      DO K = 2,NROOT
+!        GX = ( SMC(K) - SMCWLT ) / ( SMCREF - SMCWLT )
+!        GX = MAX ( MIN ( GX, 1. ), 0. )
+! TEST CANOPY RESISTANCE
+!        GX = 1.0
+!        ET(K) = ((ZSOIL(K)-ZSOIL(K-1))/ZSOIL(NROOT))*GX*ETP1A
+!        ET(K) = ((ZSOIL(K)-ZSOIL(K-1))/ZSOIL(NROOT))*ETP1A
+! ----------------------------------------------------------------------
+! USING ROOT DISTRIBUTION AS WEIGHTING FACTOR
+! ----------------------------------------------------------------------
+!        ET(K) = RTDIS(K) * ETP1A
+!        ET(K) = ETP1A*PART(K)
+!      END DO
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE TRANSP_gpu
+! ----------------------------------------------------------------------
+
       SUBROUTINE WDFCND (WDF,WCND,SMC,SMCMAX,BEXP,DKSAT,DWSAT,          &
      &                      SICEMAX)
 
@@ -4506,6 +9102,68 @@ IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE WDFCND
+! ----------------------------------------------------------------------
+
+      SUBROUTINE WDFCND_gpu (WDF,WCND,SMC,SMCMAX,BEXP,DKSAT,DWSAT,          &
+     &                      SICEMAX)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE WDFCND
+! ----------------------------------------------------------------------
+! CALCULATE SOIL WATER DIFFUSIVITY AND SOIL HYDRAULIC CONDUCTIVITY.
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+      REAL     BEXP
+      REAL     DKSAT
+      REAL     DWSAT
+      REAL     EXPON
+      REAL     FACTR1
+      REAL     FACTR2
+      REAL     SICEMAX
+      REAL     SMC
+      REAL     SMCMAX
+      REAL     VKWGT
+      REAL     WCND
+
+! ----------------------------------------------------------------------
+!     CALC THE RATIO OF THE ACTUAL TO THE MAX PSBL SOIL H2O CONTENT
+! ----------------------------------------------------------------------
+      REAL     WDF
+      FACTR1 = 0.05 / SMCMAX
+
+! ----------------------------------------------------------------------
+! PREP AN EXPNTL COEF AND CALC THE SOIL WATER DIFFUSIVITY
+! ----------------------------------------------------------------------
+      FACTR2 = SMC / SMCMAX
+      FACTR1 = MIN(FACTR1,FACTR2)
+      EXPON = BEXP + 2.0
+
+! ----------------------------------------------------------------------
+! FROZEN SOIL HYDRAULIC DIFFUSIVITY.  VERY SENSITIVE TO THE VERTICAL
+! GRADIENT OF UNFROZEN WATER. THE LATTER GRADIENT CAN BECOME VERY
+! EXTREME IN FREEZING/THAWING SITUATIONS, AND GIVEN THE RELATIVELY
+! FEW AND THICK SOIL LAYERS, THIS GRADIENT SUFFERES SERIOUS
+! TRUNCTION ERRORS YIELDING ERRONEOUSLY HIGH VERTICAL TRANSPORTS OF
+! UNFROZEN WATER IN BOTH DIRECTIONS FROM HUGE HYDRAULIC DIFFUSIVITY.
+! THEREFORE, WE FOUND WE HAD TO ARBITRARILY CONSTRAIN WDF
+! --
+! VERSION D_10CM: ........  FACTR1 = 0.2/SMCMAX
+! WEIGHTED APPROACH...................... PABLO GRUNMANN, 28_SEP_1999.
+! ----------------------------------------------------------------------
+      WDF = DWSAT * FACTR2 ** EXPON
+      IF (SICEMAX .gt. 0.0) THEN
+         VKWGT = 1./ (1. + (500.* SICEMAX)**3.)
+         WDF = VKWGT * WDF + (1. - VKWGT)* DWSAT * FACTR1** EXPON
+! ----------------------------------------------------------------------
+! RESET THE EXPNTL COEF AND CALC THE HYDRAULIC CONDUCTIVITY
+! ----------------------------------------------------------------------
+      END IF
+      EXPON = (2.0 * BEXP) + 3.0
+      WCND = DKSAT * FACTR2 ** EXPON
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE WDFCND_gpu
 ! ----------------------------------------------------------------------
 
       SUBROUTINE SFCDIF_off (ZLM,Z0,THZ0,THLM,SFCSPD,CZIL,AKMS,AKHS)
@@ -4743,6 +9401,244 @@ IF ( OPT_THCND == 1 .OR. ( OPT_THCND == 2 .AND. (SOILTYP /= 4 .AND. SOILTYP /= 3
       END DO
 ! ----------------------------------------------------------------------
   END SUBROUTINE SFCDIF_off
+! ----------------------------------------------------------------------
+
+      SUBROUTINE SFCDIF_off_gpu (ZLM,Z0,THZ0,THLM,SFCSPD,CZIL,AKMS,AKHS)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! SUBROUTINE SFCDIF (renamed SFCDIF_off to avoid clash with Eta PBL)
+! ----------------------------------------------------------------------
+! CALCULATE SURFACE LAYER EXCHANGE COEFFICIENTS VIA ITERATIVE PROCESS.
+! SEE CHEN ET AL (1997, BLM)
+! ----------------------------------------------------------------------
+
+      IMPLICIT NONE
+      REAL     WWST, WWST2, G, VKRM, EXCM, BETA, BTG, ELFC, WOLD, WNEW
+      REAL     PIHF, EPSU2, EPSUST, EPSIT, EPSA, ZTMIN, ZTMAX, HPBL,     &
+     & SQVISC
+      REAL     RIC, RRIC, FHNEU, RFC, RFAC, ZZ, PSLMU, PSLMS, PSLHU,     &
+     & PSLHS
+      REAL     XX, PSPMU, YY, PSPMS, PSPHU, PSPHS, ZLM, Z0, THZ0, THLM
+      REAL     SFCSPD, CZIL, AKMS, AKHS, ZILFC, ZU, ZT, RDZ, CXCH
+      REAL     DTHV, DU2, BTGH, WSTAR2, USTAR, ZSLU, ZSLT, RLOGU, RLOGT
+      REAL     RLMO, ZETALT, ZETALU, ZETAU, ZETAT, XLU4, XLT4, XU4, XT4
+!CC   ......REAL ZTFC
+
+      REAL     XLU, XLT, XU, XT, PSMZ, SIMM, PSHZ, SIMH, USTARK, RLMN,  &
+     &         RLMA
+
+      INTEGER  ITRMX, ILECH, ITR
+      PARAMETER                                                         &
+     &        (WWST = 1.2,WWST2 = WWST * WWST,G = 9.8,VKRM = 0.40,      &
+     &         EXCM = 0.001                                             &
+     &        ,BETA = 1./270.,BTG = BETA * G,ELFC = VKRM * BTG          &
+     &                  ,WOLD =.15,WNEW = 1. - WOLD,ITRMX = 05,         &
+     &                   PIHF = 3.14159265/2.)
+      PARAMETER                                                         &
+     &         (EPSU2 = 1.E-4,EPSUST = 0.07,EPSIT = 1.E-4,EPSA = 1.E-8  &
+     &         ,ZTMIN = -5.,ZTMAX = 1.,HPBL = 1000.0                    &
+     &          ,SQVISC = 258.2)
+      PARAMETER                                                         &
+     &       (RIC = 0.183,RRIC = 1.0/ RIC,FHNEU = 0.8,RFC = 0.191       &
+     &        ,RFAC = RIC / (FHNEU * RFC * RFC))
+
+! ----------------------------------------------------------------------
+! NOTE: THE TWO CODE BLOCKS BELOW DEFINE FUNCTIONS
+! ----------------------------------------------------------------------
+! LECH'S SURFACE FUNCTIONS
+! ----------------------------------------------------------------------
+      PSLMU (ZZ)= -0.96* log (1.0-4.5* ZZ)
+      PSLMS (ZZ)= ZZ * RRIC -2.076* (1. -1./ (ZZ +1.))
+      PSLHU (ZZ)= -0.96* log (1.0-4.5* ZZ)
+
+! ----------------------------------------------------------------------
+! PAULSON'S SURFACE FUNCTIONS
+! ----------------------------------------------------------------------
+      PSLHS (ZZ)= ZZ * RFAC -2.076* (1. -1./ (ZZ +1.))
+      PSPMU (XX)= -2.* log ( (XX +1.)*0.5) - log ( (XX * XX +1.)*0.5)   &
+     &        +2.* ATAN (XX)                                            &
+     &- PIHF
+      PSPMS (YY)= 5.* YY
+      PSPHU (XX)= -2.* log ( (XX * XX +1.)*0.5)
+
+! ----------------------------------------------------------------------
+! THIS ROUTINE SFCDIF CAN HANDLE BOTH OVER OPEN WATER (SEA, OCEAN) AND
+! OVER SOLID SURFACE (LAND, SEA-ICE).
+! ----------------------------------------------------------------------
+      PSPHS (YY)= 5.* YY
+
+! ----------------------------------------------------------------------
+!     ZTFC: RATIO OF ZOH/ZOM  LESS OR EQUAL THAN 1
+!     C......ZTFC=0.1
+!     CZIL: CONSTANT C IN Zilitinkevich, S. S.1995,:NOTE ABOUT ZT
+! ----------------------------------------------------------------------
+      ILECH = 0
+
+! ----------------------------------------------------------------------
+      ZILFC = - CZIL * VKRM * SQVISC
+!     C.......ZT=Z0*ZTFC
+      ZU = Z0
+      RDZ = 1./ ZLM
+      CXCH = EXCM * RDZ
+      DTHV = THLM - THZ0
+
+! ----------------------------------------------------------------------
+! BELJARS CORRECTION OF USTAR
+! ----------------------------------------------------------------------
+      DU2 = MAX (SFCSPD * SFCSPD,EPSU2)
+!cc   If statements to avoid TANGENT LINEAR problems near zero
+      BTGH = BTG * HPBL
+      IF (BTGH * AKHS * DTHV .ne. 0.0) THEN
+         WSTAR2 = WWST2* ABS (BTGH * AKHS * DTHV)** (2./3.)
+      ELSE
+         WSTAR2 = 0.0
+      END IF
+
+! ----------------------------------------------------------------------
+! ZILITINKEVITCH APPROACH FOR ZT
+! ----------------------------------------------------------------------
+      USTAR = MAX (SQRT (AKMS * SQRT (DU2+ WSTAR2)),EPSUST)
+
+! ----------------------------------------------------------------------
+      ZT = EXP (ZILFC * SQRT (USTAR * Z0))* Z0
+      ZSLU = ZLM + ZU
+!     PRINT*,'ZSLT=',ZSLT
+!     PRINT*,'ZLM=',ZLM
+!     PRINT*,'ZT=',ZT
+
+      ZSLT = ZLM + ZT
+      RLOGU = log (ZSLU / ZU)
+
+      RLOGT = log (ZSLT / ZT)
+!     PRINT*,'RLMO=',RLMO
+!     PRINT*,'ELFC=',ELFC
+!     PRINT*,'AKHS=',AKHS
+!     PRINT*,'DTHV=',DTHV
+!     PRINT*,'USTAR=',USTAR
+
+      RLMO = ELFC * AKHS * DTHV / USTAR **3
+! ----------------------------------------------------------------------
+! 1./MONIN-OBUKKHOV LENGTH-SCALE
+! ----------------------------------------------------------------------
+      DO ITR = 1,ITRMX
+         ZETALT = MAX (ZSLT * RLMO,ZTMIN)
+         RLMO = ZETALT / ZSLT
+         ZETALU = ZSLU * RLMO
+         ZETAU = ZU * RLMO
+
+         ZETAT = ZT * RLMO
+         IF (ILECH .eq. 0) THEN
+            IF (RLMO .lt. 0.)THEN
+               XLU4 = 1. -16.* ZETALU
+               XLT4 = 1. -16.* ZETALT
+               XU4 = 1. -16.* ZETAU
+
+               XT4 = 1. -16.* ZETAT
+               XLU = SQRT (SQRT (XLU4))
+               XLT = SQRT (SQRT (XLT4))
+               XU = SQRT (SQRT (XU4))
+
+               XT = SQRT (SQRT (XT4))
+!     PRINT*,'-----------1------------'
+!     PRINT*,'PSMZ=',PSMZ
+!     PRINT*,'PSPMU(ZETAU)=',PSPMU(ZETAU)
+!     PRINT*,'XU=',XU
+!     PRINT*,'------------------------'
+               PSMZ = PSPMU (XU)
+               SIMM = PSPMU (XLU) - PSMZ + RLOGU
+               PSHZ = PSPHU (XT)
+               SIMH = PSPHU (XLT) - PSHZ + RLOGT
+            ELSE
+               ZETALU = MIN (ZETALU,ZTMAX)
+               ZETALT = MIN (ZETALT,ZTMAX)
+!     PRINT*,'-----------2------------'
+!     PRINT*,'PSMZ=',PSMZ
+!     PRINT*,'PSPMS(ZETAU)=',PSPMS(ZETAU)
+!     PRINT*,'ZETAU=',ZETAU
+!     PRINT*,'------------------------'
+               PSMZ = PSPMS (ZETAU)
+               SIMM = PSPMS (ZETALU) - PSMZ + RLOGU
+               PSHZ = PSPHS (ZETAT)
+               SIMH = PSPHS (ZETALT) - PSHZ + RLOGT
+            END IF
+! ----------------------------------------------------------------------
+! LECH'S FUNCTIONS
+! ----------------------------------------------------------------------
+         ELSE
+            IF (RLMO .lt. 0.)THEN
+!     PRINT*,'-----------3------------'
+!     PRINT*,'PSMZ=',PSMZ
+!     PRINT*,'PSLMU(ZETAU)=',PSLMU(ZETAU)
+!     PRINT*,'ZETAU=',ZETAU
+!     PRINT*,'------------------------'
+               PSMZ = PSLMU (ZETAU)
+               SIMM = PSLMU (ZETALU) - PSMZ + RLOGU
+               PSHZ = PSLHU (ZETAT)
+               SIMH = PSLHU (ZETALT) - PSHZ + RLOGT
+            ELSE
+               ZETALU = MIN (ZETALU,ZTMAX)
+
+               ZETALT = MIN (ZETALT,ZTMAX)
+!     PRINT*,'-----------4------------'
+!     PRINT*,'PSMZ=',PSMZ
+!     PRINT*,'PSLMS(ZETAU)=',PSLMS(ZETAU)
+!     PRINT*,'ZETAU=',ZETAU
+!     PRINT*,'------------------------'
+               PSMZ = PSLMS (ZETAU)
+               SIMM = PSLMS (ZETALU) - PSMZ + RLOGU
+               PSHZ = PSLHS (ZETAT)
+               SIMH = PSLHS (ZETALT) - PSHZ + RLOGT
+            END IF
+! ----------------------------------------------------------------------
+! BELJAARS CORRECTION FOR USTAR
+! ----------------------------------------------------------------------
+         END IF
+
+! ----------------------------------------------------------------------
+! ZILITINKEVITCH FIX FOR ZT
+! ----------------------------------------------------------------------
+         USTAR = MAX (SQRT (AKMS * SQRT (DU2+ WSTAR2)),EPSUST)
+
+         ZT = EXP (ZILFC * SQRT (USTAR * Z0))* Z0
+         ZSLT = ZLM + ZT
+!-----------------------------------------------------------------------
+         RLOGT = log (ZSLT / ZT)
+         USTARK = USTAR * VKRM
+         AKMS = MAX (USTARK / SIMM,CXCH)
+!-----------------------------------------------------------------------
+! IF STATEMENTS TO AVOID TANGENT LINEAR PROBLEMS NEAR ZERO
+!-----------------------------------------------------------------------
+         AKHS = MAX (USTARK / SIMH,CXCH)
+         IF (BTGH * AKHS * DTHV .ne. 0.0) THEN
+            WSTAR2 = WWST2* ABS (BTGH * AKHS * DTHV)** (2./3.)
+         ELSE
+            WSTAR2 = 0.0
+         END IF
+!-----------------------------------------------------------------------
+         RLMN = ELFC * AKHS * DTHV / USTAR **3
+!-----------------------------------------------------------------------
+!     IF(ABS((RLMN-RLMO)/RLMA).LT.EPSIT)    GO TO 110
+!-----------------------------------------------------------------------
+         RLMA = RLMO * WOLD+ RLMN * WNEW
+!-----------------------------------------------------------------------
+         RLMO = RLMA
+!     PRINT*,'----------------------------'
+!     PRINT*,'SFCDIF OUTPUT !  ! ! ! ! ! ! ! !  !   !    !'
+
+!     PRINT*,'ZLM=',ZLM
+!     PRINT*,'Z0=',Z0
+!     PRINT*,'THZ0=',THZ0
+!     PRINT*,'THLM=',THLM
+!     PRINT*,'SFCSPD=',SFCSPD
+!     PRINT*,'CZIL=',CZIL
+!     PRINT*,'AKMS=',AKMS
+!     PRINT*,'AKHS=',AKHS
+!     PRINT*,'----------------------------'
+
+      END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE SFCDIF_off_gpu
 ! ----------------------------------------------------------------------
 
 END MODULE module_sf_noahlsm

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
@@ -9,7 +9,7 @@ use module_wrf_error
 #define FATAL_ERROR(M) call wrf_error_fatal( M )
 #endif
 
-  USE module_sf_noahlsm, ONLY : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, ROSR12
+  USE module_sf_noahlsm, ONLY : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, ROSR12, ROSR12_gpu
   USE module_sf_noahlsm, ONLY : LVCOEF_DATA
 
   PRIVATE :: ALCALC
@@ -409,6 +409,500 @@ CONTAINS
   END SUBROUTINE SFLX_GLACIAL
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE SFLX_GLACIAL_gpu (ims,ime,its,ite,XLAND,ICE,               &
+                           IILOC,JJLOC,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,     &    !C
+       &                   LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2,           &    !F
+       &                   TH2,Q2SAT,DQSDT2,                            &    !I
+       &                   ALB, SNOALB,TBOT, Z0BRD, Z0, EMISSI, EMBRD,  &    !S
+       &                   T1,STC,SNOWH,SNEQV,ALBEDO,CH,                &    !H
+! ----------------------------------------------------------------------
+! OUTPUTS, DIAGNOSTICS, PARAMETERS BELOW GENERALLY NOT NECESSARY WHEN
+! COUPLED WITH E.G. A NWP MODEL (SUCH AS THE NOAA/NWS/NCEP MESOSCALE ETA
+! MODEL).  OTHER APPLICATIONS MAY REQUIRE DIFFERENT OUTPUT VARIABLES.
+! ----------------------------------------------------------------------
+       &                   ETA,SHEAT, ETA_KINEMATIC,FDOWN,              &    !O
+       &                   ESNOW,DEW,                                   &    !O
+       &                   ETP,SSOIL,                                   &    !O
+       &                   FLX1,FLX2,FLX3,                              &    !O
+       &                   SNOMLT,SNCOVR,                               &    !O
+       &                   RUNOFF1,                                     &    !O
+       &                   Q1,                                          &    !D
+       &                   SNOTIME1,                                    &
+       &                   RIBB)
+! ----------------------------------------------------------------------
+! SUB-DRIVER FOR "Noah LSM" FAMILY OF PHYSICS SUBROUTINES FOR A
+! SOIL/VEG/SNOWPACK LAND-SURFACE MODEL TO UPDATE ICE TEMPERATURE, SKIN 
+! TEMPERATURE, SNOWPACK WATER CONTENT, SNOWDEPTH, AND ALL TERMS OF THE 
+! SURFACE ENERGY BALANCE (EXCLUDING INPUT ATMOSPHERIC FORCINGS OF 
+! DOWNWARD RADIATION AND PRECIP)
+! ----------------------------------------------------------------------
+! SFLX ARGUMENT LIST KEY:
+! ----------------------------------------------------------------------
+!  C  CONFIGURATION INFORMATION
+!  F  FORCING DATA
+!  I  OTHER (INPUT) FORCING DATA
+!  S  SURFACE CHARACTERISTICS
+!  H  HISTORY (STATE) VARIABLES
+!  O  OUTPUT VARIABLES
+!  D  DIAGNOSTIC OUTPUT
+! ----------------------------------------------------------------------
+! 1. CONFIGURATION INFORMATION (C):
+! ----------------------------------------------------------------------
+!   DT         TIMESTEP (SEC) (DT SHOULD NOT EXCEED 3600 SECS, RECOMMEND
+!                1800 SECS OR LESS)
+!   ZLVL       HEIGHT (M) ABOVE GROUND OF ATMOSPHERIC FORCING VARIABLES
+!   NSOIL      NUMBER OF SOIL LAYERS (AT LEAST 2, AND NOT GREATER THAN
+!                PARAMETER NSOLD SET BELOW)
+!   SLDPTH     THE THICKNESS OF EACH SOIL LAYER (M)
+! ----------------------------------------------------------------------
+! 3. FORCING DATA (F):
+! ----------------------------------------------------------------------
+!   LWDN       LW DOWNWARD RADIATION (W M-2; POSITIVE, NOT NET LONGWAVE)
+!   SOLNET     NET DOWNWARD SOLAR RADIATION ((W M-2; POSITIVE)
+!   SFCPRS     PRESSURE AT HEIGHT ZLVL ABOVE GROUND (PASCALS)
+!   PRCP       PRECIP RATE (KG M-2 S-1) (NOTE, THIS IS A RATE)
+!   SFCTMP     AIR TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   TH2        AIR POTENTIAL TEMPERATURE (K) AT HEIGHT ZLVL ABOVE GROUND
+!   Q2         MIXING RATIO AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   FFROZP     FRACTION OF FROZEN PRECIPITATION
+! ----------------------------------------------------------------------
+! 4. OTHER FORCING (INPUT) DATA (I):
+! ----------------------------------------------------------------------
+!   Q2SAT      SAT SPECIFIC HUMIDITY AT HEIGHT ZLVL ABOVE GROUND (KG KG-1)
+!   DQSDT2     SLOPE OF SAT SPECIFIC HUMIDITY CURVE AT T=SFCTMP
+!                (KG KG-1 K-1)
+! ----------------------------------------------------------------------
+! 5. CANOPY/SOIL CHARACTERISTICS (S):
+! ----------------------------------------------------------------------
+!   ALB        BACKROUND SNOW-FREE SURFACE ALBEDO (FRACTION), FOR JULIAN
+!                DAY OF YEAR (USUALLY FROM TEMPORAL INTERPOLATION OF
+!                MONTHLY MEAN VALUES' CALLING PROG MAY OR MAY NOT
+!                INCLUDE DIURNAL SUN ANGLE EFFECT)
+!   SNOALB     UPPER BOUND ON MAXIMUM ALBEDO OVER DEEP SNOW (E.G. FROM
+!                ROBINSON AND KUKLA, 1985, J. CLIM. & APPL. METEOR.)
+!   TBOT       BOTTOM SOIL TEMPERATURE (LOCAL YEARLY-MEAN SFC AIR
+!                TEMPERATURE)
+!   Z0BRD      Background fixed roughness length (M)
+!   Z0         Time varying roughness length (M) as function of snow depth
+!   EMBRD      Background surface emissivity (between 0 and 1)
+!   EMISSI     Surface emissivity (between 0 and 1)
+! ----------------------------------------------------------------------
+! 6. HISTORY (STATE) VARIABLES (H):
+! ----------------------------------------------------------------------
+!  T1          GROUND/CANOPY/SNOWPACK) EFFECTIVE SKIN TEMPERATURE (K)
+!  STC(NSOIL)  SOIL TEMP (K)
+!  SNOWH       ACTUAL SNOW DEPTH (M)
+!  SNEQV       LIQUID WATER-EQUIVALENT SNOW DEPTH (M)
+!                NOTE: SNOW DENSITY = SNEQV/SNOWH
+!  ALBEDO      SURFACE ALBEDO INCLUDING SNOW EFFECT (UNITLESS FRACTION)
+!                =SNOW-FREE ALBEDO (ALB) WHEN SNEQV=0, OR
+!                =FCT(MSNOALB,ALB,SHDFAC,SHDMIN) WHEN SNEQV>0
+!  CH          SURFACE EXCHANGE COEFFICIENT FOR HEAT AND MOISTURE
+!                (M S-1); NOTE: CH IS TECHNICALLY A CONDUCTANCE SINCE
+!                IT HAS BEEN MULTIPLIED BY WIND SPEED.
+! ----------------------------------------------------------------------
+! 7. OUTPUT (O):
+! ----------------------------------------------------------------------
+! OUTPUT VARIABLES NECESSARY FOR A COUPLED NUMERICAL WEATHER PREDICTION
+! MODEL, E.G. NOAA/NWS/NCEP MESOSCALE ETA MODEL.  FOR THIS APPLICATION,
+! THE REMAINING OUTPUT/DIAGNOSTIC/PARAMETER BLOCKS BELOW ARE NOT
+! NECESSARY.  OTHER APPLICATIONS MAY REQUIRE DIFFERENT OUTPUT VARIABLES.
+!   ETA        ACTUAL LATENT HEAT FLUX (W m-2: NEGATIVE, IF UP FROM
+!              SURFACE)
+!  ETA_KINEMATIC atctual latent heat flux in Kg m-2 s-1
+!   SHEAT      SENSIBLE HEAT FLUX (W M-2: NEGATIVE, IF UPWARD FROM
+!              SURFACE)
+!   FDOWN      Radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+! ----------------------------------------------------------------------
+!   ESNOW      SUBLIMATION FROM (OR DEPOSITION TO IF <0) SNOWPACK
+!                (W m-2)
+!   DEW        DEWFALL (OR FROSTFALL FOR T<273.15) (M)
+! ----------------------------------------------------------------------
+!   ETP        POTENTIAL EVAPORATION (W m-2)
+!   SSOIL      SOIL HEAT FLUX (W M-2: NEGATIVE IF DOWNWARD FROM SURFACE)
+! ----------------------------------------------------------------------
+!   FLX1       PRECIP-SNOW SFC (W M-2)
+!   FLX2       FREEZING RAIN LATENT HEAT FLUX (W M-2)
+!   FLX3       PHASE-CHANGE HEAT FLUX FROM SNOWMELT (W M-2)
+! ----------------------------------------------------------------------
+!   SNOMLT     SNOW MELT (M) (WATER EQUIVALENT)
+!   SNCOVR     FRACTIONAL SNOW COVER (UNITLESS FRACTION, 0-1)
+! ----------------------------------------------------------------------
+!   RUNOFF1    SURFACE RUNOFF (M S-1), NOT INFILTRATING THE SURFACE
+! ----------------------------------------------------------------------
+! 8. DIAGNOSTIC OUTPUT (D):
+! ----------------------------------------------------------------------
+!   Q1         Effective mixing ratio at surface (kg kg-1), used for
+!              diagnosing the mixing ratio at 2 meter for coupled model
+!  Documentation for SNOTIME1 and SNOABL2 ?????
+!  What categories of arguments do these variables fall into ????
+!  Documentation for RIBB ?????
+!  What category of argument does RIBB fall into ?????
+! ----------------------------------------------------------------------
+
+    IMPLICIT NONE
+! ----------------------------------------------------------------------
+    INTEGER, INTENT(IN) :: ims,ime,its,ite
+    REAL,    DIMENSION( ims:ime ), INTENT(IN) :: XLAND
+    INTEGER, DIMENSION( ims:ime ), INTENT(IN) :: ICE
+    INTEGER, INTENT(IN) ::  IILOC,JJLOC
+    INTEGER, INTENT(IN) ::  ISICE
+! ----------------------------------------------------------------------
+    LOGICAL, DIMENSION( ims:ime ) ::  FRZGRA, SNOWNG
+
+! ----------------------------------------------------------------------
+! 1. CONFIGURATION INFORMATION (C):
+! ----------------------------------------------------------------------
+    INTEGER, INTENT(IN) ::  NSOIL
+    INTEGER             ::  KZ
+
+! ----------------------------------------------------------------------
+! 2. LOGICAL:
+! ----------------------------------------------------------------------
+
+    REAL, INTENT(IN)   :: DT
+    REAL, DIMENSION( ims:ime ), INTENT(IN) :: FFROZP,ZLVL,LWDN,    &
+                   SOLNET,SFCPRS,PRCP,SFCTMP,Q2,TH2,Q2SAT,DQSDT2,  &
+                   SNOALB,TBOT
+    REAL, DIMENSION( ims:ime ), INTENT(OUT) :: EMBRD,ALBEDO
+    REAL, DIMENSION( ims:ime ), INTENT(INOUT):: SNCOVR
+    REAL, DIMENSION( ims:ime ), INTENT(INOUT) :: ALB,Z0BRD,EMISSI,T1, &
+                    SNOWH,SNEQV,CH
+    REAL, DIMENSION( ims:ime ), INTENT(INOUT):: SNOTIME1
+    REAL, DIMENSION( ims:ime ), INTENT(INOUT):: RIBB
+    REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(IN)    :: SLDPTH
+    REAL, DIMENSION(1:NSOIL,ims:ime), INTENT(INOUT) ::  STC
+    REAL, DIMENSION(1:NSOIL,ims:ime) ::   ZSOIL
+
+    REAL, DIMENSION( ims:ime ), INTENT(OUT) :: ETA,SHEAT,ETA_KINEMATIC, &
+                          FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,FLX2,FLX3,     &
+                          SNOMLT,RUNOFF1,Q1
+    REAL               :: PRCP1,RSNOW,     &
+         &                T1V,TH2V,TSNOW
+    REAL, DIMENSION( ims:ime ) :: Z0,SNDENS,SNCOND,SN_NEW,PRCPF,DF1,    &
+                          DSOIL,DTOT,FRCSNO,FRCSOI,T2V,RHO,RCH,T24,     &
+                          RR
+    INTEGER :: I
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - PARAMETERS
+! ----------------------------------------------------------------------
+    REAL, PARAMETER :: TFREEZ = 273.15
+    REAL, PARAMETER :: LVH2O = 2.501E+6
+    REAL, PARAMETER :: LSUBS = 2.83E+6
+    REAL, PARAMETER :: R = 287.04
+
+!!!$acc update device(XLAND,ICE,FFROZP,ZLVL,LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2,TH2,Q2SAT,DQSDT2, &
+!!!$acc               SNOALB,TBOT,EMBRD,ALBEDO,SNCOVR,ALB,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,       &
+!!!$acc               SNOTIME1,RIBB,SLDPTH,STC,ETA,SHEAT,ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,    &
+!!!$acc               SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,Q1,Z0)
+! ----------------------------------------------------------------------
+    ILOC = IILOC
+    JLOC = JJLOC
+!$acc data present(XLAND,ICE,FFROZP,ZLVL,LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2,TH2,Q2SAT,DQSDT2, &
+!$acc               SNOALB,TBOT,EMBRD,ALBEDO,SNCOVR,ALB,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,       &
+!$acc               SNOTIME1,RIBB,SLDPTH,STC,ETA,SHEAT,ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,    &
+!$acc               SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,Q1,Z0) &
+!$acc       create(SNDENS,SNCOND,SN_NEW,PRCPF,DF1,DSOIL,DTOT,FRCSNO,FRCSOI, &
+!$acc             T2V,RHO,RCH,T24,RR,ZSOIL,FRZGRA,SNOWNG)
+! ----------------------------------------------------------------------
+
+!$acc parallel vector_length(32)
+!$acc loop gang vector
+DO I=its,ite
+  IF((XLAND(I)-1.5).LT.0.)THEN
+    IF (ICE(I) == -1) THEN
+
+    ZSOIL (1,I) = - SLDPTH (1,I)
+    DO KZ = 2,NSOIL
+       ZSOIL (KZ,I) = - SLDPTH (KZ,I) + ZSOIL (KZ -1,I)
+    END DO
+
+! ----------------------------------------------------------------------
+! IF S.W.E. (SNEQV) BELOW THRESHOLD LOWER BOUND (0.10 M FOR GLACIAL 
+! ICE), THEN SET AT LOWER BOUND
+! ----------------------------------------------------------------------
+    IF ( SNEQV(I) < 0.10 ) THEN
+       SNEQV(I) = 0.10
+       SNOWH(I) = 0.50
+    ENDIF
+! ----------------------------------------------------------------------
+! IF INPUT SNOWPACK IS NONZERO, THEN COMPUTE SNOW DENSITY "SNDENS" AND
+! SNOW THERMAL CONDUCTIVITY "SNCOND"
+! ----------------------------------------------------------------------
+    SNDENS(I) = SNEQV(I) / SNOWH(I)
+    IF(SNDENS(I) > 1.0) THEN
+!!!       FATAL_ERROR( 'Physical snow depth is less than snow water equiv.' )
+    ENDIF
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+! ----------------------------------------------------------------------
+! DETERMINE IF IT'S PRECIPITATING AND WHAT KIND OF PRECIP IT IS.
+! IF IT'S PRCPING AND THE AIR TEMP IS COLDER THAN 0 C, IT'S SNOWING!
+! IF IT'S PRCPING AND THE AIR TEMP IS WARMER THAN 0 C, BUT THE GRND
+! TEMP IS COLDER THAN 0 C, FREEZING RAIN IS PRESUMED TO BE FALLING.
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    SNOWNG(I) = .FALSE.
+    FRZGRA(I) = .FALSE.
+    IF (PRCP(I) > 0.0) THEN
+! ----------------------------------------------------------------------
+! Snow defined when fraction of frozen precip (FFROZP) > 0.5,
+! passed in from model microphysics.
+! ----------------------------------------------------------------------
+       IF (FFROZP(I) .GT. 0.5) THEN
+          SNOWNG(I) = .TRUE.
+       ELSE
+          IF (T1(I) <= TFREEZ) FRZGRA(I) = .TRUE.
+       END IF
+    END IF
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+! ----------------------------------------------------------------------
+! IF EITHER PRCP FLAG IS SET, DETERMINE NEW SNOWFALL (CONVERTING PRCP
+! RATE FROM KG M-2 S-1 TO A LIQUID EQUIV SNOW DEPTH IN METERS) AND ADD
+! IT TO THE EXISTING SNOWPACK.
+! NOTE THAT SINCE ALL PRECIP IS ADDED TO SNOWPACK, NO PRECIP INFILTRATES
+! INTO THE SOIL SO THAT PRCP1 IS SET TO ZERO.
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    IF ( (SNOWNG(I)) .OR. (FRZGRA(I)) ) THEN
+       SN_NEW(I) = PRCP(I) * DT * 0.001
+       SNEQV(I) = SNEQV(I) + SN_NEW(I)
+       PRCPF(I) = 0.0
+
+! ----------------------------------------------------------------------
+! UPDATE SNOW DENSITY BASED ON NEW SNOWFALL, USING OLD AND NEW SNOW.
+! UPDATE SNOW THERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+       CALL SNOW_NEW_gpu (SFCTMP(I),SN_NEW(I),SNOWH(I),SNDENS(I))
+
+! ----------------------------------------------------------------------
+! kmh 09/04/2006 set Snow Density at 0.2 g/cm**3
+! for "cold permanent ice" or new "dry" snow
+! if soil temperature less than 268.15 K, treat as typical 
+! Antarctic/Greenland snow firn
+! ----------------------------------------------------------------------
+       IF ( SNCOVR(I) .GT. 0.99 ) THEN
+          IF ( STC(1,I) .LT. (TFREEZ - 5.) ) SNDENS(I) = 0.2
+          IF ( SNOWNG(I) .AND. (T1(I).LT.273.) .AND. (SFCTMP(I).LT.273.) ) SNDENS(I)=0.2
+       ENDIF
+
+       CALL CSNOW_gpu (SNCOND(I),SNDENS(I))
+
+! ----------------------------------------------------------------------
+! PRECIP IS LIQUID (RAIN), HENCE SAVE IN THE PRECIP VARIABLE THAT
+! LATER CAN WHOLELY OR PARTIALLY INFILTRATE THE SOIL
+! ----------------------------------------------------------------------
+    ELSE
+       PRCPF(I) = PRCP(I)
+    ENDIF
+
+! ----------------------------------------------------------------------
+! DETERMINE SNOW FRACTIONAL COVERAGE.
+!      KWM:  Set SNCOVR to 1.0 because SNUP is set small in VEGPARM.TBL,
+!      and SNEQV is at least 0.1 (as set above)
+! ----------------------------------------------------------------------
+    SNCOVR(I) = 1.0 
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! DETERMINE SURFACE ALBEDO MODIFICATION DUE TO SNOWDEPTH STATE.
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    CALL ALCALC_gpu (ALB(I),SNOALB(I),EMBRD(I),T1(I),ALBEDO(I),EMISSI(I),   &
+         &       DT,SNOWNG(I),SNOTIME1(I)) 
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! THERMAL CONDUCTIVITY 
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    DF1(I) = SNCOND(I)
+
+    DSOIL(I) = - (0.5 * ZSOIL (1,I))
+    DTOT(I) = SNOWH(I) + DSOIL(I)
+    FRCSNO(I) = SNOWH(I) / DTOT(I)
+
+! 1. HARMONIC MEAN (SERIES FLOW)
+!        DF1(I) = (SNCOND(I)*DF1(I))/(FRCSOI(I)*SNCOND(I)+FRCSNO(I)*DF1(I))
+    FRCSOI(I) = DSOIL(I) / DTOT(I)
+
+! 3. GEOMETRIC MEAN (INTERMEDIATE BETWEEN HARMONIC AND ARITHMETIC MEAN)
+!        DF1(I) = (SNCOND(I)**FRCSNO(I))*(DF1(I)**FRCSOI(I))
+    DF1(I) = FRCSNO(I) * SNCOND(I) + FRCSOI(I) * DF1(I)
+
+! ----------------------------------------------------------------------
+! CALCULATE SUBSURFACE HEAT FLUX, SSOIL, FROM FINAL THERMAL DIFFUSIVITY
+! OF SURFACE MEDIUMS, DF1 ABOVE, AND SKIN TEMPERATURE AND TOP
+! MID-LAYER SOIL TEMPERATURE
+! ----------------------------------------------------------------------
+    IF ( DTOT(I) .GT. 2.*DSOIL(I) ) then
+       DTOT(I) = 2.*DSOIL(I)
+    ENDIF
+    SSOIL(I) = DF1(I) * ( T1(I) - STC(1,I) ) / DTOT(I)
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! DETERMINE SURFACE ROUGHNESS OVER SNOWPACK USING SNOW CONDITION FROM
+! THE PREVIOUS TIMESTEP.
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    CALL SNOWZ0_gpu (Z0(I),Z0BRD(I),SNOWH(I))
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL DOWNWARD RADIATION (SOLAR PLUS LONGWAVE) NEEDED IN
+! PENMAN EP SUBROUTINE THAT FOLLOWS
+! ----------------------------------------------------------------------
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    FDOWN(I) = SOLNET(I) + LWDN(I)
+
+! ----------------------------------------------------------------------
+! CALC VIRTUAL TEMPS AND VIRTUAL POTENTIAL TEMPS NEEDED BY SUBROUTINES
+! PENMAN.
+! ----------------------------------------------------------------------
+
+    T2V(I) = SFCTMP(I) * (1.0+ 0.61 * Q2(I) )
+    RHO(I) = SFCPRS(I) / (RD * T2V(I))
+    RCH(I) = RHO(I) * 1004.6 * CH(I)
+    T24(I) = SFCTMP(I) * SFCTMP(I) * SFCTMP(I) * SFCTMP(I)
+
+! ----------------------------------------------------------------------
+! CALL PENMAN SUBROUTINE TO CALCULATE POTENTIAL EVAPORATION (ETP), AND
+! OTHER PARTIAL PRODUCTS AND SUMS SAVE IN COMMON/RITE FOR LATER
+! CALCULATIONS.
+! ----------------------------------------------------------------------
+
+    ! PENMAN returns ETP, FLX2, and RR
+    CALL PENMAN_gpu (SFCTMP(I),SFCPRS(I),CH(I),TH2(I),PRCP(I),FDOWN(I),T24(I),SSOIL(I),     &
+         &       Q2(I),Q2SAT(I),ETP(I),RCH(I),RR(I),SNOWNG(I),FRZGRA(I),             &
+         &       DQSDT2(I),FLX2(I),EMISSI(I),T1(I))
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+    CALL SNOPAC_gpu (ETP(I),ETA(I),PRCP(I),PRCPF(I),SNOWNG(I),NSOIL,DT,DF1(I),        &
+         &       Q2(I),T1(I),SFCTMP(I),T24(I),TH2(I),FDOWN(I),SSOIL(I),STC(1:NSOIL,I),          &
+         &       SFCPRS(I),RCH(I),RR(I),SNEQV(I),SNDENS(I),SNOWH(I),ZSOIL(1:NSOIL,I),TBOT(I),   &
+         &       SNOMLT(I),DEW(I),FLX1(I),FLX2(I),FLX3(I),ESNOW(I),EMISSI(I),RIBB(I))
+!!!    ENDIF
+!!!  ENDIF
+!!!ENDDO
+!!!!$acc end parallel
+
+!!!!$acc parallel vector_length(32)
+!!!!$acc loop gang vector 
+!!!DO I=its,ite
+!!!  IF((XLAND(I)-1.5).LT.0.)THEN
+!!!    IF (ICE(I) == -1) THEN
+!   ETA_KINEMATIC =  ESNOW
+    ETA_KINEMATIC(I) =  ETP(I)
+
+! ----------------------------------------------------------------------
+! Effective mixing ratio at grnd level (skin)
+! ----------------------------------------------------------------------
+    Q1(I)=Q2(I)+ETA_KINEMATIC(I)*CP/RCH(I)
+
+! ----------------------------------------------------------------------
+! DETERMINE SENSIBLE HEAT (H) IN ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+    SHEAT(I) = - (CH(I) * CP * SFCPRS(I))/ (R * T2V(I)) * ( TH2(I)- T1(I) )
+
+! ----------------------------------------------------------------------
+! CONVERT EVAP TERMS FROM KINEMATIC (KG M-2 S-1) TO ENERGY UNITS (W M-2)
+! ----------------------------------------------------------------------
+    ESNOW(I) = ESNOW(I) * LSUBS
+    ETP(I)   = ETP(I)   * LSUBS
+    IF (ETP(I) .GT. 0.) THEN
+       ETA(I) = ESNOW(I)
+    ELSE
+       ETA(I) = ETP(I)
+    ENDIF
+
+! ----------------------------------------------------------------------
+! CONVERT THE SIGN OF SOIL HEAT FLUX SO THAT:
+!   SSOIL>0: WARM THE SURFACE  (NIGHT TIME)
+!   SSOIL<0: COOL THE SURFACE  (DAY TIME)
+! ----------------------------------------------------------------------
+    SSOIL(I) = -1.0* SSOIL(I)
+
+! ----------------------------------------------------------------------
+! FOR THE CASE OF GLACIAL-ICE, ADD ANY SNOWMELT DIRECTLY TO SURFACE 
+! RUNOFF (RUNOFF1) SINCE THERE IS NO SOIL MEDIUM
+! ----------------------------------------------------------------------
+    RUNOFF1(I) = SNOMLT(I) / DT
+
+    ENDIF
+  ENDIF
+ENDDO
+!$acc end parallel
+
+!$acc end data
+!!!$acc update host(EMBRD,ALBEDO,SNCOVR,ALB,Z0BRD,EMISSI,T1,SNOWH,SNEQV,CH,SNOTIME1,RIBB,STC,Z0,   &
+!!!$acc             ETA,SHEAT,ETA_KINEMATIC,FDOWN,ESNOW,DEW,ETP,SSOIL,FLX1,FLX2,FLX3,SNOMLT,RUNOFF1,Q1)
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SFLX_GLACIAL_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE ALCALC (ALB,SNOALB,EMBRD,TSNOW,ALBEDO,EMISSI,   &
        &             DT,SNOWNG,SNOTIME1)
 
@@ -523,6 +1017,120 @@ CONTAINS
   END SUBROUTINE ALCALC
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE ALCALC_gpu (ALB,SNOALB,EMBRD,TSNOW,ALBEDO,EMISSI,   &
+       &             DT,SNOWNG,SNOTIME1)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE ALBEDO INCLUDING SNOW EFFECT (0 -> 1)
+!   ALB     SNOWFREE ALBEDO
+!   SNOALB  MAXIMUM (DEEP) SNOW ALBEDO
+!   ALBEDO  SURFACE ALBEDO INCLUDING SNOW EFFECT
+!   TSNOW   SNOW SURFACE TEMPERATURE (K)
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+
+! ----------------------------------------------------------------------
+! SNOALB IS ARGUMENT REPRESENTING MAXIMUM ALBEDO OVER DEEP SNOW,
+! AS PASSED INTO SFLX, AND ADAPTED FROM THE SATELLITE-BASED MAXIMUM
+! SNOW ALBEDO FIELDS PROVIDED BY D. ROBINSON AND G. KUKLA
+! (1985, JCAM, VOL 24, 402-411)
+! ----------------------------------------------------------------------
+    REAL,    INTENT(IN)    :: ALB, SNOALB, EMBRD, TSNOW
+    REAL,    INTENT(IN)    :: DT
+    LOGICAL, INTENT(IN)    :: SNOWNG
+    REAL,    INTENT(INOUT) :: SNOTIME1
+    REAL,    INTENT(OUT)   :: ALBEDO, EMISSI
+    REAL                   :: SNOALB2
+    REAL                   :: TM,SNOALB1
+    REAL,    PARAMETER     :: SNACCA=0.94,SNACCB=0.58,SNTHWA=0.82,SNTHWB=0.46
+! turn off vegetation effect
+!      ALBEDO = ALB + (1.0- (SHDFAC - SHDMIN))* SNCOVR * (SNOALB - ALB)
+!      ALBEDO = (1.0-SNCOVR)*ALB + SNCOVR*SNOALB !this is equivalent to below
+    ALBEDO = ALB + (SNOALB-ALB)
+    EMISSI = EMBRD + (EMISSI_S - EMBRD)
+
+!     BASE FORMULATION (DICKINSON ET AL., 1986, COGLEY ET AL., 1990)
+!          IF (TSNOW.LE.263.16) THEN
+!            ALBEDO=SNOALB
+!          ELSE
+!            IF (TSNOW.LT.273.16) THEN
+!              TM=0.1*(TSNOW-263.16)
+!              SNOALB1=0.5*((0.9-0.2*(TM**3))+(0.8-0.16*(TM**3)))
+!            ELSE
+!              SNOALB1=0.67
+!             IF(SNCOVR.GT.0.95) SNOALB1= 0.6
+!             SNOALB1 = ALB + SNCOVR*(SNOALB-ALB)
+!            ENDIF
+!          ENDIF
+!            ALBEDO = ALB + SNCOVR*(SNOALB1-ALB)
+
+!     ISBA FORMULATION (VERSEGHY, 1991; BAKER ET AL., 1990)
+!          SNOALB1 = SNOALB+COEF*(0.85-SNOALB)
+!          SNOALB2=SNOALB1
+!!m          LSTSNW=LSTSNW+1
+!          SNOTIME1 = SNOTIME1 + DT
+!          IF (SNOWNG) THEN
+!             SNOALB2=SNOALB
+!!m             LSTSNW=0
+!             SNOTIME1 = 0.0
+!          ELSE
+!            IF (TSNOW.LT.273.16) THEN
+!!              SNOALB2=SNOALB-0.008*LSTSNW*DT/86400
+!!m              SNOALB2=SNOALB-0.008*SNOTIME1/86400
+!              SNOALB2=(SNOALB2-0.65)*EXP(-0.05*DT/3600)+0.65
+!!              SNOALB2=(ALBEDO-0.65)*EXP(-0.01*DT/3600)+0.65
+!            ELSE
+!              SNOALB2=(SNOALB2-0.5)*EXP(-0.0005*DT/3600)+0.5
+!!              SNOALB2=(SNOALB-0.5)*EXP(-0.24*LSTSNW*DT/86400)+0.5
+!!m              SNOALB2=(SNOALB-0.5)*EXP(-0.24*SNOTIME1/86400)+0.5
+!            ENDIF
+!          ENDIF
+!
+!!               print*,'SNOALB2',SNOALB2,'ALBEDO',ALBEDO,'DT',DT
+!          ALBEDO = ALB + SNCOVR*(SNOALB2-ALB)
+!          IF (ALBEDO .GT. SNOALB2) ALBEDO=SNOALB2
+!!m          LSTSNW1=LSTSNW
+!!          SNOTIME = SNOTIME1
+
+! formulation by Livneh
+! ----------------------------------------------------------------------
+! SNOALB IS CONSIDERED AS THE MAXIMUM SNOW ALBEDO FOR NEW SNOW, AT
+! A VALUE OF 85%. SNOW ALBEDO CURVE DEFAULTS ARE FROM BRAS P.263. SHOULD
+! NOT BE CHANGED EXCEPT FOR SERIOUS PROBLEMS WITH SNOW MELT.
+! TO IMPLEMENT ACCUMULATIN PARAMETERS, SNACCA AND SNACCB, ASSERT THAT IT
+! IS INDEED ACCUMULATION SEASON. I.E. THAT SNOW SURFACE TEMP IS BELOW
+! ZERO AND THE DATE FALLS BETWEEN OCTOBER AND FEBRUARY
+! ----------------------------------------------------------------------
+    SNOALB1 = SNOALB+LVCOEF_DATA*(0.85-SNOALB)
+    SNOALB2=SNOALB1
+! ---------------- Initial LSTSNW --------------------------------------
+    IF (SNOWNG) THEN
+       SNOTIME1 = 0.
+    ELSE
+       SNOTIME1=SNOTIME1+DT
+!               IF (TSNOW.LT.273.16) THEN
+       SNOALB2=SNOALB1*(SNACCA**((SNOTIME1/86400.0)**SNACCB))
+!               ELSE
+!                  SNOALB2 =SNOALB1*(SNTHWA**((SNOTIME1/86400.0)**SNTHWB))
+!               ENDIF
+    ENDIF
+
+    SNOALB2 = MAX ( SNOALB2, ALB )
+    ALBEDO = ALB + (SNOALB2-ALB)
+    IF (ALBEDO .GT. SNOALB2) ALBEDO=SNOALB2
+
+!          IF (TSNOW.LT.273.16) THEN
+!            ALBEDO=SNOALB-0.008*DT/86400
+!          ELSE
+!            ALBEDO=(SNOALB-0.5)*EXP(-0.24*DT/86400)+0.5
+!          ENDIF
+
+!      IF (ALBEDO > SNOALB) ALBEDO = SNOALB
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE ALCALC_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE CSNOW (SNCOND,DSNOW)
 
 ! ----------------------------------------------------------------------
@@ -560,6 +1168,45 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE CSNOW
+! ----------------------------------------------------------------------
+
+  SUBROUTINE CSNOW_gpu (SNCOND,DSNOW)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE SNOW TERMAL CONDUCTIVITY
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+    REAL, INTENT(IN)  :: DSNOW
+    REAL, INTENT(OUT) :: SNCOND
+    REAL              :: C
+    REAL, PARAMETER   :: UNIT = 0.11631
+
+! ----------------------------------------------------------------------
+! SNCOND IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! CSNOW IN UNITS OF CAL/(CM*HR*C), RETURNED IN W/(M*C)
+! BASIC VERSION IS DYACHKOVA EQUATION (1960), FOR RANGE 0.1-0.4
+! ----------------------------------------------------------------------
+    C = 0.328*10** (2.25* DSNOW)
+!      CSNOW=UNIT*C
+
+! ----------------------------------------------------------------------
+! DE VAUX EQUATION (1933), IN RANGE 0.1-0.6
+! ----------------------------------------------------------------------
+!      SNCOND=0.0293*(1.+100.*DSNOW**2)
+!      CSNOW=0.0293*(1.+100.*DSNOW**2)
+
+! ----------------------------------------------------------------------
+! E. ANDERSEN FROM FLERCHINGER
+! ----------------------------------------------------------------------
+!      SNCOND=0.021+2.51*DSNOW**2
+!      CSNOW=0.021+2.51*DSNOW**2
+
+!      SNCOND = UNIT * C
+! double snow thermal conductivity
+    SNCOND = 2.0 * UNIT * C
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE CSNOW_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE HRTICE (RHSTS,STC,TBOT,NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
@@ -707,6 +1354,151 @@ CONTAINS
   END SUBROUTINE HRTICE
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE HRTICE_gpu (RHSTS,STC,TBOT,NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE THE RIGHT HAND SIDE OF THE TIME TENDENCY TERM OF THE SOIL
+! THERMAL DIFFUSION EQUATION IN THE CASE OF SEA-ICE (ICE=1) OR GLACIAL
+! ICE (ICE=-1). COMPUTE (PREPARE) THE MATRIX COEFFICIENTS FOR THE
+! TRI-DIAGONAL MATRIX OF THE IMPLICIT TIME SCHEME.
+!
+! (NOTE:  THIS SUBROUTINE ONLY CALLED FOR SEA-ICE OR GLACIAL ICE, BUT
+! NOT FOR NON-GLACIAL LAND (ICE = 0).
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+
+
+    INTEGER,                  INTENT(IN)  :: NSOIL
+    REAL,                     INTENT(IN)  :: DF1,YY,ZZ1
+    REAL, DIMENSION(1:NSOIL), INTENT(OUT) :: AI, BI,CI
+    REAL, DIMENSION(1:NSOIL), INTENT(IN)  :: STC, ZSOIL
+    REAL, DIMENSION(1:NSOIL), INTENT(OUT) :: RHSTS
+    REAL,                     INTENT(IN)  :: TBOT
+    INTEGER                :: K
+    REAL                   :: DDZ,DDZ2,DENOM,DTSDZ,DTSDZ2,SSOIL,HCPCT
+    REAL                   :: DF1K,DF1N
+    REAL                   :: ZMD
+    REAL, PARAMETER        :: ZBOT = -25.0
+
+! ----------------------------------------------------------------------
+! SET A NOMINAL UNIVERSAL VALUE OF GLACIAL-ICE SPECIFIC HEAT CAPACITY,
+!   HCPCT = 2100.0*900.0 = 1.89000E+6 (SOURCE:  BOB GRUMBINE, 2005)
+!   TBOT PASSED IN AS ARGUMENT, VALUE FROM GLOBAL DATA SET
+    !
+    ! A least-squares fit for the four points provided by
+    ! Keith Hines for the Yen (1981) values for Antarctic
+    ! snow firn.
+    !
+    HCPCT = 1.E6 * (0.8194 - 0.1309*0.5*ZSOIL(1))
+    DF1K = DF1
+
+! ----------------------------------------------------------------------
+! THE INPUT ARGUMENT DF1 IS A UNIVERSALLY CONSTANT VALUE OF SEA-ICE
+! THERMAL DIFFUSIVITY, SET IN ROUTINE SNOPAC AS DF1 = 2.2.
+! ----------------------------------------------------------------------
+! SET ICE PACK DEPTH.  USE TBOT AS ICE PACK LOWER BOUNDARY TEMPERATURE
+! (THAT OF UNFROZEN SEA WATER AT BOTTOM OF SEA ICE PACK).  ASSUME ICE
+! PACK IS OF N=NSOIL LAYERS SPANNING A UNIFORM CONSTANT ICE PACK
+! THICKNESS AS DEFINED BY ZSOIL(NSOIL) IN ROUTINE SFLX.
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEFFICIENTS AI, BI, AND CI FOR THE TOP LAYER
+! ----------------------------------------------------------------------
+    DDZ = 1.0 / ( -0.5 * ZSOIL (2) )
+    AI (1) = 0.0
+    CI (1) = (DF1 * DDZ) / (ZSOIL (1) * HCPCT)
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT BTWN THE TOP AND 2ND SOIL LAYERS.
+! RECALC/ADJUST THE SOIL HEAT FLUX.  USE THE GRADIENT AND FLUX TO CALC
+! RHSTS FOR THE TOP SOIL LAYER.
+! ----------------------------------------------------------------------
+    BI (1) = - CI (1) + DF1/ (0.5 * ZSOIL (1) * ZSOIL (1) * HCPCT *    &
+         &   ZZ1)
+    DTSDZ = ( STC (1) - STC (2) ) / ( -0.5 * ZSOIL (2) )
+    SSOIL = DF1 * ( STC (1) - YY ) / ( 0.5 * ZSOIL (1) * ZZ1 )
+
+! ----------------------------------------------------------------------
+! INITIALIZE DDZ2
+! ----------------------------------------------------------------------
+    RHSTS (1) = ( DF1 * DTSDZ - SSOIL ) / ( ZSOIL (1) * HCPCT )
+
+! ----------------------------------------------------------------------
+! LOOP THRU THE REMAINING SOIL LAYERS, REPEATING THE ABOVE PROCESS
+! ----------------------------------------------------------------------
+    DDZ2 = 0.0
+    DF1K = DF1
+    DF1N = DF1
+    DO K = 2,NSOIL
+
+       ZMD = 0.5 * (ZSOIL(K)+ZSOIL(K-1))
+       ! For the land-ice case
+! kmh 09/03/2006 use Yen (1981)'s values for Antarctic snow firn
+!         IF ( K .eq. 2 ) HCPCT = 0.855108E6
+!         IF ( K .eq. 3 ) HCPCT = 0.922906E6
+!         IF ( K .eq. 4 ) HCPCT = 1.009986E6
+
+       ! Least squares fit to the four points supplied by Keith Hines
+       ! from Yen (1981) for Antarctic snow firn.  Not optimal, but
+       ! probably better than just a constant.
+       HCPCT = 1.E6 * ( 0.8194 - 0.1309*ZMD )
+
+!         IF ( K .eq. 2 ) DF1N = 0.345356
+!         IF ( K .eq. 3 ) DF1N = 0.398777
+!         IF ( K .eq. 4 ) DF1N = 0.472653
+
+       ! Least squares fit to the three points supplied by Keith Hines
+       ! from Yen (1981) for Antarctic snow firn.  Not optimal, but
+       ! probably better than just a constant.
+       DF1N = 0.32333 - ( 0.10073 * ZMD )
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU THIS LAYER.
+! ----------------------------------------------------------------------
+       IF (K /= NSOIL) THEN
+          DENOM = 0.5 * ( ZSOIL (K -1) - ZSOIL (K +1) )
+
+! ----------------------------------------------------------------------
+! CALC THE MATRIX COEF, CI, AFTER CALC'NG ITS PARTIAL PRODUCT.
+! ----------------------------------------------------------------------
+          DTSDZ2 = ( STC (K) - STC (K +1) ) / DENOM
+          DDZ2 = 2. / (ZSOIL (K -1) - ZSOIL (K +1))
+          CI (K) = - DF1N * DDZ2 / ( (ZSOIL (K -1) - ZSOIL (K))*HCPCT)
+
+! ----------------------------------------------------------------------
+! CALC THE VERTICAL SOIL TEMP GRADIENT THRU THE LOWEST LAYER.
+! ----------------------------------------------------------------------
+       ELSE
+
+! ----------------------------------------------------------------------
+! SET MATRIX COEF, CI TO ZERO.
+! ----------------------------------------------------------------------
+          DTSDZ2 = (STC (K) - TBOT)/ (.5 * (ZSOIL (K -1) + ZSOIL (K)) &
+               &   - ZBOT)
+          CI (K) = 0.
+! ----------------------------------------------------------------------
+! CALC RHSTS FOR THIS LAYER AFTER CALC'NG A PARTIAL PRODUCT.
+! ----------------------------------------------------------------------
+       END IF
+       DENOM = ( ZSOIL (K) - ZSOIL (K -1) ) * HCPCT
+
+! ----------------------------------------------------------------------
+! CALC MATRIX COEFS, AI, AND BI FOR THIS LAYER.
+! ----------------------------------------------------------------------
+       RHSTS (K) = ( DF1N * DTSDZ2- DF1K * DTSDZ ) / DENOM
+       AI (K) = - DF1K * DDZ / ( (ZSOIL (K -1) - ZSOIL (K)) * HCPCT)
+
+! ----------------------------------------------------------------------
+! RESET VALUES OF DTSDZ AND DDZ FOR LOOP TO NEXT SOIL LYR.
+! ----------------------------------------------------------------------
+       BI (K) = - (AI (K) + CI (K))
+       DF1K = DF1N
+       DTSDZ = DTSDZ2
+       DDZ = DDZ2
+    END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE HRTICE_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE HSTEP (STCOUT,STCIN,RHSTS,DT,NSOIL,AI,BI,CI)
 
 ! ----------------------------------------------------------------------
@@ -753,6 +1545,54 @@ CONTAINS
     END DO
 ! ----------------------------------------------------------------------
   END SUBROUTINE HSTEP
+! ----------------------------------------------------------------------
+
+  SUBROUTINE HSTEP_gpu (STCOUT,STCIN,RHSTS,DT,NSOIL,AI,BI,CI)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE/UPDATE THE SOIL TEMPERATURE FIELD.
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+    INTEGER,                  INTENT(IN)    :: NSOIL
+    REAL, DIMENSION(1:NSOIL), INTENT(IN)    :: STCIN
+    REAL, DIMENSION(1:NSOIL), INTENT(OUT)   :: STCOUT
+    REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: RHSTS
+    REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: AI,BI,CI
+    REAL, DIMENSION(1:NSOIL) :: RHSTSin
+    REAL, DIMENSION(1:NSOIL) :: CIin
+    REAL                     :: DT
+    INTEGER                  :: K
+
+! ----------------------------------------------------------------------
+! CREATE FINITE DIFFERENCE VALUES FOR USE IN ROSR12 ROUTINE
+! ----------------------------------------------------------------------
+    DO K = 1,NSOIL
+       RHSTS (K) = RHSTS (K) * DT
+       AI (K) = AI (K) * DT
+       BI (K) = 1. + BI (K) * DT
+       CI (K) = CI (K) * DT
+    END DO
+! ----------------------------------------------------------------------
+! COPY VALUES FOR INPUT VARIABLES BEFORE CALL TO ROSR12
+! ----------------------------------------------------------------------
+    DO K = 1,NSOIL
+       RHSTSin (K) = RHSTS (K)
+    END DO
+    DO K = 1,NSOIL
+       CIin (K) = CI (K)
+    END DO
+! ----------------------------------------------------------------------
+! SOLVE THE TRI-DIAGONAL MATRIX EQUATION
+! ----------------------------------------------------------------------
+    CALL ROSR12_gpu (CI,AI,BI,CIin,RHSTSin,RHSTS,NSOIL)
+! ----------------------------------------------------------------------
+! CALC/UPDATE THE SOIL TEMPS USING MATRIX SOLUTION
+! ----------------------------------------------------------------------
+    DO K = 1,NSOIL
+       STCOUT (K) = STCIN (K) + CI (K)
+    END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE HSTEP_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE PENMAN (SFCTMP,SFCPRS,CH,TH2,PRCP,FDOWN,T24,SSOIL, &
@@ -821,6 +1661,73 @@ CONTAINS
   END SUBROUTINE PENMAN
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE PENMAN_gpu (SFCTMP,SFCPRS,CH,TH2,PRCP,FDOWN,T24,SSOIL, &
+       &             Q2,Q2SAT,ETP,RCH,RR,SNOWNG,FRZGRA,       &
+       &             DQSDT2,FLX2,EMISSI,T1)
+!$acc routine seq
+
+! ----------------------------------------------------------------------
+! CALCULATE POTENTIAL EVAPORATION FOR THE CURRENT POINT.  VARIOUS
+! PARTIAL SUMS/PRODUCTS ARE ALSO CALCULATED AND PASSED BACK TO THE
+! CALLING ROUTINE FOR LATER USE.
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+    LOGICAL, INTENT(IN)  :: SNOWNG, FRZGRA
+    REAL,    INTENT(IN)  :: CH, DQSDT2,FDOWN,PRCP,Q2,Q2SAT,SSOIL,SFCPRS, &
+         &                  SFCTMP,TH2,EMISSI,T1,RCH,T24
+    REAL,    INTENT(OUT) :: ETP,FLX2,RR
+
+    REAL                 :: A, DELTA, FNET,RAD,ELCP1,LVS,EPSCA
+
+    REAL, PARAMETER      :: ELCP = 2.4888E+3, LSUBC = 2.501000E+6
+    REAL, PARAMETER      :: LSUBS = 2.83E+6
+
+! ----------------------------------------------------------------------
+! PREPARE PARTIAL QUANTITIES FOR PENMAN EQUATION.
+! ----------------------------------------------------------------------
+    IF ( T1 > 273.15 ) THEN
+       ELCP1 = ELCP
+       LVS   = LSUBC
+    ELSE
+       ELCP1 = ELCP*LSUBS/LSUBC
+       LVS   = LSUBS
+    ENDIF
+    DELTA = ELCP1 * DQSDT2
+    A = ELCP1 * (Q2SAT - Q2)
+    RR = EMISSI*T24 * 6.48E-8 / (SFCPRS * CH) + 1.0
+
+! ----------------------------------------------------------------------
+! ADJUST THE PARTIAL SUMS / PRODUCTS WITH THE LATENT HEAT
+! EFFECTS CAUSED BY FALLING PRECIPITATION.
+! ----------------------------------------------------------------------
+    IF (.NOT. SNOWNG) THEN
+       IF (PRCP >  0.0) RR = RR + CPH2O * PRCP / RCH
+    ELSE
+       RR = RR + CPICE * PRCP / RCH
+    END IF
+
+! ----------------------------------------------------------------------
+! INCLUDE THE LATENT HEAT EFFECTS OF FREEZING RAIN CONVERTING TO ICE ON
+! IMPACT IN THE CALCULATION OF FLX2 AND FNET.
+! ----------------------------------------------------------------------
+    IF (FRZGRA) THEN
+       FLX2 = - LSUBF * PRCP
+    ELSE
+       FLX2 = 0.0
+    ENDIF
+    FNET = FDOWN -  ( EMISSI * SIGMA * T24 ) - SSOIL - FLX2
+
+! ----------------------------------------------------------------------
+! FINISH PENMAN EQUATION CALCULATIONS.
+! ----------------------------------------------------------------------
+    RAD = FNET / RCH + TH2 - SFCTMP
+    EPSCA = (A * RR + RAD * DELTA) / (DELTA + RR)
+    ETP = EPSCA * RCH / LVS
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE PENMAN_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE SHFLX (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
 ! ----------------------------------------------------------------------
 ! UPDATE THE TEMPERATURE STATE OF THE SOIL COLUMN BASED ON THE THERMAL
@@ -851,6 +1758,39 @@ CONTAINS
     END DO
 ! ----------------------------------------------------------------------
   END SUBROUTINE SHFLX
+! ----------------------------------------------------------------------
+
+  SUBROUTINE SHFLX_gpu (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! UPDATE THE TEMPERATURE STATE OF THE SOIL COLUMN BASED ON THE THERMAL
+! DIFFUSION EQUATION AND UPDATE THE FROZEN SOIL MOISTURE CONTENT BASED
+! ON THE TEMPERATURE.
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+
+    INTEGER,                  INTENT(IN)    :: NSOIL
+    REAL,                     INTENT(IN)    :: DF1,DT,TBOT,YY, ZZ1
+    REAL, DIMENSION(1:NSOIL), INTENT(IN)    :: ZSOIL
+    REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
+
+    REAL, DIMENSION(1:NSOIL) :: AI, BI, CI, STCF,RHSTS
+    INTEGER                  :: I
+    REAL, PARAMETER          :: T0 = 273.15
+
+! ----------------------------------------------------------------------
+! HRT ROUTINE CALCS THE RIGHT HAND SIDE OF THE SOIL TEMP DIF EQN
+! ----------------------------------------------------------------------
+
+    CALL HRTICE_gpu (RHSTS,STC,TBOT, NSOIL,ZSOIL,YY,ZZ1,DF1,AI,BI,CI)
+
+    CALL HSTEP_gpu (STCF,STC,RHSTS,DT,NSOIL,AI,BI,CI)
+
+    DO I = 1,NSOIL
+       STC (I) = STCF (I)
+    END DO
+! ----------------------------------------------------------------------
+  END SUBROUTINE SHFLX_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE SNOPAC (ETP,ETA,PRCP,PRCPF,SNOWNG,NSOIL,DT,DF1,           &
@@ -1073,6 +2013,226 @@ CONTAINS
   END SUBROUTINE SNOPAC
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE SNOPAC_gpu (ETP,ETA,PRCP,PRCPF,SNOWNG,NSOIL,DT,DF1,           &
+       &             Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,STC,             &
+       &             SFCPRS,RCH,RR,SNEQV,SNDENS,SNOWH,ZSOIL,TBOT,      &
+       &             SNOMLT,DEW,FLX1,FLX2,FLX3,ESNOW,EMISSI,RIBB)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE SOIL MOISTURE AND HEAT FLUX VALUES & UPDATE SOIL MOISTURE
+! CONTENT AND SOIL HEAT CONTENT VALUES FOR THE CASE WHEN A SNOW PACK IS
+! PRESENT.
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN)   :: NSOIL
+    LOGICAL, INTENT(IN)   :: SNOWNG
+    REAL,    INTENT(IN)   :: DF1,DT,FDOWN,PRCP,Q2,RCH,RR,SFCPRS,SFCTMP, &
+         &                   T24,TBOT,TH2,EMISSI
+    REAL, INTENT(INOUT)   :: SNEQV,FLX2,PRCPF,SNOWH,SNDENS,T1,RIBB,ETP
+    REAL, INTENT(OUT)     :: DEW,ESNOW,FLX1,FLX3,SSOIL,SNOMLT
+    REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: ZSOIL
+    REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
+    REAL, DIMENSION(1:NSOIL) :: ET1
+    INTEGER               :: K
+    REAL                  :: DENOM,DSOIL,DTOT,ESDFLX,ETA,        &
+         &                   ESNOW1,ESNOW2,ETA1,ETP1,ETP2,       &
+         &                   ETP3,ETANRG,EX,                     &
+         &                   FRCSNO,FRCSOI,PRCP1,QSAT,RSNOW,SEH, &
+         &                   SNCOND,T12,T12A,T12B,T14,YY,ZZ1
+
+    REAL, PARAMETER       :: ESDMIN = 1.E-6, LSUBC = 2.501000E+6,     &
+         &                   LSUBS = 2.83E+6, TFREEZ = 273.15,        &
+         &                   SNOEXP = 2.0
+
+! ----------------------------------------------------------------------
+! FOR GLACIAL-ICE, SNOWCOVER FRACTION = 1.0, AND SUBLIMATION IS AT THE 
+! POTENTIAL RATE.
+! ----------------------------------------------------------------------
+! INITIALIZE EVAP TERMS.
+! ----------------------------------------------------------------------
+! conversions:
+! ESNOW [KG M-2 S-1]
+! ESDFLX [KG M-2 S-1] .le. ESNOW
+! ESNOW1 [M S-1]
+! ESNOW2 [M]
+! ETP [KG M-2 S-1]
+! ETP1 [M S-1]
+! ETP2 [M]
+! ----------------------------------------------------------------------
+    SNOMLT = 0.0
+    DEW = 0.
+    ESNOW = 0.
+    ESNOW1 = 0.
+    ESNOW2 = 0.
+
+! ----------------------------------------------------------------------
+! CONVERT POTENTIAL EVAP (ETP) FROM KG M-2 S-1 TO ETP1 IN M S-1
+! ----------------------------------------------------------------------
+    PRCP1 = PRCPF *0.001
+! ----------------------------------------------------------------------
+! IF ETP<0 (DOWNWARD) THEN DEWFALL (=FROSTFALL IN THIS CASE).
+! ----------------------------------------------------------------------
+    IF (ETP <= 0.0) THEN
+       IF ( ( RIBB >= 0.1 ) .AND. ( FDOWN > 150.0 ) ) THEN
+          ETP=(MIN(ETP*(1.0-RIBB),0.)/0.980 + ETP*(0.980-1.0))/0.980
+       ENDIF
+       ETP1 = ETP * 0.001
+       DEW = -ETP1
+       ESNOW2 = ETP1*DT
+       ETANRG = ETP*LSUBS
+    ELSE
+       ETP1 = ETP * 0.001
+       ESNOW = ETP
+       ESNOW1 = ESNOW*0.001
+       ESNOW2 = ESNOW1*DT
+       ETANRG = ESNOW*LSUBS
+    END IF
+
+! ----------------------------------------------------------------------
+! IF PRECIP IS FALLING, CALCULATE HEAT FLUX FROM SNOW SFC TO NEWLY
+! ACCUMULATING PRECIP.  NOTE THAT THIS REFLECTS THE FLUX APPROPRIATE FOR
+! THE NOT-YET-UPDATED SKIN TEMPERATURE (T1).  ASSUMES TEMPERATURE OF THE
+! SNOWFALL STRIKING THE GROUND IS =SFCTMP (LOWEST MODEL LEVEL AIR TEMP).
+! ----------------------------------------------------------------------
+    FLX1 = 0.0
+    IF (SNOWNG) THEN
+       FLX1 = CPICE * PRCP * (T1- SFCTMP)
+    ELSE
+       IF (PRCP >  0.0) FLX1 = CPH2O * PRCP * (T1- SFCTMP)
+    END IF
+! ----------------------------------------------------------------------
+! CALCULATE AN 'EFFECTIVE SNOW-GRND SFC TEMP' (T12) BASED ON HEAT FLUXES
+! BETWEEN THE SNOW PACK AND THE SOIL AND ON NET RADIATION.
+! INCLUDE FLX1 (PRECIP-SNOW SFC) AND FLX2 (FREEZING RAIN LATENT HEAT)
+! FLUXES.  FLX1 FROM ABOVE, FLX2 BROUGHT IN VIA COMMOM BLOCK RITE.
+! FLX2 REFLECTS FREEZING RAIN LATENT HEAT FLUX USING T1 CALCULATED IN
+! PENMAN.
+! ----------------------------------------------------------------------
+    DSOIL = - (0.5 * ZSOIL (1))
+    DTOT = SNOWH + DSOIL
+    DENOM = 1.0+ DF1 / (DTOT * RR * RCH)
+    T12A = ( (FDOWN - FLX1- FLX2- EMISSI * SIGMA * T24)/ RCH                    &
+         + TH2- SFCTMP - ETANRG / RCH ) / RR
+    T12B = DF1 * STC (1) / (DTOT * RR * RCH)
+
+    T12 = (SFCTMP + T12A + T12B) / DENOM
+    IF (T12 <=  TFREEZ) THEN
+! ----------------------------------------------------------------------
+! SUB-FREEZING BLOCK
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS AT OR BELOW FREEZING, NO SNOW
+! MELT WILL OCCUR.  SET THE SKIN TEMP TO THIS EFFECTIVE TEMP.  REDUCE
+! (BY SUBLIMINATION ) OR INCREASE (BY FROST) THE DEPTH OF THE SNOWPACK,
+! DEPENDING ON SIGN OF ETP.
+! UPDATE SOIL HEAT FLUX (SSOIL) USING NEW SKIN TEMPERATURE (T1)
+! SINCE NO SNOWMELT, SET ACCUMULATED SNOWMELT TO ZERO, SET 'EFFECTIVE'
+! PRECIP FROM SNOWMELT TO ZERO, SET PHASE-CHANGE HEAT FLUX FROM SNOWMELT
+! TO ZERO.
+! ----------------------------------------------------------------------
+       T1 = T12
+       SSOIL = DF1 * (T1- STC (1)) / DTOT
+       SNEQV = MAX(0.0, SNEQV-ESNOW2)
+       FLX3 = 0.0
+       EX = 0.0
+       SNOMLT = 0.0
+    ELSE
+! ----------------------------------------------------------------------
+! ABOVE FREEZING BLOCK
+! ----------------------------------------------------------------------
+! IF THE 'EFFECTIVE SNOW-GRND SFC TEMP' IS ABOVE FREEZING, SNOW MELT
+! WILL OCCUR.  CALL THE SNOW MELT RATE,EX AND AMT, SNOMLT.  REVISE THE
+! EFFECTIVE SNOW DEPTH.  REVISE THE SKIN TEMP BECAUSE IT WOULD HAVE CHGD
+! DUE TO THE LATENT HEAT RELEASED BY THE MELTING. CALC THE LATENT HEAT
+! RELEASED, FLX3. SET THE EFFECTIVE PRECIP, PRCP1 TO THE SNOW MELT RATE,
+! EX FOR USE IN SMFLX.  ADJUSTMENT TO T1 TO ACCOUNT FOR SNOW PATCHES.
+! CALCULATE QSAT VALID AT FREEZING POINT.  NOTE THAT ESAT (SATURATION
+! VAPOR PRESSURE) VALUE OF 6.11E+2 USED HERE IS THAT VALID AT FRZZING
+! POINT.  NOTE THAT ETP FROM CALL PENMAN IN SFLX IS IGNORED HERE IN
+! FAVOR OF BULK ETP OVER 'OPEN WATER' AT FREEZING TEMP.
+! UPDATE SOIL HEAT FLUX (S) USING NEW SKIN TEMPERATURE (T1)
+! ----------------------------------------------------------------------
+       T1 = TFREEZ
+       IF ( DTOT .GT. 2.0*DSOIL ) THEN
+          DTOT = 2.0*DSOIL
+       ENDIF
+       SSOIL = DF1 * (T1- STC (1)) / DTOT
+       IF (SNEQV-ESNOW2 <= ESDMIN) THEN
+          SNEQV = 0.0
+          EX = 0.0
+          SNOMLT = 0.0
+          FLX3 = 0.0
+! ----------------------------------------------------------------------
+! SUBLIMATION LESS THAN DEPTH OF SNOWPACK
+! SNOWPACK (SNEQV) REDUCED BY ESNOW2 (DEPTH OF SUBLIMATED SNOW)
+! ----------------------------------------------------------------------
+       ELSE
+          SNEQV = SNEQV-ESNOW2
+          ETP3 = ETP * LSUBC
+          SEH = RCH * (T1- TH2)
+          T14 = ( T1 * T1 ) * ( T1 * T1 )
+          FLX3 = FDOWN - FLX1- FLX2- EMISSI*SIGMA * T14- SSOIL - SEH - ETANRG
+          IF (FLX3 <= 0.0) FLX3 = 0.0
+          EX = FLX3*0.001/ LSUBF
+          SNOMLT = EX * DT
+! ----------------------------------------------------------------------
+! ESDMIN REPRESENTS A SNOWPACK DEPTH THRESHOLD VALUE BELOW WHICH WE
+! CHOOSE NOT TO RETAIN ANY SNOWPACK, AND INSTEAD INCLUDE IT IN SNOWMELT.
+! ----------------------------------------------------------------------
+          IF (SNEQV- SNOMLT >=  ESDMIN) THEN
+             SNEQV = SNEQV- SNOMLT
+          ELSE
+! ----------------------------------------------------------------------
+! SNOWMELT EXCEEDS SNOW DEPTH
+! ----------------------------------------------------------------------
+             EX = SNEQV / DT
+             FLX3 = EX *1000.0* LSUBF
+             SNOMLT = SNEQV
+
+             SNEQV = 0.0
+          ENDIF
+       ENDIF
+
+! ----------------------------------------------------------------------
+! FOR GLACIAL ICE, THE SNOWMELT WILL BE ADDED TO SUBSURFACE
+! RUNOFF/BASEFLOW LATER NEAR THE END OF SFLX (AFTER RETURN FROM CALL TO
+! SUBROUTINE SNOPAC)
+! ----------------------------------------------------------------------
+
+    ENDIF
+
+! ----------------------------------------------------------------------
+! BEFORE CALL SHFLX IN THIS SNOWPACK CASE, SET ZZ1 AND YY ARGUMENTS TO
+! SPECIAL VALUES THAT ENSURE THAT GROUND HEAT FLUX CALCULATED IN SHFLX
+! MATCHES THAT ALREADY COMPUTED FOR BELOW THE SNOWPACK, THUS THE SFC
+! HEAT FLUX TO BE COMPUTED IN SHFLX WILL EFFECTIVELY BE THE FLUX AT THE
+! SNOW TOP SURFACE.  
+! ----------------------------------------------------------------------
+    ZZ1 = 1.0
+    YY = STC (1) -0.5* SSOIL * ZSOIL (1)* ZZ1/ DF1
+
+! ----------------------------------------------------------------------
+! SHFLX WILL CALC/UPDATE THE SOIL TEMPS.
+! ----------------------------------------------------------------------
+    CALL SHFLX_gpu (STC,NSOIL,DT,YY,ZZ1,ZSOIL,TBOT,DF1)
+
+! ----------------------------------------------------------------------
+! SNOW DEPTH AND DENSITY ADJUSTMENT BASED ON SNOW COMPACTION.  YY IS
+! ASSUMED TO BE THE SOIL TEMPERTURE AT THE TOP OF THE SOIL COLUMN.
+! ----------------------------------------------------------------------
+    IF (SNEQV .GE. 0.10) THEN
+       CALL SNOWPACK_gpu (SNEQV,DT,SNOWH,SNDENS,T1,YY)
+    ELSE
+       SNEQV = 0.10
+       SNOWH = 0.50
+!KWM???? SNDENS =
+!KWM???? SNCOND =
+    ENDIF
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOPAC_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE SNOWPACK (SNEQV,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL)
 
 ! ----------------------------------------------------------------------
@@ -1199,6 +2359,132 @@ CONTAINS
   END SUBROUTINE SNOWPACK
 ! ----------------------------------------------------------------------
 
+  SUBROUTINE SNOWPACK_gpu (SNEQV,DTSEC,SNOWH,SNDENS,TSNOW,TSOIL)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE COMPACTION OF SNOWPACK UNDER CONDITIONS OF INCREASING SNOW
+! DENSITY, AS OBTAINED FROM AN APPROXIMATE SOLUTION OF E. ANDERSON'S
+! DIFFERENTIAL EQUATION (3.29), NOAA TECHNICAL REPORT NWS 19, BY VICTOR
+! KOREN, 03/25/95.
+! ----------------------------------------------------------------------
+! SNEQV     WATER EQUIVALENT OF SNOW (M)
+! DTSEC   TIME STEP (SEC)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! TSNOW   SNOW SURFACE TEMPERATURE (K)
+! TSOIL   SOIL SURFACE TEMPERATURE (K)
+
+! SUBROUTINE WILL RETURN NEW VALUES OF SNOWH AND SNDENS
+! ----------------------------------------------------------------------
+      IMPLICIT NONE
+
+      INTEGER                :: IPOL, J
+      REAL, INTENT(IN)       :: SNEQV, DTSEC,TSNOW,TSOIL
+      REAL, INTENT(INOUT)    :: SNOWH, SNDENS
+      REAL                   :: BFAC,DSX,DTHR,DW,SNOWHC,PEXP,           &
+                                TAVGC,TSNOWC,TSOILC,ESDC,ESDCX
+      REAL, PARAMETER        :: C1 = 0.01, C2 = 21.0, G = 9.81,         &
+                                KN = 4000.0
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+      SNOWHC = SNOWH *100.
+      ESDC   = SNEQV *100.
+      DTHR   = DTSEC /3600.
+      TSNOWC = TSNOW -273.15
+      TSOILC = TSOIL -273.15
+
+! ----------------------------------------------------------------------
+! CALCULATING OF AVERAGE TEMPERATURE OF SNOW PACK
+! ----------------------------------------------------------------------
+! ----------------------------------------------------------------------
+! CALCULATING OF SNOW DEPTH AND DENSITY AS A RESULT OF COMPACTION
+!  SNDENS=DS0*(EXP(BFAC*SNEQV)-1.)/(BFAC*SNEQV)
+!  BFAC=DTHR*C1*EXP(0.08*TAVGC-C2*DS0)
+! NOTE: BFAC*SNEQV IN SNDENS EQN ABOVE HAS TO BE CAREFULLY TREATED
+! NUMERICALLY BELOW:
+!   C1 IS THE FRACTIONAL INCREASE IN DENSITY (1/(CM*HR))
+!   C2 IS A CONSTANT (CM3/G) KOJIMA ESTIMATED AS 21 CMS/G
+! ----------------------------------------------------------------------
+      TAVGC = 0.5* (TSNOWC + TSOILC)
+      IF (ESDC >  1.E-2) THEN
+         ESDCX = ESDC
+      ELSE
+         ESDCX = 1.E-2
+      END IF
+
+!      DSX = SNDENS*((DEXP(BFAC*ESDC)-1.)/(BFAC*ESDC))
+! ----------------------------------------------------------------------
+! THE FUNCTION OF THE FORM (e**x-1)/x IMBEDDED IN ABOVE EXPRESSION
+! FOR DSX WAS CAUSING NUMERICAL DIFFICULTIES WHEN THE DENOMINATOR "x"
+! (I.E. BFAC*ESDC) BECAME ZERO OR APPROACHED ZERO (DESPITE THE FACT THAT
+! THE ANALYTICAL FUNCTION (e**x-1)/x HAS A WELL DEFINED LIMIT AS
+! "x" APPROACHES ZERO), HENCE BELOW WE REPLACE THE (e**x-1)/x
+! EXPRESSION WITH AN EQUIVALENT, NUMERICALLY WELL-BEHAVED
+! POLYNOMIAL EXPANSION.
+
+! NUMBER OF TERMS OF POLYNOMIAL EXPANSION, AND HENCE ITS ACCURACY,
+! IS GOVERNED BY ITERATION LIMIT "IPOL".
+!      IPOL GREATER THAN 9 ONLY MAKES A DIFFERENCE ON DOUBLE
+!            PRECISION (RELATIVE ERRORS GIVEN IN PERCENT %).
+!       IPOL=9, FOR REL.ERROR <~ 1.6 E-6 % (8 SIGNIFICANT DIGITS)
+!       IPOL=8, FOR REL.ERROR <~ 1.8 E-5 % (7 SIGNIFICANT DIGITS)
+!       IPOL=7, FOR REL.ERROR <~ 1.8 E-4 % ...
+! ----------------------------------------------------------------------
+      BFAC = DTHR * C1* EXP (0.08* TAVGC - C2* SNDENS)
+      IPOL = 4
+      PEXP = 0.
+!        PEXP = (1. + PEXP)*BFAC*ESDC/REAL(J+1)
+      DO J = IPOL,1, -1
+         PEXP = (1. + PEXP)* BFAC * ESDCX / REAL (J +1)
+      END DO
+
+      PEXP = PEXP + 1.
+! ----------------------------------------------------------------------
+! ABOVE LINE ENDS POLYNOMIAL SUBSTITUTION
+! ----------------------------------------------------------------------
+!     END OF KOREAN FORMULATION
+
+!     BASE FORMULATION (COGLEY ET AL., 1990)
+!     CONVERT DENSITY FROM G/CM3 TO KG/M3
+!       DSM=SNDENS*1000.0
+
+!       DSX=DSM+DTSEC*0.5*DSM*G*SNEQV/
+!    &      (1E7*EXP(-0.02*DSM+KN/(TAVGC+273.16)-14.643))
+
+!  &   CONVERT DENSITY FROM KG/M3 TO G/CM3
+!       DSX=DSX/1000.0
+
+!     END OF COGLEY ET AL. FORMULATION
+
+! ----------------------------------------------------------------------
+! SET UPPER/LOWER LIMIT ON SNOW DENSITY
+! ----------------------------------------------------------------------
+      DSX = SNDENS * (PEXP)
+      IF (DSX > 0.40) DSX = 0.40
+      IF (DSX < 0.05) DSX = 0.05
+! ----------------------------------------------------------------------
+! UPDATE OF SNOW DEPTH AND DENSITY DEPENDING ON LIQUID WATER DURING
+! SNOWMELT.  ASSUMED THAT 13% OF LIQUID WATER CAN BE STORED IN SNOW PER
+! DAY DURING SNOWMELT TILL SNOW DENSITY 0.40.
+! ----------------------------------------------------------------------
+      SNDENS = DSX
+      IF (TSNOWC >=  0.) THEN
+         DW = 0.13* DTHR /24.
+         SNDENS = SNDENS * (1. - DW) + DW
+         IF (SNDENS >=  0.40) SNDENS = 0.40
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH (CM) FROM SNOW WATER EQUIVALENT AND SNOW DENSITY.
+! CHANGE SNOW DEPTH UNITS TO METERS
+! ----------------------------------------------------------------------
+      END IF
+      SNOWHC = ESDC / SNDENS
+      SNOWH = SNOWHC * 0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWPACK_gpu
+! ----------------------------------------------------------------------
+
   SUBROUTINE SNOWZ0 (Z0, Z0BRD, SNOWH)
 ! ----------------------------------------------------------------------
 ! CALCULATE TOTAL ROUGHNESS LENGTH OVER SNOW
@@ -1224,6 +2510,34 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SNOWZ0
+! ----------------------------------------------------------------------
+
+  SUBROUTINE SNOWZ0_gpu (Z0, Z0BRD, SNOWH)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE TOTAL ROUGHNESS LENGTH OVER SNOW
+! Z0      ROUGHNESS LENGTH (m)
+! Z0S     SNOW ROUGHNESS LENGTH:=0.001 (m)
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+    REAL, INTENT(IN)        :: Z0BRD
+    REAL, INTENT(OUT)       :: Z0
+    REAL, PARAMETER         :: Z0S=0.001
+    REAL, INTENT(IN)        :: SNOWH
+    REAL                    :: BURIAL
+    REAL                    :: Z0EFF
+
+    BURIAL = 7.0*Z0BRD - SNOWH
+    IF(BURIAL.LE.0.0007) THEN
+       Z0EFF = Z0S
+    ELSE      
+       Z0EFF = BURIAL/7.0
+    ENDIF
+
+    Z0 = Z0EFF
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOWZ0_gpu
 ! ----------------------------------------------------------------------
 
   SUBROUTINE SNOW_NEW (TEMP,NEWSN,SNOWH,SNDENS)
@@ -1275,6 +2589,57 @@ CONTAINS
 
 ! ----------------------------------------------------------------------
   END SUBROUTINE SNOW_NEW
+! ----------------------------------------------------------------------
+
+  SUBROUTINE SNOW_NEW_gpu (TEMP,NEWSN,SNOWH,SNDENS)
+!$acc routine seq
+! ----------------------------------------------------------------------
+! CALCULATE SNOW DEPTH AND DENSITY TO ACCOUNT FOR THE NEW SNOWFALL.
+! UPDATED VALUES OF SNOW DEPTH AND DENSITY ARE RETURNED.
+
+! TEMP    AIR TEMPERATURE (K)
+! NEWSN   NEW SNOWFALL (M)
+! SNOWH   SNOW DEPTH (M)
+! SNDENS  SNOW DENSITY (G/CM3=DIMENSIONLESS FRACTION OF H2O DENSITY)
+! ----------------------------------------------------------------------
+    IMPLICIT NONE
+    REAL, INTENT(IN)        :: NEWSN, TEMP
+    REAL, INTENT(INOUT)     :: SNDENS, SNOWH
+    REAL                    :: DSNEW, HNEWC, SNOWHC,NEWSNC,TEMPC
+
+! ----------------------------------------------------------------------
+! CALCULATING NEW SNOWFALL DENSITY DEPENDING ON TEMPERATURE
+! EQUATION FROM GOTTLIB L. 'A GENERAL RUNOFF MODEL FOR SNOWCOVERED
+! AND GLACIERIZED BASIN', 6TH NORDIC HYDROLOGICAL CONFERENCE,
+! VEMADOLEN, SWEDEN, 1980, 172-177PP.
+!-----------------------------------------------------------------------
+    TEMPC = TEMP - 273.15
+    IF ( TEMPC <=  -15. ) THEN
+       DSNEW = 0.05
+    ELSE
+       DSNEW = 0.05 + 0.0017 * ( TEMPC + 15. ) ** 1.5
+    ENDIF
+
+! ----------------------------------------------------------------------
+! CONVERSION INTO SIMULATION UNITS
+! ----------------------------------------------------------------------
+    SNOWHC = SNOWH * 100.
+    NEWSNC = NEWSN * 100.
+
+! ----------------------------------------------------------------------
+! ADJUSTMENT OF SNOW DENSITY DEPENDING ON NEW SNOWFALL
+! ----------------------------------------------------------------------
+    HNEWC = NEWSNC / DSNEW
+    IF ( SNOWHC + HNEWC < 1.0E-3 ) THEN
+       SNDENS = MAX ( DSNEW , SNDENS )
+    ELSE
+       SNDENS = ( SNOWHC * SNDENS + HNEWC * DSNEW ) / ( SNOWHC + HNEWC )
+    ENDIF
+    SNOWHC = SNOWHC + HNEWC
+    SNOWH = SNOWHC * 0.01
+
+! ----------------------------------------------------------------------
+  END SUBROUTINE SNOW_NEW_gpu
 ! ----------------------------------------------------------------------
 
 END MODULE module_sf_noahlsm_glacial_only

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfcdiags.F
@@ -68,4 +68,77 @@ CONTAINS
 
   END SUBROUTINE SFCDIAGS
 
+   SUBROUTINE SFCDIAGS_gpu(HFX,QFX,TSK,QSFC,CHS2,CQS2,T2,TH2,Q2,       &
+                     PSFC,CP,R_d,ROVCP,CHS,T3D,QV3D,UA_PHYS,       &
+                     ids,ide, jds,jde, kds,kde,                    &
+                     ims,ime, jms,jme, kms,kme,                    &
+                     its,ite, jts,jte, kts,kte                     )
+!-------------------------------------------------------------------
+      IMPLICIT NONE
+!-------------------------------------------------------------------
+      INTEGER,  INTENT(IN )   ::        ids,ide, jds,jde, kds,kde, &
+                                        ims,ime, jms,jme, kms,kme, &
+                                        its,ite, jts,jte, kts,kte
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(IN)                  ::                HFX, &
+                                                              QFX, &
+                                                              TSK, &
+                                                             QSFC
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)               ::                Q2, &
+                                                             TH2, &
+                                                              T2
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(IN)                  ::               PSFC, &
+                                                             CHS2, &
+                                                             CQS2
+      REAL,     INTENT(IN   )               ::       CP,R_d,ROVCP
+
+! UA changes
+      LOGICAL, INTENT(IN) :: UA_PHYS   ! UA: flag for UA option
+      REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D,T3D
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(IN)                  ::               CHS
+
+! LOCAL VARS
+      INTEGER ::  I,J
+      REAL    ::  RHO
+
+!!!$acc update device(PSFC,TSK,CQS2,Q2,QSFC,CHS,QV3D,QFX,CHS2,T2,T3D,HFX,TH2)
+
+!$acc data present(PSFC,TSK,CQS2,Q2,QSFC,CHS,QV3D,QFX,CHS2,T2,T3D,HFX,TH2)
+!$acc parallel vector_length(32)
+!$acc loop gang vector collapse(2) private(RHO)
+      DO J=jts,jte
+        DO I=its,ite
+          RHO = PSFC(I,J)/(R_d * TSK(I,J))
+          if(CQS2(I,J).lt.1.E-5) then
+             Q2(I,J)=QSFC(I,J)
+          else
+              IF ( UA_PHYS ) THEN
+                  Q2(I,J) = QSFC(I,J) - CHS(I,J)/CQS2(I,J)*(QSFC(I,J) - QV3D(i,1,j))
+              ELSE
+                  Q2(I,J) = QSFC(I,J) - QFX(I,J)/(RHO*CQS2(I,J))
+              ENDIF
+          endif
+          if(CHS2(I,J).lt.1.E-5) then
+             T2(I,J) = TSK(I,J) 
+          else
+              IF ( UA_PHYS ) THEN
+                  T2(I,J) = TSK(I,J) - CHS(I,J)/CHS2(I,J)*(TSK(I,J) - T3D(i,1,j))
+              ELSE
+                  T2(I,J) = TSK(I,J) - HFX(I,J)/(RHO*CP*CHS2(I,J))
+              ENDIF
+          endif
+          TH2(I,J) = T2(I,J)*(1.E5/PSFC(I,J))**ROVCP
+        ENDDO
+      ENDDO
+!$acc end parallel
+!$acc end data
+
+!!!$acc update host(Q2,T2,TH2)
+
+  END SUBROUTINE SFCDIAGS_gpu
+
 END MODULE module_sf_sfcdiags


### PR DESCRIPTION
This PR contains NOAH LSM code ported to GPUs using OpenACC.
This PR needs to be merged only after #926 , #928 and #947  has been merged into atmosphere/develop-openacc branch.

- [x] #928 has to be merged into [atmosphere/develop-openacc](https://github.com/MPAS-Dev/MPAS-Model/tree/atmosphere/develop-openacc) before merging this PR.
- [x]  #926 has to be merged into [atmosphere/develop-openacc](https://github.com/MPAS-Dev/MPAS-Model/tree/atmosphere/develop-openacc) before merging this PR.
- [x] #947  has to be merged into [atmsophere/develop-openacc](https://github.com/MPAS-Dev/MPAS-Model/tree/atmosphere/develop-openacc) before merging this PR.

**Note:** #928 has to be merged first and only then this PR needs to be submitted. If planning to use NOAH LSM as independently without the surface layer #928 in the physics configuration, then please uncomment the `!$acc update device(chs_sea,chs2_sea,...)` in the `lsm_to_MPAS` subroutine in `src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F`