### PR TITLE
Ensure that calls to MPAS_coupler_transfer_field only happen from one thread

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -411,6 +411,8 @@
  if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
      mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, latCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, lonCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, m_hybiField, ierr=ierr)
@@ -429,6 +431,8 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, cldfracField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, o3climField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, o3vmrField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
  end if
 
@@ -840,6 +844,8 @@
     if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
         mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, glwField   , ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwcfField  , ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwdnbField , ierr=ierr)
@@ -852,6 +858,8 @@
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwuptcField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, olrtoaField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenlwField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
     end if
 
@@ -928,6 +936,8 @@
  if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
      mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, glwField   , ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwcfField  , ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwdnbField , ierr=ierr)
@@ -940,6 +950,8 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, lwuptcField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, olrtoaField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenlwField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
  end if
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -404,6 +404,8 @@
  if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
      mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, latCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, lonCellField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, m_hybiField, ierr=ierr)
@@ -423,6 +425,8 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, sfc_emissField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, cldfracField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, o3climField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
  end if
 
@@ -757,6 +761,8 @@
     if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
         mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swcfField, ierr=ierr)
@@ -769,6 +775,8 @@
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swuptField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swuptcField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenswField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
     end if
 
@@ -848,6 +856,8 @@
  if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
      mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, coszrField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, gswField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swcfField, ierr=ierr)
@@ -860,6 +870,8 @@
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swuptField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, swuptcField, ierr=ierr)
     call MPAS_coupler_transfer_field(mpas_cpl, cells_from_rad_handle, rthratenswField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
  end if
 

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -319,6 +319,8 @@
     if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
         mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_pField, ierr=ierr)
@@ -332,6 +334,8 @@
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, scalarsField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, surface_pressureField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, plradField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
     end if
  end if
@@ -646,6 +650,8 @@
     if (mpas_cpl%role_is(ROLE_INTEGRATE) .or. &
         mpas_cpl%role_is(ROLE_RADIATION)) then
 
+!$OMP BARRIER
+!$OMP MASTER
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, exnerField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_bField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, pressure_pField, ierr=ierr)
@@ -659,6 +665,8 @@
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, scalarsField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, surface_pressureField, ierr=ierr)
        call MPAS_coupler_transfer_field(mpas_cpl, cells_to_rad_handle, plradField, ierr=ierr)
+!$OMP END MASTER
+!$OMP BARRIER
 
     end if
 !$acc update device(exner, pressure_b, pressure_p, rtheta_b, rtheta_p, u, v, rho_zz, &


### PR DESCRIPTION
This PR addresses a correctness issue when MPAS-A is run with lagged radiation
and OpenMP threading by ensuring that calls to MPAS_coupler_transfer_field are
only made by one thread.

Various calls to MPAS_coupler_transfer_field, which uses MPI to transfer fields
between different roles, are made inside threaded regions in the MPAS-A physics
drivers. However, these calls to MPAS_coupler_transfer_field should only be made
by a single thread. These calls should only happen after all threads have
reached the call site, and furthermore, no thread should continue executing
until after the field transfers have completed.

To ensure correct execution when MPAS-A is running with lagged radiation (which
necessitates calls to transfer fields between radiation and dynamics ranks) and
OpenMP threading enabled, the calls to MPAS_coupler_transfer_field are preceded
by an OMP BARRIER, surrounded by OMP MASTER directives, and followed by another
OMP BARRIER.
