### PR TITLE
Report build options at the beginning of log files for atmosphere and init_atmosphere cores

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -266,10 +266,42 @@ module atm_core_interface
       iErr = ior(iErr, local_err)
 
       call mpas_log_write('')
-#ifdef SINGLE_PRECISION
-      call mpas_log_write('Using default single-precision reals')
+      call mpas_log_write('MPAS-Atmosphere Version '//trim(domain % core % modelVersion))
+      call mpas_log_write('')
+      call mpas_log_write('')
+      call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
+      call mpas_log_write('')
+      call mpas_log_write('Compile-time options:')
+      call mpas_log_write('  Build target: '//trim(domain % core % build_target))
+      call mpas_log_write('  OpenMP support: ' // &
+#ifdef MPAS_OPENMP
+                          'yes')
 #else
-      call mpas_log_write('Using default double-precision reals')
+                          'no')
+#endif
+      call mpas_log_write('  OpenACC support: ' // &
+#ifdef MPAS_OPENACC
+                          'yes')
+#else
+                          'no')
+#endif
+      call mpas_log_write('  Default real precision: ' // &
+#ifdef SINGLE_PRECISION
+                          'single')
+#else
+                          'double')
+#endif
+      call mpas_log_write('  Compiler flags: ' // &
+#ifdef MPAS_DEBUG
+                          'debug')
+#else
+                          'optimize')
+#endif
+      call mpas_log_write('  PIO version: ' // &
+#ifdef USE_PIO2
+                          '2.x')
+#else
+                          '1.x')
 #endif
       call mpas_log_write('')
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -337,13 +337,44 @@ module init_atm_core_interface
       iErr = ior(iErr, local_err)
 
       call mpas_log_write('')
-#ifdef SINGLE_PRECISION
-      call mpas_log_write('Using default single-precision reals')
+      call mpas_log_write('MPAS Init-Atmosphere Version '//trim(domain % core % modelVersion))
+      call mpas_log_write('')
+      call mpas_log_write('')
+      call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
+      call mpas_log_write('')
+      call mpas_log_write('Compile-time options:')
+      call mpas_log_write('  Build target: '//trim(domain % core % build_target))
+      call mpas_log_write('  OpenMP support: ' // &
+#ifdef MPAS_OPENMP
+                          'yes')
 #else
-      call mpas_log_write('Using default double-precision reals')
+                          'no')
+#endif
+      call mpas_log_write('  OpenACC support: ' // &
+#ifdef MPAS_OPENACC
+                          'yes')
+#else
+                          'no')
+#endif
+      call mpas_log_write('  Default real precision: ' // &
+#ifdef SINGLE_PRECISION
+                          'single')
+#else
+                          'double')
+#endif
+      call mpas_log_write('  Compiler flags: ' // &
+#ifdef MPAS_DEBUG
+                          'debug')
+#else
+                          'optimize')
+#endif
+      call mpas_log_write('  PIO version: ' // &
+#ifdef USE_PIO2
+                          '2.x')
+#else
+                          '1.x')
 #endif
       call mpas_log_write('')
-
 
    end function init_atm_setup_log!}}}
 


### PR DESCRIPTION
This PR adds messages to the beginning of the init_atmosphere and atmosphere
cores's log files to describe various aspects of the build: the code version that was
used, which build target was used, the default precision for reals, whether OpenMP
is active, whether the build is an optimized or debug build, and which major
version of PIO was used.

For example, a double-precision debug build with the GNU compilers might result
in the following at the beginning of the log:
```
 Output from 'git describe --dirty': v7.1-328-g283c936-dirty

 Compile-time options:
   Build target: gfortran
   OpenMP support: no
   OpenACC support: no
   Default real precision: double
   Compiler flags: debug
   PIO version: 2.x
```