### PR TITLE
Avoid use of hardwired Fortran unit number 22 in atm_core module

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -11,6 +11,7 @@ module atm_core
    use mpas_pool_routines
    use mpas_dmpar
    use mpas_log, only : mpas_log_write, mpas_log_info
+   use mpas_io_units, only : mpas_new_unit, mpas_release_unit
 
    type (MPAS_Clock_type), pointer :: clock
 
@@ -210,6 +211,7 @@ module atm_core
       character (len=StrKIND), pointer :: config_run_duration
       character (len=StrKIND), pointer :: config_stop_time
       character (len=StrKIND) :: startTimeStamp
+      integer :: iounit
 
 
       ierr = 0
@@ -221,9 +223,11 @@ module atm_core
       call mpas_pool_get_config(configs, 'config_stop_time', config_stop_time)
 
       if(trim(config_start_time) == 'file') then
-         open(22,file=trim(config_restart_timestamp_name),form='formatted',status='old')
-         read(22,*) startTimeStamp
-         close(22)
+         call mpas_new_unit(iounit)
+         open(iounit,file=trim(config_restart_timestamp_name),form='formatted',status='old')
+         read(iounit,*) startTimeStamp
+         close(iounit)
+         call mpas_release_unit(iounit)
       else
         startTimeStamp = config_start_time
       end if
@@ -498,6 +502,7 @@ module atm_core
       character(len=StrKIND) :: timeStamp
       character (len=StrKIND), pointer :: config_restart_timestamp_name
       integer :: itimestep
+      integer :: iounit
 
       integer :: stream_dir
       character(len=StrKIND) :: input_stream, read_time
@@ -735,9 +740,11 @@ module atm_core
          !    write the restart_timestamp file
          if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_OUTPUT, ierr=ierr)) then
             if (domain % dminfo % my_proc_id == 0) then
-               open(22,file=trim(config_restart_timestamp_name),form='formatted',status='replace')
-               write(22,*) trim(timeStamp)
-               close(22)
+               call mpas_new_unit(iounit)
+               open(iounit,file=trim(config_restart_timestamp_name),form='formatted',status='replace')
+               write(iounit,*) trim(timeStamp)
+               close(iounit)
+               call mpas_release_unit(iounit)
             end if
          end if
 


### PR DESCRIPTION
This PR updates the atm_core module to avoid the use of a hardwired Fortran
unit number.

The atm_core module used a hardwired value of 22 for the Fortran unit
number used to read and write the 'restart_timestamp' file. Although not known
to be an issue at present, the use of hardwired unit numbers could in principle
lead to the use of a unit number that was already in use by other code.

To avoid potential problems, the atm_core module now uses mpas_new_unit and
mpas_release_unit from the mpas_io_units module to more safely obtain and
release Fortran unit numbers.