### PR TITLE
Initial support for Cray OpenMP offloading on AMD GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ stream_list.*
 *.i90
 
 src/core_*/inc
+
+# cray acc offloading assembly files
+*.acc.s
+# cray intermediate files
+*.opt
+*.cg
+*.lst

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2013-2019,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
 Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD)
 
 All rights reserved. 
 
@@ -23,7 +24,7 @@ list of conditions and the following disclaimer.
 this list of conditions and the following disclaimer in the documentation and/or
 other materials provided with the distribution.
 
-3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+3) None of the names of LANS, UCAR, AMD, or the names of its contributors, if any, may
 be used to endorse or promote products derived from this software without
 specific prior written permission.
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,33 @@ ftn:
 	"OPENACC = $(OPENACC)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
+ftn-offload:
+	( $(MAKE) all \
+	"FC_PARALLEL = ftn" \
+	"CC_PARALLEL = cc" \
+	"CXX_PARALLEL = CC" \
+	"FC_SERIAL = ftn" \
+	"CC_SERIAL = cc" \
+	"CXX_SERIAL = CC" \
+	"FFLAGS_PROMOTION = -default64" \
+	"FFLAGS_OPT = -s integer32 -O2 -f free -N 1023 -em -ef -hlist=aimd" \
+	"CFLAGS_OPT = -O2" \
+	"LDFLAGS_OPT = -O2 -fopenmp" \
+	"FFLAGS_OMP = -fopenmp" \
+	"CFLAGS_OMP = -fopenmp" \
+	"FFLAGS_ACC =" \
+	"CFLAGS_ACC =" \
+        "FFLAGS_GPU = -fopenmp -hnoacc -homp" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP_AMD_OFFLOAD = $(OPENMP_AMD_OFFLOAD)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
+
+
 titan-cray:
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
@@ -128,6 +155,36 @@ pgi:
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
 	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback" \
+	"CFLAGS_DEBUG = -O0 -g -traceback" \
+	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
+	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback" \
+	"FFLAGS_OMP = -mp" \
+	"CFLAGS_OMP = -mp" \
+	"FFLAGS_ACC = -Mnofma -acc -ta=tesla:cc70,cc80 -Minfo=accel" \
+	"CFLAGS_ACC =" \
+	"PICFLAG = -fpic" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI -DCPRPGI" )
+
+nvfortran:
+	( $(MAKE) all \
+	"FC_PARALLEL = mpif90" \
+	"CC_PARALLEL = mpicc" \
+	"CXX_PARALLEL = mpicxx" \
+	"FC_SERIAL = pgf90" \
+	"CC_SERIAL = pgcc" \
+	"CXX_SERIAL = pgc++" \
+	"FFLAGS_PROMOTION = -r8" \
+	"FFLAGS_OPT = -O4 -Mbyteswapio -Mfree" \
+	"CFLAGS_OPT = -O3" \
+	"CXXFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT = -O3 -lhdf5 -lhdf5_hl" \
+	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Mbyteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback" \
 	"CFLAGS_DEBUG = -O0 -g -traceback" \
 	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback" \
@@ -788,6 +845,14 @@ ifeq "$(OPENMP_OFFLOAD)" "true"
 	LDFLAGS += $(LDFLAGS_GPU)
 endif #OPENMP_OFFLOAD IF
 
+ifeq "$(OPENMP_AMD_OFFLOAD)" "true"
+	FFLAGS += $(FFLAGS_GPU)
+	CFLAGS += $(FFLAGS_GPU)
+	CXXFLAGS += $(FFLAGS_GPU)
+	override CPPFLAGS += "-DMPAS_AMD_OFFLOAD"
+	LDFLAGS += $(LDFLAGS_GPU)
+endif #OPENMP_AMD_OFFLOAD IF
+
 ifeq "$(PRECISION)" "single"
 	CFLAGS += "-DSINGLE_PRECISION"
 	CXXFLAGS += "-DSINGLE_PRECISION"
@@ -881,7 +946,11 @@ endif
 ifeq "$(OPENMP_OFFLOAD)" "true"
 	OPENMP_OFFLOAD_MESSAGE="MPAS was built with OpenMP-offload GPU support enabled."
 else
-	OPENMP_OFFLOAD_MESSAGE="MPAS was built without OpenMP-offload GPU support."
+ifeq "$(OPENMP_AMD_OFFLOAD)" "true"
+	OPENMP_OFFLOAD_MESSAGE="MPAS was built with OpenMP-offload AMD GPU support enabled."
+else
+        OPENMP_OFFLOAD_MESSAGE="MPAS was built without OpenMP-offload GPU support."
+endif
 endif
 
 ifeq "$(OPENACC)" "true"

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -56,7 +56,8 @@ atmcore: $(PHYSCORE) dycore diagcore $(OBJS)
 
 mpas_atm_core_interface.o: mpas_atm_core.o
 
-mpas_atm_core.o: dycore diagcore mpas_atm_threading.o
+#mpas_atm_core.o: dycore diagcore mpas_atm_threading.o
+mpas_atm_core.o: mpas_atm_threading.o
 
 mpas_atm_dimensions.o:
 

--- a/src/core_atmosphere/dynamics/Makefile
+++ b/src/core_atmosphere/dynamics/Makefile
@@ -2,8 +2,13 @@
 
 OBJS = mpas_atm_time_integration.o \
        mpas_atm_boundaries.o
+#OBJS = opt_subroutines.o \
+#       mpas_atm_time_integration.o \
+#       mpas_atm_boundaries.o
 
 all: $(OBJS)
+
+#opt_subroutines.o: mpas_atm_iau.o
 
 mpas_atm_time_integration.o: mpas_atm_boundaries.o mpas_atm_iau.o
 
@@ -15,6 +20,7 @@ clean:
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+	$(RM) *.acc.s
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1,13 +1,16 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 
-module atm_time_integration
 
+#include "mpas_openmp.inc"
+module atm_time_integration
+   !use atm_time_integration_test
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_kind_types
@@ -274,6 +277,17 @@ module atm_time_integration
 !      call mpas_log_write(' MPI rank $i',intArgs=(/rrpk_rank/))
 !#endif
 
+GPUOMP !$omp target enter data map(to:compactHaloInfo_c_v,compactHaloInfo_c_vP1,compactHaloInfo_c_v_s,compactHaloInfo_e_v, compactHaloInfo_c_2_v,&
+GPUOMP !$omp gpu_bufferOffset_send_c_v, gpu_nList_send_c_v, gpu_idx_send_c_v, gpu_bufferOffset_recv_c_v, gpu_nList_recv_c_v,&
+GPUOMP !$omp gpu_idx_recv_c_v, gpu_dimsizes_c_v, gpu_nHaloLayers_c_v, gpu_bufferOffset_send_c_vP1, &
+GPUOMP !$omp gpu_nList_send_c_vP1, gpu_idx_send_c_vP1, gpu_bufferOffset_recv_c_vP1, gpu_nList_recv_c_vP1,&
+GPUOMP !$omp gpu_idx_recv_c_vP1, gpu_dimsizes_c_vP1, gpu_nHaloLayers_c_vP1, gpu_bufferOffset_send_e_v, &
+GPUOMP !$omp gpu_nList_send_e_v, gpu_idx_send_e_v, gpu_bufferOffset_recv_e_v, gpu_nList_recv_e_v,&
+GPUOMP !$omp gpu_idx_recv_e_v, gpu_dimsizes_e_v, gpu_nHaloLayers_e_v,gpu_bufferOffset_send_c_v_s, &
+GPUOMP !$omp gpu_nList_send_c_v_s, gpu_idx_send_c_v_s, gpu_bufferOffset_recv_c_v_s, gpu_nList_recv_c_v_s,&
+GPUOMP !$omp gpu_idx_recv_c_v_s, gpu_dimsizes_c_v_s, gpu_nHaloLayers_c_v_s, gpu_bufferOffset_send_c_2_v, &
+GPUOMP !$omp gpu_nList_send_c_2_v, gpu_idx_send_c_2_v, gpu_bufferOffset_recv_c_2_v, gpu_nList_recv_c_2_v,&
+GPUOMP !$omp gpu_idx_recv_c_2_v, gpu_dimsizes_c_2_v, gpu_nHaloLayers_c_2_v)
 !$acc enter data copyin(compactHaloInfo_c_v,compactHaloInfo_c_vP1,compactHaloInfo_c_v_s,compactHaloInfo_e_v, compactHaloInfo_c_2_v,&
 !$acc gpu_bufferOffset_send_c_v, gpu_nList_send_c_v, gpu_idx_send_c_v, gpu_bufferOffset_recv_c_v, gpu_nList_recv_c_v,&
 !$acc gpu_idx_recv_c_v, gpu_dimsizes_c_v, gpu_nHaloLayers_c_v, gpu_bufferOffset_send_c_vP1, &
@@ -530,6 +544,8 @@ module atm_time_integration
       allocate(tend_ru_physics(nVertLevels,nEdges+1))
 !      tend_ru_physics(:,nEdges+1) = 0.0_RKIND
       allocate(tend_th(nVertLevels,nCellsSolve))
+      GPUOMP !$omp target enter data map(alloc:qtot,tend_rtheta_physics,tend_rho_physics,&
+      GPUOMP !$omp tend_ru_physics,tend_th)
 
       !
       ! Initialize RK weights
@@ -635,7 +651,7 @@ module atm_time_integration
          call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
          call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
          do thread=1,nThreads
             call atm_rk_integration_setup(state, diag, &
                                           cellThreadStart(thread), cellThreadEnd(thread), &
@@ -645,7 +661,7 @@ module atm_time_integration
                                           vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                           edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
          end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
          block => block % next
       end do
@@ -676,7 +692,7 @@ module atm_time_integration
          call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
          call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
          do thread=1,nThreads
             call atm_compute_moist_coefficients( block % dimensions, state, diag, mesh, &     !MGD could do away with dimensions arg
                                                  cellThreadStart(thread), cellThreadEnd(thread), &
@@ -686,7 +702,7 @@ module atm_time_integration
                                                  vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                                  edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
          end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
          block => block % next
       end do
@@ -760,6 +776,8 @@ module atm_time_integration
 !               ke_vertex(:,nVertices+1) = 0.0_RKIND
                allocate(ke_edge(nVertLevels,nEdges+1))
 !               ke_edge(:,nEdges+1) = 0.0_RKIND
+GPUOMP !$omp target enter data map(alloc:delsq_theta,delsq_w,delsq_divergence,delsq_u,&
+GPUOMP !$omp delsq_vorticity,dpdz,ke_vertex,ke_edge)
 
       DYNAMICS_SUBSTEPS : do dynamics_substep = 1, dynamics_split
 
@@ -788,7 +806,7 @@ module atm_time_integration
             call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
             rk_step = 1
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
             do thread=1,nThreads
                call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
                                           cellThreadStart(thread), cellThreadEnd(thread), &
@@ -796,7 +814,7 @@ module atm_time_integration
                                           cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                           edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
             end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
             block => block % next
          end do
          call mpas_timer_stop('atm_compute_vert_imp_coefs')
@@ -842,7 +860,7 @@ module atm_time_integration
                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                  do thread=1,nThreads
                     call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
                                                      cellThreadStart(thread), cellThreadEnd(thread), &
@@ -850,7 +868,7 @@ module atm_time_integration
                                                      cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                                      edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                  end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
                  block => block % next
               end do
             end if  
@@ -903,7 +921,7 @@ module atm_time_integration
 !               allocate(dpdz(nVertLevels,nCells+1))
 !               dpdz(:,nCells+1) = 0.0_RKIND
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_compute_dyn_tend( tend, tend_physics, state, diag, mesh, block % configs, nVertLevels, rk_step, dt, & 
                                              cellThreadStart(thread), cellThreadEnd(thread), &
@@ -913,7 +931,7 @@ module atm_time_integration
                                              vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
    
                block => block % next
@@ -961,7 +979,7 @@ module atm_time_integration
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
                
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_set_smlstep_pert_variables( tend, diag, mesh, block % configs, &
                                              cellThreadStart(thread), cellThreadEnd(thread), &
@@ -969,7 +987,7 @@ module atm_time_integration
                                              cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
                block => block % next
             end do
             call mpas_timer_stop('small_step_prep')
@@ -1006,7 +1024,7 @@ module atm_time_integration
                   ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nEdges, 'ru', 0.0_RKIND )
                   rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
                   rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_dynamics_speczone_tend( tend, mesh, block % configs, nVertLevels,                 &
                                                                  ru_driving_tend, rt_driving_tend, rho_driving_tend,       &
@@ -1015,7 +1033,7 @@ module atm_time_integration
                                                                  cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                                                  edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                   deallocate(ru_driving_tend)
                   deallocate(rt_driving_tend)
@@ -1056,7 +1074,7 @@ module atm_time_integration
                   rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
                   rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_dynamics_relaxzone_tend( tend, state, diag, mesh, nVertLevels, dt,                   &
                                                                   ru_driving_values, rt_driving_values, rho_driving_values,   &
@@ -1065,7 +1083,7 @@ module atm_time_integration
                                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread),   &
                                                                   edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                   deallocate(ru_driving_values)
                   deallocate(rt_driving_values)
@@ -1122,7 +1140,7 @@ module atm_time_integration
                   call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
                   call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_advance_acoustic_step( state, diag, tend,  mesh, block % configs, nCells, nVertLevels, &
                                              rk_sub_timestep(rk_step), small_step, &
@@ -1133,7 +1151,7 @@ module atm_time_integration
                                              vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                   block => block % next
                end do
@@ -1167,12 +1185,12 @@ module atm_time_integration
                   call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
                   call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_divergence_damping_3d( state, diag, mesh, block % configs, rk_sub_timestep(rk_step), &
                                                      edgeThreadStart(thread), edgeThreadEnd(thread) )
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                   block => block % next
                end do
@@ -1244,7 +1262,7 @@ module atm_time_integration
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_recover_large_step_variables( state, diag, tend, mesh, block % configs, rk_timestep(rk_step), &
                                              number_sub_steps(rk_step), rk_step, &
@@ -1255,7 +1273,7 @@ module atm_time_integration
                                              vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                block => block % next
             end do
@@ -1383,16 +1401,20 @@ module atm_time_integration
                   !flux_array(:,nEdges+1) = 0.0_RKIND
                   allocate(wdtn_arr(nVertLevels+1,nCells+1))
                   !wdtn_arr(:,nCells+1) = 0.0_RKIND
+GPUOMP !$omp target enter data map(alloc:scalar_old_arr,scalar_new_arr,s_max_arr,s_min_arr,scale_array,&
+GPUOMP !$omp flux_array,wdtn_arr)
                   if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
                      allocate(horiz_flux_array(num_scalars,nVertLevels,nEdges+1))
+GPUOMP !$omp target enter data map(alloc:horiz_flux_array)
                      !horiz_flux_array(:,:,nEdges+1) = 0.0_RKIND
                   else
                      allocate(flux_upwind_tmp_arr(nVertLevels,nEdges+1))
                      !flux_upwind_tmp_arr(:,nEdges+1) = 0.0_RKIND
                      allocate(flux_tmp_arr(nVertLevels,nEdges+1))
                      !flux_tmp_arr(:,nEdges+1) = 0.0_RKIND
+GPUOMP !$omp target enter data map(alloc:flux_upwind_tmp_arr,flux_tmp_arr)
                   end if
-
+GPUOMP !$omp target teams distribute parallel do simd
 !$acc parallel
 !$acc loop gang worker vector
                   do levelsIdx=1,tmpnVertLevels
@@ -1406,10 +1428,14 @@ module atm_time_integration
                      wdtn_arr(levelsIdx,tmpnCells+1) = 0.0_RKIND
                   enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
+GPUOMP !$omp target
 !$acc parallel num_gangs(1) num_workers(1) vector_length(1)
                   wdtn_arr(tmpnVertLevels+1,tmpnCells+1) = 0.0_RKIND
 !$acc end parallel
+GPUOMP !$omp end target
                   if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel
 !$acc loop gang worker vector collapse(2)
                      do levelsIdx=1,tmpnVertLevels
@@ -1418,7 +1444,9 @@ module atm_time_integration
                         enddo
                      enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
                   else
+GPUOMP !$omp target teams distribute parallel do simd
 !$acc parallel
 !$acc loop gang worker vector
                      do levelsIdx=1,tmpnVertLevels
@@ -1426,6 +1454,7 @@ module atm_time_integration
                         flux_tmp_arr(levelsIdx,tmpnEdges+1) = 0.0_RKIND
                      enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
                   end if
 
                   !
@@ -1433,7 +1462,7 @@ module atm_time_integration
                   !       the functionality of the advance_scalars routine; however, it is noticeably slower, 
                   !       so we use the advance_scalars routine for the first two RK substeps.
                   !
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
                         call atm_advance_scalars( tend, state, diag, mesh, block % configs, num_scalars, nCells, nVertLevels, rk_timestep(rk_step), &
@@ -1460,8 +1489,10 @@ module atm_time_integration
                                                 advance_density=.false.)
                      end if
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
+GPUOMP !$omp target exit data map(delete:scalar_old_arr,scalar_new_arr,s_max_arr,s_min_arr,scale_array,&
+GPUOMP !$omp flux_array,wdtn_arr)
                   deallocate(scalar_old_arr)
                   deallocate(scalar_new_arr)
                   deallocate(s_max_arr)
@@ -1470,8 +1501,10 @@ module atm_time_integration
                   deallocate(flux_array)
                   deallocate(wdtn_arr)
                   if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+GPUOMP !$omp target exit data map(delete:horiz_flux_array)
                      deallocate(horiz_flux_array)
                   else
+GPUOMP !$omp target exit data map(delete:flux_upwind_tmp_arr,flux_tmp_arr)
                      deallocate(flux_upwind_tmp_arr)
                      deallocate(flux_tmp_arr)
                   end if
@@ -1545,13 +1578,13 @@ module atm_time_integration
                         scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                      end if
                   
-                     !$OMP PARALLEL DO
+                     CPUOMP !$OMP PARALLEL DO
                      do thread=1,nThreads
                         call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
                                                      cellThreadStart(thread), cellThreadEnd(thread), &
                                                      cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
                      end do
-                     !$OMP END PARALLEL DO
+                     CPUOMP !$OMP END PARALLEL DO
 
                      deallocate(scalars_driving)
 
@@ -1585,14 +1618,18 @@ module atm_time_integration
                call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
    
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                do thread=1,nThreads
+                  !call atm_compute_solve_diagnostics_gpu_test(dt, state, 2, diag, mesh, block % configs, &
+                  !                                   cellThreadStart(thread), cellThreadEnd(thread), &
+                  !                                   vertexThreadStart(thread), vertexThreadEnd(thread), &
+                  !                                   edgeThreadStart(thread), edgeThreadEnd(thread), rk_step,ke_edge,ke_vertex)
                   call atm_compute_solve_diagnostics_gpu(dt, state, 2, diag, mesh, block % configs, &
                                                      cellThreadStart(thread), cellThreadEnd(thread), &
                                                      vertexThreadStart(thread), vertexThreadEnd(thread), &
                                                      edgeThreadStart(thread), edgeThreadEnd(thread), rk_step)
                end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
 
                block => block % next
@@ -1656,12 +1693,12 @@ module atm_time_integration
 
                 call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
                 call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                 do thread=1,nThreads
                    call atm_zero_gradient_w_bdy( state, mesh, &
                                                  cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
                 end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                 block => block % next
               end do
@@ -1739,7 +1776,7 @@ module atm_time_integration
             call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
             call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
             do thread=1,nThreads
                call atm_rk_dynamics_substep_finish(state, diag, dynamics_substep, dynamics_split, &
                                                 cellThreadStart(thread), cellThreadEnd(thread), &
@@ -1749,7 +1786,7 @@ module atm_time_integration
                                                 vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
                                                 edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
             end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
             block => block % next
          end do
@@ -1757,6 +1794,8 @@ module atm_time_integration
 
       end do DYNAMICS_SUBSTEPS
 
+GPUOMP !$omp target exit data map(delete:delsq_theta,delsq_w,delsq_divergence,delsq_u,&
+GPUOMP !$omp delsq_vorticity,dpdz,ke_vertex,ke_edge)
                deallocate(ke_vertex)
                deallocate(ke_edge)
                deallocate(delsq_theta)
@@ -1767,7 +1806,9 @@ module atm_time_integration
 !!               deallocate(delsq_circulation)    ! no longer used -> removed 
                deallocate(delsq_vorticity)
                deallocate(dpdz)
-
+      
+GPUOMP !$omp target exit data map(delete:qtot,tend_rtheta_physics,tend_rho_physics,&
+GPUOMP !$omp tend_ru_physics,tend_th)
       deallocate(qtot)  !  we are finished with these now
       deallocate(tend_rtheta_physics)
       deallocate(tend_rho_physics)
@@ -1845,16 +1886,21 @@ module atm_time_integration
                !rho_zz_int(:,nCells+1) = 0.0_RKIND
                allocate(scalar_tend_array(num_scalars,nVertLevels,nCells+1))
                !scalar_tend_array(:,:,nCells+1) = 0.0_RKIND
+GPUOMP !$omp target enter data map(alloc:scalar_old_arr,scalar_new_arr,s_max_arr,s_min_arr,scale_array,&
+GPUOMP !$omp flux_array,wdtn_arr,rho_zz_int,scalar_tend_array)
                if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
                   allocate(horiz_flux_array(num_scalars,nVertLevels,nEdges+1))
+GPUOMP !$omp target enter data map(alloc:horiz_flux_array)
                   !horiz_flux_array(:,:,nEdges+1) = 0.0_RKIND
                else
                   allocate(flux_upwind_tmp_arr(nVertLevels,nEdges+1))
                   !flux_upwind_tmp_arr(:,nEdges+1) = 0.0_RKIND
                   allocate(flux_tmp_arr(nVertLevels,nEdges+1))
+GPUOMP !$omp target enter data map(alloc:flux_upwind_tmp_arr,flux_tmp_arr)
                   !flux_tmp_arr(:,nEdges+1) = 0.0_RKIND
                end if
 
+GPUOMP !$omp target teams distribute !parallel do thread_limit(64)
 !$acc parallel
 !$acc loop gang worker
                   do levelsIdx=1,tmpnVertLevels
@@ -1868,24 +1914,34 @@ module atm_time_integration
                      wdtn_arr(levelsIdx,tmpnCells+1) = 0.0_RKIND
                      rho_zz_int(levelsIdx,tmpnCells+1) = 0.0_RKIND
 !$acc loop gang vector
+GPUOMP !$omp parallel do simd
                      do scalarsIdx=1,tmpnum_scalars
                         scalar_tend_array(scalarsIdx,levelsIdx,tmpnCells+1) = 0.0_RKIND
                      enddo
+GPUOMP !$omp end parallel do simd
                   enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+GPUOMP !$omp target
 !$acc parallel num_gangs(1) num_workers(1) vector_length(1)
                   wdtn_arr(tmpnVertLevels+1,tmpnCells+1) = 0.0_RKIND
 !$acc end parallel
+GPUOMP !$omp end target
                   if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+GPUOMP !$omp target teams distribute !parallel do simd collapse(2)
 !$acc parallel
 !$acc loop gang worker vector collapse(2)
                      do levelsIdx=1,tmpnVertLevels
+GPUOMP !$omp parallel do simd
                         do scalarsIdx=1,tmpnum_scalars
                            horiz_flux_array(scalarsIdx,levelsIdx,tmpnEdges+1) = 0.0_RKIND
                         enddo
+GPUOMP !$omp end parallel do simd
                      enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do simd
                   else
+GPUOMP !$omp target teams distribute !parallel do simd
 !$acc parallel
 !$acc loop gang worker vector
                      do levelsIdx=1,tmpnVertLevels
@@ -1893,6 +1949,7 @@ module atm_time_integration
                         flux_tmp_arr(levelsIdx,tmpnEdges+1) = 0.0_RKIND
                      enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do simd
                   end if
 
 
@@ -1904,7 +1961,7 @@ module atm_time_integration
 
                !  The latest version of atm_advance_scalars does not need the arrays scalar_tend_array or rho_zz_int
                !  We can remove scalar_tend_array????  WCS 20160921
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                do thread=1,nThreads
                   if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
                      call atm_advance_scalars( tend, state, diag, mesh, block % configs, num_scalars, nCells, nVertLevels, rk_timestep(rk_step), &
@@ -1931,8 +1988,10 @@ module atm_time_integration
                                              advance_density=.true., rho_zz_int=rho_zz_int)
                   end if
                end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
+GPUOMP !$omp target exit data map(delete:scalar_old_arr,scalar_new_arr,s_max_arr,s_min_arr,scale_array,&
+GPUOMP !$omp flux_array,wdtn_arr,rho_zz_int,scalar_tend_array)
                deallocate(scalar_old_arr)
                deallocate(scalar_new_arr)
                deallocate(s_max_arr)
@@ -1943,8 +2002,10 @@ module atm_time_integration
                deallocate(rho_zz_int)
                deallocate(scalar_tend_array)
                if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+GPUOMP !$omp target exit data map(delete:horiz_flux_array)
                   deallocate(horiz_flux_array)
                else
+GPUOMP !$omp target exit data map(delete:flux_upwind_tmp_arr,flux_tmp_arr)
                   deallocate(flux_upwind_tmp_arr)
                   deallocate(flux_tmp_arr)
                end if
@@ -2020,13 +2081,13 @@ module atm_time_integration
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
                   
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
                                                   cellThreadStart(thread), cellThreadEnd(thread), &
                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
                   end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
                   deallocate(scalars_driving)
 
@@ -2109,6 +2170,7 @@ module atm_time_integration
          call mpas_pool_get_array_gpu(state, 'scalars', scalars_1, 1)
          call mpas_pool_get_array_gpu(state, 'scalars', scalars_2, 2)
          call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
 
          call mpas_pool_get_config(block % configs, 'config_microp_scheme', config_microp_scheme)
          call mpas_pool_get_config(block % configs, 'config_convection_scheme', config_convection_scheme)
@@ -2131,6 +2193,7 @@ module atm_time_integration
             !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
             !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
             if (config_monotonic) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2)
                do cellsIdx=1,nCells+1
@@ -2139,8 +2202,10 @@ module atm_time_integration
                  end do
                end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 !!!               rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
             else
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2)
                do cellsIdx=1,nCells+1
@@ -2149,12 +2214,14 @@ module atm_time_integration
                  end do
                end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 !!!               rqvdynten(:,:) = 0._RKIND
             end if
 
          end if
 
          !simply set to zero negative mixing ratios of different water species (for now):
+GPUOMP !$omp target teams distribute parallel do simd collapse(3)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(3)
          do cellsIdx=1,nCells+1
@@ -2165,6 +2232,7 @@ module atm_time_integration
            end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 !!!         where ( scalars_2(:,:,:) < 0.0)  &
 !!!            scalars_2(:,:,:) = 0.0
 
@@ -2174,12 +2242,12 @@ module atm_time_integration
          !call microphysics schemes:
          if (trim(config_microp_scheme) /= 'off')  then
             call mpas_timer_start('microphysics')
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
             do thread=1,nThreads
                call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
                                           cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
             end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
             call mpas_timer_stop('microphysics')
          end if
          block => block % next
@@ -2218,14 +2286,14 @@ module atm_time_integration
             rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
             rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
             do thread=1,nThreads
                call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
                                                    rt_driving_values, rho_driving_values,                        &
                                                    cellThreadStart(thread), cellThreadEnd(thread),               &
                                                    cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
             end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
             deallocate(rt_driving_values)
             deallocate(rho_driving_values)
@@ -2301,13 +2369,13 @@ module atm_time_integration
                scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
             end if
       
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
             do thread=1,nThreads
                call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
                                          cellThreadStart(thread), cellThreadEnd(thread), &
                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
             end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
             deallocate(scalars_driving)
 
@@ -2410,14 +2478,20 @@ module atm_time_integration
                                                         theta_m_1, theta_m_2
       real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1) :: scalars_1, scalars_2
       integer:: i,j, k
+TMPOMP !$omp target update to(ru, ru_save, rw, rw_save, &
+TMPOMP !$omp rtheta_p,rtheta_p_save,rho_p,rho_p_save, &
+TMPOMP !$omp rho_zz_old_split,scalars_1,scalars_2, &
+TMPOMP !$omp u_1,u_2,w_1,w_2,theta_m_1,theta_m_2,rho_zz_1,rho_zz_2)
 !$acc data present(ru, ru_save, rw, rw_save, &
 !$acc rtheta_p,rtheta_p_save,rho_p,rho_p_save, &
 !$acc rho_zz_old_split,scalars_1,scalars_2, &
 !$acc u_1,u_2,w_1,w_2,theta_m_1,theta_m_2,rho_zz_1,rho_zz_2)
 
+GPUOMP !$omp target teams distribute thread_limit(64) !parallel do thread_limit(64)
 !$acc parallel vector_length(32)
 !$acc loop gang
          do i = cellStart,cellEnd
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                 do j=1,nVertLevels
                       rtheta_p_save(j,i) = rtheta_p(j,i)
@@ -2429,12 +2503,17 @@ module atm_time_integration
                            scalars_2(k,j,i) = scalars_1(k,j,i)
                       enddo
                 enddo
+GPUOMP !$omp end parallel do simd
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                 do j=1,nVertLevels+1
                       rw_save(j,i) = rw(j,i)
                       w_2(j,i) = w_1(j,i)
                 enddo
+GPUOMP !$omp end parallel do simd
          enddo
+GPUOMP !$omp end target teams distribute !parallel do
+GPUOMP !$omp target teams distribute parallel do collapse(2)
 !$acc loop gang
          do i = edgeStart,edgeEnd
 !$acc loop vector
@@ -2444,6 +2523,9 @@ module atm_time_integration
                 enddo
          enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
+TMPOMP !$omp target update from(rtheta_p_save,rho_p_save,theta_m_2,rho_zz_2,rho_zz_old_split,scalars_2,&
+TMPOMP !$omp rw_save,w_2,ru_save,u_2)
 !$acc end data
    end subroutine atm_rk_integration_setup_work
 
@@ -2509,6 +2591,8 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: cqw
       real (kind=RKIND), dimension(nVertLevels,nEdges+1) :: cqu
       integer, dimension(2,nEdges+1) :: cellsOnEdge
+TMPOMP !$omp target update to(scalars,cqw,cqu,qtot)
+GPUOMP !$omp target teams distribute parallel do collapse(2) thread_limit(256)
 !$acc data present(scalars,cqw,cqu, qtot)
 !$acc parallel num_gangs(256)  vector_length(32)
 !$acc loop gang 
@@ -2519,9 +2603,13 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
+
+GPUOMP !$omp target teams distribute thread_limit(64) !parallel do thread_limit(64)
 !$acc parallel num_gangs(256)  vector_length(32)
 !$acc loop gang 
       do iCell = cellStart,cellEnd
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k = 1,nVertLevels
            qtot(k,iCell) = 0.0
@@ -2532,20 +2620,26 @@ module atm_time_integration
                qtot(k,iCell) = qtot(k,iCell) + scalars(iq, k, iCell)
             end do
          end do
+GPUOMP !$omp end parallel do simd
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k = 2, nVertLevels
             qtotal = 0.5*(qtot(k,iCell)+qtot(k-1,iCell))
             cqw(k,iCell) = 1.0 / (1.0 + qtotal)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
+GPUOMP !$omp target teams distribute thread_limit(64) !parallel do thread_limit(64)
 !$acc parallel  vector_length(32)
 !$acc loop gang
       do iEdge = edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve) then
+GPUOMP !$omp parallel do simd
 !$acc loop vector  
            do k = 1, nVertLevels
                qtotal = 0.0
@@ -2555,9 +2649,12 @@ module atm_time_integration
                end do
                cqu(k,iEdge) = 1.0 / (1.0 + qtotal)
             end do
+GPUOMP !$omp end parallel do simd
          end if
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+TMPOMP !$omp target update from(cqw,cqu,qtot,tend_ru_physics,tend_rtheta_physics,tend_rho_physics)
 !$acc end data
    end subroutine atm_compute_moist_coefficients_work
 
@@ -2628,6 +2725,11 @@ module atm_time_integration
       call mpas_pool_get_dimension(state, 'moist_end', moist_end)
 
 
+      !call atm_compute_vert_imp_coefs_work_test(nCells, moist_start, moist_end, dts, epssm, &
+      !                             zz, cqw, p, t, rb, rtb, pb, rt, cofwr, cofwz, coftz, cofwt, &
+      !                             a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
+      !                             cellStart, cellEnd, edgeStart, edgeEnd, &
+      !                             cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd,qtot)
       call atm_compute_vert_imp_coefs_work(nCells, moist_start, moist_end, dts, epssm, &
                                    zz, cqw, p, t, rb, rtb, pb, rt, cofwr, cofwz, coftz, cofwt, &
                                    a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
@@ -2688,7 +2790,10 @@ module atm_time_integration
       integer :: iCell, k, iq
       real (kind=RKIND) :: dtseps, c2, qtotal, rcv
       real (kind=RKIND), dimension( nVertLevels ,nCells+1) :: b_tri, c_tri
-
+GPUOMP !$omp target data map(alloc:b_tri,c_tri)
+TMPOMP !$omp target update to(cofrz, gamma_tri, a_tri, alpha_tri, &
+TMPOMP !$omp coftz, cofwr, cofwt, cofwz, &
+TMPOMP !$omp rdzw, cqw, fzm, fzp, p, pb, qtot, rb, rdzu, rt, rtb, t, zz)
 !$acc data present(cofrz, gamma_tri, a_tri, alpha_tri, &
 !$acc coftz, cofwr, cofwt, cofwz, &
 !$acc rdzw, cqw, fzm, fzp, p, pb, qtot, rb, rdzu, rt, rtb, t, zz)&
@@ -2700,32 +2805,39 @@ module atm_time_integration
       c2 = cp*rcv
 
 !$acc parallel num_workers(8) vector_length(32)
+GPUOMP !$omp target teams distribute parallel do simd thread_limit(64)
 !$acc loop vector
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
          cofrz(k) = dtseps*rdzw(k)
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker
       do iCell = cellSolveStart,cellSolveEnd  !  we only need to do cells we are solving for, not halo cells
 !DIR$ IVDEP
-         do k=2,nVertLevels
-            cofwr(k,iCell) =.5*dtseps*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
-         end do
-         coftz(1,iCell) = 0.0
+         GPUACC do k=2,nVertLevels
+         GPUACC    cofwr(k,iCell) =.5*dtseps*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
+         GPUACC end do
+         GPUACC coftz(1,iCell) = 0.0
 !DIR$ IVDEP
          do k=2,nVertLevels
+         GPUOMP    cofwr(k,iCell) =.5*dtseps*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
             cofwz(k,iCell) = dtseps*c2*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))  &
                  *rdzu(k)*cqw(k,iCell)*(fzm(k)*p (k,iCell)+fzp(k)*p (k-1,iCell))
             coftz(k,iCell) = dtseps*   (fzm(k)*t (k,iCell)+fzp(k)*t (k-1,iCell))
          end do
+         GPUOMP coftz(1,iCell) = 0.0
          coftz(nVertLevels+1,iCell) = 0.0
         end do
 !$acc end parallel	  
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd private(qtotal) collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker private(qtotal)
         do iCell = cellSolveStart,cellSolveEnd
@@ -2740,7 +2852,9 @@ module atm_time_integration
          end do
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker
         do iCell = cellSolveStart,cellSolveEnd
@@ -2751,11 +2865,16 @@ module atm_time_integration
          alpha_tri(1,iCell) = 0.  ! note, this value is never used
         enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
+!GPUOMP NOTE: Problematic subroutine below
+!GPUOMP !$omp target teams distribute parallel do thread_limit(64)
+GPUOMP !$omp target teams distribute thread_limit(64)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker
         do iCell = cellSolveStart,cellSolveEnd
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
          do k=2,nVertLevels
             a_tri(k,iCell) = -cofwz(k  ,iCell)* coftz(k-1,iCell)*rdzw(k-1)*zz(k-1,iCell)   &
                          +cofwr(k  ,iCell)* cofrz(k-1  )                       &
@@ -2770,19 +2889,25 @@ module atm_time_integration
                          -cofwr(k  ,iCell)* cofrz(k    )                       &
                          +cofwt(k  ,iCell)* coftz(k+1,iCell)*rdzw(k  )
          end do
+GPUOMP !$omp end parallel do simd
 !        end do
 !MGD VECTOR DEPENDENCE
 !        do iCell = cellSolveStart,cellSolveEnd
+GPUOMP !$omp parallel do simd
          do k=2,nVertLevels
             alpha_tri(k,iCell) = 1./(b_tri(k,iCell)-a_tri(k,iCell)*gamma_tri(k-1,iCell))
             gamma_tri(k,iCell) = c_tri(k,iCell)*alpha_tri(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
 
       end do ! loop over cells
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+!GPUOMP NOTE: Problematic subroutine above
+TMPOMP !$omp target update from(cofrz,cofwz,cofwr,coftz,cofwt,a_tri,gamma_tri,alpha_tri)
 
 !$acc end data
-
+GPUOMP !$omp end target data
    end subroutine atm_compute_vert_imp_coefs_work
 
 
@@ -2941,9 +3066,14 @@ module atm_time_integration
       ! here we need to compute the omega tendency in a manner consistent with our diagnosis of omega.
       ! this requires us to use the same flux divergence as is used in the theta eqn - see Klemp et al MWR 2003.
 
+TMPOMP !$omp target update to(w_tend, &
+TMPOMP !$omp edgesoncell, edgesoncell_sign, fzm, fzp,nedgesoncell, u_tend, &
+TMPOMP !$omp zb3_cell, zb_cell, zz)
 !$acc data present(w_tend, &
 !$acc edgesoncell, edgesoncell_sign, fzm, fzp,nedgesoncell, u_tend, &
 !$acc zb3_cell, zb_cell, zz)
+!GPUOMP !$omp target teams distribute parallel do private(iEdge,flux) thread_limit(64)
+GPUOMP !$omp target teams distribute private(iEdge,flux) thread_limit(64)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker private(iEdge, flux)
       do iCell=cellSolveStart,cellSolveEnd
@@ -2952,20 +3082,26 @@ module atm_time_integration
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
             do k = 2, nVertLevels
                flux = edgesOnCell_sign(i,iCell) * (fzm(k) * u_tend(k,iEdge) + fzp(k) * u_tend(k-1,iEdge))
                w_tend(k,iCell) = w_tend(k,iCell)   &
                         - (zb_cell(k,i,iCell) + sign(1.0_RKIND, u_tend(k,iEdge)) * zb3_cell(k,i,iCell)) * flux
             end do
+GPUOMP !$omp end parallel do simd
          end do
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
          do k = 2, nVertLevels
             w_tend(k,iCell) = ( fzm(k) * zz(k,iCell) + fzp(k) * zz(k-1,iCell)   ) * w_tend(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
          end if ! no conversion in specified zone
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 !$acc end data
+TMPOMP !$omp target update from(w_tend)
 
    end subroutine atm_set_smlstep_pert_variables_work
 
@@ -3095,6 +3231,15 @@ module atm_time_integration
 !      call mpas_pool_get_config(configs, 'config_smdiv', smdiv) 
 !      call mpas_pool_get_config(configs, 'config_smdiv_p_forward', smdiv_p_forward) 
 
+      !call atm_advance_acoustic_step_work_test(nCells, nEdges, nCellsSolve, cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
+      !                             cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
+      !                             rho_zz, theta_m, ru_p, rw_p, rtheta_pp, rtheta_pp_old, zz, exner, cqu, ruAvg, wwAvg, &
+      !                             rho_pp, cofwt, coftz, zxu, a_tri, alpha_tri, gamma_tri, dss, tend_ru, tend_rho, tend_rt, &
+      !                             tend_rw, zgrid, cofwr, cofwz, w, ru, ru_save, rw, rw_save, fzm, fzp, rdzw, dcEdge, invDcEdge, &
+      !                             invAreaCell, cofrz, dvEdge, nEdgesOnCell, cellsOnEdge, edgesOnCell, edgesOnCell_sign, &
+      !                             dts, small_step, epssm, cf1, cf2, cf3, &
+      !                             specZoneMaskEdge, specZoneMaskCell &
+      !                             )
       call atm_advance_acoustic_step_work(nCells, nEdges, nCellsSolve, cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                                    cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd, &
                                    rho_zz, theta_m, ru_p, rw_p, rtheta_pp, rtheta_pp_old, zz, exner, cqu, ruAvg, wwAvg, &
@@ -3191,9 +3336,9 @@ module atm_time_integration
       !
       ! Local variables
       !
-      integer :: cell1, cell2, iEdge, iCell, i, k
+      integer :: cell1, cell2, iEdge, iCell, i, k, k1
       real (kind=RKIND) :: c2, rcv, rtheta_pp_tmp
-      real (kind=RKIND) :: pgrad, flux, resm, rdts
+      real (kind=RKIND) :: pgrad, flux, resm, rdts, k2
 
 
       rcv = rgas / (cp - rgas)
@@ -3208,13 +3353,22 @@ module atm_time_integration
 !$acc coftz, cofwr, cofwt, cofwz, dss, dvedge, edgesoncell, edgesoncell_sign, &
 !$acc fzm, fzp, gamma_tri, invareacell, nedgesoncell, rdzw, rho_zz, rw, &
 !$acc rw_save, tend_rho, tend_rt, tend_rw, theta_m, w)
+TMPOMP !$omp target update to(rtheta_pp, rtheta_pp_old, ru_p, ruavg, rho_pp, &
+TMPOMP !$omp rw_p, wwavg, &
+TMPOMP !$omp zz, cellsonedge, cqu, dcedge, exner, invdcedge, &
+TMPOMP !$omp tend_ru, zxu, tend_rho, a_tri, alpha_tri, cofrz, &
+TMPOMP !$omp coftz, cofwr, cofwt, cofwz, dss, dvedge, edgesoncell, edgesoncell_sign, &
+TMPOMP !$omp fzm, fzp, gamma_tri, invareacell, nedgesoncell, rdzw, rho_zz, rw, &
+TMPOMP !$omp rw_save, tend_rho, tend_rt, tend_rw, theta_m, w)
 
       if(small_step /= 1) then  !  not needed on first small step 
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang
         do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
-
+GPUOMP     do k=1,nVertLevels
+           
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
 
@@ -3222,31 +3376,36 @@ module atm_time_integration
            if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve ) then
 !DIR$ IVDEP
 !$acc loop vector
-              do k=1,nVertLevels
+              GPUACC do k=1,nVertLevels
                  pgrad = ((rtheta_pp(k,cell2)-rtheta_pp(k,cell1))*invDcEdge(iEdge) )/(.5*(zz(k,cell2)+zz(k,cell1)))
                  pgrad = cqu(k,iEdge)*0.5*c2*(exner(k,cell1)+exner(k,cell2))*pgrad
                  pgrad = pgrad + 0.5*zxu(k,iEdge)*gravity*(rho_pp(k,cell1)+rho_pp(k,cell2))
                  ru_p(k,iEdge) = ru_p(k,iEdge) + dts*(tend_ru(k,iEdge) - (1.0_RKIND - specZoneMaskEdge(iEdge))*pgrad)
-              end do
+                 GPUOMP ruAvg(k,iEdge) = ruAvg(k,iEdge) + ru_p(k,iEdge)
+              GPUACC end do
 
               ! accumulate ru_p for use later in scalar transport
 !DIR$ IVDEP
 !$acc loop vector
-              do k=1,nVertLevels
-                 ruAvg(k,iEdge) = ruAvg(k,iEdge) + ru_p(k,iEdge)
-              end do
+              GPUACC do k=1,nVertLevels
+              GPUACC    ruAvg(k,iEdge) = ruAvg(k,iEdge) + ru_p(k,iEdge)
+              GPUACC end do
 
            end if ! end test for block-owned cells
 
+GPUOMP  end do
         end do ! end loop over edges
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
         end if
 
         if(small_step ==1) then
 !      else !  this is all that us needed for ru_p update for first acoustic step in RK substep
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang
         do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
+GPUOMP     do k=1,nVertLevels
 
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
@@ -3255,42 +3414,168 @@ module atm_time_integration
            if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve ) then
 !DIR$ IVDEP
 !$acc loop vector
-              do k=1,nVertLevels
+              GPUACC do k=1,nVertLevels
                  ru_p(k,iEdge) = dts*tend_ru(k,iEdge)
-              end do
+                 GPUOMP ruAvg(k,iEdge) = ru_p(k,iEdge)                 
+              GPUACC end do
 !DIR$ IVDEP
 !$acc loop vector
-              do k=1,nVertLevels
-!!                 ruAvg(k,iEdge) = ruAvg(k,iEdge) + ru_p(k,iEdge)
-                 ruAvg(k,iEdge) = ru_p(k,iEdge)                 
-              end do
+              GPUACC do k=1,nVertLevels
+!!                  ruAvg(k,iEdge) = ruAvg(k,iEdge) + ru_p(k,iEdge)
+              GPUACC    ruAvg(k,iEdge) = ru_p(k,iEdge)                 
+              GPUACC end do
 
            end if ! end test for block-owned cells
 
+GPUOMP  end do
         end do ! end loop over edges
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       end if ! test for first acoustic step
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       if (small_step == 1) then  ! initialize here on first small timestep.
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang vector
          do iCell=cellStart,cellEnd
-            rtheta_pp_old(1:nVertLevels,iCell) = 0.0
+            GPUACC rtheta_pp_old(1:nVertLevels,iCell) = 0.0
+            GPUOMP do k=1,nVertLevels
+            GPUOMP   rtheta_pp_old(k,iCell) = 0.0
+            GPUOMP enddo
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       else
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang vector
         do iCell=cellStart,cellEnd
-           rtheta_pp_old(1:nVertLevels,iCell) = rtheta_pp(1:nVertLevels,iCell)
+           GPUACC rtheta_pp_old(1:nVertLevels,iCell) = rtheta_pp(1:nVertLevels,iCell)
+           GPUOMP do k=1,nVertLevels
+           GPUOMP    rtheta_pp_old(k,iCell) = rtheta_pp(k,iCell)
+           GPUOMP enddo
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       end if
 
 
 !!!OMP BARRIER -- not needed, since rtheta_pp_old not used below when small_step == 1
+#ifdef MPAS_AMD_OFFLOAD
+      if(small_step == 1) then  ! initialize here on first small timestep.
+GPUOMP !$omp target teams distribute parallel do thread_limit(64)
+      do iCell=cellSolveStart,cellSolveEnd
+         wwAvg(1:nVertLevels+1,iCell) = 0.0            
+         rho_pp(1:nVertLevels,iCell) = 0.0            
+         rtheta_pp(1:nVertLevels,iCell) = 0.0            
+!MGD moved to loop above over all cells
+!            rtheta_pp_old(1:nVertLevels,iCell) = 0.0
+         rw_p(:,iCell) = 0.0
+      end do
+GPUOMP !$omp end target teams distribute parallel do
+      end if
+
+GPUOMP !$omp target teams distribute private(rs,ts,k1,k2) thread_limit(64)
+      do iCell=cellsolveStart,cellSolveEnd
+         if (specZoneMaskCell(iCell) == 0.0) then
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+               ts(k) = 0.0
+               rs(k) = 0.0
+            end do
+GPUOMP !$omp end parallel do simd
+            do i=1,nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i,iCell)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+GPUOMP !$omp parallel do simd
+               do k=1,nVertLevels
+                  flux = edgesOnCell_sign(i,iCell)*dts*dvEdge(iEdge)*ru_p(k,iEdge) * invAreaCell(iCell)
+                  rs(k) = rs(k)-flux
+                  ts(k) = ts(k)-flux*0.5*(theta_m(k,cell2)+theta_m(k,cell1))
+               end do
+GPUOMP !$omp end parallel do simd
+            end do
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+               rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &
+                               - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell)) 
+               ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &
+                                  - resm*rdzw(k)*( coftz(k+1,iCell)*rw_p(k+1,iCell)     &
+                                                  -coftz(k,iCell)*rw_p(k,iCell))
+            end do
+GPUOMP !$omp end parallel do simd
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+               k1 = max(k-1,1)
+               k2 = merge(1,0,k>1)
+               wwavg(k,iCell) = wwavg(k,iCell) + k2*0.5*(1.0-epssm)*rw_p(k,iCell)
+               rw_p(k,iCell) = rw_p(k,iCell) +  k2*(dts*tend_rw(k,iCell)                   &
+                          - cofwz(k,iCell)*((zz(k  ,iCell)*ts(k)                           &
+                                        -zz(k1,iCell)*ts(k1))                            &
+                                  +resm*(zz(k  ,iCell)*rtheta_pp(k  ,iCell)                &
+                                        -zz(k1,iCell)*rtheta_pp(k1,iCell)))              &
+                          - cofwr(k,iCell)*((rs(k)+rs(k1))                                &
+                                  +resm*(rho_pp(k,iCell)+rho_pp(k1,iCell)))               &
+                          + cofwt(k  ,iCell)*(ts(k)+resm*rtheta_pp(k  ,iCell))           &
+                          + cofwt(k1,iCell)*(ts(k1)+resm*rtheta_pp(k1,iCell)))
+            end do
+GPUOMP !$omp end parallel do simd
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+               ! Store local arrays
+               rho_pp(k,iCell) = rs(k)
+               rtheta_pp(k,iCell) = ts(k)
+            end do
+GPUOMP !$omp end parallel do simd
+         else
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+               rho_pp(k,iCell) = rho_pp(k,iCell) + dts*tend_rho(k,iCell)
+               rtheta_pp(k,iCell) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell)
+               rw_p(k,iCell) = rw_p(k,iCell) + dts*tend_rw(k,iCell)
+               wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)
+            end do
+GPUOMP !$omp end parallel do simd
+         endif
+      end do
+GPUOMP !$omp end target teams distribute !parallel do
+GPUOMP !$omp target teams distribute parallel do simd thread_limit(128)
+      do iCell=cellsolveStart,cellSolveEnd
+         if(specZoneMaskCell(iCell) == 0.0) then  ! not specified zone, compute...
+            do k=2,nVertLevels
+               rw_p(k,iCell) = (rw_p(k,iCell)-a_tri(k,iCell)*rw_p(k-1,iCell))*alpha_tri(k,iCell)
+            end do
+            do k=nVertLevels,1,-1
+               rw_p(k,iCell) = rw_p(k,iCell) - gamma_tri(k,iCell)*rw_p(k+1,iCell)     
+            end do
+         endif
+      end do
+GPUOMP !$omp end target teams distribute parallel do simd
+
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
+!$acc loop vector
+      do iCell=cellSolveStart,cellSolveEnd
+         do k=1,nVertLevels
+            if(specZoneMaskCell(iCell) == 0.0) then  ! not specified zone, compute...
+                k1 = max(k-1,1)
+                k2 = merge(1,0,k>1)
+                rw_p(k,iCell) = (rw_p(k,iCell) +k2*((rw_save(k  ,iCell) - rw(k  ,iCell)) -dts*dss(k,iCell)*               &
+                            (fzm(k)*zz (k,iCell)+fzp(k)*zz (k1,iCell))        &
+                            *(fzm(k)*rho_zz(k,iCell)+fzp(k)*rho_zz(k1,iCell))       &
+                                     *w(k,iCell)    ))/(1.0+k2*dts*dss(k,iCell)) &
+                             - (rw_save(k  ,iCell) - rw(k  ,iCell))
+                wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)
+                rho_pp(k,iCell) = rho_pp(k,iCell) - cofrz(k) *(rw_p(k+1,iCell)-rw_p(k  ,iCell))
+                rtheta_pp(k,iCell) = rtheta_pp(k,iCell) - rdzw(k)*(coftz(k+1,iCell)*rw_p(k+1,iCell)  &
+                                   -coftz(k  ,iCell)*rw_p(k  ,iCell))
+            endif
+         end do
+      end do
+GPUOMP !$omp end target teams distribute parallel do simd
+#else
 !$acc parallel vector_length(32)
 !$acc loop gang private(ts, rs)
       do iCell=cellSolveStart,cellSolveEnd  ! loop over all owned cells to solve
