### PR TITLE
Report time to read initial state stream in atmosphere log file

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -48,6 +48,9 @@ module atm_core
       type (MPAS_Time_Type) :: startTime
 
       integer, pointer :: nVertLevels, maxEdges, maxEdges2, num_scalars
+      character (len=ShortStrKIND) :: init_stream_name
+      real (kind=R8KIND) :: input_start_time, input_stop_time
+
 
       ierr = 0
 
@@ -90,17 +93,28 @@ module atm_core
       ! input streams.
       !
       if (config_do_restart) then
-         call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=ierr)
+         init_stream_name = 'restart'
       else
-         call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=ierr)
+         init_stream_name = 'input'
       end if
+      call mpas_log_write('Reading initial state from '''//trim(init_stream_name)//''' stream')
+
+      call mpas_dmpar_get_time(input_start_time)
+      call MPAS_stream_mgr_read(domain % streamManager, streamID=trim(init_stream_name), ierr=ierr)
+      call mpas_dmpar_get_time(input_stop_time)
+
       if (ierr /= MPAS_STREAM_MGR_NOERR) then
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('Error reading initial conditions',                                                 messageType=MPAS_LOG_ERR)
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_CRIT)
       end if
+
+      call mpas_log_write(' Timing for read of '''//trim(init_stream_name)//''' stream: $r s', &
+                          realArgs=(/real(input_stop_time - input_start_time, kind=RKIND)/))
+
       call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='input', direction=MPAS_STREAM_INPUT, ierr=ierr)
       call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_INPUT, ierr=ierr)
+      call mpas_log_write(' ----- done reading initial state -----')
 
       !
       ! Read all other inputs


### PR DESCRIPTION
This PR adds timers around the call to `mpas_stream_mgr_read` that is
responsible for reading the initial state for MPAS-Atmosphere (either from
the `input` stream or from the `restart` stream). This timing info is written
to the atmosphere log file along with several other new messages that indicate
that the initial state will be read and that the initial state has been read.
These messages may help a user to more easily identify when the model has
failed when reading ICs, or whether a model failure is happening before or
after the reading of ICS. The new log output might look like the following,
for example, when doing a restart simulation:
```
 Reading initial state from 'restart' stream
  Timing for read of 'restart' stream: 21.2681 s
  ----- done reading initial state -----
```