### PR TITLE
In the regional MPAS solver relaxation-zone filtering, increase the m…

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6380,8 +6380,8 @@ module atm_time_integration
             ! Compute diffusion, computed as \nabla divergence - k \times \nabla vorticity
             !
              do k=1,nVertLevels
-                tend_ru(k,iEdge) = tend_ru(k,iEdge) + laplacian_filter_coef * (  ( divergence2(k) - divergence1(k) ) * r_dc  &
-                                                                                -( vorticity2(k)  - vorticity1(k)  ) * r_dv )
+                tend_ru(k,iEdge) = tend_ru(k,iEdge) + laplacian_filter_coef * (  4.0*( divergence2(k) - divergence1(k) ) * r_dc  &
+                                                                                    -( vorticity2(k)  - vorticity1(k)  ) * r_dv )
              end do
 
           end if  !  end test for relaxation-zone edge


### PR DESCRIPTION
In the regional MPAS solver relaxation-zone filtering, increase the magnitude of the divergent portion of the Laplacian for the horizontal velocity by a factor of 4 relative to the vorticity component of the Laplacian.  This increases the robustness of the regional configruation as demonstated in CONUS test forecasts performed by NOAA/NSSL in winter/spring 2023.  Change Dynamics 1.1 for Version 8 release.