### PR TITLE
Start module names in atmosphere diagnostics with "mpas_"

### DIFF
--- a/src/core_atmosphere/diagnostics/README
+++ b/src/core_atmosphere/diagnostics/README
@@ -9,7 +9,8 @@ generally required to implement a diagnostic.
    Registry_diagnostics.xml.
 
 2) Create a new module for the diagnostic; the "mpas_atm_diagnostic_template.F" 
-   module file may be used as a template.
+   module file may be used as a template. By convention, the module name is
+   expected to begin with "mpas_".
 
 3) Add calls to the diagnostic's "setup", "update", "compute", "reset", and 
    "cleanup" routines in the main diagnostic driver. Note that some diagnostics

--- a/src/core_atmosphere/diagnostics/cloud_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/cloud_diagnostics.F
@@ -4,7 +4,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at https://mpas-dev.github.io/license.html
 !
-module cloud_diagnostics
+module mpas_cloud_diagnostics
 
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type
     use mpas_kind_types, only : RKIND
@@ -140,4 +140,4 @@ module cloud_diagnostics
 
     end subroutine cloud_diagnostics_compute
 
-end module cloud_diagnostics
+end module mpas_cloud_diagnostics

--- a/src/core_atmosphere/diagnostics/convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/convective_diagnostics.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-module convective_diagnostics
+module mpas_convective_diagnostics
 
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type, MPAS_LOG_ERR, MPAS_LOG_CRIT
     use mpas_kind_types, only : RKIND, R8KIND
@@ -1096,4 +1096,4 @@ module convective_diagnostics
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !-----------------------------------------------------------------------
 
-end module convective_diagnostics
+end module mpas_convective_diagnostics

--- a/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/isobaric_diagnostics.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-module isobaric_diagnostics
+module mpas_isobaric_diagnostics
 
     use mpas_dmpar
     use mpas_kind_types
@@ -1244,4 +1244,4 @@ module isobaric_diagnostics
    
     end subroutine compute_layer_mean
    
-end module isobaric_diagnostics
+end module mpas_isobaric_diagnostics

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostic_template.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostic_template.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-module diagnostic_template
+module mpas_diagnostic_template
 
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type
 
@@ -134,4 +134,4 @@ module diagnostic_template
    
     end subroutine diagnostic_template_cleanup
 
-end module diagnostic_template
+end module mpas_diagnostic_template

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -33,7 +33,7 @@ module mpas_atm_diagnostics_manager
         use mpas_atm_diagnostics_utils, only : mpas_atm_diag_utils_init
         use mpas_derived_types, only : MPAS_streamManager_type, MPAS_pool_type, MPAS_clock_type, dm_info
         use diagnostic_template, only : diagnostic_template_setup
-        use isobaric_diagnostics, only : isobaric_diagnostics_setup
+        use mpas_isobaric_diagnostics, only : isobaric_diagnostics_setup
         use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
         use mpas_convective_diagnostics, only : convective_diagnostics_setup
         use pv_diagnostics, only : pv_diagnostics_setup
@@ -100,7 +100,7 @@ module mpas_atm_diagnostics_manager
     subroutine mpas_atm_diag_compute()
 
         use diagnostic_template, only : diagnostic_template_compute
-        use isobaric_diagnostics, only : isobaric_diagnostics_compute
+        use mpas_isobaric_diagnostics, only : isobaric_diagnostics_compute
         use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
         use mpas_convective_diagnostics, only : convective_diagnostics_compute
         use pv_diagnostics, only : pv_diagnostics_compute

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -36,7 +36,7 @@ module mpas_atm_diagnostics_manager
         use mpas_isobaric_diagnostics, only : isobaric_diagnostics_setup
         use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
         use mpas_convective_diagnostics, only : convective_diagnostics_setup
-        use pv_diagnostics, only : pv_diagnostics_setup
+        use mpas_pv_diagnostics, only : pv_diagnostics_setup
         use soundings, only : soundings_setup
 
         implicit none
