### PR TITLE
Add qv and rh to soundings output files

### DIFF
--- a/src/core_atmosphere/diagnostics/soundings.F
+++ b/src/core_atmosphere/diagnostics/soundings.F
@@ -284,7 +284,7 @@ module soundings
                             end if
                             dir = dir * 180.0_RKIND / pi_const
                         end if
-+                        write(97,'(f10.2,f10.2,f9.2,f9.2,f9.2,f9.2,F10.6,F7.2)') &
+                        write(97,'(f10.2,f10.2,f9.2,f9.2,f9.2,f9.2,F10.6,F7.2)') &
                                     pres, &
                                     0.5 * (zgrid(k,stationCells(iStn)) + zgrid(k+1,stationCells(iStn))), &               ! Avg to layer midpoint
                                     tmpc, &


### PR DESCRIPTION
This mod adds mixing ratio and relative humidity written to the sounding text files from the diagnostics routing.
As the number of files can get very large in the main folder for longer simulations, I added a line so that a directory "SOUNDINGS" is created where the text file will be written to.


