### PR TITLE
Correct Fortran 2008 non-conformance in atmosphere core

### DIFF
--- a/src/core_atmosphere/diagnostics/convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/convective_diagnostics.F
@@ -8,7 +8,7 @@
 module convective_diagnostics
 
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type, MPAS_LOG_ERR, MPAS_LOG_CRIT
-    use mpas_kind_types, only : RKIND
+    use mpas_kind_types, only : RKIND, R8KIND
     use mpas_log, only : mpas_log_write
 
     type (MPAS_pool_type), pointer :: mesh
@@ -669,7 +669,7 @@ module convective_diagnostics
     real (kind=RKIND) :: th1,p1,t1,qv1,ql1,qi1,b1,pi1,thv1,qt,dp,dz,ps,frac
     real (kind=RKIND) :: th2,p2,t2,qv2,ql2,qi2,b2,pi2,thv2
     real (kind=RKIND) :: thlast,fliq,fice,tbar,qvbar,qlbar,qibar,lhv,lhs,lhf,rm,cpm
-    real*8 :: avgth,avgqv
+    real (kind=R8KIND) :: avgth,avgqv
 !    real (kind=RKIND) :: getqvs,getqvi,getthe
 
 !-----------------------------------------------------------------------

--- a/src/core_atmosphere/physics/physics_wrf/libmassv.F
+++ b/src/core_atmosphere/physics/physics_wrf/libmassv.F
@@ -1,9 +1,13 @@
 ! IBM libmassv compatibility library
 ! 
+#define R4KIND selected_real_kind(6)
+#define R8KIND selected_real_kind(12)
 
 #ifndef NATIVE_MASSV
       subroutine vdiv(z,x,y,n)
