### PR TITLE
Add MPAS-Atmosphere layer interface projection option

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -93,6 +93,11 @@
                      description="Number of halo layers for fields"
                      possible_values="Integer values, typically 2 or 3; DO NOT CHANGE"/>
 
+                <nml_option name="config_interface_projection" type="character"     default_value="linear_interpolation"
+                     units="-"
+                     description="projecting layer values to the interface, linear vertical interpolation or integral" 
+                     possible_values="'linear_interpolation' or 'layer_integral' (layer average value)"/>
+
         </nml_record>
 
         <nml_record name="dimensions" in_defaults="true">

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -134,7 +134,7 @@ module init_atm_cases
             call mpas_pool_get_subpool(block_ptr % structs, 'diag', diag)
 
             call mpas_log_write(' calling test case setup ')
-            call init_atm_case_squall_line(domain % dminfo, mesh, nCells, nVertLevels, state, diag, config_init_case)
+            call init_atm_case_squall_line(domain % dminfo, mesh, nCells, nVertLevels, state, diag, block_ptr % configs, config_init_case)
             call decouple_variables(mesh, nCells, nVertLevels, state, diag)
             call mpas_log_write(' returned from test case setup ')
             block_ptr => block_ptr % next
@@ -483,11 +483,12 @@ module init_atm_cases
       integer, pointer :: config_theta_adv_order
       integer, pointer :: config_init_case
 
+      character (len=StrKIND), pointer :: config_interface_projection
 
       call mpas_pool_get_config(configs, 'config_init_case', config_init_case)
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_theta_adv_order', config_theta_adv_order)
-
+      call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
 
       !
       ! Scale all distances and areas from a unit sphere to one with radius sphere_radius
@@ -669,11 +670,24 @@ module init_atm_cases
       do k=2,nz1
          dzu (k)  = .5*(dzw(k)+dzw(k-1))
          rdzu(k)  =  1./dzu(k)
-         fzp (k)  = .5* dzw(k  )/dzu(k)
-         fzm (k)  = .5* dzw(k-1)/dzu(k)
          rdzwp(k) = dzw(k-1)/(dzw(k  )*(dzw(k)+dzw(k-1)))
          rdzwm(k) = dzw(k  )/(dzw(k-1)*(dzw(k)+dzw(k-1)))
       end do
