### PR TITLE
Add four new timers in atm_core module for file I/O and diagnostic computation

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -26,6 +26,7 @@ module atm_core
       use mpas_atm_dimensions, only : mpas_atm_set_dims
       use mpas_atm_diagnostics_manager, only : mpas_atm_diag_setup
       use mpas_atm_threading, only : mpas_atm_threading_init
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
 
       implicit none
 
@@ -89,11 +90,13 @@ module atm_core
       ! input alarms for both input and restart before reading any remaining
       ! input streams.
       !
+      call mpas_timer_start('read_ICs')
       if (config_do_restart) then
          call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=ierr)
       else
          call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=ierr)
       end if
+      call mpas_timer_stop('read_ICs')
       if (ierr /= MPAS_STREAM_MGR_NOERR) then
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('Error reading initial conditions',                                                 messageType=MPAS_LOG_ERR)
@@ -480,7 +483,7 @@ module atm_core
       use mpas_kind_types
       use mpas_stream_manager
       use mpas_derived_types, only : MPAS_STREAM_LATEST_BEFORE, MPAS_STREAM_INPUT, MPAS_STREAM_INPUT_OUTPUT
-      use mpas_timer
+      use mpas_timer, only : mpas_timer_start, mpas_timer_stop
       use mpas_atm_boundaries, only : mpas_atm_update_bdy_tend
       use mpas_atm_diagnostics_manager, only : mpas_atm_diag_update, mpas_atm_diag_compute, mpas_atm_diag_reset
    
@@ -546,15 +549,19 @@ module atm_core
             block_ptr => block_ptr % next
          end do
       end if
+      call mpas_timer_start('diagnostic_fields')
       call mpas_atm_diag_reset()
       call mpas_atm_diag_update()
       call mpas_atm_diag_compute()
+      call mpas_timer_stop('diagnostic_fields')
 
       call mpas_dmpar_get_time(diag_stop_time)
 
+      call mpas_timer_start('stream_output')
       call mpas_dmpar_get_time(output_start_time)
       call mpas_stream_mgr_write(domain % streamManager, ierr=ierr)
       call mpas_dmpar_get_time(output_stop_time)
+      call mpas_timer_stop('stream_output')
       if (ierr /= MPAS_STREAM_MGR_NOERR .and. &
           ierr /= MPAS_STREAM_MGR_ERR_CLOBBER_FILE .and. &
           ierr /= MPAS_STREAM_MGR_ERR_CLOBBER_REC) then
@@ -567,7 +574,9 @@ module atm_core
          call mpas_log_write('Timing for stream output: $r s', realArgs=(/real(output_stop_time - output_start_time, kind=RKIND)/))
       end if
 
+      call mpas_timer_start('diagnostic_fields')
       call mpas_atm_diag_reset()
+      call mpas_timer_stop('diagnostic_fields')
 
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
 
@@ -639,10 +648,12 @@ module atm_core
             if (stream_dir == MPAS_STREAM_INPUT .or. stream_dir == MPAS_STREAM_INPUT_OUTPUT) then
                if (MPAS_stream_mgr_ringing_alarms(domain % streamManager, streamID=input_stream, &
                                                   direction=MPAS_STREAM_INPUT, ierr=ierr)) then
+                  call mpas_timer_start('stream_input')
                   call mpas_dmpar_get_time(input_start_time)
                   call MPAS_stream_mgr_read(domain % streamManager, streamID=input_stream, whence=MPAS_STREAM_LATEST_BEFORE, &
                                             actualWhen=read_time, ierr=ierr)
                   call mpas_dmpar_get_time(input_stop_time)
+                  call mpas_timer_stop('stream_input')
                   if (ierr /= MPAS_STREAM_MGR_NOERR) then
                      call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
                      call mpas_log_write('Error reading input stream '//trim(input_stream),                                  messageType=MPAS_LOG_ERR)
@@ -697,13 +708,17 @@ module atm_core
            end do
          end if
 
+         call mpas_timer_start('diagnostic_fields')
          call mpas_atm_diag_update()
          call mpas_atm_diag_compute()
+         call mpas_timer_stop('diagnostic_fields')
          call mpas_dmpar_get_time(diag_stop_time)
 
+         call mpas_timer_start('stream_output')
          call mpas_dmpar_get_time(output_start_time)
          call mpas_stream_mgr_write(domain % streamManager, ierr=ierr)
          call mpas_dmpar_get_time(output_stop_time)
+         call mpas_timer_stop('stream_output')
          if (ierr /= MPAS_STREAM_MGR_NOERR .and. &
              ierr /= MPAS_STREAM_MGR_ERR_CLOBBER_FILE .and. &
              ierr /= MPAS_STREAM_MGR_ERR_CLOBBER_REC) then
@@ -741,7 +756,9 @@ module atm_core
             end if
          end if
 
+         call mpas_timer_start('diagnostic_fields')
          call mpas_atm_diag_reset()
+         call mpas_timer_stop('diagnostic_fields')
 
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
 


### PR DESCRIPTION
This PR adds four new timers in the atm_core module to give a more complete
view of where time is being spent in an MPAS-A run:

  read_ICs : measures the time spent reading either the "input" stream or the
             "restart" stream during model start up

  diagnostic_fields : measures the time for calls to the diagnostics compute,
             update, and reset phases

  stream_input : measures time spent in periodic calls to MPAS_stream_mgr_read
             (excluding the call to MPAS_stream_mgr_read to read ICs, which is
             measured by the read_ICs timer)

  stream_output : measures time spent in calls to MPAS_stream_mgr_write