### PR TITLE
Initialize tend_u_phys as zero

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -235,6 +235,7 @@
  do i = 1, nEdgesScalar+1
  do k = 1, nVertLevels
     tend_ru_physics(k,i) = 0._RKIND
+    tend_u_phys(k,i) = 0._RKIND
  enddo
  enddo
 !$acc loop gang vector collapse(3)


### PR DESCRIPTION
I've added code to initialize and reset tend_u_phys as 0._RKIND during each time step. Otherwise, these tendency values accumulate over successive time steps, which impacts the PV budget calculation in pv_diagnostics.F