### PR TITLE
Fix zero values of LWDNT and LWDNTC in RRTMG LW

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -12083,8 +12083,8 @@ CONTAINS
           !output up and down toa fluxes for total and clear sky:
           lwupt(i,j)  = uflx(1,nlayers+1)
           lwuptc(i,j) = uflxc(1,nlayers+1)
-          lwdnt(i,j)  = dflx(1,nlayers+1)
-          lwdntc(i,j) = dflxc(1,nlayers+1)
+          lwdnt(i,j)  = dflx(1,nlayers)
+          lwdntc(i,j) = dflxc(1,nlayers)
           !output up and down surface fluxes for total and clear sky:
           lwupb(i,j)  = uflx(1,1)
           lwupbc(i,j) = uflxc(1,1)


### PR DESCRIPTION
This bug fix prevents that LWDNT and LWDNTC show zero values in RRTMG LW. 

In the original version, the indices of dflx and dflxc were running from (1,nlayers+1) but this leads to zero values for LWDNT and LWDNTC. The index has to be limited to (1,nlayers).

