### PR TITLE
Remove whitespace to make machine parsable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ xlf:
 	"USE_PAPI = $(USE_PAPI)" \
 	"OPENMP = $(OPENMP)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
- 
+
 ftn:
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \


### PR DESCRIPTION
Remove a space on an otherwise blank line separating two build targets in the top-level Makefile for consistency.

