### PR TITLE
Improve performance of parallel static field remapping by bounding k-d tree searches

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -99,6 +99,8 @@
  integer, pointer :: category_min
  integer, pointer :: category_max
 
+ real(kind=RKIND) :: max_kdtree_distance2
+
  contains
 
 !==================================================================================================
@@ -196,6 +198,8 @@
  logical :: all_pixels_mapped_to_halo_cells
  integer :: ierr
 
+ real(kind=RKIND) :: max_diameter
+
 !--------------------------------------------------------------------------------------------------
 
 
@@ -284,6 +288,15 @@
  areaCell = areaCell * sphere_radius**2.0
  areaTriangle = areaTriangle * sphere_radius**2.0
  kiteAreasOnVertex = kiteAreasOnVertex * sphere_radius**2.0
+
+!
+! Set max squared distance for k-d tree search to twice the squared cell diameter
+! The factor of two is simply a safety factor to account for possible inaccuracies
+! in the distance function used in the k-d tree
+!
+ max_diameter = max_cell_diameter(nCells, nEdgesOnCell, verticesOnCell, latCell, lonCell, &
+                                  latVertex, lonVertex, sphere_radius)
+ max_kdtree_distance2 = 2.0_RKIND * max_diameter**2
 
 !
 ! Initialize the KD-Tree
@@ -498,7 +511,9 @@
 
                     call mgr % tile_to_latlon(tile, j, i, lat_pt, lon_pt, supersample_fac)
                     call mpas_latlon_to_xyz(xPixel, yPixel, zPixel, sphere_radius, lat_pt, lon_pt)
-                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res)
+                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res, max_distance=max_kdtree_distance2)
+
+                    if (.not. associated(res)) cycle
 
                     if (bdyMaskCell(res % id) < nBdyLayers) then
                         !
@@ -734,7 +749,9 @@
 
                     call mgr % tile_to_latlon(tile, j, i, lat_pt, lon_pt)
                     call mpas_latlon_to_xyz(xPixel, yPixel, zPixel, sphere_radius, lat_pt, lon_pt)
-                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res)
+                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res, max_distance=max_kdtree_distance2)
+
+                    if (.not. associated(res)) cycle
 
                     !
                     ! This field only matters for land cells, and for all but the outermost boundary cells,
@@ -969,7 +986,9 @@
 
                     call mgr % tile_to_latlon(tile, j, i, lat_pt, lon_pt, supersample_fac)
                     call mpas_latlon_to_xyz(xPixel, yPixel, zPixel, sphere_radius, lat_pt, lon_pt)
-                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res)
+                    call mpas_kd_search(tree, (/xPixel, yPixel, zPixel/), res, max_distance=max_kdtree_distance2)
+
+                    if (.not. associated(res)) cycle
 
                     if (bdyMaskCell(res % id) < nBdyLayers) then
                         if (landMask(res % id) == 1) then
@@ -1291,7 +1310,9 @@
 
                     call mgr % tile_to_latlon(tile, j, i, lat, lon, supersample_fac_lcl)
                     call mpas_latlon_to_xyz(xPixel, yPixel, zPixel, sphere_radius, lat, lon)
-                    call mpas_kd_search(kdtree, (/xPixel, yPixel, zPixel/), res)
+                    call mpas_kd_search(kdtree, (/xPixel, yPixel, zPixel/), res, max_distance=max_kdtree_distance2)
+
+                    if (.not. associated(res)) cycle
 
                     !
                     ! For outermost boundary cells, extra work is needed to be done to determine if a pixel actually

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -1920,6 +1920,40 @@
 
  end function sphere_distance
 
