### PR TITLE
Add a new build target, 'gnu', for the GNU Fortran, C, and C++ compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,36 @@ endif
 dummy:
 	( $(MAKE) error )
 
+gnu:   # BUILDTARGET GNU Fortran, C, and C++ compilers
+	( $(MAKE) all \
+	"FC_PARALLEL = mpif90" \
+	"CC_PARALLEL = mpicc" \
+	"CXX_PARALLEL = mpicxx" \
+	"FC_SERIAL = gfortran" \
+	"CC_SERIAL = gcc" \
+	"CXX_SERIAL = g++" \
+	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
+	"FFLAGS_OPT = -std=f2008 -O3 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
+	"CFLAGS_OPT = -O3" \
+	"CXXFLAGS_OPT = -O3" \
+	"LDFLAGS_OPT = -O3" \
+	"FFLAGS_DEBUG = -g -ffree-line-length-none -fconvert=big-endian -ffree-form -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"CFLAGS_DEBUG = -g" \
+	"CXXFLAGS_DEBUG = -g" \
+	"LDFLAGS_DEBUG = -g" \
+	"FFLAGS_OMP = -fopenmp" \
+	"CFLAGS_OMP = -fopenmp" \
+	"FFLAGS_ACC =" \
+	"CFLAGS_ACC =" \
+	"PICFLAG = -fPIC" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
+
 xlf:   # BUILDTARGET IBM XL compilers
 	( $(MAKE) all \
 	"FC_PARALLEL = mpifort" \


### PR DESCRIPTION
This PR adds a new build target, `gnu`, for the GNU Fortran, C, and C++ compilers.

The only difference between the new `gnu` target and the existing `gfortran` target is the addition of `-std=f2008` to the `FFLAGS` variable to check for compliance with the Fortran 2008 standard.

With the new `gnu` target, builds with the GNU 7.4.0 (and presumably, earlier) compilers fail with the error
```
   mpas_stream_manager.F:5844:32:

        call c_f_pointer(manager_c, manager)
                                1
   Error: TS 29113/TS 18508: Noninteroperable array FPTR at (1) to C_F_POINTER: Expression is a noninteroperable derived type
```
However, builds with the GNU 8.3.0 and later compilers are successful.

In future, the `gfortran` target will likely be deprecated and superseded by the `gnu` target.