### PR TITLE
Eliminate the use of hard-coded Fortran unit numbers in atmosphere code

### DIFF
--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -232,6 +232,7 @@ module soundings
         use mpas_derived_types, only : MPAS_Time_type, MPAS_NOW
         use mpas_timekeeping, only : MPAS_is_alarm_ringing, MPAS_reset_clock_alarm, MPAS_get_clock_time, MPAS_get_time
         use mpas_constants, only : rvord
+        use mpas_io_units, only: mpas_new_unit, mpas_release_unit
 
         implicit none
 
@@ -244,6 +245,7 @@ module soundings
         type (MPAS_time_type) :: now
         character(len=StrKIND) :: nowString
         integer :: yyyy, mm, dd, h, m, s
+        integer :: sndUnit
         character(len=StrKIND) :: fname
         character(len=10) :: stid
 
@@ -271,16 +273,17 @@ module soundings
 !                    call mpas_log_write('Writing sounding for station '//trim(stationNames(iStn)))
 
                     write(fname,'(a,i4.4,i2.2,i2.2,i2.2,i2.2,a)') trim(stationNames(iStn))//'.', yyyy, mm, dd, h, m, '.snd'
-                    open(97,file=trim(fname),form='formatted',status='replace')
+                    call mpas_new_unit(sndUnit)
+                    open(sndUnit,file=trim(fname),form='formatted',status='replace')
 
                     write(stid,'(a)') trim(stationNames(iStn))
 
-                    write(97,'(a)') '  SNPARM = PRES;HGHT;TMPC;DWPC;DRCT;SPED;'
-                    write(97,'(a)') ''
-                    write(97,'(a,i2.2,i2.2,i2.2,a,i2.2,i2.2)') ' STID = '//stid//'  STNM = 99999       TIME = ', mod(yyyy,100), mm, dd,'/', h, m
-                    write(97,'(a,f6.2,a,f7.2,a)') ' SLAT = ', stationLats(iStn), '      SLON = ', stationLons(iStn), '     SELV =    -999'
-                    write(97,'(a)') ''
-                    write(97,'(a)') '      PRES      HGHT     TMPC     DWPC     DRCT     SPED'
+                    write(sndUnit,'(a)') '  SNPARM = PRES;HGHT;TMPC;DWPC;DRCT;SPED;'
+                    write(sndUnit,'(a)') ''
+                    write(sndUnit,'(a,i2.2,i2.2,i2.2,a,i2.2,i2.2)') ' STID = '//stid//'  STNM = 99999       TIME = ', mod(yyyy,100), mm, dd,'/', h, m
+                    write(sndUnit,'(a,f6.2,a,f7.2,a)') ' SLAT = ', stationLats(iStn), '      SLON = ', stationLons(iStn), '     SELV =    -999'
+                    write(sndUnit,'(a)') ''
+                    write(sndUnit,'(a)') '      PRES      HGHT     TMPC     DWPC     DRCT     SPED'
 
                     do k=1,nVertLevels
                         tmpc = theta_m(k,stationCells(iStn)) / (1.0_RKIND + rvord * scalars(index_qv,k,stationCells(iStn))) * exner(k,stationCells(iStn))
@@ -305,7 +308,7 @@ module soundings
                             end if
                             dir = dir * 180.0_RKIND / pi_const
                         end if
-                        write(97,'(f10.2,f10.2,f9.2,f9.2,f9.2,f9.2)') &
+                        write(sndUnit,'(f10.2,f10.2,f9.2,f9.2,f9.2,f9.2)') &
                                     pres, &
                                     0.5 * (zgrid(k,stationCells(iStn)) + zgrid(k+1,stationCells(iStn))), &               ! Avg to layer midpoint
                                     tmpc, &
@@ -314,7 +317,8 @@ module soundings
                                     spd
                     end do
 
-                    close(97)
+                    close(sndUnit)
+                    call mpas_release_unit(sndUnit)
                 end if
             end do
 

--- a/src/core_atmosphere/physics/mpas_atmphys_o3climatology.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_o3climatology.F
@@ -12,6 +12,7 @@
  use mpas_atmphys_date_time
  use mpas_atmphys_constants
  use mpas_atmphys_utilities
+ use mpas_io_units, only: mpas_new_unit, mpas_release_unit
 
 !wrf physics:
  use module_ra_cam_support, only: r8, getfactors
@@ -74,9 +75,7 @@
  real(kind=RKIND),dimension(:,:,:),pointer:: ozmixm
 
 !local variables:
- integer,parameter:: pin_unit = 27
- integer,parameter:: lat_unit = 28
- integer,parameter:: oz_unit  = 29
+ integer :: pin_unit, lat_unit, oz_unit
  integer,parameter:: open_ok  = 0
 
  integer:: i,i1,i2,istat,k,j,m
@@ -100,6 +99,7 @@
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
 
 !-- read in ozone pressure data:
+ call mpas_new_unit(pin_unit)
  open(pin_unit,file='OZONE_PLEV.TBL',action='READ',status='OLD',iostat=istat)
  if(istat /= open_ok) &
     call physics_error_fatal('subroutine oznini: ' // &
@@ -108,8 +108,10 @@
     read(pin_unit,*) pin(k)
  enddo
  close(pin_unit)
+ call mpas_release_unit(pin_unit)
 
 !-- read in ozone lat data:
+ call mpas_new_unit(lat_unit)
  open(lat_unit, file='OZONE_LAT.TBL',action='READ',status='OLD',iostat=istat) 
  if(istat /= open_ok) &
     call physics_error_fatal('subroutine oznini: ' // &
@@ -119,8 +121,10 @@
 !   call mpas_log_write('$i $r', intArgs=(/j/), realArgs=(/lat_ozone(j)/))
  enddo
  close(lat_unit)
+ call mpas_release_unit(lat_unit)
 
 !-- read in ozone data:
+ call mpas_new_unit(oz_unit)
  open(oz_unit,file='OZONE_DAT.TBL',action='READ',status='OLD',iostat=istat)
  if(istat /= open_ok) &
     call physics_error_fatal('subroutine oznini: ' // &
@@ -137,6 +141,7 @@
  enddo
  enddo
  close(oz_unit)
+ call mpas_release_unit(oz_unit)
 
 !INTERPOLATION OF INPUT OZONE DATA TO MPAS GRID:
 !call mpas_log_write('max latCell=$r', realArgs=(/maxval(latCell)/degrad/))

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -411,6 +411,7 @@
 
 !=================================================================================================================
  subroutine thompson_init(l_mp_tables)
+ use mpas_io_units, only : mpas_new_unit, mpas_release_unit
  implicit none
 !=================================================================================================================
 
@@ -421,6 +422,7 @@
  integer:: i,j,k,l,m,n
  integer:: istat
  logical:: micro_init
+ integer:: mp_unit
 
 !..Allocate space for lookup tables (J. Michalakes 2009Jun08).
       micro_init = .FALSE.
@@ -833,18 +835,19 @@
       call table_dropEvap
 
 !..Rain collecting graupel & graupel collecting rain.
-      open(unit=11,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
+      call mpas_new_unit(mp_unit, unformatted = .true.)
+      open(unit=mp_unit,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
            iostat = istat)
       if(istat /= open_OK) &
          call physics_error_fatal('subroutine thompson_init: ' // &
                                   'failure opening MP_THOMPSON_QRacrQG.DBL')
-      read(11) tcg_racg
-      read(11) tmr_racg
-      read(11) tcr_gacr
-      read(11) tmg_gacr
-      read(11) tnr_racg
-      read(11) tnr_gacr
-      close(unit=11)
+      read(mp_unit) tcg_racg
+      read(mp_unit) tmr_racg
+      read(mp_unit) tcr_gacr
+      read(mp_unit) tmg_gacr
+      read(mp_unit) tnr_racg
+      read(mp_unit) tnr_gacr
+      close(unit=mp_unit)
 !     write(0,*) '--- end read MP_THOMPSON_QRacrQG.DBL'
 !     write(0,*) 'max tcg_racg =',maxval(tcg_racg)
 !     write(0,*) 'min tcg_racg =',minval(tcg_racg)
@@ -860,24 +863,24 @@
 !     write(0,*) 'min tnr_gacr =',minval(tnr_gacr)
 
 !..Rain collecting snow & snow collecting rain.
-      open(unit=11,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
+      open(unit=mp_unit,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
            iostat=istat)
       if(istat /= open_OK) &
          call physics_error_fatal('subroutine thompson_init: ' // &
                                   'failure opening MP_THOMPSON_QRacrQS.DBL')
-      read(11) tcs_racs1
-      read(11) tmr_racs1
-      read(11) tcs_racs2
-      read(11) tmr_racs2
-      read(11) tcr_sacr1
-      read(11) tms_sacr1
-      read(11) tcr_sacr2
-      read(11) tms_sacr2
-      read(11) tnr_racs1
-      read(11) tnr_racs2
-      read(11) tnr_sacr1
-      read(11) tnr_sacr2
-      close(unit=11)
+      read(mp_unit) tcs_racs1
+      read(mp_unit) tmr_racs1
+      read(mp_unit) tcs_racs2
+      read(mp_unit) tmr_racs2
+      read(mp_unit) tcr_sacr1
+      read(mp_unit) tms_sacr1
+      read(mp_unit) tcr_sacr2
+      read(mp_unit) tms_sacr2
+      read(mp_unit) tnr_racs1
+      read(mp_unit) tnr_racs2
+      read(mp_unit) tnr_sacr1
+      read(mp_unit) tnr_sacr2
+      close(unit=mp_unit)
 !     write(0,*) '--- end read MP_THOMPSON_QRacrQS.DBL'
 !     write(0,*) 'max tcs_racs1 =',maxval(tcs_racs1)
 !     write(0,*) 'min tcs_racs1 =',minval(tcs_racs1)
@@ -905,18 +908,18 @@
 !     write(0,*) 'min tnr_sacr2 =',minval(tnr_sacr2)
 
 !..Cloud water and rain freezing (Bigg, 1953).
-      open(unit=11,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
+      open(unit=mp_unit,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
            iostat=istat)
       if(istat /= open_OK) &
          call physics_error_fatal('subroutine thompson_init: ' // &
                                   'failure opening MP_THOMPSON_freezeH2O.DBL')
-      read(11) tpi_qrfz
-      read(11) tni_qrfz
-      read(11) tpg_qrfz
-      read(11) tnr_qrfz
-      read(11) tpi_qcfz
-      read(11) tni_qcfz
-      close(unit=11)
+      read(mp_unit) tpi_qrfz
+      read(mp_unit) tni_qrfz
+      read(mp_unit) tpg_qrfz
+      read(mp_unit) tnr_qrfz
+      read(mp_unit) tpi_qcfz
+      read(mp_unit) tni_qcfz
+      close(unit=mp_unit)
 !     write(0,*) '--- end read MP_THOMPSON_freezeH2O.DBL:'
 !     write(0,*) 'max tpi_qrfz =',maxval(tpi_qrfz)
 !     write(0,*) 'min tpi_qrfz =',minval(tpi_qrfz)
@@ -932,15 +935,16 @@
 !     write(0,*) 'min tni_qcfz =',minval(tni_qcfz)
 
 !..Conversion of some ice mass into snow category.
-      open(unit=11,file='MP_THOMPSON_QIautQS_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
+      open(unit=mp_unit,file='MP_THOMPSON_QIautQS_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
            iostat=istat)
       if(istat /= open_OK) &
          call physics_error_fatal('subroutine thompson_init: ' // &
                                   'failure opening MP_THOMPSON_QIautQS.DBL')
-      read(11) tpi_ide
-      read(11) tps_iaus
-      read(11) tni_iaus
-      close(unit=11)
+      read(mp_unit) tpi_ide
+      read(mp_unit) tps_iaus
+      read(mp_unit) tni_iaus
+      close(unit=mp_unit)
+      call mpas_release_unit(mp_unit)
 !     write(0,*) '--- end read MP_THOMPSON_QIautQS.DBL '
 !     write(0,*) 'max tps_iaus =',maxval(tps_iaus)
 !     write(0,*) 'min tps_iaus =',minval(tps_iaus)

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -63,6 +63,7 @@
       use mpas_kind_types
       use mpas_atmphys_functions, only: gammp,wgamma,rslf,rsif
       use mpas_atmphys_utilities
+      use mpas_io_units, only : mpas_new_unit, mpas_release_unit
       use module_mp_radar
 
       implicit none
@@ -411,7 +412,6 @@
 
 !=================================================================================================================
  subroutine thompson_init(l_mp_tables)
- use mpas_io_units, only : mpas_new_unit, mpas_release_unit
  implicit none
 !=================================================================================================================
 
@@ -835,7 +835,11 @@
       call table_dropEvap
 
 !..Rain collecting graupel & graupel collecting rain.
+#if defined(mpas)
       call mpas_new_unit(mp_unit, unformatted = .true.)
+#else
+      mp_unit = 11
+#endif
       open(unit=mp_unit,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='UNFORMATTED',status='OLD',action='READ', &
            iostat = istat)
       if(istat /= open_OK) &
@@ -944,7 +948,9 @@
       read(mp_unit) tps_iaus
       read(mp_unit) tni_iaus
       close(unit=mp_unit)
+#if defined(mpas)
       call mpas_release_unit(mp_unit)
+#endif
 !     write(0,*) '--- end read MP_THOMPSON_QIautQS.DBL '
 !     write(0,*) 'max tps_iaus =',maxval(tps_iaus)
 !     write(0,*) 'min tps_iaus =',minval(tps_iaus)

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
@@ -5,6 +5,7 @@ MODULE module_ra_cam_support
 ! Laura D. Fowler (birch.ucar.edu) / 2013-07-01.
   use mpas_atmphys_utilities
   use mpas_kind_types, only : R8KIND
+  use mpas_io_units, only: mpas_new_unit, mpas_release_unit
   implicit none
       integer, parameter :: r8 = R8KIND
 #else
@@ -3348,12 +3349,19 @@ subroutine oznini(ozmixm,pin,levsiz,num_months,XLAT,                &
      WRITE(message,*)'num_months = ',num_months
      CALL wrf_debug(50,message)
 
+#if defined(mpas)
+      call mpas_new_unit(pin_unit)
+#else
       pin_unit = 27
+#endif
         OPEN(pin_unit, FILE='ozone_plev.formatted',FORM='FORMATTED',STATUS='OLD')
         do k = 1,levsiz
         READ (pin_unit,*)pin(k)
         end do
-      close(27)
+      close(pin_unit)
+#if defined(mpas)
+      call mpas_release_unit(pin_unit)
+#endif
 
       do k=1,levsiz
         pin(k) = pin(k)*100.
@@ -3361,17 +3369,28 @@ subroutine oznini(ozmixm,pin,levsiz,num_months,XLAT,                &
 
 !-- read in ozone lat data
 
+#if defined(mpas)
+      call mpas_new_unit(lat_unit)
+#else
       lat_unit = 28
+#endif
         OPEN(lat_unit, FILE='ozone_lat.formatted',FORM='FORMATTED',STATUS='OLD')
         do j = 1,latsiz
         READ (lat_unit,*)lat_ozone(j)
         end do
-      close(28)
+      close(lat_unit)
+#if defined(mpas)
+      call mpas_release_unit(lat_unit)
+#endif
 
 
 !-- read in ozone data
 
+#if defined(mpas)
+      call mpas_new_unit(oz_unit)
+#else
       oz_unit = 29
+#endif
       OPEN(oz_unit, FILE='ozone.formatted',FORM='FORMATTED',STATUS='OLD')
 
       do m=2,num_months
@@ -3383,7 +3402,10 @@ subroutine oznini(ozmixm,pin,levsiz,num_months,XLAT,                &
       enddo
       enddo
       enddo
-      close(29)
+      close(oz_unit)
+#if defined(mpas)
+      call mpas_release_unit(oz_unit)
+#endif
 
 
 !-- latitudinally interpolate ozone data (and extend longitudinally)

--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -25,85 +25,91 @@
  subroutine build_tables_thompson
 !=================================================================================================================
 
+ use mpas_io_units, only : mpas_new_unit, mpas_release_unit
+
 !local variables:
  logical, parameter:: l_mp_tables = .false.
  integer:: istatus
+ integer:: mp_unit
 
 !-----------------------------------------------------------------------------------------------------------------
 
 !--- partial initialization before building the look-up tables:
  call thompson_init(l_mp_tables)
 
+ call mpas_new_unit(mp_unit, unformatted = .true.)
+
 !--- building look-up table for rain collecting graupel:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QRacrQG_DATA.DBL'
- open(unit=11,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ open(unit=mp_unit,file='MP_THOMPSON_QRacrQG_DATA.DBL',form='unformatted',status='new',iostat=istatus)
  if (istatus /= 0) then
     call print_parallel_mesg('MP_THOMPSON_QRacrQG_DATA.DBL')
     return
  end if
  call qr_acr_qg
- write(11) tcg_racg
- write(11) tmr_racg
- write(11) tcr_gacr
- write(11) tmg_gacr
- write(11) tnr_racg
- write(11) tnr_gacr
- close(unit=11)
+ write(mp_unit) tcg_racg
+ write(mp_unit) tmr_racg
+ write(mp_unit) tcr_gacr
+ write(mp_unit) tmg_gacr
+ write(mp_unit) tnr_racg
+ write(mp_unit) tnr_gacr
+ close(unit=mp_unit)
 
 !--- building look-up table for rain collecting snow:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QRacrQS_DATA.DBL'
- open(unit=11,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ open(unit=mp_unit,file='MP_THOMPSON_QRacrQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
  if (istatus /= 0) then
     call print_parallel_mesg('MP_THOMPSON_QRacrQS_DATA.DBL')
     return
  end if
  call qr_acr_qs
- write(11)tcs_racs1
- write(11)tmr_racs1
- write(11)tcs_racs2
- write(11)tmr_racs2
- write(11)tcr_sacr1
- write(11)tms_sacr1
- write(11)tcr_sacr2
- write(11)tms_sacr2
- write(11)tnr_racs1
- write(11)tnr_racs2
- write(11)tnr_sacr1
- write(11)tnr_sacr2
- close(unit=11)
+ write(mp_unit)tcs_racs1
+ write(mp_unit)tmr_racs1
+ write(mp_unit)tcs_racs2
+ write(mp_unit)tmr_racs2
+ write(mp_unit)tcr_sacr1
+ write(mp_unit)tms_sacr1
+ write(mp_unit)tcr_sacr2
+ write(mp_unit)tms_sacr2
+ write(mp_unit)tnr_racs1
+ write(mp_unit)tnr_racs2
+ write(mp_unit)tnr_sacr1
+ write(mp_unit)tnr_sacr2
+ close(unit=mp_unit)
 
 !--- building look-up table for freezing of cloud droplets:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_freezeH2O_DATA.DBL'
- open(unit=11,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ open(unit=mp_unit,file='MP_THOMPSON_freezeH2O_DATA.DBL',form='unformatted',status='new',iostat=istatus)
  if (istatus /= 0) then
     call print_parallel_mesg('MP_THOMPSON_freezeH2O_DATA.DBL')
     return
  end if
  call freezeH2O
- write(11) tpi_qrfz
- write(11) tni_qrfz
- write(11) tpg_qrfz
- write(11) tnr_qrfz
- write(11) tpi_qcfz
- write(11) tni_qcfz
- close(unit=11)
+ write(mp_unit) tpi_qrfz
+ write(mp_unit) tni_qrfz
+ write(mp_unit) tpg_qrfz
+ write(mp_unit) tnr_qrfz
+ write(mp_unit) tpi_qcfz
+ write(mp_unit) tni_qcfz
+ close(unit=mp_unit)
  
 !--- building look-up table for autoconversion of cloud ice to snow:
  write(0,*)
  write(0,*) '--- building MP_THOMPSON_QIautQS_DATA.DBL'
- open(unit=11,file='MP_THOMPSON_QIautQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
+ open(unit=mp_unit,file='MP_THOMPSON_QIautQS_DATA.DBL',form='unformatted',status='new',iostat=istatus)
  if (istatus /= 0) then
     call print_parallel_mesg('MP_THOMPSON_QIautQS_DATA.DBL')
     return
  end if
  call qi_aut_qs
- write(11) tpi_ide
- write(11) tps_iaus
- write(11) tni_iaus
- close(unit=11)
+ write(mp_unit) tpi_ide
+ write(mp_unit) tps_iaus
+ write(mp_unit) tni_iaus
+ close(unit=mp_unit)
+ call mpas_release_unit(mp_unit)
 
  write(0,*)
  write(0,*) 'Finished building all tables.'

--- a/src/core_init_atmosphere/mpas_init_atm_read_met.F
+++ b/src/core_init_atmosphere/mpas_init_atm_read_met.F
@@ -51,6 +51,7 @@ module init_atm_read_met
 
       use mpas_derived_types, only : MPAS_LOG_ERR
       use mpas_log, only : mpas_log_write
+      use mpas_io_units, only : mpas_new_unit
  
       implicit none
   
@@ -75,11 +76,8 @@ module init_atm_read_met
       end if
   
       !  2) OPEN FILE
-      do input_unit=10,100
-         inquire(unit=input_unit, opened=is_used)
-         if (.not. is_used) exit
-      end do 
-      if (input_unit > 100) call mpas_log_write('In read_met_init(), couldn''t find an available Fortran unit.', messageType=MPAS_LOG_ERR)
+      call mpas_new_unit(input_unit, unformatted = .true.)
+      if (input_unit < 0) call mpas_log_write('In read_met_init(), couldn''t find an available Fortran unit.', messageType=MPAS_LOG_ERR)
       open(unit=input_unit, file=trim(filename), status='old', form='unformatted', iostat=io_status)
 
       if (io_status > 0) istatus = 1
@@ -418,9 +416,12 @@ module init_atm_read_met
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    subroutine read_met_close()
  
+      use mpas_io_units, only : mpas_release_unit
+
       implicit none
   
       close(unit=input_unit)
+      call mpas_release_unit(input_unit)
       filename = 'UNINITIALIZED_FILENAME'
   
    end subroutine read_met_close


### PR DESCRIPTION
Some files contained hard-coded numbers for file units instead of searching for unused units. This PR changes those in the atmosphere core to instead use `mpas_io_units` via the `mpas_new_unit` and `mpas_release_unit` subroutines. This ensures that MPAS can be used in more contexts where it isn't certain whether a particular unit (e.g. 27) is already in use.

This PR copies and extends the work done in JCSDA-internal/MPAS-Model PR#12