### PR TITLE
Correct units and descriptions for GWDO fields var2d, con, oa[1-4], ol[1-4]

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3067,35 +3067,35 @@
                 <!-- ... PARAMETERIZATION OF GRAVITY WAVE DRAG OVER OROGRAPHY:                                          -->
                 <!-- ================================================================================================== -->
 
-                <var name="var2d" type="real" dimensions="nCells" units="m^{2}"
-                     description="variance of orography"/>
+                <var name="var2d" type="real" dimensions="nCells" units="m"
+                     description="standard deviation of subgrid-scale orography"/>
 
-                <var name="con" type="real" dimensions="nCells" units="m^{2}"
-                     description="convexity of orography"/>
+                <var name="con" type="real" dimensions="nCells" units="unitless"
+                     description="orographic convexity"/>
 
                 <var name="oa1" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for westerly flow"/>
 
                 <var name="oa2" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for southerly flow"/>
 
                 <var name="oa3" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for south-westerly flow"/>
 
                 <var name="oa4" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for north-westerly flow"/>
 
                 <var name="ol1" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for westerly flow"/>
 
                 <var name="ol2" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for southerly flow"/>
 
                 <var name="ol3" type="real" dimensions="nCells" units="unitles"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for south-westerly flow"/>
 
                 <var name="ol4" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for north-westerly flow"/>
         </var_struct>
 
         <var_struct name="tend_iau" time_levs="1" packages="iau">

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -245,7 +245,7 @@
 
                 <nml_option name="config_native_gwd_static"     type="logical"       default_value="true"
                      units="-"
-                     description="Whether to recompute sub-grid-scale orography statistics directly on the native MPAS mesh (case 7 only)"
+                     description="Whether to recompute subgrid-scale orography statistics directly on the native MPAS mesh (case 7 only)"
                      possible_values="true or false"/>
 
                 <nml_option name="config_gwd_cell_scaling"      type="real"          default_value="1.0"      in_defaults="false"
@@ -773,35 +773,35 @@
                      description="Index category for water"/>
 
                 <!-- GWDO fields -->
-                <var name="var2d" type="real" dimensions="nCells" units="m^{2}"
-                     description="variance of orography"/>
+                <var name="var2d" type="real" dimensions="nCells" units="m"
+                     description="standard deviation of subgrid-scale orography"/>
 
-                <var name="con" type="real" dimensions="nCells" units="m^{2}"
-                     description="convexity of orography"/>
+                <var name="con" type="real" dimensions="nCells" units="unitless"
+                     description="orographic convexity"/>
 
                 <var name="oa1" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for westerly flow"/>
 
                 <var name="oa2" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for southerly flow"/>
 
                 <var name="oa3" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for south-westerly flow"/>
 
                 <var name="oa4" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="asymmetry of subgrid-scale orography for north-westerly flow"/>
 
                 <var name="ol1" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for westerly flow"/>
 
                 <var name="ol2" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for southerly flow"/>
 
                 <var name="ol3" type="real" dimensions="nCells" units="unitles"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for south-westerly flow"/>
 
                 <var name="ol4" type="real" dimensions="nCells" units="unitless"
-                     description="directional asymmetry function of orography"/>
+                     description="effective orographic length for north-westerly flow"/>
 
                 <!-- description of the vertical grid structure -->
                 <var name="hx" type="real" dimensions="nVertLevelsP1 nCells" units="m"


### PR DESCRIPTION
This PR corrects the units and description attributes for the GWDO
fields var2d, con, oa1, oa2, oa3, oa4, ol1, ol2, ol3, and ol4 in both
the init_atmosphere and atmosphere core Registry.xml files.