### PR TITLE
Define top-level build target for cores as both a macro and as a member of core_type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,6 +903,8 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 endif
 ####################################################
 
+override CPPFLAGS += -DMPAS_BUILD_TARGET=$(BUILD_TARGET)
+
 ifeq ($(wildcard src/core_$(CORE)), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
 
 all: core_error

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -152,6 +152,7 @@
       character (len=StrKIND) :: modelVersion !< Constant: Version number
       character (len=StrKIND) :: executableName !< Constant: Name of executable generated at build time.
       character (len=StrKIND) :: git_version !< Constant: Version string from git-describe.
+      character (len=StrKIND) :: build_target !< Constant: Build target from top-level Makefile.
       character (len=StrKIND*2) :: history !< History attribute, read in from input file.
       character (len=StrKIND) :: Conventions !< Conventions attribute, read in from input file.
       character (len=StrKIND) :: source !< source attribute, read in from input file.

--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -22,6 +22,7 @@ void write_model_variables(ezxml_t registry){/*{{{*/
 	const char * suffix = MACRO_TO_STR(MPAS_NAMELIST_SUFFIX);
 	const char * exe_name = MACRO_TO_STR(MPAS_EXE_NAME);
 	const char * git_ver = MACRO_TO_STR(MPAS_GIT_VERSION);
+	const char * build_target = MACRO_TO_STR(MPAS_BUILD_TARGET);
 
 	const char *modelname, *corename, *version;
 	FILE *fd;
@@ -37,6 +38,7 @@ void write_model_variables(ezxml_t registry){/*{{{*/
 	fortprintf(fd, "       core %% modelVersion = '%s'\n", version);
 	fortprintf(fd, "       core %% executableName = '%s'\n", exe_name);
 	fortprintf(fd, "       core %% git_version = '%s'\n", git_ver);
+	fortprintf(fd, "       core %% build_target = '%s'\n", build_target);
 
 	fclose(fd);
 


### PR DESCRIPTION
This PR makes the top-level build target used to compile an MPAS core available
through the preprocessing macro `MPAS_BUILD_TARGET` and through the new
`build_target` member of the `core_type` derived type. Having access to the name
of the build target will allow MPAS cores to be aware of or to report the target
that was used to build them.