### PR TITLE
Remove 'meshScaling*' fields from the atmosphere core's restart stream

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -570,10 +570,6 @@
 			<var name="fEdge"/>
 			<var name="fVertex"/>
 			<var name="meshDensity"/>
-			<var name="meshScalingDel2"/>
-			<var name="meshScalingDel4"/>
-			<var name="meshScalingRegionalCell"/>
-			<var name="meshScalingRegionalEdge"/>
 			<var name="bdyMaskCell"/>
 			<var name="bdyMaskEdge"/>
 			<var name="bdyMaskVertex"/>


### PR DESCRIPTION
This PR removes the `meshScaling*` fields from the atmosphere core's restart stream.

The `meshScalingDel2`, `meshScalingDel4`, `meshScalingRegionalCell`, and `meshScalingRegionalEdge` fields are always computed by the `atm_mpas_mesh_scaling` routine when the model starts up, and they therefore do not need to be written and read from the restart stream by the atmosphere core.