### PR TITLE
Remove block loops from mpas_atm_time_integration.F

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -203,8 +203,8 @@ module atm_time_integration
       clock => domain % clock
       block => domain % blocklist
 
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_time_integration', config_time_integration)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_apply_lbcs', config_apply_lbcs)
+      call mpas_pool_get_config(block % configs, 'config_time_integration', config_time_integration)
+      call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
 
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep)
@@ -323,24 +323,24 @@ module atm_time_integration
       !
       ! Retrieve configuration options
       !
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_number_of_sub_steps', config_number_of_sub_steps)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_time_integration_order', config_time_integration_order)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_scalar_advection', config_scalar_advection)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_positive_definite', config_positive_definite)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_monotonic', config_monotonic)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', config_dt)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_IAU_option', config_IAU_option)
+      call mpas_pool_get_config(block % configs, 'config_number_of_sub_steps', config_number_of_sub_steps)
+      call mpas_pool_get_config(block % configs, 'config_time_integration_order', config_time_integration_order)
+      call mpas_pool_get_config(block % configs, 'config_scalar_advection', config_scalar_advection)
+      call mpas_pool_get_config(block % configs, 'config_positive_definite', config_positive_definite)
+      call mpas_pool_get_config(block % configs, 'config_monotonic', config_monotonic)
+      call mpas_pool_get_config(block % configs, 'config_dt', config_dt)
+      call mpas_pool_get_config(block % configs, 'config_IAU_option', config_IAU_option)
 
       !  config variables for dynamics-transport splitting, WCS 18 November 2014
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_split_dynamics_transport', config_split_dynamics_transport)
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_dynamics_split_steps', config_dynamics_split)
+      call mpas_pool_get_config(block % configs, 'config_split_dynamics_transport', config_split_dynamics_transport)
+      call mpas_pool_get_config(block % configs, 'config_dynamics_split_steps', config_dynamics_split)
 
       !
       ! Retrieve field structures
       !
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'tend_physics', tend_physics)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
 
       !
       ! Retrieve fields
@@ -713,7 +713,7 @@ module atm_time_integration
             !***********************************
 
 ! tend_u
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'tend', tend)
+            call mpas_pool_get_subpool(block % structs, 'tend', tend)
             call mpas_pool_get_field(tend, 'u', tend_u_field)
             call mpas_dmpar_exch_halo_field(tend_u_field, (/ 1 /))
    
@@ -776,9 +776,9 @@ module atm_time_integration
                   allocate(ru_driving_tend(nVertLevels,nEdges+1))
                   allocate(rt_driving_tend(nVertLevels,nCells+1))
                   allocate(rho_driving_tend(nVertLevels,nCells+1))
-                  ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nEdges, 'ru', 0.0_RKIND )
-                  rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
-                  rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
+                  ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nEdges, 'ru', 0.0_RKIND )
+                  rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
+                  rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
 !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_dynamics_speczone_tend( tend, mesh, block % configs, nVertLevels,                 &
@@ -821,9 +821,9 @@ module atm_time_integration
                   allocate(rho_driving_values(nVertLevels,nCells+1))
 
                   time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nEdges, 'ru', time_dyn_step )
-                  rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-                  rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
+                  rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+                  rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
 
 !$OMP PARALLEL DO
                   do thread=1,nThreads
@@ -851,7 +851,7 @@ module atm_time_integration
 
             do small_step = 1, number_sub_steps(rk_step)
 
-               call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_field(diag, 'rho_pp', rho_pp_field)
                call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
 
@@ -900,7 +900,7 @@ module atm_time_integration
 ! rtheta_pp
 ! This is the only communications needed during the acoustic steps because we solve for u on all edges of owned cells
 
-               call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_field(diag, 'rtheta_pp', rtheta_pp_field)
                call mpas_dmpar_exch_halo_field(rtheta_pp_field, (/ 1 /))
 
@@ -927,7 +927,7 @@ module atm_time_integration
             end do  ! end of acoustic steps loop
 
             !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_field(diag, 'rw_p', rw_p_field)
             call mpas_dmpar_exch_halo_field(rw_p_field)
 
@@ -1002,7 +1002,7 @@ module atm_time_integration
 
                   time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
 
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nEdges, 'u', time_dyn_step )
+                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'u', time_dyn_step )
                   ! do this inline at present - it is simple enough
                   do iEdge = 1, nEdgesSolve
                      if(bdyMaskEdge(iEdge) > nRelaxZone) then
@@ -1012,7 +1012,7 @@ module atm_time_integration
                      end if
                   end do
 
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nEdges, 'ru', time_dyn_step )
+                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
                   call mpas_pool_get_array(diag, 'ru', u)
                   ! do this inline at present - it is simple enough
                   do iEdge = 1, nEdges
@@ -1031,7 +1031,7 @@ module atm_time_integration
             
             ! u
             !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % state % time_levs(2) % state % u, (/ 3 /))
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'u', u_field, 2)
             call mpas_dmpar_exch_halo_field(u_field)
 
@@ -1078,28 +1078,28 @@ module atm_time_integration
                      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
                      if (index_qv > 0) then
-                        scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
+                        scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
                      end if
                      if (index_qc > 0) then
-                        scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
+                        scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
                      end if
                      if (index_qr > 0) then
-                        scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
+                        scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
                      end if
                      if (index_qi > 0) then
-                        scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
+                        scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
                      end if
                      if (index_qs > 0) then
-                        scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
+                        scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
                      end if
                      if (index_qg > 0) then
-                        scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
+                        scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
                      end if
                      if (index_nr > 0) then
-                        scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
+                        scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                      end if
                      if (index_ni > 0) then
-                        scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                        scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                      end if
                   
                      !$OMP PARALLEL DO
@@ -1158,12 +1158,12 @@ module atm_time_integration
 
 
             ! w
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'w', w_field, 2)
             call mpas_dmpar_exch_halo_field(w_field)
 
             ! pv_edge
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_field(diag, 'pv_edge', pv_edge_field)
             call mpas_dmpar_exch_halo_field(pv_edge_field)
 
@@ -1196,7 +1196,7 @@ module atm_time_integration
 
 
               ! w halo values needs resetting after regional boundary update
-              call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
+              call mpas_pool_get_subpool(block % structs, 'state', state)
               call mpas_pool_get_field(state, 'w', w_field, 2)
               call mpas_dmpar_exch_halo_field(w_field)
 
@@ -1205,7 +1205,7 @@ module atm_time_integration
          end do RK3_DYNAMICS
 
          if (dynamics_substep < dynamics_split) then
-            call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'theta_m', theta_m_field, 2)
 
             call mpas_dmpar_exch_halo_field(theta_m_field)
@@ -1326,28 +1326,28 @@ module atm_time_integration
                   call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
                   if (index_qv > 0) then
-                     scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
+                     scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
                   end if
                   if (index_qc > 0) then
-                     scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
+                     scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
                   end if
                   if (index_qr > 0) then
-                     scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
+                     scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
                   end if
                   if (index_qi > 0) then
-                     scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
+                     scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
                   end if
                   if (index_qs > 0) then
-                     scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
+                     scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
                   end if
                   if (index_qg > 0) then
-                     scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
+                     scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
                   end if
                   if (index_nr > 0) then
-                     scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
+                     scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
                   end if
                   if (index_ni > 0) then
-                     scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                     scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
                   
 !$OMP PARALLEL DO
@@ -1482,8 +1482,8 @@ module atm_time_integration
             allocate(rho_driving_values(nVertLevels,nCells+1))
             time_dyn_step = dt  ! end of full timestep values
 
-            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
 
 !$OMP PARALLEL DO
             do thread=1,nThreads
@@ -1539,28 +1539,28 @@ module atm_time_integration
             call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
 
             if (index_qv > 0) then
-               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qv', dt )
+               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
             end if
             if (index_qc > 0) then
-               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qc', dt )
+               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', dt )
             end if
             if (index_qr > 0) then
-               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qr', dt )
+               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', dt )
             end if
             if (index_qi > 0) then
-               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qi', dt )
+               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', dt )
             end if
             if (index_qs > 0) then
-               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qs', dt )
+               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', dt )
             end if
             if (index_qg > 0) then
-               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'qg', dt )
+               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
             end if
             if (index_nr > 0) then
-               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'nr', dt )
+               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
             end if
             if (index_ni > 0) then
-               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, domain % blocklist, nVertLevels, nCells, 'ni', dt )
+               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
             end if
       
 !$OMP PARALLEL DO
@@ -6658,9 +6658,9 @@ module atm_time_integration
        real (kind=RKIND), dimension(:,:), pointer :: u, v, uReconstructZonal, uReconstructMeridional, uReconstructX, uReconstructY, uReconstructZ
        real (kind=RKIND), dimension(:,:,:), pointer :: scalars, scalars_1, scalars_2
 
-       call mpas_pool_get_config(domain % blocklist % configs, 'config_print_global_minmax_vel', config_print_global_minmax_vel)
-       call mpas_pool_get_config(domain % blocklist % configs, 'config_print_detailed_minmax_vel', config_print_detailed_minmax_vel)
-       call mpas_pool_get_config(domain % blocklist % configs, 'config_print_global_minmax_sca', config_print_global_minmax_sca)
+       call mpas_pool_get_config(block % configs, 'config_print_global_minmax_vel', config_print_global_minmax_vel)
+       call mpas_pool_get_config(block % configs, 'config_print_detailed_minmax_vel', config_print_detailed_minmax_vel)
+       call mpas_pool_get_config(block % configs, 'config_print_global_minmax_sca', config_print_global_minmax_sca)
 
       if (config_print_detailed_minmax_vel) then
          call mpas_log_write('')

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -343,8 +343,13 @@ module atm_time_integration
       ! Retrieve field structures
       !
       call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
       call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'tend', tend)
       call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
+#ifdef DO_PHYSICS
+      call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
+#endif
 
       !
       ! Retrieve fields
@@ -443,12 +448,6 @@ module atm_time_integration
 
 
       call mpas_timer_start('atm_rk_integration_setup')
-
-      call mpas_pool_get_subpool(block % structs, 'state', state)
-      call mpas_pool_get_subpool(block % structs, 'diag', diag)
-      ! mesh is needed for atm_compute_moist_coefficients
-      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
       call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
@@ -481,11 +480,6 @@ module atm_time_integration
       call mpas_timer_stop('atm_rk_integration_setup')
 
       call mpas_timer_start('atm_compute_moist_coefficients')
-      call mpas_pool_get_subpool(block % structs, 'state', state)
-      call mpas_pool_get_subpool(block % structs, 'diag', diag)
-      ! mesh is needed for atm_compute_moist_coefficients
-      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
       call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
@@ -519,11 +513,6 @@ module atm_time_integration
 
 #ifdef DO_PHYSICS
       call mpas_timer_start('physics_get_tend')
-      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-      call mpas_pool_get_subpool(block % structs, 'state', state)
-      call mpas_pool_get_subpool(block % structs, 'diag', diag)
-      call mpas_pool_get_subpool(block % structs, 'tend', tend)
-      call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
       rk_step = 1
       dynamics_substep = 1
       call physics_get_tend( block, &
@@ -564,10 +553,6 @@ module atm_time_integration
          !  Compute the coefficients for the vertically implicit solve in the acoustic step.
          !  These coefficients will work for the first acoustic step in all cases.
          call mpas_timer_start('atm_compute_vert_imp_coefs')
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
 
          call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
@@ -610,11 +595,6 @@ module atm_time_integration
 
               !  Compute the coefficients for the vertically implicit solve in the acoustic step.
               !  These coefficients will work for the 2nd and 3rd acoustic steps (dt is the same for both).
-              call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-              call mpas_pool_get_subpool(block % structs, 'state', state)
-              call mpas_pool_get_subpool(block % structs, 'diag', diag)
-              call mpas_pool_get_subpool(block % structs, 'tend', tend)
-   
               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
@@ -641,13 +621,6 @@ module atm_time_integration
             end if  
 
             call mpas_timer_start('atm_compute_dyn_tend')
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
-#ifdef DO_PHYSICS
-            call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-#endif
    
             call mpas_pool_get_dimension(mesh, 'nCells', nCells)
             call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
@@ -717,16 +690,10 @@ module atm_time_integration
             !***********************************
 
 ! tend_u
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
             call mpas_pool_get_field(tend, 'u', tend_u_field)
             call mpas_dmpar_exch_halo_field(tend_u_field, (/ 1 /))
    
             call mpas_timer_start('small_step_prep')
-
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
    
             call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
@@ -757,10 +724,6 @@ module atm_time_integration
 !------------------------------------------------------------------------------------------------------------------------
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
-
-
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'tend', tend)
    
                call mpas_pool_get_dimension(mesh, 'nCells', nCells)
                call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
@@ -799,11 +762,6 @@ module atm_time_integration
                deallocate(rho_driving_tend)
 
 ! -------- next, add in the tendencies for the horizontal filters and Rayleigh damping.  We will keep the spec zone and relax zone adjustments separate for now...
-               
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'tend', tend)
    
                call mpas_pool_get_dimension(mesh, 'nCells', nCells)
                call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
@@ -853,17 +811,10 @@ module atm_time_integration
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
             do small_step = 1, number_sub_steps(rk_step)
-
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_field(diag, 'rho_pp', rho_pp_field)
                call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
 
                call mpas_timer_start('atm_advance_acoustic_step')
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'tend', tend)
-
                call mpas_pool_get_dimension(mesh, 'nCells', nCells)
                call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
@@ -902,18 +853,12 @@ module atm_time_integration
   
 ! rtheta_pp
 ! This is the only communications needed during the acoustic steps because we solve for u on all edges of owned cells
-
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_field(diag, 'rtheta_pp', rtheta_pp_field)
                call mpas_dmpar_exch_halo_field(rtheta_pp_field, (/ 1 /))
 
 !  complete update of horizontal momentum by including 3d divergence damping at the end of the acoustic step
 
                call mpas_timer_start('atm_divergence_damping_3d')
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-
                call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
                call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
                call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
@@ -930,7 +875,6 @@ module atm_time_integration
             end do  ! end of acoustic steps loop
 
             !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_field(diag, 'rw_p', rw_p_field)
             call mpas_dmpar_exch_halo_field(rw_p_field)
 
@@ -946,12 +890,6 @@ module atm_time_integration
             call mpas_dmpar_exch_halo_field(rtheta_pp_field, (/ 2 /))
 
             call mpas_timer_start('atm_recover_large_step_variables')
-
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
-
             call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
             call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
@@ -990,9 +928,6 @@ module atm_time_integration
 
                ! First, (re)set the value of u and ru in the specified zone at the outermost edge (we will reset all for now).
                ! atm_recover_large_step_variables will not have set outermost edge velocities correctly.
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
                call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
                call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
@@ -1032,7 +967,6 @@ module atm_time_integration
             
             ! u
             !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % state % time_levs(2) % state % u, (/ 3 /))