+
+      call mpas_log_write(" interface_projection is " // trim(config_interface_projection))
+      if (trim(config_interface_projection) .eq. "linear_interpolation") then
+        do k=2,nz1
+           fzp (k)  = .5* dzw(k  )/dzu(k)
+           fzm (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else if (trim(config_interface_projection) .eq. "layer_integral") then
+        do k=2,nz1
+           fzm (k)  = .5* dzw(k  )/dzu(k)
+           fzp (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else
+        call mpas_log_write('only linear_interpolation or layer_integral are supported', messageType=MPAS_LOG_CRIT)
+      end if
 
 !**********  how are we storing cf1, cf2 and cf3?
 
@@ -1325,7 +1339,7 @@ module init_atm_cases
    end subroutine init_atm_recompute_geostrophic_wind
 
 
-   subroutine init_atm_case_squall_line(dminfo, mesh, nCells, nVertLevels, state, diag, test_case)
+   subroutine init_atm_case_squall_line(dminfo, mesh, nCells, nVertLevels, state, diag, configs, test_case)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Setup squall line and supercell test case
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1338,6 +1352,7 @@ module init_atm_cases
       integer, intent(in) :: nVertLevels
       type (mpas_pool_type), intent(inout) :: state
       type (mpas_pool_type), intent(inout) :: diag
+      type (mpas_pool_type), intent(in) :: configs
       integer, intent(in) :: test_case
 
       real (kind=RKIND), dimension(:), pointer :: rdzw, dzu, rdzu, fzm, fzp
@@ -1387,6 +1402,8 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: t_init, w, rw, v, rho, theta
       real (kind=RKIND), dimension(:), pointer :: u_init, qv_init, angleEdge, fEdge, fVertex
 
+      character (len=StrKIND), pointer :: config_interface_projection
+
       call mpas_pool_get_array(mesh, 'xCell', xCell)
       call mpas_pool_get_array(mesh, 'yCell', yCell)
       call mpas_pool_get_array(mesh, 'zCell', zCell)
@@ -1404,6 +1421,7 @@ module init_atm_cases
 
       call mpas_pool_get_config(mesh, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
+      call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
 
       !
       ! Scale all distances
@@ -1552,11 +1570,24 @@ module init_atm_cases
       do k=2,nz1
          dzu (k)  = .5*(dzw(k)+dzw(k-1))
          rdzu(k)  =  1./dzu(k)
-         fzp (k)  = .5* dzw(k  )/dzu(k)
-         fzm (k)  = .5* dzw(k-1)/dzu(k)
          rdzwp(k) = dzw(k-1)/(dzw(k  )*(dzw(k)+dzw(k-1)))
          rdzwm(k) = dzw(k  )/(dzw(k-1)*(dzw(k)+dzw(k-1)))
       end do
+
+      call mpas_log_write(" interface_projection is " // trim(config_interface_projection))
+      if (trim(config_interface_projection) .eq. "linear_interpolation") then
+        do k=2,nz1
+           fzp (k)  = .5* dzw(k  )/dzu(k)
+           fzm (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else if (trim(config_interface_projection) .eq. "layer_integral") then
+        do k=2,nz1
+           fzm (k)  = .5* dzw(k  )/dzu(k)
+           fzp (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else
+        call mpas_log_write('only linear_interpolation or layer_integral supported', messageType=MPAS_LOG_CRIT)
+      end if
 
 !**********  how are we storing cf1, cf2 and cf3?
 
@@ -1981,6 +2012,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:,:), pointer :: t_init, w, rw, v, rho, theta
       real (kind=RKIND), dimension(:), pointer :: u_init, v_init, angleEdge, fEdge, fVertex
 
+      character (len=StrKIND), pointer :: config_interface_projection
 
       call mpas_pool_get_array(mesh, 'xCell', xCell)
       call mpas_pool_get_array(mesh, 'yCell', yCell)
@@ -2002,6 +2034,7 @@ module init_atm_cases
 
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_theta_adv_order', config_theta_adv_order)
+      call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
 
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
@@ -2143,11 +2176,24 @@ module init_atm_cases
       do k=2,nz1
          dzu (k)  = .5*(dzw(k)+dzw(k-1))
          rdzu(k)  =  1./dzu(k)
-         fzp (k)  = .5* dzw(k  )/dzu(k)
-         fzm (k)  = .5* dzw(k-1)/dzu(k)
          rdzwp(k) = dzw(k-1)/(dzw(k  )*(dzw(k)+dzw(k-1)))
          rdzwm(k) = dzw(k  )/(dzw(k-1)*(dzw(k)+dzw(k-1)))
       end do
+
+      call mpas_log_write(" interface_projection is " // trim(config_interface_projection))
+      if (trim(config_interface_projection) .eq. "linear_interpolation") then
+        do k=2,nz1
+           fzp (k)  = .5* dzw(k  )/dzu(k)
+           fzm (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else if (trim(config_interface_projection) .eq. "layer_integral") then
+        do k=2,nz1
+           fzm (k)  = .5* dzw(k  )/dzu(k)
+           fzp (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else
+        call mpas_log_write('only linear_interpolation or layer_integral supported', messageType=MPAS_LOG_CRIT)
+      end if
 
 !**********  how are we storing cf1, cf2 and cf3?
 
@@ -2756,6 +2802,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: t2m
 
       character (len=StrKIND) :: errstring
+      character (len=StrKIND), pointer :: config_interface_projection
 
       call mpas_pool_get_config(configs, 'config_met_prefix', config_met_prefix)
       call mpas_pool_get_config(configs, 'config_start_time', config_start_time)
@@ -2774,6 +2821,7 @@ module init_atm_cases
       call mpas_pool_get_config(configs, 'config_theta_adv_order', config_theta_adv_order)
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_blend_bdy_terrain', config_blend_bdy_terrain)
+      call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
       
       call mpas_pool_get_config(configs, 'config_extrap_airtemp', config_extrap_airtemp)
       if (trim(config_extrap_airtemp) == 'constant') then
@@ -3125,11 +3173,24 @@ module init_atm_cases
       do k=2,nz1
          dzu (k)  = .5*(dzw(k)+dzw(k-1))
          rdzu(k)  =  1./dzu(k)
-         fzp (k)  = .5* dzw(k  )/dzu(k)
-         fzm (k)  = .5* dzw(k-1)/dzu(k)
          rdzwp(k) = dzw(k-1)/(dzw(k  )*(dzw(k)+dzw(k-1)))
          rdzwm(k) = dzw(k  )/(dzw(k-1)*(dzw(k)+dzw(k-1)))
       end do
+
+      call mpas_log_write(" interface_projection is " // trim(config_interface_projection))
+      if (trim(config_interface_projection) .eq. "linear_interpolation") then
+        do k=2,nz1
+           fzp (k)  = .5* dzw(k  )/dzu(k)
+           fzm (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else if (trim(config_interface_projection) .eq. "layer_integral") then
+        do k=2,nz1
+           fzm (k)  = .5* dzw(k  )/dzu(k)
+           fzp (k)  = .5* dzw(k-1)/dzu(k)
+        end do
+      else
+        call mpas_log_write('only linear_interpolation or layer_integral supported', messageType=MPAS_LOG_CRIT)
+      end if
 
 !**********  how are we storing cf1, cf2 and cf3?
 


### PR DESCRIPTION
MPAS-Atmosphere vertically projects cell (layer) values (u, rho, theta, etc) to the level interface (where w is located) using linear interpolation. This adds the option of using the integrated (average) value between the layers. This new approach is consistent with the hydrostatic integral used in MPAS-A, whereas the linear interpolation is not.  This option is set in the init_atmosphere namelist.

The default setting is still to use linear interpolation.

Change Dynamics 1.3 for Version 8 release.