+!==================================================================================================
+ real (kind=RKIND) function max_cell_diameter(nCells, nEdgesOnCell, verticesOnCell, latCell, lonCell, &
+                                              latVertex, lonVertex, sphere_radius) result(max_diameter)
+
+! Calculate upper bound on maximum diameter of any cell in block owned by this task
+!==================================================================================================
+ implicit none
+
+ ! Arguments
+ integer, intent(in) :: nCells
+ integer, dimension(:), intent(in) :: nEdgesOnCell
+ integer, dimension(:,:), intent(in) :: verticesOnCell
+ real(kind=RKIND), dimension(:), intent(in) :: latCell, lonCell
+ real(kind=RKIND), dimension(:), intent(in) :: latVertex, lonVertex
+ real(kind=RKIND), intent(in) :: sphere_radius
+
+ ! Local variables
+ integer :: iCell, j
+
+
+ max_diameter = 0.0_RKIND
+ do iCell = 1, nCells
+    do j = 1, nEdgesOnCell(iCell)
+       max_diameter = max(max_diameter, &
+                          sphere_distance(latCell(iCell), lonCell(iCell), &
+                                          latVertex(verticesOnCell(j,iCell)), lonVertex(verticesOnCell(j,iCell)), &
+                                          sphere_radius))
+    end do
+ end do
+
+ max_diameter = 2.0_RKIND * max_diameter
+
+ end function max_cell_diameter
+
 
 !==================================================================================================
  end module mpas_init_atm_static

--- a/src/core_init_atmosphere/mpas_kd_tree.F
+++ b/src/core_init_atmosphere/mpas_kd_tree.F
@@ -286,38 +286,55 @@ module mpas_kd_tree
    !> \date    01/28/20
    !> \details
    !> Search kdtree and returned the nearest point to query into the
-   !> res argument. Optionally, if distance is present, returned the
-   !> squared distance between query and res.
+   !> res argument, or an unassociated res pointer in case no point in the
+   !> tree is within a specified maximum distance from any point in the tree.
+   !>
+   !> If present, the optional distance argument will contain the squared
+   !> distance between query and res in the case that res is associated.
+   !>
+   !> The optional input argument max_distance, if provided, specifies an
+   !> upper bound on the distance from the query point for points in the tree
+   !> to be considered. (Note: the max_distance is more like the maximum
+   !> squared distance due to implementation details of the kd-tree.) This
+   !> parameter can be useful, for example, if some query points are known
+   !> to be far from any point in the tree and in such cases it is desirable
+   !> to return no closest point.
    !>
    !> If the dimension of query does not match the dimensions of points
    !> within kdtree, then res will be returned as unassociated. Likewise,
    !> if kdtree is empty/unassociated, res will be returned as unassociated.
    !
    !-----------------------------------------------------------------------
-   subroutine mpas_kd_search(kdtree, query, res, distance)
+   subroutine mpas_kd_search(kdtree, query, res, distance, max_distance)
 
       implicit none
       type (mpas_kd_type), pointer, intent(in) :: kdtree
       real (kind=RKIND), dimension(:), intent(in) :: query
       type (mpas_kd_type), pointer, intent(inout) :: res
-      real (kind=RKIND), intent(out), optional :: distance
+      real (kind=RKIND), intent(inout), optional :: distance
+      real (kind=RKIND), intent(in), optional :: max_distance
 
       real (kind=RKIND) :: dis
 
+      nullify(res)
+
       if (.not. associated(kdtree)) then
-         res => null()
          return
       end if
 
       if (size(kdtree % point) /= size(query)) then
-         res => null()
          return
       endif
 
-      dis = huge(dis)
+      if (present(max_distance)) then
+         dis = max_distance
+      else
+         dis = huge(dis)
+      endif
+
       call mpas_kd_search_internal(kdtree, query, res, dis)
 
-      if (present(distance)) then
+      if (present(distance) .and. associated(res)) then
          distance = dis
       endif
 


### PR DESCRIPTION
This PR significantly improves the performance of parallel static field 
remapping in the init_atmosphere core by bounding searches for the nearest cell 
to each pixel of a static field. Aside from the positive impact on runtime
performance, the changes in this merge have no impact on the resulting fields.

Previously, searches for the nearest cell to a static field pixel that was 
sufficiently far from any point in the k-d tree of cells could effectively
trigger a search through all or nearly all branches in the tree. Since we
ultimately only want to consider searches that result in an MPAS mesh cell that
actually contains the pixel, and not just the nearest cell -- which may in fact be
geographically far from the pixel -- a reasonable upper bound for the search
distance is based on the maximum diameter of any cell in the block of cells
assigned to an MPI task.