### PR TITLE
Updated MPAS_to_physics_gpu subroutine

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -707,8 +707,8 @@
  enddo
 !$acc end parallel
  enddo
-!$acc update host(qv_p,qc_p,qr_p,qi_p,qs_p,qg_p,u_p,v_p, &
-!$acc zz_p,rho_p,th_p,t_p,pi_p,pres_p,zmid_p,dz_p)
+!!!$acc update host(qv_p,qc_p,qr_p,qi_p,qs_p,qg_p,u_p,v_p, &
+!!!$acc zz_p,rho_p,th_p,t_p,pi_p,pres_p,zmid_p,dz_p)
 
  pbl_select: select case (trim(pbl_scheme))
     case("bl_mynn")
@@ -766,28 +766,28 @@
  enddo
 !$acc end parallel
  enddo
-!$acc update host(znu_p,w_p,z_p)
+!!!$acc update host(znu_p,w_p,z_p)
 
 !check that the pressure in the layer above the surface is greater than that in the layer
 !above it:
-!$acc update host(pressure_b,pressure_p)
- do j = jts,jte
- do i = its,ite
-    if(pres_p(i,1,j) .le. pres_p(i,2,j)) then
-       call mpas_log_write('')
-       call mpas_log_write('--- subroutine MPAS_to_phys - pressure(1) < pressure(2):')
-       call mpas_log_write('i      =$i', intArgs=(/i/))
-       call mpas_log_write('latCell=$r', realArgs=(/latCell(i)/degrad/))
-       call mpas_log_write('lonCell=$r', realArgs=(/lonCell(i)/degrad/))
-       do k = kts,kte
-          call mpas_log_write('$i $i $i $r $r $r $r $r $r $r $r', intArgs=(/j,i,k/),&
-             realArgs=(/dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
-                        rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)/))
-       enddo
-!      call mpas_log_write('pressure increasing with height', messageType=MPAS_LOG_CRIT)
-    endif
- enddo
- enddo
+!!!!$acc update host(pressure_b,pressure_p,pres_p,dz_p,rho_p,th_p,t_p,qv_p)
+!!! do j = jts,jte
+!!! do i = its,ite
+!!!    if(pres_p(i,1,j) .le. pres_p(i,2,j)) then
+!!!       call mpas_log_write('')
+!!!       call mpas_log_write('--- subroutine MPAS_to_phys - pressure(1) < pressure(2):')
+!!!       call mpas_log_write('i      =$i', intArgs=(/i/))
+!!!       call mpas_log_write('latCell=$r', realArgs=(/latCell(i)/degrad/))
+!!!       call mpas_log_write('lonCell=$r', realArgs=(/lonCell(i)/degrad/))
+!!!       do k = kts,kte
+!!!          call mpas_log_write('$i $i $i $r $r $r $r $r $r $r $r', intArgs=(/j,i,k/),&
+!!!             realArgs=(/dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
+!!!                        rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)/))
+!!!       enddo
+!!!!      call mpas_log_write('pressure increasing with height', messageType=MPAS_LOG_CRIT)
+!!!    endif
+!!! enddo
+!!! enddo
 
 !interpolation of pressure and temperature from theta points to w points:
  do j = jts,jte
@@ -844,7 +844,7 @@
  enddo
 !$acc end parallel
  enddo
-!$acc update host(fzm_p,fzp_p,t2_p,pres2_p,psfc_p)
+!!!$acc update host(fzm_p,fzp_p,t2_p,pres2_p,psfc_p)
 
 !calculation of the hydrostatic pressure:
  do j = jts,jte
@@ -904,8 +904,8 @@
  enddo
 !$acc end parallel
  enddo
-!$acc update host(pres2_hyd_p,pres2_hydd_p,pres_hyd_p, &
-!$acc pres_hydd_p,psfc_hyd_p,psfc_hydd_p,znu_hyd_p)
+!!!$acc update host(pres2_hyd_p,pres2_hydd_p,pres_hyd_p, &
+!!!$acc pres_hydd_p,psfc_hyd_p,psfc_hydd_p,znu_hyd_p)
 
 !save the model-top pressure:
  do j = jts,jte

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -770,24 +770,26 @@
 
 !check that the pressure in the layer above the surface is greater than that in the layer
 !above it:
-!!!!$acc update host(pressure_b,pressure_p,pres_p,dz_p,rho_p,th_p,t_p,qv_p)
-!!! do j = jts,jte
-!!! do i = its,ite
-!!!    if(pres_p(i,1,j) .le. pres_p(i,2,j)) then
-!!!       call mpas_log_write('')
-!!!       call mpas_log_write('--- subroutine MPAS_to_phys - pressure(1) < pressure(2):')
-!!!       call mpas_log_write('i      =$i', intArgs=(/i/))
-!!!       call mpas_log_write('latCell=$r', realArgs=(/latCell(i)/degrad/))
-!!!       call mpas_log_write('lonCell=$r', realArgs=(/lonCell(i)/degrad/))
-!!!       do k = kts,kte
-!!!          call mpas_log_write('$i $i $i $r $r $r $r $r $r $r $r', intArgs=(/j,i,k/),&
-!!!             realArgs=(/dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
-!!!                        rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)/))
-!!!       enddo
-!!!!      call mpas_log_write('pressure increasing with height', messageType=MPAS_LOG_CRIT)
-!!!    endif
-!!! enddo
-!!! enddo
+!!$acc update host(pressure_b,pressure_p,pres_p,dz_p,rho_p,th_p,t_p,qv_p)
+#ifndef MPAS_OPENACC
+ do j = jts,jte
+ do i = its,ite
+    if(pres_p(i,1,j) .le. pres_p(i,2,j)) then
+       call mpas_log_write('')
+       call mpas_log_write('--- subroutine MPAS_to_phys - pressure(1) < pressure(2):')
+       call mpas_log_write('i      =$i', intArgs=(/i/))
+       call mpas_log_write('latCell=$r', realArgs=(/latCell(i)/degrad/))
+       call mpas_log_write('lonCell=$r', realArgs=(/lonCell(i)/degrad/))
+       do k = kts,kte
+          call mpas_log_write('$i $i $i $r $r $r $r $r $r $r $r', intArgs=(/j,i,k/),&
+             realArgs=(/dz_p(i,k,j),pressure_b(k,i),pressure_p(k,i),pres_p(i,k,j), &
+                        rho_p(i,k,j),th_p(i,k,j),t_p(i,k,j),qv_p(i,k,j)/))
+       enddo
+!      call mpas_log_write('pressure increasing with height', messageType=MPAS_LOG_CRIT)
+    endif
+ enddo
+ enddo
+#endif
 
 !interpolation of pressure and temperature from theta points to w points:
  do j = jts,jte


### PR DESCRIPTION
In this PR, the data transfers to host in the `MPAS_to_physics_gpu` subroutine are commented out as they are not required if all the physics scheme are on GPU. In addition, the loop which checks if the pressure in the layer above the surface is greater than that in the layer above it is placed in-between 'MPAS_OPENACC' preprocessor directives as we are not updating the variables on host.
