### PR TITLE
Change of air density constant in ocean mxed layer model

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_oml.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_oml.F
@@ -61,7 +61,7 @@ CONTAINS
 
       hu1=huml
       hv1=hvml
-      rhoair=1.
+      rhoair=1.2
       rhowater=1000.
       cwater=4200.
 ! Deep ocean lapse rate (K/m) - from Rich


### PR DESCRIPTION
In module_sf_oml.F the air density is set to a constant value of 1 kg/m³. According to the literature, a value of 1.2 kg/m³ seems to be more reasonable at sea level pressure.