-            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'u', u_field, 2)
             call mpas_dmpar_exch_halo_field(u_field)
 
@@ -1048,10 +982,6 @@ module atm_time_integration
 
                   call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                   call mpas_dmpar_exch_halo_field(scalars_field)
-
-                  call mpas_pool_get_subpool(block % structs, 'state', state)
-                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
    
                   call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
                   call mpas_pool_get_dimension(mesh, 'nCells', nCells)
@@ -1118,10 +1048,6 @@ module atm_time_integration
             end if
 
             call mpas_timer_start('atm_compute_solve_diagnostics')
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-   
             call mpas_pool_get_dimension(state, 'nEdges', nEdges)
             call mpas_pool_get_dimension(state, 'nVertices', nVertices)
             call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
@@ -1158,12 +1084,10 @@ module atm_time_integration
 
 
             ! w
-            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'w', w_field, 2)
             call mpas_dmpar_exch_halo_field(w_field)
 
             ! pv_edge
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_field(diag, 'pv_edge', pv_edge_field)
             call mpas_dmpar_exch_halo_field(pv_edge_field)
 
@@ -1180,8 +1104,6 @@ module atm_time_integration
             ! set the zero-gradient condition on w for regional_MPAS
             
             if ( config_apply_lbcs ) then  ! regional_MPAS addition
-              call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-              call mpas_pool_get_subpool(block % structs, 'state', state)
               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
@@ -1195,7 +1117,6 @@ module atm_time_integration
 
 
               ! w halo values needs resetting after regional boundary update
-              call mpas_pool_get_subpool(block % structs, 'state', state)
               call mpas_pool_get_field(state, 'w', w_field, 2)
               call mpas_dmpar_exch_halo_field(w_field)
             end if ! end of regional_MPAS addition 
@@ -1203,7 +1124,6 @@ module atm_time_integration
          end do RK3_DYNAMICS
 
          if (dynamics_substep < dynamics_split) then
-            call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_field(state, 'theta_m', theta_m_field, 2)
 
             call mpas_dmpar_exch_halo_field(theta_m_field)
@@ -1225,8 +1145,6 @@ module atm_time_integration
          !  Notes:  physics tendencies for scalars should be OK coming out of dynamics
 
          call mpas_timer_start('atm_rk_dynamics_substep_finish')
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
 
          call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
@@ -1293,11 +1211,6 @@ module atm_time_integration
 
                call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                call mpas_dmpar_exch_halo_field(scalars_field)
-
-
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
    
                call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
                call mpas_pool_get_dimension(mesh, 'nCells', nCells)
@@ -1375,10 +1288,6 @@ module atm_time_integration
       !
       ! reconstruct full velocity vectors at cell centers:
       !
-      call mpas_pool_get_subpool(block % structs, 'state', state)
-      call mpas_pool_get_subpool(block % structs, 'diag', diag)
-      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
       call mpas_pool_get_array(state, 'u', u, 2)
       call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
       call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
@@ -1401,13 +1310,6 @@ module atm_time_integration
       !
 
 #ifdef DO_PHYSICS
-
-      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-      call mpas_pool_get_subpool(block % structs, 'state', state)
-      call mpas_pool_get_subpool(block % structs, 'diag', diag)
-      call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
-      call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-      call mpas_pool_get_subpool(block % structs, 'tend', tend)
       call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
       call mpas_pool_get_dimension(state, 'index_qv', index_qv)
@@ -1459,10 +1361,6 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
-        call mpas_pool_get_subpool(block % structs, 'state', state)
-        call mpas_pool_get_subpool(block % structs, 'diag', diag)
-        call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-
         call mpas_pool_get_dimension(mesh, 'nCells', nCells)
         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
@@ -1498,9 +1396,6 @@ module atm_time_integration
 
          call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
          call mpas_dmpar_exch_halo_field(scalars_field)
-
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
    
          call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(mesh, 'nCells', nCells)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -70,7 +70,7 @@ module atm_time_integration
    real (kind=RKIND), allocatable, dimension(:,:) :: ke_edge
 
    type (MPAS_Clock_type), pointer, private :: clock
-   type (block_type), pointer, private :: blocklist
+   type (block_type), pointer, private :: block
 
 
    ! Used for Rayleigh damping on u
@@ -192,7 +192,6 @@ module atm_time_integration
       integer, intent(in) :: itimestep
 
 
-      type (block_type), pointer :: block
       type (MPAS_Time_type) :: currTime
       type (MPAS_TimeInterval_type) :: dtInterval
       character (len=StrKIND), pointer :: xtime
@@ -202,7 +201,7 @@ module atm_time_integration
 
 
       clock => domain % clock
-      blocklist => domain % blocklist
+      block => domain % blocklist
 
       call mpas_pool_get_config(domain % blocklist % configs, 'config_time_integration', config_time_integration)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_apply_lbcs', config_apply_lbcs)
@@ -218,13 +217,9 @@ module atm_time_integration
       currTime = nowTime + dtInterval
       call mpas_get_time(currTime, dateTimeString=xtime_new)
 
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_array(state, 'xtime', xtime, 2)
          xtime = xtime_new
-         block => block % next
-      end do
 
    end subroutine atm_timestep
 
@@ -251,7 +246,6 @@ module atm_time_integration
 
       integer :: thread
       integer :: iCell, k, iEdge
-      type (block_type), pointer :: block
 
       integer, pointer :: nThreads
       integer, dimension(:), pointer :: cellThreadStart, cellThreadEnd
@@ -446,8 +440,6 @@ module atm_time_integration
 
       call mpas_timer_start('atm_rk_integration_setup')
 
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'diag', diag)
          ! mesh is needed for atm_compute_moist_coefficients
@@ -482,13 +474,9 @@ module atm_time_integration
          end do
 !$OMP END PARALLEL DO
 
-         block => block % next
-      end do
       call mpas_timer_stop('atm_rk_integration_setup')
 
       call mpas_timer_start('atm_compute_moist_coefficients')
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'diag', diag)
          ! mesh is needed for atm_compute_moist_coefficients
@@ -523,14 +511,10 @@ module atm_time_integration
          end do
 !$OMP END PARALLEL DO
 
-         block => block % next
-      end do
       call mpas_timer_stop('atm_compute_moist_coefficients')
 
 #ifdef DO_PHYSICS
       call mpas_timer_start('physics_get_tend')
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -550,8 +534,6 @@ module atm_time_integration
                       tend_ru_physics, &
                   tend_rtheta_physics, &
                      tend_rho_physics )
-         block => block % next
-      end do
       call mpas_timer_stop('physics_get_tend')
 #else
 #ifndef MPAS_CAM_DYCORE
@@ -568,12 +550,8 @@ module atm_time_integration
       ! IAU - Incremental Analysis Update
       !
       if (trim(config_IAU_option) /= 'off') then
-         block => domain % blocklist
-         do while (associated(block))
             call atm_add_tend_anal_incr(block % configs, block % structs, itimestep, dt, &
                                         tend_ru_physics, tend_rtheta_physics, tend_rho_physics)
-            block => block % next
-        end do
       end if
 
 
@@ -582,8 +560,6 @@ module atm_time_integration
          !  Compute the coefficients for the vertically implicit solve in the acoustic step.
          !  These coefficients will work for the first acoustic step in all cases.
          call mpas_timer_start('atm_compute_vert_imp_coefs')
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
             call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -613,8 +589,6 @@ module atm_time_integration
                                           edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
             end do
 !$OMP END PARALLEL DO
-            block => block % next
-         end do
          call mpas_timer_stop('atm_compute_vert_imp_coefs')
 
          call mpas_pool_get_field(diag, 'exner', exner_field)
@@ -632,8 +606,6 @@ module atm_time_integration
 
               !  Compute the coefficients for the vertically implicit solve in the acoustic step.
               !  These coefficients will work for the 2nd and 3rd acoustic steps (dt is the same for both).
-              block => domain % blocklist
-              do while (associated(block))
                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                  call mpas_pool_get_subpool(block % structs, 'state', state)
                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -662,13 +634,9 @@ module atm_time_integration
                                                      edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                  end do
 !$OMP END PARALLEL DO
-                 block => block % next
-              end do
             end if  
 
             call mpas_timer_start('atm_compute_dyn_tend')
-            block => domain % blocklist
-            do while (associated(block))
                call mpas_pool_get_subpool(block % structs, 'state', state)
                call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -735,8 +703,6 @@ module atm_time_integration
                deallocate(delsq_vorticity)
                deallocate(dpdz)
    
-               block => block % next
-            end do
             call mpas_timer_stop('atm_compute_dyn_tend')
 
 
@@ -753,8 +719,6 @@ module atm_time_integration
    
             call mpas_timer_start('small_step_prep')
 
-            block => domain % blocklist
-            do while (associated(block))
                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                call mpas_pool_get_subpool(block % structs, 'state', state)
                call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -783,8 +747,6 @@ module atm_time_integration
                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                end do
 !$OMP END PARALLEL DO
-               block => block % next
-            end do
             call mpas_timer_stop('small_step_prep')
 
           
@@ -792,8 +754,6 @@ module atm_time_integration
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
 
-               block => domain % blocklist
-               do while (associated(block))
 
                   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                   call mpas_pool_get_subpool(block % structs, 'tend', tend)
@@ -833,13 +793,9 @@ module atm_time_integration
                   deallocate(ru_driving_tend)
                   deallocate(rt_driving_tend)
                   deallocate(rho_driving_tend)
-                  block => block % next
-               end do
 
 ! -------- next, add in the tendencies for the horizontal filters and Rayleigh damping.  We will keep the spec zone and relax zone adjustments separate for now...
                
-               block => domain % blocklist
-               do while (associated(block))
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'diag', diag)
                   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -883,8 +839,6 @@ module atm_time_integration
                   deallocate(ru_driving_values)
                   deallocate(rt_driving_values)
                   deallocate(rho_driving_values)
-                  block => block % next
-               end do
 
 
             end if  ! regional_MPAS addition
@@ -902,8 +856,6 @@ module atm_time_integration
                call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
 
                call mpas_timer_start('atm_advance_acoustic_step')
-               block => domain % blocklist
-               do while (associated(block))
                   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -942,8 +894,6 @@ module atm_time_integration
                   end do
 !$OMP END PARALLEL DO
 
-                  block => block % next
-               end do
                call mpas_timer_stop('atm_advance_acoustic_step')
 
   
@@ -957,8 +907,6 @@ module atm_time_integration
 !  complete update of horizontal momentum by including 3d divergence damping at the end of the acoustic step
 
                call mpas_timer_start('atm_divergence_damping_3d')
-               block => domain % blocklist
-               do while (associated(block))
                   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -974,8 +922,6 @@ module atm_time_integration
                   end do
 !$OMP END PARALLEL DO
 
-                  block => block % next
-               end do
                call mpas_timer_stop('atm_divergence_damping_3d')
 
             end do  ! end of acoustic steps loop
@@ -997,8 +943,6 @@ module atm_time_integration
             call mpas_dmpar_exch_halo_field(rtheta_pp_field, (/ 2 /))
 
             call mpas_timer_start('atm_recover_large_step_variables')
-            block => domain % blocklist
-            do while (associated(block))
 
                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                call mpas_pool_get_subpool(block % structs, 'state', state)
@@ -1035,8 +979,6 @@ module atm_time_integration
                end do
 !$OMP END PARALLEL DO
 
-               block => block % next
-            end do
             call mpas_timer_stop('atm_recover_large_step_variables')
 
 !-------------------------------------------------------------------
@@ -1046,8 +988,6 @@ module atm_time_integration
                ! First, (re)set the value of u and ru in the specified zone at the outermost edge (we will reset all for now).
                ! atm_recover_large_step_variables will not have set outermost edge velocities correctly.
                
-               block => domain % blocklist
-               do while (associated(block))
 
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -1083,8 +1023,6 @@ module atm_time_integration
                      end if
                   end do
                   
-                  block => block % next
-               end do
                deallocate(ru_driving_values)
 
             end if  ! regional_MPAS addition
@@ -1110,8 +1048,6 @@ module atm_time_integration
                   call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                   call mpas_dmpar_exch_halo_field(scalars_field)
 
-                  block => domain % blocklist
-                  do while (associated(block))
 
                      call mpas_pool_get_subpool(block % structs, 'state', state)
                      call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -1176,16 +1112,12 @@ module atm_time_integration
 
                      deallocate(scalars_driving)
 
-                     block => block % next
-                  end do
 
                end if  ! regional_MPAS addition
 
             end if
 
             call mpas_timer_start('atm_compute_solve_diagnostics')
-            block => domain % blocklist
-            do while (associated(block))
                call mpas_pool_get_subpool(block % structs, 'state', state)
                call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -1222,8 +1154,6 @@ module atm_time_integration
                deallocate(ke_vertex)
                deallocate(ke_edge)
 
-               block => block % next
-            end do
             call mpas_timer_stop('atm_compute_solve_diagnostics')
 
 
@@ -1250,8 +1180,6 @@ module atm_time_integration
             ! set the zero-gradient condition on w for regional_MPAS
             
             if ( config_apply_lbcs ) then  ! regional_MPAS addition
-              block => domain % blocklist
-              do while (associated(block))
 
                 call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                 call mpas_pool_get_subpool(block % structs, 'state', state)
@@ -1266,8 +1194,6 @@ module atm_time_integration
                 end do
 !$OMP END PARALLEL DO
 
-                block => block % next
-              end do
 
               ! w halo values needs resetting after regional boundary update
               call mpas_pool_get_subpool(domain % blocklist % structs, 'state', state)
@@ -1301,8 +1227,6 @@ module atm_time_integration
          !  Notes:  physics tendencies for scalars should be OK coming out of dynamics
 
          call mpas_timer_start('atm_rk_dynamics_substep_finish')
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_subpool(block % structs, 'diag', diag)
 
@@ -1335,8 +1259,6 @@ module atm_time_integration
             end do
 !$OMP END PARALLEL DO
 
-            block => block % next
-         end do
          call mpas_timer_stop('atm_rk_dynamics_substep_finish')
 
       end do DYNAMICS_SUBSTEPS
@@ -1374,8 +1296,6 @@ module atm_time_integration
                call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                call mpas_dmpar_exch_halo_field(scalars_field)
 
-               block => domain % blocklist
-               do while (associated(block))
 
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -1440,8 +1360,6 @@ module atm_time_integration
 
                   deallocate(scalars_driving)
 
-                  block => block % next
-               end do
 
             end if  ! regional_MPAS addition
 
@@ -1459,8 +1377,6 @@ module atm_time_integration
       !
       ! reconstruct full velocity vectors at cell centers:
       !
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'diag', diag)
          call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -1480,8 +1396,6 @@ module atm_time_integration
                                uReconstructMeridional  &
                               )
 
-         block => block % next
-      end do
 
       !
       ! call to parameterizations of cloud microphysics. calculation of the tendency of water vapor to horizontal and
@@ -1489,8 +1403,6 @@ module atm_time_integration
       !
 
 #ifdef DO_PHYSICS
