### PR TITLE
Remove 'east' and 'north' fields from atmosphere restart stream

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -599,8 +599,6 @@
 			<var name="defc_a"/>
 			<var name="defc_b"/>
 			<var name="coeffs_reconstruct"/>
-			<var name="east"/>
-			<var name="north"/>
 			<var_array name="scalars"/>
 			<var name="rainprod" packages="mp_thompson_in"/>
 			<var name="evapprod" packages="mp_thompson_in"/>


### PR DESCRIPTION
This PR removes the `east` and `north` fields from the atmosphere core's restart stream.

The `east` and `north` fields are always computed when the model starts up, and
do not need to be written to and read from the restart stream.

Note that the `init_dirs_forphys` subroutine that computes the `east` and
`north` fields is only active if the model was compiled with DO_PHYSICS defined;
but, these fields are currently only used in physics-related code (specifically,
`physics_get_tend`) that is active if the model was compiled with DO_PHYSICS.