### PR TITLE
Fixes issue in calc_pvBudget subroutine and adapts floodFillStrato subroutine to allow for domain communication

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1723,7 +1723,7 @@
                      description="tendency of coupled potential temperature rho*theta_m/zz from dynamics and physics, updated each RK step"/>
 
                 <var name="rt_diabatic_tend" type="real" dimensions="nVertLevels nCells Time" units="kg K s^{-1}"
-                     description="Tendency of coupled potential temperature from physics"/>
+                     description="Tendency of coupled potential temperature from microphysics"/>
 
                 <var name="euler_tend_u" name_in_code="u_euler" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
                      description="Tendency of u from dynamics"/>

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -1396,6 +1396,7 @@ module pv_diagnostics
       real(kind=RKIND), dimension(:,:), pointer :: depv_dt_diab, depv_dt_fric
       real(kind=RKIND), dimension(:,:), pointer :: tend_u_phys, tend_u_euler, rho_edge, tend_w_euler
       real(kind=RKIND), dimension(:,:), pointer :: rthblten, rthcuten, rthratenlw, rthratensw, &
+                                                   rt_diabatic_tend, &  ! MW added 04/20/2022 
                                                    dtheta_dt_mp, dtheta_dt_mix
       real(kind=RKIND), dimension(:,:,:), pointer :: cellTangentPlane
       
@@ -1436,6 +1437,7 @@ module pv_diagnostics
       call mpas_pool_get_array(tend_physics, 'rthcuten', rthcuten)
       call mpas_pool_get_array(tend_physics, 'rthratenlw', rthratenlw)
       call mpas_pool_get_array(tend_physics, 'rthratensw', rthratensw)
+      call mpas_pool_get_array(tend, 'rt_diabatic_tend', rt_diabatic_tend)  !MW added 04/20/2022
       call mpas_pool_get_array(diag, 'dtheta_dt_mp', dtheta_dt_mp)
       call mpas_pool_get_array(diag, 'dtheta_dt_mix', dtheta_dt_mix)
       
@@ -1523,18 +1525,23 @@ module pv_diagnostics
                depv_dt_cu(k,iCell) = 0.0_RKIND
             end if
             
-            if (associated(dtheta_dt_mp)) then
+            
+            !if (associated(dtheta_dt_mp)) then -- routine modified on 04/21/22 by May Wong; original called dtheta_dt_mp instead of diabatic heating tendency from mp
+            if (associated(rt_diabatic_tend)) then
                call calc_grad_cell(gradtheta, &
                                 iCell, k, nVertLevels, nEdgesOnCell(iCell), verticesOnCell, kiteAreasOnVertex, &
                                 cellsOnCell, edgesOnCell, cellsOnEdge, dvEdge, edgeNormalVectors, &
                                 cellsOnVertex, &
                                 cellTangentPlane, localVerticalUnitVectors, zgrid, areaCell(iCell), &
-                                dtheta_dt_mp)
+                                rt_diabatic_tend)
+                                !dtheta_dt_mp)
+               dtheta_dt_mp(k,iCell) = rt_diabatic_tend(k,iCell) ! MW added 04/21/2022
                depv_dt_mp(k,iCell) = dotProduct(gradxu, gradtheta,3)* 1.0e6
             else
+               dtheta_dt_mp(k,iCell) = 0.0_RKIND ! MW added 04/21/2022
                depv_dt_mp(k,iCell) = 0.0_RKIND
             end if