@@ -3315,7 +3600,6 @@ module atm_time_integration
          end do
 
 !$acc loop seq
-
          do i=1,nEdgesOnCell(iCell) 
             iEdge = edgesOnCell(i,iCell)
             cell1 = cellsOnEdge(1,iEdge)
@@ -3416,7 +3700,9 @@ module atm_time_integration
 
       end do !  end of loop over cells
 !$acc end parallel
+#endif
 !$acc end data
+TMPOMP !$omp target update from(rtheta_pp,rtheta_pp_old,ru_p,ruavg,rho_pp,rw_p,wwavg)
    end subroutine atm_advance_acoustic_step_work
 
    subroutine atm_divergence_damping_3d( state, diag, mesh, configs, dts, edgeStart, edgeEnd )
@@ -3498,18 +3784,23 @@ module atm_time_integration
 
 !$acc data present(rtheta_pp, rtheta_pp_old, &
 !$acc ru_p, theta_m, cellsOnEdge, specZoneMaskEdge)
+TMPOMP !$omp target update to(rtheta_pp, rtheta_pp_old, &
+TMPOMP !$omp ru_p, theta_m, cellsOnEdge, specZoneMaskEdge)
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) &
+GPUOMP !$omp private(cell1, cell2, divCell1, divCell2)
 !$acc parallel num_workers(8) vector_length(16)
 !$acc loop gang worker private(cell1, cell2, divCell1, divCell2)
       do iEdge=edgeStart,edgeEnd ! MGD do we really just need edges touching owned cells?
 
+            GPUOMP do k=1,nVertLevels
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-
+         
          ! update edges for block-owned cells
          if (cell1 <= nCellsSolve .or. cell2 <= nCellsSolve ) then
 
 !DIR$ IVDEP
-            do k=1,nVertLevels
+            GPUACC do k=1,nVertLevels
 
 !!  unscaled 3d divergence damping
 !!               divCell1 = -(rtheta_pp(k,cell1)-rtheta_pp_old(k,cell1))*rdts
@@ -3523,10 +3814,13 @@ module atm_time_integration
                ru_p(k,iEdge) = ru_p(k,iEdge) + coef_divdamp*(divCell2-divCell1)*(1.0_RKIND - specZoneMaskEdge(iEdge)) &
                                                       /(theta_m(k,cell1)+theta_m(k,cell2))
 
-            end do
+            GPUACC end do
          end if ! edges for block-owned cells
+         GPUOMP end do
       end do ! end loop over edges
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
+TMPOMP !$omp target update from(ru_p)
 !$acc end data
 
    end subroutine atm_divergence_damping_3d_work
@@ -3721,6 +4015,12 @@ module atm_time_integration
       rcv = rgas/(cp-rgas)
       p0 = 1.0e+05  ! this should come from somewhere else...
 
+TMPOMP !$omp target update to(rho_zz, exner, pressure_p, rho_p, rtheta_p, rw, theta_m, w, &
+TMPOMP !$omp wwavg, ru, ruavg, u, &
+TMPOMP !$omp exner_base, fzm, fzp, rho_base, rho_p_save, rho_pp, rt_diabatic_tend, &
+TMPOMP !$omp rtheta_base, rtheta_p_save, rtheta_pp, rw_p, rw_save, zz, cellsonedge, &
+TMPOMP !$omp ru_p, ru_save, edgesoncell, edgesoncell_sign, nedgesoncell, zb3_cell, &
+TMPOMP !$omp zb_cell)
 !$acc data present(rho_zz, exner, pressure_p, rho_p, rtheta_p, rw, theta_m, w, &
 !$acc wwavg, ru, ruavg, u, &
 !$acc exner_base, fzm, fzp, rho_base, rho_p_save, rho_pp, rt_diabatic_tend, &
@@ -3730,17 +4030,20 @@ module atm_time_integration
 
       ! Avoid FP errors caused by a potential division by zero below by 
       ! initializing the "garbage cell" of rho_zz to a non-zero value
+GPUOMP !$omp target teams distribute parallel do simd thread_limit(64)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop vector
       do k=1,nVertLevels
          rho_zz(k,nCells+1) = 1.0
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       ! compute new density everywhere so we can compute u from ru.
       ! we will also need it to compute theta_m below
 
       invNs = 1 / real(ns,RKIND)
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker
       do iCell=cellStart,cellEnd
@@ -3755,7 +4058,9 @@ module atm_time_integration
          w(1,iCell) = 0.0
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker
         do iCell=cellStart,cellEnd
@@ -3772,9 +4077,11 @@ module atm_time_integration
          w(nVertLevels+1,iCell) = 0.0
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
          if (rk_step == 3) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker collapse(2)
         do iCell=cellStart,cellEnd
@@ -3790,10 +4097,12 @@ module atm_time_integration
             end do
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
         end if
 
         if (rk_step /= 3) then
 !         else
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker collapse(2)
         do iCell=cellStart,cellEnd
@@ -3804,6 +4113,7 @@ module atm_time_integration
             end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
          end if
 
 
@@ -3811,24 +4121,29 @@ module atm_time_integration
       ! we solved for these in the acoustic-step loop.  
       ! we will compute ru and u here also, given we are here, even though we only need them on nEdgesSolve
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) private(cell1,cell2)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker private(cell1, cell2)
       do iEdge=edgeStart,edgeEnd
+         GPUOMP do k = 1, nVertLevels
 
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 
 !DIR$ IVDEP
-         do k = 1, nVertLevels
+         GPUACC do k = 1, nVertLevels
             ruAvg(k,iEdge) = ru_save(k,iEdge) + (ruAvg(k,iEdge) * invNs)
             ru(k,iEdge) = ru_save(k,iEdge) + ru_p(k,iEdge)
             u(k,iEdge) = 2.*ru(k,iEdge)/(rho_zz(k,cell1)+rho_zz(k,cell2))
          end do
       end do
 !$acc end parallel
-!$OMP BARRIER
+GPUOMP !$omp end target teams distribute parallel do simd
+CPUOMP !$OMP BARRIER
+!GPUOMP !$omp target teams distribute parallel do private(iEdge,flux) thread_limit(64)
+GPUOMP !$omp target teams distribute private(iEdge,flux) thread_limit(64)
 !$acc parallel num_workers(8) vector_length(32)
 !$acc loop gang worker private(iEdge, flux)
       do iCell=cellStart,cellEnd
@@ -3847,11 +4162,13 @@ module atm_time_integration
                                    (zb_cell(1,i,iCell) + sign(1.0_RKIND,flux)*zb3_cell(1,i,iCell))*flux
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
             do k = 2, nVertLevels
                flux = (fzm(k)*ru(k,iEdge)+fzp(k)*ru(k-1,iEdge))
                w(k,iCell) = w(k,iCell) + edgesOnCell_sign(i,iCell) * &
                                     (zb_cell(k,i,iCell)+sign(1.0_RKIND,flux)*zb3_cell(k,i,iCell))*flux
             end do
+GPUOMP !$omp end parallel do simd
 
          end do
 
@@ -3859,14 +4176,18 @@ module atm_time_integration
 
 
          !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
          do k = 2, nVertLevels
            w(k,iCell) = w(k,iCell)/(fzm(k)*rho_zz(k,iCell)+fzp(k)*rho_zz(k-1,iCell))
          end do
+GPUOMP !$omp end parallel do simd
 
          end if ! addition for regional_MPAS, no spec zone update
 
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+TMPOMP !$omp target update from(rho_zz,rho_p,w,wwAvg,rw,u,ruAvg,ru,rtheta_p,theta_m,exner,pressure_p)
 !$acc end data
    end subroutine atm_recover_large_step_variables_work
 
@@ -4125,6 +4446,13 @@ module atm_time_integration
       end if
       weight_time_old = 1. - weight_time_new
 
+!GPUOMP NOTE: this subroutine atm_advance_scalars_work untested!
+TMPOMP !$omp target update to(adv_coefs, uhAvg, adv_coefs_3rd, &
+TMPOMP !$omp advCellsForEdge, scalar_new, &
+TMPOMP !$omp scalar_tend_save,horiz_flux_arr,edgesoncell_sign, &
+TMPOMP !$omp invAreaCell, wwAvg, fnm, fnp,edgesoncell,scalar_old, &
+TMPOMP !$omp nadvcellsforedge, rho_zz_old, rho_zz_new, &
+TMPOMP !$omp nEdgesOnCell,rdnw,bdyMaskCell,bdyMaskEdge,cellsOnEdge,dvEdge,edgesOnCell)
 !$acc data present(adv_coefs, uhAvg, adv_coefs_3rd, &
 !$acc advCellsForEdge, scalar_new, &
 !$acc scalar_tend_save,horiz_flux_arr,edgesoncell_sign, &
@@ -4132,6 +4460,7 @@ module atm_time_integration
 !$acc nadvcellsforedge, rho_zz_old, rho_zz_new, &
 !$acc nEdgesOnCell,rdnw,bdyMaskCell,bdyMaskEdge,cellsOnEdge,dvEdge,edgesOnCell)
 
