### PR TITLE
Fix invalid OpenMP directive placement in physics_driver

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -225,21 +225,23 @@
     !
     ! For all timesteps, we transfer MPAS state to physics
     !
-!$OMP PARALLEL DO
     if (mpas_cpl%role_is(ROLE_RADIATION)) then
+!$OMP PARALLEL DO
     do thread=1,nThreads
        call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
     end do
+!$OMP END PARALLEL DO
     else
+!$OMP PARALLEL DO
     do thread=1,nThreads
        call MPAS_to_physics_gpu(block%configs,mesh,state,time_lev,diag,diag_physics, &
                             mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
     end do
-    end if
 !$OMP END PARALLEL DO
+    end if
 
     !call to cloud scheme:
     if(l_radtlw .or. l_radtsw) then


### PR DESCRIPTION
This PR corrects invalid placement of OpenMP directives in the MPAS-A `physics_driver` routine.

Prior to the introduction of the lagged radiation capability in MPAS-A, the call
to MPAS_to_physics that was made within the physics_driver routine was threaded
with OMP PARALLEL directives like so:
```fortran
!$OMP PARALLEL DO
    do thread=1,nThreads
       call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                            cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
    end do
!$OMP END PARALLEL DO
```
Later, during the introduction of lagged radiation and subsequent OpenACC port,
an MPAS_to_physics_gpu version of the the MPAS_to_physics was introduced, and a
conditional surrounding the calls to these routines was added:
```fortran
!$OMP PARALLEL DO
    if (mpas_cpl%role_is(ROLE_RADIATION)) then
    do thread=1,nThreads
       call MPAS_to_physics(block%configs,mesh,state,time_lev,diag,diag_physics, &
                            mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                            cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
    end do
    else
    do thread=1,nThreads
       call MPAS_to_physics_gpu(block%configs,mesh,state,time_lev,diag,diag_physics, &
                            mpas_cpl, cells_to_rad_handle, cells_from_rad_handle, &
                            cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
    end do
    end if
!$OMP END PARALLEL DO
```
Because the OMP PARALLEL DO directives weren't properly updated, this lead to a
compilation failure when OPENMP=true is specified in the build command, since
the OMP PARALLEL DO directives are no longer immediately before do-loops.

The simple fix in this PR is to place OMP PARALLEL DO directives immediately
around the two do-loops over nThreads for both the MPAS_to_physics and
MPAS_to_physics_gpu calls.
