### PR TITLE
Fix order of dummy argument declarations in mpas_spline_interpolation.F

### DIFF
--- a/src/operators/mpas_spline_interpolation.F
+++ b/src/operators/mpas_spline_interpolation.F
@@ -115,6 +115,10 @@ module mpas_spline_interpolation
 
 ! INPUT PARAMETERS:
 
+  integer, intent(in) :: &
+    n,      &!< Input: number of nodes, input grid
+    nOut       !< Input: number of nodes, output grid
+
   real (kind=RKIND), dimension(n), intent(in) :: &
     x,         &!< Input: node location, input grid
     y,       &!< Input: interpolation variable, input grid
@@ -122,10 +126,6 @@ module mpas_spline_interpolation
 
   real (kind=RKIND), dimension(nOut), intent(in) :: &
     xOut          !< Input: node location, output grid
-
-  integer, intent(in) :: &
-    n,      &!< Input: number of nodes, input grid
-    nOut       !< Input: number of nodes, output grid
 
 ! OUTPUT PARAMETERS:
 
@@ -359,16 +359,16 @@ subroutine mpas_integrate_cubic_spline(x,y,y2ndDer,n,x1,x2,y_integral)  !{{{
 
 ! !INPUT PARAMETERS:
 
+  integer, intent(in) :: &
+    N,      &!< Input: number of nodes, input grid
+    NOut       !< Input: number of nodes, output grid
+
   real (kind=RKIND), dimension(n), intent(in) :: &
     x,         &!< Input: node location, input grid
     y         !< Input: interpolation variable, input grid
 
   real (kind=RKIND), dimension(nOut), intent(in) :: &
     xOut          !< Input: node location, output grid
-
-  integer, intent(in) :: &
-    N,      &!< Input: number of nodes, input grid
-    NOut       !< Input: number of nodes, output grid
 
 ! !OUTPUT PARAMETERS:
 


### PR DESCRIPTION
This PR fixes the order of dummy argument declarations in mpas_spline_interpolation.F.

The mpas_spline_interpolation module contained argument lists in which arguments
were not always declared before they were used to dimension other array
arguments.

The GNU compiler pointed out these order-of-declaration issues with the
-std=f2008 option:
```
   mpas_spline_interpolation.F:118:31:

     118 |   real (kind=RKIND), dimension(n), intent(in) :: &
         |                               1
   Error: GNU Extension: Symbol ‘n’ is used before it is typed at (1)
   mpas_spline_interpolation.F:123:31:

     123 |   real (kind=RKIND), dimension(nOut), intent(in) :: &
         |                               1
   Error: GNU Extension: Symbol ‘nout’ is used before it is typed at (1)
   mpas_spline_interpolation.F:362:31:

     362 |   real (kind=RKIND), dimension(n), intent(in) :: &
         |                               1
   Error: GNU Extension: Symbol ‘n’ is used before it is typed at (1)
   mpas_spline_interpolation.F:366:31:

     366 |   real (kind=RKIND), dimension(nOut), intent(in) :: &
         |                               1
   Error: GNU Extension: Symbol ‘nout’ is used before it is typed at (1)
```
The simple fix involves reordering the declaration of dummy arguments, with no
changes needed to order of actual arguments.