+GPUOMP !$omp target teams distribute parallel do private(scalar_weight2,ica,iAdvCell,cell1,cell2)
 !$acc parallel vector_length(32)
 !$acc loop gang private(scalar_weight2,ica,iAdvCell,cell1,cell2)
       do iEdge=edgeStart,edgeEnd
@@ -4223,11 +4552,13 @@ module atm_time_integration
 
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
 !  scalar update, for each column sum fluxes over horizontal edges, add physics tendency, and add vertical flux divergence in update.
 
+GPUOMP !$omp target teams distribute parallel do private(scalar_tend_column,iEdge,wdtn)
 !$acc parallel vector_length(32)
 !$acc loop gang private(scalar_tend_column,iEdge,wdtn)
       do iCell=cellSolveStart,cellSolveEnd
@@ -4324,6 +4655,8 @@ module atm_time_integration
 
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
+TMPOMP !$omp target update from(scalar_new,wdtn,scalar_tend_column,scalar_tend_save,horiz_flux_arr)
 !$acc end data
 
    end subroutine atm_advance_scalars_work
@@ -4557,6 +4890,15 @@ module atm_time_integration
       !  Note, however, that we enforce positive-definiteness in this update.
       !  The transport will maintain this positive definite solution and optionally, shape preservation (monotonicity).
 
+!GPUOMP NOTE: this subroutine atm_advance_scalars_mono_work is untested
+TMPOMP !$omp target update to(uhAvg,wwAvg,scalar_tend, &
+TMPOMP !$omp rho_zz_old,rho_zz_new,scalars_old, &
+TMPOMP !$omp invAreaCell,dvEdge,cellsOnEdge,cellsOnCell, &
+TMPOMP !$omp edgesOnCell,edgesOnCell_sign,nEdgesOnCell,fnm, &
+TMPOMP !$omp fnp,rdnw,nAdvCellsForEdge,advCellsForEdge,adv_coefs, &
+TMPOMP !$omp adv_coefs_3rd, scalars_new, flux_arr, rho_zz_int, &
+TMPOMP !$omp scalar_new, wdtn, scale_arr, scalar_old, flux_upwind_tmp, &
+TMPOMP !$omp s_min, s_max, flux_tmp, bdyMaskCell, bdyMaskEdge)
 !$acc data present(uhAvg,wwAvg,scalar_tend, &
 !$acc rho_zz_old,rho_zz_new,scalars_old, &
 !$acc invAreaCell,dvEdge,cellsOnEdge,cellsOnCell, &
@@ -4566,6 +4908,7 @@ module atm_time_integration
 !$acc scalar_new, wdtn, scale_arr, scalar_old, flux_upwind_tmp, &
 !$acc s_min, s_max, flux_tmp, bdyMaskCell, bdyMaskEdge)
 
+GPUOMP !$omp target teams distribute parallel do collapse(3)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(3)
 
@@ -4586,15 +4929,16 @@ module atm_time_integration
       end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
-!$OMP BARRIER
-!$OMP MASTER
+CPUOMP !$OMP BARRIER
+CPUOMP !$OMP MASTER
       call mpas_dmpar_exch_halo_acc(scalars_old, compactHaloInfo_c_v_s, sendList_c_v_s, recvList_c_v_s, gpu_bufferOffset_send_c_v_s, &
                                      gpu_nList_send_c_v_s, gpu_idx_send_c_v_s, gpu_bufferOffset_recv_c_v_s, gpu_nList_recv_c_v_s,&
                                      gpu_idx_recv_c_v_s, gpu_dimsizes_c_v_s, gpu_nHaloLayers_c_v_s, gpu_send_size_c_v_s, gpu_recv_size_c_v_s,&
                                      gpu_compactHaloInfoSize_c_v_s, num_scalars, nVertLevels, nCells+1)
-!$OMP END MASTER
-!$OMP BARRIER
+CPUOMP !$OMP END MASTER
+CPUOMP !$OMP BARRIER
 
 
       !
@@ -4607,6 +4951,7 @@ module atm_time_integration
          end if
 
          !  begin with update of density
+GPUOMP !$omp target teams distribute parallel do collapse(2)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2)
          do iCell=cellStart,cellEnd
@@ -4615,8 +4960,10 @@ module atm_time_integration
          end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
+GPUOMP !$omp target teams distribute parallel do collapse(2) private(iEdge)
 !$acc parallel vector_length(32)
 !$acc loop gang vector collapse(2) private(iEdge)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4636,7 +4983,9 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
+GPUOMP !$omp target teams distribute parallel do collapse(2)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4645,13 +4994,15 @@ module atm_time_integration
                rho_zz_int(k,iCell) = rho_zz_old(k,iCell) + dt*( rho_zz_int(k,iCell) - rdnw(k)*(wwAvg(k+1,iCell)-wwAvg(k,iCell)) )
             end do
          end do
-!$OMP BARRIER
+GPUOMP !$omp end target teams distribute parallel do
+CPUOMP !$OMP BARRIER
 !$acc end parallel
       end if
 
       ! next, do one scalar at a time
 
       do iScalar = 1, num_scalars
+GPUOMP !$omp target teams distribute parallel do collapse(2)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2)
          do iCell=cellStart,cellEnd
@@ -4662,8 +5013,10 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
 ! ***** TEMPORARY TEST ******* WCS 20161012
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(64)
 !$acc loop gang vector
             do k=1,nVertLevels
@@ -4671,8 +5024,9 @@ module atm_time_integration
                scalar_new(k,nCells+1) = 0.
             end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
 #ifdef DEBUG_TRANSPORT
          scmin = scalar_old(1,1)
@@ -4704,6 +5058,7 @@ module atm_time_integration
          !
          !  vertical flux divergence, and min and max bounds for flux limiter
          !
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(32)
 !$acc loop gang
          do iCell=cellSolveStart,cellSolveEnd
@@ -4777,11 +5132,13 @@ module atm_time_integration
 
          end do
 !$acc end parallel
-!$OMP BARRIER
+GPUOMP !$omp end target teams distribute parallel do
+CPUOMP !$OMP BARRIER
 
          !
          !  horizontal flux divergence
          !
+GPUOMP !$omp target teams distribute parallel do private(cell1,cell2,ica,swa,iCell)
 !$acc parallel vector_length(32)
 !$acc loop gang private(cell1, cell2,ica,swa,iCell)
          do iEdge=edgeStart,edgeEnd
@@ -4834,11 +5191,13 @@ module atm_time_integration
 
          end do
 !$acc end parallel
-!$OMP BARRIER
+GPUOMP !$omp end target teams distribute parallel do
+CPUOMP !$OMP BARRIER
 
          !
          !  vertical flux divergence for upwind update, we will put upwind update into scalar_new, and put factor of dt in fluxes
          !
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(32)
 !$acc loop gang private(flux_upwind_arr)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4878,11 +5237,13 @@ module atm_time_integration
 
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
          !
          !  horizontal flux divergence for upwind update
          !
 
          !  upwind flux computation
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(64)
 !$acc loop gang
          do iEdge=edgeStart,edgeEnd
@@ -4908,7 +5269,9 @@ module atm_time_integration
 
          end do
 !$acc end parallel
-!$OMP BARRIER
+GPUOMP !$omp end target teams distribute parallel do
+CPUOMP !$OMP BARRIER
+GPUOMP !$omp target teams distribute parallel do collapse(2) private(iEdge)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2) private(iEdge)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4932,6 +5295,7 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
          !
          !  next, the limiter
          !
@@ -4940,6 +5304,7 @@ module atm_time_integration
          ! worked through algebra and found equivalent form
          ! added benefit that it should address ifort single prec overflow issue
       if (local_advance_density) then
+GPUOMP !$omp target teams distribute parallel do collapse(2) private(scale_factor)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2) private(scale_factor)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4956,7 +5321,9 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
       else
+GPUOMP !$omp target teams distribute parallel do collapse(2) private(scale_factor)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2) private(scale_factor)
          do iCell=cellSolveStart,cellSolveEnd
@@ -4973,23 +5340,25 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
       end if
 
          !
          !  communicate scale factors here.
          !  communicate only first halo row in these next two exchanges
          !
-!$OMP BARRIER
-!$OMP MASTER
+CPUOMP !$OMP BARRIER
+CPUOMP !$OMP MASTER
 !MGDHALO         call mpas_dmpar_exch_halo_acc(scale_arr, compactHaloInfo_c_2_v, sendList_c_2_v, recvList_c_2_v, (/ 1 /))
          call mpas_dmpar_exch_halo_acc(scale_arr, compactHaloInfo_c_2_v, sendList_c_2_v, recvList_c_2_v, gpu_bufferOffset_send_c_2_v, &
                                        gpu_nList_send_c_2_v, gpu_idx_send_c_2_v, gpu_bufferOffset_recv_c_2_v, gpu_nList_recv_c_2_v,&
                                        gpu_idx_recv_c_2_v, gpu_dimsizes_c_2_v, gpu_nHaloLayers_c_2_v, gpu_send_size_c_2_v, gpu_recv_size_c_2_v,&
                                        gpu_compactHaloInfoSize_c_2_v, nVertLevels, 2, nCells+1 )
-!$OMP END MASTER
-!$OMP BARRIER
+CPUOMP !$OMP END MASTER
+CPUOMP !$OMP BARRIER
 
 
+GPUOMP !$omp target teams distribute parallel do private(cell1,cell2)
 !$acc parallel vector_length(32)
 !$acc loop gang worker private(cell1,cell2)
          do iEdge=edgeStart,edgeEnd
@@ -5014,12 +5383,14 @@ module atm_time_integration
             end if
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
          !
          !  rescale the fluxes
          !
 
          ! moved assignment to scalar_new from separate loop (see commented code below)
          ! into the following loops. Avoids having to save elements of flux array
+GPUOMP !$omp target teams distribute parallel do private(cell1,cell2)
 !$acc parallel vector_length(32)
 !$acc loop gang worker private(cell1, cell2)
          do iEdge=edgeStart,edgeEnd
@@ -5037,11 +5408,13 @@ module atm_time_integration
             end if
          end do
 !$acc end parallel
- 
+GPUOMP !$omp end target teams distribute parallel do
+
         !
         ! rescale the vertical flux
         !
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
+GPUOMP !$omp target teams distribute parallel do private(flux)
 !$acc parallel vector_length(128)
 !$acc loop gang vector collapse(2) private(flux)
          do iCell=cellSolveStart,cellSolveEnd
@@ -5054,10 +5427,12 @@ module atm_time_integration
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 
          !
          !  do the scalar update now that we have the fluxes
          !
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(32)
 !$acc loop gang
          do iCell=cellSolveStart,cellSolveEnd
@@ -5089,6 +5464,7 @@ module atm_time_integration
       end if
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
 #ifdef DEBUG_TRANSPORT
          scmin = scalar_new(1,1)
          scmax = scalar_new(1,1)
@@ -5113,7 +5489,7 @@ module atm_time_integration
 
          ! the update should be positive definite. but roundoff can sometimes leave small negative values
          ! hence the enforcement of PD in the copy back to the model state.
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 #if 0
 !!!
 !!! MGD OPENACC TO DO: here is the original code that we can probably handle
@@ -5132,6 +5508,7 @@ module atm_time_integration
 !$acc end parallel
       end do !  loop over scalars
 #else
+GPUOMP !$omp target teams distribute parallel do
 !$acc parallel vector_length(64)
 !$acc loop gang
          do iCell=cellStart,cellEnd
@@ -5143,9 +5520,11 @@ module atm_time_integration
             end if
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do
       end do !  loop over scalars
 #endif
-
+TMPOMP !$omp target update from(scalars_old,scalar_tend,rho_zz_int,scalar_old,scalar_new,wdtn,s_max,s_min,flux_arr,&
+TMPOMP !$omp flux_upwind_tmp,flux_tmp,flux_arr,scale_arr,scalars_new)
 !$acc end data
    end subroutine atm_advance_scalars_mono_work
 
@@ -5390,12 +5769,15 @@ module atm_time_integration
          !rthdynten(:,nCells+1) = 0.0_RKIND\
          inactive_rthdynten = .true.
       end if
+GPUOMP !$omp target data map(alloc:rthdynten)
+GPUOMP !$omp target teams distribute parallel do thread_limit(64)
       !$acc data create(rthdynten)
       !$acc kernels
       do temp1=1,nVertLevels
            rthdynten(temp1,temp_nCells+1) = 0.0_RKIND
       end do
       !$acc end kernels
+GPUOMP !$omp end target teams distribute parallel do
  
       if(rk_step == 1) then
 
@@ -5445,6 +5827,7 @@ module atm_time_integration
 	  end if 
 	  
       !$acc end data
+GPUOMP !$omp end target data
       if (inactive_rthdynten) then
          deallocate(rthdynten)
       end if
@@ -5660,6 +6043,20 @@ module atm_time_integration
 !$acc adv_coefs_3rd, advcellsforedge, nadvcellsforedge, w, cqw, rdzu, rho_zz, &
 !$acc theta_m, theta_m_save, rt_diabatic_tend, tend_rtheta_physics, t_init, &
 !$acc rw_save,tend_rtheta_adv,rthdynten)
+TMPOMP !$omp target update to(kdiff, h_divergence, dpdz, tend_rho, tend_u_euler, &
+TMPOMP !$omp tend_u, delsq_u, delsq_vorticity, delsq_divergence, &
+TMPOMP !$omp tend_w, delsq_w, tend_w_euler, tend_theta, &
+TMPOMP !$omp delsq_theta, tend_theta_euler, &
+TMPOMP !$omp defc_a, defc_b, edgesoncell, nedgesoncell, u, v, &
+TMPOMP !$omp dvedge, edgesoncell_sign, invareacell, ru, qtot, rb, rdzw, rr_save, rw, &
+TMPOMP !$omp tend_rho_physics, cellsonedge, cqu, invdcedge, pp, zxu, zz, &
+TMPOMP !$omp fzm, fzp, edgesonedge, ke, nedgesonedge, pv_edge, rho_edge, weightsonedge, &
+TMPOMP !$omp divergence, invdvedge, meshscalingdel2, verticesonedge, vorticity, &
+TMPOMP !$omp dcedge, edgesonvertex, edgesonvertex_sign, invareatriangle, &
+TMPOMP !$omp meshscalingdel4, zgrid, angleedge, u_init, tend_ru_physics, adv_coefs, &
+TMPOMP !$omp adv_coefs_3rd, advcellsforedge, nadvcellsforedge, w, cqw, rdzu, rho_zz, &
+TMPOMP !$omp theta_m, theta_m_save, rt_diabatic_tend, tend_rtheta_physics, t_init, &
+TMPOMP !$omp rw_save,tend_rtheta_adv)
 
 
          ! Smagorinsky eddy viscosity, based on horizontal deformation (in this case on model coordinate surfaces).
@@ -5667,9 +6064,12 @@ module atm_time_integration
 !!$acc kernels
 
 if (config_horiz_mixing == "2d_smagorinsky") then
+!GPUOMP !$omp target teams distribute parallel do private (d_diag,d_off_diag)
+GPUOMP !$omp target teams distribute private (d_diag,d_off_diag)
 !$acc parallel vector_length(64)
 !$acc loop gang private(d_diag,d_off_diag)
          do iCell = cellStart,cellEnd
+GPUOMP !$omp parallel do simd
 !$acc cache(d_diag)
 !$acc cache(d_off_diag)
 !$acc loop vector
@@ -5677,8 +6077,10 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                d_diag(k) = 0.0
                d_off_diag(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
             do iEdge=1,nEdgesOnCell(iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   d_diag(k)     = d_diag(k)     + defc_a(iEdge,iCell)*u(k,EdgesOnCell(iEdge,iCell))  &
@@ -5686,19 +6088,22 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                   d_off_diag(k) = d_off_diag(k) + defc_b(iEdge,iCell)*u(k,EdgesOnCell(iEdge,iCell))  &
                                                 + defc_a(iEdge,iCell)*v(k,EdgesOnCell(iEdge,iCell))
                end do
+GPUOMP !$omp end parallel do simd
             end do
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1, nVertLevels
                kdiff(k,iCell) = min((c_s * config_len_disp)**2 * sqrt(d_diag(k)**2 + d_off_diag(k)**2),(0.01*config_len_disp**2) * invDt)
             end do
+GPUOMP !$omp end parallel do simd
          end do
+GPUOMP !$omp end target teams distribute !parallel do
 
          h_mom_eddy_visc4   = config_visc4_2dsmag * config_len_disp**3
          h_theta_eddy_visc4 = h_mom_eddy_visc4
 
 !$acc end parallel
-
       end if
         ! else
          if(config_horiz_mixing == "2d_fixed") then
@@ -5729,31 +6134,40 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
       ! accumulate horizontal mass-flux
 
+!GPUOMP !$omp target teams distribute parallel do private(h_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(h_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(h_wk)
  do iCell=cellStart,cellEnd
+GPUOMP !omp parallel do simd
 !$acc cache(h_wk)
 !$acc loop vector
          do k=1,nVertLevels
             h_wk(k) = 0.0
          end do
+GPUOMP !omp end parallel do simd
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             edge_sign = edgesOnCell_sign(i,iCell) * dvEdge(iEdge)
 !DIR$ IVDEP
+GPUOMP !omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                h_wk(k) = h_wk(k) + edge_sign * ru(k,iEdge)
             end do
+GPUOMP !omp end parallel do simd
          end do
+GPUOMP !omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             r = invAreaCell(iCell)
             h_divergence(k,iCell) = h_wk(k) * r
          end do
+GPUOMP !omp parallel do simd
       end do
 !$acc end parallel 
+GPUOMP !$omp end target teams distribute !parallel do
 
       !
       ! dp / dz and tend_rho
@@ -5763,6 +6177,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
       !  rgas_cprcv = rgas*cp/cv
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
         do iCell = cellStart,cellEnd
@@ -5774,13 +6189,17 @@ if (config_horiz_mixing == "2d_smagorinsky") then
           end do
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       !
       ! Compute u (normal) velocity tendency for each edge (cell face)
       !
-
+!GPUOMP NOTE: Problematic region below
+!GPUOMP !$omp target teams distribute parallel do &
+GPUOMP !$omp target teams distribute &
+GPUOMP !$omp private(wduz, tend_wk, eoe_w, we_w) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(wduz, tend_wk, eoe_w, we_w)
       do iEdge=edgeSolveStart,edgeSolveEnd
@@ -5794,6 +6213,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
          ! horizontal pressure gradient 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_u_euler(k,iEdge) = - cqu(k,iEdge) * &
@@ -5802,26 +6222,52 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                               -0.5*zxu(k,iEdge)*(dpdz(k,cell1)+dpdz(k,cell2)) )
             tend_wk(k) = u(k,iEdge)
          end do
-
+GPUOMP !$omp end parallel do simd
+         GPUOMP wduz(k) = 0
+         GPUOMP wduz(nVertLevels+1) = 0
 !$acc loop vector shortloop
-         do k=1,nVertLevels+1,nVertLevels
-            wduz(k) = 0.
-         end do
+         GPUACC do k=1,nVertLevels+1,nVertLevels
+         GPUACC    wduz(k) = 0.
+         GPUACC end do
+         GPUOMP wduz(2) = 0.5*( rw(2,cell1)+rw(2,cell2))*(fzm(2)*tend_wk(2)+fzp(2)*tend_wk(2-1))
+         GPUOMP wduz(nVertLevels) = 0.5*( rw(nVertLevels,cell1)+rw(nVertLevels,cell2))*(fzm(nVertLevels)*tend_wk(nVertLevels)+fzp(nVertLevels)*tend_wk(nVertLevels-1))
 !$acc loop vector shortloop
-         do k=2,nVertLevels,nVertLevels-2
-            wduz(k) = 0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*tend_wk(k)+fzp(k)*tend_wk(k-1))
-         end do
+         GPUACC do k=2,nVertLevels,nVertLevels-2
+         GPUACC    wduz(k) = 0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*tend_wk(k)+fzp(k)*tend_wk(k-1))
+         GPUACC end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wduz(k) = flux3( tend_wk(k-2),tend_wk(k-1),tend_wk(k),tend_wk(k+1),0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
          end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
          do j = 1,nEdgesOnEdge(iEdge)
             eoe_w(j) = edgesOnEdge(j,iEdge)
             we_w(j)  = weightsOnEdge(j,iEdge)
          end do
+GPUOMP !$omp end parallel do simd
 
+#ifdef MPAS_AMD_OFFLOAD
+GPUOMP !$omp parallel do simd
+        do k=1,nVertLevels
+            t_w = - rdzw(k)*(wduz(k+1)-wduz(k))
+            tend_u(k,iEdge) = t_w + rho_edge(k,iEdge) * &
+                             (-(ke(k,cell2) - ke(k,cell1))* invDcEdge(iEdge)) - tend_wk(k) * 0.5 * &
+                             (h_divergence(k,cell1)+h_divergence(k,cell2))
+        end do
+GPUOMP !$omp end parallel do simd
+        do j = 1,nEdgesOnEdge(iEdge)
+           eoe = eoe_w(j)
+GPUOMP !$omp parallel do simd
+           do k=1,nVertLevels
+              tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge) * we_w(j) * u(k,eoe) * 0.5 * (pv_edge(k,iEdge) + pv_edge(k,eoe))
+           end do
+GPUOMP !$omp end parallel do simd
+        end do
+#else
 !DIR$ IVDEP
 !$acc loop vector
          do k=1,nVertLevels
@@ -5839,9 +6285,10 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                              invDcEdge(iEdge)) - tend_wk(k) * 0.5 * &
                              (h_divergence(k,cell1)+h_divergence(k,cell2))
          end do
+#endif
       end do
 !$acc end parallel
-
+GPUOMP !$omp end target teams distribute !parallel do
 
       !
       !  horizontal mixing for u
@@ -5850,14 +6297,16 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          ! del^4 horizontal filter.  We compute this as del^2 ( del^2 (u) ).
          ! First, storage to hold the result from the first del^2 computation.
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)   
 !$acc loop gang
          do iEdge=edgeStart,edgeEnd
+            GPUOMP do k=1,nVertLevels
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             vertex1 = verticesOnEdge(1,iEdge)
@@ -5866,7 +6315,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             r_dv = min(invDvEdge(iEdge), 4*invDcEdge(iEdge))
 !DIR$ IVDEP
 !$acc loop vector
-            do k=1,nVertLevels
+            GPUACC do k=1,nVertLevels
 
               u_diffusion =   ( divergence(k,cell2)  - divergence(k,cell1) ) * r_dc  &
                               -( vorticity(k,vertex2) - vorticity(k,vertex1) ) * r_dv
