### PR TITLE
Handle periodicity in latlon_to_pixel when pixel_x >= mgr % pixel_nx

### DIFF
--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -701,6 +701,8 @@ module mpas_geotile_manager
 
         if (pixel_x < 0) then
             pixel_x = pixel_x + mgr % pixel_nx
+        else if (pixel_x >= mgr % pixel_nx) then
+            pixel_x = pixel_x - mgr % pixel_nx
         endif
 
         if (pixel_y < 0) then


### PR DESCRIPTION
This PR adds logic to the latlon_to_pixel routine to handle the case where the computed x-coordinate
of a pixel in geographical data is larger than the number of columns in the global dataset.

The mpas_geotile_mgr_latlon_to_pixel routine -- called latlon_to_pixel in instances of the mpas_geotile_mgr_type type -- previously handled the case where a pixel's x-coordinate was less than 0, but it didn't handle the case where a pixel's x-coordinate was equal to or larger than the value of pixel_nx, i.e., the number of columns in the full dataset. As a result, the mpas_geotile_mgr_gen_tile_name routine (gen_filename in instances of mpas_geotile_mgr_type) could end up generating filenames for non-existent tiles.