-      block => domain % blocklist
-      do while(associated(block))
 
          call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
          call mpas_pool_get_subpool(block % structs, 'state', state)
@@ -1541,8 +1453,6 @@ module atm_time_integration
 !$OMP END PARALLEL DO
             call mpas_timer_stop('microphysics')
          end if
-         block => block % next
-      end do
 
       !
       ! Note: A halo exchange for 'exner' here as well as at the end of
@@ -1555,8 +1465,6 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -1588,9 +1496,6 @@ module atm_time_integration
 
             deallocate(rt_driving_values)
             deallocate(rho_driving_values)
-            block => block % next
-
-         end do
 
       end if  ! regional_MPAS addition
 
@@ -1600,8 +1505,6 @@ module atm_time_integration
          call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
          call mpas_dmpar_exch_halo_field(scalars_field)
 
-         block => domain % blocklist
-         do while (associated(block))
 
             call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -1670,8 +1573,6 @@ module atm_time_integration
 
             deallocate(scalars_driving)
 
-            block => block % next
-         end do
 
       end if  ! regional_MPAS addition
 
@@ -1729,8 +1630,6 @@ module atm_time_integration
       type (mpas_pool_type), pointer :: diag
       type (mpas_pool_type), pointer :: mesh
 
-      type (block_type), pointer :: block
-
       integer, pointer :: nCells
       integer, pointer :: nEdges
       integer, pointer :: nVertLevels
@@ -1751,8 +1650,6 @@ module atm_time_integration
          call mpas_timer_start('atm_advance_scalars_mono')
       end if
 
-      block => domain % blocklist
-      do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'tend', tend)
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -1843,8 +1740,6 @@ module atm_time_integration
             deallocate(flux_tmp_arr)
          end if
 
-         block => block % next
-      end do
 
       if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
          call mpas_timer_stop('atm_advance_scalars')
@@ -6737,8 +6632,6 @@ module atm_time_integration
        logical, pointer :: config_print_detailed_minmax_vel
        logical, pointer :: config_print_global_minmax_sca
 
-       type (block_type), pointer :: block
-
        integer :: iCell, k, iEdge, iScalar
        integer, pointer :: num_scalars, nCellsSolve, nEdgesSolve, nVertLevels
 
@@ -6772,8 +6665,6 @@ module atm_time_integration
       if (config_print_detailed_minmax_vel) then
          call mpas_log_write('')
 
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'state', state)
             call mpas_pool_get_subpool(block % structs, 'diag', diag)
             call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
@@ -6990,14 +6881,10 @@ module atm_time_integration
             end do
             end do
 
-            block => block % next
-         end do
 
       else if (config_print_global_minmax_vel) then
          call mpas_log_write('')
 
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'state', state)
 
             call mpas_pool_get_array(state, 'w', w, 2)
@@ -7030,8 +6917,6 @@ module atm_time_integration
             call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
             call mpas_log_write('global min, max u $r $r', realArgs=(/global_scalar_min, global_scalar_max/))
 
-            block => block % next
-         end do
       end if
 
       if (config_print_global_minmax_sca) then
@@ -7039,8 +6924,6 @@ module atm_time_integration
             call mpas_log_write('')
          end if
 
-         block => domain % blocklist
-         do while (associated(block))
             call mpas_pool_get_subpool(block % structs, 'state', state)
 
             call mpas_pool_get_array(state, 'scalars', scalars, 2)
@@ -7062,8 +6945,6 @@ module atm_time_integration
                call mpas_log_write(' global min, max scalar $i $r $r', intArgs=(/iScalar/), realArgs=(/global_scalar_min, global_scalar_max/))
             end do
 
-            block => block % next
-         end do
       end if
 
    end subroutine summarize_timestep

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -352,6 +352,52 @@ module atm_time_integration
 #endif
 
       !
+      ! Retrieve dimensions
+      ! Note: nCellsSolve and nVerticesSolve are not currently used in this function
+      !
+      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(mesh, 'nVertices', nVertices)
+      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+
+      !call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
+      call mpas_pool_get_dimension(mesh, 'nEdgesSolve', nEdgesSolve)
+      !call mpas_pool_get_dimension(mesh, 'nVerticesSolve', nVerticesSolve)
+
+      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+
+
+#ifdef DO_PHYSICS
+      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+#endif
+      if (config_apply_lbcs) then
+         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+         call mpas_pool_get_dimension(state, 'index_qc', index_qc)
+         call mpas_pool_get_dimension(state, 'index_qr', index_qr)
+         call mpas_pool_get_dimension(state, 'index_qi', index_qi)
+         call mpas_pool_get_dimension(state, 'index_qs', index_qs)
+         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+         call mpas_pool_get_dimension(state, 'index_nr', index_nr)
+         call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+      endif
+
+      !
       ! Retrieve fields
       !
       call mpas_pool_get_field(state, 'theta_m', theta_m_field, 1)
@@ -362,10 +408,6 @@ module atm_time_integration
       !
       ! allocate storage for physics tendency save
       !