@@ -5882,65 +6331,86 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
          if (h_mom_eddy_visc4 > 0.0) then
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
+!GPUOMP !$omp target teams distribute parallel do private(delsq_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(delsq_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(delsq_wk)
             do iVertex=vertexStart,vertexEnd
 !$acc cache(delsq_wk)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   delsq_wk(k) = 0.0
                end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
                do i=1,vertexDegree
                   iEdge = edgesOnVertex(i,iVertex)
                   edge_sign = invAreaTriangle(iVertex) * dcEdge(iEdge) * edgesOnVertex_sign(i,iVertex)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                   do k=1,nVertLevels
                      delsq_wk(k) = delsq_wk(k) + edge_sign * delsq_u(k,iEdge)
                   end do
+GPUOMP !$omp end parallel do simd
                end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   delsq_vorticity(k,iVertex) = delsq_wk(k)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
+!GPUOMP !$omp target teams distribute parallel do private(delsq_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(delsq_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(delsq_wk)
             do iCell=cellStart,cellEnd
 !$acc cache(delsq_wk)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   delsq_wk(k) = 0.0
                end do
+GPUOMP !$omp end parallel do simd
                r = invAreaCell(iCell)
 !$acc loop seq
                do i=1,nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(i,iCell)
                   edge_sign = r * dvEdge(iEdge) * edgesOnCell_sign(i,iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                   do k=1,nVertLevels
                      delsq_wk(k) = delsq_wk(k) + edge_sign * delsq_u(k,iEdge)
                   end do
+GPUOMP !$omp end parallel do simd
                end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   delsq_divergence(k,iCell) = delsq_wk(k)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
          end if
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          if (h_mom_eddy_visc4 > 0.0) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
             do iEdge=edgeSolveStart,edgeSolveEnd
+               GPUOMP do k=1,nVertLevels
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                vertex1 = verticesOnEdge(1,iEdge)
@@ -5952,7 +6422,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
 !DIR$ IVDEP
 !$acc loop vector
-               do k=1,nVertLevels
+               GPUACC do k=1,nVertLevels
 
                   ! Compute diffusion, computed as \nabla divergence - k \times \nabla vorticity
                   !                    only valid for h_mom_eddy_visc4 == constant
@@ -5967,6 +6437,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                end do
             end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
          end if
 
       !
@@ -5975,15 +6446,16 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          if ( v_mom_eddy_visc2 > 0.0 ) then
             if (config_mix_full) then  ! mix full state
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
                do iEdge=edgeSolveStart,edgeSolveEnd
+                  GPUOMP do k=2,nVertLevels-1
 
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
-
 !$acc loop vector
-                  do k=2,nVertLevels-1
+                  GPUACC do k=2,nVertLevels-1
 
                      z1 = 0.5*(zgrid(k-1,cell1)+zgrid(k-1,cell2))
                      z2 = 0.5*(zgrid(k  ,cell1)+zgrid(k  ,cell2))
@@ -6000,10 +6472,13 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                   end do
                end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
             end if
 
             if (.not. config_mix_full) then  ! mix full state
             !else  ! idealized cases where we mix on the perturbation from the initial 1-D state
+!GPUOMP !$omp target teams distribute parallel do private(u_mix) thread_limit(64)
+GPUOMP !$omp target teams distribute private(u_mix) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(u_mix)
                do iEdge=edgeSolveStart,edgeSolveEnd
@@ -6012,12 +6487,15 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                   do k=1,nVertLevels
                      u_mix(k) = u(k,iEdge) - u_init(k) * cos( angleEdge(iEdge) ) &
                                            - v_init(k) * sin( angleEdge(iEdge) )
                   end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                   do k=2,nVertLevels-1
 
@@ -6034,19 +6512,22 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                                         (u_mix(k+1)-u_mix(k  ))/(zp-z0)                      &
                                        -(u_mix(k  )-u_mix(k-1))/(z0-zm) )/(0.5*(zp-zm))
                   end do
+GPUOMP !$omp end parallel do simd
                end do
 
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
             end if  ! mix perturbation state
          end if  ! vertical mixing of horizontal momentum
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
 !  add in mixing and physics tendency for u
 
 !  Rayleigh damping on u
       if (config_rayleigh_damp_u) then
+GPUOMP !$omp target
 !$acc kernels
          rayleigh_coef_inverse = 1.0 / ( real(config_number_rayleigh_damp_u_levels) &
                                          * (config_rayleigh_damp_u_timescale_days*seconds_per_day) )
@@ -6061,8 +6542,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 !$acc end kernels
+GPUOMP !$omp end target
       end if
 
+
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
       do iEdge=edgeSolveStart,edgeSolveEnd
@@ -6073,6 +6557,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
 !----------- rhs for w
@@ -6082,6 +6567,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !  horizontal advection for w
       !
 
+!GPUOMP !$omp target teams distribute parallel do &
+GPUOMP !$omp target teams distribute &
+GPUOMP !$omp private(ru_edge_w,flux_arr,iadv_cell_w,coefs_w,coefs_3rd_w,tend_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -6093,29 +6581,37 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(tend_wk)
 
 !$acc loop vector
+GPUOMP !$omp parallel do simd
          do k=1,nVertLevels+1
            tend_wk(k) = 0.0
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do k=2,nVertLevels
                ru_edge_w(k) = fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do j=1,nAdvCellsForEdge(iEdge)
                iadv_cell_w(j) = advCellsForEdge(j,iEdge)
                coefs_w(j)     = adv_coefs(j,iEdge)
                coefs_3rd_w(j) = adv_coefs_3rd(j,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do k=1,nVertLevels
                flux_arr(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 
             ! flux_arr stores the value of w at the cell edge used in the
             ! horizontal transport
@@ -6123,27 +6619,34 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc loop seq
             do j=1,nAdvCellsForEdge(iEdge)
 !$acc loop vector
+GPUOMP !$omp parallel do simd
                do k=2,nVertLevels
                   iAdvCell = iadv_cell_w(j)
                   scalar_weight = coefs_w(j) + sign(1.0_RKIND,ru_edge_w(k)) * coefs_3rd_w(j)
                   flux_arr(k) = flux_arr(k) + scalar_weight * w(k,iAdvCell)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=2,nVertLevels
                tend_wk(k) = tend_wk(k) - edgesOnCell_sign(i,iCell)*ru_edge_w(k)*flux_arr(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=2,nVertLevels
            tend_w(k,iCell) = tend_wk(k)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
       !
       !  horizontal mixing for w - we could combine this with advection directly (i.e. as a turbulent flux),
@@ -6158,6 +6661,8 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          ! First, storage to hold the result from the first del^2 computation.
          !  we copied code from the theta mixing, hence the theta* names.
 
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk,delsq_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk,delsq_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(tend_wk, delsq_wk)
          do iCell=cellStart,cellEnd
@@ -6166,10 +6671,12 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
             r_areaCell = invAreaCell(iCell)
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do k = 1, nVertLevels+1
                delsq_wk(k) = 0.0
                tend_wk(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 
 ! BDL could do something here with edgesOnCell and edgesOnCell_sign
 !$acc loop seq
@@ -6182,6 +6689,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                cell2 = cellsOnEdge(2,iEdge)
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
               do k=2,nVertLevels
 
@@ -6191,28 +6699,36 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                                   (kdiff(k,cell1)+kdiff(k,cell2)+kdiff(k-1,cell1)+kdiff(k-1,cell2))
                   tend_wk(k) = tend_wk(k) + w_turb_flux
                end do
+GPUOMP !$omp end parallel do simd
             end do
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do k=1,nVertLevels
                delsq_w(k,iCell) = delsq_wk(k)
                tend_w_euler(k,iCell) = tend_wk(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
         if(h_mom_eddy_visc4 > 0.0) then
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(tend_wk)
          do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
 !$acc cache(tend_wk)
             r_areaCell = h_mom_eddy_visc4 * invAreaCell(iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k = 1, nVertLevels
                tend_wk(k) = tend_w_euler(k,iCell)
             end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i,iCell)
@@ -6221,18 +6737,23 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
                edge_sign = meshScalingDel4(iEdge)*r_areaCell*dvEdge(iEdge)*edgesOnCell_sign(i,iCell) * invDcEdge(iEdge)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=2,nVertLevels
                   tend_wk(k) = tend_wk(k) - edge_sign * (delsq_w(k,cell2) - delsq_w(k,cell1))
                end do
+GPUOMP !$omp end parallel do simd
 
             end do
 !$acc loop vector
+GPUOMP !$omp parallel do simd
             do k=2,nVertLevels
                tend_w_euler(k,iCell) = tend_wk(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
       end if ! horizontal mixing for w computed in first rk_step
 
 
@@ -6247,45 +6768,62 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !  vertical advection, pressure gradient and buoyancy for w
       !
 
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk,wdwz) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk,wdwz) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(tend_wk, wdwz)
       do iCell=cellSolveStart,cellSolveEnd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_wk(k) = w(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
          do k=1,nVertLevels+1,nVertLevels
             wdwz(k) = 0.
          end do
+GPUOMP !$omp end parallel do simd
+
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
          do k=2,nVertLevels,nVertLevels-2
             wdwz(k) = 0.25*(rw(k,iCell)+rw(k-1,iCell))*(tend_wk(k)+tend_wk(k-1))
          end do
+GPUOMP !$omp end parallel do simd
+
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wdwz(k) = flux3(tend_wk(k-2),tend_wk(k-1),tend_wk(k),tend_wk(k+1),0.5*(rw(k,iCell)+rw(k-1,iCell)), 1.0_RKIND )
          end do
+GPUOMP !$omp end parallel do simd
 
 !DIR$ IVDEP
 !$acc loop vector
-         do k=2,nVertLevels
-            tend_w(k,iCell) = tend_w(k,iCell) * invAreaCell(iCell) - rdzu(k)*(wdwz(k+1)-wdwz(k))
-         end do
+         GPUACC do k=2,nVertLevels
+         GPUACC    tend_w(k,iCell) = tend_w(k,iCell) * invAreaCell(iCell) - rdzu(k)*(wdwz(k+1)-wdwz(k))
+         GPUACC end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=2,nVertLevels
+            GPUOMP tend_w(k,iCell) = tend_w(k,iCell) * invAreaCell(iCell) - rdzu(k)*(wdwz(k+1)-wdwz(k))
             tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - cqw(k,iCell)*(   &
                                            rdzu(k)*(pp(k,iCell)-pp(k-1,iCell)) &
                                          - (fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )  ! dpdz is the buoyancy term here.
             end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
          if ( v_mom_eddy_visc2 > 0.0 ) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
             do iCell=cellSolveStart,cellSolveEnd
@@ -6297,9 +6835,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                                           -(w(k  ,iCell)-w(k-1,iCell))*rdzw(k-1) )*rdzu(k)
                end do
             end do
+GPUOMP !$omp end target teams distribute parallel do simd
 !$acc end parallel
          end if
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
       do iCell = cellSolveStart,cellSolveEnd
@@ -6310,13 +6850,17 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel 
+GPUOMP !$omp end target teams distribute parallel do simd
+
 
 !----------- rhs for theta
 
       !
       !  horizontal advection for theta
       !
-
+!GPUOMP !$omp target teams distribute parallel do &
+GPUOMP !$omp target teams distribute &
+GPUOMP !$omp private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -6327,58 +6871,74 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(coefs_3rd_w)
 !$acc cache(tend_wk)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels+1
            tend_wk(k) = 0.0
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                ru_edge_w(k) = ru(k,iEdge)
                flux_arr(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
             do j=1,nAdvCellsForEdge(iEdge)
                iadv_cell_w(j) = advCellsForEdge(j,iEdge)
                coefs_w(j)     = adv_coefs(j,iEdge)
                coefs_3rd_w(j) = adv_coefs_3rd(j,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
             do j=1,nAdvCellsForEdge(iEdge)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   iAdvCell = iadv_cell_w(j)
                   scalar_weight = coefs_w(j) + sign(1.0_RKIND,ru_edge_w(k))*coefs_3rd_w(j)
                   flux_arr(k) = flux_arr(k) + scalar_weight* theta_m(k,iAdvCell)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                tend_wk(k) = tend_wk(k) - edgesOnCell_sign(i,iCell) * ru_edge_w(k) * flux_arr(k)
             end do
+GPUOMP !$omp end parallel do simd
 
          end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_theta(k,iCell) = tend_wk(k)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+
 
       !
       !  horizontal mixing for theta_m - we could combine this with advection directly (i.e. as a turbulent flux),
       !  but here we can also code in hyperdiffusion if we wish (2nd order at present)
       !
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk,delsq_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk,delsq_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(tend_wk, delsq_wk)
          do iCell=cellStart,cellEnd
@@ -6386,11 +6946,13 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(delsq_wk)
 
             r_areaCell = invAreaCell(iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k = 1, nVertLevels
                delsq_wk(k) = 0.0
                tend_wk(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i,iCell)
@@ -6400,6 +6962,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                cell2 = cellsOnEdge(2,iEdge)
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k = 1, nVertLevels
                   theta_turb_flux = edge_sign*(theta_m(k,cell2) - theta_m(k,cell1))*rho_edge(k,iEdge)
@@ -6407,29 +6970,37 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                   theta_turb_flux = theta_turb_flux*0.5*(kdiff(k,cell1)+kdiff(k,cell2)) * pr_scale
                   tend_wk(k) = tend_wk(k) + theta_turb_flux
                end do
+GPUOMP !$omp end parallel do simd
             end do
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k = 1, nVertLevels
                delsq_theta(k,iCell) = delsq_wk(k)
                tend_theta_euler(k,iCell) = tend_wk(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
         if(h_theta_eddy_visc4 > 0.0) then
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk) thread_limit(64)
 !$acc parallel vector_length(64) private(tend_wk)
 !$acc loop gang
          do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
 !$acc cache(tend_wk)
             r_areaCell = h_theta_eddy_visc4 * prandtl_inv * invAreaCell(iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k = 1, nVertLevels
                tend_wk(k) = tend_theta_euler(k,iCell)
             end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
 
@@ -6439,18 +7010,23 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   tend_wk(k) = tend_wk(k) - edge_sign*(delsq_theta(k,cell2) - delsq_theta(k,cell1))
                end do
+GPUOMP !$omp end parallel do simd
 
             end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                tend_theta_euler(k,iCell) = tend_wk(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
       end if ! theta mixing calculated first rk_step
             
 
@@ -6459,15 +7035,25 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !  Note: we are also dividing through by the cell area after the horizontal flux divergence
       !
 
+!GPUOMP !$omp target teams distribute parallel do private(wdtz) thread_limit(64)
+GPUOMP !$omp target teams distribute private(wdtz) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(wdtz)
       do iCell = cellSolveStart,cellSolveEnd
 !$acc cache(wdtz)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
          do k=1,nVertLevels+1,nVertLevels
             wdtz(k) = 0.
          end do
+GPUOMP !$omp end parallel do simd
+!GPUOMP NOTE: workaround for shortloop with if statement
+#ifdef MPAS_AMD_OFFLOAD
+         wdtz(2) = rw(2,icell)*(fzm(2)*theta_m(2,iCell)+fzp(2)*theta_m(1,iCell))
+         wdtz(2) = wdtz(2) + (rw_save(2,icell)-rw(2,icell))*(fzm(2)*theta_m_save(2,iCell)+fzp(2)*theta_m_save(1,iCell))
+         wdtz(nVertLevels) = rw_save(nVertLevels,icell)*(fzm(nVertLevels)*theta_m(nVertLevels,iCell)+fzp(nVertLevels)*theta_m(nVertLevels-1,iCell))
+#else
 !$acc loop vector shortloop
          do k=2,nVertLevels,nVertLevels-2
             if (k.eq.2) then
@@ -6477,13 +7063,17 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                wdtz(k) = rw_save(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))  !rtheta_pp redefinition
             end if
          end do
+#endif
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wdtz(k) = flux3( theta_m(k-2,iCell),theta_m(k-1,iCell),theta_m(k,iCell),theta_m(k+1,iCell), rw(k,iCell), coef_3rd_order )
             wdtz(k) =  wdtz(k) + (rw_save(k,icell)-rw(k,iCell))*(fzm(k)*theta_m_save(k,iCell)+fzp(k)*theta_m_save(k-1,iCell)) ! rtheta_pp redefinition
          end do
+GPUOMP !$omp end parallel do simd
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_theta(k,iCell) = tend_theta(k,iCell)*invAreaCell(iCell) -rdzw(k)*(wdtz(k+1)-wdtz(k))
@@ -6491,8 +7081,10 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             rthdynten(k,iCell) = tend_theta(k,iCell)/rho_zz(k,iCell)  !  this is for the Grell-Freitas scheme
             tend_theta(k,iCell) = tend_theta(k,iCell) + rho_zz(k,iCell)*rt_diabatic_tend(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
       !
       !  vertical mixing for theta - 2nd order 
@@ -6503,6 +7095,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc parallel num_gangs(256) num_workers(4) vector_length(32)
             if (config_mix_full) then
 !$acc loop gang worker
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
                do iCell = cellSolveStart,cellSolveEnd
                   do k=2,nVertLevels-1
                      z1 = zgrid(k-1,iCell)
@@ -6519,6 +7112,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                                              -(theta_m(k  ,iCell)-theta_m(k-1,iCell))/(z0-zm) )/(0.5*(zp-zm))
                   end do
                end do
+GPUOMP !$omp end target teams distribute parallel do simd
           end if
 !$acc end parallel
 
@@ -6526,6 +7120,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
           if (.not.config_mix_full) then
          !else  ! idealized cases where we mix on the perturbation from the initial 1-D state
 !$acc loop gang worker
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
                do iCell = cellSolveStart,cellSolveEnd
                   do k=2,nVertLevels-1
                      z1 = zgrid(k-1,iCell)
@@ -6542,11 +7137,13 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                                              -((theta_m(k  ,iCell)-t_init(k,iCell))-(theta_m(k-1,iCell)-t_init(k-1,iCell)))/(z0-zm) )/(0.5*(zp-zm))
                   end do
                end do
+GPUOMP !$omp end target teams distribute parallel do simd
 
             end if
 !$acc end parallel
          end if
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
       do iCell = cellSolveStart,cellSolveEnd
@@ -6557,6 +7154,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
+TMPOMP !$omp target update from(kdiff,h_divergence,tend_rho,dpdz,tend_u_euler,tend_u,delsq_u,delsq_w,tend_w,&
+TMPOMP !$omp tend_w_euler,tend_theta,tend_theta_euler,tend_rtheta_adv,rthdynten)
 !$acc end data
    end subroutine atm_compute_dyn_tend_work
 
@@ -6759,6 +7359,22 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc h_divergence,tend_u, &
 !$acc tend_theta,tend_w,&
 !$acc tend_rtheta_adv, rthdynten)
+TMPOMP !$omp target update to(cellsonedge,dvedge,edgesoncell, &
+TMPOMP !$omp tend_ru_physics, &
+TMPOMP !$omp tend_rtheta_physics, &
+TMPOMP !$omp edgesoncell_sign,fzm,fzp,invareacell,nedgesoncell &
+TMPOMP !$omp ,ru,rw,u,edgesonedge, &
+TMPOMP !$omp invdcedge,ke,nedgesonedge, &
+TMPOMP !$omp pv_edge,rdzw,rho_edge, &
+TMPOMP !$omp weightsonedge,adv_coefs,adv_coefs_3rd,advcellsforedge, &
+TMPOMP !$omp w,rdzu, tend_w_euler, &
+TMPOMP !$omp theta_m,ru_save,theta_m_save,tend_u_euler, &
+TMPOMP !$omp nadvcellsforedge,rho_zz, &
+TMPOMP !$omp rt_diabatic_tend,rw_save, &
+TMPOMP !$omp tend_theta_euler,  &
+TMPOMP !$omp h_divergence,tend_u, &
+TMPOMP !$omp tend_theta,tend_w,&
+TMPOMP !$omp tend_rtheta_adv)
 
  
 
@@ -6767,31 +7383,40 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       ! accumulate total water here for later use in w tendency calculation.
 
       ! accumulate horizontal mass-flux
+!GPUOMP !$omp target teams distribute parallel do private(h_wk) thread_limit(64)
+GPUOMP !$omp target teams distribute private(h_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(h_wk)
  do iCell=cellStart,cellEnd
 !$acc cache(h_wk)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             h_wk(k) = 0.0
          end do
+GPUOMP !$omp end parallel do simd
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             edge_sign = edgesOnCell_sign(i,iCell) * dvEdge(iEdge)
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                h_wk(k) = h_wk(k) + edge_sign * ru(k,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
          end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             r = invAreaCell(iCell)
             h_divergence(k,iCell) = h_wk(k) * r
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel 
+GPUOMP !$omp end target teams distribute !parallel do
 
      
 
@@ -6800,10 +7425,12 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !
       ! only needed on first rk_step with pert variables defined a pert from time t
       !
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
       !
       ! Compute u (normal) velocity tendency for each edge (cell face)
       !
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk, wduz, eoe_w, we_w) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk, wduz, eoe_w, we_w) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(wduz, tend_wk, eoe_w, we_w)
       do iEdge=edgeSolveStart,edgeSolveEnd
@@ -6816,30 +7443,59 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          cell2 = cellsOnEdge(2,iEdge)
 
          ! horizontal pressure gradient 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_wk(k) = u(k,iEdge)
          end do
+GPUOMP !$omp end parallel do simd
 
+         GPUOMP wduz(1) = 0
+         GPUOMP wduz(nVertLevels+1) = 0
 !$acc loop vector shortloop
-         do k=1,nVertLevels+1,nVertLevels
-            wduz(k) = 0.
-         end do
+         GPUACC do k=1,nVertLevels+1,nVertLevels
+         GPUACC    wduz(k) = 0.
+         GPUACC end do
+         GPUOMP wduz(2) = 0.5*( rw(2,cell1)+rw(2,cell2))*(fzm(2)*tend_wk(2)+fzp(2)*tend_wk(2-1))
+         GPUOMP wduz(nVertLevels) = 0.5*( rw(nVertLevels,cell1)+rw(nVertLevels,cell2))*(fzm(nVertLevels)*tend_wk(nVertLevels)+fzp(nVertLevels)*tend_wk(nVertLevels-1))
 !$acc loop vector shortloop
-         do k=2,nVertLevels,nVertLevels-2
-            wduz(k) = 0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*tend_wk(k)+fzp(k)*tend_wk(k-1))
-         end do
+         GPUACC do k=2,nVertLevels,nVertLevels-2
+         GPUACC    wduz(k) = 0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*tend_wk(k)+fzp(k)*tend_wk(k-1))
+         GPUACC end do
+
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wduz(k) = flux3( tend_wk(k-2),tend_wk(k-1),tend_wk(k),tend_wk(k+1),0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop vector shortloop
+GPUOMP !$omp parallel do simd
          do j = 1,nEdgesOnEdge(iEdge)
             eoe_w(j) = edgesOnEdge(j,iEdge)
             we_w(j)  = weightsOnEdge(j,iEdge)
          end do
+GPUOMP !$omp end parallel do simd
 
+#ifdef MPAS_AMD_OFFLOAD
+GPUOMP !$omp parallel do simd
+         do k=1,nVertLevels
+            t_w = - rdzw(k)*(wduz(k+1)-wduz(k))
+            tend_u(k,iEdge) = t_w + rho_edge(k,iEdge) * &
+                             (-(ke(k,cell2) - ke(k,cell1))* invDcEdge(iEdge)) - tend_wk(k) * 0.5 * &
+                             (h_divergence(k,cell1)+h_divergence(k,cell2))
+         end do
+GPUOMP !$omp end parallel do simd
+         do j = 1,nEdgesOnEdge(iEdge)
+            eoe = eoe_w(j)
+GPUOMP !$omp parallel do simd
+            do k=1,nVertLevels
+              tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge) * we_w(j) * u(k,eoe) * 0.5 * (pv_edge(k,iEdge) + pv_edge(k,eoe))
+            enddo
+GPUOMP !$omp end parallel do simd
+         end do
+#else
 !$acc loop vector
          do k=1,nVertLevels
             q1 = pv_edge(k,iEdge)
@@ -6856,9 +7512,12 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                              invDcEdge(iEdge)) - tend_wk(k) * 0.5 * &
                              (h_divergence(k,cell1)+h_divergence(k,cell2))
          end do
+#endif
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang
       do iEdge=edgeSolveStart,edgeSolveEnd
@@ -6868,13 +7527,14 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
       !  mixing terms are integrated using forward-Euler, so this tendency is only computed in the
       !  first Runge-Kutta substep and saved for use in later RK substeps 2 and 3.
       !
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
 !  add in mixing for u
 
@@ -6885,6 +7545,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !
       !  horizontal advection for w
       !
+!GPUOMP !$omp target teams distribute parallel do &
+GPUOMP !$omp target teams distribute &
+GPUOMP !$omp private(ru_edge_w,flux_arr,iadv_cell_w,coefs_w,coefs_3rd_w,tend_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -6895,58 +7558,73 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(coefs_3rd_w)
 !$acc cache(tend_wk)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels+1
            tend_wk(k) = 0.0
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=2,nVertLevels
                ru_edge_w(k) = fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do j=1,nAdvCellsForEdge(iEdge)
                iadv_cell_w(j) = advCellsForEdge(j,iEdge)
                coefs_w(j)     = adv_coefs(j,iEdge)
                coefs_3rd_w(j) = adv_coefs_3rd(j,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                flux_arr(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 
             ! flux_arr stores the value of w at the cell edge used in the
             ! horizontal transport
 
 !$acc loop seq
             do j=1,nAdvCellsForEdge(iEdge)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=2,nVertLevels
                   iAdvCell = iadv_cell_w(j)
                   scalar_weight = coefs_w(j) + sign(1.0_RKIND,ru_edge_w(k)) * coefs_3rd_w(j)
                   flux_arr(k) = flux_arr(k) + scalar_weight * w(k,iAdvCell)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=2,nVertLevels
                tend_wk(k) = tend_wk(k) - edgesOnCell_sign(i,iCell)*ru_edge_w(k)*flux_arr(k)
             end do
+GPUOMP !$omp end parallel do simd
          end do
 
 !DIR$ IVDEP
 !$acc loop vector
+GPUOMP !$omp parallel do simd
          do k=2,nVertLevels
            tend_w(k,iCell) = tend_wk(k)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
 
 
@@ -6967,14 +7645,18 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !  vertical advection, pressure gradient and buoyancy for w
       !
 
+!GPUOMP !$omp target teams distribute parallel do private(tend_wk,wdwz) thread_limit(64)
+GPUOMP !$omp target teams distribute private(tend_wk,wdwz) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(tend_wk, wdwz)
       do iCell=cellSolveStart,cellSolveEnd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_wk(k) = w(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop vector shortloop
          do k=1,nVertLevels+1,nVertLevels
@@ -6984,19 +7666,25 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          do k=2,nVertLevels,nVertLevels-2
             wdwz(k) = 0.25*(rw(k,iCell)+rw(k-1,iCell))*(tend_wk(k)+tend_wk(k-1))
          end do
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wdwz(k) = flux3(tend_wk(k-2),tend_wk(k-1),tend_wk(k),tend_wk(k+1),0.5*(rw(k,iCell)+rw(k-1,iCell)), 1.0_RKIND )
          end do
+GPUOMP !$omp end parallel do simd
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=2,nVertLevels
             tend_w(k,iCell) = tend_w(k,iCell) * invAreaCell(iCell) - rdzu(k)*(wdwz(k+1)-wdwz(k))
          end do
+GPUOMP !$omp end parallel do simd
      end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(64)
 !$acc loop gang worker
       do iCell = cellSolveStart,cellSolveEnd
@@ -7006,6 +7694,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel 
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
 !----------- rhs for theta
@@ -7013,6 +7702,10 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !
       !  horizontal advection for theta
       !
+!GPUOMP Note: could likely be optimized a lot
+!GPUOMP !$omp target teams distribute parallel do &
+GPUOMP !$omp target teams distribute &
+GPUOMP !$omp private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(ru_edge_w, flux_arr, iadv_cell_w, coefs_w, coefs_3rd_w, tend_wk)
       do iCell=cellSolveStart,cellSolveEnd    ! Technically updating fewer cells than before...
@@ -7023,54 +7716,70 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(coefs_3rd_w)
 !$acc cache(tend_wk)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels+1
            tend_wk(k) = 0.0
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                ru_edge_w(k) = ru(k,iEdge)
                flux_arr(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector shortloop
             do j=1,nAdvCellsForEdge(iEdge)
                iadv_cell_w(j) = advCellsForEdge(j,iEdge)
                coefs_w(j)     = adv_coefs(j,iEdge)
                coefs_3rd_w(j) = adv_coefs_3rd(j,iEdge)
             end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop seq
             do j=1,nAdvCellsForEdge(iEdge)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
                do k=1,nVertLevels
                   iAdvCell = iadv_cell_w(j)
                   scalar_weight = coefs_w(j) + sign(1.0_RKIND,ru_edge_w(k))*coefs_3rd_w(j)
                   flux_arr(k) = flux_arr(k) + scalar_weight* theta_m(k,iAdvCell)
                end do
+GPUOMP !$omp end parallel do simd
             end do
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                tend_wk(k) = tend_wk(k) - edgesOnCell_sign(i,iCell) * ru_edge_w(k) * flux_arr(k)
             end do
+GPUOMP !$omp end parallel do simd
 
          end do
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_theta(k,iCell) = tend_wk(k)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 !  addition to pick up perturbation flux for rtheta_pp equation
 
+!GPUOMP !$omp target teams distribute parallel do thread_limit(64) &
+GPUOMP !$omp target teams distribute thread_limit(64) &
+GPUOMP !$omp private(flux_arr1,tend_wk, ru_edge_w,ru_save_temp)
 !$acc parallel vector_length(64)
 !$acc loop gang private(flux_arr1,tend_wk, ru_edge_w,ru_save_temp)
         do iCell=cellSolveStart,cellSolveEnd
@@ -7079,35 +7788,43 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc cache(ru_save_temp)
 !$acc cache(tend_wk)
 
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
            tend_wk(k) = tend_theta(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
 
 !$acc loop vector
             do i=1,nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i,iCell)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                ru_edge_w(k) = ru(k,iEdge)
                ru_save_temp(k) = ru_save(k,iEdge)
                flux_arr1(k) = 0.0
             end do
+GPUOMP !$omp end parallel do simd
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k=1,nVertLevels
                flux_arr1(k) = edgesOnCell_sign(i,iCell)*dvEdge(iEdge)*(ru_save_temp(k)-ru_edge_w(k))*0.5*(theta_m_save(k,cell2)+theta_m_save(k,cell1))
                !flux_arr1(k) = edgesOnCell_sign(i,iCell) *dvEdge(iEdge)*(ru_save(k,iCell)-ru_edge_w(k)) &
                ! *0.5*(theta_m_save(k,cell2)+theta_m_save(k,cell1))
             end do
+GPUOMP !$omp end parallel do simd
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
             do k = 1,nVertLevels
 !               tend_theta(k,iCell) = tend_theta(k,iCell)-flux_arr1(k)  ! division by areaCell picked up down below
                tend_wk(k) = tend_wk(k)-flux_arr1(k)
             end do
+GPUOMP !$omp end parallel do simd
           end do
 !$acc loop vector
          do k=1,nVertLevels
@@ -7116,6 +7833,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
 
       !
       !  horizontal mixing for theta_m - we could combine this with advection directly (i.e. as a turbulent flux),
@@ -7124,6 +7842,8 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       !  Note: we are also dividing through by the cell area after the horizontal flux divergence
       !
 
+!GPUOMP !$omp target teams distribute parallel do private(wdtz) thread_limit(64)
+GPUOMP !$omp target teams distribute private(wdtz) thread_limit(64)
 !$acc parallel vector_length(64)
 !$acc loop gang private(wdtz)
       do iCell = cellSolveStart,cellSolveEnd
@@ -7133,6 +7853,12 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          do k=1,nVertLevels+1,nVertLevels
             wdtz(k) = 0.
          end do
+#ifdef MPAS_AMD_OFFLOAD
+         wdtz(2) = rw(2,icell)*(fzm(2)*theta_m(2,iCell)+fzp(2)*theta_m(1,iCell))
+         wdtz(2) = wdtz(2)+(rw_save(2,icell)-rw(2,icell))*(fzm(2)*theta_m_save(2,iCell)+fzp(2)*theta_m_save(1,iCell))
+         wdtz(nVertLevels) = rw_save(nVertLevels,icell)*(fzm(nVertLevels)*theta_m(nVertLevels,iCell)+fzp(nVertLevels)*theta_m(nVertLevels-1,iCell))  !rtheta_pp redefinition
+
+#else
 !$acc loop vector shortloop
          do k=2,nVertLevels,nVertLevels-2
             if (k.eq.2) then
@@ -7142,13 +7868,17 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                wdtz(k) = rw_save(k,icell)*(fzm(k)*theta_m(k,iCell)+fzp(k)*theta_m(k-1,iCell))  !rtheta_pp redefinition
             end if
          end do
+#endif
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=3,nVertLevels-1
             wdtz(k) = flux3( theta_m(k-2,iCell),theta_m(k-1,iCell),theta_m(k,iCell),theta_m(k+1,iCell), rw(k,iCell), coef_3rd_order )
             wdtz(k) =  wdtz(k) + (rw_save(k,icell)-rw(k,iCell))*(fzm(k)*theta_m_save(k,iCell)+fzp(k)*theta_m_save(k-1,iCell))! rtheta_pp redefinition
          end do
+GPUOMP !$omp end parallel do simd
 
 !DIR$ IVDEP
+GPUOMP !$omp parallel do simd
 !$acc loop vector
          do k=1,nVertLevels
             tend_theta(k,iCell) = tend_theta(k,iCell)*invAreaCell(iCell) -rdzw(k)*(wdtz(k+1)-wdtz(k))
@@ -7157,8 +7887,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             tend_theta(k,iCell) = tend_theta(k,iCell) + rho_zz(k,iCell)*rt_diabatic_tend(k,iCell)
             tend_theta(k,iCell) = tend_theta(k,iCell) + tend_theta_euler(k,iCell) + tend_rtheta_physics(k,iCell)
          end do
+GPUOMP !$omp end parallel do simd
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute !parallel do
+TMPOMP !$omp target update from(h_divergence,tend_u,tend_w,tend_theta,tend_rtheta_adv,rthdynten)
 
 !$acc end data
    end subroutine atm_compute_dyn_tend_work_rk23
@@ -7339,13 +8072,24 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 !$acc kiteareasonvertex, kiteforcell, verticesoncell, edgesonedge, &
 !$acc nedgesonedge, weightsonedge, fvertex, verticesonedge, &
 !$acc invdcedge, invdvedge)
+TMPOMP !$omp target update to(h_edge,  vorticity, divergence, ke, &
+TMPOMP !$omp ke_vertex, v, pv_vertex, pv_edge, pv_cell, gradpvn, &
+TMPOMP !$omp gradpvt, ke_edge, &
+TMPOMP !$omp cellsonedge, dcedge, dvedge, h, u, edgesonvertex, &
+TMPOMP !$omp edgesonvertex_sign, invareatriangle, edgesoncell, &
+TMPOMP !$omp edgesoncell_sign, invareacell, nedgesoncell, &
+TMPOMP !$omp kiteareasonvertex, kiteforcell, verticesoncell, edgesonedge, &
+TMPOMP !$omp nedgesonedge, weightsonedge, fvertex, verticesonedge, &
+TMPOMP !$omp invdcedge, invdvedge)
 
       !
       ! Compute height on cell edges at velocity locations
       !
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32) 
 !$acc loop gang
       do iEdge=edgeStart,edgeEnd
+GPUOMP         do k=1,nVertLevels
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          efac = dcEdge(iEdge)*dvEdge(iEdge)
@@ -7353,17 +8097,19 @@ if (config_horiz_mixing == "2d_smagorinsky") then
        !   efac = efactemp * efactemp
 !DIR$ IVDEP
 !$acc loop vector
-         do k=1,nVertLevels
+         GPUACC do k=1,nVertLevels
             h_edge(k,iEdge) = 0.5 * (h(k,cell1) + h(k,cell2))
             ke_edge(k,iEdge) = efac*u(k,iEdge)**2
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
       !
       ! Compute circulation and relative vorticity at each vertex
       !
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel num_workers(4) vector_length(32)
 !$acc loop gang worker
       do iVertex=vertexStart,vertexEnd
@@ -7380,19 +8126,22 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
       !
       ! Compute the divergence at each cell center
       !
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
 !$acc loop gang
       do iCell=cellStart,cellEnd
+GPUOMP         do k=1,nVertLevels
        r = invAreaCell(iCell)
 !DIR$ IVDEP
 !$acc loop vector
-         do k=1,nVertLevels
+       GPUACC do k=1,nVertLevels
          divergence(k,iCell) = 0.0
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
@@ -7403,14 +8152,16 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
       !
       ! Compute kinetic energy in each cell (Ringler et al JCP 2009)
       !
       ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
       ! compiler will actually allow "float raised to float" operation
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel num_workers(4) vector_length(32)
 !$acc loop gang worker
      do iCell=cellStart,cellEnd
@@ -7426,31 +8177,36 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
       if (hollingsworth) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
       ! if (hollingsworth) then
 !$acc loop gang
          do iVertex=vertexStart,vertexEnd
+            GPUOMP do k=1,nVertLevels
             temp1 = EdgesOnVertex(1,iVertex)
             temp2 = EdgesOnVertex(2,iVertex)
             temp3 = EdgesOnVertex(3,iVertex)
             r = 0.25 * invAreaTriangle(iVertex)
 !$acc loop vector
-            do k=1,nVertLevels
+            GPUACC do k=1,nVertLevels
 
                ke_vertex(k,iVertex) = ( ke_edge(k,temp1)+ke_edge(k,temp2)+ke_edge(k,temp3) )*r
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          ! adjust ke at cell vertices - AG's new KE construction, part 2
          !
 
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel num_workers(4) vector_length(32)
 !$acc loop gang worker
          do iCell=cellStart,cellEnd
@@ -7461,8 +8217,10 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
 !$acc loop gang
          do iCell=cellStart,cellEnd
@@ -7478,6 +8236,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       end if
 
 
@@ -7491,6 +8250,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       end if
 
       if (reconstruct_v) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
 !$acc loop gang
         do iEdge = edgeStart,edgeEnd
@@ -7505,6 +8265,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
            end do
         end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       end if
 
 
@@ -7515,6 +8276,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       ! Avoid dividing h_vertex by areaTriangle and move areaTriangle into
       ! numerator for the pv_vertex calculation
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel num_workers(4) vector_length(32)
 !$acc loop gang worker
       do iVertex = vertexStart,vertexEnd
@@ -7525,15 +8287,17 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       !
       ! Compute pv at the edges
       !   ( this computes pv_edge at all edges bounding real cells )
       !
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel num_workers(4) vector_length(32)
 !$acc loop gang worker
       do iEdge = edgeStart,edgeEnd
@@ -7544,9 +8308,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 
       if (config_apvm_upwinding > 0.0) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
 !$acc loop gang
       do iCell=cellStart,cellEnd
@@ -7563,8 +8329,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          !
          ! Modify PV edge with upstream bias. 
@@ -7581,9 +8348,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          ! Also precomputed inverses of dvEdge and dcEdge to avoid repeated divisions
          !
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) thread_limit(256)
 !$acc parallel vector_length(32)
 !$acc loop gang
          do iEdge = edgeStart,edgeEnd
+            GPUOMP do k = 1,nVertLevels
             r1 = 1.0_RKIND * invDvEdge(iEdge)
             r2 = 1.0_RKIND * invDcEdge(iEdge)
             cell1 = cellsOnEdge(1,iEdge)
@@ -7592,7 +8361,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             v2 = verticesOnEdge(2,iEdge)
 !DIR$ IVDEP
 !$acc loop vector
-            do k = 1,nVertLevels
+            GPUACC do k = 1,nVertLevels
 
                gradPVt(k,iEdge) = (pv_vertex(k,v2) - pv_vertex(k,v1)) * r1
                gradPVn(k,iEdge) = (pv_cell(k,cell2) - pv_cell(k,cell1)) * r2
@@ -7602,7 +8371,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       end if  ! apvm upwinding
+TMPOMP !$omp target update from(h_edge,ke_edge,vorticity,divergence,ke,ke_vertex,v,pv_vertex,pv_edge,pv_cell,gradPVt,gradPVn)
 !$acc end data
 
    end subroutine atm_compute_solve_diagnostics_work_gpu
@@ -7831,7 +8602,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       end do
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       !
       ! Compute kinetic energy in each cell (Ringler et al JCP 2009)
@@ -7876,7 +8647,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             end do
          end do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          ! adjust ke at cell vertices - AG's new KE construction, part 2
          !
@@ -7946,7 +8717,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       !
       ! Compute pv at the edges
@@ -7980,7 +8751,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       end do
 
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
          !
          ! Modify PV edge with upstream bias. 
@@ -8104,7 +8875,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       do iEdge=edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
@@ -8114,7 +8885,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
          end do
       end do
 
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       ! Compute rw (i.e. rho_zz * omega) from rho_zz, w, and ru.
       ! We are reversing the procedure we use in subroutine atm_recover_large_step_variables.
@@ -8276,11 +9047,16 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       real (kind=RKIND) :: inv_dynamics_split
       integer:: i,j
       inv_dynamics_split = 1.0_RKIND / real(dynamics_split)
+TMPOMP !$omp target update to(ru, ru_save, rw, rw_save, &
+TMPOMP !$omp rtheta_p,rtheta_p_save,rho_p,rho_p_save, &
+TMPOMP !$omp rho_zz_old_split,ruAvg,ruAvg_split, wwAvg, wwAvg_split, &
+TMPOMP !$omp u_1,u_2,w_1,w_2,theta_m_1,theta_m_2,rho_zz_1,rho_zz_2)
 !$acc data present(ru, ru_save, rw, rw_save, &
 !$acc rtheta_p,rtheta_p_save,rho_p,rho_p_save, &
 !$acc rho_zz_old_split,ruAvg,ruAvg_split, wwAvg, wwAvg_split, &
 !$acc u_1,u_2,w_1,w_2,theta_m_1,theta_m_2,rho_zz_1,rho_zz_2)
       if (dynamics_substep < dynamics_split) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang
          do i = cellStart,cellEnd
@@ -8290,13 +9066,19 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                          theta_m_1(j,i) = theta_m_2(j,i)
                          rtheta_p_save(j,i) = rtheta_p(j,i)
                          rho_zz_1(j,i) = rho_zz_2(j,i)
+                GPUOMP   rw_save(j,i) = rw(j,i)
+                GPUOMP   w_1(j,i) = w_2(j,i)
                 enddo
+                GPUOMP rw_save(nVertLevels+1,i) = rw(nVertLevels+1,i)
+                GPUOMP w_1(nVertLevels+1,i) = w_2(nVertLevels+1,i)
 !$acc loop vector
-                do j=1,nVertLevels+1
-                         rw_save(j,i) = rw(j,i)
-                         w_1(j,i) = w_2(j,i)
-                enddo
+                GPUACC do j=1,nVertLevels+1
+                GPUACC          rw_save(j,i) = rw(j,i)
+                GPUACC          w_1(j,i) = w_2(j,i)
+                GPUACC enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang
          do i = edgeStart,edgeEnd
 !$acc loop vector
@@ -8306,6 +9088,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                 enddo
          enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 !         ru_save(:,edgeStart:edgeEnd) = ru(:,edgeStart:edgeEnd)
 !         rw_save(:,cellStart:cellEnd) = rw(:,cellStart:cellEnd)
@@ -8320,6 +9103,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
       end if
       if (dynamics_substep == 1) then
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_gangs(256) vector_length(32)
 !$acc loop gang
          do i = cellStart,cellEnd
@@ -8328,7 +9112,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                         wwAvg_split(j,i) = wwAvg(j,i)
                 enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang
          do i = edgeStart,edgeEnd
 !$acc loop vector
@@ -8336,9 +9122,11 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                         ruAvg_split(j,i) = ruAvg(j,i)
                 enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 !$acc end parallel
       else
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_gangs(256) vector_length(32)
 !$acc loop gang
          do i = cellStart,cellEnd
@@ -8347,7 +9135,9 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                         wwAvg_split(j,i) = wwAvg(j,i)+wwAvg_split(j,i)
                 enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang
          do i = edgeStart,edgeEnd
 !$acc loop vector
@@ -8355,24 +9145,30 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                         ruAvg_split(j,i) = ruAvg(j,i)+ruAvg_split(j,i)
                 enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 !$acc end parallel
 
       end if
 
 
       if (dynamics_substep == dynamics_split) then
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel num_gangs(256) vector_length(32)
 !$acc loop gang
          do i = cellStart,cellEnd
 !$acc loop vector
-                do j=1,nVertLevels+1
-                        wwAvg(j,i) = wwAvg_split(j,i) * inv_dynamics_split
-                enddo
+                GPUACC do j=1,nVertLevels+1
+                GPUACC         wwAvg(j,i) = wwAvg_split(j,i) * inv_dynamics_split
+                GPUACC enddo
                 do j=1,nVertLevels
+                GPUOMP  wwAvg(j,i) = wwAvg_split(j,i) * inv_dynamics_split
                         rho_zz_1(j,i) = rho_zz_old_split(j,i)
                 enddo
+                GPUOMP  wwAvg(nVertLevels+1,i) = wwAvg_split(nVertLevels+1,i) * inv_dynamics_split
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang
          do i = edgeStart,edgeEnd
 !$acc loop vector
@@ -8380,9 +9176,12 @@ if (config_horiz_mixing == "2d_smagorinsky") then
                         ruAvg(j,i) = ruAvg_split(j,i) * inv_dynamics_split
                 enddo
          enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 !$acc end parallel
       end if
 
+TMPOMP !$omp target update from(rho_p_save,theta_m_1,rtheta_p_save,rho_zz_1,rw_save,w_1,ru_save,u_1,&
+TMPOMP !$omp wwAvg_split,ruAvg_split,wwAvg,ruAvg)
 
 !$acc end data
 
@@ -8884,7 +9683,7 @@ if (config_horiz_mixing == "2d_smagorinsky") then
 
       end do  ! updates now in temp storage
             
-!$OMP BARRIER
+CPUOMP !$OMP BARRIER
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
          if (bdyMaskCell(iCell) > 1) then ! update values
@@ -9360,6 +10159,8 @@ if (config_horiz_mixing == "2d_smagorinsky") then
             call mpas_pool_get_array_gpu(state, 'u', u, 2)
 
 !add the variables in the "update host" clause below to update the data on host
+        GPUOMP !$omp target update from(w, &
+        GPUOMP !$omp u)
         !$acc update host(w, &
         !$acc u)
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1,10 +1,12 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
+#include "mpas_openmp.inc"
 module atm_core
 
    use mpas_derived_types
@@ -440,7 +442,7 @@ end if
       call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
       call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
       do thread=1,nThreads
          if (.not. config_do_restart .or. (config_do_restart .and. config_do_DAcycling)) then
             call atm_init_coupled_diagnostics(state, 1, diag, mesh, block % configs, &
@@ -457,7 +459,7 @@ end if
                                             vertexThreadStart(thread), vertexThreadEnd(thread), &
                                             edgeThreadStart(thread), edgeThreadEnd(thread))
       end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
       deallocate(ke_vertex)
       deallocate(ke_edge)

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -102,6 +102,10 @@ module atm_core_interface
       use openacc, only : acc_get_num_devices, acc_set_device_num, acc_set_device_type, &
                           acc_device_nvidia, acc_device_host
 #endif
+#ifdef MPAS_AMD_OFFLOAD
+      ! NOTE: crayftn only
+      use omp_lib
+#endif
 
       implicit none
 
@@ -127,7 +131,7 @@ module atm_core_interface
       integer :: on_node_comm
       integer :: socket_rank
 
-#ifdef MPAS_OPENACC
+#if defined(MPAS_OPENACC) || defined(MPAS_AMD_OFFLOAD) 
       integer :: num_devices, my_device
       integer :: role_comm, role_rank, role_size
 #endif
@@ -197,7 +201,7 @@ module atm_core_interface
               !
               ! Assign devices based on rank in the role within a shared-memory node
               !
-#ifdef MPAS_OPENACC
+#if defined(MPAS_OPENACC) || defined(MPAS_AMD_OFFLOAD)
 #ifdef _MPI
               call MPI_Comm_split(on_node_comm, role, local_rank, role_comm, ierr)
               call MPI_Comm_rank(role_comm, role_rank, ierr)
@@ -208,11 +212,19 @@ module atm_core_interface
 #endif
 
               if (role == ROLE_INTEGRATE) then
+#ifdef MPAS_OPENACC
                   num_devices = acc_get_num_devices(acc_device_nvidia)
                   my_device = (role_rank * num_devices) / role_size
                   call acc_set_device_num(my_device, acc_device_nvidia)
+#else
+                  num_devices = omp_get_num_devices()
+                  my_device = (role_rank * num_devices) / role_size
+                  call omp_set_default_device(my_device)
+#endif
               else
+#ifdef MPAS_OPENACC
                   call acc_set_device_type(acc_device_host)
+#endif
               end if
 #endif
 

--- a/src/core_atmosphere/mpas_atm_threading.F
+++ b/src/core_atmosphere/mpas_atm_threading.F
@@ -1,10 +1,12 @@
 ! Copyright (c) 2015,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
+#include "mpas_openmp.inc"
 module mpas_atm_threading
 
 
@@ -64,11 +66,11 @@ module mpas_atm_threading
         block => blocklist
         do while (associated(block))
 #ifdef MPAS_OPENMP
-!$OMP PARALLEL
-!$OMP MASTER
+CPUOMP !$OMP PARALLEL
+CPUOMP !$OMP MASTER
             nThreads = OMP_get_num_threads()
-!$OMP END MASTER
-!$OMP END PARALLEL
+CPUOMP !$OMP END MASTER
+CPUOMP !$OMP END PARALLEL
 #else 
             nThreads = 1
 #endif 
@@ -94,7 +96,7 @@ module mpas_atm_threading
             call mpas_pool_get_dimension(block % dimensions, 'nVerticesSolve', nVerticesSolve)
 
 #ifdef MPAS_OPENMP
-!$OMP PARALLEL PRIVATE(threadid)
+CPUOMP !$OMP PARALLEL PRIVATE(threadid)
             threadid = OMP_get_thread_num()
 
             cellThreadStart(threadid+1) = (threadid * nCells / nThreads) + 1
@@ -109,7 +111,7 @@ module mpas_atm_threading
             vertexThreadEnd(threadid+1)   = ((threadid+1) * nVertices / nThreads)
             vertexSolveThreadStart(threadid+1) = (threadid * nVerticesSolve / nThreads) + 1
             vertexSolveThreadEnd(threadid+1)   = ((threadid+1) * nVerticesSolve / nThreads)
-!$OMP END PARALLEL
+CPUOMP !$OMP END PARALLEL
 #else 
             cellThreadStart(1) = 1
             cellThreadEnd(1)   = nCells

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -197,6 +197,7 @@ clean:
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+	$(RM) *.acc.s
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver
  use mpas_kind_types
  use mpas_pool_routines
@@ -202,54 +204,56 @@
     ! For timesteps other than the first, we transfer previous radiation tendencies back to integration tasks
     !
     if ((itimestep > 2) .and. (l_radtsw .or. l_radtlw)) then
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call lagged_driver_radiation_sw(itimestep,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics,xtime_s, &
                                    mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                                    cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call lagged_driver_radiation_lw(itimestep,xtime_s,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics, &
                                    mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                                    cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
     end if
 
 
     !
     ! For all timesteps, we transfer MPAS state to physics
     !
-!$OMP PARALLEL DO
     if (mpas_cpl%role_is(ROLE_RADIATION)) then
+CPUOMP !$OMP PARALLEL DO
     do thread=1,nThreads
        call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
     end do
+CPUOMP !$OMP END PARALLEL DO
     else
+CPUOMP !$OMP PARALLEL DO
     do thread=1,nThreads
        call MPAS_to_physics_gpu(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
     end do
+CPUOMP !$OMP END PARALLEL DO
     end if
-!$OMP END PARALLEL DO
 
     !call to cloud scheme:
     if(l_radtlw .or. l_radtsw) then
        call allocate_cloudiness
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_cloudiness(block%configs,mesh,diag_physics,sfc_input, &
                                  cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
     endif
 
     !call to short wave radiation scheme:
@@ -264,7 +268,7 @@
        !
        ! For all timesteps, we transfer MPAS radiation-specific fields to physics
        !
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call radiation_sw_from_MPAS(block%configs,mesh,state,time_lev,diag_physics,atm_input,sfc_input,xtime_s, &
                                       mpas_cpl,cells_to_rad_handle,cells_from_rad_handle, &
@@ -273,9 +277,9 @@
                                       mpas_cpl,cells_to_rad_handle,cells_from_rad_handle, &
                                       cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_radiation_sw(itimestep,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics,xtime_s, &
@@ -283,10 +287,10 @@
                                    (itimestep == 1), &
                                    cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
     !call to long wave radiation scheme:
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_radiation_lw(itimestep,xtime_s,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics, &
@@ -294,7 +298,7 @@
                                    (itimestep == 1), &
                                    cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
 
        if (mpas_cpl%role_includes(ROLE_RADIATION)) then
           call deallocate_radiation_sw(block%configs)
@@ -304,12 +308,12 @@
 
     !call to accumulate long- and short-wave diagnostics if needed:
      if(config_bucket_update /= 'none' .and. config_bucket_radt .gt. 0._RKIND) then
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call update_radiation_diagnostics(block%configs,mesh,diag_physics, &
                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
      endif
 
     !deallocate all radiation arrays:
@@ -321,12 +325,12 @@ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
     !call to surface-layer scheme:
     if(config_sfclayer_scheme .ne. 'off') then
        call allocate_sfclayer(block%configs)
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_sfclayer(itimestep,block%configs,mesh,diag_physics,sfc_input, &
                                cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
        call deallocate_sfclayer(block%configs)
     endif
 
@@ -336,24 +340,24 @@ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
     !call to land-surface scheme:
     if(config_lsm_scheme .ne. 'off') then
        call allocate_lsm(config_frac_seaice)
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_lsm(itimestep,block%configs,mesh,diag_physics,sfc_input, &
                           cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
        call deallocate_lsm(config_frac_seaice)
     endif
 
     !call to pbl schemes:
     if(config_pbl_scheme .ne. 'off' .and. config_sfclayer_scheme .ne. 'off') then
        call allocate_pbl(block%configs)
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_pbl(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
                           cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
        call deallocate_pbl(block%configs)
 
     endif
@@ -361,40 +365,40 @@ if (mpas_cpl%role_includes(ROLE_INTEGRATE)) then
     !call to gravity wave drag over orography scheme:
     if(config_gwdo_scheme .ne. 'off') then
        call allocate_gwdo
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_gwdo(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
                            cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
        call deallocate_gwdo
     endif
 
     !call to convection scheme:
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
     do thread=1,nThreads
        call update_convection_step1(block%configs,diag_physics,tend_physics, &
                             cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
     end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
     if(l_conv) then
        call allocate_convection(block%configs)
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_convection(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
                                  cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
        call deallocate_convection(block%configs)
     endif
     !update diagnostics:
     if(config_convection_scheme .ne. 'off') then
-!$OMP PARALLEL DO
+CPUOMP !$OMP PARALLEL DO
        do thread=1,nThreads
           call update_convection_step2(block%configs,diag_physics, &
                                cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
-!$OMP END PARALLEL DO
+CPUOMP !$OMP END PARALLEL DO
     end if
 end if
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_cloudiness
  use mpas_kind_types
  use mpas_derived_types
@@ -71,6 +73,7 @@
  if(.not.allocated(qcrad_p)  ) allocate(qcrad_p(ims:ime,kms:kme,jms:jme)  )
  if(.not.allocated(qirad_p)  ) allocate(qirad_p(ims:ime,kms:kme,jms:jme)  )
  if(.not.allocated(qsrad_p)  ) allocate(qsrad_p(ims:ime,kms:kme,jms:jme)  )
+GPUOMP !$omp target enter data map(alloc:dx_p,xland_p,cldfrac_p,qvrad_p,qcrad_p,qirad_p,qsrad_p)
 
  end subroutine allocate_cloudiness
 
@@ -78,6 +81,7 @@
  subroutine deallocate_cloudiness
 !=================================================================================================================
 
+GPUOMP !$omp target exit data map(delete:dx_p,xland_p,cldfrac_p,qvrad_p,qcrad_p,qirad_p,qsrad_p)
  if(allocated(dx_p)     ) deallocate(dx_p     )
  if(allocated(xland_p)  ) deallocate(xland_p  )
  if(allocated(cldfrac_p)) deallocate(cldfrac_p)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_convection
  use mpas_kind_types
  use mpas_pool_routines
@@ -119,6 +121,8 @@
  if(.not.allocated(rqicuten_p) ) allocate(rqicuten_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(pratec_p)   ) allocate(pratec_p(ims:ime,jms:jme)          )
  if(.not.allocated(raincv_p)   ) allocate(raincv_p(ims:ime,jms:jme)          )
+GPUOMP !$omp target enter data map(alloc:cu_act_flag,rthcuten_p,rqvcuten_p,rqccuten_p,&
+GPUOMP !$omp rqicuten_p,pratec_p,raincv_p)
 
 !$acc parallel vector_length(32)
 !$acc loop gang vector collapse(2)
@@ -210,7 +214,7 @@
        if(.not.allocated(xland_p)      ) allocate(xland_p(ims:ime,jms:jme)              )
        if(.not.allocated(rucuten_p)    ) allocate(rucuten_p(ims:ime,kms:kme,jms:jme)    )
        if(.not.allocated(rvcuten_p)    ) allocate(rvcuten_p(ims:ime,kms:kme,jms:jme)    )
-
+GPUOMP !$omp target enter data map(alloc:hfx_p,qfx_p,xland_p,rucuten_p,rvcuten_p)
 !$acc parallel vector_length(32)
 !$acc loop gang vector collapse(2)
        do j = jts,jte
@@ -253,6 +257,7 @@
              if(.not.allocated(dx_p)     ) allocate(dx_p(ims:ime,jms:jme)             )
              if(.not.allocated(rqvften_p)) allocate(rqvften_p(ims:ime,kms:kme,jms:jme))
              if(.not.allocated(rthften_p)) allocate(rthften_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:dx_p,rqvften_p,rthften_p)
 
 !$acc parallel vector_length(32)
 !$acc loop gang vector collapse(3)
@@ -290,6 +295,8 @@
 
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
 
+GPUOMP !$omp target exit data map(delete:cu_act_flag,rthcuten_p,rqvcuten_p,rqccuten_p,&
+GPUOMP !$omp rqicuten_p,pratec_p,raincv_p)
  if(allocated(cu_act_flag)) deallocate(cu_act_flag)
  if(allocated(rthcuten_p) ) deallocate(rthcuten_p )
  if(allocated(rqvcuten_p) ) deallocate(rqvcuten_p )
@@ -297,6 +304,7 @@
  if(allocated(rqicuten_p) ) deallocate(rqicuten_p )
  if(allocated(pratec_p)   ) deallocate(pratec_p   )
  if(allocated(raincv_p)   ) deallocate(raincv_p   )
+GPUOMP
 
  convection_select: select case(convection_scheme)
 
@@ -342,6 +350,7 @@
        if(allocated(rqscuten_p)   ) deallocate(rqscuten_p   )
 
     case ("cu_tiedtke","cu_ntiedtke")
+GPUOMP !$omp target exit data map(delete:hfx_p,qfx_p,xland_p,rucuten_p,rvcuten_p)
        if(allocated(hfx_p)        ) deallocate(hfx_p        )
        if(allocated(qfx_p)        ) deallocate(qfx_p        )
        if(allocated(xland_p)      ) deallocate(xland_p      )
@@ -355,6 +364,7 @@
              if(allocated(rqvdynblten_p)) deallocate(rqvdynblten_p)
 
           case ("cu_ntiedtke")
+GPUOMP !$omp target enter data map(alloc:dx_p,rqvften_p,rthften_p)
              if(allocated(dx_p)     ) deallocate(dx_p)
              if(allocated(rqvften_p)) deallocate(rqvften_p)
              if(allocated(rthften_p)) deallocate(rthften_p)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_gwdo
  use mpas_kind_types
  use mpas_pool_routines
@@ -91,6 +93,8 @@
  if(.not.allocated(dtauy3d_p)) allocate(dtauy3d_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(rublten_p)) allocate(rublten_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(rvblten_p)) allocate(rvblten_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:cosa_p,sina_p,dx_p,var2d_p,con_p,oa1_p,oa2_p,oa3_p,oa4_p,ol1_p,ol2_p,&
+GPUOMP !$omp ol3_p,ol4_p,kpbl_p,dusfcg_p,dvsfcg_p,dtaux3d_p,dtauy3d_p,rublten_p,rvblten_p)
 
  end subroutine allocate_gwdo
 
@@ -98,6 +102,8 @@
  subroutine deallocate_gwdo
 !=================================================================================================================
 
+GPUOMP !$omp target exit data map(delete:cosa_p,sina_p,dx_p,var2d_p,con_p,oa1_p,oa2_p,oa3_p,oa4_p,ol1_p,ol2_p,&
+GPUOMP !$omp ol3_p,ol4_p,kpbl_p,dusfcg_p,dvsfcg_p,dtaux3d_p,dtauy3d_p,rublten_p,rvblten_p)
  if(allocated(cosa_p)  ) deallocate(cosa_p  )
  if(allocated(sina_p)  ) deallocate(sina_p  )
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -1,12 +1,14 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
- module mpas_atmphys_driver_microphysics
+#include "mpas_openmp.inc"
+module mpas_atmphys_driver_microphysics
  use mpas_kind_types
  use mpas_pool_routines
  use mpas_timer, only : mpas_timer_start, mpas_timer_stop
@@ -124,6 +126,8 @@
  if(.not.allocated(rainnc_p) ) allocate(rainnc_p(ims:ime,jms:jme) )
  if(.not.allocated(rainncv_p)) allocate(rainncv_p(ims:ime,jms:jme))
 
+GPUOMP !$omp target enter data map(alloc:rho_p,th_p,pi_p,pres_p,z_p,dz_p,w_p,qv_p,qc_p,qr_p,&
+GPUOMP !$omp rainnc_p,rainncv_p)
  microp_select: select case(microp_scheme)
 
     case ("mp_thompson","mp_wsm6")
@@ -143,6 +147,8 @@
        if(.not.allocated(recloud_p) ) allocate(recloud_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(reice_p)   ) allocate(reice_p(ims:ime,kms:kme,jms:jme)  )
        if(.not.allocated(resnow_p)  ) allocate(resnow_p(ims:ime,kms:kme,jms:jme) )
+GPUOMP !$omp target enter data map(alloc:qi_p,qs_p,qg_p,sr_p,snownc_p,snowncv_p,snowncv_p,&
+GPUOMP !$omp graupelnc_p,graupelncv_p,recloud_p,reice_p,resnow_p)
 
     microp2_select: select case(microp_scheme)
 
@@ -155,6 +161,7 @@
 
           if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:ntc_p,muc_p,ni_p,nr_p,rainprod_p,evapprod_p)
 
        case default
 
@@ -180,6 +187,8 @@
 
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
 
+GPUOMP !$omp target exit data map(delete:rho_p,th_p,pi_p,pres_p,z_p,dz_p,w_p,qv_p,qc_p,qr_p,&
+GPUOMP !$omp rainnc_p,rainncv_p)
 !sounding variables:
  if(allocated(rho_p)     ) deallocate(rho_p     )
  if(allocated(th_p)      ) deallocate(th_p      )
@@ -201,6 +210,8 @@
  microp_select: select case(microp_scheme)
 
     case ("mp_thompson","mp_wsm6")
+GPUOMP !$omp target exit data map(delete:qi_p,qs_p,qg_p,sr_p,snownc_p,snowncv_p,snowncv_p,&
+GPUOMP !$omp graupelnc_p,graupelncv_p,recloud_p,reice_p,resnow_p)
        !mass mixing ratios:
        if(allocated(qi_p)         ) deallocate(qi_p         )
        if(allocated(qs_p)         ) deallocate(qs_p         )
@@ -221,6 +232,7 @@
     microp2_select: select case(microp_scheme)
 
        case("mp_thompson")
+GPUOMP !$omp target exit data map(delete:ntc_p,muc_p,ni_p,nr_p,rainprod_p,evapprod_p)
           !number concentrations:
           if(allocated(ntc_p)) deallocate(ntc_p)
           if(allocated(muc_p)) deallocate(muc_p)
@@ -307,10 +319,10 @@
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
 
 !... allocation of microphysics arrays:
-!$OMP MASTER
+CPUOMP !$OMP MASTER
  call allocate_microphysics(configs)
-!$OMP END MASTER
-!$OMP BARRIER
+CPUOMP !$OMP END MASTER
+CPUOMP !$OMP BARRIER
 
 !... initialization of precipitation related arrays:
  call precip_from_MPAS(configs,diag_physics,its,ite)
@@ -415,10 +427,10 @@
  call microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend,itimestep,its,ite)
 
 !... deallocation of all microphysics arrays:
-!$OMP BARRIER
-!$OMP MASTER
+CPUOMP !$OMP BARRIER
+CPUOMP !$OMP MASTER
  call deallocate_microphysics(configs)
-!$OMP END MASTER
+CPUOMP !$OMP END MASTER
 
 !call mpas_log_write('---enter subroutine driver_microphysics:')
 !call mpas_log_write('')

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_pbl
  use mpas_kind_types
  use mpas_pool_routines
@@ -114,6 +116,8 @@
  if(.not.allocated(kzh_p)) allocate(kzh_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(kzm_p)) allocate(kzm_p(ims:ime,kms:kme,jms:jme))
  if(.not.allocated(kzq_p)) allocate(kzq_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:hfx_p,qfx_p,ust_p,wspd_p,xland_p,hpbl_p,kpbl_p,znt_p,delta_p,wstar_p,&
+GPUOMP !$omp uoce_p,voce_p,rublten_p,rvblten_p,rthblten_p,rqvblten_p,rqiblten_p,kzh_p,kzm_p,kzq_p)
 
  pbl_select: select case (trim(pbl_scheme))
 
@@ -130,6 +134,7 @@
        if(.not.allocated(exch_p)  ) allocate(exch_p(ims:ime,kms:kme,jms:jme))
        !from radiation schemes:
        if(.not.allocated(rthraten_p)) allocate(rthraten_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:br_p,ctopo_p,ctopo2_p,psih_p,psim_p,regime_p,u10_p,v10_p,exch_p,rthraten_p)
 
     case("bl_mynn")
        if(.not.allocated(dx_p)   ) allocate(dx_p(ims:ime,jms:jme)   )
@@ -156,6 +161,8 @@
        if(.not.allocated(qwt_p)   ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)   )
 
        if(.not.allocated(rniblten_p)) allocate(rniblten_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:dx_p,ch_p,qcg_p,qsfc_p,rmol_p,tsk_p,vdfg_p,cov_p,qke_p,qsq_p,tsq_p,qkeadv_p,&
+GPUOMP !$omp elpbl_p,tkepbl_p,sh3d_p,dqke_p,qbuoy_p,qdiss_p,qshear_p,qwt_p,rniblten_p)
 
     case default
 
@@ -177,6 +184,8 @@
 
  call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
 
+GPUOMP !$omp target exit data map(delete:hfx_p,qfx_p,ust_p,wspd_p,xland_p,hpbl_p,kpbl_p,znt_p,delta_p,wstar_p,&
+GPUOMP !$omp uoce_p,voce_p,rublten_p,rvblten_p,rthblten_p,rqvblten_p,rqiblten_p,kzh_p,kzm_p,kzq_p)
  if(allocated(hfx_p)  ) deallocate(hfx_p  )
  if(allocated(qfx_p)  ) deallocate(qfx_p  )
  if(allocated(ust_p)  ) deallocate(ust_p  )
@@ -206,6 +215,7 @@
  pbl_select: select case (trim(pbl_scheme))
 
     case("bl_ysu")
+GPUOMP !$omp target exit data map(delete:br_p,ctopo_p,ctopo2_p,psih_p,psim_p,regime_p,u10_p,v10_p,exch_p,rthraten_p)
        !from surface-layer model:
        if(allocated(br_p)    ) deallocate(br_p    )
        if(allocated(ctopo_p) ) deallocate(ctopo_p )
@@ -220,6 +230,8 @@
        if(allocated(rthraten_p)) deallocate(rthraten_p)
 
     case("bl_mynn")
+GPUOMP !$omp target exit data map(delete:dx_p,ch_p,qcg_p,qsfc_p,rmol_p,tsk_p,vdfg_p,cov_p,qke_p,qsq_p,tsq_p,qkeadv_p,&
+GPUOMP !$omp elpbl_p,tkepbl_p,sh3d_p,dqke_p,qbuoy_p,qdiss_p,qshear_p,qwt_p,rniblten_p)
        if(allocated(dx_p)   ) deallocate(dx_p   )
        if(allocated(ch_p)   ) deallocate(ch_p   )
        if(allocated(qcg_p)  ) deallocate(qcg_p  )

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_radiation_lw
  use mpas_kind_types
  use mpas_pool_routines
@@ -1118,10 +1120,10 @@
 
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
-!$OMP SINGLE
+CPUOMP !$OMP SINGLE
        !... calculates solar declination:
        call radconst(declin,solcon,curr_julday,degrad,dpd)
-!$OMP END SINGLE
+CPUOMP !$OMP END SINGLE
 
 !... convert the radiation time_step to minutes:
        radt = dt_radtlw/60.

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_radiation_sw
  use mpas_kind_types
  use mpas_pool_routines
@@ -971,7 +973,7 @@
 
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
-!$OMP SINGLE
+CPUOMP !$OMP SINGLE
 
 !... convert the radiation time_step to minutes:
  radt = dt_radtsw/60.
@@ -996,7 +998,7 @@
 !call mpas_log_write('     CURR_JULDAY = $r', realArgs=(/curr_julday/))
 !call mpas_log_write('     SOLCON      = $r', realArgs=(/solcon/))
 !call mpas_log_write('     DECLIN      = $r', realArgs=(/declin/))
-!$OMP END SINGLE
+CPUOMP !$OMP END SINGLE
 
  call mpas_log_write('RUNNING SW RADIATION SCHEME FOR XTIME_M = $r', realArgs=(/xtime_m/))
     

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_driver_sfclayer
  use mpas_kind_types
  use mpas_pool_routines
@@ -137,6 +139,9 @@
  if(.not.allocated(xland_p) ) allocate(xland_p(ims:ime,jms:jme) )
  if(.not.allocated(zol_p)   ) allocate(zol_p(ims:ime,jms:jme)   )
  if(.not.allocated(znt_p)   ) allocate(znt_p(ims:ime,jms:jme)   )
+GPUOMP !$omp target enter data map(alloc:dx_p,br_p,cd_p,cda_p,chs_p,chs2_p,ck_p,cka_p,cpm_p,cqs2_p,gz1oz0_p,&
+GPUOMP !$omp flhc_p,flqc_p,hfx_p,hpbl_p,lh_p,mavail_p,mol_p,psih_p,psim_p,q2_p,qfx_p,qgh_p,qsfc_p,regime_p,&
+GPUOMP !$omp rmol_p,t2m_p,tsk_p,th2m_p,u10_p,ust_p,ustm_p,v10_p,wspd_p,xland_p,zol_p,znt_p)
 
  if(config_frac_seaice) then
     if(.not.allocated(sst_p)      ) allocate(sst_p(ims:ime,jms:jme)      )
@@ -180,6 +185,10 @@
     if(.not.allocated(v10_sea)    ) allocate(v10_sea(ims:ime,jms:jme)    )
 
     if(.not.allocated(regime_hold)) allocate(regime_hold(ims:ime,jms:jme))
+GPUOMP !$omp target enter data map(alloc:sst_p,xice_p,br_sea,chs_sea,chs2_sea,cqs2_sea,flhc_sea,flqc_sea,gz1oz0_sea,&
+GPUOMP !$omp hfx_sea,qfx_sea,mavail_sea,mol_sea,lh_sea,psih_sea,psim_sea,qgh_sea,qsfc_sea,regime_sea,rmol_sea,tsk_sea,&
+GPUOMP !$omp ust_sea,ustm_sea,wspd_sea,xland_sea,zol_sea,znt_sea,cd_sea,cda_sea,ck_sea,cka_sea,t2m_sea,th2m_sea,q2_sea,&
+GPUOMP !$omp u10_sea,v10_sea,regime_hold)
  endif
 
  sfclayer_select: select case (trim(sfclayer_scheme))
@@ -191,6 +200,7 @@
           if(.not.allocated(fh_sea)) allocate(fh_sea(ims:ime,jms:jme))
           if(.not.allocated(fm_sea)) allocate(fm_sea(ims:ime,jms:jme))
        endif
+GPUOMP !$omp target enter data map(alloc:fh_p,fm_p,fh_sea,fm_sea)
 
     case("sf_mynn")
        if(.not.allocated(snowh_p)) allocate(snowh_p(ims:ime,jms:jme))
@@ -205,6 +215,7 @@
        if(.not.allocated(tsq_p)     ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)     )
        if(.not.allocated(sh3d_p)    ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)    )
        if(.not.allocated(elpbl_p)   ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)   )
+GPUOMP !$omp target enter data map(alloc:snowh_p,ch_p,qcg_p,ch_sea,ch_sea,cov_p,qsq_p,tsq_p,sh3d_p,elpbl_p)
 
     case default
 
@@ -228,6 +239,9 @@
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme   )
 
+GPUOMP !$omp target exit data map(delete:dx_p,br_p,cd_p,cda_p,chs_p,chs2_p,ck_p,cka_p,cpm_p,cqs2_p,gz1oz0_p,&
+GPUOMP !$omp flhc_p,flqc_p,hfx_p,hpbl_p,lh_p,mavail_p,mol_p,psih_p,psim_p,q2_p,qfx_p,qgh_p,qsfc_p,regime_p,&
+GPUOMP !$omp rmol_p,t2m_p,tsk_p,th2m_p,u10_p,ust_p,ustm_p,v10_p,wspd_p,xland_p,zol_p,znt_p)
  if(allocated(dx_p)    ) deallocate(dx_p    )
  if(allocated(br_p)    ) deallocate(br_p    )
  if(allocated(cd_p)    ) deallocate(cd_p    )
@@ -267,6 +281,10 @@
  if(allocated(znt_p)   ) deallocate(znt_p   )
 
  if(config_frac_seaice) then
+GPUOMP !$omp target exit data map(delete:sst_p,xice_p,br_sea,chs_sea,chs2_sea,cqs2_sea,flhc_sea,flqc_sea,gz1oz0_sea,&
+GPUOMP !$omp hfx_sea,qfx_sea,mavail_sea,mol_sea,lh_sea,psih_sea,psim_sea,qgh_sea,qsfc_sea,regime_sea,rmol_sea,tsk_sea,&
+GPUOMP !$omp ust_sea,ustm_sea,wspd_sea,xland_sea,zol_sea,znt_sea,cd_sea,cda_sea,ck_sea,cka_sea,t2m_sea,th2m_sea,q2_sea,&
+GPUOMP !$omp u10_sea,v10_sea,regime_hold)
     if(allocated(sst_p)      ) deallocate(sst_p      )
     if(allocated(xice_p)     ) deallocate(xice_p     )
 
@@ -302,6 +320,7 @@
  sfclayer_select: select case (trim(sfclayer_scheme))
 
     case("sf_monin_obukhov")
+GPUOMP !$omp target exit data map(delete:fh_p,fm_p,fh_sea,fm_sea)
        if(allocated(fh_p)) deallocate(fh_p)
        if(allocated(fm_p)) deallocate(fm_p)
        if(config_frac_seaice) then
@@ -310,6 +329,7 @@
        endif
 
     case("sf_mynn")
+GPUOMP !$omp target exit data map(delete:snowh_p,ch_p,qcg_p,ch_sea,ch_sea,cov_p,qsq_p,tsq_p,sh3d_p,elpbl_p)
        if(allocated(snowh_p)) deallocate(snowh_p)
        if(allocated(ch_p)   ) deallocate(ch_p   )
        if(allocated(qcg_p)  ) deallocate(qcg_p  )

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_interface
  use mpas_kind_types
  use mpas_pool_routines
@@ -114,10 +116,16 @@
  if(.not.allocated(qi_p)   ) allocate(qi_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qs_p)   ) allocate(qs_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qg_p)   ) allocate(qg_p(ims:ime,kms:kme,jms:jme)   )
+GPUOMP !$omp target enter data map(alloc:psfc_p,ptop_p,u_p,v_p,fzm_p,fzp_p,&
+GPUOMP !$omp zz_p,pres_p,pi_p,z_p,zmid_p,dz_p,t_p,th_p,al_p,rho_p,rh_p,znu_p,&
+GPUOMP !$omp w_p,pres2_p,t2_p,qv_p,qc_p,qr_p,qi_p,qs_p,qg_p)
+GPUOMP !$omp target enter data map(alloc:psfc_hyd_p,psfc_hydd_p,pres_hyd_p,pres_hydd_p,&
+GPUOMP !$omp pres2_hyd_p,pres2_hydd_p,znu_hyd_p)
 
  pbl_select: select case (trim(pbl_scheme))
     case("bl_mynn")
        if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+GPUOMP !$omp target enter data map(alloc:ni_p)
 
     case default
 
@@ -148,6 +156,11 @@
 
  call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
 
+GPUOMP !$omp target exit data map(delete:psfc_p,ptop_p,u_p,v_p,fzm_p,fzp_p,&
+GPUOMP !$omp zz_p,pres_p,pi_p,z_p,zmid_p,dz_p,t_p,th_p,al_p,rho_p,rh_p,znu_p,&
+GPUOMP !$omp w_p,pres2_p,t2_p,qv_p,qc_p,qr_p,qi_p,qs_p,qg_p)
+GPUOMP !$omp target exit data map(delete:psfc_hyd_p,psfc_hydd_p,pres_hyd_p,pres_hydd_p,&
+GPUOMP !$omp pres2_hyd_p,pres2_hydd_p,znu_hyd_p)
  if(allocated(psfc_p)  ) deallocate(psfc_p  )
  if(allocated(ptop_p)  ) deallocate(ptop_p  )
 
@@ -181,6 +194,7 @@
 
  pbl_select: select case (trim(pbl_scheme))
     case("bl_mynn")
+GPUOMP !$omp target exit data map(delete:ni_p)
        if(allocated(ni_p)) deallocate(ni_p)
 
     case default

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -1,11 +1,13 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
+#include "mpas_openmp.inc"
  module mpas_atmphys_todynamics
  use mpas_kind_types
  use mpas_pool_routines
@@ -217,27 +219,42 @@
 ! tend_rho_physics(:,:) = 0._RKIND       ! NB: rho tendency is not currently supplied by physics, but this
                                         !     field may be later filled with IAU or other tendencies
 
+!GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel vector_length(32)
 !$acc loop gang vector collapse(2)
+ GPUOMP !$omp target teams
+ GPUOMP !$omp distribute parallel do simd collapse(2)
  do i = 1, nCellsSolveScalar
  do k = 1, nVertLevels
     tend_th(k,i) = 0._RKIND
  enddo
  enddo
+ GPUOMP !$omp end distribute parallel do simd
+!GPUOMP !$omp end target teams distribute parallel do simd
+!GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang vector collapse(2)
+ GPUOMP !$omp distribute parallel do simd collapse(2)
  do i = 1, nCellsScalar+1
  do k = 1, nVertLevels
     tend_rtheta_physics(k,i) = 0._RKIND
     tend_rho_physics(k,i) = 0._RKIND
  enddo
  enddo
+ GPUOMP !$omp end distribute parallel do simd
+!GPUOMP !$omp end target teams distribute parallel do simd
+!GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc loop gang vector collapse(2)
+ GPUOMP !$omp distribute parallel do simd collapse(2)
  do i = 1, nEdgesScalar+1
  do k = 1, nVertLevels
     tend_ru_physics(k,i) = 0._RKIND
  enddo
  enddo
+ GPUOMP !$omp end distribute parallel do simd
+!GPUOMP !$omp end target teams distribute parallel do simd
+!GPUOMP !$omp target teams distribute parallel do simd collapse(3)
 !$acc loop gang vector collapse(3)
+ GPUOMP !$omp distribute parallel do simd collapse(3)
  do i = 1, nCellsScalar+1
  do j = 1, nVertLevels
  do k = 1, num_scalars
@@ -245,7 +262,10 @@
  enddo
  enddo
  enddo
+ GPUOMP !$omp end distribute parallel do simd
+ GPUOMP !$omp end target teams
 !$acc end parallel
+!GPUOMP !$omp end target teams distribute parallel do simd
 
 !!!
 ! !$acc update device(tend_th, tend_scalars, tend_ru_physics, tend_rtheta_physics, tend_rho_physics)
@@ -431,13 +451,20 @@
     real (kind=RKIND) :: coeff
 
 !!!
- !$acc data present(rublten, rvblten, mass_edge, rublten_Edge, tend_u, &
- !$acc              rucuten, rvcuten, rucuten_Edge, &
- !$acc              tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, &
- !$acc              rthcuten, rqvcuten, rqccuten, rqicuten,  &
- !$acc              rthratenlw, rthratensw, rthdynten, &
- !$acc              tend_u_phys, tend_rtheta_adv, tend_diabatic, &
- !$acc              theta_m, scalars, tend_theta, tend_theta_euler)
+ TMPOMP !$omp target update to(rublten, rvblten, mass_edge, rublten_Edge, tend_u, &
+ TMPOMP !$omp              rucuten, rvcuten, rucuten_Edge, &
+ TMPOMP !$omp              tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, &
+ TMPOMP !$omp              rthcuten, rqvcuten, rqccuten, rqicuten,  &
+ TMPOMP !$omp              rthratenlw, rthratensw, rthdynten, &
+ TMPOMP !$omp              tend_u_phys, tend_rtheta_adv, tend_diabatic, &
+ TMPOMP !$omp              theta_m, scalars, tend_theta, tend_theta_euler)
+ !!$acc data present(rublten, rvblten, mass_edge, rublten_Edge, tend_u, &
+ !!$acc              rucuten, rvcuten, rucuten_Edge, &
+ !!$acc              tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, &
+ !!$acc              rthcuten, rqvcuten, rqccuten, rqicuten,  &
+ !!$acc              rthratenlw, rthratensw, rthdynten, &
+ !!$acc              tend_u_phys, tend_rtheta_adv, tend_diabatic, &
+ !!$acc              theta_m, scalars, tend_theta, tend_theta_euler)
 
     !add coupled tendencies due to PBL processes:
     if (config_pbl_scheme .ne. 'off') then
@@ -455,6 +482,7 @@
 
           !MGD for PV budget? should a similar line be in the cumulus section below?
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
           do i = 1, nEdges
@@ -463,12 +491,14 @@
           tend_u_phys(k,i) = rublten_Edge(k,i)
           enddo
           enddo
- 
+GPUOMP !$omp end target teams distribute parallel do simd
+
 !!!
  !$acc end parallel
        end if
 
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
        do i = 1, nEdgesSolve
@@ -478,8 +508,10 @@
        enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
        do i = 1, nCellsSolve
@@ -492,12 +524,14 @@
        enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
        pbl_select: select case (trim(config_pbl_scheme))
 
           case("bl_mynn")
 
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
              do i = 1, nCellsSolve
@@ -507,6 +541,7 @@
              enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
    
           case default         
 
@@ -517,6 +552,7 @@
     if (config_convection_scheme .ne. 'off') then
 
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
        do i = 1, nCellsSolve
@@ -529,11 +565,13 @@
        enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
         convection_select: select case(config_convection_scheme)
 
            case('cu_kain_fritsch')
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
               do i = 1, nCellsSolve
@@ -542,6 +580,7 @@
                  tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqscuten(k,i)*mass(k,i)
               enddo
               enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 !!!
  !$acc end parallel
     
@@ -559,6 +598,7 @@
                                        gpu_compactHaloInfoSize_c_v )
                  
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
                  do i = 1, nEdges
@@ -566,11 +606,13 @@
                     tend_u_phys(k,i) = tend_u_phys(k,i) + rucuten_Edge(k,i)
                  enddo
                  enddo
+GPUOMP !$omp end target teams distribute parallel do simd
 
 !!!
  !$acc end parallel
               end if
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
               do i = 1, nEdgesSolve
@@ -580,6 +622,7 @@
               enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
             case default
         end select convection_select
@@ -588,6 +631,7 @@
     !add coupled tendencies due to longwave radiation:
     if (config_radt_lw_scheme .ne. 'off') then
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
        do i = 1, nCellsSolve
@@ -596,12 +640,14 @@
        enddo
        enddo
 !!!
+GPUOMP !$omp end target teams distribute parallel do simd
  !$acc end parallel
     endif
     
     !add coupled tendencies due to shortwave radiation:
     if (config_radt_sw_scheme .ne. 'off') then
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
        do i = 1, nCellsSolve
@@ -611,11 +657,13 @@
        enddo
 !!!
  !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
     endif
 
     !if non-hydrostatic core, convert the tendency for the potential temperature to a
     !tendency for the modified potential temperature:
 !!!
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
  !$acc parallel vector_length(32)
  !$acc loop gang vector collapse(2)
     do i = 1, nCellsSolve
@@ -625,9 +673,11 @@
        tend_theta(k,i) = tend_theta(k,i) + tend_th(k,i)
     enddo
     enddo
+GPUOMP !$omp end target teams distribute parallel do simd
+TMPOMP !$omp target update from(tend_u_phys,tend_u,tend_scalars,tend_th(1:nCellsSolve),tend_theta)
 !!!
  !$acc end parallel
- !$acc end data
+ !!$acc end data
 
  end subroutine physics_get_tend_work
 

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -101,6 +101,7 @@ clean:
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+	$(RM) *.acc.s
 
 .F.o:
 ifeq "$(GEN_F90)" "true"

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_gwdo.F
@@ -13,6 +13,8 @@
 
 !WRF:model_layer:physics
 !
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 module module_bl_gwdo
 contains
 !-------------------------------------------------------------------------------
@@ -133,7 +135,7 @@ contains
 !!!$acc update device(u3d,v3d,t3d,qv3d,p3d,p3di,pi3d,z,rublten,rvblten,dtaux3d,dtauy3d,&
 !!!$acc               dusfcg,dvsfcg,var2d,oc12d,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,   &
 !!!$acc               ol2d3,ol2d4,sina,cosa,dx,kpbl2d)
-
+GPUOMP !$omp target data map(alloc:delprsi,pdh,ugeo,vgeo,dudt,dvdt,dtaux,dtauy,dusfc,dvsfc,pdhi,oa4,ol4)
 !$acc data create(delprsi,pdh,ugeo,vgeo,dudt,dvdt,dtaux,dtauy,dusfc,dvsfc,pdhi,oa4,ol4) &
 !$acc      present(u3d,v3d,t3d,qv3d,p3d,p3di,pi3d,z,rublten,rvblten,dtaux3d,dtauy3d,&
 !$acc               dusfcg,dvsfcg,var2d,oc12d,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,   &
@@ -226,6 +228,7 @@ contains
    enddo
 !
 !$acc end data
+GPUOMP !$omp end target data
 
 !!!$acc update host(rublten,rvblten,dtaux3d,dtauy3d,dusfcg,dvsfcg)
    end subroutine gwdo
@@ -377,6 +380,10 @@ contains
 !!!$acc update device(dudt,dvdt,dtaux2d,dtauy2d,u1,v1,t1,q1,del,prsi,prsl,prslk,zl,&
 !!!$acc               var,oc1,oa4,ol4,dusfc,dvsfc,dxmeter,kpbl)
 
+GPUOMP !$omp target data map(alloc:ldrag,icrilv,flag,kloop1,coefm,taub, xn, yn, ubar, vbar, fr,&
+GPUOMP !$omp      ulow, rulow, bnv, oa, ol, rhobar,dtfac, brvf, xlinv, delks,delks1,&
+GPUOMP !$omp      zlowtop,cleff,taup,velco,bnv2, usqj, taud, rho, vtk, vtj,kbl, klowtop,&
+GPUOMP !$omp      delx, dely,dxy4, dxy4p,dxy, dxyp, olp, od,taufb,komax) map(to:nwdir) 
 !$acc data create(ldrag,icrilv,flag,kloop1,coefm,taub, xn, yn, ubar, vbar, fr,&
 !$acc             ulow, rulow, bnv, oa, ol, rhobar,dtfac, brvf, xlinv, delks,delks1,&
 !$acc             zlowtop,cleff,taup,velco,bnv2, usqj, taud, rho, vtk, vtj,kbl, klowtop,&
@@ -895,6 +902,7 @@ contains
 !$acc end parallel
 !
 !$acc end data
+GPUOMP !$omp end target data
 
 !!!$acc update host(dudt,dvdt,dtaux2d,dtauy2d,dusfc,dvsfc)
    return                                                            

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -9,6 +9,8 @@
 !
 !
 !
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 module module_bl_ysu
 contains
 !
@@ -211,6 +213,7 @@ contains
 !!!$acc               dz8w,psfc,znt,ust,hpbl,psim,psih,&
 !!!$acc               xland,hfx,qfx,wspd,br,kpbl2d,exch_h,exch_m,wstar,delta,   &
 !!!$acc               u10,v10,uoce,voce,rthraten,ctopo,ctopo2,regime)
+GPUOMP !$omp target data map(alloc:rqvbl2dt,qv2d,pdh,pdhi,dusfc,dvsfc,dtsfc,dqsfc)
 !$acc data create(rqvbl2dt,qv2d,pdh,pdhi,dusfc,dvsfc,dtsfc,dqsfc) &
 !$acc     present(u3d,v3d,th3d,t3d,qv3d,qc3d,qi3d,p3d,p3di,pi3d,               &
 !$acc               rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,         &
@@ -295,6 +298,7 @@ contains
    enddo
 
 !$acc end data
+GPUOMP !$omp end target data
 !!!$acc update host(rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,   &
 !!!$acc               znt,ust,hpbl,&
 !!!$acc               wspd,kpbl2d,exch_h,exch_m,wstar,delta,   &
@@ -580,6 +584,15 @@ contains
 !!!$acc               exch_mx,wstar,delta,u10,v10,uox,vox,rthraten,p2diORG,&
 !!!$acc               ctopo,ctopo2,regime)
 
+GPUOMP !$omp target data map(alloc:hol,zq,thx,thvx,thlix,del,dza,dzq,xkzom,xkzoh,za,rhox,govrth,zl1, &
+GPUOMP !$omp             thermal,wscale,hgamt,hgamq,brdn,brup,phim,phih, &
+GPUOMP !$omp             prpbl,wspd1,thermalli,xkzm,xkzh,f1,f2,r1,r2,ad,au,cu,al,xkzq,&
+GPUOMP !$omp             zfac,rhox2,hgamt2,brcr,sflux,zol1, &
+GPUOMP !$omp             brcr_sbro,r3,f3,kpbl,kpblold,pblflg,sfcflg,stable,cloudflg,wscalek,&
+GPUOMP !$omp             wscalek2,xkzml,xkzhl,zfacent,entfac,ust3,wstar3,wstar3_2,&
+GPUOMP !$omp             hgamu,hgamv,wm2,we,bfxpbl,hfxpbl,qfxpbl,ufxpbl,vfxpbl,dthvx,fric,  &
+GPUOMP !$omp             tke_ysu,el_ysu,shear_ysu,buoy_ysu,pblh_ysu,vconvfx,thvxTmp,dzqTmp, &
+GPUOMP !$omp             tke_ysuTmp,zqTmp)
 !$acc data create(hol,zq,thx,thvx,thlix,del,dza,dzq,xkzom,xkzoh,za,rhox,govrth,zl1, &
 !$acc             thermal,wscale,hgamt,hgamq,brdn,brup,phim,phih, &
 !$acc             prpbl,wspd1,thermalli,xkzm,xkzh,f1,f2,r1,r2,ad,au,cu,al,xkzq,&
@@ -1700,6 +1713,7 @@ contains
 !$acc end parallel
 !
 !$acc end data
+GPUOMP !$omp end target data
 
 !!!$acc update host(utnp,vtnp,ttnp,qtnp,znt,ust,hpbl,&
 !!!$acc               wspd,dusfc,dvsfc,dtsfc,dqsfc,kpbl1d,exch_hx,&

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -43,6 +43,8 @@
 !===========================================================
 !###########################################################
 
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 module module_cu_ntiedtke
 
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -330,6 +332,9 @@ contains
 !-------other local variables----
       integer                      :: zz, pp
 !-----------------------------------------------------------------------
+GPUOMP !$omp target data map(alloc:rcs,rn,evap,heatflux,dx2d, &
+GPUOMP !$omp slimsk,prsi,ghti,zi,dot,prsl,q1,q2,q3,q1b,t1b,q11,q12,t1,u1,v1,zl, &
+GPUOMP !$omp omg,ghtl,kbot,ktop)
 !$acc data create(rcs,rn,evap,heatflux,dx2d, &
 !$acc slimsk,prsi,ghti,zi,dot,prsl,q1,q2,q3,q1b,t1b,q11,q12,t1,u1,v1,zl, &
 !$acc omg,ghtl,kbot,ktop)
@@ -516,6 +521,7 @@ contains
 
    enddo
 !$acc end data
+GPUOMP !$omp end target data
 
    end subroutine cu_ntiedtke
 
@@ -628,6 +634,9 @@ contains
       integer i,j,k,lq,km,km1
       real dt,ztpp1
       real zew,zqs,zcor
+GPUOMP !$omp target data map(alloc:pum1,pvm1,ztt,ptte,pqte,pvom,pvol,pverv,pgeo, &
+GPUOMP !$omp zqq,pcte,ztp1,zqp1,ztu,zqu,zlu,zlude,zmfu,zmfd,zqsat,pqhfl, &
+GPUOMP !$omp prsfc,pssfc,phhfl,zrain,pgeoh,icbot,ictop,locum)
 !$acc data create(pum1,pvm1,ztt,ptte,pqte,pvom,pvol,pverv,pgeo, &
 !$acc zqq,pcte,ztp1,zqp1,ztu,zqu,zlu,zlude,zmfu,zmfd,zqsat,pqhfl, &
 !$acc prsfc,pssfc,phhfl,zrain,pgeoh,icbot,ictop,locum)
@@ -737,6 +746,7 @@ contains
       endif
 !
 !$acc end data
+GPUOMP !$omp end target data
       return
       end subroutine tiecnvn
 
@@ -1670,6 +1680,7 @@ contains
       integer  jl,jk
       integer  icall,ik
       real     zzs
+GPUOMP !$omp target data map(alloc:zwmax,zph,loflag)
 !$acc data create(zwmax,zph,loflag)
 !------------------------------------------------------------
 !*    1.       specify large scale parameters at half levels
@@ -1765,6 +1776,7 @@ contains
       end do
 !$acc end parallel
 !$acc end data
+GPUOMP !$omp end target data
       return
       end subroutine cuinin
 
@@ -1866,6 +1878,9 @@ contains
       integer  jl,jk,ik,icall,levels
       logical  needreset, lldcum(klon)
 	  logical  flag
+GPUOMP !$omp target data map(alloc:ptu,pqu,plu,zph,klab,kctop,kcbot,loflag,deepflag, &
+GPUOMP !$omp resetflag,dhen,dh,plude,kup,vptu,vten,zbuo,abuoy,zqold,eta,dz, &
+GPUOMP !$omp coef,zcbase,itoppacel,lldcum)
 !$acc data create(ptu,pqu,plu,zph,klab,kctop,kcbot,loflag,deepflag, &
 !$acc resetflag,dhen,dh,plude,kup,vptu,vten,zbuo,abuoy,zqold,eta,dz, &
 !$acc coef,zcbase,itoppacel,lldcum)
@@ -2366,6 +2381,7 @@ contains
 
       end do ! end all cycles
 !$acc end data
+GPUOMP !$omp end target data
       return
       end subroutine cutypen
 
@@ -2502,6 +2518,9 @@ contains
       real     zrnew,zz,zdmfeu,zdmfdu,dp
       real     zfac,zbuoc,zdkbuo,zdken,zvv,zarg,zchange,zxe,zxs,zdshrd
       real     atop1,atop2,abot
+GPUOMP !$omp target data map(alloc:zlrain,zbuo,kup,zodetr,zph,zdmfen,zdmfde,zmfuu, &
+GPUOMP !$omp zmfuv,zpbase,zqold,zluold,zprecip,eta,dz,pdmfen,zoentr, &
+GPUOMP !$omp zdpmean,loflag,llo1)
 !$acc data create(zlrain,zbuo,kup,zodetr,zph,zdmfen,zdmfde,zmfuu, &
 !$acc zmfuv,zpbase,zqold,zluold,zprecip,eta,dz,pdmfen,zoentr, &
 !$acc zdpmean,loflag,llo1)
@@ -2929,6 +2948,7 @@ contains
 !$acc end parallel
 
 !$acc end data
+GPUOMP !$omp end target data
       return
       end subroutine cuascn
 !---------------------------------------------------------
@@ -3059,6 +3079,7 @@ contains
       integer  is,ik,icall,ike
       real     zhsk,zttest,zqtest,zbuo,zmftop
                                                                                    
+GPUOMP !$omp target data map(alloc:ztenwb,zqenwb,zcond,zph,zhsmin,ikhsmin,llo2)
 !$acc data create(ztenwb,zqenwb,zcond,zph,zhsmin,ikhsmin,llo2)
 !----------------------------------------------------------------------          
                                                                                  
@@ -3167,6 +3188,7 @@ contains
       enddo                                                                      
                                                                                  
 !$acc end data
+GPUOMP !$omp end target data
       return                                                                     
       end subroutine cudlfsn  
 
@@ -3276,6 +3298,7 @@ contains
       integer  ik,icall,ike, itopde(klon)
       real     zentr,zdz,zzentr,zseen,zqeen,zsdde,zqdde,zdmfdp
       real     zmfdsk,zmfdqk,zbuo,zrain,zbuoyz,zmfduk,zmfdvk
+GPUOMP !$omp target data map(alloc:zdmfen,zdmfde,zcond,zoentr,zbuoy,zph,llo2,itopde)
 !$acc data create(zdmfen,zdmfde,zcond,zoentr,zbuoy,zph,llo2,itopde)
 !----------------------------------------------------------------------   
 !     1.           calculate moist descent for cumulus downdraft by       
@@ -3422,6 +3445,7 @@ contains
       enddo                                                               
                                                                           
 !$acc end data
+GPUOMP !$omp end target data
       return                                                              
       end subroutine cuddrafn
 !---------------------------------------------------------
@@ -3543,6 +3567,7 @@ contains
       real     rhevap(klon)
       integer  idbas(klon)
       logical  llddraf
+GPUOMP !$omp target data map(alloc:rhevap,idbas)
 !$acc data create(rhevap,idbas)
 !--------------------------------------------------------------------          
 !*             specify constants  
@@ -3774,6 +3799,7 @@ contains
       enddo
                                       
 !$acc end data
+GPUOMP !$omp end target data
       return
       end subroutine cuflxn 
 !---------------------------------------------------------
@@ -3805,6 +3831,7 @@ contains
     integer  jk , ik , jl
     real     zalv , zzp
     real     zdtdt(klon,klev) , zdqdt(klon,klev) , zdp(klon,klev)
+GPUOMP !$omp target data map(alloc:zdtdt,zdqdt,zdp)
 !$acc data create(zdtdt,zdqdt,zdp)
     !*    1.0          SETUP AND INITIALIZATIONS
     ! -------------------------
@@ -3873,6 +3900,7 @@ contains
 !$acc end parallel
 
 !$acc end data
+GPUOMP !$omp end target data
 
     return
   end subroutine cudtdqn
@@ -3902,6 +3930,7 @@ contains
     real     zzp, zdtdt
    
     real     zdudt(klon,klev), zdvdt(klon,klev), zdp(klon,klev)
+GPUOMP !$omp target data map(alloc:zuen,zven,zmfuu,zmfdu,zmfuv,zmfdv,zdudt,zdvdt,zdp)
 !$acc data create(zuen,zven,zmfuu,zmfdu,zmfuv,zmfdv,zdudt,zdvdt,zdp)
 !
 !$acc parallel vector_length(128)
@@ -3995,6 +4024,7 @@ contains
 !$acc end parallel
 !----------------------------------------------------------------------
 !$acc end data
+GPUOMP !$omp end target data
     return
     end subroutine cududvn
 !---------------------------------------------------------

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
@@ -1,3 +1,5 @@
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 MODULE module_sf_noah_seaice
 #if defined(mpas)
 use mpas_atmphys_constants,only: cp,R_D=>R_d,XLF,XLV,RHOWATER=>rho_w,STBOLT
@@ -24,7 +26,7 @@ use module_wrf_error
 
   INTEGER, PRIVATE :: ILOC
   INTEGER, PRIVATE :: JLOC
-!$omp threadprivate(iloc, jloc)
+CPUOMP !$omp threadprivate(iloc, jloc)
 
   REAL, PARAMETER, PRIVATE :: TFREEZ = 273.15
 !

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
@@ -1,3 +1,5 @@
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 MODULE module_sf_noahlsm
 #if defined(mpas)
 use mpas_atmphys_constants,only: CP=>cp,R_D=>R_d,XLF=>xlf,XLV=>xlv,RHOWATER=>rho_w,STBOLT=>stbolt,KARMAN=>karman
@@ -71,7 +73,7 @@ use module_wrf_error
 !$acc         SLOPE_DATA,SBETA_DATA,FXEXP_DATA,CSOIL_DATA,SALP_DATA,REFDK_DATA,     &
 !$acc         REFKDT_DATA,FRZK_DATA,ZBOT_DATA,CZIL_DATA,SMLOW_DATA,SMHIGH_DATA,LVCOEF_DATA)
 
-!$omp threadprivate(iloc, jloc)
+CPUOMP !$omp threadprivate(iloc, jloc)
 !
 CONTAINS
 !

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
@@ -1,3 +1,5 @@
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 MODULE module_sf_noahlsm_glacial_only
 #if defined(mpas)
 use mpas_atmphys_constants
@@ -24,7 +26,7 @@ use module_wrf_error
   PRIVATE :: SNOW_NEW
 
   integer, private :: iloc, jloc
-!$omp threadprivate(iloc, jloc)
+CPUOMP !$omp threadprivate(iloc, jloc)
 
 CONTAINS
 

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
@@ -1,5 +1,7 @@
 !WRF:MODEL_LAYER:PHYSICS
 !
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved
+#include "mpas_openmp.inc"
 MODULE module_sf_sfclay
 
  REAL    , PARAMETER ::  VCONVC=1.
@@ -7,6 +9,7 @@ MODULE module_sf_sfclay
  REAL    , PARAMETER ::  OZO=1.59E-5
 
  REAL,   DIMENSION(0:1000 ),SAVE          :: PSIMTB,PSIHTB
+GPUOMP !$omp declare target to(PSIMTB,PSIHTB)
 !$acc declare create(PSIMTB,PSIHTB)
 
 CONTAINS
@@ -212,6 +215,7 @@ CONTAINS
 
       INTEGER ::  I,J
 
+GPUOMP !$omp target data map(alloc:dz8w1d,U1D,V1D,QV1D,P1D,T1D)
 !$acc data create(dz8w1d,U1D,V1D,QV1D,P1D,T1D)
       DO J=jts,jte
 !$acc parallel vector_length(32)
@@ -261,6 +265,7 @@ CONTAINS
                                                                    )
       ENDDO
 !$acc end data
+GPUOMP !$omp end target data
  
    END SUBROUTINE SFCLAY
 
@@ -393,6 +398,9 @@ CONTAINS
       REAL    ::  FLUXC,VSGD,Z0Q,VISC,RESTAR,CZIL,GZ0OZQ,GZ0OZT
       REAL    ::  ZW, ZN1, ZN2
       REAL    ::  Z0T, CZC
+GPUOMP !$omp target data map(alloc:PSFC,TGDSA,THGB,SCR3,THX,SCR4,THVX,QX,ZQKLP1, &
+GPUOMP !$omp ZQKL,ZA,GOVRTH,RHOX,GZ2OZ0,GZ10OZ0,PSIM10,PSIH10,PSIM2, &
+GPUOMP !$omp PSIH2,WSPDI,DENOMQ,DENOMQ2,DENOMT2)
 !$acc data create(PSFC,TGDSA,THGB,SCR3,THX,SCR4,THVX,QX,ZQKLP1, &
 !$acc ZQKL,ZA,GOVRTH,RHOX,GZ2OZ0,GZ10OZ0,PSIM10,PSIH10,PSIM2, &
 !$acc PSIH2,WSPDI,DENOMQ,DENOMQ2,DENOMT2)
@@ -1044,6 +1052,7 @@ CONTAINS
 !     ENDDO
 !jdf
 !$acc end data
+GPUOMP !$omp end target data
 !                                                                                
    END SUBROUTINE SFCLAY1D
 

--- a/src/driver/Makefile
+++ b/src/driver/Makefile
@@ -4,7 +4,7 @@ OBJS = mpas_subdriver.o \
        mpas.o
 
 all:
-	($(MAKE) clean)
+	#($(MAKE) clean)
 	($(MAKE) driver)
 
 driver: $(OBJS)

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -119,6 +119,7 @@ clean:
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+	$(RM) *.acc.s
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -69,6 +70,12 @@ module mpas_derived_types
 #include "mpas_core_types.inc"
 
 #include "mpas_forcing_types.inc"
+
+! Note: This header include must be included in every *.F file containing OpenMP code
+!       Use "CPUONLY" for code that runs OpenMP on the host
+!       Use "GPUONLY" for code that runs OpenMP on the device
+!       Only applies to core_atmosphere, framework, and operators directories
+#include "mpas_openmp.inc"
 
    contains
 

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -15,6 +16,8 @@
 !>  This module contains all communication routines. All MPI calls should be made in this module.
 !
 !-----------------------------------------------------------------------
+#include "mpas_openmp.inc"
+#define PACKHALO 1
 module mpas_dmpar
 
 #define COMMA ,
@@ -2342,6 +2345,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       integer :: idx
       integer :: endPointID
       integer :: i, n
+      integer, dimension(:), pointer :: sendListTotal, recvListTotal
+      integer :: nListTotal_send, nListTotal_recv
 
 
       ! We only need the product of all dimension sizes (except the last), so calculate that now
@@ -2368,6 +2373,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       n = idx         ! The number of endpoints to send to
       idx = idx + 1
       commListPtr => sendCommList
+      allocate(sendListTotal(compactHaloInfo(n)))
+      nListTotal_send = 0
       do iEndpt=1,compactHaloInfo(n)
          endPointID = compactHaloInfo(idx)
          idx = idx + 1
@@ -2388,12 +2395,18 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
 
             idx = idx + 2 * compactHaloInfo(idx) + 1
          end do
+         commListPtr % rStart = nListTotal_send + 1
+         sendListTotal(iEndpt) = nListTotal_send
+         nListTotal_send = nListTotal_send + commListPtr % nList
+         commListPtr % rEnd = nListTotal_send
       end do
 
 
       n = idx         ! The number of endpoints to receive from
       idx = idx + 1   ! The index of the first recv list (nList, srcList, destList)
       commListPtr => recvCommList
+      allocate(recvListTotal(compactHaloInfo(n)))
+      nListTotal_recv = 0
       do iEndpt=1,compactHaloInfo(n)
          endPointID = compactHaloInfo(idx)
          idx = idx + 1
@@ -2414,6 +2427,10 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
 
             idx = idx + 2 * compactHaloInfo(idx) + 1
          end do
+         commListPtr % rStart = nListTotal_recv + 1
+         recvListTotal(iEndpt) = nListTotal_recv
+         nListTotal_recv = nListTotal_recv + commListPtr % nList
+         commListPtr % rEnd = nListTotal_recv
       end do
 
 
@@ -2425,6 +2442,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       commListPtr => recvCommList
       recvCommList => recvCommList % next
       deallocate(commListPtr)
+
+      sendCommList % nListTotal = nListTotal_send
+      sendCommList % rStartTotal => sendListTotal
+      recvCommList % nListTotal = nListTotal_recv
+      recvCommList % rStartTotal => recvListTotal
+      GPUOMP !$omp target enter data map(to:sendListTotal,recvListTotal)
+      !$acc enter data copyin(sendListTotal,recvListTotal)
 
    end subroutine mpas_dmpar_build_comm_lists_acc !}}}
 
@@ -6449,6 +6473,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
@@ -6465,6 +6490,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
@@ -7334,6 +7360,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       integer, intent(in) :: nHaloLayers
       integer :: mpi_comm, mpi_proc_id
       real (kind=RKIND), dimension(:), pointer :: tempRbuffer
+      real (kind=RKIND), dimension(:), pointer :: tempRbufferTotal
+      integer, dimension(:), pointer :: rStartTotal
       integer :: localMax, counter
       !
       ! Unpack fields from the compacted halo info array
@@ -7355,28 +7383,94 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       
       nFieldHaloLayers = compactHaloInfo(9)
 #ifdef _MPI
+      TMPOMP !$omp target update to(array)
       ! Allocate space in recv lists, and initiate mpi_irecv calls
       commListPtr => recvList
+#ifdef PACKHALO
+      do while(associated(commListPtr))
+        if (.not. associated(recvList % rbufferTotal)) then
+           allocate(tempRbufferTotal(recvList % nListTotal))
+           recvList % rbufferTotal => tempRbufferTotal
+        GPUOMP !$omp target enter data map(alloc:tempRbufferTotal)
+        !$acc enter data create(tempRbufferTotal)
+        else 
+           tempRbufferTotal => recvList % rbufferTotal
+        end if
+        nullify(commListPtr % ibuffer)
+        tempRbuffer => tempRbufferTotal(commListPtr % rStart: commListPtr % rEnd)
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
+        !$acc host_data use_device(tempRbuffer) 
+        call MPI_Irecv(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, commListPtr % procID, mpi_comm, commListPtr % reqID, mpi_ierr)
+        !$acc end host_data
+        MPIGPU !$omp end target data
+        commListPtr => commListPtr % next
+      end do
+#else
       do while(associated(commListPtr))
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
         end if
         nullify(commListPtr % ibuffer)
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
         !$acc host_data use_device(tempRbuffer) 
         call MPI_Irecv(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, commListPtr % procID, mpi_comm, commListPtr % reqID, mpi_ierr)
         !$acc end host_data
+        MPIGPU !$omp end target data
         commListPtr => commListPtr % next
       end do
+#endif
       ! Allocate space in send lists, copy data into buffer, and initiate mpi_isend calls
       commListPtr => sendList
+#ifdef PACKHALO
+      do while(associated(commListPtr))
+        if (.not. associated(sendList % rbufferTotal)) then
+           allocate(tempRbufferTotal(sendList % nListTotal))
+           sendList % rbufferTotal => tempRbufferTotal
+        GPUOMP !$omp target enter data map(alloc:tempRbufferTotal)
+        !$acc enter data create(tempRbufferTotal)
+        else 
+           tempRbufferTotal => sendList % rbufferTotal
+        end if
+        nullify(commListPtr % ibuffer)
+        commListPtr => commListPtr % next
+      enddo
+      commListPtr => sendList   
+      tempRbufferTotal => commListPtr % rbufferTotal
+      rStartTotal => commListPtr % rStartTotal
+      if (associated(commListPtr)) then
+        localMax=maxval(gpu_nList_send(:))
+        !$acc data present(tempRbufferTotal, rStartTotal, array, compactHaloInfo, dimsizes, nHaloLayers, gpu_nList_send, gpu_idx_send, gpu_bufferOffset_send)
+        GPUOMP !$omp target teams distribute parallel do simd collapse(4)
+        !$acc parallel num_workers(4) vector_length(128)
+        !$acc loop independent collapse(4) gang worker vector
+        do counter = 0,size(rStartTotal)-1
+          do iHalo = 1, nHaloLayers
+            do  i = 1, localMax
+              do j = 1, dimSizes(1)
+                if(i<=gpu_nList_send(counter*nHaloLayers+iHalo)) then
+                   tempRbufferTotal(rStartTotal(counter+1) + (compactHaloInfo(gpu_idx_send(counter*nHaloLayers+iHalo) + gpu_nList_send(counter*nHaloLayers+iHalo) + i)-1) * dimSizes(1) + j &
+                  + gpu_bufferOffset_send(counter*nHaloLayers+iHalo)) = array(j, compactHaloInfo(gpu_idx_send(counter*nHaloLayers+iHalo) + i))
+                end if 
+              end do
+            end do
+          end do
+        end do
+        !$acc end parallel
+        GPUOMP !$omp end target teams distribute parallel do simd
+        MPICPU !$omp target update from(tempRbufferTotal)
+        !$acc end data
+      endif
+#else
       do while(associated(commListPtr))
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
@@ -7390,6 +7484,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       do while(associated(commListPtr))
           tempRbuffer => commListPtr % rbuffer
           !$acc data present(tempRbuffer, array, compactHaloInfo, dimsizes, nHaloLayers, gpu_nList_send, gpu_idx_send, gpu_bufferOffset_send) async(counter+1)
+          MPIGPU !$omp target teams distribute parallel do simd collapse(3)
+          MPICPU !$omp target teams distribute parallel do simd collapse(3) nowait depend(out:tempRbuffer)
           !$acc parallel default(none) num_workers(4) vector_length(128) async(counter+1) 
           !$acc loop independent collapse(3) gang worker vector
           do iHalo = 1, nHaloLayers
@@ -7403,19 +7499,38 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             end do
           end do
           !$acc end parallel
+          GPUOMP !$omp end target teams distribute parallel do simd
+          MPICPU !$omp target update from(tempRbuffer) nowait depend(in:tempRbuffer)
           !$acc end data
         counter=counter+1
         commListPtr => commListPtr % next
       end do
+!GPUOMP !$omp taskwait
 !$acc wait
+#endif
       commListPtr => sendList
+#ifdef PACKHALO
+      tempRbufferTotal => commListPtr % rbuffertotal
       do while(associated(commListPtr))
-        tempRbuffer => commListPtr % rbuffer
+        tempRbuffer => tempRbufferTotal(commListPtr % rStart : commListPtr % rEnd)
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
         !$acc host_data use_device(tempRbuffer)
         call MPI_Isend(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, mpi_proc_id, mpi_comm, commListPtr % reqID, mpi_ierr)
         !$acc end host_data
+        MPIGPU !$omp end target data
         commListPtr => commListPtr % next
       end do
+#else
+      do while(associated(commListPtr))
+        tempRbuffer => commListPtr % rbuffer
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
+        !$acc host_data use_device(tempRbuffer)
+        call MPI_Isend(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, mpi_proc_id, mpi_comm, commListPtr % reqID, mpi_ierr)
+        !$acc end host_data
+        MPIGPU !$omp end target data
+        commListPtr => commListPtr % next
+      end do
+#endif
       commListPtr => recvList
 !RRPKComment: Forced to wait for all recv buffers to be filled up else CUDA streams throws exceptions
 !RRPKComment: I'll figure out to wait for any, after consulting with PGI/OpenMPI
@@ -7425,11 +7540,41 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       end do
 
       commListPtr => recvList
+#ifdef PACKHALO
+      localMax=maxval(gpu_nList_recv(:))
+      tempRbufferTotal => commListPtr % rbufferTotal
+      rStartTotal => commListPtr % rStartTotal
+      if (associated(commListPtr)) then
+        !$acc data present(tempRbufferTotal,rStartTotal,array,compactHaloInfo,dimsizes, nHaloLayers,dimSizes,gpu_idx_recv,gpu_bufferOffset_recv,gpu_nList_recv)
+        MPICPU !$omp target update to(tempRbufferTotal)
+        GPUOMP !$omp target teams distribute parallel do simd collapse(4) 
+        !$acc parallel num_workers(4) vector_length(128)
+        !$acc loop independent collapse(4) gang worker vector
+        do counter = 0,size(rStartTotal)-1
+          do iHalo = 1, nHaloLayers
+            do i = 1, localMax 
+              do j = 1, dimSizes(1)
+                if(i<=gpu_nList_recv(counter*nHaloLayers+iHalo)) then
+                  array(j, compactHaloInfo(gpu_idx_recv(counter*nHaloLayers+iHalo) + gpu_nList_recv(counter*nHaloLayers+iHalo) + i)) &
+                  = tempRbufferTotal(rStartTotal(counter+1)+(compactHaloInfo(gpu_idx_recv(counter*nHaloLayers+iHalo) + i)-1)*dimSizes(1) + j + gpu_bufferOffset_recv(counter*nHaloLayers+iHalo))
+                end if
+              end do
+            end do
+          end do
+        end do
+        !$acc end parallel
+        GPUOMP !$omp end target teams distribute parallel do simd
+        !$acc end data
+      endif 
+#else
       counter=0
       localMax=maxval(gpu_nList_recv(:))
       do while(associated(commListPtr))
         tempRbuffer => commListPtr % rbuffer
           !$acc data present(tempRbuffer,array,compactHaloInfo,dimsizes, nHaloLayers,dimSizes,gpu_idx_recv,gpu_bufferOffset_recv,gpu_nList_recv) async(counter+1)
+          MPICPU !$omp target update to(tempRbuffer) nowait depend(out:tempRbuffer)
+          MPICPU !$omp target teams distribute parallel do simd collapse(3) nowait depend(in:tempRbuffer)
+          MPIGPU !$omp target teams distribute parallel do simd collapse(3) 
           !$acc parallel num_workers(4) vector_length(128) async(counter+1)
           !$acc loop independent collapse(3) gang worker vector
           do iHalo = 1, nHaloLayers
@@ -7443,11 +7588,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             end do
           end do
           !$acc end parallel
+          GPUOMP !$omp end target teams distribute parallel do simd
           !$acc end data
         commListPtr => commListPtr % next
         counter=counter+1
       end do
+!GPUOMP !$omp taskwait
 !$acc wait
+#endif
 
       ! wait for mpi_isend to finish.
       commListPtr => sendList
@@ -7458,6 +7606,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      ! Destroy commLists.
 !     call mpas_dmpar_destroy_communication_list(sendList)
 !     call mpas_dmpar_destroy_communication_list(recvList)
+      TMPOMP !$omp target update from(array)
 #endif
 
      deallocate(haloLayers)
@@ -7689,7 +7838,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         !if (.not. associated(commListPtr % rbuffer)) then
         !   allocate(tempRbuffer(commListPtr % nList))
         !   commListPtr % rbuffer => tempRbuffer
-        !$acc enter data create(tempRbuffer)
+        !!$acc enter data create(tempRbuffer)
         !else 
         !   tempRbuffer => commListPtr % rbuffer
         !end if
@@ -8247,6 +8396,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       integer, intent(in) :: nHaloLayers
       integer :: mpi_comm, mpi_proc_id
       real (kind=RKIND), dimension(:), pointer :: tempRbuffer
+      real (kind=RKIND), dimension(:), pointer :: tempRbufferTotal
+      integer, dimension(:), pointer :: rStartTotal
       integer :: localMax, counter
       !
       ! Unpack fields from the compacted halo info array
@@ -8270,28 +8421,96 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
 
       nFieldHaloLayers = compactHaloInfo(9)
 #ifdef _MPI
+      TMPOMP !$omp target update to(array)
       ! Allocate space in recv lists, and initiate mpi_irecv calls
       commListPtr => recvList
+#ifdef PACKHALO
+      do while(associated(commListPtr))
+        if (.not. associated(recvList % rbufferTotal)) then
+           allocate(tempRbufferTotal(recvList % nListTotal))
+           recvList % rbufferTotal => tempRbufferTotal
+        GPUOMP !$omp target enter data map(alloc:tempRbufferTotal)
+        !$acc enter data create(tempRbufferTotal)
+        else 
+           tempRbufferTotal => recvList % rbufferTotal
+        end if
+        nullify(commListPtr % ibuffer)
+        tempRbuffer => tempRbufferTotal(commListPtr % rStart: commListPtr % rEnd)
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
+        !$acc host_data use_device(tempRbuffer) 
+        call MPI_Irecv(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, commListPtr % procID, mpi_comm, commListPtr % reqID, mpi_ierr)
+        !$acc end host_data
+        MPIGPU !$omp end target data
+        commListPtr => commListPtr % next
+      end do
+#else
       do while(associated(commListPtr))
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
         end if
         nullify(commListPtr % ibuffer)
+        GPUOMP !$omp target data use_device_ptr(tempRbuffer)
         !$acc host_data use_device(tempRbuffer) 
         call MPI_Irecv(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, commListPtr % procID, mpi_comm, commListPtr % reqID, mpi_ierr)
         !$acc end host_data
+        GPUOMP !$omp end target data
         commListPtr => commListPtr % next
       end do
+#endif
       ! Allocate space in send lists, copy data into buffer, and initiate mpi_isend calls
       commListPtr => sendList
+#ifdef PACKHALO
+      do while(associated(commListPtr))
+        if (.not. associated(sendList % rbufferTotal)) then
+           allocate(tempRbufferTotal(sendList % nListTotal))
+           sendList % rbufferTotal => tempRbufferTotal
+        GPUOMP !$omp target enter data map(alloc:tempRbufferTotal)
+        !$acc enter data create(tempRbufferTotal)
+        else 
+           tempRbufferTotal => sendList % rbufferTotal
+        end if
+        nullify(commListPtr % ibuffer)
+        commListPtr => commListPtr % next
+      enddo
+      commListPtr => sendList   
+      tempRbufferTotal => commListPtr % rbufferTotal
+      rStartTotal => commListPtr % rStartTotal
+      if (associated(commListPtr)) then
+        localMax=maxval(gpu_nList_send(:))
+        !$acc data present(tempRbufferTotal, rStartTotal, array, compactHaloInfo, dimsizes, nHaloLayers, gpu_nList_send, gpu_idx_send, gpu_bufferOffset_send)
+        GPUOMP !$omp target teams distribute parallel do simd collapse(5)
+        !$acc parallel default(none) num_workers(8) vector_length(128)
+        !$acc loop independent collapse(5) gang worker vector
+        do counter = 0, size(rStartTotal)-1
+          do iHalo = 1, nHaloLayers
+            do  i = 1, localMax
+              do j = 1, dimSizes(2) 
+                do k = 1, dimSizes(1)
+                  if(i<=gpu_nList_send(counter*nHaloLayers+iHalo)) then
+                    tempRbufferTotal(rStartTotal(counter+1)+(compactHaloInfo(gpu_idx_send(counter*nHaloLayers+iHalo) + gpu_nList_send(counter*nHaloLayers+iHalo) + i)-1) * dimSizes(1) * dimSizes(2) + (j-1) * dimSizes(1) + k + gpu_bufferOffset_send(counter*nHaloLayers+iHalo)) = array(k, j, compactHaloInfo(gpu_idx_send(counter*nHaloLayers+iHalo) + i))
+                  end if
+                end do
+              end do
+            end do
+          end do
+        end do
+        !!$acc end kernels
+        !$acc end parallel
+        GPUOMP !$omp end target teams distribute parallel do simd
+        MPICPU !$omp target update from(tempRbufferTotal)
+        !$acc end data
+      endif
+#else
       do while(associated(commListPtr))
         if (.not. associated(commListPtr % rbuffer)) then
            allocate(tempRbuffer(commListPtr % nList))
            commListPtr % rbuffer => tempRbuffer
+        GPUOMP !$omp target enter data map(alloc:tempRbuffer)
         !$acc enter data create(tempRbuffer)
         else 
            tempRbuffer => commListPtr % rbuffer
@@ -8305,6 +8524,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       do while(associated(commListPtr))
           tempRbuffer => commListPtr % rbuffer
           !$acc data present(tempRbuffer, array, compactHaloInfo, dimsizes, nHaloLayers, gpu_nList_send, gpu_idx_send, gpu_bufferOffset_send) async(counter+1)
+          GPUOMP !$omp target teams distribute parallel do simd collapse(4) !nowait
           !$acc parallel default(none) num_workers(8) vector_length(128) async(counter+1)
           !!$acc kernels async(counter+1)
           !$acc loop independent collapse(4) gang worker vector
@@ -8321,19 +8541,37 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           end do
           !!$acc end kernels
           !$acc end parallel
+          GPUOMP !$omp end target teams distribute parallel do simd
           !$acc end data
         counter=counter+1
         commListPtr => commListPtr % next
       end do
+!GPUOMP !$omp taskwait
 !$acc wait
+#endif
       commListPtr => sendList
+#ifdef PACKHALO
+      tempRbufferTotal => commListPtr % rbuffertotal
       do while(associated(commListPtr))
-        tempRbuffer => commListPtr % rbuffer
+        tempRbuffer => tempRbufferTotal(commListPtr % rStart : commListPtr % rEnd)
+        MPIGPU !$omp target data use_device_ptr(tempRbuffer)
         !$acc host_data use_device(tempRbuffer)
         call MPI_Isend(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, mpi_proc_id, mpi_comm, commListPtr % reqID, mpi_ierr)
         !$acc end host_data
+        MPIGPU !$omp end target data
         commListPtr => commListPtr % next
       end do
+#else
+      do while(associated(commListPtr))
+        tempRbuffer => commListPtr % rbuffer
+        GPUOMP !$omp target data use_device_ptr(tempRbuffer)
+        !$acc host_data use_device(tempRbuffer)
+        call MPI_Isend(tempRbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, mpi_proc_id, mpi_comm, commListPtr % reqID, mpi_ierr)
+        !$acc end host_data
+        GPUOMP !$omp end target data
+        commListPtr => commListPtr % next
+      end do
+#endif
       commListPtr => recvList
 !RRPKComment: Forced to wait for all recv buffers to be filled up else CUDA streams throws exceptions
 !RRPKComment: I'll figure out to wait for any, after consulting with PGI/OpenMPI
@@ -8343,11 +8581,40 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       end do
 
       commListPtr => recvList
+#ifdef PACKHALO
+      localMax=maxval(gpu_nList_recv(:))
+      tempRbufferTotal => commListPtr % rbufferTotal
+      rStartTotal => commListPtr % rStartTotal
+      if (associated(commListPtr)) then
+        !$acc data present(tempRbufferTotal,rStartTotal,array,compactHaloInfo,dimsizes, nHaloLayers,dimSizes,gpu_idx_recv,gpu_bufferOffset_recv,gpu_nList_recv)
+        MPICPU !$omp target update to(tempRbufferTotal)
+        GPUOMP !$omp target teams distribute parallel do simd collapse(5)
+        !$acc parallel num_workers(8) vector_length(128)
+        !$acc loop independent collapse(5) gang worker vector
+        do counter = 0, size(rStartTotal)-1
+          do iHalo = 1, nHaloLayers
+           do i = 1, localMax 
+             do j = 1, dimSizes(2)
+               do k = 1, dimSizes(1)
+                 if(i<=gpu_nList_recv(counter*nHaloLayers+iHalo)) then
+                    array(k, j, compactHaloInfo(gpu_idx_recv(counter*nHaloLayers+iHalo) + gpu_nList_recv(counter*nHaloLayers+iHalo) + i)) = tempRbufferTotal(rStartTotal(counter+1)+(compactHaloInfo(gpu_idx_recv(counter*nHaloLayers+iHalo) + i)-1)*dimSizes(1) * dimSizes(2) + (j-1) * dimSizes(1) + k + gpu_bufferOffset_recv(counter*nHaloLayers+iHalo))
+                 end if
+               end do
+             end do
+            end do
+          end do
+        end do
+        !$acc end parallel
+        GPUOMP !$omp end target teams distribute parallel do simd
+        !$acc end data
+      endif
+#else
       counter=0
       localMax=maxval(gpu_nList_recv(:))
       do while(associated(commListPtr))
         tempRbuffer => commListPtr % rbuffer
           !$acc data present(tempRbuffer,array,compactHaloInfo,dimsizes, nHaloLayers,dimSizes,gpu_idx_recv,gpu_bufferOffset_recv,gpu_nList_recv) async(counter+1)
+          GPUOMP !$omp target teams distribute parallel do simd collapse(4) !nowait
           !$acc parallel num_workers(8) vector_length(128) async(counter+1)
           !$acc loop independent collapse(4) gang worker vector
           !!$acc kernels async(counter+1)
@@ -8364,11 +8631,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           end do
           !!$acc end kernels
           !$acc end parallel
+          GPUOMP !$omp end target teams distribute parallel do simd
           !$acc end data
         commListPtr => commListPtr % next
         counter=counter+1
       end do
+!GPUOMP !$omp taskwait
 !$acc wait
+#endif
 
       ! wait for mpi_isend to finish.
       commListPtr => sendList
@@ -8376,6 +8646,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         call MPI_Wait(commListPtr % reqID, MPI_STATUS_IGNORE, mpi_ierr)
         commListPtr => commListPtr % next
       end do
+      TMPOMP !$omp target update from(array)
      ! Destroy commLists.
 !     call mpas_dmpar_destroy_communication_list(sendList)
 !     call mpas_dmpar_destroy_communication_list(recvList)
@@ -10492,7 +10763,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           if ( groupName(1:nLen) == exchGroupPtr % groupName(1:exchGroupPtr % nLen) ) then
             DMPAR_DEBUG_WRITE(' -- Performing a full exchange for reused group ' // trim(groupName))
 
-            !$omp master
+            CPUOMP !$omp master
               commListPtr => exchGroupPtr % sendList
               do while ( associated(commListPtr) )
                 commListPtr % bufferOffset = 0
@@ -10524,7 +10795,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   exchFieldListPtr => exchFieldListPtr % next
                 end do
               end if
-            !$omp end master
+            CPUOMP !$omp end master
             call mpas_threading_barrier()
 
             call mpas_dmpar_exch_group_start_recv(domain % dminfo, exchGroupPtr)
@@ -10540,14 +10811,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             ! Print out buffers for debugging
             !call mpas_dmpar_exch_group_print_buffers(exchGroupPtr)
 
-            !$omp master
+            CPUOMP !$omp master
               ! Wait for isends to finish
               commListPtr => exchGroupPtr % sendList
               do while ( associated(commListPtr) )
                 call MPI_Wait(commListPtr % reqID, MPI_STATUS_IGNORE, mpi_ierr)
                 commListPtr => commListPtr % next
               end do
-            !$omp end master
+            CPUOMP !$omp end master
             call mpas_threading_barrier()
 
             return
@@ -10589,7 +10860,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       end if
 
       call mpas_threading_barrier()
-      !$omp master
+      CPUOMP !$omp master
         ! Destroy communication lists
         nLen = len_trim(groupName)
         exchGroupPtr => domain % exchangeGroups
@@ -10604,7 +10875,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchGroupPtr => exchGroupPtr % next
         end do
         call mpas_dmpar_exch_group_destroy(domain, groupName)
-      !$omp end master
+      CPUOMP !$omp end master
       call mpas_threading_barrier()
 
    end subroutine mpas_dmpar_exch_group_destroy_reusable_buffers!}}}
@@ -11428,7 +11699,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             commListPtr => commListPtr % next 
           end do
         end if
-        !$omp flush
+        CPUOMP !$omp flush
 
         call mpas_threading_barrier()   !! to make sure thread 0 has tested the list before \
                                         !! any thread attempts to read its status
@@ -11671,9 +11942,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
       ! workaround for PGI compiler (CPR): ICE on pointers in private clause of omp-do workshare
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -11700,7 +11971,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field1d_integer!}}}
 
@@ -11740,9 +12011,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -11772,7 +12043,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field2d_integer!}}}
 
@@ -11812,9 +12083,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -11847,7 +12118,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field3d_integer!}}}
 
@@ -11886,9 +12157,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -11915,7 +12186,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field1d_real!}}}
 
@@ -11955,9 +12226,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -11986,7 +12257,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field2d_real!}}}
 
