### PR TITLE
Remove whitespace in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ xlf:
 	"USE_PAPI = $(USE_PAPI)" \
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
- 
+
 ftn:
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \


### PR DESCRIPTION
This seems trivial but I have actually written an sed parser that trips over
this here:
https://github.com/spack/spack/blob/43673fee808f9e02efcb4330c6a7fa2c9b80c14c/var/spack/repos/builtin/packages/mpas-model/package.py#L74