-      call mpas_pool_get_dimension(state, 'nCells', nCells)
-      call mpas_pool_get_dimension(state, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
-
       allocate(qtot(nVertLevels,nCells+1))
       qtot(:,nCells+1) = 0.0_RKIND
 
@@ -448,22 +490,6 @@ module atm_time_integration
 
 
       call mpas_timer_start('atm_rk_integration_setup')
-      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
       do thread=1,nThreads
@@ -480,22 +506,6 @@ module atm_time_integration
       call mpas_timer_stop('atm_rk_integration_setup')
 
       call mpas_timer_start('atm_compute_moist_coefficients')
-      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
       do thread=1,nThreads
@@ -554,20 +564,6 @@ module atm_time_integration
          !  These coefficients will work for the first acoustic step in all cases.
          call mpas_timer_start('atm_compute_vert_imp_coefs')
 
-         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
          rk_step = 1
 !$OMP PARALLEL DO
          do thread=1,nThreads
@@ -595,20 +591,6 @@ module atm_time_integration
 
               !  Compute the coefficients for the vertically implicit solve in the acoustic step.
               !  These coefficients will work for the 2nd and 3rd acoustic steps (dt is the same for both).
-              call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-              call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-              call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-              call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-              call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-              call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-              call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-              call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
 !$OMP PARALLEL DO
               do thread=1,nThreads
                  call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
@@ -622,28 +604,6 @@ module atm_time_integration
 
             call mpas_timer_start('atm_compute_dyn_tend')
    
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-            call mpas_pool_get_dimension(mesh, 'nVertices', nVertices)
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
             allocate(delsq_theta(nVertLevels,nCells+1))
             delsq_theta(:,nCells+1) = 0.0_RKIND
             allocate(delsq_w(nVertLevels,nCells+1))
@@ -695,20 +655,6 @@ module atm_time_integration
    
             call mpas_timer_start('small_step_prep')
    
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-               
 !$OMP PARALLEL DO
             do thread=1,nThreads
                call atm_set_smlstep_pert_variables( tend, diag, mesh, block % configs, &
@@ -725,21 +671,6 @@ module atm_time_integration
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
    
-               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-               call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
                allocate(ru_driving_tend(nVertLevels,nEdges+1))
                allocate(rt_driving_tend(nVertLevels,nCells+1))
                allocate(rho_driving_tend(nVertLevels,nCells+1))
@@ -762,21 +693,6 @@ module atm_time_integration
                deallocate(rho_driving_tend)
 
 ! -------- next, add in the tendencies for the horizontal filters and Rayleigh damping.  We will keep the spec zone and relax zone adjustments separate for now...
-   
-               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-               call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
                allocate(ru_driving_values(nVertLevels,nEdges+1))
                allocate(rt_driving_values(nVertLevels,nCells+1))
@@ -815,25 +731,6 @@ module atm_time_integration
                call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
 
                call mpas_timer_start('atm_advance_acoustic_step')
-               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
                do thread=1,nThreads
@@ -859,9 +756,6 @@ module atm_time_integration
 !  complete update of horizontal momentum by including 3d divergence damping at the end of the acoustic step
 
                call mpas_timer_start('atm_divergence_damping_3d')
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
 !$OMP PARALLEL DO
                do thread=1,nThreads
@@ -890,22 +784,6 @@ module atm_time_integration
             call mpas_dmpar_exch_halo_field(rtheta_pp_field, (/ 2 /))
 
             call mpas_timer_start('atm_recover_large_step_variables')
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
             do thread=1,nThreads
@@ -928,9 +806,6 @@ module atm_time_integration
 
                ! First, (re)set the value of u and ru in the specified zone at the outermost edge (we will reset all for now).
                ! atm_recover_large_step_variables will not have set outermost edge velocities correctly.
-               call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-               call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
                call mpas_pool_get_array(state, 'u', u, 2)
                call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
 
@@ -983,30 +858,10 @@ module atm_time_integration
                   call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                   call mpas_dmpar_exch_halo_field(scalars_field)
    
-                  call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-                  call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-                  call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
                   allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
 
                   !  get the scalar values driving the regional boundary conditions
                   !
-                  call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-                  call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-                  call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-                  call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-                  call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-                  call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-                  call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-                  call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
                   if (index_qv > 0) then
                      scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
                   end if
@@ -1048,20 +903,6 @@ module atm_time_integration
             end if
 
             call mpas_timer_start('atm_compute_solve_diagnostics')
-            call mpas_pool_get_dimension(state, 'nEdges', nEdges)
-            call mpas_pool_get_dimension(state, 'nVertices', nVertices)
-            call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
             allocate(ke_vertex(nVertLevels,nVertices+1))
             ke_vertex(:,nVertices+1) = 0.0_RKIND
@@ -1104,17 +945,13 @@ module atm_time_integration
             ! set the zero-gradient condition on w for regional_MPAS
             
             if ( config_apply_lbcs ) then  ! regional_MPAS addition
-              call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 !$OMP PARALLEL DO
               do thread=1,nThreads
                  call atm_zero_gradient_w_bdy( state, mesh, &
                                                cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
               end do
 !$OMP END PARALLEL DO
-
 
               ! w halo values needs resetting after regional boundary update
               call mpas_pool_get_field(state, 'w', w_field, 2)
@@ -1145,23 +982,6 @@ module atm_time_integration
          !  Notes:  physics tendencies for scalars should be OK coming out of dynamics
 
          call mpas_timer_start('atm_rk_dynamics_substep_finish')
-
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
          do thread=1,nThreads
@@ -1212,30 +1032,10 @@ module atm_time_integration
                call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                call mpas_dmpar_exch_halo_field(scalars_field)
    
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-               call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
                allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
 
                !  get the scalar values driving the regional boundary conditions
                !
-               call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-               call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-               call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-               call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-               call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-               call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-               call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-               call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
                if (index_qv > 0) then
                   scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
                end if
@@ -1312,11 +1112,6 @@ module atm_time_integration
 #ifdef DO_PHYSICS
       call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
-      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
       if(config_convection_scheme == 'cu_grell_freitas'          .or. &
          config_convection_scheme == 'cu_tiedtke'                .or. &
@@ -1361,15 +1156,6 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
-        call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-        call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-        call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-        call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-        call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-        call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-        call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
         allocate(rt_driving_values(nVertLevels,nCells+1))
         allocate(rho_driving_values(nVertLevels,nCells+1))
         time_dyn_step = dt  ! end of full timestep values
@@ -1397,35 +1183,10 @@ module atm_time_integration
          call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
          call mpas_dmpar_exch_halo_field(scalars_field)
    
-         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-         call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
          allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
 
          !  get the scalar values driving the regional boundary conditions
          !
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-         call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-         call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-         call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-         call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-         call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-         call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
          if (index_qv > 0) then
             scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
          end if

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -330,10 +330,14 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_monotonic', config_monotonic)
       call mpas_pool_get_config(block % configs, 'config_dt', config_dt)
       call mpas_pool_get_config(block % configs, 'config_IAU_option', config_IAU_option)
-
       !  config variables for dynamics-transport splitting, WCS 18 November 2014
       call mpas_pool_get_config(block % configs, 'config_split_dynamics_transport', config_split_dynamics_transport)
       call mpas_pool_get_config(block % configs, 'config_dynamics_split_steps', config_dynamics_split)
+      !  config variables for cloud microphysics
+#ifdef DO_PHYSICS
+      call mpas_pool_get_config(block % configs, 'config_microp_scheme', config_microp_scheme)
+      call mpas_pool_get_config(block % configs, 'config_convection_scheme', config_convection_scheme)
+#endif
 
       !
       ! Retrieve field structures
@@ -1407,10 +1411,6 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
       call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
       call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-
-      call mpas_pool_get_config(block % configs, 'config_microp_scheme', config_microp_scheme)
-      call mpas_pool_get_config(block % configs, 'config_convection_scheme', config_convection_scheme)
-
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
       call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -217,9 +217,9 @@ module atm_time_integration
       currTime = nowTime + dtInterval
       call mpas_get_time(currTime, dateTimeString=xtime_new)
 
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_array(state, 'xtime', xtime, 2)
-         xtime = xtime_new
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_array(state, 'xtime', xtime, 2)
+      xtime = xtime_new
 
    end subroutine atm_timestep
 
@@ -440,100 +440,100 @@ module atm_time_integration
 
       call mpas_timer_start('atm_rk_integration_setup')
 
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         ! mesh is needed for atm_compute_moist_coefficients
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      ! mesh is needed for atm_compute_moist_coefficients
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
 
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
-         do thread=1,nThreads
-            call atm_rk_integration_setup(state, diag, &
-                                          cellThreadStart(thread), cellThreadEnd(thread), &
-                                          vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                          vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-         end do
+      do thread=1,nThreads
+         call atm_rk_integration_setup(state, diag, &
+                                       cellThreadStart(thread), cellThreadEnd(thread), &
+                                       vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                       edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                       vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                       edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+      end do
 !$OMP END PARALLEL DO
 
       call mpas_timer_stop('atm_rk_integration_setup')
 
       call mpas_timer_start('atm_compute_moist_coefficients')
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         ! mesh is needed for atm_compute_moist_coefficients
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      ! mesh is needed for atm_compute_moist_coefficients
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
 
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
-         do thread=1,nThreads
-            call atm_compute_moist_coefficients( block % dimensions, state, diag, mesh, &     !MGD could do away with dimensions arg
-                                                 cellThreadStart(thread), cellThreadEnd(thread), &
-                                                 vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                                 edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                                 cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                                 vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                                 edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-         end do
+      do thread=1,nThreads
+         call atm_compute_moist_coefficients( block % dimensions, state, diag, mesh, &     !MGD could do away with dimensions arg
+                                              cellThreadStart(thread), cellThreadEnd(thread), &
+                                              vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                              edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                              cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                              vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+      end do
 !$OMP END PARALLEL DO
 
       call mpas_timer_stop('atm_compute_moist_coefficients')
 
 #ifdef DO_PHYSICS
       call mpas_timer_start('physics_get_tend')
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
-         call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-         rk_step = 1
-         dynamics_substep = 1
-         call physics_get_tend( block, &
-                                 mesh, &
-                                state, &     
-                                 diag, &
-                                 tend, &
-                         tend_physics, &
-                      block % configs, &
-                              rk_step, &
-                     dynamics_substep, &
-                      tend_ru_physics, &
-                  tend_rtheta_physics, &
-                     tend_rho_physics )
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'tend', tend)
+      call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
+      rk_step = 1
+      dynamics_substep = 1
+      call physics_get_tend( block, &
+                              mesh, &
+                             state, &     
+                              diag, &
+                              tend, &
+                      tend_physics, &
+                   block % configs, &
+                           rk_step, &
+                  dynamics_substep, &
+                   tend_ru_physics, &
+               tend_rtheta_physics, &
+                  tend_rho_physics )
       call mpas_timer_stop('physics_get_tend')
 #else
 #ifndef MPAS_CAM_DYCORE
@@ -550,8 +550,8 @@ module atm_time_integration
       ! IAU - Incremental Analysis Update
       !
       if (trim(config_IAU_option) /= 'off') then
-            call atm_add_tend_anal_incr(block % configs, block % structs, itimestep, dt, &
-                                        tend_ru_physics, tend_rtheta_physics, tend_rho_physics)
+         call atm_add_tend_anal_incr(block % configs, block % structs, itimestep, dt, &
+                                     tend_ru_physics, tend_rtheta_physics, tend_rho_physics)
       end if
 
 
@@ -560,34 +560,34 @@ module atm_time_integration
          !  Compute the coefficients for the vertically implicit solve in the acoustic step.
          !  These coefficients will work for the first acoustic step in all cases.
          call mpas_timer_start('atm_compute_vert_imp_coefs')
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
+         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'diag', diag)
+         call mpas_pool_get_subpool(block % structs, 'tend', tend)
 
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-            rk_step = 1
+         rk_step = 1
 !$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
-                                          cellThreadStart(thread), cellThreadEnd(thread), &
-                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-            end do
+         do thread=1,nThreads
+            call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
+                                       cellThreadStart(thread), cellThreadEnd(thread), &
+                                       edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                       edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+         end do
 !$OMP END PARALLEL DO
          call mpas_timer_stop('atm_compute_vert_imp_coefs')
 
@@ -606,48 +606,261 @@ module atm_time_integration
 
               !  Compute the coefficients for the vertically implicit solve in the acoustic step.
               !  These coefficients will work for the 2nd and 3rd acoustic steps (dt is the same for both).
-                 call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                 call mpas_pool_get_subpool(block % structs, 'state', state)
-                 call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                 call mpas_pool_get_subpool(block % structs, 'tend', tend)
+              call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+              call mpas_pool_get_subpool(block % structs, 'state', state)
+              call mpas_pool_get_subpool(block % structs, 'diag', diag)
+              call mpas_pool_get_subpool(block % structs, 'tend', tend)
    
-                 call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+              call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
-                 call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+              call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-                 call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                 call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                 call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                 call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+              call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+              call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-                 call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-                 call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-                 call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-                 call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+              call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+              call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+              call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+              call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
-                 do thread=1,nThreads
-                    call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
-                                                     cellThreadStart(thread), cellThreadEnd(thread), &
-                                                     edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                                     cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                                     edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-                 end do
+              do thread=1,nThreads
+                 call atm_compute_vert_imp_coefs( state, mesh, diag, block % configs, nVertLevels, rk_sub_timestep(rk_step), &
+                                                  cellThreadStart(thread), cellThreadEnd(thread), &
+                                                  edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                                  cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                                  edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+              end do
 !$OMP END PARALLEL DO
             end if  
 
             call mpas_timer_start('atm_compute_dyn_tend')
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+            call mpas_pool_get_subpool(block % structs, 'tend', tend)
+#ifdef DO_PHYSICS
+            call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
+#endif
+   
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+            call mpas_pool_get_dimension(mesh, 'nVertices', nVertices)
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+
+            allocate(delsq_theta(nVertLevels,nCells+1))
+            delsq_theta(:,nCells+1) = 0.0_RKIND
+            allocate(delsq_w(nVertLevels,nCells+1))
+            delsq_w(:,nCells+1) = 0.0_RKIND
+!!            allocate(qtot(nVertLevels,nCells+1))  ! initializing this earlier in solution sequence
+            allocate(delsq_divergence(nVertLevels,nCells+1))
+            delsq_divergence(:,nCells+1) = 0.0_RKIND
+            allocate(delsq_u(nVertLevels,nEdges+1))
+            delsq_u(:,nEdges+1) = 0.0_RKIND
+!!            allocate(delsq_circulation(nVertLevels,nVertices+1))  ! no longer used -> removed 
+            allocate(delsq_vorticity(nVertLevels,nVertices+1))
+            delsq_vorticity(:,nVertices+1) = 0.0_RKIND
+            allocate(dpdz(nVertLevels,nCells+1))
+            dpdz(:,nCells+1) = 0.0_RKIND
+
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_compute_dyn_tend( tend, tend_physics, state, diag, mesh, block % configs, nVertLevels, rk_step, dt, & 
+                                          cellThreadStart(thread), cellThreadEnd(thread), &
+                                          vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                          vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(delsq_theta)
+            deallocate(delsq_w)
+!!            deallocate(qtot)  ! deallocation after dynamics step complete, see below
+            deallocate(delsq_divergence)
+            deallocate(delsq_u)
+!!            deallocate(delsq_circulation)    ! no longer used -> removed 
+            deallocate(delsq_vorticity)
+            deallocate(dpdz)
+   
+            call mpas_timer_stop('atm_compute_dyn_tend')
+
+
+            !***********************************
+            !  need tendencies at all edges of owned cells -
+            !  we are solving for all edges of owned cells to minimize communications
+            !  during the acoustic substeps
+            !***********************************
+
+! tend_u
+            call mpas_pool_get_subpool(block % structs, 'tend', tend)
+            call mpas_pool_get_field(tend, 'u', tend_u_field)
+            call mpas_dmpar_exch_halo_field(tend_u_field, (/ 1 /))
+   
+            call mpas_timer_start('small_step_prep')
+
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'tend', tend)
+   
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+               
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_set_smlstep_pert_variables( tend, diag, mesh, block % configs, &
+                                          cellThreadStart(thread), cellThreadEnd(thread), &
+                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+            end do
+!$OMP END PARALLEL DO
+            call mpas_timer_stop('small_step_prep')
+
+          
+!------------------------------------------------------------------------------------------------------------------------
+
+            if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
+
+
+               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+               call mpas_pool_get_subpool(block % structs, 'tend', tend)
+   
+               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+               call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+
+               allocate(ru_driving_tend(nVertLevels,nEdges+1))
+               allocate(rt_driving_tend(nVertLevels,nCells+1))
+               allocate(rho_driving_tend(nVertLevels,nCells+1))
+               ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nEdges, 'ru', 0.0_RKIND )
+               rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
+               rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
+!$OMP PARALLEL DO
+               do thread=1,nThreads
+                  call atm_bdy_adjust_dynamics_speczone_tend( tend, mesh, block % configs, nVertLevels,                 &
+                                                              ru_driving_tend, rt_driving_tend, rho_driving_tend,       &
+                                                              cellThreadStart(thread), cellThreadEnd(thread),           &
+                                                              edgeThreadStart(thread), edgeThreadEnd(thread),           &
+                                                              cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                                              edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
+               end do
+!$OMP END PARALLEL DO
+
+               deallocate(ru_driving_tend)
+               deallocate(rt_driving_tend)
+               deallocate(rho_driving_tend)
+
+! -------- next, add in the tendencies for the horizontal filters and Rayleigh damping.  We will keep the spec zone and relax zone adjustments separate for now...
+               
                call mpas_pool_get_subpool(block % structs, 'state', state)
                call mpas_pool_get_subpool(block % structs, 'diag', diag)
                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
                call mpas_pool_get_subpool(block % structs, 'tend', tend)
-#ifdef DO_PHYSICS
-               call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-#endif
    
                call mpas_pool_get_dimension(mesh, 'nCells', nCells)
                call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-               call mpas_pool_get_dimension(mesh, 'nVertices', nVertices)
+               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+
+               allocate(ru_driving_values(nVertLevels,nEdges+1))
+               allocate(rt_driving_values(nVertLevels,nCells+1))
+               allocate(rho_driving_values(nVertLevels,nCells+1))
+
+               time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
+               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
+               rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+               rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+
+!$OMP PARALLEL DO
+               do thread=1,nThreads
+                  call atm_bdy_adjust_dynamics_relaxzone_tend( tend, state, diag, mesh, nVertLevels, dt,                   &
+                                                               ru_driving_values, rt_driving_values, rho_driving_values,   &
+                                                               cellThreadStart(thread), cellThreadEnd(thread),             &
+                                                               edgeThreadStart(thread), edgeThreadEnd(thread),             &
+                                                               cellSolveThreadStart(thread), cellSolveThreadEnd(thread),   &
+                                                               edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
+               end do
+!$OMP END PARALLEL DO
+
+               deallocate(ru_driving_values)
+               deallocate(rt_driving_values)
+               deallocate(rho_driving_values)
+
+            end if  ! regional_MPAS addition
+
+!------------------------------------------------------------------------------------------------------------------------
+
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            ! begin acoustic steps loop
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+            do small_step = 1, number_sub_steps(rk_step)
+
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
+               call mpas_pool_get_field(diag, 'rho_pp', rho_pp_field)
+               call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
+
+               call mpas_timer_start('atm_advance_acoustic_step')
+               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+               call mpas_pool_get_subpool(block % structs, 'state', state)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
+               call mpas_pool_get_subpool(block % structs, 'tend', tend)
+
+               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
                call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
                call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
@@ -667,231 +880,17 @@ module atm_time_integration
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
                call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
-               allocate(delsq_theta(nVertLevels,nCells+1))
-               delsq_theta(:,nCells+1) = 0.0_RKIND
-               allocate(delsq_w(nVertLevels,nCells+1))
-               delsq_w(:,nCells+1) = 0.0_RKIND
-!!               allocate(qtot(nVertLevels,nCells+1))  ! initializing this earlier in solution sequence
-               allocate(delsq_divergence(nVertLevels,nCells+1))
-               delsq_divergence(:,nCells+1) = 0.0_RKIND
-               allocate(delsq_u(nVertLevels,nEdges+1))
-               delsq_u(:,nEdges+1) = 0.0_RKIND
-!!               allocate(delsq_circulation(nVertLevels,nVertices+1))  ! no longer used -> removed 
-               allocate(delsq_vorticity(nVertLevels,nVertices+1))
-               delsq_vorticity(:,nVertices+1) = 0.0_RKIND
-               allocate(dpdz(nVertLevels,nCells+1))
-               dpdz(:,nCells+1) = 0.0_RKIND
-
 !$OMP PARALLEL DO
                do thread=1,nThreads
-                  call atm_compute_dyn_tend( tend, tend_physics, state, diag, mesh, block % configs, nVertLevels, rk_step, dt, & 
-                                             cellThreadStart(thread), cellThreadEnd(thread), &
-                                             vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                             vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                             edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+                  call atm_advance_acoustic_step( state, diag, tend,  mesh, block % configs, nCells, nVertLevels, &
+                                          rk_sub_timestep(rk_step), small_step, &
+                                          cellThreadStart(thread), cellThreadEnd(thread), &
+                                          vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                          vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
                end do
-!$OMP END PARALLEL DO
-
-               deallocate(delsq_theta)
-               deallocate(delsq_w)
-!!               deallocate(qtot)  ! deallocation after dynamics step complete, see below
-               deallocate(delsq_divergence)
-               deallocate(delsq_u)
-!!               deallocate(delsq_circulation)    ! no longer used -> removed 
-               deallocate(delsq_vorticity)
-               deallocate(dpdz)
-   
-            call mpas_timer_stop('atm_compute_dyn_tend')
-
-
-            !***********************************
-            !  need tendencies at all edges of owned cells -
-            !  we are solving for all edges of owned cells to minimize communications
-            !  during the acoustic substeps
-            !***********************************
-
-! tend_u
-            call mpas_pool_get_subpool(block % structs, 'tend', tend)
-            call mpas_pool_get_field(tend, 'u', tend_u_field)
-            call mpas_dmpar_exch_halo_field(tend_u_field, (/ 1 /))
-   
-            call mpas_timer_start('small_step_prep')
-
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'tend', tend)
-   
-               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-               
-!$OMP PARALLEL DO
-               do thread=1,nThreads
-                  call atm_set_smlstep_pert_variables( tend, diag, mesh, block % configs, &
-                                             cellThreadStart(thread), cellThreadEnd(thread), &
-                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                             edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-               end do
-!$OMP END PARALLEL DO
-            call mpas_timer_stop('small_step_prep')
-
-          
-!------------------------------------------------------------------------------------------------------------------------
-
-            if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS dry dynamics in the specified zone
-
-
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                  call mpas_pool_get_subpool(block % structs, 'tend', tend)
-   
-                  call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-                  call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-                  call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-                  call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
-                  allocate(ru_driving_tend(nVertLevels,nEdges+1))
-                  allocate(rt_driving_tend(nVertLevels,nCells+1))
-                  allocate(rho_driving_tend(nVertLevels,nCells+1))
-                  ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nEdges, 'ru', 0.0_RKIND )
-                  rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
-                  rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
-!$OMP PARALLEL DO
-                  do thread=1,nThreads
-                     call atm_bdy_adjust_dynamics_speczone_tend( tend, mesh, block % configs, nVertLevels,                 &
-                                                                 ru_driving_tend, rt_driving_tend, rho_driving_tend,       &
-                                                                 cellThreadStart(thread), cellThreadEnd(thread),           &
-                                                                 edgeThreadStart(thread), edgeThreadEnd(thread),           &
-                                                                 cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                                                 edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
-                  end do
-!$OMP END PARALLEL DO
-
-                  deallocate(ru_driving_tend)
-                  deallocate(rt_driving_tend)
-                  deallocate(rho_driving_tend)
-
-! -------- next, add in the tendencies for the horizontal filters and Rayleigh damping.  We will keep the spec zone and relax zone adjustments separate for now...
-               
-                  call mpas_pool_get_subpool(block % structs, 'state', state)
-                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                  call mpas_pool_get_subpool(block % structs, 'tend', tend)
-   
-                  call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-                  call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-                  call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-                  call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
-                  allocate(ru_driving_values(nVertLevels,nEdges+1))
-                  allocate(rt_driving_values(nVertLevels,nCells+1))
-                  allocate(rho_driving_values(nVertLevels,nCells+1))
-
-                  time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
-                  rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-                  rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
-
-!$OMP PARALLEL DO
-                  do thread=1,nThreads
-                     call atm_bdy_adjust_dynamics_relaxzone_tend( tend, state, diag, mesh, nVertLevels, dt,                   &
-                                                                  ru_driving_values, rt_driving_values, rho_driving_values,   &
-                                                                  cellThreadStart(thread), cellThreadEnd(thread),             &
-                                                                  edgeThreadStart(thread), edgeThreadEnd(thread),             &
-                                                                  cellSolveThreadStart(thread), cellSolveThreadEnd(thread),   &
-                                                                  edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread) )
-                  end do
-!$OMP END PARALLEL DO
-
-                  deallocate(ru_driving_values)
-                  deallocate(rt_driving_values)
-                  deallocate(rho_driving_values)
-
-
-            end if  ! regional_MPAS addition
-
-!------------------------------------------------------------------------------------------------------------------------
-
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            ! begin acoustic steps loop
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-            do small_step = 1, number_sub_steps(rk_step)
-
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_field(diag, 'rho_pp', rho_pp_field)
-               call mpas_dmpar_exch_halo_field(rho_pp_field, (/ 1 /))
-
-               call mpas_timer_start('atm_advance_acoustic_step')
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                  call mpas_pool_get_subpool(block % structs, 'state', state)
-                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                  call mpas_pool_get_subpool(block % structs, 'tend', tend)
-
-                  call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-                  call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
-!$OMP PARALLEL DO
-                  do thread=1,nThreads
-                     call atm_advance_acoustic_step( state, diag, tend,  mesh, block % configs, nCells, nVertLevels, &
-                                             rk_sub_timestep(rk_step), small_step, &
-                                             cellThreadStart(thread), cellThreadEnd(thread), &
-                                             vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                             vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                             edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-                  end do
 !$OMP END PARALLEL DO
 
                call mpas_timer_stop('atm_advance_acoustic_step')
@@ -907,19 +906,19 @@ module atm_time_integration
 !  complete update of horizontal momentum by including 3d divergence damping at the end of the acoustic step
 
                call mpas_timer_start('atm_divergence_damping_3d')
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                  call mpas_pool_get_subpool(block % structs, 'state', state)
-                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
+               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+               call mpas_pool_get_subpool(block % structs, 'state', state)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
 
-                  call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-                  call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
 !$OMP PARALLEL DO
-                  do thread=1,nThreads
-                     call atm_divergence_damping_3d( state, diag, mesh, block % configs, rk_sub_timestep(rk_step), &
-                                                     edgeThreadStart(thread), edgeThreadEnd(thread) )
-                  end do
+               do thread=1,nThreads
+                  call atm_divergence_damping_3d( state, diag, mesh, block % configs, rk_sub_timestep(rk_step), &
+                                                  edgeThreadStart(thread), edgeThreadEnd(thread) )
+               end do
 !$OMP END PARALLEL DO
 
                call mpas_timer_stop('atm_divergence_damping_3d')
@@ -944,39 +943,39 @@ module atm_time_integration
 
             call mpas_timer_start('atm_recover_large_step_variables')
 
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'tend', tend)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'tend', tend)
 
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
 
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
 
 !$OMP PARALLEL DO
-               do thread=1,nThreads
-                  call atm_recover_large_step_variables( state, diag, tend, mesh, block % configs, rk_timestep(rk_step), &
-                                             number_sub_steps(rk_step), rk_step, &
-                                             cellThreadStart(thread), cellThreadEnd(thread), &
-                                             vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                             vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                             edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-               end do
+            do thread=1,nThreads
+               call atm_recover_large_step_variables( state, diag, tend, mesh, block % configs, rk_timestep(rk_step), &
+                                          number_sub_steps(rk_step), rk_step, &
+                                          cellThreadStart(thread), cellThreadEnd(thread), &
+                                          vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                          vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                          edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+            end do
 !$OMP END PARALLEL DO
 
             call mpas_timer_stop('atm_recover_large_step_variables')
@@ -987,42 +986,40 @@ module atm_time_integration
 
                ! First, (re)set the value of u and ru in the specified zone at the outermost edge (we will reset all for now).
                ! atm_recover_large_step_variables will not have set outermost edge velocities correctly.
+               call mpas_pool_get_subpool(block % structs, 'state', state)
+               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
+               call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+               call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
+               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+               call mpas_pool_get_array(state, 'u', u, 2)
+               call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
+
+               allocate(ru_driving_values(nVertLevels,nEdges+1))
+
+               time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
+
+               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'u', time_dyn_step )
+               ! do this inline at present - it is simple enough
+               do iEdge = 1, nEdgesSolve
+                  if(bdyMaskEdge(iEdge) > nRelaxZone) then
+                     do k = 1, nVertLevels
+                        u(k,iEdge) = ru_driving_values(k,iEdge)
+                     end do
+                  end if
+               end do
+
+               ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
+               call mpas_pool_get_array(diag, 'ru', u)
+               ! do this inline at present - it is simple enough
+               do iEdge = 1, nEdges
+                  if(bdyMaskEdge(iEdge) > nRelaxZone) then
+                     do k = 1, nVertLevels
+                        u(k,iEdge) = ru_driving_values(k,iEdge)
+                     end do
+                  end if
+               end do
                
-
-                  call mpas_pool_get_subpool(block % structs, 'state', state)
-                  call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                  call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                  call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-                  call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
-                  call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-                  call mpas_pool_get_array(state, 'u', u, 2)
-                  call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
-
-                  allocate(ru_driving_values(nVertLevels,nEdges+1))
-
-                  time_dyn_step = dt_dynamics*real(dynamics_substep-1) + rk_timestep(rk_step)
-
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'u', time_dyn_step )
-                  ! do this inline at present - it is simple enough
-                  do iEdge = 1, nEdgesSolve
-                     if(bdyMaskEdge(iEdge) > nRelaxZone) then
-                        do k = 1, nVertLevels
-                           u(k,iEdge) = ru_driving_values(k,iEdge)
-                        end do
-                     end if
-                  end do
-
-                  ru_driving_values(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nEdges, 'ru', time_dyn_step )
-                  call mpas_pool_get_array(diag, 'ru', u)
-                  ! do this inline at present - it is simple enough
-                  do iEdge = 1, nEdges
-                     if(bdyMaskEdge(iEdge) > nRelaxZone) then
-                        do k = 1, nVertLevels
-                           u(k,iEdge) = ru_driving_values(k,iEdge)
-                        end do
-                     end if
-                  end do
-                  
                deallocate(ru_driving_values)
 
             end if  ! regional_MPAS addition
@@ -1047,255 +1044,6 @@ module atm_time_integration
 
                   call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
                   call mpas_dmpar_exch_halo_field(scalars_field)
-
-
-                     call mpas_pool_get_subpool(block % structs, 'state', state)
-                     call mpas_pool_get_subpool(block % structs, 'diag', diag)
-                     call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-   
-                     call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-                     call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-                     call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-                     allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
-
-
-                     !  get the scalar values driving the regional boundary conditions
-                     !
-                     call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-                     call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-                     call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-                     call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-                     call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-                     call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-                     call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-                     call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-
-                     call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                     call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-                     call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-                     call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                     call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-                     if (index_qv > 0) then
-                        scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
-                     end if
-                     if (index_qc > 0) then
-                        scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
-                     end if
-                     if (index_qr > 0) then
-                        scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
-                     end if
-                     if (index_qi > 0) then
-                        scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
-                     end if
-                     if (index_qs > 0) then
-                        scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
-                     end if
-                     if (index_qg > 0) then
-                        scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
-                     end if
-                     if (index_nr > 0) then
-                        scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
-                     end if
-                     if (index_ni > 0) then
-                        scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                     end if
-                  
-                     !$OMP PARALLEL DO
-                     do thread=1,nThreads
-                        call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
-                                                     cellThreadStart(thread), cellThreadEnd(thread), &
-                                                     cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-                     end do
-                     !$OMP END PARALLEL DO
-
-                     deallocate(scalars_driving)
-
-
-               end if  ! regional_MPAS addition
-
-            end if
-
-            call mpas_timer_start('atm_compute_solve_diagnostics')
-               call mpas_pool_get_subpool(block % structs, 'state', state)
-               call mpas_pool_get_subpool(block % structs, 'diag', diag)
-               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-   
-               call mpas_pool_get_dimension(state, 'nEdges', nEdges)
-               call mpas_pool_get_dimension(state, 'nVertices', nVertices)
-               call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
-
-               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-               call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-
-               allocate(ke_vertex(nVertLevels,nVertices+1))
-               ke_vertex(:,nVertices+1) = 0.0_RKIND
-               allocate(ke_edge(nVertLevels,nEdges+1))
-               ke_edge(:,nEdges+1) = 0.0_RKIND
-   
-!$OMP PARALLEL DO
-               do thread=1,nThreads
-                  call atm_compute_solve_diagnostics(dt, state, 2, diag, mesh, block % configs, &
-                                                     cellThreadStart(thread), cellThreadEnd(thread), &
-                                                     vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                                     edgeThreadStart(thread), edgeThreadEnd(thread), rk_step)
-               end do
-!$OMP END PARALLEL DO
-
-               deallocate(ke_vertex)
-               deallocate(ke_edge)
-
-            call mpas_timer_stop('atm_compute_solve_diagnostics')
-
-
-            ! w
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_field(state, 'w', w_field, 2)
-            call mpas_dmpar_exch_halo_field(w_field)
-
-            ! pv_edge
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_field(diag, 'pv_edge', pv_edge_field)
-            call mpas_dmpar_exch_halo_field(pv_edge_field)
-
-            ! rho_edge
-            call mpas_pool_get_field(diag, 'rho_edge', rho_edge_field)
-            call mpas_dmpar_exch_halo_field(rho_edge_field)
-
-            ! scalars
-            if (config_scalar_advection .and. (.not. config_split_dynamics_transport) ) then
-               call mpas_pool_get_field(state, 'scalars', scalars_field, 2)
-               call mpas_dmpar_exch_halo_field(scalars_field)
-            end if
-
-            ! set the zero-gradient condition on w for regional_MPAS
-            
-            if ( config_apply_lbcs ) then  ! regional_MPAS addition
-
-                call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-                call mpas_pool_get_subpool(block % structs, 'state', state)
-                call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-                call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-                call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-!$OMP PARALLEL DO
-                do thread=1,nThreads
-                   call atm_zero_gradient_w_bdy( state, mesh, &
-                                                 cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-                end do
-!$OMP END PARALLEL DO
-
-
-              ! w halo values needs resetting after regional boundary update
-              call mpas_pool_get_subpool(block % structs, 'state', state)
-              call mpas_pool_get_field(state, 'w', w_field, 2)
-              call mpas_dmpar_exch_halo_field(w_field)
-
-            end if ! end of regional_MPAS addition 
-
-         end do RK3_DYNAMICS
-
-         if (dynamics_substep < dynamics_split) then
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_field(state, 'theta_m', theta_m_field, 2)
-
-            call mpas_dmpar_exch_halo_field(theta_m_field)
-            call mpas_dmpar_exch_halo_field(pressure_p_field)
-            call mpas_dmpar_exch_halo_field(rtheta_p_field)
-
-            !
-            ! Note: A halo exchange for 'exner' here as well as after the call
-            ! to driver_microphysics() can substitute for the exchange at
-            ! the beginning of each dynamics subcycle. Placing halo exchanges
-            ! here and after microphysics may in future allow for aggregation of
-            ! the 'exner' exchange with other exchanges.
-            !
-         end if
-
-         !  dynamics-transport split, WCS 18 November 2014
-         !  (1) time level 1 needs to be set to time level 2
-         !  (2) need to accumulate ruAvg and wwAvg over the dynamics substeps, prepare for use in transport
-         !  Notes:  physics tendencies for scalars should be OK coming out of dynamics
-
-         call mpas_timer_start('atm_rk_dynamics_substep_finish')
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
-
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
-
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
-
-!$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_rk_dynamics_substep_finish(state, diag, dynamics_substep, dynamics_split, &
-                                                cellThreadStart(thread), cellThreadEnd(thread), &
-                                                vertexThreadStart(thread), vertexThreadEnd(thread), &
-                                                edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                                cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                                vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
-                                                edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
-            end do
-!$OMP END PARALLEL DO
-
-         call mpas_timer_stop('atm_rk_dynamics_substep_finish')
-
-      end do DYNAMICS_SUBSTEPS
-
-
-      deallocate(qtot)  !  we are finished with these now
-
-#ifndef MPAS_CAM_DYCORE
-      call mpas_deallocate_scratch_field(tend_rtheta_physicsField)
-      call mpas_deallocate_scratch_field(tend_rho_physicsField)
-      call mpas_deallocate_scratch_field(tend_ru_physicsField)
-#endif
-
-
-      !
-      !  split transport, at present RK3
-      !
-
-      if (config_scalar_advection .and. config_split_dynamics_transport) then
-
-         rk_timestep(1) = dt/3.
-         rk_timestep(2) = dt/2.
-         rk_timestep(3) = dt
-         !  switch for 2nd order time integration for scalar transport
-         if(config_time_integration_order == 2) rk_timestep(1) = dt/2.
-
-         RK3_SPLIT_TRANSPORT : do rk_step = 1, 3  ! Runge-Kutta loop
-
-
-            call advance_scalars('scalars', domain, rk_step, rk_timestep, config_monotonic, config_positive_definite, &
-                                 config_time_integration_order, config_split_dynamics_transport)
-
-            if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS scalar transport
-
-               call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
-               call mpas_dmpar_exch_halo_field(scalars_field)
-
 
                   call mpas_pool_get_subpool(block % structs, 'state', state)
                   call mpas_pool_get_subpool(block % structs, 'diag', diag)
@@ -1350,15 +1098,261 @@ module atm_time_integration
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
                   
-!$OMP PARALLEL DO
+                  !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
                                                   cellThreadStart(thread), cellThreadEnd(thread), &
                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
                   end do
-!$OMP END PARALLEL DO
+                  !$OMP END PARALLEL DO
 
                   deallocate(scalars_driving)
+
+
+               end if  ! regional_MPAS addition
+
+            end if
+
+            call mpas_timer_start('atm_compute_solve_diagnostics')
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+   
+            call mpas_pool_get_dimension(state, 'nEdges', nEdges)
+            call mpas_pool_get_dimension(state, 'nVertices', nVertices)
+            call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
+
+            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+            call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+
+            allocate(ke_vertex(nVertLevels,nVertices+1))
+            ke_vertex(:,nVertices+1) = 0.0_RKIND
+            allocate(ke_edge(nVertLevels,nEdges+1))
+            ke_edge(:,nEdges+1) = 0.0_RKIND
+   
+!$OMP PARALLEL DO
+            do thread=1,nThreads
+               call atm_compute_solve_diagnostics(dt, state, 2, diag, mesh, block % configs, &
+                                                  cellThreadStart(thread), cellThreadEnd(thread), &
+                                                  vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                                  edgeThreadStart(thread), edgeThreadEnd(thread), rk_step)
+            end do
+!$OMP END PARALLEL DO
+
+            deallocate(ke_vertex)
+            deallocate(ke_edge)
+
+            call mpas_timer_stop('atm_compute_solve_diagnostics')
+
+
+            ! w
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_field(state, 'w', w_field, 2)
+            call mpas_dmpar_exch_halo_field(w_field)
+
+            ! pv_edge
+            call mpas_pool_get_subpool(block % structs, 'diag', diag)
+            call mpas_pool_get_field(diag, 'pv_edge', pv_edge_field)
+            call mpas_dmpar_exch_halo_field(pv_edge_field)
+
+            ! rho_edge
+            call mpas_pool_get_field(diag, 'rho_edge', rho_edge_field)
+            call mpas_dmpar_exch_halo_field(rho_edge_field)
+
+            ! scalars
+            if (config_scalar_advection .and. (.not. config_split_dynamics_transport) ) then
+               call mpas_pool_get_field(state, 'scalars', scalars_field, 2)
+               call mpas_dmpar_exch_halo_field(scalars_field)
+            end if
+
+            ! set the zero-gradient condition on w for regional_MPAS
+            
+            if ( config_apply_lbcs ) then  ! regional_MPAS addition
+              call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+              call mpas_pool_get_subpool(block % structs, 'state', state)
+              call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+              call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+!$OMP PARALLEL DO
+              do thread=1,nThreads
+                 call atm_zero_gradient_w_bdy( state, mesh, &
+                                               cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+              end do
+!$OMP END PARALLEL DO
+
+
+              ! w halo values needs resetting after regional boundary update
+              call mpas_pool_get_subpool(block % structs, 'state', state)
+              call mpas_pool_get_field(state, 'w', w_field, 2)
+              call mpas_dmpar_exch_halo_field(w_field)
+            end if ! end of regional_MPAS addition 
+
+         end do RK3_DYNAMICS
+
+         if (dynamics_substep < dynamics_split) then
+            call mpas_pool_get_subpool(block % structs, 'state', state)
+            call mpas_pool_get_field(state, 'theta_m', theta_m_field, 2)
+
+            call mpas_dmpar_exch_halo_field(theta_m_field)
+            call mpas_dmpar_exch_halo_field(pressure_p_field)
+            call mpas_dmpar_exch_halo_field(rtheta_p_field)
+
+            !
+            ! Note: A halo exchange for 'exner' here as well as after the call
+            ! to driver_microphysics() can substitute for the exchange at
+            ! the beginning of each dynamics subcycle. Placing halo exchanges
+            ! here and after microphysics may in future allow for aggregation of
+            ! the 'exner' exchange with other exchanges.
+            !
+         end if
+
+         !  dynamics-transport split, WCS 18 November 2014
+         !  (1) time level 1 needs to be set to time level 2
+         !  (2) need to accumulate ruAvg and wwAvg over the dynamics substeps, prepare for use in transport
+         !  Notes:  physics tendencies for scalars should be OK coming out of dynamics
+
+         call mpas_timer_start('atm_rk_dynamics_substep_finish')
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'diag', diag)
+
+         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+
+         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadStart', edgeSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'edgeSolveThreadEnd', edgeSolveThreadEnd)
+
+!$OMP PARALLEL DO
+         do thread=1,nThreads
+            call atm_rk_dynamics_substep_finish(state, diag, dynamics_substep, dynamics_split, &
+                                             cellThreadStart(thread), cellThreadEnd(thread), &
+                                             vertexThreadStart(thread), vertexThreadEnd(thread), &
+                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                             vertexSolveThreadStart(thread), vertexSolveThreadEnd(thread), &
+                                             edgeSolveThreadStart(thread), edgeSolveThreadEnd(thread))
+         end do
+!$OMP END PARALLEL DO
+
+         call mpas_timer_stop('atm_rk_dynamics_substep_finish')
+
+      end do DYNAMICS_SUBSTEPS
+
+
+      deallocate(qtot)  !  we are finished with these now
+
+#ifndef MPAS_CAM_DYCORE
+      call mpas_deallocate_scratch_field(tend_rtheta_physicsField)
+      call mpas_deallocate_scratch_field(tend_rho_physicsField)
+      call mpas_deallocate_scratch_field(tend_ru_physicsField)
+#endif
+
+
+      !
+      !  split transport, at present RK3
+      !
+
+      if (config_scalar_advection .and. config_split_dynamics_transport) then
+
+         rk_timestep(1) = dt/3.
+         rk_timestep(2) = dt/2.
+         rk_timestep(3) = dt
+         !  switch for 2nd order time integration for scalar transport
+         if(config_time_integration_order == 2) rk_timestep(1) = dt/2.
+
+         RK3_SPLIT_TRANSPORT : do rk_step = 1, 3  ! Runge-Kutta loop
+
+
+            call advance_scalars('scalars', domain, rk_step, rk_timestep, config_monotonic, config_positive_definite, &
+                                 config_time_integration_order, config_split_dynamics_transport)
+
+            if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS scalar transport
+
+               call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
+               call mpas_dmpar_exch_halo_field(scalars_field)
+
+
+               call mpas_pool_get_subpool(block % structs, 'state', state)
+               call mpas_pool_get_subpool(block % structs, 'diag', diag)
+               call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+   
+               call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+               call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+               call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+               allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
+
+
+               !  get the scalar values driving the regional boundary conditions
+               !
+               call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+               call mpas_pool_get_dimension(state, 'index_qc', index_qc)
+               call mpas_pool_get_dimension(state, 'index_qr', index_qr)
+               call mpas_pool_get_dimension(state, 'index_qi', index_qi)
+               call mpas_pool_get_dimension(state, 'index_qs', index_qs)
+               call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+               call mpas_pool_get_dimension(state, 'index_nr', index_nr)
+               call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+
+               call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+               call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+
+               if (index_qv > 0) then
+                  scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
+               end if
+               if (index_qc > 0) then
+                  scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
+               end if
+               if (index_qr > 0) then
+                  scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
+               end if
+               if (index_qi > 0) then
+                  scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
+               end if
+               if (index_qs > 0) then
+                  scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
+               end if
+               if (index_qg > 0) then
+                  scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
+               end if
+               if (index_nr > 0) then
+                  scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
+               end if
+               if (index_ni > 0) then
+                  scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+               end if
+               
+!$OMP PARALLEL DO
+               do thread=1,nThreads
+                  call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
+                                               cellThreadStart(thread), cellThreadEnd(thread), &
+                                               cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+               end do
+!$OMP END PARALLEL DO
+
+               deallocate(scalars_driving)
 
 
             end if  ! regional_MPAS addition
@@ -1377,24 +1371,24 @@ module atm_time_integration
       !
       ! reconstruct full velocity vectors at cell centers:
       !
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-         call mpas_pool_get_array(state, 'u', u, 2)
-         call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
-         call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
-         call mpas_pool_get_array(diag, 'uReconstructZ', uReconstructZ)
-         call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
-         call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
+      call mpas_pool_get_array(state, 'u', u, 2)
+      call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
+      call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
+      call mpas_pool_get_array(diag, 'uReconstructZ', uReconstructZ)
+      call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
+      call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
 
-         call mpas_reconstruct(mesh, u,                &
-                               uReconstructX,          &
-                               uReconstructY,          &
-                               uReconstructZ,          &
-                               uReconstructZonal,      &
-                               uReconstructMeridional  &
-                              )
+      call mpas_reconstruct(mesh, u,                &
+                            uReconstructX,          &
+                            uReconstructY,          &
+                            uReconstructZ,          &
+                            uReconstructZonal,      &
+                            uReconstructMeridional  &
+                           )
 
 
       !
@@ -1404,55 +1398,55 @@ module atm_time_integration
 
 #ifdef DO_PHYSICS
 
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
-         call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
-         call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
+      call mpas_pool_get_subpool(block % structs, 'tend_physics', tend_physics)
+      call mpas_pool_get_subpool(block % structs, 'tend', tend)
+      call mpas_pool_get_array(state, 'scalars', scalars_1, 1)
+      call mpas_pool_get_array(state, 'scalars', scalars_2, 2)
+      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
 
-         call mpas_pool_get_config(block % configs, 'config_microp_scheme', config_microp_scheme)
-         call mpas_pool_get_config(block % configs, 'config_convection_scheme', config_convection_scheme)
+      call mpas_pool_get_config(block % configs, 'config_microp_scheme', config_microp_scheme)
+      call mpas_pool_get_config(block % configs, 'config_convection_scheme', config_convection_scheme)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-         if(config_convection_scheme == 'cu_grell_freitas'          .or. &
-            config_convection_scheme == 'cu_tiedtke'                .or. &
-            config_convection_scheme == 'cu_ntiedtke') then
+      if(config_convection_scheme == 'cu_grell_freitas'          .or. &
+         config_convection_scheme == 'cu_tiedtke'                .or. &
+         config_convection_scheme == 'cu_ntiedtke') then
 
-            call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
+         call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
 
-            !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
-            !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
-            !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
-            if (config_monotonic) then
-               rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
-            else
-               rqvdynten(:,:) = 0._RKIND
-            end if
+         !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
+         !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
+         !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
+         if (config_monotonic) then
+            rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
+         else
+            rqvdynten(:,:) = 0._RKIND
          end if
+      end if
 
-         !simply set to zero negative mixing ratios of different water species (for now):
-         where ( scalars_2(:,:,:) < 0.0)  &
-            scalars_2(:,:,:) = 0.0
+      !simply set to zero negative mixing ratios of different water species (for now):
+      where ( scalars_2(:,:,:) < 0.0)  &
+         scalars_2(:,:,:) = 0.0
 
-         !call microphysics schemes:
-         if (trim(config_microp_scheme) /= 'off')  then
-            call mpas_timer_start('microphysics')
+      !call microphysics schemes:
+      if (trim(config_microp_scheme) /= 'off')  then
+        call mpas_timer_start('microphysics')
 !$OMP PARALLEL DO
-            do thread=1,nThreads
-               call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
-                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
-            end do
+        do thread=1,nThreads
+           call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
+                                      cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+        end do
 !$OMP END PARALLEL DO
-            call mpas_timer_stop('microphysics')
-         end if
+        call mpas_timer_stop('microphysics')
+      end if
 
       !
       ! Note: A halo exchange for 'exner' here as well as at the end of
@@ -1465,37 +1459,37 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! reset boundary values of rtheta in the specified zone - microphysics has messed with them
 
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+        call mpas_pool_get_subpool(block % structs, 'state', state)
+        call mpas_pool_get_subpool(block % structs, 'diag', diag)
+        call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+        call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+        call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+        call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+        call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+        call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+        call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+        call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-            allocate(rt_driving_values(nVertLevels,nCells+1))
-            allocate(rho_driving_values(nVertLevels,nCells+1))
-            time_dyn_step = dt  ! end of full timestep values
+        allocate(rt_driving_values(nVertLevels,nCells+1))
+        allocate(rho_driving_values(nVertLevels,nCells+1))
+        time_dyn_step = dt  ! end of full timestep values
 
-            rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
-            rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
+        rt_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rtheta_m', time_dyn_step )
+        rho_driving_values(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'rho_zz', time_dyn_step )
 
 !$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
-                                                   rt_driving_values, rho_driving_values,                        &
-                                                   cellThreadStart(thread), cellThreadEnd(thread),               &
-                                                   cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
+        do thread=1,nThreads
+           call atm_bdy_reset_speczone_values( state, diag, mesh, nVertLevels, &
+                                               rt_driving_values, rho_driving_values,                        &
+                                               cellThreadStart(thread), cellThreadEnd(thread),               &
+                                               cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+        end do
 !$OMP END PARALLEL DO
 
-            deallocate(rt_driving_values)
-            deallocate(rho_driving_values)
+        deallocate(rt_driving_values)
+        deallocate(rho_driving_values)
 
       end if  ! regional_MPAS addition
 
@@ -1505,74 +1499,72 @@ module atm_time_integration
          call mpas_pool_get_field(state, 'scalars', scalars_field, 2)  ! need to fill halo for horizontal filter
          call mpas_dmpar_exch_halo_field(scalars_field)
 
-
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
    
-            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-            allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
+         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+         allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
 
-            !  get the scalar values driving the regional boundary conditions
-            !
-            call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-            call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-            call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-            call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-            call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-            call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-            call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-            call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+         !  get the scalar values driving the regional boundary conditions
+         !
+         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+         call mpas_pool_get_dimension(state, 'index_qc', index_qc)
+         call mpas_pool_get_dimension(state, 'index_qr', index_qr)
+         call mpas_pool_get_dimension(state, 'index_qi', index_qi)
+         call mpas_pool_get_dimension(state, 'index_qs', index_qs)
+         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
+         call mpas_pool_get_dimension(state, 'index_nr', index_nr)
+         call mpas_pool_get_dimension(state, 'index_ni', index_ni)
 
-            call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
-            call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadStart', vertexThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexThreadEnd', vertexThreadEnd)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadStart', vertexSolveThreadStart)
+         call mpas_pool_get_dimension(block % dimensions, 'vertexSolveThreadEnd', vertexSolveThreadEnd)
 
-            if (index_qv > 0) then
-               scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
-            end if
-            if (index_qc > 0) then
-               scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', dt )
-            end if
-            if (index_qr > 0) then
-               scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', dt )
-            end if
-            if (index_qi > 0) then
-               scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', dt )
-            end if
-            if (index_qs > 0) then
-               scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', dt )
-            end if
-            if (index_qg > 0) then
-               scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
-            end if
-            if (index_nr > 0) then
-               scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
-            end if
-            if (index_ni > 0) then
-               scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-            end if
+         if (index_qv > 0) then
+            scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
+         end if
+         if (index_qc > 0) then
+            scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', dt )
+         end if
+         if (index_qr > 0) then
+            scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', dt )
+         end if
+         if (index_qi > 0) then
+            scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', dt )
+         end if
+         if (index_qs > 0) then
+            scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', dt )
+         end if
+         if (index_qg > 0) then
+            scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
+         end if
+         if (index_nr > 0) then
+            scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
+         end if
+         if (index_ni > 0) then
+            scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
+         end if
       
 !$OMP PARALLEL DO
-            do thread=1,nThreads
-               call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
-                                         cellThreadStart(thread), cellThreadEnd(thread), &
-                                         cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
-            end do
+         do thread=1,nThreads
+            call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &
+                                      cellThreadStart(thread), cellThreadEnd(thread), &
+                                      cellSolveThreadStart(thread), cellSolveThreadEnd(thread) )
+         end do
 !$OMP END PARALLEL DO
 
-            deallocate(scalars_driving)
-
+         deallocate(scalars_driving)
 
       end if  ! regional_MPAS addition
 
@@ -1650,96 +1642,95 @@ module atm_time_integration
          call mpas_timer_start('atm_advance_scalars_mono')
       end if
 
-         call mpas_pool_get_subpool(block % structs, 'tend', tend)
-         call mpas_pool_get_subpool(block % structs, 'state', state)
-         call mpas_pool_get_subpool(block % structs, 'diag', diag)
-         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+      call mpas_pool_get_subpool(block % structs, 'tend', tend)
+      call mpas_pool_get_subpool(block % structs, 'state', state)
+      call mpas_pool_get_subpool(block % structs, 'diag', diag)
+      call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-         call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-         call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
-         call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
+      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
 
-         call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
+      call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadStart', cellThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellThreadEnd', cellThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadStart', cellSolveThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'cellSolveThreadEnd', cellSolveThreadEnd)
 
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
-         call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadStart', edgeThreadStart)
+      call mpas_pool_get_dimension(block % dimensions, 'edgeThreadEnd', edgeThreadEnd)
 
-         allocate(scalar_old_arr(nVertLevels,nCells+1))
-         scalar_old_arr(:,nCells+1) = 0.0_RKIND
-         allocate(scalar_new_arr(nVertLevels,nCells+1))
-         scalar_new_arr(:,nCells+1) = 0.0_RKIND
-         allocate(s_max_arr(nVertLevels,nCells+1))
-         s_max_arr(:,nCells+1) = 0.0_RKIND
-         allocate(s_min_arr(nVertLevels,nCells+1))
-         s_min_arr(:,nCells+1) = 0.0_RKIND
-         allocate(scale_array(nVertLevels,2,nCells+1))
-         scale_array(:,:,nCells+1) = 0.0_RKIND
-         allocate(flux_array(nVertLevels,nEdges+1))
-         flux_array(:,nEdges+1) = 0.0_RKIND
-         allocate(wdtn_arr(nVertLevels+1,nCells+1))
-         wdtn_arr(:,nCells+1) = 0.0_RKIND
-         if (config_split_dynamics_transport) then
-            allocate(rho_zz_int(nVertLevels,nCells+1))
-            rho_zz_int(:,nCells+1) = 0.0_RKIND
-         else
-            allocate(rho_zz_int(1,1))
-         end if
+      allocate(scalar_old_arr(nVertLevels,nCells+1))
+      scalar_old_arr(:,nCells+1) = 0.0_RKIND
+      allocate(scalar_new_arr(nVertLevels,nCells+1))
+      scalar_new_arr(:,nCells+1) = 0.0_RKIND
+      allocate(s_max_arr(nVertLevels,nCells+1))
+      s_max_arr(:,nCells+1) = 0.0_RKIND
+      allocate(s_min_arr(nVertLevels,nCells+1))
+      s_min_arr(:,nCells+1) = 0.0_RKIND
+      allocate(scale_array(nVertLevels,2,nCells+1))
+      scale_array(:,:,nCells+1) = 0.0_RKIND
+      allocate(flux_array(nVertLevels,nEdges+1))
+      flux_array(:,nEdges+1) = 0.0_RKIND
+      allocate(wdtn_arr(nVertLevels+1,nCells+1))
+      wdtn_arr(:,nCells+1) = 0.0_RKIND
+      if (config_split_dynamics_transport) then
+         allocate(rho_zz_int(nVertLevels,nCells+1))
+         rho_zz_int(:,nCells+1) = 0.0_RKIND
+      else
+         allocate(rho_zz_int(1,1))
+      end if
+      if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+         allocate(horiz_flux_array(num_scalars,nVertLevels,nEdges+1))
+         horiz_flux_array(:,:,nEdges+1) = 0.0_RKIND
+      else
+         allocate(flux_upwind_tmp_arr(nVertLevels,nEdges+1))
+         flux_upwind_tmp_arr(:,nEdges+1) = 0.0_RKIND
+         allocate(flux_tmp_arr(nVertLevels,nEdges+1))
+         flux_tmp_arr(:,nEdges+1) = 0.0_RKIND
+      end if
+
+      !
+      ! Note: The advance_scalars_mono routine can be used without limiting, and thus, encompasses 
+      !       the functionality of the advance_scalars routine; however, it is noticeably slower, 
+      !       so we use the advance_scalars routine for the first two RK substeps.
+      !
+      !$OMP PARALLEL DO
+      do thread=1,nThreads
          if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
-            allocate(horiz_flux_array(num_scalars,nVertLevels,nEdges+1))
-            horiz_flux_array(:,:,nEdges+1) = 0.0_RKIND
+            call atm_advance_scalars(field_name, tend, state, diag, mesh, block % configs, rk_timestep(rk_step), &
+                                     edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                     cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                     horiz_flux_array, rk_step, config_time_integration_order, &
+                                     advance_density=config_split_dynamics_transport)
          else
-            allocate(flux_upwind_tmp_arr(nVertLevels,nEdges+1))
-            flux_upwind_tmp_arr(:,nEdges+1) = 0.0_RKIND
-            allocate(flux_tmp_arr(nVertLevels,nEdges+1))
-            flux_tmp_arr(:,nEdges+1) = 0.0_RKIND
+            call atm_advance_scalars_mono(field_name, block, tend, state, diag, mesh, block % configs, rk_timestep(rk_step), &
+                                          cellThreadStart(thread), cellThreadEnd(thread), &
+                                          edgeThreadStart(thread), edgeThreadEnd(thread), &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
+                                          scalar_old_arr, scalar_new_arr, s_max_arr, s_min_arr, wdtn_arr, &
+                                          scale_array, flux_array, flux_upwind_tmp_arr, flux_tmp_arr, &
+                                          advance_density=config_split_dynamics_transport, rho_zz_int=rho_zz_int)
          end if
+      end do
+      !$OMP END PARALLEL DO
 
-         !
-         ! Note: The advance_scalars_mono routine can be used without limiting, and thus, encompasses 
-         !       the functionality of the advance_scalars routine; however, it is noticeably slower, 
-         !       so we use the advance_scalars routine for the first two RK substeps.
-         !
-         !$OMP PARALLEL DO
-         do thread=1,nThreads
-            if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
-               call atm_advance_scalars(field_name, tend, state, diag, mesh, block % configs, rk_timestep(rk_step), &
-                                        edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                        cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                        horiz_flux_array, rk_step, config_time_integration_order, &
-                                        advance_density=config_split_dynamics_transport)
-            else
-               call atm_advance_scalars_mono(field_name, block, tend, state, diag, mesh, block % configs, rk_timestep(rk_step), &
-                                             cellThreadStart(thread), cellThreadEnd(thread), &
-                                             edgeThreadStart(thread), edgeThreadEnd(thread), &
-                                             cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
-                                             scalar_old_arr, scalar_new_arr, s_max_arr, s_min_arr, wdtn_arr, &
-                                             scale_array, flux_array, flux_upwind_tmp_arr, flux_tmp_arr, &
-                                             advance_density=config_split_dynamics_transport, rho_zz_int=rho_zz_int)
-            end if
-         end do
-         !$OMP END PARALLEL DO
-
-         deallocate(scalar_old_arr)
-         deallocate(scalar_new_arr)
-         deallocate(s_max_arr)
-         deallocate(s_min_arr)
-         deallocate(scale_array)
-         deallocate(flux_array)
-         deallocate(wdtn_arr)
-         deallocate(rho_zz_int)
-         if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
-            deallocate(horiz_flux_array)
-         else
-            deallocate(flux_upwind_tmp_arr)
-            deallocate(flux_tmp_arr)
-         end if
-
+      deallocate(scalar_old_arr)
+      deallocate(scalar_new_arr)
+      deallocate(s_max_arr)
+      deallocate(s_min_arr)
+      deallocate(scale_array)
+      deallocate(flux_array)
+      deallocate(wdtn_arr)
+      deallocate(rho_zz_int)
+      if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
+         deallocate(horiz_flux_array)
+      else
+         deallocate(flux_upwind_tmp_arr)
+         deallocate(flux_tmp_arr)
+      end if
 
       if (rk_step < 3 .or. (.not. config_monotonic .and. .not. config_positive_definite)) then
          call mpas_timer_stop('atm_advance_scalars')
@@ -6665,258 +6656,255 @@ module atm_time_integration
       if (config_print_detailed_minmax_vel) then
          call mpas_log_write('')
 
-            call mpas_pool_get_subpool(block % structs, 'state', state)
-            call mpas_pool_get_subpool(block % structs, 'diag', diag)
-            call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'diag', diag)
+         call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
 
-            call mpas_pool_get_array(state, 'w', w, 2)
-            call mpas_pool_get_array(state, 'u', u, 2)
-            call mpas_pool_get_array(diag, 'v', v)
-            call mpas_pool_get_array(mesh, 'indexToCellID', indexToCellID)
-            call mpas_pool_get_array(mesh, 'latCell', latCell)
-            call mpas_pool_get_array(mesh, 'lonCell', lonCell)
-            call mpas_pool_get_array(mesh, 'latEdge', latEdge)
-            call mpas_pool_get_array(mesh, 'lonEdge', lonEdge)
-            call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
-            call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
-            call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_array(state, 'w', w, 2)
+         call mpas_pool_get_array(state, 'u', u, 2)
+         call mpas_pool_get_array(diag, 'v', v)
+         call mpas_pool_get_array(mesh, 'indexToCellID', indexToCellID)
+         call mpas_pool_get_array(mesh, 'latCell', latCell)
+         call mpas_pool_get_array(mesh, 'lonCell', lonCell)
+         call mpas_pool_get_array(mesh, 'latEdge', latEdge)
+         call mpas_pool_get_array(mesh, 'lonEdge', lonEdge)
+         call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
+         call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
 
-            scalar_min = 1.0e20
-            indexMax = -1
-            kMax = -1
-            latMax = 0.0
-            lonMax = 0.0
-            do iCell = 1, nCellsSolve
-            do k = 1, nVertLevels
-               if (w(k,iCell) < scalar_min) then
-                  scalar_min = w(k,iCell)
-                  indexMax = iCell
-                  kMax = k
-                  latMax = latCell(iCell)
-                  lonMax = lonCell(iCell)
-               end if
-            end do
-            end do
-            localVals(1) = scalar_min
-            localVals(2) = real(indexMax,kind=RKIND)
-            localVals(3) = real(kMax,kind=RKIND)
-            localVals(4) = latMax
-            localVals(5) = lonMax
-            call mpas_dmpar_minattributes_real(domain % dminfo, scalar_min, localVals, globalVals)
-            global_scalar_min = globalVals(1)
-            indexMax_global = int(globalVals(2))
-            kMax_global = int(globalVals(3))
-            latMax_global = globalVals(4)
-            lonMax_global = globalVals(5)
-            latMax_global = latMax_global * 180.0_RKIND / pi_const
-            lonMax_global = lonMax_global * 180.0_RKIND / pi_const
-            if (lonMax_global > 180.0) then
-               lonMax_global = lonMax_global - 360.0
+         scalar_min = 1.0e20
+         indexMax = -1
+         kMax = -1
+         latMax = 0.0
+         lonMax = 0.0
+         do iCell = 1, nCellsSolve
+         do k = 1, nVertLevels
+            if (w(k,iCell) < scalar_min) then
+               scalar_min = w(k,iCell)
+               indexMax = iCell
+               kMax = k
+               latMax = latCell(iCell)
+               lonMax = lonCell(iCell)
             end if
-            ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
-            call mpas_log_write(' global min w: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
-                                realArgs=(/global_scalar_min, latMax_global, lonMax_global/))
+         end do
+         end do
+         localVals(1) = scalar_min
+         localVals(2) = real(indexMax,kind=RKIND)
+         localVals(3) = real(kMax,kind=RKIND)
+         localVals(4) = latMax
+         localVals(5) = lonMax
+         call mpas_dmpar_minattributes_real(domain % dminfo, scalar_min, localVals, globalVals)
+         global_scalar_min = globalVals(1)
+         indexMax_global = int(globalVals(2))
+         kMax_global = int(globalVals(3))
+         latMax_global = globalVals(4)
+         lonMax_global = globalVals(5)
+         latMax_global = latMax_global * 180.0_RKIND / pi_const
+         lonMax_global = lonMax_global * 180.0_RKIND / pi_const
+         if (lonMax_global > 180.0) then
+            lonMax_global = lonMax_global - 360.0
+         end if
+         ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
+         call mpas_log_write(' global min w: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
+                             realArgs=(/global_scalar_min, latMax_global, lonMax_global/))
 
-            scalar_max = -1.0e20
-            indexMax = -1
-            kMax = -1
-            latMax = 0.0
-            lonMax = 0.0
-            do iCell = 1, nCellsSolve
-            do k = 1, nVertLevels
-               if (w(k,iCell) > scalar_max) then
-                  scalar_max = w(k,iCell)
-                  indexMax = iCell
-                  kMax = k
-                  latMax = latCell(iCell)
-                  lonMax = lonCell(iCell)
-               end if
-            end do
-            end do
-            localVals(1) = scalar_max
-            localVals(2) = real(indexMax,kind=RKIND)
-            localVals(3) = real(kMax,kind=RKIND)
-            localVals(4) = latMax
-            localVals(5) = lonMax
-            call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
-            global_scalar_max = globalVals(1)
-            indexMax_global = int(globalVals(2))
-            kMax_global = int(globalVals(3))
-            latMax_global = globalVals(4)
-            lonMax_global = globalVals(5)
-            latMax_global = latMax_global * 180.0_RKIND / pi_const
-            lonMax_global = lonMax_global * 180.0_RKIND / pi_const
-            if (lonMax_global > 180.0) then
-               lonMax_global = lonMax_global - 360.0
+         scalar_max = -1.0e20
+         indexMax = -1
+         kMax = -1
+         latMax = 0.0
+         lonMax = 0.0
+         do iCell = 1, nCellsSolve
+         do k = 1, nVertLevels
+            if (w(k,iCell) > scalar_max) then
+               scalar_max = w(k,iCell)
+               indexMax = iCell
+               kMax = k
+               latMax = latCell(iCell)
+               lonMax = lonCell(iCell)
             end if
-            ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
-            call mpas_log_write(' global max w: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
-                                realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
+         end do
+         end do
+         localVals(1) = scalar_max
+         localVals(2) = real(indexMax,kind=RKIND)
+         localVals(3) = real(kMax,kind=RKIND)
+         localVals(4) = latMax
+         localVals(5) = lonMax
+         call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
+         global_scalar_max = globalVals(1)
+         indexMax_global = int(globalVals(2))
+         kMax_global = int(globalVals(3))
+         latMax_global = globalVals(4)
+         lonMax_global = globalVals(5)
+         latMax_global = latMax_global * 180.0_RKIND / pi_const
+         lonMax_global = lonMax_global * 180.0_RKIND / pi_const
+         if (lonMax_global > 180.0) then
+            lonMax_global = lonMax_global - 360.0
+         end if
+         ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
+         call mpas_log_write(' global max w: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
+                             realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
 
-            scalar_min = 1.0e20
-            indexMax = -1
-            kMax = -1
-            latMax = 0.0
-            lonMax = 0.0
-            do iEdge = 1, nEdgesSolve
-            do k = 1, nVertLevels
-               if (u(k,iEdge) < scalar_min) then
-                  scalar_min = u(k,iEdge)
-                  indexMax = iEdge
-                  kMax = k
-                  latMax = latEdge(iEdge)
-                  lonMax = lonEdge(iEdge)
-               end if
-            end do
-            end do
-            localVals(1) = scalar_min
-            localVals(2) = real(indexMax,kind=RKIND)
-            localVals(3) = real(kMax,kind=RKIND)
-            localVals(4) = latMax
-            localVals(5) = lonMax
-            call mpas_dmpar_minattributes_real(domain % dminfo, scalar_min, localVals, globalVals)
-            global_scalar_min = globalVals(1)
-            indexMax_global = int(globalVals(2))
-            kMax_global = int(globalVals(3))
-            latMax_global = globalVals(4)
-            lonMax_global = globalVals(5)
-            latMax_global = latMax_global * 180.0_RKIND / pi_const
-            lonMax_global = lonMax_global * 180.0_RKIND / pi_const
-            if (lonMax_global > 180.0) then
-               lonMax_global = lonMax_global - 360.0
+         scalar_min = 1.0e20
+         indexMax = -1
+         kMax = -1
+         latMax = 0.0
+         lonMax = 0.0
+         do iEdge = 1, nEdgesSolve
+         do k = 1, nVertLevels
+            if (u(k,iEdge) < scalar_min) then
+               scalar_min = u(k,iEdge)
+               indexMax = iEdge
+               kMax = k
+               latMax = latEdge(iEdge)
+               lonMax = lonEdge(iEdge)
             end if
-            ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
-            call mpas_log_write(' global min u: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
-                                realArgs=(/global_scalar_min, latMax_global, lonMax_global/))
+         end do
+         end do
+         localVals(1) = scalar_min
+         localVals(2) = real(indexMax,kind=RKIND)
+         localVals(3) = real(kMax,kind=RKIND)
+         localVals(4) = latMax
+         localVals(5) = lonMax
+         call mpas_dmpar_minattributes_real(domain % dminfo, scalar_min, localVals, globalVals)
+         global_scalar_min = globalVals(1)
+         indexMax_global = int(globalVals(2))
+         kMax_global = int(globalVals(3))
+         latMax_global = globalVals(4)
+         lonMax_global = globalVals(5)
+         latMax_global = latMax_global * 180.0_RKIND / pi_const
+         lonMax_global = lonMax_global * 180.0_RKIND / pi_const
+         if (lonMax_global > 180.0) then
+            lonMax_global = lonMax_global - 360.0
+         end if
+         ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
+         call mpas_log_write(' global min u: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
+                             realArgs=(/global_scalar_min, latMax_global, lonMax_global/))
 
-            scalar_max = -1.0e20
-            indexMax = -1
-            kMax = -1
-            latMax = 0.0
-            lonMax = 0.0
-            do iEdge = 1, nEdgesSolve
-            do k = 1, nVertLevels
-               if (u(k,iEdge) > scalar_max) then
-                  scalar_max = u(k,iEdge)
-                  indexMax = iEdge
-                  kMax = k
-                  latMax = latEdge(iEdge)
-                  lonMax = lonEdge(iEdge)
-               end if
-            end do
-            end do
-            localVals(1) = scalar_max
-            localVals(2) = real(indexMax,kind=RKIND)
-            localVals(3) = real(kMax,kind=RKIND)
-            localVals(4) = latMax
-            localVals(5) = lonMax
-            call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
-            global_scalar_max = globalVals(1)
-            indexMax_global = int(globalVals(2))
-            kMax_global = int(globalVals(3))
-            latMax_global = globalVals(4)
-            lonMax_global = globalVals(5)
-            latMax_global = latMax_global * 180.0_RKIND / pi_const
-            lonMax_global = lonMax_global * 180.0_RKIND / pi_const
-            if (lonMax_global > 180.0) then
-               lonMax_global = lonMax_global - 360.0
+         scalar_max = -1.0e20
+         indexMax = -1
+         kMax = -1
+         latMax = 0.0
+         lonMax = 0.0
+         do iEdge = 1, nEdgesSolve
+         do k = 1, nVertLevels
+            if (u(k,iEdge) > scalar_max) then
+               scalar_max = u(k,iEdge)
+               indexMax = iEdge
+               kMax = k
+               latMax = latEdge(iEdge)
+               lonMax = lonEdge(iEdge)
             end if
-            ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
-            call mpas_log_write(' global max u: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
-                                realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
+         end do
+         end do
+         localVals(1) = scalar_max
+         localVals(2) = real(indexMax,kind=RKIND)
+         localVals(3) = real(kMax,kind=RKIND)
+         localVals(4) = latMax
+         localVals(5) = lonMax
+         call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
+         global_scalar_max = globalVals(1)
+         indexMax_global = int(globalVals(2))
+         kMax_global = int(globalVals(3))
+         latMax_global = globalVals(4)
+         lonMax_global = globalVals(5)
+         latMax_global = latMax_global * 180.0_RKIND / pi_const
+         lonMax_global = lonMax_global * 180.0_RKIND / pi_const
+         if (lonMax_global > 180.0) then
+            lonMax_global = lonMax_global - 360.0
+         end if
+         ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
+         call mpas_log_write(' global max u: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
+                             realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
 
-            scalar_max = -1.0e20
-            indexMax = -1
-            kMax = -1
-            latMax = 0.0
-            lonMax = 0.0
-            do iEdge = 1, nEdgesSolve
-            do k = 1, nVertLevels
-               spd = sqrt(u(k,iEdge)*u(k,iEdge) + v(k,iEdge)*v(k,iEdge))
-               if (spd > scalar_max) then
-                  scalar_max = spd
-                  indexMax = iEdge
-                  kMax = k
-                  latMax = latEdge(iEdge)
-                  lonMax = lonEdge(iEdge)
-               end if
-            end do
-            end do
-            localVals(1) = scalar_max
-            localVals(2) = real(indexMax,kind=RKIND)
-            localVals(3) = real(kMax,kind=RKIND)
-            localVals(4) = latMax
-            localVals(5) = lonMax
-            call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
-            global_scalar_max = globalVals(1)
-            indexMax_global = int(globalVals(2))
-            kMax_global = int(globalVals(3))
-            latMax_global = globalVals(4)
-            lonMax_global = globalVals(5)
-            latMax_global = latMax_global * 180.0_RKIND / pi_const
-            lonMax_global = lonMax_global * 180.0_RKIND / pi_const
-            if (lonMax_global > 180.0) then
-               lonMax_global = lonMax_global - 360.0
+         scalar_max = -1.0e20
+         indexMax = -1
+         kMax = -1
+         latMax = 0.0
+         lonMax = 0.0
+         do iEdge = 1, nEdgesSolve
+         do k = 1, nVertLevels
+            spd = sqrt(u(k,iEdge)*u(k,iEdge) + v(k,iEdge)*v(k,iEdge))
+            if (spd > scalar_max) then
+               scalar_max = spd
+               indexMax = iEdge
+               kMax = k
+               latMax = latEdge(iEdge)
+               lonMax = lonEdge(iEdge)
             end if
-            ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
-            call mpas_log_write(' global max wsp: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
-                                realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
+         end do
+         end do
+         localVals(1) = scalar_max
+         localVals(2) = real(indexMax,kind=RKIND)
+         localVals(3) = real(kMax,kind=RKIND)
+         localVals(4) = latMax
+         localVals(5) = lonMax
+         call mpas_dmpar_maxattributes_real(domain % dminfo, scalar_max, localVals, globalVals)
+         global_scalar_max = globalVals(1)
+         indexMax_global = int(globalVals(2))
+         kMax_global = int(globalVals(3))
+         latMax_global = globalVals(4)
+         lonMax_global = globalVals(5)
+         latMax_global = latMax_global * 180.0_RKIND / pi_const
+         lonMax_global = lonMax_global * 180.0_RKIND / pi_const
+         if (lonMax_global > 180.0) then
+            lonMax_global = lonMax_global - 360.0
+         end if
+         ! format statement should be '(a,f9.4,a,i4,a,f7.3,a,f8.3,a)'
+         call mpas_log_write(' global max wsp: $r k=$i, $r lat, $r lon', intArgs=(/kMax_global/), &
+                             realArgs=(/global_scalar_max, latMax_global, lonMax_global/))
 
-            !
-            ! Check for NaNs
-            !
-            do iCell = 1, nCellsSolve
-            do k = 1, nVertLevels
-               if (ieee_is_nan(w(k,iCell))) then
-                  call mpas_log_write('NaN detected in ''w'' field.', messageType=MPAS_LOG_CRIT)
-               end if
-            end do
-            end do
+         !
+         ! Check for NaNs
+         !
+         do iCell = 1, nCellsSolve
+         do k = 1, nVertLevels
+            if (ieee_is_nan(w(k,iCell))) then
+               call mpas_log_write('NaN detected in ''w'' field.', messageType=MPAS_LOG_CRIT)
+            end if
+         end do
+         end do
 
-            do iEdge = 1, nEdgesSolve
-            do k = 1, nVertLevels
-               if (ieee_is_nan(u(k,iEdge))) then
-                  call mpas_log_write('NaN detected in ''u'' field.', messageType=MPAS_LOG_CRIT)
-               end if
-            end do
-            end do
-
+         do iEdge = 1, nEdgesSolve
+         do k = 1, nVertLevels
+            if (ieee_is_nan(u(k,iEdge))) then
+               call mpas_log_write('NaN detected in ''u'' field.', messageType=MPAS_LOG_CRIT)
+            end if
+         end do
+         end do
 
       else if (config_print_global_minmax_vel) then
          call mpas_log_write('')
 
-            call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_array(state, 'w', w, 2)
+         call mpas_pool_get_array(state, 'u', u, 2)
+         call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
+         call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
 
-            call mpas_pool_get_array(state, 'w', w, 2)
-            call mpas_pool_get_array(state, 'u', u, 2)
-            call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
-            call mpas_pool_get_dimension(state, 'nEdgesSolve', nEdgesSolve)
-            call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
+         scalar_min = 0.0
+         scalar_max = 0.0
+         do iCell = 1, nCellsSolve
+         do k = 1, nVertLevels
+            scalar_min = min(scalar_min, w(k,iCell))
+            scalar_max = max(scalar_max, w(k,iCell))
+         end do
+         end do
+         call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
+         call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
+         call mpas_log_write('global min, max w $r $r', realArgs=(/global_scalar_min, global_scalar_max/))
 
-            scalar_min = 0.0
-            scalar_max = 0.0
-            do iCell = 1, nCellsSolve
-            do k = 1, nVertLevels
-               scalar_min = min(scalar_min, w(k,iCell))
-               scalar_max = max(scalar_max, w(k,iCell))
-            end do
-            end do
-            call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
-            call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
-            call mpas_log_write('global min, max w $r $r', realArgs=(/global_scalar_min, global_scalar_max/))
-
-            scalar_min = 0.0
-            scalar_max = 0.0
-            do iEdge = 1, nEdgesSolve
-            do k = 1, nVertLevels
-               scalar_min = min(scalar_min, u(k,iEdge))
-               scalar_max = max(scalar_max, u(k,iEdge))
-            end do
-            end do
-            call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
-            call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
-            call mpas_log_write('global min, max u $r $r', realArgs=(/global_scalar_min, global_scalar_max/))
-
+         scalar_min = 0.0
+         scalar_max = 0.0
+         do iEdge = 1, nEdgesSolve
+         do k = 1, nVertLevels
+            scalar_min = min(scalar_min, u(k,iEdge))
+            scalar_max = max(scalar_max, u(k,iEdge))
+         end do
+         end do
+         call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
+         call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
+         call mpas_log_write('global min, max u $r $r', realArgs=(/global_scalar_min, global_scalar_max/))
       end if
 
       if (config_print_global_minmax_sca) then
@@ -6924,27 +6912,25 @@ module atm_time_integration
             call mpas_log_write('')
          end if
 
-            call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_subpool(block % structs, 'state', state)
+         call mpas_pool_get_array(state, 'scalars', scalars, 2)
+         call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
 
-            call mpas_pool_get_array(state, 'scalars', scalars, 2)
-            call mpas_pool_get_dimension(state, 'nCellsSolve', nCellsSolve)
-            call mpas_pool_get_dimension(state, 'nVertLevels', nVertLevels)
-            call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-
-            do iScalar = 1, num_scalars
-               scalar_min = 0.0
-               scalar_max = 0.0
-               do iCell = 1, nCellsSolve
-               do k = 1, nVertLevels
-                  scalar_min = min(scalar_min, scalars(iScalar,k,iCell))
-                  scalar_max = max(scalar_max, scalars(iScalar,k,iCell))
-               end do
-               end do
-               call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
-               call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
-               call mpas_log_write(' global min, max scalar $i $r $r', intArgs=(/iScalar/), realArgs=(/global_scalar_min, global_scalar_max/))
+         do iScalar = 1, num_scalars
+            scalar_min = 0.0
+            scalar_max = 0.0
+            do iCell = 1, nCellsSolve
+            do k = 1, nVertLevels
+               scalar_min = min(scalar_min, scalars(iScalar,k,iCell))
+               scalar_max = max(scalar_max, scalars(iScalar,k,iCell))
             end do
-
+            end do
+            call mpas_dmpar_min_real(domain % dminfo, scalar_min, global_scalar_min)
+            call mpas_dmpar_max_real(domain % dminfo, scalar_max, global_scalar_max)
+            call mpas_log_write(' global min, max scalar $i $r $r', intArgs=(/iScalar/), realArgs=(/global_scalar_min, global_scalar_max/))
+         end do
       end if
 
    end subroutine summarize_timestep


### PR DESCRIPTION
A MPAS domain encompasses the entire problem space being simulated and is decomposed across blocks when running in parallel. To maintain generality it was not initially assumed that one thread would be associated with one block (i.e. one thread could have multiple blocks or blocks could be shared across threads). This means that any operation that would modify a variable in a subpool (e.g. horizontal wind speed `u`), would need to start at the head of the blocklist, fetch the necessary subpools from the block, fetch arrays/fields/dimensions from subpools, perform computation, and then repeat for each block in the blocklist. These "block loops" and are illustrated in the example below. Since there should now only be one block per thread, the block loops, the whitespace they consumed, and repeated fetching of pointers is unnecessary.

This pull request removes the block loops from `mpas_atm_time_integration.F`, reclaims the blank lines and columns used for the loops, and moves the calls to `mpas_pool_get_subpool` and `mpas_pool_get_dimensions` within `atm_srk3` to the top of the subroutine where feasible. 

General form of a block loop:
```
block => domain % blocklist
do while (associated(block))
   ! Get the subpools that contain arrays, fields, or dimensions that are needed
   call mpas_pool_get_subpool(block % structs, 'state', state)
   call mpas_pool_get_subpool(block % structs, 'mesh', mesh)

   ! Get the dimensions and arrays needed
   call mpas_pool_get_dimension(state, 'nThreads', nThreads)
   call mpas_pool_get_dimension(mesh, 'nCells', nCells)
   call mpas_pool_get_array(state, 'u', u)

    ...
   ! Code that updates u for this block
   ...
   ! Advance to the next block in the blocklist
   block => block % next
end do
``` 