@@ -103,7 +103,7 @@ module mpas_atm_diagnostics_manager
         use mpas_isobaric_diagnostics, only : isobaric_diagnostics_compute
         use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
         use mpas_convective_diagnostics, only : convective_diagnostics_compute
-        use pv_diagnostics, only : pv_diagnostics_compute
+        use mpas_pv_diagnostics, only : pv_diagnostics_compute
         use soundings, only : soundings_compute
 
         implicit none

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -37,7 +37,7 @@ module mpas_atm_diagnostics_manager
         use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
         use mpas_convective_diagnostics, only : convective_diagnostics_setup
         use mpas_pv_diagnostics, only : pv_diagnostics_setup
-        use soundings, only : soundings_setup
+        use mpas_soundings, only : soundings_setup
 
         implicit none
 
@@ -104,7 +104,7 @@ module mpas_atm_diagnostics_manager
         use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
         use mpas_convective_diagnostics, only : convective_diagnostics_compute
         use mpas_pv_diagnostics, only : pv_diagnostics_compute
-        use soundings, only : soundings_compute
+        use mpas_soundings, only : soundings_compute
 
         implicit none
 
@@ -157,7 +157,7 @@ module mpas_atm_diagnostics_manager
 
         use mpas_atm_diagnostics_utils, only : mpas_atm_diag_utils_finalize
         use diagnostic_template, only : diagnostic_template_cleanup
-        use soundings, only : soundings_cleanup
+        use mpas_soundings, only : soundings_cleanup
 
         implicit none
 

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -32,7 +32,7 @@ module mpas_atm_diagnostics_manager
 
         use mpas_atm_diagnostics_utils, only : mpas_atm_diag_utils_init
         use mpas_derived_types, only : MPAS_streamManager_type, MPAS_pool_type, MPAS_clock_type, dm_info
-        use diagnostic_template, only : diagnostic_template_setup
+        use mpas_diagnostic_template, only : diagnostic_template_setup
         use mpas_isobaric_diagnostics, only : isobaric_diagnostics_setup
         use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
         use mpas_convective_diagnostics, only : convective_diagnostics_setup
@@ -75,7 +75,7 @@ module mpas_atm_diagnostics_manager
     !-----------------------------------------------------------------------
     subroutine mpas_atm_diag_update()
 
-        use diagnostic_template, only : diagnostic_template_update
+        use mpas_diagnostic_template, only : diagnostic_template_update
         use mpas_convective_diagnostics, only : convective_diagnostics_update
 
         implicit none
@@ -99,7 +99,7 @@ module mpas_atm_diagnostics_manager
     !-----------------------------------------------------------------------
     subroutine mpas_atm_diag_compute()
 
-        use diagnostic_template, only : diagnostic_template_compute
+        use mpas_diagnostic_template, only : diagnostic_template_compute
         use mpas_isobaric_diagnostics, only : isobaric_diagnostics_compute
         use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
         use mpas_convective_diagnostics, only : convective_diagnostics_compute
@@ -131,7 +131,7 @@ module mpas_atm_diagnostics_manager
     !-----------------------------------------------------------------------
     subroutine mpas_atm_diag_reset()
 
-        use diagnostic_template, only : diagnostic_template_reset
+        use mpas_diagnostic_template, only : diagnostic_template_reset
         use mpas_convective_diagnostics, only : convective_diagnostics_reset
 
         implicit none
@@ -156,7 +156,7 @@ module mpas_atm_diagnostics_manager
     subroutine mpas_atm_diag_cleanup()
 
         use mpas_atm_diagnostics_utils, only : mpas_atm_diag_utils_finalize
-        use diagnostic_template, only : diagnostic_template_cleanup
+        use mpas_diagnostic_template, only : diagnostic_template_cleanup
         use mpas_soundings, only : soundings_cleanup
 
         implicit none

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -35,7 +35,7 @@ module mpas_atm_diagnostics_manager
         use diagnostic_template, only : diagnostic_template_setup
         use isobaric_diagnostics, only : isobaric_diagnostics_setup
         use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
