### PR TITLE
Updates raincv variable to CPU in each iteration.

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -478,6 +478,7 @@ contains
 !!!     pp = pp + 1
       enddo
 !$acc end parallel
+!$acc update host (raincv)
 
       if(present(rqccuten))then
         if ( f_qc ) then


### PR DESCRIPTION
Changes are provided by @cponder 
Comments by @cponder:
The changes in the module_cu_ntiedtke.F pushes the raincv array to the CPU each iteration, and seems to fix the problems we'd had with divergences between the CPU & OpenACC implementations.