@@ -12026,9 +12297,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -12060,7 +12331,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field3d_real!}}}
 
@@ -12100,9 +12371,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, l, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, l, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -12137,7 +12408,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
         commListPtr % bufferOffset = commListPtr % bufferOffset + nAdded
         commListPtr => commListPtr % next
       end do
-      !$omp end do
+      CPUOMP !$omp end do
 
    end subroutine mpas_dmpar_exch_group_pack_buffer_field4d_real!}}}
 
@@ -12177,9 +12448,9 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       if (.not. associated(commListPtr)) return
       commListSize = commListPtr % commListSize
 #ifdef CPRPGI
-      !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
+      CPUOMP !$omp do private(listPosition, bufferOffset, nAdded, iExch, iBuffer)
 #else
-      !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, l, m, iBuffer) 
+      CPUOMP !$omp do private(commListPtr, listPosition, bufferOffset, nAdded, fieldCursor, exchListPtr, iExch, j, k, l, m, iBuffer) 
 #endif
       do listItem = 1, commListSize
         commListPtr => exchangeGroup % sendList
@@ -12261,11 +12532,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(exchListPtr % destList(iExch)) = fieldCursor % array(exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12316,11 +12587,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, exchListPtr % destList(iExch)) = fieldCursor % array(:, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12371,12 +12642,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12427,11 +12698,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(exchListPtr % destList(iExch)) = fieldCursor % array(exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12482,11 +12753,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, exchListPtr % destList(iExch)) = fieldCursor % array(:, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12537,12 +12808,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if(exchListPtr % endPointID == fieldCursor2 % block % localBlockID) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12593,12 +12864,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, :, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12649,12 +12920,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
-                  !$omp do schedule(runtime)
+                  CPUOMP !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, :, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, :, :, exchListPtr % srcList(iExch))
                   end do
-                  !$omp end do
+                  CPUOMP !$omp end do
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -12716,13 +12987,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(iBuffer)
                do iExch = 1, exchListPtr % nList
                   iBuffer = exchListPtr % srcList(iExch) + bufferOffset
                   fieldCursor % array(exchListPtr % destList(iExch)) = transfer(recvList % rbuffer(iBuffer), &
                                                                                 fieldCursor % array(1))
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList))
             end if
             exchListPtr => exchListPtr % next