-            
+           
             if (associated(dtheta_dt_mix)) then
                call calc_grad_cell(gradtheta, &
                                 iCell, k, nVertLevels, nEdgesOnCell(iCell), verticesOnCell, kiteAreasOnVertex, &

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -1360,8 +1360,13 @@ module pv_diagnostics
       pvuVal = 2.0_RKIND
       missingVal = -99999.0_RKIND
       stratoPV = 10.0_RKIND
-      !call floodFill_strato(mesh, diag, pvuVal, stratoPV)
-      call floodFill_tropo(mesh,diag,pvuVal)
+      
+      ! Either call floodFill_strato or floodFill_tropo to estimate level of dynamic tropopause.
+      ! floodFill_tropo was toggled on, but switch to floodFill_strato. 
+      
+      call floodFill_strato(mesh, diag, pvuVal, stratoPV)
+      !call floodFill_tropo(mesh,diag,pvuVal)
+      
       call interp_pv_diagnostics(mesh, diag, pvuVal, missingVal)
    
    end subroutine atm_compute_pv_diagnostics

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -491,7 +491,7 @@ module pv_diagnostics
       end do
       
       !seed flood fill with model top that's above DT.
-      !can have model top below 2pvu (eg, tropics)
+      !can have model top with PV below 2 PVU (e.g., in tropics)
       nChanged = 0
       do iCell=1,nCells
          do k=nVertLevels-5,nVertLevels
@@ -591,25 +591,33 @@ module pv_diagnostics
    end subroutine floodFill_strato
    
    subroutine floodFill_tropo(mesh, diag, pvuVal)
-      !Searching down each column from TOA to find 2pvu surface is buggy with stratospheric wave breaking,
-      !since will find 2 pvu at a higher level than "tropopause". This looks to be worse as mesh gets finer and vertical vorticity jumps.
-      !Note that stratospheric blobs may persist for long times w/ slow mixing downstream of mountains or deep convection.
-      !A few quicker fixes (make sure <2pvu for a number of layers; search down from 10PVU instead of TOA) are hacky and not robust.
+      !To find model level of dynamic tropopause: 
+      !Simply searching down from TOA within each column to find first instance of 2-PVU surface (i.e., where the PV drops below values characteristic of the stratosphere) 
+      !is buggy due to stratospheric wave breaking, which may induce regions of low PV (i.e., PV < 2 PVU) within the stratosphere and thus yield artifically
+      !high estimations of the tropopause height. This seems to be more problematic as the mesh gets finer and the vertical vorticity field exhibits greater variability
+      !or jumps. 
+      !Note that these low-PV anomalies in the stratosphere may persist for long times w/ slow mixing downstream of mountains or deep convection.
+      !A few quicker fixes (e.g., make sure PV < 2 PVU for a number of layers; search down from 10 PVU instead of TOA) are hacky and not robust.
       
-      !Two flood fill options are to:
-      ! (1) flood fill stratosphere (>2pvu) from stratosphere seeds near model top. Strong surface PV anomalies can connect to 2pvu, 
-      !     and the resulting "flood-filled 2 pvu" can have sizeable areas that are just at the surface while there is clearly a tropopause above (e.g., in a cross-section).
-      !     To address large surface blobs, take the flood fill mask and try to go up from the surface to 10 pvu w/in column. If can, all stratosphere. Else, disconnect "surface blob".
-      ! (2) flood fill troposphere (<2pvu) from troposphere seeds near surface.
-      !Somewhat paradoxically, the bottom of the stratosphere is lower than the top of the troposphere.
-      
-      !Originally, it was assumed that each (MPI) domain would have >0 cells with "right" DT found by flood filling.
-      !However, for "small" domains over the Arctic say during winter, the entire surface can be capped by high PV.
-      !So, we need to communicate between domains during the flood fill or else we find the DT at the surface.
-      !The extreme limiting case is if we had every cell as its own domain; then, it's clear that there has to be communication.
-
-      !The "output" is iLev_DT, which is the vertical index for the level >= pvuVal. If >nVertLevels, pvuVal above column. If <2, pvuVal below column.
+      !Two flood fill subroutine options are to:
+      ! (1) floodFill_strato: flood fill the stratosphere (PV >= 2 PVU) from stratosphere seeds placed near model top. Strong surface PV anomalies can connect to 2-PVU region aloft, 
+      !     and the resulting "flood-filled 2 PVU" can have sizeable areas that are located just at/near the surface, while there is clearly a tropopause above
+      !     (i.e., as evident in a vertical cross-section). To address the large near-surface blobs of PV > 2 PVU, will take the flood fill mask and try to move upward from
+      !     near the surface to 10 PVU within a vertical column. If this can be done, then the low-level PV anomaly extends to the stratosphere. Else, remove the stratospheric
+      !     designation to disconnect the "surface blob".
+      ! (2) floodFill_tropo: flood fill the troposphere (PV < 2 PVU) from troposphere seeds placed near the surface.
+      !
+      ! Comparing the two procedures... Somewhat paradoxically, the bottom of the stratosphere is located lower than the top of the troposphere.  
+     
+      !The "output" is iLev_DT, which is the vertical index for the model level just above the dynamic tropopause (i.e., where PV >= pvuVal, which is set below in atm_compute_pv_diagnostics to 2 PVU). 
+      !If iLev_DT > nVertLevels, then pvuVal is found only above the column (i.e., entire column is in troposphere). If iLev_DT < 1, PV >= pvuVal extends vertically through the entire column 
+      !(i.e., the entire column is within the stratosphere).
       !Communication between blocks during the flood fill may be needed to treat some edge cases appropriately.
+      
+      !Originally, it was assumed that each (MPI) domain would have > 0 cells with "right" DT found by flood filling.
+      !However, for "small" domains (especially over the poles -- for example, in the Arctic say during winter, when the entire surface can be capped by high PV), 
+      !this becomes problematic. So, we need to communicate between domains during the flood fill procedure or else we will find the DT located at/near the surface.
+      !The extreme limiting case is if we had every cell as its own domain; then, it's clear that there has to be communication.
 
       use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array, mpas_pool_get_field
       use mpas_dmpar, only : mpas_dmpar_max_int,mpas_dmpar_exch_halo_field

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -424,7 +424,7 @@ module pv_diagnostics
    !Below are two subroutines (floodFill_strato and floodFill_tropo) designed to determine the model level above the dynamic tropopause, iLev_DT, which
    !is designated as the 2-PVU isosurface. 
    !Only one of these subroutines is used (toggled with "call floodFill_strato(mesh, diag, pvuVal, stratoPV)" and "call floodFill_tropo(mesh,diag,pvuVal)"
-   !in the subroutines below.
+   !in the subroutines below. The routines *should* produce equivalent estimates for iLev_DT. 
    
    subroutine floodFill_strato(mesh, diag, pvuVal, stratoPV)
       !To find model level of dynamic tropopause: 
@@ -506,7 +506,7 @@ module pv_diagnostics
          do k=nVertLevels-5,nVertLevels
             if (candInStrato(k,iCell) .GT. 0) then
                inStrato(k,iCell) = 1
-               candInStrato(k,iCell) = 0
+               !candInStrato(k,iCell) = 0
                nChanged = nChanged+1
             end if
          end do
@@ -546,7 +546,8 @@ module pv_diagnostics
                       inStrato(k,iCell) = 1
                       !candInStrato(k,iCell) = 0 ! commented out to be consistent with trop routine
                       nChanged = nChanged+1
-                      exit ! was cycle, but tropspheric loop has exit here. why?
+                      !exit ! was cycle, but tropspheric loop has exit here. why?
+                      cycle
                     end if
                   end do
                 
@@ -1362,10 +1363,9 @@ module pv_diagnostics
       stratoPV = 10.0_RKIND
       
       ! Either call floodFill_strato or floodFill_tropo to estimate level of dynamic tropopause.
-      ! floodFill_tropo was toggled on, but switch to floodFill_strato. 
       
-      call floodFill_strato(mesh, diag, pvuVal, stratoPV)
-      !call floodFill_tropo(mesh,diag,pvuVal)
+      !call floodFill_strato(mesh, diag, pvuVal, stratoPV)
+      call floodFill_tropo(mesh,diag,pvuVal)
       
       call interp_pv_diagnostics(mesh, diag, pvuVal, missingVal)
    

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -448,7 +448,9 @@ module pv_diagnostics
       !(i.e., the entire column is within the stratosphere).
       !Communication between blocks during the flood fill may be needed to treat some edge cases appropriately.
 
-      use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array
+      use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array, mpas_pool_get_field
+      use mpas_dmpar, only : mpas_dmpar_max_int,mpas_dmpar_exch_halo_field
+      use mpas_derived_types, only : dm_info, field2DInteger
      
       implicit none
       
@@ -456,18 +458,23 @@ module pv_diagnostics
       type (mpas_pool_type), intent(inout) :: diag
       real(kind=RKIND), intent(in) :: pvuVal, stratoPV
       
-      integer :: iCell, k, nChanged, iNbr, iCellNbr
-      integer, pointer :: nCells, nVertLevels
+      integer :: iCell, k, nChanged, iNbr, iCellNbr, levInd, haloChanged, global_haloChanged !INCORPORATE LEVEL INDEX FOR REMOVING SFC BLOB
+      integer, pointer :: nCells, nVertLevels, nCellsSolve
       integer, dimension(:), pointer :: nEdgesOnCell, iLev_DT
-      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell, inStrato ! inStrato wasn't here in original procedure
+      
+      type (field2DInteger), pointer :: inStrato_f ! line added to match troposphere procedure workflow
       
       real(kind=RKIND) :: sgnHemi, sgn
       real(kind=RKIND),dimension(:),pointer:: latCell
       real(kind=RKIND), dimension(:,:), pointer :: ertel_pv
       
-      integer, dimension(:,:), allocatable :: candInStrato, inStrato
+      type (dm_info), pointer :: dminfo
+      
+      integer, dimension(:,:), allocatable :: candInStrato ! whether point is potentially inStrato
       
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+      call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
@@ -475,12 +482,14 @@ module pv_diagnostics
 
       call mpas_pool_get_array(diag, 'ertel_pv', ertel_pv)
       call mpas_pool_get_array(diag, 'iLev_DT', iLev_DT)
+      call mpas_pool_get_array(diag, 'inStrato', inStrato) ! was allocated below in original script
       
       allocate(candInStrato(nVertLevels, nCells+1))
-      allocate(inStrato(nVertLevels, nCells+1))
+      !allocate(inStrato(nVertLevels, nCells+1))
       candInStrato(:,:) = 0
       inStrato(:,:) = 0
-      !store whether each level above DT to avoid repeating logic. we'll use candInStrato as a isVisited marker further below.
+      
+      !store whether each grid point has |PV| >= pvuVal to avoid repeating logic. we'll use candInStrato as a isVisited marker for potential stratosphere grid points further below.
       do iCell=1,nCells
          sgnHemi = sign(1.0_RKIND, latCell(iCell)) !at the equator, sign(0)=0
          if (sgnHemi .EQ. 0.0) sgnHemi = 1.0_RKIND
@@ -490,7 +499,7 @@ module pv_diagnostics
          end do
       end do
       
-      !seed flood fill with model top that's above DT.
+      !loop over cells and top 5 model levels to seed flood fill with model top that's located above DT (i.e., where |PV| >= pvuVal).
       !can have model top with PV below 2 PVU (e.g., in tropics)
       nChanged = 0
       do iCell=1,nCells
@@ -503,48 +512,70 @@ module pv_diagnostics
          end do
       end do
       
-      !flood fill from the given seeds. since I don't know enough fortran,
+      !flood fill from the determined seeds. since I don't know enough fortran,
       !we'll just brute force a continuing loop rather than queue.
-      do while(nChanged .GT. 0)
-        nChanged = 0
-        do iCell=1,nCells
-          do k=nVertLevels,1,-1
-             !update if candidate and neighbor in strato
-             if (candInStrato(k,iCell) .GT. 0) then
-                !nbr above
-                if (k .LT. nVertLevels) then
-                  if (inStrato(k+1,iCell) .GT. 0) then
-                    inStrato(k,iCell) = 1
-                    candInStrato(k,iCell) = 0
-                    nChanged = nChanged+1
-                    cycle
+      !here is where the changes to account for domain communication are needed.
+      
+      call mpas_pool_get_field(diag, 'inStrato', inStrato_f)
+      dminfo => inStrato_f % block % domain % dminfo
+      global_haloChanged = 1
+      
+      do while(global_haloChanged .GT. 0) !any cell in a halo has changed, to propagate to other domains
+        global_haloChanged = 0 !aggregate the number of changed cells w/in the loop below
+        do while(nChanged .GT. 0)
+          nChanged = 0
+          do iCell=1,nCells !should we look for neighbors of halo cells?
+          !do iCell=1,nCellsSolve !should we look for neighbors of halo cells?
+            do k=nVertLevels,1,-1 ! loop over vertical levels from top down
+               !update if candidate and neighbor in strato
+               if ((candInStrato(k,iCell) .GT. 0) .AND. (inStrato(k,iCell).LT.1) ) then ! modified to match trop routine
+                  !nbr above
+                  if (k .LT. nVertLevels) then
+                    if (inStrato(k+1,iCell) .GT. 0) then
+                      inStrato(k,iCell) = 1
+                      !candInStrato(k,iCell) = 0 ! commented out to be consistent with trop routine
+                      nChanged = nChanged+1
+                      cycle
+                    end if
                   end if
-                end if
                 
-                !side nbrs
-                do iNbr = 1, nEdgesOnCell(iCell)
-                  iCellNbr = cellsOnCell(iNbr,iCell)
-                  if (inStrato(k,iCellNbr) .GT. 0) then
-                    inStrato(k,iCell) = 1
-                    candInStrato(k,iCell) = 0
-                    nChanged = nChanged+1
-                    cycle
-                  end if
-                end do
+                  !side nbrs
+                  do iNbr = 1, nEdgesOnCell(iCell)
+                    iCellNbr = cellsOnCell(iNbr,iCell)
+                    if (inStrato(k,iCellNbr) .GT. 0) then
+                      inStrato(k,iCell) = 1
+                      !candInStrato(k,iCell) = 0 ! commented out to be consistent with trop routine
+                      nChanged = nChanged+1
+                      exit ! was cycle, but tropspheric loop has exit here. why?
+                    end if
+                  end do
                 
-                !nbr below
-                if (k .GT. 1) then
-                  if (inStrato(k-1,iCell) .GT. 0) then
-                    inStrato(k,iCell) = 1
-                    candInStrato(k,iCell) = 0
-                    nChanged = nChanged+1
-                    cycle
+                  !nbr below
+                  if (k .GT. 1) then
+                    if (inStrato(k-1,iCell) .GT. 0) then
+                      inStrato(k,iCell) = 1
+                      !candInStrato(k,iCell) = 0 ! commented out to be consistent with trop routine
+                      nChanged = nChanged+1
+                      cycle
+                    end if
                   end if
-                end if
-             end if !candInStrato
-          end do !levels
-        end do !cells
-      end do !while
+                    
+               end if !candInStrato
+            end do !levels
+          end do !cells
+          global_haloChanged = global_haloChanged+nChanged
+        end do !while w/in domain
+        
+        !communicate to other domains for edge case where a chunk of a block hasn't gotten to fill
+        nChanged = global_haloChanged
+        call mpas_dmpar_max_int(dminfo, nChanged, global_haloChanged)
+        if (global_haloChanged .GT. 0) then !communicate inStrato everywhere
+          call mpas_dmpar_exch_halo_field(inStrato_f)
+        end if
+        nChanged = global_haloChanged !so each block will iterate again if anything changed
+      end do !while haloChanged
+      deallocate(candInStrato)
+      
       
       !Detach high surface PV blobs w/o vertical connection to "stratosphere"
       do iCell=1,nCells

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -421,23 +421,31 @@ module pv_diagnostics
 
    end function calc_vertDeriv_one
    
-   !Below are two subroutines (floodFill_strato and floodFill_tropo) designed to determine the model level above the dynamic tropopause, iLev_DT. 
+   !Below are two subroutines (floodFill_strato and floodFill_tropo) designed to determine the model level above the dynamic tropopause, iLev_DT, which
+   !is designated as the 2-PVU isosurface. 
    !Only one of these subroutines is used (toggled with "call floodFill_strato(mesh, diag, pvuVal, stratoPV)" and "call floodFill_tropo(mesh,diag,pvuVal)"
    !in the subroutines below.
    
    subroutine floodFill_strato(mesh, diag, pvuVal, stratoPV)
-      !Searching down each column from TOA to find 2pvu surface is buggy with stratospheric wave breaking,
-      !since will find 2 pvu at a higher level than "tropopause". This looks to be worse as mesh gets finer and vertical vorticity jumps.
-      !Note that stratospheric blobs may persist for long times w/ slow mixing downstream of mountains or deep convection.
-      !A few quicker fixes (make sure <2pvu for a number of layers; search down from 10PVU instead of TOA) are hacky and not robust.
+      !To find model level of dynamic tropopause: 
+      !Simply searching down from TOA within each column to find first instance of 2-PVU surface (i.e., where the PV drops below values characteristic of the stratosphere) 
+      !is buggy due to stratospheric wave breaking, which may induce regions of low PV (i.e., PV < 2 PVU) within the stratosphere and thus yield artifically
+      !high estimations of the tropopause height. This seems to be more problematic as the mesh gets finer and the vertical vorticity field exhibits greater variability
+      !or jumps. 
+      !Note that these low-PV anomalies in the stratosphere may persist for long times w/ slow mixing downstream of mountains or deep convection.
+      !A few quicker fixes (e.g., make sure PV < 2 PVU for a number of layers; search down from 10 PVU instead of TOA) are hacky and not robust.
       
-      !To alleviate the (hopefully) pockets of wave breaking, we can flood fill from a known
-      !stratosphere region (e.g., model top > 2pvu) and hopefully filter down around any trouble regions.
-      !The problem w/ using only the flood fill is that strong surface PV anomalies can connect to 2pvu, 
-      !and the resulting "flood-filled 2 pvu" can have sizeable areas that are just at the surface while there is clearly a tropopause above (e.g., in a cross-section).
-      !To address large surface blobs, take the flood fill mask and try to go up from the surface to 10 pvu w/in column. If can, all stratosphere. Else, disconnect "surface blob".
+      !To (hopefully) alleviate the problems resulting from wave breaking, we can flood fill from a known
+      !stratosphere region (e.g., where the model top > 2 PVU) and filter down and around any problematic regions.
+      !The problem w/ using only the flood fill is that strong surface PV anomalies can connect to the 2-PVU surface aloft,
+      !and the resulting "flood-filled 2 PVU" region can have sizeable areas that are located just at/near the surface, while there is clearly a 
+      !tropopause above (i.e., as evident in a vertical cross-section).
+      !To address the large near-surface blobs of PV > 2 PVU, will take the flood fill mask and try to move upward from near the surface to 10 PVU within a vertical column. 
+      !If this can be done, then the low-level PV anomaly extends to the stratosphere. Else, remove the stratospheric designation to disconnect the "surface blob".
       
-      !The "output" is iLev_DT, which is the vertical index for the level >= pvuVal. If >nVertLevels, pvuVal above column. If <2, pvuVal below column.
+      !The "output" is iLev_DT, which is the vertical index for the model level just above the dynamic tropopause (i.e., where PV >= pvuVal, which is set below in atm_compute_pv_diagnostics to 2 PVU). 
+      !If iLev_DT > nVertLevels, then pvuVal is found only above the column (i.e., entire column is in troposphere). If iLev_DT < 1, PV >= pvuVal extends vertically through the entire column 
+      !(i.e., the entire column is within the stratosphere).
       !Communication between blocks during the flood fill may be needed to treat some edge cases appropriately.
 
       use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -421,6 +421,10 @@ module pv_diagnostics
 
    end function calc_vertDeriv_one
    
+   !Below are two subroutines (floodFill_strato and floodFill_tropo) designed to determine the model level above the dynamic tropopause, iLev_DT. 
+   !Only one of these subroutines is used (toggled with "call floodFill_strato(mesh, diag, pvuVal, stratoPV)" and "call floodFill_tropo(mesh,diag,pvuVal)"
+   !in the subroutines below.
+   
    subroutine floodFill_strato(mesh, diag, pvuVal, stratoPV)
       !Searching down each column from TOA to find 2pvu surface is buggy with stratospheric wave breaking,
       !since will find 2 pvu at a higher level than "tropopause". This looks to be worse as mesh gets finer and vertical vorticity jumps.


### PR DESCRIPTION
This merge fixes an issue in the calc_pvBudget subroutine, which mistakenly called dtheta_dt_mp instead of the diabatic heating tendency from the microphysics scheme. The floodFillStrato subroutine was also modified to be consistent with the domain communication modifications that were previously added to the floodFillTropo subroutine. 
