### PR TITLE
Initialize climatological ozone profiles for both cold-start and restart runs

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -801,8 +801,6 @@
 			<var name="rniblten"/>
 			<var name="rthratensw"/>
 			<var name="rthratenlw"/>
-			<var name="pin"/>
-			<var name="ozmixm"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
 			<var name="mminlu"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -341,8 +341,7 @@
  endif
 
 !read the input files that contain the monthly-mean ozone climatology on fixed pressure levels:
- if(config_o3climatology .and. (.not. config_do_restart)) &
-    call init_o3climatology(mesh,atm_input)
+ if(config_o3climatology) call init_o3climatology(mesh,atm_input)
 
 !initialization of global surface properties. set here for now, but may be moved when time
 !manager is implemented:


### PR DESCRIPTION
This PR modifies the atmosphere core so that climatological ozone profiles are initialized for both cold-start
and restart runs. Previously, this initialization was handled by the `init_o3climatology` routine only for cold-start
runs, with the expectation that the climatological ozone field on the MPAS mesh was available in restart files.

By interpolating the monthly-mean ozone profiles from `OZONE_PLEV.TBL`, `OZONE_LAT.TBL`, and `OZONE_DAT.TBL` when `config_o3climatology` is `.true.` regardless of whether the run is a cold-start or a restart run, it is no longer necessary to write the `pin` and `ozmixm` fields to restart files in the atmosphere core.