@@ -12779,7 +13050,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(1)
                      iBuffer = (exchListPtr % srcList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
@@ -12787,7 +13058,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                                                                                       fieldCursor % array(1,1))
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1))
             end if
             exchListPtr => exchListPtr % next
@@ -12844,7 +13115,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, k, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, k, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(2)
                      do k = 1, fieldCursor % dimSizes(1)
@@ -12855,7 +13126,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                      end do
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2))
             end if
             exchListPtr => exchListPtr % next
@@ -12911,12 +13182,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(iBuffer)
                do iExch = 1, exchListPtr % nList
                   iBuffer = exchListPtr % srcList(iExch) + bufferOffset
                   fieldCursor % array(exchListPtr % destList(iExch)) = recvList % rbuffer(iBuffer)
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList))
             end if
             exchListPtr => exchListPtr % next
@@ -12973,14 +13244,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(1)
                      iBuffer = (exchListPtr % srcList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
                      fieldCursor % array(j, exchListPtr % destList(iExch)) = recvList % rbuffer(iBuffer)
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1))
             end if
             exchListPtr => exchListPtr % next
@@ -13037,7 +13308,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, k, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, k, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(2)
                      do k = 1, fieldCursor % dimSizes(1)
@@ -13047,7 +13318,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                      end do
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2))
             end if
             exchListPtr => exchListPtr % next
