### PR TITLE
Changes for the extrapolation of temperature and horizontal velocity

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -229,7 +229,7 @@
 
         <nml_record name="interpolation_control" in_defaults="true">
 
-                <nml_option name="config_extrap_airtemp"        type="character"     default_value="linear"
+                <nml_option name="config_extrap_airtemp"        type="character"     default_value="lapse-rate"
                      units="-"
                      description="Method of extrapolation of air temperature above/below first-guess levels."
                      possible_values="`constant' (last valid value), `linear' (linear extrapolation based on last two values), `lapse-rate' (0.0065 K/m from last valid value)"/>

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -4649,7 +4649,7 @@ call mpas_log_write('Done with soil consistency check')
          do k=1,nVertLevels
             target_z = 0.25 * (zgrid(k,cellsOnEdge(1,iEdge)) + zgrid(k+1,cellsOnEdge(1,iEdge)) + zgrid(k,cellsOnEdge(2,iEdge)) + zgrid(k+1,cellsOnEdge(2,iEdge)))
 !           u(k,iEdge) = vertical_interp(target_z, nfglevels_actual, sorted_arr, order=1, extrap=0)
-            u(k,iEdge) = vertical_interp(target_z, nfglevels_actual-1, sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=1)
+            u(k,iEdge) = vertical_interp(target_z, nfglevels_actual-1, sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
          end do
 
       end do


### PR DESCRIPTION
Changes for the extrapolation of temperature and horizontal velocity in real-data initializations.

(1) Reset the default for the lower air-temperature extrapolation (config_extrap_airtemp) from "linear" to "lapse-rate" in the namelist. (2) Set the condition for the lower extrapolation of the horizontal velocity such that it returns the lowest analysis level value instead of a linear extrapolation when the requested level is below the analysis level.

Change Dynamics 1.8 for the Version 8 release.