### PR TITLE
Remove 'uReconstruct{Zonal,Meridional}' fields from atmosphere restart stream

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -619,8 +619,6 @@
 			<var name="rho"/>
 			<var name="theta"/>
 			<var name="relhum"/>
-			<var name="uReconstructZonal"/>
-			<var name="uReconstructMeridional"/>
 			<var name="circulation"/>
 			<var name="exner"/>
 			<var name="exner_base"/>


### PR DESCRIPTION
This PR removes the `uReconstruct{Zonal,Meridional}` fields from the atmosphere core's
restart stream.

The `uReconstructZonal` and `uReconstructMeridional` fields are always computed
via the call to `mpas_reconstruct` in the `atm_mpas_init_block` routine when the
model starts up and do not need to be written to and read from the atmosphere
core's restart stream.