@@ -13104,7 +13375,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, k, l, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, k, l, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(3)
                      do k = 1, fieldCursor % dimSizes(2)
@@ -13118,7 +13389,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                      end do
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) &
                       * fieldCursor % dimSizes(2) * fieldCursor % dimSizes(3))
             end if
@@ -13176,7 +13447,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
          exchListPtr => fieldCursor % recvList % halos(haloLayer) % exchList
          do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == recvList % procID ) then
-               !$omp do schedule(runtime) private(j, k, l, m, iBuffer)
+               CPUOMP !$omp do schedule(runtime) private(j, k, l, m, iBuffer)
                do iExch = 1, exchListPtr % nList
                   do j = 1, fieldCursor % dimSizes(4)
                      do k = 1, fieldCursor % dimSizes(3)
@@ -13194,7 +13465,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                      end do
                   end do
                end do
-               !$omp end do
+               CPUOMP !$omp end do
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2) &
                       * fieldCursor % dimSizes(3) * fieldCursor % dimSizes(4))
             end if

--- a/src/framework/mpas_dmpar_types.inc
+++ b/src/framework/mpas_dmpar_types.inc
@@ -1,3 +1,4 @@
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
    integer, parameter :: MPAS_DMPAR_NOERR = 0
    integer, parameter :: MPAS_DMPAR_MISSING_GROUP = 1
    integer, parameter :: MPAS_DMPAR_EXISTING_GROUP = 2
