### PR TITLE
Switch from unencrypted Git protocol to HTTPS when obtaining MPAS-Data repo

### DIFF
--- a/src/core_atmosphere/physics/checkout_data_files.sh
+++ b/src/core_atmosphere/physics/checkout_data_files.sh
@@ -73,7 +73,7 @@ fi
 which git
 if [ $? -eq 0 ]; then
    echo "*** Trying git to obtain WRF physics tables ***"
-   git clone git://github.com/${github_org}/MPAS-Data.git
+   git clone https://github.com/${github_org}/MPAS-Data.git
    if [ $? -eq 0 ]; then
       cd MPAS-Data
       git checkout v${mpas_vers}


### PR DESCRIPTION
This PR updates the `checkout_data_files.sh` script to use HTTPS rather than the
unencrypted Git protocol when obtaining the MPAS-Data repository.

On 15 March 2022, GitHub removed support for the unencrypted Git protocol (i.e.,
for obtaining repositories with URLs beginning with `git://`). As part of the
MPAS-Atmosphere build process, the `checkout_data_files.sh` script first tries to
obtain the MPAS-Data repository, which contains look-up tables used by physics
schemes, using the URL `git://github.com/MPAS-Dev/MPAS-Data.git`. Doing so results
in the messages
```
  *** Trying git to obtain WRF physics tables ***
  Cloning into 'MPAS-Data'...
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
The simple solution is to switch to the use of HTTPS when obtaining the
MPAS-Data repository.

Note that, although the `checkout_data_files.sh` script is no longer able to obtain
the `MPAS-Data` repository through the unencrypted Git protocol, the script does
implement several fallback methods for obtaining the physics lookup tables (specifically,
as a Subversion (SVN) repository and as a `.tar.gz` file using curl).