### PR TITLE
fixed option for the seaice albedo

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -758,7 +758,6 @@
 			<var name="noahres"/>
 			<var name="potevp"/>
 			<var name="sfc_albedo"/>
-			<var name="sfc_albedo_seaice"/>
 			<var name="sfc_emiss"/>
 			<var name="sfc_emibck"/>
 			<var name="sfcrunoff"/>
@@ -2780,9 +2779,6 @@
 
                 <var name="sfc_albedo" type="real" dimensions="nCells Time" units="unitless"
                      description="surface albedo"/>
-
-                <var name="sfc_albedo_seaice" type="real" dimensions="nCells Time" units="unitless"
-                     description="surface albedo over seaice"/>
 
                 <var name="sfc_emiss" type="real" dimensions="nCells Time" units="unitless"
                      description="surface emissivity"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -93,6 +93,10 @@
 ! * added call to seaice_noah to include the parameterization of seaice for the updated Noah land surface
 !   scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-19.
+! * the initialization of the variable albsi_p is switched from sfc_albedo_seaice (which is originally
+!   initialized to albbck to seaice_albedo_default. Note that albsi_p is not used if seaice_albedo_opt = 0.
+!   Laura D. Fowler (laura@ucar.edu) / 2020-05-10.
+
 
 !
 ! DOCUMENTATION:
@@ -507,7 +511,7 @@
     !seaice thickness.
     do j = jts,jte
     do i = its,ite
-       albsi_p(i,j)    = sfc_albedo_seaice(i)
+       albsi_p(i,j)    = seaice_albedo_default
        icedepth_p(i,j) = seaice_thickness_default
        snowsi_p(i,j)   = seaice_snowdepth_min
     enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -317,9 +317,8 @@
 
  real(kind=RKIND),dimension(:),pointer  :: acsnom,acsnow,canwat,chs,chs2,chklowq,cpm,cqs2,glw,   &
                                            grdflx,gsw,hfx,lai,lh,noahres,potevp,qfx,qgh,qsfc,    &
-                                           br,sfc_albedo,sfc_albedo_seaice,sfc_emibck,sfc_emiss, &
-                                           sfcrunoff,smstav,smstot,snotime,snopcx,sr,udrunoff,   &
-                                           z0,znt
+                                           br,sfc_albedo,sfc_emibck,sfc_emiss,sfcrunoff,smstav,  &
+                                           smstot,snotime,snopcx,sr,udrunoff,z0,znt
  real(kind=RKIND),dimension(:),pointer  :: shdmin,shdmax,snoalb,sfc_albbck,snow,snowc,snowh,tmn, &
                                            skintemp,vegfra,xice,xland
  real(kind=RKIND),dimension(:),pointer  :: t2m,th2m,q2
@@ -358,7 +357,6 @@
  call mpas_pool_get_array(diag_physics,'qsfc'             ,qsfc             )
  call mpas_pool_get_array(diag_physics,'br'               ,br               )
  call mpas_pool_get_array(diag_physics,'sfc_albedo'       ,sfc_albedo       )
- call mpas_pool_get_array(diag_physics,'sfc_albedo_seaice',sfc_albedo_seaice)
  call mpas_pool_get_array(diag_physics,'sfc_emibck'       ,sfc_emibck       )
  call mpas_pool_get_array(diag_physics,'sfc_emiss'        ,sfc_emiss        )
  call mpas_pool_get_array(diag_physics,'sfcrunoff'        ,sfcrunoff        )

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -108,7 +108,7 @@
  real(kind=RKIND),dimension(:),pointer:: latCell
  real(kind=RKIND),dimension(:),pointer:: snoalb,snowc,xice
  real(kind=RKIND),dimension(:),pointer:: albbck,embck,xicem,xland,z0
- real(kind=RKIND),dimension(:),pointer:: mavail,sfc_albedo,sfc_albedo_seaice,sfc_emiss,thc,ust,znt
+ real(kind=RKIND),dimension(:),pointer:: mavail,sfc_albedo,sfc_emiss,thc,ust,znt
 
 !local variables:
  character(len=StrKIND) :: lutype
@@ -155,7 +155,6 @@
  call mpas_pool_get_array(diag_physics,'sfc_emibck'       ,embck            )
  call mpas_pool_get_array(diag_physics,'mavail'           ,mavail           )
  call mpas_pool_get_array(diag_physics,'sfc_albedo'       ,sfc_albedo       )
- call mpas_pool_get_array(diag_physics,'sfc_albedo_seaice',sfc_albedo_seaice)
  call mpas_pool_get_array(diag_physics,'sfc_emiss'        ,sfc_emiss        )
  call mpas_pool_get_array(diag_physics,'thc'              ,thc              )
  call mpas_pool_get_array(diag_physics,'ust'              ,ust              )
@@ -286,7 +285,6 @@
     if(xice(iCell) .ge. xice_threshold) then
        albbck(iCell) = albd(isice,isn) / 100.
        embck(iCell)  = sfem(isice,isn)
-       sfc_albedo_seaice(iCell) = albbck(iCell)
        if(config_frac_seaice) then
           !0.08 is the albedo over open water.
           !0.98 is the emissivity over open water.
@@ -301,9 +299,6 @@
        znt(iCell) = z0(iCell)
 
        if(associated(mavail)) mavail(iCell) = slmo(isice,isn)
-    else
-       !over seaice-free cells, initialize sfc_albedo_seaice with the background surface albedo:
-       sfc_albedo_seaice(iCell) = albbck(iCell)
     endif
 
  enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -110,6 +110,10 @@
 ! * added the local variables cosa_p and sina_p needed in call to subroutine gwdo after updating module_bl_gwdo.F
 !   to that of WRF version 4.0.2
 !   Laura D. Fowler (laura@ucar.edu) / 2019-01-30.
+! * reverted the option seaice_albedo_opt = 2 to seaic_albedo_opt = 0 since MPAS does not currently support the
+!   input of "observed" 2D seaice albedos. In conjunction with this update, we also change the initialization of
+!   albsi from albbck to seaice_albedo_default.
+!   Laura D. Fowler (laura@ucar.edu) / 2022-05-10.
 
 
 !=================================================================================================================
@@ -489,10 +493,12 @@
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of seaice:
+!... the options set for seaice_albedo_opt, seaice_thickness_opt, and seaicesnowdepth_opt must not be changed
+!    since they are the only ones currently available.
 !=================================================================================================================
 
  integer,parameter:: &
-    seaice_albedo_opt    = 2           !option to set albedo over sea ice.
+    seaice_albedo_opt    = 0           !option to set albedo over sea ice.
                                        !0 = seaice albedo is constant set in seaice_albedo_default.
                                        !1 = seaice albedo is f(Tair,Tskin,Tsnow), following Mill (2011).
                                        !2 = seaice albedo is read in from input variable albsi.


### PR DESCRIPTION
The parameter seaice_albedo_opt that initializes the seaice albedo was wrongly set to 2 instead of 0 in mpas_atmphys_vars.F. Setting seaice_albedo_opt to 2 assumes that we will read an input array (albsi) of the seaice albedo (for example observed values). This option is currently not available in MPAS. We set seaice_albedo_opt to 0 which initializes the seaice albedo to its default value (seaice_albedo_default) for all grid cells with fractional seaice vales greater than zero. 