@@ -52,6 +53,12 @@
      integer :: commListSize
      logical :: received
      logical :: unpacked
+     ! Packed halo exch buffers
+     real (kind=RKIND), dimension(:), pointer :: rbufferTotal => null()
+     integer, dimension(:), pointer :: rstartTotal => null()
+     integer :: nListTotal
+     integer :: rStart
+     integer :: rEnd
    end type mpas_communication_list
 
    type mpas_exchange_field_list

--- a/src/framework/mpas_field_routines.F
+++ b/src/framework/mpas_field_routines.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -17,6 +18,7 @@
 !> All routines defined in this module are non-blocking for threads.
 !
 !-----------------------------------------------------------------------
+#include "mpas_openmp.inc"
 module mpas_field_routines
 
    use mpas_kind_types
@@ -182,11 +184,11 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do schedule(runtime)
+           CPUOMP !$omp do schedule(runtime)
            do i = 1, f_cursor % dimSizes(1)
              f_cursor % array(i) = f_cursor % defaultValue
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -203,11 +205,11 @@ module mpas_field_routines
 
          ! then all threads initialize it
          if ( init_array ) then
-         !$omp do schedule(runtime)
+         CPUOMP !$omp do schedule(runtime)
          do i = 1, f % dimSizes(1)
            f % array(i) = f % defaultValue
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -270,13 +272,13 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(2) schedule(runtime)
+           CPUOMP !$omp do collapse(2) schedule(runtime)
            do i = 1, f_cursor % dimSizes(2)
              do j = 1, f_cursor % dimSizes(1)
                f_cursor % array(j, i) = f_cursor % defaultValue
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -293,13 +295,13 @@ module mpas_field_routines
 
          ! then all threads initialize it
          if ( init_array ) then
-         !$omp do collapse(2) schedule(runtime)
+         CPUOMP !$omp do collapse(2) schedule(runtime)
          do i = 1, f % dimSizes(2)
            do j = 1, f % dimSizes(1)
              f % array(j, i) = f % defaultValue
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -360,7 +362,7 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(3) schedule(runtime)
+           CPUOMP !$omp do collapse(3) schedule(runtime)
            do i = 1, f_cursor % dimSizes(3)
              do j = 1, f_cursor % dimSizes(2)
                do k = 1, f_cursor % dimSizes(1)
@@ -368,7 +370,7 @@ module mpas_field_routines
                end do
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -383,7 +385,7 @@ module mpas_field_routines
          call mpas_threading_barrier()
 
          if ( init_array ) then
-         !$omp do collapse(3) schedule(runtime)
+         CPUOMP !$omp do collapse(3) schedule(runtime)
          do i = 1, f % dimSizes(3)
            do j = 1, f % dimSizes(2)
              do k = 1, f % dimSizes(1)
@@ -391,7 +393,7 @@ module mpas_field_routines
              end do
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -454,11 +456,11 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do schedule(runtime)
+           CPUOMP !$omp do schedule(runtime)
            do i = 1, f_cursor % dimSizes(1)
              f_cursor % array(i) = f_cursor % defaultValue
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -475,11 +477,11 @@ module mpas_field_routines
 
          ! then all threads initialize
          if ( init_array ) then
-         !$omp do schedule(runtime)
+         CPUOMP !$omp do schedule(runtime)
          do i = 1, f % dimSizes(1)
            f % array(i) = f % defaultValue
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -542,13 +544,13 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(2) schedule(runtime)
+           CPUOMP !$omp do collapse(2) schedule(runtime)
            do i = 1, f_cursor % dimSizes(2)
              do j = 1, f_cursor % dimSizes(1)
                f_cursor % array(j, i) = f_cursor % defaultValue
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -563,13 +565,13 @@ module mpas_field_routines
          call mpas_threading_barrier()
 
          if ( init_array ) then
-         !$omp do schedule(runtime) collapse(2)
+         CPUOMP !$omp do schedule(runtime) collapse(2)
          do i = 1, f % dimSizes(2)
            do j = 1, f % dimSizes(1)
              f % array(j, i) = f % defaultValue
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -630,7 +632,7 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(3) schedule(runtime)
+           CPUOMP !$omp do collapse(3) schedule(runtime)
            do i = 1, f_cursor % dimSizes(3)
              do j = 1, f_cursor % dimSizes(2)
                do k = 1, f_cursor % dimSizes(1)
@@ -638,7 +640,7 @@ module mpas_field_routines
                end do
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -653,7 +655,7 @@ module mpas_field_routines
          call mpas_threading_barrier()
 
          if ( init_array ) then
-         !$omp do collapse(3) schedule(runtime)
+         CPUOMP !$omp do collapse(3) schedule(runtime)
          do i = 1, f % dimSizes(3)
            do j = 1, f % dimSizes(2)
              do k = 1, f % dimSizes(1)
@@ -661,7 +663,7 @@ module mpas_field_routines
              end do
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -722,7 +724,7 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(4) schedule(runtime)
+           CPUOMP !$omp do collapse(4) schedule(runtime)
            do i = 1, f_cursor % dimSizes(4)
              do j = 1, f_cursor % dimSizes(3)
                do k = 1, f_cursor % dimSizes(2)
@@ -732,7 +734,7 @@ module mpas_field_routines
                end do
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -747,7 +749,7 @@ module mpas_field_routines
          call mpas_threading_barrier()
 
          if ( init_array ) then
-         !$omp do collapse(4) schedule(runtime)
+         CPUOMP !$omp do collapse(4) schedule(runtime)
          do i = 1, f % dimSizes(4)
            do j = 1, f % dimSizes(3)
              do k = 1, f % dimSizes(2)
@@ -757,7 +759,7 @@ module mpas_field_routines
              end do
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -818,7 +820,7 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do collapse(5) schedule(runtime)
+           CPUOMP !$omp do collapse(5) schedule(runtime)
            do i = 1, f_cursor % dimSizes(5)
              do j = 1, f_cursor % dimSizes(4)
                do k = 1, f_cursor % dimSizes(3)
@@ -830,7 +832,7 @@ module mpas_field_routines
                end do
              end do
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -845,7 +847,7 @@ module mpas_field_routines
          call mpas_threading_barrier()
 
          if ( init_array ) then
-         !$omp do collapse(5) schedule(runtime)
+         CPUOMP !$omp do collapse(5) schedule(runtime)
          do i = 1, f % dimSizes(5)
            do j = 1, f % dimSizes(4)
              do k = 1, f % dimSizes(3)
@@ -857,7 +859,7 @@ module mpas_field_routines
              end do
            end do
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 
@@ -920,11 +922,11 @@ module mpas_field_routines
          if ( init_array ) then
          f_cursor => f
          do while(associated(f_cursor))
-           !$omp do schedule(runtime)
+           CPUOMP !$omp do schedule(runtime)
            do i = 1, f_cursor % dimSizes(1)
              f_cursor % array(i) = f_cursor % defaultValue
            end do
-           !$omp end do
+           CPUOMP !$omp end do
            f_cursor => f_cursor % next
          end do
          end if
@@ -941,11 +943,11 @@ module mpas_field_routines
 
          ! then all threads initialize
          if ( init_array ) then
-         !$omp do schedule(runtime)
+         CPUOMP !$omp do schedule(runtime)
          do i = 1, f % dimSizes(1)
            f % array(i) = f % defaultValue
          end do
-         !$omp end do
+         CPUOMP !$omp end do
          end if
        end if
 

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -36,7 +37,7 @@
 !
 !-----------------------------------------------------------------------
 
-
+#include "mpas_openmp.inc"
 module mpas_log
 
    use mpas_derived_types
@@ -571,7 +572,7 @@ module mpas_log
             ! --- Actually write the message here! ---
             !    We have to treat MPAS_LOG_OUT messages separately from others because that type
             !    does not have a prefix and we want to add a space after the trimmed prefix for other types.
-!$OMP CRITICAL (mpas_log_write_section)
+CPUOMP !$OMP CRITICAL (mpas_log_write_section)
             write(mpas_log_info % outputLog % unitNum, '(a,a,a)') trim(messageExtendedPrefix), ' ', trim(messageExpanded)
 
             ! Optionally flush the buffer (only attempt if the file is active)
@@ -599,7 +600,7 @@ module mpas_log
             case default
                ! TODO handle this error? (would have encountered it above...)
             end select
-!$OMP END CRITICAL (mpas_log_write_section)
+CPUOMP !$OMP END CRITICAL (mpas_log_write_section)
 
          endif
       endif
@@ -611,7 +612,7 @@ module mpas_log
          if ( ( ((masterOnlyWrite) .and. (mpas_log_info % taskID == 0)) .or. (.not. masterOnlyWrite)) .and. &  ! Check masterOnly
                mpas_log_info % errorLog % isActive ) then ! By default, all error logs are active, but a core could override that!
 
-!$OMP CRITICAL (mpas_log_critical_write)
+CPUOMP !$OMP CRITICAL (mpas_log_critical_write)
             ! if err file is not already open, we need to open it
             if (.not. mpas_log_info % errorLog % isOpen) then
                call mpas_log_open(openErrorFile = .true., err = ierr_tmp)
@@ -627,7 +628,7 @@ module mpas_log
                ! Now abort
                call log_abort()
             endif
-!$OMP END CRITICAL (mpas_log_critical_write)
+CPUOMP !$OMP END CRITICAL (mpas_log_critical_write)
 
          endif
       endif

--- a/src/framework/mpas_openmp.inc
+++ b/src/framework/mpas_openmp.inc
@@ -1,0 +1,31 @@
+! +++++++++++++++++++++
+! BSD 3 Clause
+! Copyright 2022 Advanced Micro Devices, Inc (AMD)
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifdef MPAS_AMD_OFFLOAD
+#define GPUOMP
+#define TMPOMP !
+#define GPUACC !
+#ifdef MPAS_OPENMP
+#define CPUOMP
+#else
+#define CPUOMP !
+#endif
+#else
+#define GPUOMP !
+#define TMPOMP !
+#define GPUACC
+#define CPUOMP
+#endif
+#ifdef _GPUMPI_OFF
+#define MPIGPU !
+#define MPICPU
+#else
+#define MPIGPU 
+#define MPICPU !
+#endif

--- a/src/framework/mpas_pool_routines.F
+++ b/src/framework/mpas_pool_routines.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -16,6 +17,7 @@
 !> This module defines subroutines and functions for handling pools.
 !
 !-----------------------------------------------------------------------
+#include "mpas_openmp.inc"
 module mpas_pool_routines
 
    use mpas_kind_types
@@ -4236,6 +4238,7 @@ module mpas_pool_routines
               scalar => field % scalar
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%scalar)
                       !$acc enter data copyin(field%scalar)
               end if
 #endif
@@ -4293,6 +4296,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4350,6 +4354,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4409,6 +4414,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4466,6 +4472,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4524,6 +4531,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4582,6 +4590,7 @@ module mpas_pool_routines
               scalar => field % scalar
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%scalar)
                       !$acc enter data copyin(field%scalar)
               end if
 #endif
@@ -4640,6 +4649,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4698,6 +4708,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4756,6 +4767,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:field%array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -4814,6 +4826,7 @@ module mpas_pool_routines
               string => field % scalar
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:string)
                       !$acc enter data copyin(field%scalar)
               end if
 #endif
@@ -4872,6 +4885,7 @@ module mpas_pool_routines
               array => field % array
 #ifdef CORE_ATMOSPHERE
               if (coupler % role_includes(ROLE_INTEGRATE)) then
+                      GPUOMP !$omp target enter data map(to:array)
                       !$acc enter data copyin(field%array)
               end if
 #endif
@@ -5776,7 +5790,7 @@ module mpas_pool_routines
          inPool % iterator => inPool % iteration_head
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_pool_begin_iteration!}}}
 
@@ -5804,7 +5818,7 @@ module mpas_pool_routines
       integer :: i, threadNum
 
       threadNum = mpas_threading_get_thread_num()
-      !$omp barrier
+      CPUOMP !$omp barrier
 
       !
       ! As long as there are members left to be iterated over, the inPool%iterator
@@ -5828,7 +5842,7 @@ module mpas_pool_routines
          mpas_pool_get_next_member = .false.
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
       if ( threadNum == 0 .and. associated(inPool % iterator) ) then
          ! Only thread 0 can advance iterator to next item

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -1,3 +1,5 @@
+! Modification Copyright (C) 2022, Advanced Micro Devices, Inc (AMD). All rights reserved.
+#include "mpas_openmp.inc"
 module mpas_stream_manager
 
 #define COMMA ,
@@ -5583,7 +5585,7 @@ module mpas_stream_manager
 
         end if
 
-        !$omp barrier
+        CPUOMP !$omp barrier
 
     end subroutine MPAS_stream_mgr_begin_iteration !}}}
 
@@ -5642,7 +5644,7 @@ module mpas_stream_manager
            return
         end if
 
-        !$omp barrier
+        CPUOMP !$omp barrier
 
         if ( present(streamID) ) then
            streamID = manager % currentStream % name

--- a/src/framework/mpas_threading.F
+++ b/src/framework/mpas_threading.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -16,6 +17,7 @@
 !
 !-----------------------------------------------------------------------
 
+#include "mpas_openmp.inc"
 module mpas_threading
 
    use mpas_kind_types
@@ -129,7 +131,7 @@ module mpas_threading
    subroutine mpas_threading_barrier()!{{{
 
 #ifdef MPAS_OPENMP
-      !$omp barrier
+      CPUOMP !$omp barrier
 #endif
 
    end subroutine mpas_threading_barrier!}}}

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -1,10 +1,12 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
+#include "mpas_openmp.inc"
 module mpas_timekeeping
 
    use mpas_kind_types
@@ -214,7 +216,7 @@ module mpas_timekeeping
          nullify(clock % alarmListHead)
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_create_clock
 
@@ -245,7 +247,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_destroy_clock
 
@@ -330,7 +332,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_set_clock_direction
 
@@ -368,7 +370,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_set_clock_timestep
 
@@ -419,7 +421,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_advance_clock
 
@@ -452,7 +454,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_set_clock_time
 
@@ -559,7 +561,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_add_clock_alarm
 
@@ -598,7 +600,7 @@ module mpas_timekeeping
          end do
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_remove_clock_alarm
 
@@ -804,7 +806,7 @@ module mpas_timekeeping
             alarmPtr => alarmPtr % next
          end do
       end if
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_print_alarm
 
@@ -978,7 +980,7 @@ module mpas_timekeeping
          end do
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
 
    end subroutine mpas_reset_clock_alarm
 
@@ -1048,7 +1050,7 @@ module mpas_timekeeping
          end do
       end if ! thread check
 
-      !$omp barrier
+      CPUOMP !$omp barrier
    end subroutine mpas_adjust_alarm_to_reference_time
 
 
@@ -1125,7 +1127,7 @@ module mpas_timekeeping
          end if
       end if
 
-      !$omp barrier
+      CPUOMP !$omp barrier
    
    end subroutine mpas_calibrate_alarms
 

--- a/src/operators/Makefile
+++ b/src/operators/Makefile
@@ -34,6 +34,7 @@ clean:
 	@# Certain systems with intel compilers generate *.i files
 	@# This removes them during the clean process
 	$(RM) *.i
+	$(RM) *.acc.s
 
 .F.o:
 	$(RM) $@ $*.mod

--- a/src/operators/mpas_vector_reconstruction.F
+++ b/src/operators/mpas_vector_reconstruction.F
@@ -1,5 +1,6 @@
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Modifications Copyright (c) 2022, Advanced Micro Devices, Inc (AMD). All rights Reserved.
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -16,6 +17,7 @@
 !> This module provides routines for performing vector reconstruction from edges to cell centers.
 !
 !-----------------------------------------------------------------------
+#include "mpas_openmp.inc"
 module mpas_vector_reconstruction
 
   use mpas_derived_types
@@ -248,7 +250,7 @@ module mpas_vector_reconstruction
     call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
 
     ! loop over cell centers
-    !$omp do schedule(runtime)
+    CPUOMP !$omp do schedule(runtime)
     do iCell = 1, nCells
       ! initialize the reconstructed vectors
       uReconstructX(:,iCell) = 0.0
@@ -268,12 +270,12 @@ module mpas_vector_reconstruction
 
       enddo
     enddo   ! iCell
-    !$omp end do
+    CPUOMP !$omp end do
 
     call mpas_threading_barrier()
 
     if (on_a_sphere) then
-      !$omp do schedule(runtime)
+      CPUOMP !$omp do schedule(runtime)
       do iCell = 1, nCells
         clat = cos(latCell(iCell))
         slat = sin(latCell(iCell))
@@ -285,14 +287,14 @@ module mpas_vector_reconstruction
                                           + uReconstructY(:,iCell)*slon)*slat &
                                           + uReconstructZ(:,iCell)*clat
       end do
-      !$omp end do
+      CPUOMP !$omp end do
     else
-      !$omp do schedule(runtime)
+      CPUOMP !$omp do schedule(runtime)
       do iCell = 1, nCells
         uReconstructZonal     (:,iCell) = uReconstructX(:,iCell)
         uReconstructMeridional(:,iCell) = uReconstructY(:,iCell)
       end do
-      !$omp end do
+      CPUOMP !$omp end do
     end if
 
   end subroutine mpas_reconstruct_2d!}}}
@@ -397,7 +399,9 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
    
      ! loop over cell centers
     !!!$omp do schedule(runtime)
+TMPOMP !$omp target update to(u, uReconstructZonal, uReconstructMeridional, nedgesOnCell,edgesOnCell,latCell,lonCell, coeffs_reconstruct)
 !$acc data present(u,uReconstructX, uReconstructY, uReconstructZ, uReconstructZonal, uReconstructMeridional, nedgesOnCell,edgesOnCell,latCell,lonCell, coeffs_reconstruct)
+GPUOMP !$omp target teams distribute parallel do simd collapse(2)
 !$acc parallel
 !$acc loop gang worker
     do iCell = 1, nCellParent
@@ -410,12 +414,14 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
      end do
    enddo
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
 
       ! a more efficient reconstruction where
       ! rbf_values*matrix_reconstruct
 
       ! has been precomputed in coeffs_reconstruct
 
+GPUOMP !$omp target teams distribute parallel do thread_limit(64)
 !$acc parallel
 !$acc loop gang private(iEdge)
     do iCell = 1, nCellParent
@@ -433,6 +439,7 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
  
       enddo
     enddo   ! iCell
+GPUOMP !$omp end target teams distribute parallel do
 
 !$acc end parallel
     !!!$omp end do
@@ -441,15 +448,17 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
  
     if (on_a_sphere) then
       !!!$omp do schedule(runtime)
+GPUOMP !$omp target teams distribute parallel do simd collapse(2) private(clat,slat,clon,slon)
 !$acc parallel
 !$acc loop gang worker private(clat,slat,clon,slon)
       do iCell = 1, nCellParent
+        GPUOMP do temp= 1, nVertLevels
         clat = cos(latCell(iCell))
         slat = sin(latCell(iCell))
         clon = cos(lonCell(iCell))
         slon = sin(lonCell(iCell))
         !$acc loop vector
-        do temp= 1, nVertLevels
+        GPUACC do temp= 1, nVertLevels
           uReconstructZonal(temp,iCell) = -uReconstructX(temp,iCell)*slon + &
                                       uReconstructY(temp,iCell)*clon
           uReconstructMeridional(temp,iCell) = -(uReconstructX(temp,iCell)*clon       &
@@ -458,9 +467,11 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
         end do
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       !!!$omp end do
     else
       !!!$omp do schedule(runtime)
+GPUOMP !$omp target teams distribute parallel do simd
 !$acc parallel
 !$acc loop gang worker vector
       do iCell = 1, nCellParent
@@ -468,9 +479,12 @@ uReconstructZonal, uReconstructMeridional, includeHalos)!{{{
         uReconstructMeridional(:,iCell) = uReconstructY(:,iCell)
       end do
 !$acc end parallel
+GPUOMP !$omp end target teams distribute parallel do simd
       !!!$omp end do
     end if
 !$acc end data
+TMPOMP !$omp target update from(uReconstructZ,uReconstructY,uReconstructZ,&
+TMPOMP !$omp uReconstructZonal,uReconstructMeridional)
 
    
 end subroutine mpas_reconstruct_2d_gpu_work
@@ -541,7 +555,7 @@ end subroutine mpas_reconstruct_2d_gpu_work
     call mpas_pool_get_config(meshPool, 'on_a_sphere', on_a_sphere)
 
     ! loop over cell centers
-    !$omp do schedule(runtime)
+    CPUOMP !$omp do schedule(runtime)
     do iCell = 1, nCells
       ! initialize the reconstructed vectors
       uReconstructX(iCell) = 0.0
@@ -561,12 +575,12 @@ end subroutine mpas_reconstruct_2d_gpu_work
 
       enddo
     enddo   ! iCell
-    !$omp end do
+    CPUOMP !$omp end do
 
     call mpas_threading_barrier()
 
     if (on_a_sphere) then
-      !$omp do schedule(runtime)
+      CPUOMP !$omp do schedule(runtime)
       do iCell = 1, nCells
         clat = cos(latCell(iCell))
         slat = sin(latCell(iCell))
@@ -578,14 +592,14 @@ end subroutine mpas_reconstruct_2d_gpu_work
                                         + uReconstructY(iCell)*slon)*slat &
                                         + uReconstructZ(iCell)*clat
       end do
-      !$omp end do
+      CPUOMP !$omp end do
     else
-      !$omp do schedule(runtime)
+      CPUOMP !$omp do schedule(runtime)
       do iCell = 1, nCells
         uReconstructZonal     (iCell) = uReconstructX(iCell)
         uReconstructMeridional(iCell) = uReconstructY(iCell)
       end do
-      !$omp end do
+      CPUOMP !$omp end do
     end if
 
   end subroutine mpas_reconstruct_1d!}}}


### PR DESCRIPTION
Currently only supported through the cray ftn compiler. 
All OMP directives added on top of existing ACC directives.
Only core dynamics ported. Physics not touched.
Macro definitions (MPAS_AMD_OFFLOAD, GPUOMP, etc) are temporary measures and will be renamed or removed when the AOMP compiler is supported. Should also eventually work with Intel and NVIDIA GPUs.