-      real*8 x(*),y(*),z(*)
+      real(kind=R8KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=x(j)/y(j)
    10 continue
@@ -11,7 +15,9 @@
       end
 
       subroutine vsdiv(z,x,y,n)
-      real*4 x(*),y(*),z(*)
+      real(kind=R4KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=x(j)/y(j)
    10 continue
@@ -19,7 +25,9 @@
       end
 
       subroutine vexp(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=exp(x(j))
    10 continue
@@ -27,7 +35,9 @@
       end
 
       subroutine vsexp(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=exp(x(j))
    10 continue
@@ -35,7 +45,9 @@
       end
 
       subroutine vlog(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=log(x(j))
    10 continue
@@ -43,7 +55,9 @@
       end
 
       subroutine vslog(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=log(x(j))
    10 continue
@@ -51,7 +65,9 @@
       end
 
       subroutine vrec(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=1.d0/x(j)
    10 continue
@@ -59,7 +75,9 @@
       end
 
       subroutine vsrec(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=1.e0/x(j)
    10 continue
@@ -67,7 +85,9 @@
       end
 
       subroutine vrsqrt(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=1.d0/sqrt(x(j))
    10 continue
@@ -75,7 +95,9 @@
       end
 
       subroutine vsrsqrt(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=1.e0/sqrt(x(j))
    10 continue
@@ -83,7 +105,9 @@
       end
 
       subroutine vsincos(x,y,z,n)
-      real*8 x(*),y(*),z(*)
+      real(kind=R8KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       x(j)=sin(z(j))
       y(j)=cos(z(j))
@@ -92,7 +116,9 @@
       end
 
       subroutine vssincos(x,y,z,n)
-      real*4 x(*),y(*),z(*)
+      real(kind=R4KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       x(j)=sin(z(j))
       y(j)=cos(z(j))
@@ -101,7 +127,9 @@
       end
 
       subroutine vsqrt(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sqrt(x(j))
    10 continue
@@ -109,7 +137,9 @@
       end
 
       subroutine vssqrt(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sqrt(x(j))
    10 continue
@@ -117,7 +147,9 @@
       end
 
       subroutine vtan(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=tan(x(j))
    10 continue
@@ -125,7 +157,9 @@
       end
 
       subroutine vstan(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=tan(x(j))
    10 continue
@@ -133,7 +167,9 @@
       end
 
       subroutine vatan2(z,y,x,n)
-      real*8 x(*),y(*),z(*)
+      real(kind=R8KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=atan2(y(j),x(j))
    10 continue
@@ -141,7 +177,9 @@
       end
 
       subroutine vsatan2(z,y,x,n)
-      real*4 x(*),y(*),z(*)
+      real(kind=R4KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=atan2(y(j),x(j))
    10 continue
@@ -149,7 +187,9 @@
       end
 
       subroutine vasin(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=asin(x(j))
    10 continue
@@ -157,7 +197,9 @@
       end
 
       subroutine vsin(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sin(x(j))
    10 continue
@@ -165,7 +207,9 @@
       end
 
       subroutine vssin(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sin(x(j))
    10 continue
@@ -173,7 +217,9 @@
       end
 
       subroutine vacos(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=acos(x(j))
    10 continue
@@ -181,7 +227,9 @@
       end
 
       subroutine vcos(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=cos(x(j))
    10 continue
@@ -189,7 +237,9 @@
       end
 
       subroutine vscos(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=cos(x(j))
    10 continue
@@ -197,25 +247,31 @@
       end
 
       subroutine vcosisin(y,x,n)
-      complex*16 y(*)
-      real*8 x(*)
+      complex(kind=R8KIND) y(*)
+      real(kind=R8KIND) x(*)
+      integer n
+      integer j
       do 10 j=1,n
-      y(j)=dcmplx(cos(x(j)),sin(x(j)))
+      y(j)=cmplx(cos(x(j)),sin(x(j)),kind=R8KIND)
    10 continue
       return
       end
 
       subroutine vscosisin(y,x,n)
-      complex*8 y(*)
-      real*4 x(*)
+      complex(kind=R4KIND) y(*)
+      real(kind=R4KIND) x(*)
+      integer n
+      integer j
       do 10 j=1,n
-      y(j)= cmplx(cos(x(j)),sin(x(j)))
+      y(j)= cmplx(cos(x(j)),sin(x(j)),kind=R4KIND)
    10 continue
       return
       end
 
       subroutine vdint(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
 !     y(j)=dint(x(j))
       y(j)=int(x(j))
@@ -224,7 +280,9 @@
       end
 
       subroutine vdnint(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
 !     y(j)=dnint(x(j))
       y(j)=nint(x(j))
@@ -233,7 +291,9 @@
       end
 
       subroutine vlog10(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=log10(x(j))
    10 continue
@@ -241,10 +301,10 @@
       end
 
 !      subroutine vlog1p(y,x,n)
-!      real*8 x(*),y(*)
+!      real(kind=R8KIND) x(*),y(*)
 !      interface
-!        real*8 function log1p(%val(x))
-!          real*8 x
+!        real(kind=R8KIND) function log1p(%val(x))
+!          real(kind=R8KIND) x
 !        end function log1p
 !      end interface
 !      do 10 j=1,n
@@ -254,7 +314,9 @@
 !      end
 
       subroutine vcosh(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=cosh(x(j))
    10 continue
@@ -262,7 +324,9 @@
       end
 
       subroutine vsinh(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sinh(x(j))
    10 continue
@@ -270,7 +334,9 @@
       end
 
       subroutine vtanh(y,x,n)
-      real*8 x(*),y(*)
+      real(kind=R8KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=tanh(x(j))
    10 continue
@@ -278,10 +344,10 @@
       end
 
 !      subroutine vexpm1(y,x,n)
-!      real*8 x(*),y(*)
+!      real(kind=R8KIND) x(*),y(*)
 !      interface
-!        real*8 function expm1(%val(x))
-!          real*8 x
+!        real(kind=R8KIND) function expm1(%val(x))
+!          real(kind=R8KIND) x
 !        end function expm1
 !      end interface 
 !      do 10 j=1,n
@@ -292,7 +358,9 @@
 
 
       subroutine vsasin(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=asin(x(j))
    10 continue
@@ -300,7 +368,9 @@
       end
 
       subroutine vsacos(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
 #if defined (G95)
 ! no reason why g95 should fail - oh well, we don't use this routine anyways
@@ -313,7 +383,9 @@
       end
 
       subroutine vscosh(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=cosh(x(j))
    10 continue
@@ -321,10 +393,10 @@
       end
 
 !      subroutine vsexpm1(y,x,n)
-!      real*4 x(*),y(*)
+!      real(kind=R4KIND) x(*),y(*)
 !      interface
-!        real*8 function expm1(%val(x))
-!          real*8 x
+!        real(kind=R8KIND) function expm1(%val(x))
+!          real(kind=R8KIND) x
 !        end function expm1
 !      end interface
 !      do 10 j=1,n
@@ -334,7 +406,9 @@
 !      end
 
       subroutine vslog10(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=log10(x(j))
    10 continue
@@ -342,10 +416,10 @@
       end
 
 !      subroutine vslog1p(y,x,n)
-!      real*4 x(*),y(*)
+!      real(kind=R4KIND) x(*),y(*)
 !      interface
-!        real*8 function log1p(%val(x))
-!          real*8 x
+!        real(kind=R8KIND) function log1p(%val(x))
+!          real(kind=R8KIND) x
 !        end function log1p
 !      end interface
 !      do 10 j=1,n
@@ -356,7 +430,9 @@
 
 
       subroutine vssinh(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=sinh(x(j))
    10 continue
@@ -364,7 +440,9 @@
       end
 
       subroutine vstanh(y,x,n)
-      real*4 x(*),y(*)
+      real(kind=R4KIND) x(*),y(*)
+      integer n
+      integer j
       do 10 j=1,n
       y(j)=tanh(x(j))
    10 continue
@@ -373,7 +451,9 @@
 #endif
 
       subroutine vspow(z,y,x,n)
-      real*4 x(*),y(*),z(*)
+      real(kind=R4KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=y(j)**x(j)
    10 continue
@@ -381,7 +461,9 @@
       end
 
       subroutine vpow(z,y,x,n)
-      real*8 x(*),y(*),z(*)
+      real(kind=R8KIND) x(*),y(*),z(*)
+      integer n
+      integer j
       do 10 j=1,n
       z(j)=y(j)**x(j)
    10 continue

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -562,6 +562,7 @@ contains
 !-----------------------------------------------------------------
       implicit none
 !
+      integer lq,km,km1
       real pu(lq,km),   pv(lq,km),   pt(lq,km),   pqv(lq,km)
       real poz(lq,km),  pomg(lq,km), evap(lq),    zprecc(lq)
       real pzz(lq,km1)
@@ -582,7 +583,7 @@ contains
       logical locum(lq)
 !
       real ztmst,fliq,fice,ztc,zalf,tt
-      integer i,j,k,lq,km,km1
+      integer i,j,k
       real dt,ztpp1
       real zew,zqs,zcor
 !
@@ -3729,6 +3730,7 @@ contains
 !   ---------
 !          none
 ! ----------------------------------------------------------------
+      integer  klon, klev
       real     pten(klon,klev),        pqen(klon,klev),&
      &         puen(klon,klev),        pven(klon,klev),&
      &         pqsen(klon,klev),       pverv(klon,klev),&
@@ -3744,7 +3746,7 @@ contains
      &         klab(klon,klev)
       logical  ldcum(klon)
 ! local variabels
-      integer  jl,kk,klev,klon,klevp1,klevm1
+      integer  jl,kk,klevp1,klevm1
       real     zzzmb
 !--------------------------------------------------------
 !*    1.      calculate entrainment and detrainment rates

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
@@ -564,6 +564,7 @@ contains
 !-----------------------------------------------------------------
       implicit none
 
+      integer lq,km,km1
       real pu(lq,km),pv(lq,km),pt(lq,km),pqv(lq,km),pqvf(lq,km)
       real poz(lq,km),pomg(lq,km),evap(lq),zprecc(lq),pqvbl(lq,km)
 
@@ -589,7 +590,7 @@ contains
 
       real psheat,psrain,psevap,psmelt,psdiss,tt
       real ztmst,ztpp1,fliq,fice,ztc,zalf
-      integer i,j,k,lq,lp,km,km1
+      integer i,j,k,lp
 !     real tlucua
 !     external tlucua
 

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_radar.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_radar.F
@@ -25,6 +25,7 @@ MODULE module_mp_radar
 #if defined(mpas)
       USE mpas_atmphys_functions
       USE mpas_atmphys_utilities
+      USE mpas_kind_types, ONLY : R8KIND
 #else
       USE module_wrf_error
 #endif
@@ -44,12 +45,16 @@ MODULE module_mp_radar
       PRIVATE :: GAMMLN
 #endif
 
+#if !defined(mpas)
+      INTEGER, PARAMETER :: R8KIND = SELECTED_REAL_KIND(12)
+#endif
+
       INTEGER, PARAMETER, PUBLIC:: nrbins = 50
       DOUBLE PRECISION, DIMENSION(nrbins+1), PUBLIC:: xxDx
       DOUBLE PRECISION, DIMENSION(nrbins), PUBLIC:: xxDs,xdts,xxDg,xdtg
       DOUBLE PRECISION, PARAMETER, PUBLIC:: lamda_radar = 0.10           ! in meters
       DOUBLE PRECISION, PUBLIC:: K_w, PI5, lamda4
-      COMPLEX*16, PUBLIC:: m_w_0, m_i_0
+      COMPLEX(KIND=R8KIND), PUBLIC:: m_w_0, m_i_0
       DOUBLE PRECISION, DIMENSION(nrbins+1), PUBLIC:: simpson
       DOUBLE PRECISION, DIMENSION(3), PARAMETER, PUBLIC:: basis =       &
                            (/1.d0/3.d0, 4.d0/3.d0, 1.d0/3.d0/)
@@ -130,7 +135,7 @@ CONTAINS
       xxDx(1) = 100.D-6
       xxDx(nrbins+1) = 0.02d0
       do n = 2, nrbins
-         xxDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nrbins) &
+         xxDx(n) = DEXP(REAL(n-1,KIND=R8KIND)/REAL(nrbins,KIND=R8KIND) &
                   *DLOG(xxDx(nrbins+1)/xxDx(1)) +DLOG(xxDx(1)))
       enddo
       do n = 1, nrbins
@@ -142,7 +147,7 @@ CONTAINS
       xxDx(1) = 100.D-6
       xxDx(nrbins+1) = 0.05d0
       do n = 2, nrbins
-         xxDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nrbins) &
+         xxDx(n) = DEXP(REAL(n-1,KIND=R8KIND)/REAL(nrbins,KIND=R8KIND) &
                   *DLOG(xxDx(nrbins+1)/xxDx(1)) +DLOG(xxDx(1)))
       enddo
       do n = 1, nrbins
@@ -197,7 +202,7 @@ CONTAINS
 !+---+-----------------------------------------------------------------+
 !+---+-----------------------------------------------------------------+
 
-      COMPLEX*16 FUNCTION m_complex_water_ray(lambda,T)
+      COMPLEX(KIND=R8KIND) FUNCTION m_complex_water_ray(lambda,T)
 
 !      Complex refractive Index of Water as function of Temperature T
 !      [deg C] and radar wavelength lambda [m]; valid for
@@ -208,7 +213,7 @@ CONTAINS
       DOUBLE PRECISION, INTENT(IN):: T,lambda
       DOUBLE PRECISION:: epsinf,epss,epsr,epsi
       DOUBLE PRECISION:: alpha,lambdas,sigma,nenner
-      COMPLEX*16, PARAMETER:: i = (0d0,1d0)
+      COMPLEX(KIND=R8KIND), PARAMETER:: i = (0d0,1d0)
       DOUBLE PRECISION, PARAMETER:: PIx=3.1415926535897932384626434d0
 
       epsinf  = 5.27137d0 + 0.02164740d0 * T - 0.00131198d0 * T*T
@@ -232,7 +237,7 @@ CONTAINS
 
 !+---+-----------------------------------------------------------------+
       
-      COMPLEX*16 FUNCTION m_complex_ice_maetzler(lambda,T)
+      COMPLEX(KIND=R8KIND) FUNCTION m_complex_ice_maetzler(lambda,T)
       
 !      complex refractive index of ice as function of Temperature T
 !      [deg C] and radar wavelength lambda [m]; valid for
@@ -281,11 +286,11 @@ CONTAINS
       DOUBLE PRECISION, INTENT(in):: x_g, a_geo, b_geo, fmelt, lambda,  &
                                      meltratio_outside
       DOUBLE PRECISION, INTENT(out):: C_back
-      COMPLEX*16, INTENT(in):: m_w, m_i
+      COMPLEX(KIND=R8KIND), INTENT(in):: m_w, m_i
       CHARACTER(len=*), INTENT(in):: mixingrule, matrix, inclusion,     &
                                      host, hostmatrix, hostinclusion
 
-      COMPLEX*16:: m_core, m_air
+      COMPLEX(KIND=R8KIND):: m_core, m_air
       DOUBLE PRECISION:: D_large, D_g, rhog, x_w, xw_a, fm, fmgrenz,    &
                          volg, vg, volair, volice, volwater,            &
                          meltratio_outside_grenz, mra
@@ -368,20 +373,20 @@ CONTAINS
 
 !+---+-----------------------------------------------------------------+
 
-      complex*16 function get_m_mix_nested (m_a, m_i, m_w, volair,      &
+      complex(kind=R8KIND) function get_m_mix_nested (m_a, m_i, m_w, volair,      &
                      volice, volwater, mixingrule, host, matrix,        &
                      inclusion, hostmatrix, hostinclusion, cumulerror)
 
       IMPLICIT NONE
 
       DOUBLE PRECISION, INTENT(in):: volice, volair, volwater
-      COMPLEX*16, INTENT(in):: m_a, m_i, m_w
+      COMPLEX(KIND=R8KIND), INTENT(in):: m_a, m_i, m_w
       CHARACTER(len=*), INTENT(in):: mixingrule, host, matrix,          &
                      inclusion, hostmatrix, hostinclusion
       INTEGER, INTENT(out):: cumulerror
 
       DOUBLE PRECISION:: vol1, vol2
-      COMPLEX*16:: mtmp
+      COMPLEX(KIND=R8KIND):: mtmp
       INTEGER:: error
 
       !..Folded: ( (m1 + m2) + m3), where m1,m2,m3 could each be
@@ -538,13 +543,13 @@ CONTAINS
 
 !+---+-----------------------------------------------------------------+
 
-      COMPLEX*16 FUNCTION get_m_mix (m_a, m_i, m_w, volair, volice,     &
+      COMPLEX(KIND=R8KIND) FUNCTION get_m_mix (m_a, m_i, m_w, volair, volice,     &
                      volwater, mixingrule, matrix, inclusion, error)
 
       IMPLICIT NONE
 
       DOUBLE PRECISION, INTENT(in):: volice, volair, volwater
-      COMPLEX*16, INTENT(in):: m_a, m_i, m_w
+      COMPLEX(KIND=R8KIND), INTENT(in):: m_a, m_i, m_w
       CHARACTER(len=*), INTENT(in):: mixingrule, matrix, inclusion
       INTEGER, INTENT(out):: error
 
@@ -594,16 +599,16 @@ CONTAINS
 
 !+---+-----------------------------------------------------------------+
 
-      COMPLEX*16 FUNCTION m_complex_maxwellgarnett(vol1, vol2, vol3,    &
+      COMPLEX(KIND=R8KIND) FUNCTION m_complex_maxwellgarnett(vol1, vol2, vol3,    &
                      m1, m2, m3, inclusion, error)
 
       IMPLICIT NONE
 
-      COMPLEX*16 :: m1, m2, m3
+      COMPLEX(KIND=R8KIND) :: m1, m2, m3
       DOUBLE PRECISION :: vol1, vol2, vol3
       CHARACTER(len=*) :: inclusion
 
-      COMPLEX*16 :: beta2, beta3, m1t, m2t, m3t
+      COMPLEX(KIND=R8KIND) :: beta2, beta3, m1t, m2t, m3t
       INTEGER, INTENT(out) :: error
 
       error = 0
@@ -639,7 +644,7 @@ CONTAINS
 #else
        CALL wrf_debug(150, radar_debug)
 #endif
-       m_complex_maxwellgarnett=DCMPLX(-999.99d0,-999.99d0)
+       m_complex_maxwellgarnett=CMPLX(-999.99d0,-999.99d0,kind=R8KIND)
        error = 1
        return
       endif

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -659,7 +659,7 @@
       xDx(1) = D0i*1.0d0
       xDx(nbi+1) = 5.0d0*D0s
       do n = 2, nbi
-         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbi) &
+         xDx(n) = DEXP(REAL(n-1,KIND=R8SIZE)/REAL(nbi,KIND=R8SIZE) &
                   *DLOG(xDx(nbi+1)/xDx(1)) +DLOG(xDx(1)))
       enddo
       do n = 1, nbi
@@ -671,7 +671,7 @@
       xDx(1) = D0r*1.0d0
       xDx(nbr+1) = 0.005d0
       do n = 2, nbr
-         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbr) &
+         xDx(n) = DEXP(REAL(n-1,KIND=R8SIZE)/REAL(nbr,KIND=R8SIZE) &
                   *DLOG(xDx(nbr+1)/xDx(1)) +DLOG(xDx(1)))
       enddo
       do n = 1, nbr
@@ -683,7 +683,7 @@
       xDx(1) = D0s*1.0d0
       xDx(nbs+1) = 0.02d0
       do n = 2, nbs
-         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbs) &
+         xDx(n) = DEXP(REAL(n-1,KIND=R8SIZE)/REAL(nbs,KIND=R8SIZE) &
                   *DLOG(xDx(nbs+1)/xDx(1)) +DLOG(xDx(1)))
       enddo
       do n = 1, nbs
@@ -695,7 +695,7 @@
       xDx(1) = D0g*1.0d0
       xDx(nbg+1) = 0.05d0
       do n = 2, nbg
-         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbg) &
+         xDx(n) = DEXP(REAL(n-1,KIND=R8SIZE)/REAL(nbg,KIND=R8SIZE) &
                   *DLOG(xDx(nbg+1)/xDx(1)) +DLOG(xDx(1)))
       enddo
       do n = 1, nbg
@@ -707,7 +707,7 @@
       xDx(1) = 1.0d0
       xDx(nbc+1) = 3000.0d0
       do n = 2, nbc
-         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbc)                          &
+         xDx(n) = DEXP(REAL(n-1,KIND=R8SIZE)/REAL(nbc,KIND=R8SIZE)                          &
                   *DLOG(xDx(nbc+1)/xDx(1)) +DLOG(xDx(1)))
       enddo
       do n = 1, nbc
@@ -3841,7 +3841,7 @@
         T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
         do k = 1, 45
 !         print*, ' Freezing water for temp = ', -k
-         Texp = DEXP( DFLOAT(k) - T_adjust*1.0D0 ) - 1.0D0
+         Texp = DEXP( REAL(k,KIND=R8SIZE) - T_adjust*1.0D0 ) - 1.0D0
          do j = 1, ntb_r1
             do i = 1, ntb_r
                lam_exp = (N0r_exp(j)*am_r*crg(1)/r_r(i))**ore1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
@@ -4,9 +4,13 @@ MODULE module_ra_cam_support
 ! background.
 ! Laura D. Fowler (birch.ucar.edu) / 2013-07-01.
   use mpas_atmphys_utilities
-#endif
+  use mpas_kind_types, only : R8KIND
+  implicit none
+      integer, parameter :: r8 = R8KIND
+#else
   implicit none
       integer, parameter :: r8 = 8
+#endif
       real(r8), parameter:: inf = 1.e20 ! CAM sets this differently in infnan.F90
       integer, parameter:: bigint = int(O'17777777777')      ! largest possible 32-bit integer 
 


### PR DESCRIPTION
This PR makes code changes throughout the atmosphere core to achieve
conformance with the Fortran 2008 standard. Primarily, the non-conformance
issues were related to the use of non-standard kind-types and intrinsic functions.

With the changes in this PR, the atmosphere core can be successfully compiled
by the GNU compilers with `-std=f2008`. Note that there are still warnings about,
e.g., non-conforming tabs or obsolescent features, but these do not prevent
compilation and can therefore be addressed in a future PR.