### PR TITLE
Report runtime settings for MPI and OpenMP in [init_]atmosphere log files

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -240,6 +240,9 @@ module atm_core_interface
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
+#ifdef MPAS_OPENMP
+      use mpas_threading, only : mpas_threading_get_num_threads
+#endif
 
       implicit none
 
@@ -302,6 +305,13 @@ module atm_core_interface
                           '2.x')
 #else
                           '1.x')
+#endif
+      call mpas_log_write('')
+
+      call mpas_log_write('Run-time settings:')
+      call mpas_log_write('  MPI task count: $i', intArgs=[domain % dminfo % nprocs])
+#ifdef MPAS_OPENMP
+      call mpas_log_write('  OpenMP max threads: $i', intArgs=[mpas_threading_get_max_threads()])
 #endif
       call mpas_log_write('')
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -311,6 +311,9 @@ module init_atm_core_interface
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
+#ifdef MPAS_OPENMP
+      use mpas_threading, only : mpas_threading_get_num_threads
+#endif
 
       implicit none
 
@@ -373,6 +376,13 @@ module init_atm_core_interface
                           '2.x')
 #else
                           '1.x')
+#endif
+      call mpas_log_write('')
+
+      call mpas_log_write('Run-time settings:')
+      call mpas_log_write('  MPI task count: $i', intArgs=[domain % dminfo % nprocs])
+#ifdef MPAS_OPENMP
+      call mpas_log_write('  OpenMP max threads: $i', intArgs=[mpas_threading_get_max_threads()])
 #endif
       call mpas_log_write('')
 


### PR DESCRIPTION
This PR adds code to report runtime settings for MPI and OpenMP near the beginning
of log files for the init_atmosphere and atmosphere cores.

The setup_log routines for the init_atmosphere and atmosphere cores now write
messages about the runtime values of MPI task count and maximum OpenMP thread
count to log files. For example:
```
 Run-time settings:
   MPI task count: 6
   OpenMP max threads: 4
```
This information can be helpful in determining the parallel runtime settings
that were used for a run when only log files are available.

Note that, if OPENMP=true was not specified in the build options, then no
reporting of the maximum OpenMP thread count is performed. This allows for
disambiguation of cases where the model was run with a single OpenMP thread or
with no OpenMP support at all.