### PR TITLE
moving dtheta dt mp out of subroutine driver_microphysics

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1612,6 +1612,9 @@
                 <var name="pv_cell" type="real" dimensions="nVertLevels nCells Time" units="s^{-1} kg^{-1} m^3"
                      description="absolute vorticity/rho_zz averaged to the cell center from the vertices"/>
 
+                <var name="dtheta_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="Potential temperature heating rate from microphysics"/>
+
                 <!-- reconstructed horizontal velocity vectors at cell centers -->
                 <var name="uReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
                      description="Cartesian x-component of reconstructed horizontal velocity at cell centers"/>

--- a/src/core_atmosphere/diagnostics/Registry_pv.xml
+++ b/src/core_atmosphere/diagnostics/Registry_pv.xml
@@ -36,9 +36,6 @@
         <var name="depv_dt_cu" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
              description="Diabatic EPV tendency from convection"/>
 
-        <var name="dtheta_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-             description="Potential temperature heating rate from microphysics"/>
-
         <var name="depv_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
              description="Diabatic EPV tendency from microphysics"/>
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -299,30 +299,7 @@
  character(len=StrKIND),pointer:: microp_scheme
 
 !local variables and arrays:
- logical:: log_microphysics
- integer:: i,icell,icount,istep,j,k,kk
-
-!Calculate dtheta_dt_mp (NS: 2018-04-24)
-!Store theta, call microphysics->updates theta, calculate tendency
- integer, pointer :: nCells, nVertLevels, index_qv
- real(kind=RKIND), dimension(:,:), pointer :: dtheta_dt_mp, theta_m
- real (kind=RKIND), dimension(:,:,:), pointer :: scalars
-
- call mpas_pool_get_dimension(mesh, 'nCells', nCells)
- call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
- call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-
- call mpas_pool_get_array(state, 'theta_m', theta_m, time_lev)
- call mpas_pool_get_array(diag, 'dtheta_dt_mp', dtheta_dt_mp)
- call mpas_pool_get_array(state, 'scalars', scalars, time_lev)
-
- !initialize to theta before microphysics call.
- !I think the physics call actually updates variables, not generate a tendency.
- do icell=1,nCells
-    do k=1,nVertLevels
-       dtheta_dt_mp(k,icell) = theta_m(k,icell) / (1._RKIND + rvord * scalars(index_qv,k,icell))
-    end do
- end do
+ integer:: istep
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
@@ -437,14 +414,6 @@
 !... copy updated cloud microphysics variables from the wrf-physics grid back to the geodesic-
 !    dynamics grid:
  call microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend,itimestep,its,ite)
-
-!Calculate dtheta_dt_mp (NS: 2018-04-24)
-!From stored dtheta_dt_mp, calculate changeInTheta/timeStep
- do icell=1,nCells
-    do k=1,nVertLevels
-       dtheta_dt_mp(k,icell) = (theta_m(k,icell)/(1._RKIND+rvord*scalars(index_qv,k,icell)) - dtheta_dt_mp(k,icell))/(dt_dyn)
-    end do
- end do
 
 !... deallocation of all microphysics arrays:
 !$OMP BARRIER

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -638,6 +638,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,exner_b,pressure_b,rtheta_p,rtheta_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
+ real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
  real(kind=RKIND),dimension(:,:),pointer  :: ni,nr
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
@@ -663,6 +664,7 @@
  call mpas_pool_get_array(diag,'rtheta_base'     ,rtheta_b        )
  call mpas_pool_get_array(diag,'rtheta_p'        ,rtheta_p        )
  call mpas_pool_get_array(diag,'surface_pressure',surface_pressure)
+ call mpas_pool_get_array(diag,'dtheta_dt_mp'    ,dtheta_dt_mp    )
 
  call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
  call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
@@ -695,14 +697,21 @@
  do j = jts,jte
  do k = kts,kte
  do i = its,ite
+
+    !initializes tendency of coupled potential temperature potential temperature, and
+    !potential temperature heating rate from microphysics:
+    rt_diabatic_tend(k,i) = theta_m(k,i)
+    dtheta_dt_mp(k,i)     = theta_m(k,i)/(1._RKIND+rvord*qv(k,i))
+
+    !updates water vapor, cloud liquid water, rain mixing ratios, modified potential temperature,
+    !tendency of coupled potential temperature, and potential temperature heating rate from microphysics:
     qv(k,i) = qv_p(i,k,j)
     qc(k,i) = qc_p(i,k,j)
     qr(k,i) = qr_p(i,k,j)
 
-    !potential temperature and diabatic forcing:
-    rt_diabatic_tend(k,i) = theta_m(k,i)
-    theta_m(k,i) = th_p(i,k,j) * (1. + R_v/R_d * qv_p(i,k,j))
-    rt_diabatic_tend(k,i) = (theta_m(k,i) - rt_diabatic_tend(k,i)) / dt_dyn
+    theta_m(k,i) = th_p(i,k,j) * (1._RKIND+rvord*qv_p(i,k,j))
+    rt_diabatic_tend(k,i) = (theta_m(k,i) - rt_diabatic_tend(k,i))/dt_dyn
+    dtheta_dt_mp(k,i)     = (theta_m(k,i)/(1._RKIND+rvord*qv(k,i))-dtheta_dt_mp(k,i))/(dt_dyn)
 
     !density-weighted perturbation potential temperature:
     rtheta_p(k,i) = rho_zz(k,i) * theta_m(k,i) - rtheta_b(k,i)


### PR DESCRIPTION
This PR moves the variable dtheta_dt_mp from subroutine driver_microphysics in mpas_atmphys_driver_microphysics.F to subroutine microphysics_to_MPAS in mpas_atmphys_interface.F.

subroutine driver_microphysics mainly contains calls to different cloud microphysics schemes whereas interactions between physics and the MPAS framework are computed in subroutines microphysics_from_MPAS and microphysics_to_MPAS. This logic helps keep the sourcecode more consise.  Because the computation of dtheta_dt_mp is very similar to and uses the same set of variables as the variable rt_diabatic_tend, it is now computed in conjunction with rt_diabatic_tend in subroutine microphysics_to_MPAS. In addition, its definition is moved from ./diagnostics/Registry_pv.xml to Registry.xml.