-        use convective_diagnostics, only : convective_diagnostics_setup
+        use mpas_convective_diagnostics, only : convective_diagnostics_setup
         use pv_diagnostics, only : pv_diagnostics_setup
         use soundings, only : soundings_setup
 
@@ -76,7 +76,7 @@ module mpas_atm_diagnostics_manager
     subroutine mpas_atm_diag_update()
 
         use diagnostic_template, only : diagnostic_template_update
-        use convective_diagnostics, only : convective_diagnostics_update
+        use mpas_convective_diagnostics, only : convective_diagnostics_update
 
         implicit none
 
@@ -102,7 +102,7 @@ module mpas_atm_diagnostics_manager
         use diagnostic_template, only : diagnostic_template_compute
         use isobaric_diagnostics, only : isobaric_diagnostics_compute
         use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
-        use convective_diagnostics, only : convective_diagnostics_compute
+        use mpas_convective_diagnostics, only : convective_diagnostics_compute
         use pv_diagnostics, only : pv_diagnostics_compute
         use soundings, only : soundings_compute
 
@@ -132,7 +132,7 @@ module mpas_atm_diagnostics_manager
     subroutine mpas_atm_diag_reset()
 
         use diagnostic_template, only : diagnostic_template_reset
-        use convective_diagnostics, only : convective_diagnostics_reset
+        use mpas_convective_diagnostics, only : convective_diagnostics_reset
 
         implicit none
 

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -34,7 +34,7 @@ module mpas_atm_diagnostics_manager
         use mpas_derived_types, only : MPAS_streamManager_type, MPAS_pool_type, MPAS_clock_type, dm_info
         use diagnostic_template, only : diagnostic_template_setup
         use isobaric_diagnostics, only : isobaric_diagnostics_setup
-        use cloud_diagnostics, only : cloud_diagnostics_setup
+        use mpas_cloud_diagnostics, only : cloud_diagnostics_setup
         use convective_diagnostics, only : convective_diagnostics_setup
         use pv_diagnostics, only : pv_diagnostics_setup
         use soundings, only : soundings_setup
@@ -101,7 +101,7 @@ module mpas_atm_diagnostics_manager
 
         use diagnostic_template, only : diagnostic_template_compute
         use isobaric_diagnostics, only : isobaric_diagnostics_compute
-        use cloud_diagnostics, only : cloud_diagnostics_compute
+        use mpas_cloud_diagnostics, only : cloud_diagnostics_compute
         use convective_diagnostics, only : convective_diagnostics_compute
         use pv_diagnostics, only : pv_diagnostics_compute
         use soundings, only : soundings_compute

--- a/src/core_atmosphere/diagnostics/pv_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/pv_diagnostics.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-module pv_diagnostics
+module mpas_pv_diagnostics
 
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type
     use mpas_kind_types, only : RKIND
@@ -1647,4 +1647,4 @@ module pv_diagnostics
    
    end subroutine atm_compute_pvBudget_diagnostics
 
-end module pv_diagnostics
+end module mpas_pv_diagnostics

--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-module soundings
+module mpas_soundings
 
     use mpas_kind_types, only : RKIND, StrKIND
     use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type
@@ -491,4 +491,4 @@ module soundings
 
       END FUNCTION RSIF
 
-end module soundings
+end module mpas_soundings


### PR DESCRIPTION
This change prevents name collisions from occurring when MPAS-A is compiled as part of a larger system (e.g. coupled as a dynamical core in an earth system model). The diagnostics is one portion of the MPAS-A code where the modules don't already start with "mpas_", and where similarly named modules could more easily occur than others.

NOTE: none of this is of any concern in stand-alone MPAS-A since name collisions would prevent builds from succeeding.