### PR TITLE
Noah update to the WRF release 4.5

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2631,6 +2631,15 @@
                 <var name="acswuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward top-of-atmosphere shortwave radiation flux"/>
 
+                <var name="swddir" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="shortwave surface downward direct irradiance"/>
+
+                <var name="swddni" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="shortwave surface downward direct normal irradiance"/>
+
+                <var name="swddif" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="shortwave surface downward diffuse irradiance"/>
+
                 <var name="gsw" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="net surface shortwave radiation flux"/>
 

--- a/src/core_atmosphere/physics/checkout_data_files.sh
+++ b/src/core_atmosphere/physics/checkout_data_files.sh
@@ -23,7 +23,7 @@
 ################################################################################
 
 
-mpas_vers="7.0"
+mpas_vers="8.0"
 
 github_org="MPAS-Dev"   # GitHub organization where the MPAS-Data repository is found.
                         # For physics development, it can be helpful for a developer

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -72,6 +72,8 @@
 ! * modified logic in subroutine physics_tables_init so that the Thompson microphysics tables are read in each
 !   MPI task.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-12-30.
+! * replaced the option "noah" with "sf_noah" to run the NOAH land surface scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2022-02-18.
 
 
  contains
@@ -127,7 +129,7 @@
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_monin_obukhov'
-    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'noah'
+    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
 
  else if (trim(config_physics_suite) == 'convection_permitting') then
 
@@ -139,7 +141,7 @@
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_mynn'
-    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'noah'
+    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
 
  else if (trim(config_physics_suite) == 'none') then
 
@@ -278,7 +280,7 @@
                              'set config_sfclayer_scheme different than off')
     
  elseif(.not. (config_lsm_scheme .eq. 'off ' .or. &
-               config_lsm_scheme .eq. 'noah')) then
+               config_lsm_scheme .eq. 'sf_noah')) then
  
     write(mpas_err_message,'(A,A10)') 'illegal value for land surface scheme: ', &
           trim(config_lsm_scheme)
@@ -349,7 +351,7 @@
 
     lsm_select: select case(trim(config_lsm_scheme))
 
-       case("noah")
+       case("sf_noah")
        !initialize the thickness of the soil layers for the Noah scheme:
           do iCell = 1, nCells
              dzs(1,iCell) = 0.10_RKIND

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -93,6 +93,9 @@
 ! * added call to seaice_noah to include the parameterization of seaice for the updated Noah land surface
 !   scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-19.
+! * replaced the option "noah" with "sf_noah" to run the NOAH land surface scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2022-02-18.
+
 
 !
 ! DOCUMENTATION:
@@ -760,7 +763,7 @@
 
  lsm_select: select case (trim(lsm_scheme))
 
-    case ("noah")
+    case ("sf_noah")
        call noah_init_forMPAS(dminfo,mesh,configs,diag_physics,sfc_input)
     
     case default
@@ -807,8 +810,8 @@
 !call to land-surface scheme:
  lsm_select: select case (trim(lsm_scheme))
 
-    case("noah")
-       call mpas_timer_start('Noah')
+    case("sf_noah")
+       call mpas_timer_start('sf_noah')
        call lsm( &
                 dz8w        = dz_p        , p8w3d       = pres2_hyd_p  , t3d       = t_p          , &
                 qv3d        = qv_p        , xland       = xland_p      , xice      = xice_p       , &
@@ -893,7 +896,7 @@
                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
                     )
-       call mpas_timer_stop('Noah')
+       call mpas_timer_stop('sf_noah')
                 
 
     case default

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -165,6 +165,8 @@
  if(.not.allocated(snowc_p)     ) allocate(snowc_p(ims:ime,jms:jme)     )
  if(.not.allocated(snowh_p)     ) allocate(snowh_p(ims:ime,jms:jme)     )
  if(.not.allocated(sr_p)        ) allocate(sr_p(ims:ime,jms:jme)        )
+ if(.not.allocated(swddir_p)    ) allocate(swddir_p(ims:ime,jms:jme)    )
+ if(.not.allocated(swddif_p)    ) allocate(swddif_p(ims:ime,jms:jme)    )
  if(.not.allocated(swdown_p)    ) allocate(swdown_p(ims:ime,jms:jme)    )
  if(.not.allocated(tmn_p)       ) allocate(tmn_p(ims:ime,jms:jme)       )
  if(.not.allocated(tsk_p)       ) allocate(tsk_p(ims:ime,jms:jme)       )
@@ -184,9 +186,6 @@
  if(.not.allocated(frc_urb_p)   ) allocate(frc_urb_p(ims:ime,jms:jme)   )
  if(.not.allocated(ust_urb_p)   ) allocate(ust_urb_p(ims:ime,jms:jme)   )
  if(.not.allocated(utype_urb_p) ) allocate(utype_urb_p(ims:ime,jms:jme) )
- if(.not.allocated(infxsrt_p)   ) allocate(infxsrt_p(ims:ime,jms:jme)   )
- if(.not.allocated(sfcheadrt_p) ) allocate(sfcheadrt_p(ims:ime,jms:jme) )
- if(.not.allocated(soldrain_p)  ) allocate(soldrain_p(ims:ime,jms:jme)  )
 
  if(config_frac_seaice) then
     if(.not.allocated(tsk_sea)   ) allocate(tsk_sea(ims:ime,jms:jme)   )
@@ -253,6 +252,8 @@
  if(allocated(snowc_p)     ) deallocate(snowc_p     )
  if(allocated(snowh_p)     ) deallocate(snowh_p     )
  if(allocated(sr_p)        ) deallocate(sr_p        )
+ if(allocated(swddir_p)    ) deallocate(swddir_p    )
+ if(allocated(swddif_p)    ) deallocate(swddif_p    )
  if(allocated(swdown_p)    ) deallocate(swdown_p    )
  if(allocated(tmn_p)       ) deallocate(tmn_p       )
  if(allocated(tsk_p)       ) deallocate(tsk_p       )
@@ -272,9 +273,6 @@
  if(allocated(frc_urb_p)   ) deallocate(frc_urb_p   )
  if(allocated(ust_urb_p)   ) deallocate(ust_urb_p   )
  if(allocated(utype_urb_p) ) deallocate(utype_urb_p )
- if(allocated(infxsrt_p)   ) deallocate(infxsrt_p   )
- if(allocated(sfcheadrt_p) ) deallocate(sfcheadrt_p )
- if(allocated(soldrain_p)  ) deallocate(soldrain_p  )
 
  if(config_frac_seaice) then
     if(allocated(chs_sea)   ) deallocate(chs_sea   )
@@ -317,8 +315,8 @@
  real(kind=RKIND),dimension(:),pointer  :: acsnom,acsnow,canwat,chs,chs2,chklowq,cpm,cqs2,glw,   &
                                            grdflx,gsw,hfx,lai,lh,noahres,potevp,qfx,qgh,qsfc,    &
                                            br,sfc_albedo,sfc_albedo_seaice,sfc_emibck,sfc_emiss, &
-                                           sfcrunoff,smstav,smstot,snotime,snopcx,sr,udrunoff,   &
-                                           z0,znt
+                                           sfcrunoff,smstav,smstot,snotime,snopcx,sr,swddif,     &
+                                           swddir,udrunoff,z0,znt
  real(kind=RKIND),dimension(:),pointer  :: shdmin,shdmax,snoalb,sfc_albbck,snow,snowc,snowh,tmn, &
                                            skintemp,vegfra,xice,xland
  real(kind=RKIND),dimension(:),pointer  :: t2m,th2m,q2
@@ -365,6 +363,8 @@
  call mpas_pool_get_array(diag_physics,'smstot'           ,smstot           )
  call mpas_pool_get_array(diag_physics,'snotime'          ,snotime          )
  call mpas_pool_get_array(diag_physics,'snopcx'           ,snopcx           )
+ call mpas_pool_get_array(diag_physics,'swddif'           ,swddif           )
+ call mpas_pool_get_array(diag_physics,'swddir'           ,swddir           )
  call mpas_pool_get_array(diag_physics,'udrunoff'         ,udrunoff         )
  call mpas_pool_get_array(diag_physics,'z0'               ,z0               )
  call mpas_pool_get_array(diag_physics,'znt'              ,znt              )
@@ -439,6 +439,8 @@
     smstot_p(i,j)     = smstot(i)
     snotime_p(i,j)    = snotime(i)
     snopcx_p(i,j)     = snopcx(i)
+    swddif_p(i,j)     = swddif(i)
+    swddir_p(i,j)     = swddir(i)
     udrunoff_p(i,j)   = udrunoff(i)
     z0_p(i,j)         = z0(i)
     znt_p(i,j)        = znt(i)
@@ -472,13 +474,9 @@
     !initialization of arrays to run the Noah LSM urban parameterization (not currently
     frc_urb_p(i,j)    = 0._RKIND
     ust_urb_p(i,j)    = 0._RKIND
-    utype_urb_p(i,j)  = low_density_residential
+    utype_urb_p(i,j)  = 0
 
-    !initialization of arrays to run the Noah LSM hydrological parameterization (not currently
-    !implemented in MPAS):
-    infxsrt_p(i,j)    = 0._RKIND
-    sfcheadrt_p(i,j)  = 0._RKIND
-    soldrain_p(i,j)   = 0._RKIND
+    if(swddir_p(i,j).gt.0.) call mpas_log_write('--- sw: $i $r $r',intArgs=(/i/),realArgs=(/swddir_p(i,j),swddif_p(i,j)/))
  enddo
  enddo
 
@@ -838,18 +836,21 @@
                 opt_thcnd   = opt_thcnd   , ua_phys     = ua_phys      , flx4_2d   = flxsnow_p    , &
                 fvb_2d      = fvbsnow_p   , fbur_2d     = fbursnow_p   , fgsn_2d   = fgsnsnow_p   , &
                 utype_urb2d = utype_urb_p , frc_urb2d   = frc_urb_p    , ust_urb2d = ust_urb_p    , &
-                infxsrt     = infxsrt_p   , sfcheadrt   = sfcheadrt_p  , soldrain  = soldrain_p   , &
-                fasdas      = fasdas      , julian      = 0            , julyr     = 0            , &
+                swddir      = swddir_p    , swddif      = swddif_p     , fasdas    = fasdas       , &
+                julian      = 0           , julyr       = 0            ,                            &
+                num_soil_layers  = num_soils         ,                                              &
                 xice_threshold   = xice_threshold    ,                                              &
                 usemonalb        = config_sfc_albedo ,                                              &
-                mminlu           = mminlu ,                                                         &
-                num_soil_layers  = num_soils ,                                                      &
-                num_roof_layers  = num_soils ,                                                      &
-                num_wall_layers  = num_soils ,                                                      &
-                num_road_layers  = num_soils ,                                                      &
-                num_urban_layers = num_soils ,                                                      &
-                num_urban_hi     = num_soils ,                                                      &
-                sf_urban_physics = sf_urban_physics ,                                               &
+                mminlu           = mminlu            ,                                              &
+                sf_urban_physics = sf_urban_physics  ,                                              &
+                num_roof_layers  = nurb , num_wall_layers = nurb  ,                                 &
+                num_road_layers  = nurb , num_urban_hi    = nurb  ,                                 &
+                num_urban_ndm    = nurb , urban_map_zrd   = nurb  ,                                 &
+                urban_map_zwd    = nurb , urban_map_gd    = nurb  ,                                 &
+                urban_map_zd     = nurb , urban_map_zdf   = nurb  ,                                 &
+                urban_map_bd     = nurb , urban_map_wd    = nurb  ,                                 &
+                urban_map_gbd    = nurb , urban_map_fbd   = nurb  ,                                 &
+                urban_map_zgrd   = nurb ,                                                           &
                 ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,             &
                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,             &
                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte               &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_shared.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_shared.F
@@ -1,0 +1,65 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_atmphys_driver_lsm_shared
+ use mpas_kind_types
+
+
+ implicit none
+ private
+ public:: correct_tsk_over_seaice
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine correct_tsk_over_seaice(ims,ime,jms,jme,its,ite,jts,jte,xice_thresh,xice,tsk,tsk_sea,tsk_ice)
+!=================================================================================================================
+
+!input arguments:
+ integer,intent(in):: ims,ime,its,ite,jms,jme,jts,jte
+ real(kind=RKIND),intent(in):: xice_thresh
+ real(kind=RKIND),intent(in),dimension(ims:ime,jms:jme):: tsk,xice
+
+!inout arguments:
+ real(kind=RKIND),intent(inout),dimension(ims:ime,jms:jme):: tsk_sea,tsk_ice
+
+!local variables:
+ integer:: i,j
+
+!-----------------------------------------------------------------------------------------------------------------
+
+!initialize the local sea-surface temperature and local sea-ice temperature to the local surface
+!temperature:
+ do j = jts,jte
+ do i = its,ite
+    tsk_sea(i,j) = tsk(i,j)
+    tsk_ice(i,j) = tsk(i,j)
+
+    if(xice(i,j).ge.xice_thresh .and. xice(i,j).le.1._RKIND) then
+       !over sea-ice grid cells, limit sea-surface temperatures to temperatures warmer than 271.4:
+       tsk_sea(i,j) = max(tsk_sea(i,j),271.4_RKIND)
+
+       !over sea-ice grid cells, avoids unphysically too cold sea-ice temperatures for grid cells
+       !with small sea-ice fractions:
+       if(xice(i,j).lt.0.2_RKIND .and. tsk_ice(i,j).lt.253.15_RKIND) tsk_ice(i,j) = 253.15_RKIND
+       if(xice(i,j).lt.0.1_RKIND .and. tsk_ice(i,j).lt.263.15_RKIND) tsk_ice(i,j) = 263.15_RKIND
+    endif
+ enddo
+ enddo
+
+ end subroutine correct_tsk_over_seaice
+
+!=================================================================================================================
+ end module mpas_atmphys_driver_lsm_shared
+!=================================================================================================================
+
+
+
+

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -82,7 +82,9 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-10.
 ! * since we removed the local variable radt_sw_scheme from mpas_atmphys_vars.F, now defines radt_sw_scheme
 !   as a pointer to config_radt_sw_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * added the variables swddir,swddni,swddif for use in the updated version of the Noah LSM.
+!   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
 
 
  contains
@@ -144,6 +146,10 @@
        if(.not.allocated(swvisdif_p)   ) allocate(swvisdif_p(ims:ime,jms:jme)              )
        if(.not.allocated(swnirdir_p)   ) allocate(swnirdir_p(ims:ime,jms:jme)              )
        if(.not.allocated(swnirdif_p)   ) allocate(swnirdif_p(ims:ime,jms:jme)              )
+
+       if(.not.allocated(swddir_p)     ) allocate(swddir_p(ims:ime,jms:jme)                )
+       if(.not.allocated(swddni_p)     ) allocate(swddni_p(ims:ime,jms:jme)                )
+       if(.not.allocated(swddif_p)     ) allocate(swddif_p(ims:ime,jms:jme)                )
 
        if(.not.allocated(swdnflx_p)    ) allocate(swdnflx_p(ims:ime,kms:kme+1,jms:jme)     )
        if(.not.allocated(swdnflxc_p)   ) allocate(swdnflxc_p(ims:ime,kms:kme+1,jms:jme)    )
@@ -249,6 +255,14 @@
        if(allocated(alswvisdif_p) ) deallocate(alswvisdif_p )
        if(allocated(alswnirdir_p) ) deallocate(alswnirdir_p )
        if(allocated(alswnirdif_p) ) deallocate(alswnirdif_p )
+       if(allocated(swvisdir_p)   ) deallocate(swvisdir_p   )
+       if(allocated(swvisdif_p)   ) deallocate(swvisdif_p   )
+       if(allocated(swnirdir_p)   ) deallocate(swnirdir_p   )
+       if(allocated(swnirdif_p)   ) deallocate(swnirdif_p   )
+
+       if(allocated(swddir_p)     ) deallocate(swddir_p     )
+       if(allocated(swddni_p)     ) deallocate(swddni_p     )
+       if(allocated(swddif_p)     ) deallocate(swddif_p     )
 
        if(allocated(swdnflx_p)    ) deallocate(swdnflx_p    )
        if(allocated(swdnflxc_p)   ) deallocate(swdnflxc_p   )
@@ -400,6 +414,9 @@
     swupbc_p(i,j)   = 0.0_RKIND
     swupt_p(i,j)    = 0.0_RKIND
     swuptc_p(i,j)   = 0.0_RKIND
+    swddir_p(i,j)   = 0.0_RKIND
+    swddni_p(i,j)   = 0.0_RKIND
+    swddif_p(i,j)   = 0.0_RKIND
  enddo
 
  do k = kts,kte
@@ -589,10 +606,13 @@
 
 !local pointers:
  real(kind=RKIND),dimension(:),pointer  :: coszr,gsw,swcf,swdnb,swdnbc,swdnt,swdntc, &
-                                           swupb,swupbc,swupt,swuptc
+                                           swupb,swupbc,swupt,swuptc,swddir,swddni,  &
+                                           swddif
  real(kind=RKIND),dimension(:,:),pointer:: rthratensw
 
 !-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine radiation_sw_to_MPAS:')
 
  call mpas_pool_get_array(diag_physics,'coszr'     ,coszr     )
  call mpas_pool_get_array(diag_physics,'gsw'       ,gsw       )
@@ -602,9 +622,12 @@
  call mpas_pool_get_array(diag_physics,'swdnt'     ,swdnt     )
  call mpas_pool_get_array(diag_physics,'swdntc'    ,swdntc    )
  call mpas_pool_get_array(diag_physics,'swupb'     ,swupb     )
- call mpas_pool_get_array(diag_physics,'swupbc'    , swupbc   )
+ call mpas_pool_get_array(diag_physics,'swupbc'    ,swupbc    )
  call mpas_pool_get_array(diag_physics,'swupt'     ,swupt     )
  call mpas_pool_get_array(diag_physics,'swuptc'    ,swuptc    )
+ call mpas_pool_get_array(diag_physics,'swddir'    ,swddir    )
+ call mpas_pool_get_array(diag_physics,'swddni'    ,swddni    )
+ call mpas_pool_get_array(diag_physics,'swddif'    ,swddif    )
  call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
  do j = jts,jte
@@ -621,6 +644,9 @@
     swupbc(i) = swupbc_p(i,j)
     swupt(i)  = swupt_p(i,j)
     swuptc(i) = swuptc_p(i,j)
+    swddir(i) = swddir_p(i,j)
+    swddni(i) = swddni_p(i,j)
+    swddif(i) = swddif_p(i,j)
  enddo
 
  do k = kts,kte
@@ -630,6 +656,9 @@
  enddo
 
  enddo
+
+!call mpas_log_write('--- enter subroutine radiation_sw_to_MPAS:')
+!call mpas_log_write(' ')
 
  end subroutine radiation_sw_to_MPAS
 
@@ -760,6 +789,7 @@
               re_snow    = resnow_p     , swupt      = swupt_p       , swuptc   = swuptc_p , &
               swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
+              swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -210,7 +210,7 @@
                                      therin(ic,is),scfx(ic,is),sfhc(ic,is)
        enddo
 !      do ic = 1, lucats
-!         call mpas_log_write('$i $r $r $r $r $r $r $r $r', intArgs=(/ic/), &
+!         call mpas_log_write('$i $r $r $r $r $r $r $r', intArgs=(/ic/), &
 !                realArgs=(/albd(ic,is),slmo(ic,is),sfem(ic,is),sfz0(ic,is), &
 !                therin(ic,is),scfx(ic,is),sfhc(ic,is)/))
 !      enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
@@ -215,11 +215,13 @@
  character(len=*),intent(inout):: mminlu, mminsl
 
 !local variables:
- character*128:: mess , message
+ character*128:: mess,message
+ character*128:: astring
 
- integer,parameter:: open_ok = 0
+ integer,parameter:: open_ok  = 0
+ integer,parameter:: loop_max = 10
  integer:: lumatch,iindex,lc,num_slope
- integer:: read_unit, istat
+ integer:: istat,loop_count,read_unit
 
 !-----SPECIFY VEGETATION RELATED CHARACTERISTICS :
 !ALBBCK: SFC albedo (in percentage)
@@ -261,8 +263,10 @@
                                 'failure opening VEGPARM.TBL')
 
     lumatch=0
+
+    loop_count = 0
+    read(read_unit,fmt='(A)',end=2002) astring
     find_lutype : do while (lumatch == 0)
-       read(read_unit,*,end=2002)
        read(read_unit,*,end=2002) lutype
        read(read_unit,*) lucats,iindex
 
@@ -272,10 +276,17 @@
           call physics_message(mess)
           lumatch=1
        else
+          loop_count = loop_count + 1
           call physics_message('    skipping over lutype = ' // trim ( lutype ))
-          do lc = 1, lucats+20
-             read(read_unit,*)
-          enddo
+
+          find_vegetation_parameter_flag: do
+             read(read_unit,fmt='(A)',end=2002) astring
+             if(astring(1:21) .eq. 'Vegetation Parameters') then
+                exit find_vegetation_parameter_flag
+             elseif(loop_count .ge. loop_max) then
+                call physics_error_fatal('too many loops in VEGPARM.TBL')
+             endif
+          enddo find_vegetation_parameter_flag
        endif
     enddo find_lutype
 
@@ -307,6 +318,7 @@
                      albedomintbl(lc),albedomaxtbl(lc),z0mintbl(lc),z0maxtbl(lc),ztopvtbl(lc), &
                      zbotvtbl(lc)
        enddo
+
        read (read_unit,*)
        read (read_unit,*)topt_data
        read (read_unit,*)
@@ -322,11 +334,27 @@
        read (read_unit,*)
        read (read_unit,*)
        read (read_unit,*)
-       read (read_unit,*)low_density_residential
+       read (read_unit,*)lcz_1
        read (read_unit,*)
-       read (read_unit,*)high_density_residential
+       read (read_unit,*)lcz_2
        read (read_unit,*)
-       read (read_unit,*)high_intensity_industrial
+       read (read_unit,*)lcz_3
+       read (read_unit,*)
+       read (read_unit,*)lcz_4
+       read (read_unit,*)
+       read (read_unit,*)lcz_5
+       read (read_unit,*)
+       read (read_unit,*)lcz_6
+       read (read_unit,*)
+       read (read_unit,*)lcz_7
+       read (read_unit,*)
+       read (read_unit,*)lcz_8
+       read (read_unit,*)
+       read (read_unit,*)lcz_9
+       read (read_unit,*)
+       read (read_unit,*)lcz_10
+       read (read_unit,*)
+       read (read_unit,*)lcz_11
     endif
 
     2002 continue
@@ -364,9 +392,17 @@
  DM_BCAST_REAL(rsmax_data)
  DM_BCAST_INTEGER(bare)
  DM_BCAST_INTEGER(natural)
- DM_BCAST_INTEGER(low_density_residential)
- DM_BCAST_INTEGER(high_density_residential)
- DM_BCAST_INTEGER(high_intensity_industrial)
+ DM_BCAST_INTEGER(lcz_1)
+ DM_BCAST_INTEGER(lcz_2)
+ DM_BCAST_INTEGER(lcz_3)
+ DM_BCAST_INTEGER(lcz_4)
+ DM_BCAST_INTEGER(lcz_5)
+ DM_BCAST_INTEGER(lcz_6)
+ DM_BCAST_INTEGER(lcz_7)
+ DM_BCAST_INTEGER(lcz_8)
+ DM_BCAST_INTEGER(lcz_9)
+ DM_BCAST_INTEGER(lcz_10)
+ DM_BCAST_INTEGER(lcz_11)
 
 !call mpas_log_write(' LUTYPE  = '//trim(lutype))
 !call mpas_log_write(' LUCATS  = $i',intArgs=(/lucats/))
@@ -379,16 +415,24 @@
 !call mpas_log_write(' RSMAX_DATA  = $r',realArgs=(/rsmax_data/))
 !call mpas_log_write(' BARE        = $i',intArgs=(/bare/))
 !call mpas_log_write(' NATURAL     = $i',intArgs=(/natural/))
-!call mpas_log_write(' LOW_DENSITY_RESIDENTIAL   = $i , intArgs=(/low_density_residential/))
-!call mpas_log_write(' HIGH_DENSITY_RESIDENTIAL  = $i , intArgs=(/high_density_residential/))
-!call mpas_log_write(' HIGH_DENSITY_INDUSTRIAL   = $i , intArgs=(/high_density_industrial/))
+!call mpas_log_write(' LCZ_1       = $i', intArgs=(/lcz_1/))
+!call mpas_log_write(' LCZ_2       = $i', intArgs=(/lcz_2/))
+!call mpas_log_write(' LCZ_3       = $i', intArgs=(/lcz_3/))
+!call mpas_log_write(' LCZ_4       = $i', intArgs=(/lcz_4/))
+!call mpas_log_write(' LCZ_5       = $i', intArgs=(/lcz_5/))
+!call mpas_log_write(' LCZ_6       = $i', intArgs=(/lcz_6/))
+!call mpas_log_write(' LCZ_7       = $i', intArgs=(/lcz_7/))
+!call mpas_log_write(' LCZ_8       = $i', intArgs=(/lcz_8/))
+!call mpas_log_write(' LCZ_9       = $i', intArgs=(/lcz_9/))
+!call mpas_log_write(' LCZ_10      = $i', intArgs=(/lcz_10/))
+!call mpas_log_write(' LCZ_11      = $i', intArgs=(/lcz_11/))
 !call mpas_log_write('')
 !do lc = 1, lucats
 !   call mpas_log_write('$i $r $r $r $r $r $r $r $r $r $r $r $r $r $r $r $r $r', intArgs=(/lc/),     &
 !                realArgs=(/shdtbl(lc),float(nrotbl(lc)),rstbl(lc),rgltbl(lc),hstbl(lc),snuptbl(lc), &
 !                maxalb(lc),laimintbl(lc),laimaxtbl(lc),emissmintbl(lc),emissmaxtbl(lc),             &
 !                albedomintbl(lc),albedomaxtbl(lc),z0mintbl(lc),z0maxtbl(lc),ztopvtbl(lc),           &
-!                zbottvtbl(lc)/))
+!                zbotvtbl(lc)/))
 !enddo
  call mpas_log_write('    end read VEGPARM.TBL')
 

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -124,6 +124,8 @@
 ! * in subroutine physics_run_init, removed the initialization of the local variable microp_scheme.
 !   microp_scheme is no longer needed and can be replaced with config_microp_scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * replaced the option "noah" with "sf_noah" to run the NOAH land surface scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2022-02-18.
 
 
  contains
@@ -672,7 +674,7 @@
  num_months = nMonths
  num_soils  = nSoilLevels
 
- if(trim(config_lsm_scheme) .eq. "noah") sf_surface_physics = 2 
+ if(trim(config_lsm_scheme) .eq. "sf_noah") sf_surface_physics = 2
 
 !initialization of local physics time-steps:
 !... dynamics:

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -649,7 +649,7 @@
 !=================================================================================================================
 
  logical,parameter:: &
-    ua_phys=.false.    !option to activate UA Noah changes: a different snow-cover physics in the land-surface
+    ua_phys = .false.  !option to activate UA Noah changes: a different snow-cover physics in the land-surface
                        !scheme. That option is not currently implemented in MPAS.
 
  integer,parameter:: &
@@ -659,6 +659,9 @@
 
  integer,parameter:: &
     fasdas = 0         !for WRF surface data assimilation system (not used in MPAS).
+
+ integer,parameter:: &
+    nurb = 1           !generic dimension for all dimensions needed to run the urban physics.
 
  integer,public:: &
     sf_surface_physics !used to define the land surface scheme by a number instead of name. It
@@ -727,13 +730,6 @@
  real(kind=RKIND),dimension(:,:),allocatable:: &
     frc_urb_p,        &!urban fraction                                                                         [-]
     ust_urb_p          !urban u* in similarity theory                                                        [m/s]
-
-!.. arrays needed in the argument list in the call to the Noah LSM hydrology model: note that these arrays are
-!.. initialized to zero since we do not run a hydrology model:
- real(kind=RKIND),dimension(:,:),allocatable:: &
-    infxsrt_p,        &!timestep infiltration excess                                                          [mm]
-    sfcheadrt_p,      &!surface water detph                                                                   [mm]
-    soldrain_p         !soil column drainage                                                                  [mm]
 
 !=================================================================================================================
 !.. variables and arrays related to surface characteristics:

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -110,6 +110,9 @@
 ! * added the local variables cosa_p and sina_p needed in call to subroutine gwdo after updating module_bl_gwdo.F
 !   to that of WRF version 4.0.2
 !   Laura D. Fowler (laura@ucar.edu) / 2019-01-30.
+! * added the local variables swddir,swddni,and swddif which are output to subroutine rrtmg_swrad and now input
+!   to the updated module_sf_noahdrv.F.
+!   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
 
 
 !=================================================================================================================
@@ -541,6 +544,11 @@
     swvisdif_p,       &!visible diffuse downward flux                                       [W m-2]
     swnirdir_p,       &!near-IR direct downward flux                                        [W m-2]
     swnirdif_p         !near-IR diffuse downward flux                                       [W m-2]
+
+ real(kind=RKIND),dimension(:,:),allocatable:: &
+    swddir_p,         &!
+    swddni_p,         &!
+    swddif_p           !
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     swdnflx_p,        &!

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -7,6 +7,7 @@ dummy:
 
 OBJS = \
 	libmassv.o                     \
+	module_bep_bem_helper.o        \
 	module_bl_gwdo.o               \
 	module_bl_mynn.o               \
 	module_bl_ysu.o                \
@@ -69,9 +70,11 @@ module_ra_rrtmg_sw.o: \
 	module_ra_rrtmg_vinterp.o
 
 module_sf_bep.o: \
+	module_bep_bem_helper.o \
 	module_sf_urban.o
 
 module_sf_bep_bem.o: \
+	module_bep_bem_helper.o \
 	module_sf_bem.o \
 	module_sf_urban.o
 

--- a/src/core_atmosphere/physics/physics_wrf/module_bep_bem_helper.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bep_bem_helper.F
@@ -1,0 +1,4 @@
+MODULE module_bep_bem_helper
+   integer, save :: nurbm  ! Maximum number of urban classes    
+CONTAINS
+END MODULE module_bep_bem_helper

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9873,9 +9873,10 @@ CONTAINS
                        noznlevels,pin,o3clim,gsw,swcf,rthratensw,      &
                        has_reqc,has_reqi,has_reqs,re_cloud,            &
                        re_ice,re_snow,                                 &
-                       swupt, swuptc, swdnt, swdntc,                   &
-                       swupb, swupbc, swdnb, swdnbc,                   &
+                       swupt,swuptc,swdnt,swdntc,                      &
+                       swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
+                       swddir,swddni,swddif,                           &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -9916,6 +9917,8 @@ CONTAINS
  real,intent(inout),dimension(ims:ime,kms:kme,jms:jme):: rthratensw
 
 !--- output arguments:
+  real,intent(out),dimension(ims:ime,jms:jme),optional:: &
+     swddir,swddni,swddif
   real,intent(out),dimension(ims:ime,kms:kme+2,jms:jme ),optional:: &
      swupflx,swupflxc,swdnflx,swdnflxc
 
@@ -10409,6 +10412,12 @@ CONTAINS
              swupbc(i,j) = swuflxc(1,1)
              swdnb(i,j)  = swdflx(1,1)
              swdnbc(i,j) = swdflxc(1,1)
+          endif
+
+          if(present(swddir) .and. present(swddni) .and. present(swddif)) then
+             swddir(i,j)  = swdkdir(1,1)          ! jararias 2013/08/10
+             swddni(i,j)  = swddir(i,j) / coszrs  ! jararias 2013/08/10
+             swddif(i,j)  = swdkdif(1,1)          ! jararias 2013/08/10
           endif
 
           if(present (swupflx)) then

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bem.F
@@ -1,14 +1,20 @@
 MODULE module_sf_bem
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
+#if defined(mpas)
+use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
+#else
+use module_wrf_error
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
+#define WRITE_MESSAGE(M) call wrf_message(M)
+#endif
+
 ! -----------------------------------------------------------------------
 !  Variables and constants used in the BEM module
 ! -----------------------------------------------------------------------
-
-#ifdef mpas
-use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
-#else
-#define FATAL_ERROR(M) write(0,*) M ; stop
-#endif
          
         real emins		!emissivity of the internal walls
         parameter (emins=0.9) 
@@ -27,6 +33,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
         real hum_rat            !power of the A.C. drying/moistening the indoor air [(Kg/kg)/s]
         parameter(hum_rat=1.e-06)
 
+        real,parameter :: effpv=0.19  ! Efficiency of PV panels installed at the roofs, typical values [0.10,0.15] 
 
     CONTAINS
 
@@ -35,16 +42,21 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	
 	subroutine BEM(nzcanm,nlev,nhourday,dt,bw,bl,dzlev,            &
                        nwal,nflo,nrof,ngrd,hswalout,gswal,             &
-                       hswinout,hsrof,gsrof,                           &
+                       hswinout,hsrof,lsrof,gsrof,hspv,                &
                        latent,sigma,albwal,albwin,albrof,              &
      		       emrof,emwal,emwin,rswal,rlwal,rair,cp,          &
      		       rhoout,tout,humout,press,                       &
-     		       rs,rl,dzwal,cswal,kwal,pwin,cop,beta,sw_cond,   &
+     		       rs,swddif,rl,dzwal,cswal,kwal,pwin,cop,beta,sw_cond,   &
                        timeon,timeoff,targtemp,gaptemp,targhum,gaphum, &
-                       perflo,hsesf,hsequip,dzflo,                     &
+                       perflo,gr_frac_roof,pv_frac_roof,gr_flag, & 
+                       uout,vout,                                        &
+                       hsesf,hsequip,dzflo,                            &
      		       csflo,kflo,dzgrd,csgrd,kgrd,dzrof,csrof,        &
      		       krof,tlev,shumlev,twal,twin,tflo,tgrd,trof,     &
-     		       hsout,hlout,consump,hsvent,hlvent)
+     		       hsout,hlout,consump,eppv,tpv,hsvent,hlvent,hfgr,&
+                       tr_av,tpv_print,sfpv,sfr_indoor)
+
+
 
 
 ! ---------------------------------------------------------------------
@@ -97,7 +109,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 
 	real dt				!time step [s]
                                        
-        integer nzcanm                  !Maximum number of vertical levels in the urban grid
+           integer nzcanm                  !Maximum number of vertical levels in the urban grid
 	integer nlev			!number of floors in the building
 	integer nwal                    !number of levels inside the wall
 	integer nrof                    !number of levels inside the roof
@@ -127,6 +139,11 @@ use mpas_atmphys_utilities, only: physics_error_fatal
         real,    intent(in) :: targhum  ! Target humidity of A/C systems
         real,    intent(in) :: gaphum   ! Comfort range of specific humidity
         real,    intent(in) :: perflo   ! Peak number of occupants per unit floor area
+        real gr_frac_roof   
+        real pv_frac_roof
+        integer gr_flag  
+        real   uout(nzcanm) 
+        real    vout(nzcanm)
         real,    intent(in) :: hsesf    ! 
         real,    intent(in) :: hsequip(24) ! 
 	
@@ -145,11 +162,12 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real dzflo(nflo)		!Layer sizes of floors [m]
 	real dzrof(nrof)		!Layer sizes of roof [m]
 	real dzgrd(ngrd)		!Layer sizes of ground [m]
-	
+	real tpv
+        real tr_av 
 	real latent                      !latent heat of evaporation [J/Kg]	
 
-
-	real rs				!external short wave radiation [W/m2]
+        real swddif
+   	real rs				!external short wave radiation [W/m2]
 	real rl				!external long wave radiation [W/m2]
 	real rswal(4,nzcanm)		!short wave radiation reaching the exterior walls [W/m2]
         real rlwal(4,nzcanm)		!long wave radiation reaching the walls [W/m2]	
@@ -161,11 +179,11 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real hswalout(4,nzcanm)	        !outside walls sensible heat flux [W/m2]
 	real hswinout(4,nzcanm)	        !outside window sensible heat flux [W/m2]
 	real hsrof			!Sensible heat flux at the roof [W/m2]
-	
-	real rair			!ideal gas constant  [J.kg-1.K-1]
+	real lsrof
+        real rair			!ideal gas constant  [J.kg-1.K-1]
 	real sigma			!parameter (wall is not black body) [W/m2.K4]
 	real cp				!specific heat of air [J/kg.K]
-       
+        real hfgr       !Green roof heat flux
 	
 !Input-Output
 !------------
@@ -181,9 +199,11 @@ use mpas_atmphys_utilities, only: physics_error_fatal
         real consump(nzcanm)            !Consumption for the a.c. in each floor [W]
 	real hsvent(nzcanm)		!sensible heat generated by natural ventilation [W]
 	real hlvent(nzcanm)		!latent heat generated by natural ventilation [W] 
-        real gsrof                      !heat flux flowing inside the roof [W/m^2]
-        real gswal(4,nzcanm)             !heat flux flowing inside the floors [W/m^2]
-
+        real gsrof                      !heat flux flowing inside the roof [W/m2]
+        real hspv			!Sensible heat flux at the roof from the PV panels [W/m2]
+        real gswal(4,nzcanm)             !heat flux flowing inside the floors [W/m2]
+        real eppv                        !Electricity production of PV panels [W]
+        real sfr_indoor,sfpv,tpv_print
 ! Local:
 ! -----
 	integer swwal                   !swich for the physical coefficients calculation
@@ -234,10 +254,13 @@ use mpas_atmphys_utilities, only: physics_error_fatal
         real hsoutbuild                 !Total sensible heat ejected into the atmosphere[W]
                                         !by the air conditioning system and per building
         real nhourday                   !number of hours from midnight, local time
+        real hfgrd                      !Dummy variable to assign hfgr=0 to walls, windows and ground
+
+!
+        parameter(hfgrd=0) 
 !--------------------------------------------
 !Initialization
 !--------------------------------------------
-
        do ilev=1,nzcanm
           hseqocc(ilev)=0.
           hleqocc(ilev)=0.
@@ -401,11 +424,15 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	 end do ! ivw
 	end do  ! ilev
 	
-!Roof
-
-        call radfluxs(radflux,albrof,rs,emrof,rl,sigma,trof(nrof))
-
-        hrrof=radflux
+!Roof and PV panels
+        
+        if (pv_frac_roof.eq.0.) then
+           call radfluxs(radflux,albrof,rs,emrof,rl,sigma,tr_av)
+          hrrof=radflux
+          else
+            call radfluxspv(nzcanm,nlev,albrof,rs,swddif,emrof,rl,tr_av,tout,sigma,radflux,pv_frac_roof,tpv)
+            hrrof=radflux
+        endif
 
 !Internal walls for intermediate rooms
 
@@ -548,7 +575,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 !Vertical fluxes for windows
 
 	do ilev=1,nlev
-
+                                                                                                                                                                          
          do ivw=1,4
 	 
 	       call hsinsflux (2,1,tlev(ilev),twin(ivw,ilev),hs)
@@ -594,7 +621,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 		call hsinsflux (1,2,tlev(nlev),trof(1),hs)
 
 		hswalins(6,nlev)=hs	       
-      
+                sfr_indoor= hswalins(6,nlev) 
       else  ! Bottom<--->Top 
       
                 call hsinsflux (1,2,tlev(1),tgrd(ngrd),hs)
@@ -606,7 +633,15 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 		hswalins(6,nlev)=hs
       
       end if
+!!
+!! Calculation of the sensible heat fluxes from the PV panels & electricity producti
 
+
+      if(pv_frac_roof.gt.0)then
+      call hsfluxpv(nzcanm,nlev,bl,bw,albrof,rs,swddif,emrof,rl,tr_av,tout,sigma,hspv,eppv,pv_frac_roof,uout,vout,tpv,dt)
+      sfpv=hspv
+      tpv_print=tpv
+      endif       
 
 !Calculation of the temperature for the different surfaces 
 ! --------------------------------------------------------
@@ -624,7 +659,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	   do iwal=1,nwal
 	      twal1D(iwal)=twal(ivw,iwal,ilev)
 	   end do
-	  
+	    
 	   call wall(swwal,nwal,dt,dzwal,kwal,cswal,htot,twal1D)
 	
 	   do iwal=1,nwal
@@ -695,19 +730,25 @@ use mpas_atmphys_utilities, only: physics_error_fatal
       swwal=1    
 
       htot(1)=hswalins(6,nlev)+hrwalins(6,nlev)     	
-      htot(2)=hsrof+hrrof     
+      htot(2)=hsrof+hrrof+lsrof 
       gsrof=htot(2)
 
       do irof=1,nrof
          trof1D(irof)=trof(irof)
-      end do     
-      
-      call wall(swwal,nrof,dt,dzrof,krof,csrof,htot,trof1D)
- 
+        
+      end do  
+
+      if(gr_flag.eq.1)then
+      call wall_gr(hfgr,gr_frac_roof,swwal,nrof,dt,dzrof,krof,csrof,htot,trof1D)
+      else
+       call wall(swwal,nrof,dt,dzrof,krof,csrof,htot,trof1D)
+      endif
       do irof=1,nrof
          trof(irof)=trof1D(irof)
-      end do
+
+       end do
       
+
 ! Calculation of the heat fluxes and of the temperature of the rooms
 ! ------------------------------------------------------------------
 
@@ -728,6 +769,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	  call fluxvent(cpint,rhoint,vollev,tlev(ilev),tout(ilev),     &
                         latent,humout(ilev),rhoout(ilev),shumlev(ilev),&
                         beta,hsvent(ilev),hlvent(ilev))
+  
 	      
          !Calculation of the heat generated by conduction
 	  
@@ -782,11 +824,95 @@ use mpas_atmphys_utilities, only: physics_error_fatal
                 
       return
       end subroutine BEM
+!====6=8===============================================================72  
+!====6=8===============================================================72  
+      subroutine hsfluxpv(nz,n,bl,bw,albr,rs,swddif,emr,rl,tr,tair,sigma,hspv,eppv,pv_frac_roof,uout,vout,tpv,dt)
+!
+      implicit none
+!
+! Input variables
+!
+      integer,intent(in) :: nz     !Maximum number of vertical levels in the urban grid
+      real,intent(in) :: bl		!Building length [m]
+      real,intent(in) :: bw            !Building width [m]
+      real,intent(in) :: albr	!albedo of the roof (ext.) 
+      real,intent(in) :: emr   !emissivity of the roof (ext.)
+      real,intent(in) :: rs    !external short wave radiation [W/m2]
+      real,intent(in) :: rl	!external long wave radiation [W/m2]
+      real,intent(in) :: tr	!roof surface temperature [K]
+      real,intent(in) :: pv_frac_roof ! fraction of PV  []
+      real,intent(in) :: sigma !Stefan-Boltzmann constant [W/m2.K4] 
+      real,intent(in),dimension(1:nz) :: tair  !external temperature [K] 
+      integer,intent(in) :: n  !number of floors in the building
+      real,intent(in), dimension(1:nz) :: uout		
+      real,intent(in), dimension(1:nz) :: vout
+      real,intent(in)  :: dt
+      real,intent(in)  :: swddif
+! Output variables
+!
+      real,intent(inout) :: hspv ! Sensible heat flux from the PV panels to the atmosphere [W/m2]
+      real,intent(inout) :: eppv ! Electricity production from PV panels [W]
+      real,intent(inout) :: tpv       !Temperature of the PV panels [K]
+!
+! Local variables
+!
+      real,parameter :: albpv=0.11 ! albedo of the PV panels
+      real,parameter :: empv_down=0.95  ! emissivity of the PV panels
+      real,parameter :: empv_up=0.79
+      real, parameter :: T_amb=25
+      real, parameter :: tiltangle=0.
+      real, parameter :: a=3.8
+      real, parameter :: b=6.9
 
+      real, parameter :: r1=2330.
+      real, parameter :: r2=1200.
+      real, parameter :: r3=3000.
+      real, parameter :: c1=677.
+      real, parameter :: c2=1250.
+      real, parameter :: c3=500.
+      real, parameter :: d1=0.0003
+      real, parameter :: d2=0.0005
+      real, parameter :: d3=0.003
+      real, parameter :: F12=1.
+      real :: lwuppv     !Long-wave emitted by the PV panels to the sky [W/m2]
+      real :: lwdwr      !Long-wave incoming radiation on the roof [W/m2]
+      real :: lwupr      !Long-wave coming up from the roof intercepted by the PV panels [W/m2] 
+      real :: enerpv     !Energy produced by PV panels [W/m2]
+      real :: hc
+      real :: sw_d
+      real :: lw_d
+      real :: lwpv_out
+      real :: tpv_new
+      real :: hdown
+      real :: hup
+      real :: deltat
+      real :: uroof
+      real :: hrad
+      real :: Cm      
+      real :: hf
+       Cm=r1*c1*d1+r2*c2*d2+r3*c3*d3
+       hrad=sigma/((1-empv_down)/empv_down+1/F12+(1-emr)/emr)
+       uroof=(uout(n+1)**2+vout(n+1)**2)**0.5
+      deltat=tpv-tair(n+1)
+    hf=2.5*(40./100.*uroof)**(0.5)
+    hc=9.842*abs(deltat)**(1./3.)/(7.283-abs(cos(tiltangle)))
+    hup=sqrt(hc**2.+(hf)**2.)
+    hc=1.810*abs(deltat)**(1./3.)/(1.382+abs(cos(tiltangle)))
+    hdown=sqrt(hc**2.+(hf)**2.)
+    enerpv=effpv*rs*min(1.,1.-0.005*(tpv-(T_amb+273.15)))
+    sw_d=(1-albpv)*(rs)
+    lw_d=empv_up*rl
+    lwpv_out=empv_up*sigma*tpv**4.
+    lwupr=hrad*(tr**4-tpv**4.)
+    hspv=(hup+hdown)*(tpv-tair(n+1))
+    tpv=tpv+(sw_d+lw_d-lwpv_out+lwupr-hspv-enerpv)/Cm*dt
+    eppv=enerpv*pv_frac_roof*bl*bw
+     return
+      end subroutine hsfluxpv 
 !====6=8===============================================================72
 !====6=8===============================================================72
 
-	subroutine wall(swwall,nz,dt,dz,k,cs,flux,temp)
+	subroutine wall_gr(hfgr,gr_frac_roof,swwall,nz,dt,dz,k,cs,flux,temp)
 	
 !______________________________________________________________________
 
@@ -826,12 +952,16 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 		
 !Input:
 !-----
+            real hfgr        !Green roof heat flux
+            real gr_frac_roof     !Green roof fraction
+
 	integer nz		!Number of layers inside the material
 	real dt			!Time step
 	real dz(nz)		!Layer sizes [m]
 	real cs(nz)		!Specific heat of the material [J/(m3.K)] 
 	real k(nz+1)		!Thermal conductivity in each layers (face) [W/(m.K)]
 	real flux(2)		!Internal and external flux terms.
+        
 
 !Input-Output:
 !-------------
@@ -875,25 +1005,140 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 		 a(-1,1)=0.
 		 a(0,1)=1+k2(1)
 		 a(1,1)=-k2(1)
-
                  b(1)=temp(1)+flux(1)*kc(1)
 
-!!
-!!We can fixed the internal temperature	
-!!
-!!		 a(-1,1)=0.
-!!		 a(0,1)=1
-!!		 a(1,1)=0.		 	 
-!!		 
-!!		 b(1)=temp(1)
-!!
-!Computation of the internal values (iz=2,...,n-1) of A and B:
+	do iz=2,nz-1
+                a(-1,iz)=-k1(iz)
+                if(iz.eq.5)then
+                a(-1,iz)=-k1(iz)
+                a(0,iz)=1+k1(iz)+(1-gr_frac_roof)*k2(iz)
+                b(iz)=temp(iz)+(gr_frac_roof*hfgr*dt)/dz(iz)
+                a(1,iz)=-k2(iz)*(1-gr_frac_roof)
+                else
+                a(0,iz)=1.+k1(iz)+k2(iz)
+                b(iz)=temp(iz)
+                a(1,iz)=-k2(iz)
+                endif
+
+                
+	end do		
+
+!Computation of the external value (iz=n) of A and B:
+	
+		a(-1,nz)=-k1(nz)
+		a(0,nz)=1.+k1(nz)
+		a(1,nz)=0.
+                b(nz)=temp(nz)+kc(nz)*flux(2)
+                 
+!Resolution of the system A*T(n+1)=B
+
+	call tridia(nz,a,b,temp)
+	
+
+        return
+	end  subroutine wall_gr	
+
+!====6=8===============================================================72
+!====6=8===============================================================72
+
+
+	subroutine wall(swwall,nz,dt,dz,k,cs,flux,temp)
+	
+!______________________________________________________________________
+
+!The aim of this subroutine is to solve the 1D heat fiffusion equation
+!for roof, walls and streets:
+!
+!	dT/dt=d/dz[K*dT/dz] where:
+!
+!	-T is the surface temperature(wall, street, roof)
+!      	-Kz is the heat diffusivity inside the material.
+!
+!The resolution is done implicitly with a FV discretisation along the
+!different layers of the material:
+
+!	____________________________
+!     n             *
+!                   *
+!                   *
+!     	____________________________
+!    i+2
+!              	    I+1                 
+!	____________________________        
+!    i+1        
+!                    I                ==>   [T(I,n+1)-T(I,n)]/DT= 
+!	____________________________        [F(i+1)-F(i)]/DZI
+!    i
+!                   I-1               ==> A*T(n+1)=B where:
+!	____________________________         
+!   i-1              *                   * A is a TRIDIAGONAL matrix.
+!                    *                   * B=T(n)+S takes into account the sources.
+!                    *
+!     1	____________________________
+
+!________________________________________________________________
+
+	implicit none
+		
+!Input:
+!-----
+ 	integer nz		!Number of layers inside the material
+	real dt			!Time step
+	real dz(nz)		!Layer sizes [m]
+	real cs(nz)		!Specific heat of the material [J/(m3.K)] 
+	real k(nz+1)		!Thermal conductivity in each layers (face) [W/(m.K)]
+	real flux(2)		!Internal and external flux terms.
+        
+
+!Input-Output:
+!-------------
+
+	integer swwall          !swich for the physical coefficients calculation
+	real temp(nz)		!Temperature at each layer
+
+!Local:
+!-----	
+
+      real a(-1:1,nz)          !  a(-1,*) lower diagonal      A(i,i-1)
+                               !  a(0,*)  principal diagonal  A(i,i)
+                               !  a(1,*)  upper diagonal      A(i,i+1).
+      
+      real b(nz)	       !Coefficients of the second term.	
+      real k1(20)
+      real k2(20)
+      real kc(20)
+      save k1,k2,kc
+      integer iz
+        	
+!________________________________________________________________
+!
+!Calculation of the coefficients
+	
+	if (swwall.eq.1) then
+	
+           if (nz.gt.20) then
+              write(*,*) 'number of layers in the walls/roofs too big ',nz
+              write(*,*) 'please decrease under of',20
+              stop
+           endif
+
+	   call wall_coeff(nz,dt,dz,cs,k,k1,k2,kc)
+	   swwall=0
+
+	end if
+ 	
+!Computation of the first value (iz=1) of A and B:
+	
+		 a(-1,1)=0.
+		 a(0,1)=1+k2(1)
+		 a(1,1)=-k2(1)
+                   b(1)=temp(1)+flux(1)*kc(1)
 
 	do iz=2,nz-1
-		a(-1,iz)=-k1(iz)
-		a(0,iz)=1+k1(iz)+k2(iz)
-     		a(1,iz)=-k2(iz)
-		b(iz)=temp(iz)
+                a(-1,iz)=-k1(iz)
+                a(0,iz)=1+k1(iz)+k2(iz)
+                b(iz)=temp(iz)
+                a(1,iz)=-k2(iz)
 	end do		
 
 !Computation of the external value (iz=n) of A and B:
@@ -901,12 +1146,12 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 		a(-1,nz)=-k1(nz)
 		a(0,nz)=1+k1(nz)
 		a(1,nz)=0.
-	
 		b(nz)=temp(nz)+flux(2)*kc(nz)
-
+                     
 !Resolution of the system A*T(n+1)=B
 
 	call tridia(nz,a,b,temp)
+	
 
         return
 	end  subroutine wall	
@@ -983,7 +1228,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 !Input
 !----
 	integer swsurf  !swich for the type of surface (horizontal/vertical) 
-        integer swwin   !swich for the type of surface (window/wall)
+            integer swwin   !swich for the type of surface (window/wall)
 	real tin	!Inside temperature [K]
 	real tw		!Internal wall temperature [K]  	
 
@@ -993,7 +1238,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real hsins	!internal sensible heat flux [W/m2]
 !Local
 !-----
-	real hc		!heat conduction coefficient [W/C.m2]
+	real hc		!heat conduction coefficient [W/\B0C.m2]
 !--------------------------------------------------------------------
 
 	if (swsurf.eq.2) then	!vertical surface
@@ -1031,7 +1276,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real albwin		!albedo of the windows
 	real albwal		!albedo of the internal wall					
 	real rswal(4)		!incoming short wave radiation [W/m2]
-        real surwal(6) 		!surface of the indoor walls [m2]
+            real surwal(6) 		!surface of the indoor walls [m2]
 	real bw,bl		!width of the walls [m]
 	real zw			!height of the wall [m]
 	real pwin               !window proportion
@@ -1043,8 +1288,8 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 !Local
 !-----
 	real transmit   !transmittance of the direct/diffused radiation
-        real rstr	!solar radiation transmitted through the windows	
-        real surtotwal  !total indoor surface of the walls in the room
+            real rstr	!solar radiation transmitted through the windows	
+            real surtotwal  !total indoor surface of the walls in the room
 	integer iw
 	real b(6)	!second member for the system
 	real a(6,6)	!matrix for the system
@@ -1061,7 +1306,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
             enddo
 
 !We suppose that the radiation is spread isotropically within the
-!room when it passes through the windows, so the flux [W/m^2] in every 
+!room when it passes through the windows, so the flux [W/m2] in every 
 !wall is:
 
             surtotwal=0.
@@ -1315,8 +1560,8 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real zw		!height of the wall
 	real fprl_int	!view factor
 	real fnrm_int	!view factor	
-        real fnrm_intx	!view factor
-        real fnrm_inty	!view factor
+           real fnrm_intx	!view factor
+           real fnrm_inty	!view factor
 
 !Output
 !------
@@ -1329,7 +1574,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	real b_wind(6)
 	real emwal_av		!averadge emissivity of the wall
 	real emwin_av		!averadge emissivity of the window
-	real em_av		!averadge emissivity
+        real em_av		!averadge emissivity
         real twal_int(6)        !twalint 
 	real twin(4)   		!twinint 
 !------------------------------------------------------------------
@@ -1669,7 +1914,7 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	
 !Output
 !------
-	real hsequ    !sensible heat gain from equipment [W/m^2]
+	real hsequ    !sensible heat gain from equipment [Wm\AF2]
 
 !---------------------------------------------------------------------	
 
@@ -2299,7 +2544,52 @@ use mpas_atmphys_utilities, only: physics_error_fatal
 	
       return
       end subroutine radfluxs
-
+!====6=8===============================================================72  
+!====6=8===============================================================72
+      subroutine radfluxspv(nz,n,alb,rs,swddif,em,rl,twal,tair,sigma,radflux,pv_frac_roof,tpv)
+!
+      implicit none
+!
+! This routine calculates the radiative fluxes at the surfaces
+!
+!     Integer and real kinds
+!
+!     integer, parameter :: kind_im = selected_int_kind(6)   ! 4 byte integer
+!     integer, parameter :: kind_rb = selected_real_kind(12) ! 8 byte real 
+!
+! Input Variables
+!	
+      integer,intent(in) :: nz !Maximum number of vertical levels in the urban grid
+      real,intent(in) :: alb	!albedo of the surface
+      real,intent(in) :: rs	!shortwave radiation [W m-2]
+      real,intent(in) :: swddif
+      real,intent(in) :: em	!emissivity of the surface
+      real,intent(in) :: rl 	!longwave radiation [W m-2]
+      real,intent(in) :: twal	!surface temperature [K]
+      real,intent(in) :: sigma !Stefan-Boltzmann constant [W/m2.K4]
+      real,intent(in) :: tpv !Stefan-Boltzmann constant [W/m2.K4]
+      real,intent(in),dimension(1:nz) :: tair  !external temperature [K] 
+      integer,intent(in) :: n  !number of floors in the building
+      real, intent(in) :: pv_frac_roof !
+      real :: empv
+      real :: hrad
+      real :: F12
+! Output variables
+!
+      real,intent(inout) :: radflux !radiative flux at the surface [W m-2]
+!     
+! Local variables
+      F12=1. 
+      empv=0.95	
+      hrad=sigma/((1-empv)/empv+1/F12+(1-em)/em)
+      if ((n+1).gt.nz) then
+         write(*,*) 'Increase maximum number of vertical levels in the urban grid'
+         stop
+      endif
+      radflux=(1.-alb)*(1.-pv_frac_roof)*rs+em*(1.-pv_frac_roof)*rl+pv_frac_roof*hrad*(tpv**4-twal**4)- &
+               em*sigma*(1.-pv_frac_roof)*twal**4
+      return
+      end subroutine radfluxspv
 !====6=8==============================================================72 
 !====6=8==============================================================72
 !       

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep.F
@@ -1,13 +1,19 @@
 MODULE module_sf_bep
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
 #else
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M)
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
+#define WRITE_MESSAGE(M) call wrf_message(M)
 !USE module_model_constants
 #endif
  USE module_sf_urban
+ USE module_bep_bem_helper, ONLY: nurbm
 
 ! SGClarke 09/11/2008
 ! Access urban_param.tbl values through calling urban_param_init in module_physics_init
@@ -16,9 +22,8 @@ use module_wrf_error
 ! -----------------------------------------------------------------------
 !  Dimension for the array used in the BEP module
 ! -----------------------------------------------------------------------
-
-      integer nurbm           ! Maximum number of urban classes    
-      parameter (nurbm=3)
+      integer nurbmax         ! Maximum number of urban classes    
+      parameter (nurbmax=11)
 
       integer ndm             ! Maximum number of street directions 
       parameter (ndm=2)
@@ -63,7 +68,10 @@ use module_wrf_error
                       th_phy,rho,p_phy,swdown,glw,                    &
                       gmt,julday,xlong,xlat,                          &
                       declin_urb,cosz_urb2d,omg_urb2d,                &
-                      num_urban_layers,num_urban_hi,                  &
+                      num_urban_ndm,  urban_map_zrd,  urban_map_zwd, urban_map_gd, &
+                       urban_map_zd,  urban_map_zdf,   urban_map_bd, urban_map_wd, &
+                      urban_map_gbd,  urban_map_fbd,                               &
+                       num_urban_hi,                                               &
                       trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,        &
                       sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,      &
                       lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,           &
@@ -106,16 +114,25 @@ use module_wrf_error
    REAL, INTENT(IN) :: DECLIN_URB
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
-   INTEGER, INTENT(IN  ) :: num_urban_layers
+   INTEGER, INTENT(IN  ) :: num_urban_ndm
+   INTEGER, INTENT(IN  ) :: urban_map_zrd
+   INTEGER, INTENT(IN  ) :: urban_map_zwd
+   INTEGER, INTENT(IN  ) :: urban_map_gd
+   INTEGER, INTENT(IN  ) :: urban_map_zd
+   INTEGER, INTENT(IN  ) :: urban_map_zdf
+   INTEGER, INTENT(IN  ) :: urban_map_bd
+   INTEGER, INTENT(IN  ) :: urban_map_wd
+   INTEGER, INTENT(IN  ) :: urban_map_gbd
+   INTEGER, INTENT(IN  ) :: urban_map_fbd
    INTEGER, INTENT(IN  ) :: num_urban_hi
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_gd , jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ), INTENT(INOUT) :: sfg_urb3d
    REAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
    REAL, DIMENSION( ims:ime,jms:jme), INTENT(IN) :: lp_urb2d
    REAL, DIMENSION( ims:ime,jms:jme), INTENT(IN) :: lb_urb2d
@@ -164,19 +181,19 @@ use module_wrf_error
       real hb_u(nz_um)                        ! Bulding's heights
       real ss_urb(nz_um)  ! Probability that a building has an height equal to z
       real pb_urb(nz_um)  ! Probability that a building has an height greater or equal to z
-      integer nz_urb(nurbm)                   ! Number of layer in the urban grid
-      integer nzurban(nurbm)                  
+      integer nz_urb(nurbmax)                 ! Number of layer in the urban grid
+      integer nzurban(nurbmax)                
 
 !    Building parameters      
-      real alag_u(nurbm)                      ! Ground thermal diffusivity [m^2 s^-1]
-      real alaw_u(nurbm)                      ! Wall thermal diffusivity [m^2 s^-1]
-      real alar_u(nurbm)                      ! Roof thermal diffusivity [m^2 s^-1]
-      real csg_u(nurbm)                       ! Specific heat of the ground material [J m^3 K^-1]
-      real csw_u(nurbm)                       ! Specific heat of the wall material [J m^3 K^-1]
-      real csr_u(nurbm)                       ! Specific heat of the roof material [J m^3 K^-1]
-      real twini_u(nurbm)                     ! Initial temperature inside the building's wall [K]
-      real trini_u(nurbm)                     ! Initial temperature inside the building's roof [K]
-      real tgini_u(nurbm)                     ! Initial road temperature
+      real alag_u(nurbmax)                    ! Ground thermal diffusivity [m^2 s^-1]
+      real alaw_u(nurbmax)                    ! Wall thermal diffusivity [m^2 s^-1]
+      real alar_u(nurbmax)                    ! Roof thermal diffusivity [m^2 s^-1]
+      real csg_u(nurbmax)                     ! Specific heat of the ground material [J m^3 K^-1]
+      real csw_u(nurbmax)                     ! Specific heat of the wall material [J m^3 K^-1]
+      real csr_u(nurbmax)                     ! Specific heat of the roof material [J m^3 K^-1]
+      real twini_u(nurbmax)                   ! Initial temperature inside the building's wall [K]
+      real trini_u(nurbmax)                   ! Initial temperature inside the building's roof [K]
+      real tgini_u(nurbmax)                   ! Initial road temperature
 !
 !   Building materials
 !
@@ -190,39 +207,39 @@ use module_wrf_error
 ! for twini_u, and trini_u the initial value at the deepest level is kept constant during the simulation
 !
 !    Radiation parameters
-      real albg_u(nurbm)                      ! Albedo of the ground
-      real albw_u(nurbm)                      ! Albedo of the wall
-      real albr_u(nurbm)                      ! Albedo of the roof
-      real emg_u(nurbm)                       ! Emissivity of ground
-      real emw_u(nurbm)                       ! Emissivity of wall
-      real emr_u(nurbm)                       ! Emissivity of roof
+      real albg_u(nurbmax)                    ! Albedo of the ground
+      real albw_u(nurbmax)                    ! Albedo of the wall
+      real albr_u(nurbmax)                    ! Albedo of the roof
+      real emg_u(nurbmax)                     ! Emissivity of ground
+      real emw_u(nurbmax)                     ! Emissivity of wall
+      real emr_u(nurbmax)                     ! Emissivity of roof
 
 !   fww_u,fwg_u,fgw_u,fsw_u,fsg_u are the view factors used to compute the long wave
 !   and the short wave radation. 
-      real fww_u(nz_um,nz_um,ndm,nurbm)         !  from wall to wall
-      real fwg_u(nz_um,ndm,nurbm)               !  from wall to ground
-      real fgw_u(nz_um,ndm,nurbm)               !  from ground to wall
-      real fsw_u(nz_um,ndm,nurbm)               !  from sky to wall
-      real fws_u(nz_um,ndm,nurbm)               !  from sky to wall
-      real fsg_u(ndm,nurbm)                     !  from sky to ground
+      real fww_u(nz_um,nz_um,ndm,nurbmax)       !  from wall to wall
+      real fwg_u(nz_um,ndm,nurbmax)             !  from wall to ground
+      real fgw_u(nz_um,ndm,nurbmax)             !  from ground to wall
+      real fsw_u(nz_um,ndm,nurbmax)             !  from sky to wall
+      real fws_u(nz_um,ndm,nurbmax)             !  from sky to wall
+      real fsg_u(ndm,nurbmax)                   !  from sky to ground
 
 !    Roughness parameters
-      real z0g_u(nurbm)         ! The ground's roughness length
-      real z0r_u(nurbm)         ! The roof's roughness length
+      real z0g_u(nurbmax)       ! The ground's roughness length
+      real z0r_u(nurbmax)       ! The roof's roughness length
 
 !    Roughness parameters
       real z0(ndm,nz_um)           ! Roughness lengths "profiles"
 
 !    Street parameters
-      integer nd_u(nurbm)       ! Number of street direction for each urban class 
-      real strd_u(ndm,nurbm)    ! Street length (fix to greater value to the horizontal length of the cells)
-      real drst_u(ndm,nurbm)    ! Street direction
-      real ws_u(ndm,nurbm)      ! Street width
-      real bs_u(ndm,nurbm)      ! Building width
-      real h_b(nz_um,nurbm)     ! Bulding's heights
-      real d_b(nz_um,nurbm)     ! Probability that a building has an height h_b
-      real ss_u(nz_um,nurbm)  ! Probability that a building has an height equal to z
-      real pb_u(nz_um,nurbm)  ! Probability that a building has an height greater or equal to z
+      integer nd_u(nurbmax)     ! Number of street direction for each urban class 
+      real strd_u(ndm,nurbmax)  ! Street length (fix to greater value to the horizontal length of the cells)
+      real drst_u(ndm,nurbmax)  ! Street direction
+      real ws_u(ndm,nurbmax)    ! Street width
+      real bs_u(ndm,nurbmax)    ! Building width
+      real h_b(nz_um,nurbmax)   ! Bulding's heights
+      real d_b(nz_um,nurbmax)   ! Probability that a building has an height h_b
+      real ss_u(nz_um,nurbmax)  ! Probability that a building has an height equal to z
+      real pb_u(nz_um,nurbmax)  ! Probability that a building has an height greater or equal to z
 !
 !    Street parameters
 !
@@ -235,7 +252,7 @@ use module_wrf_error
 
 !    Grid parameters
 
-      integer nz_u(nurbm)       ! Number of layer in the urban grid
+      integer nz_u(nurbmax)     ! Number of layer in the urban grid
       
       real z_u(nz_um)         ! Height of the urban grid levels
 
@@ -304,8 +321,8 @@ use module_wrf_error
 !------------------------------------------------------------------------
 !prepare the arrays to collapse indexes
 
-      if(num_urban_layers.lt.nz_um*ndm*nwr_u)then
-        write(*,*)'num_urban_layers too small, please increase to at least ', nz_um*ndm*nwr_u
+      if(urban_map_zrd.lt.nz_um*ndm*nwr_u)then
+        write(*,*)'urban_map_zrd too small, please increase to at least ', nz_um*ndm*nwr_u
         stop
       endif
       iii=0
@@ -426,7 +443,7 @@ use module_wrf_error
          do iw=1,nwr_u
 !          tw1D(2*id-1,iz_u,iw)=tw1_u(ix,iy,ind_zwd(iz_u,iw,id))
 !          tw1D(2*id,iz_u,iw)=tw2_u(ix,iy,ind_zwd(iz_u,iw,id))
-            if(ind_zwd(iz_u,iw,id).gt.num_urban_layers)write(*,*)'ind_zwd too big w',ind_zwd(iz_u,iw,id)
+            if(ind_zwd(iz_u,iw,id).gt.urban_map_zwd)write(*,*)'ind_zwd too big w',ind_zwd(iz_u,iw,id)
           tw1D(2*id-1,iz_u,iw)=tw1_urb4d(ix,ind_zwd(iz_u,iw,id),iy)
           tw1D(2*id,iz_u,iw)=tw2_urb4d(ix,ind_zwd(iz_u,iw,id),iy)
          enddo
@@ -441,7 +458,7 @@ use module_wrf_error
           do iz_u=1,nz_um
           do ir=1,nwr_u
 !           tr1D(id,iz_u,ir)=tr_u(ix,iy,ind_zwd(iz_u,ir,id))
-            if(ind_zwd(iz_u,ir,id).gt.num_urban_layers)write(*,*)'ind_zwd too big r',ind_zwd(iz_u,ir,id)
+            if(ind_zwd(iz_u,ir,id).gt.urban_map_zwd)write(*,*)'ind_zwd too big r',ind_zwd(iz_u,ir,id)
             tr1D(id,iz_u,ir)=trb_urb4d(ix,ind_zwd(iz_u,ir,id),iy)
           enddo
           enddo
@@ -3065,7 +3082,7 @@ use module_wrf_error
        do iu=1,icate
               if(ndm.lt.nd_u(iu))then
                 write(*,*)'ndm too small in module_sf_bep, please increase to at least ', nd_u(iu)
-                write(*,*)'remember also that num_urban_layers should be equal or greater than nz_um*ndm*nwr-u!'
+                write(*,*)'remember also that urban_map_zrd should be equal or greater than nz_um*ndm*nwr-u!'
                 stop
               endif
          do i=1,nd_u(iu)
@@ -3077,7 +3094,7 @@ use module_wrf_error
        do iu=1,ICATE
           if(nz_um.lt.numhgt_tbl(iu)+3)then
               write(*,*)'nz_um too small in module_sf_bep, please increase to at least ',numhgt_tbl(iu)+3
-              write(*,*)'remember also that num_urban_layers should be equal or greater than nz_um*ndm*nwr-u!'
+              write(*,*)'remember also that urban_map_zrd should be equal or greater than nz_um*ndm*nwr-u!'
               stop
           endif
          do i=1,NUMHGT_TBL(iu)
@@ -3486,3 +3503,39 @@ use module_wrf_error
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
 END MODULE module_sf_bep
+
+      FUNCTION bep_nurbm () RESULT (bep_val_nurbm)
+         USE module_sf_bep
+         IMPLICIT NONE
+         INTEGER :: bep_val_nurbm
+         bep_val_nurbm = nurbm
+      END FUNCTION bep_nurbm
+      
+      FUNCTION bep_ndm () RESULT (bep_val_ndm)
+         USE module_sf_bep
+         IMPLICIT NONE
+         INTEGER :: bep_val_ndm
+         bep_val_ndm = ndm
+      END FUNCTION bep_ndm
+      
+      FUNCTION bep_nz_um () RESULT (bep_val_nz_um)
+         USE module_sf_bep
+         IMPLICIT NONE
+         INTEGER :: bep_val_nz_um
+         bep_val_nz_um = nz_um
+      END FUNCTION bep_nz_um
+      
+      FUNCTION bep_ng_u () RESULT (bep_val_ng_u)
+         USE module_sf_bep
+         IMPLICIT NONE
+         INTEGER :: bep_val_ng_u
+         bep_val_ng_u = ng_u
+      END FUNCTION bep_ng_u
+      
+      FUNCTION bep_nwr_u () RESULT (bep_val_nwr_u)
+         USE module_sf_bep
+         IMPLICIT NONE
+         INTEGER :: bep_val_nwr_u
+         bep_val_nwr_u = nwr_u
+      END FUNCTION bep_nwr_u
+      

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_bep_bem.F
@@ -1,14 +1,19 @@
 MODULE module_sf_bep_bem
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
-use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
+use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
 #else
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
-!USE module_model_constants
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
+#define WRITE_MESSAGE(M) call wrf_message(M)
 #endif
  USE module_sf_urban
  USE module_sf_bem
+ USE module_bep_bem_helper, ONLY: nurbm
 
 ! SGClarke 09/11/2008
 ! Access urban_param.tbl values through calling urban_param_init in module_physics_init
@@ -18,8 +23,8 @@ use module_wrf_error
 !  Dimension for the array used in the BEP module
 ! -----------------------------------------------------------------------
 
-      integer nurbm           ! Maximum number of urban classes    
-      parameter (nurbm=3)
+      integer nurbmax         ! Maximum number of urban classes    
+      parameter (nurbmax=11)
 
       integer ndm             ! Maximum number of street directions 
       parameter (ndm=2)
@@ -29,6 +34,10 @@ use module_wrf_error
 
       integer ng_u            ! Number of grid levels in the ground
       parameter (ng_u=10)
+ 
+      integer ngr_u            ! Number of grid levels in green roof
+      parameter (ngr_u=10)
+
       integer nwr_u            ! Number of grid levels in the walls or roofs
       parameter (nwr_u=10)
 
@@ -44,6 +53,10 @@ use module_wrf_error
       integer nbui_max         !maximum number of types of buildings in an urban class
       parameter (nbui_max=15)   !must be less or equal than nz_um 
 
+
+      real h_water
+      parameter(h_water=0.0009722) !mm of irrigation per hour
+
 !---------------------------------------------------------------------------------
 !Parameters of the windows. The glasses of windows are considered without films  -
 !Read the paper of J.Karlsson and A.Roos(2000):"modelling the angular behaviour  -
@@ -54,7 +67,6 @@ use module_wrf_error
       parameter (p_num=2)
       integer q_num            !category number for the windows (q_num= 4, standard glasses)
       parameter(q_num=4)       !Possible values 1,2,...,10
-
 
 ! The change of ng_u, nwr_u should be done in agreement with the block data
 !  in the routine "surf_temp" 
@@ -70,10 +82,12 @@ use module_wrf_error
       real rcp_u              !
       real sigma              !
       real p0                 ! Reference pressure at the sea level
-      real cdrag              ! Drag force constant
       real latent             ! Latent heat of vaporization [J/kg] (used in BEM)
+      real dgmax              ! Maximum ground water holding capacity (mm)
+      real drmax              ! Maximum ground roof holding capacity (mm)
+
       parameter(vk=0.40,g_u=9.81,pi=3.141592653,r=287.,cp_u=1004.)        
-      parameter(rcp_u=r/cp_u,sigma=5.67e-08,p0=1.e+5,cdrag=0.4,latent=2.45e+06)
+      parameter(rcp_u=r/cp_u,sigma=5.67e-08,p0=1.e+5,latent=2.45e+06,dgmax=1.,drmax=1.)
 
 ! -----------------------------------------------------------------------     
 
@@ -83,16 +97,26 @@ use module_wrf_error
    CONTAINS
  
       subroutine BEP_BEM(FRC_URB2D,UTYPE_URB2D,itimestep,dz8w,dt,u_phy,v_phy,      &
-                      th_phy,rho,p_phy,swdown,glw,                                 &
+                      th_phy,rho,p_phy,swdown,glw,                    &
                       gmt,julday,xlong,xlat,                                       &
                       declin_urb,cosz_urb2d,omg_urb2d,                             &
-                      num_urban_layers,num_urban_hi,                               &
+                      num_urban_ndm,  urban_map_zrd,  urban_map_zwd, urban_map_gd, &
+                      urban_map_zd,  urban_map_zdf,   urban_map_bd, urban_map_wd,  &
+                      urban_map_gbd,  urban_map_fbd,                               &
+                      urban_map_zgrd,  num_urban_hi,                               &
                       trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,                     &
                       tlev_urb3d,qlev_urb3d,tw1lev_urb3d,tw2lev_urb3d,             &
-                      tglev_urb3d,tflev_urb3d,sf_ac_urb3d,lf_ac_urb3d,             &
-                      cm_ac_urb3d,sfvent_urb3d,lfvent_urb3d,                       &
+                      tglev_urb3d,tflev_urb3d,sf_ac_urb3d,lf_ac_urb3d,             &        
+                      cm_ac_urb3d,                                                 & 
+                      sfvent_urb3d,lfvent_urb3d,                                   &
                       sfwin1_urb3d,sfwin2_urb3d,                                   &
                       sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,                   &
+		      ep_pv_urb3d,t_pv_urb3d,                                      &
+		      trv_urb4d,qr_urb4d,qgr_urb3d,tgr_urb3d,                      &
+                      drain_urb4d,draingr_urb3d,                                   &
+		      sfrv_urb3d,lfrv_urb3d,                                       &
+                      dgr_urb3d,dg_urb3d,                                          &
+                      lfr_urb3d,lfg_urb3d,rainbl,swddir,swddif,                    &
                       lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,                        &
                       a_u,a_v,a_t,a_e,b_u,b_v,                                     &
                       b_t,b_e,b_q,dlg,dl_u,sf,vl,                                  &
@@ -123,7 +147,9 @@ use module_wrf_error
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme )::   V
    REAL, DIMENSION( ims:ime , jms:jme )        ::   GLW
    REAL, DIMENSION( ims:ime , jms:jme )        ::   swdown
-   REAL, DIMENSION( ims:ime, jms:jme )         ::   UST
+   REAL, DIMENSION( ims:ime , jms:jme )        ::   swddir
+   REAL, DIMENSION( ims:ime , jms:jme )        ::   swddif
+    REAL, DIMENSION( ims:ime, jms:jme )         ::   UST
    INTEGER, DIMENSION( ims:ime , jms:jme ), INTENT(IN )::   UTYPE_URB2D
    REAL, DIMENSION( ims:ime , jms:jme ), INTENT(IN )::   FRC_URB2D
    REAL, INTENT(IN  )   ::                                   GMT 
@@ -133,32 +159,59 @@ use module_wrf_error
    REAL, INTENT(IN) :: DECLIN_URB
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
-   INTEGER, INTENT(IN  ) :: num_urban_layers
-   INTEGER, INTENT(IN  ) :: num_urban_hi
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   INTEGER, INTENT(IN  ) :: urban_map_zrd
+   INTEGER, INTENT(IN  ) :: urban_map_zwd
+   INTEGER, INTENT(IN  ) :: urban_map_gd
+   INTEGER, INTENT(IN  ) :: urban_map_zd
+   INTEGER, INTENT(IN  ) :: urban_map_zdf
+   INTEGER, INTENT(IN  ) :: urban_map_bd
+   INTEGER, INTENT(IN  ) :: urban_map_wd
+   INTEGER, INTENT(IN  ) :: urban_map_gbd
+   INTEGER, INTENT(IN  ) :: urban_map_fbd
+   INTEGER, INTENT(IN  ) :: num_urban_ndm
+   INTEGER, INTENT(IN) :: num_urban_hi
+   INTEGER , INTENT(IN)        ::     urban_map_zgrd
+   REAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_gd , jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ), INTENT(INOUT) :: trv_urb4d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ), INTENT(INOUT) :: qr_urb4d
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: qgr_urb3d
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: tgr_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: drain_urb4d
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: rainbl
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: draingr_urb3d
 !New variables used for BEM
    REAL, DIMENSION( ims:ime, kms:kme, jms:jme ):: qv_phy
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_bd, jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_bd , jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_gbd, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_fbd, jms:jme ), INTENT(INOUT) :: tflev_urb3d
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: ep_pv_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: t_pv_urb3d
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+
 !End variables
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: sfrv_urb3d
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: lfrv_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: dgr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: dg_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: lfr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: lfg_urb3d !G
+
    REAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
    REAL, DIMENSION( ims:ime,jms:jme), INTENT(IN) :: lp_urb2d
    REAL, DIMENSION( ims:ime,jms:jme), INTENT(IN) :: lb_urb2d
@@ -197,22 +250,22 @@ use module_wrf_error
 !------------------------------------------------------------------------
       real hi_urb(its:ite,1:nz_um,jts:jte) ! Height histograms of buildings
       real hi_urb1D(nz_um)                 ! Height histograms of buildings
-      real ss_urb(nz_um,nurbm)             ! Probability that a building has an height equal to z
+      real ss_urb(nz_um,nurbmax)           ! Probability that a building has an height equal to z
       real pb_urb(nz_um)                   ! Probability that a building has an height greater or equal to z
       real hb_u(nz_um)                     ! Bulding's heights
-      integer nz_urb(nurbm)                ! Number of layer in the urban grid
-      integer nzurban(nurbm)
+      integer nz_urb(nurbmax)              ! Number of layer in the urban grid
+      integer nzurban(nurbmax)
 
 !    Building parameters      
-      real alag_u(nurbm)                      ! Ground thermal diffusivity [m^2 s^-1]
-      real alaw_u(nurbm)                      ! Wall thermal diffusivity [m^2 s^-1]
-      real alar_u(nurbm)                      ! Roof thermal diffusivity [m^2 s^-1]
-      real csg_u(nurbm)                       ! Specific heat of the ground material [J m^3 K^-1]
-      real csw_u(nurbm)                       ! Specific heat of the wall material [J m^3 K^-1]
-      real csr_u(nurbm)                       ! Specific heat of the roof material [J m^3 K^-1]
-      real twini_u(nurbm)                     ! Initial temperature inside the building's wall [K]
-      real trini_u(nurbm)                     ! Initial temperature inside the building's roof [K]
-      real tgini_u(nurbm)                     ! Initial road temperature
+      real alag_u(nurbmax)                    ! Ground thermal diffusivity [m^2 s^-1]
+      real alaw_u(nurbmax)                    ! Wall thermal diffusivity [m^2 s^-1]
+      real alar_u(nurbmax)                    ! Roof thermal diffusivity [m^2 s^-1]
+      real csg_u(nurbmax)                     ! Specific heat of the ground material [J m^3 K^-1]
+      real csw_u(nurbmax)                     ! Specific heat of the wall material [J m^3 K^-1]
+      real csr_u(nurbmax)                     ! Specific heat of the roof material [J m^3 K^-1]
+      real twini_u(nurbmax)                   ! Initial temperature inside the building's wall [K]
+      real trini_u(nurbmax)                   ! Initial temperature inside the building's roof [K]
+      real tgini_u(nurbmax)                   ! Initial road temperature
 
 !
 !   Building materials
@@ -235,7 +288,7 @@ use module_wrf_error
 
 !
 !New street and radiation parameters
-!
+
 
       real bs(ndm)              ! Building width for the current urban class
       real ws(ndm)              ! Street widths of the current urban class
@@ -243,71 +296,76 @@ use module_wrf_error
       real drst(ndm)            ! street directions for the current urban class
       real ss(nz_um)            ! Probability to have a building with height h
       real pb(nz_um)            ! Probability to have a building with an height equal
-!
+      real HFGR_D(nz_um)
 !New roughness and buildings parameters
 !
       real z0(ndm,nz_um)        ! Roughness lengths "profiles"
-      real bs_urb(ndm,nurbm)      ! Building width
-      real ws_urb(ndm,nurbm)      ! Street width
+      real bs_urb(ndm,nurbmax)  ! Building width
+      real ws_urb(ndm,nurbmax)  ! Street width
 
 !
 ! for twini_u, and trini_u the initial value at the deepest level is kept constant during the simulation
 !
 !    Radiation paramters
-
-      real albg_u(nurbm)                      ! Albedo of the ground
-      real albw_u(nurbm)                      ! Albedo of the wall
-      real albr_u(nurbm)                      ! Albedo of the roof
-      real albwin_u(nurbm)                    ! Albedo of the windows
-      real emwind_u(nurbm)                    ! Emissivity of windows
-      real emg_u(nurbm)                       ! Emissivity of ground
-      real emw_u(nurbm)                       ! Emissivity of wall
-      real emr_u(nurbm)                       ! Emissivity of roof
+      real albg_u(nurbmax)                    ! Albedo of the ground
+      real albw_u(nurbmax)                    ! Albedo of the wall
+      real albr_u(nurbmax)                    ! Albedo of the roof
+      real albwin_u(nurbmax)                  ! Albedo of the windows
+      real emwind_u(nurbmax)                  ! Emissivity of windows
+      real emg_u(nurbmax)                     ! Emissivity of ground
+      real emw_u(nurbmax)                     ! Emissivity of wall
+      real emr_u(nurbmax)                     ! Emissivity of roof
+      real gr_frac_roof_u(nurbmax)
+      real pv_frac_roof_u(nurbmax)
+      integer gr_flag_u
+      integer gr_type_u
 
 !   fww_u,fwg_u,fgw_u,fsw_u,fsg_u are the view factors used to compute the long wave
 !   and the short wave radiation. 
-      real fww_u(nz_um,nz_um,ndm,nurbm)         !  from wall to wall
-      real fwg_u(nz_um,ndm,nurbm)               !  from wall to ground
-      real fgw_u(nz_um,ndm,nurbm)               !  from ground to wall
-      real fsw_u(nz_um,ndm,nurbm)               !  from sky to wall
-      real fws_u(nz_um,ndm,nurbm)               !  from sky to wall
-      real fsg_u(ndm,nurbm)                     !  from sky to ground
+      real fww_u(nz_um,nz_um,ndm,nurbmax)       !  from wall to wall
+      real fwg_u(nz_um,ndm,nurbmax)             !  from wall to ground
+      real fgw_u(nz_um,ndm,nurbmax)             !  from ground to wall
+      real fsw_u(nz_um,ndm,nurbmax)             !  from sky to wall
+      real fws_u(nz_um,ndm,nurbmax)             !  from sky to wall
+      real fsg_u(ndm,nurbmax)                   !  from sky to ground
 
 !    Roughness parameters
-      real z0g_u(nurbm)         ! The ground's roughness length
-      real z0r_u(nurbm)         ! The roof's roughness length
+      real z0g_u(nurbmax)       ! The ground's roughness length
+      real z0r_u(nurbmax)       ! The roof's roughness length
 
 !    Street parameters
-      integer nd_u(nurbm)       ! Number of street direction for each urban class 
-      real strd_u(ndm,nurbm)    ! Street length (fix to greater value to the horizontal length of the cells)
-      real drst_u(ndm,nurbm)    ! Street direction
-      real ws_u(ndm,nurbm)      ! Street width
-      real bs_u(ndm,nurbm)      ! Building width
-      real h_b(nz_um,nurbm)     ! Bulding's heights
-      real d_b(nz_um,nurbm)     ! Probability that a building has an height h_b
-      real ss_u(nz_um,nurbm)  ! Probability that a building has an height equal to z
-      real pb_u(nz_um,nurbm)  ! Probability that a building has an height greater or equal to z
+      integer nd_u(nurbmax)     ! Number of street direction for each urban class 
+      real strd_u(ndm,nurbmax)  ! Street length (fix to greater value to the horizontal length of the cells)
+      real drst_u(ndm,nurbmax)  ! Street direction
+      real ws_u(ndm,nurbmax)    ! Street width
+      real bs_u(ndm,nurbmax)    ! Building width
+      real h_b(nz_um,nurbmax)   ! Bulding's heights
+      real d_b(nz_um,nurbmax)   ! Probability that a building has an height h_b
+      real ss_u(nz_um,nurbmax)! Probability that a building has an height equal to z
+      real pb_u(nz_um,nurbmax)! Probability that a building has an height greater or equal to z
 
 
 !    Grid parameters
-      integer nz_u(nurbm)       ! Number of layer in the urban grid
+      integer nz_u(nurbmax)     ! Number of layer in the urban grid
       
       real z_u(nz_um)         ! Height of the urban grid levels
 !FS
-      real cop_u(nurbm)
-      real pwin_u(nurbm)
-      real beta_u(nurbm)
-      integer sw_cond_u(nurbm)
-      real time_on_u(nurbm)
-      real time_off_u(nurbm)
-      real targtemp_u(nurbm)
-      real gaptemp_u(nurbm)
-      real targhum_u(nurbm)
-      real gaphum_u(nurbm)
-      real perflo_u(nurbm)
-      real hsesf_u(nurbm)
+      real cop_u(nurbmax)
+      real bldac_frc_u(nurbmax)
+      real cooled_frc_u(nurbmax)
+      real pwin_u(nurbmax)
+      real beta_u(nurbmax)
+      integer sw_cond_u(nurbmax)
+      real time_on_u(nurbmax)
+      real time_off_u(nurbmax)
+      real targtemp_u(nurbmax)
+      real gaptemp_u(nurbmax)
+      real targhum_u(nurbmax)
+      real gaphum_u(nurbmax)
+      real perflo_u(nurbmax)
+      real hsesf_u(nurbmax)
       real hsequip(24)
-
+      real irho(24)
 ! 1D array used for the input and output of the routine "urban"
 
       real z1D(kms:kme)               ! vertical coordinates
@@ -322,11 +380,17 @@ use module_wrf_error
       real ah1D                    ! hour angle (it should come from the radiation routine)
       real rs1D                    ! solar radiation
       real rld1D                   ! downward flux of the longwave radiation
+      real swddir1D
+      real swddif1D                ! short wave diffuse solar radiation _gl
+
 
 
       real tw1D(2*ndm,nz_um,nwr_u,nbui_max) ! temperature in each layer of the wall
       real tg1D(ndm,ng_u)                   ! temperature in each layer of the ground
       real tr1D(ndm,nz_um,nwr_u)   ! temperature in each layer of the roof
+      real trv1D(ndm,nz_um,ngr_u)   ! temperature in each layer of the GREEN roof
+      real qr1D(ndm,nz_um,ngr_u)   ! humidity in each layer of the GREEN roof
+
 !
 !New variable for BEM
 !
@@ -341,12 +405,18 @@ use module_wrf_error
       real sfvlev1D(nz_um,nz_um)          ! sensible heat flux due to ventilation
       real sfwin1D(2*ndm,nz_um,nbui_max)     ! sensible heat flux from windows
       real consumlev1D(nz_um,nz_um)       ! consumption due to the air conditioning systems
+      real eppvlev1D(nz_um)               ! electricity production of PV panels 
+      real tair1D(nz_um)
+      real tpvlev1D(ndm,nz_um)
       real qv1D(kms:kme)                  ! specific humidity
       real meso_urb                       ! constant to link meso and urban scales [m-2]
+      real meso_urb_ac
+      real roof_frac                       ! Surface fraction occupied by roof 
       real d_urb(nz_um)    
       real sf_ac
       integer ibui,nbui
       integer nlev(nz_um)
+ 
 !
 !End new variables
 !
@@ -354,6 +424,17 @@ use module_wrf_error
       real sfw1D(2*ndm,nz_um,nbui_max)      ! sensible heat flux from walls
       real sfg1D(ndm)              ! sensible heat flux from ground (road)
       real sfr1D(ndm,nz_um)      ! sensible heat flux from roofs
+      real sfrpv1D(ndm,nz_um)
+
+      real tpv1D(nbui_max)
+      real sfr_indoor1D(nbui_max) 
+      real sfrv1D(ndm,nz_um)      ! sensible heat flux from roofs
+      real lfrv1D(ndm,nz_um)      ! latent heat flux from roofs
+      real dg1D(ndm)              ! water depth from ground
+      real dgr1D(ndm,nz_um)      ! water depth from roofs
+      real lfg1D(ndm)              ! latent heat flux from ground (road)
+      real lfr1D(ndm,nz_um)      ! latent heat flux from roofs
+      real drain1D(ndm,nz_um)      ! sensible heat flux from roofs
       real sf1D(kms:kme)              ! surface of the urban grid cells
       real vl1D(kms:kme)                ! volume of the urban grid cells
       real a_u1D(kms:kme)               ! Implicit component of the momentum sources or sinks in the X-direction
@@ -368,7 +449,7 @@ use module_wrf_error
       real b_q1D(kms:kme)               ! Explicit component of the Humidity sources or sinks
       real dlg1D(kms:kme)               ! Height above ground (L_ground in formula (24) of the BLM paper). 
       real dl_u1D(kms:kme)              ! Length scale (lb in formula (22) ofthe BLM paper)
-
+      real gfr1D(ndm,nz_um)
       real time_bep
 ! arrays used to collapse indexes
       integer ind_zwd(nbui_max,nz_um,nwr_u,ndm)
@@ -376,27 +457,29 @@ use module_wrf_error
       integer ind_zd(nbui_max,nz_um,ndm)
       integer ind_zdf(nz_um,ndm)
       integer ind_zrd(nz_um,nwr_u,ndm)
+      integer ind_grd(nz_um,ngr_u,ndm)
 !
       integer ind_bd(nbui_max,nz_um)
       integer ind_wd(nbui_max,nz_um,ndm)
       integer ind_gbd(nbui_max,ngb_u,ndm)  
       integer ind_fbd(nbui_max,nf_u,nz_um-1,ndm)
-!
+
       integer ix,iy,iz,iurb,id,iz_u,iw,ig,ir,ix1,iy1,k
       integer it, nint
       integer iii
-     
       logical first
       character(len=80) :: text
       data first/.true./
-      save first,time_bep 
-
+      save first,time_bep
+       
       save alag_u,alaw_u,alar_u,csg_u,csw_u,csr_u,                       &
            albg_u,albw_u,albr_u,emg_u,emw_u,emr_u,                       &
            z0g_u,z0r_u, nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,ss_u,pb_u,  &
            nz_u,z_u,albwin_u,emwind_u,cop_u,pwin_u,beta_u,sw_cond_u,     &
+           bldac_frc_u,cooled_frc_u,                                     &
            time_on_u,time_off_u,targtemp_u,gaptemp_u,targhum_u,gaphum_u, &
-           perflo_u,hsesf_u,hsequip 
+           perflo_u,gr_frac_roof_u,                    &
+           pv_frac_roof_u,hsesf_u,hsequip,irho,gr_flag_u,gr_type_u
 
 !------------------------------------------------------------------------
 !    Calculation of the momentum, heat and turbulent kinetic fluxes
@@ -408,37 +491,39 @@ use module_wrf_error
 ! 261-304
 !
 ! F. Salamanca and A. Martilli, 2009: 'A new Building Energy Model coupled 
-! with an Urban Canopy Parameterization for urban climate simulations-part II. 
+! with an Urban Canopy Parameterization for urban climate simulations - part II. 
 ! Validation with one dimension off-line simulations'. Theor Appl Climatol
 ! DOI 10.1007/s00704-009-0143-8 
 !------------------------------------------------------------------------
 !
 !prepare the arrays to collapse indexes
 
-      if(num_urban_layers.lt.nbui_max*nz_um*ndm*max(nwr_u,ng_u))then
-        write(*,*)'num_urban_layers too small, please increase to at least ', nbui_max*nz_um*ndm*max(nwr_u,ng_u)
+
+!
+     if(urban_map_zwd.lt.nbui_max*nz_um*ndm*max(nwr_u,ng_u))then
+        write(*,*)'urban_map_zwd too small, please increase to at least ', nbui_max*nz_um*ndm*max(nwr_u,ng_u)
         stop
       endif
 !
 !New conditions for BEM
 !
-      if(num_urban_layers.lt.nbui_max*nz_um)then !limit for indoor temperature and indoor humidity
-        write(*,*)'num_urban_layers too small, please increase to at least ', nbui_max*nz_um
+      if(urban_map_bd.lt.nbui_max*nz_um)then !limit for indoor temperature and indoor humidity
+        write(*,*)'urban_map_bd too small, please increase to at least ', nbui_max*nz_um
         stop
       endif
 
-      if(num_urban_layers.lt.nbui_max*nz_um*ndm)then !limit for window temperature
-        write(*,*)'num_urban_layers too small, please increase to at least ', nbui_max*nz_um*ndm
+      if(urban_map_wd.lt.nbui_max*nz_um*ndm)then !limit for window temperature
+        write(*,*)'urban_map_wd too small, please increase to at least ', nbui_max*nz_um*ndm
         stop
       endif
 
-      if(num_urban_layers.lt.nbui_max*ndm*ngb_u)then !limit for ground temperature below a building
-        write(*,*)'num_urban_layers too small, please increase to at least ', nbui_max*ndm*ngb_u
+      if(urban_map_gbd.lt.nbui_max*ndm*ngb_u)then !limit for ground temperature below a building
+        write(*,*)'urban_map_gbd too small, please increase to at least ', nbui_max*ndm*ngb_u
         stop
       endif
 
-      if(num_urban_layers.lt.(nz_um-1)*nbui_max*ndm*nf_u)then !limit for floor temperature 
-        write(*,*)'num_urban_layers too small, please increase to at least ', nbui_max*ndm*nf_u*(nz_um-1),num_urban_layers
+      if(urban_map_fbd.lt.(nz_um-1)*nbui_max*ndm*nf_u)then !limit for floor temperature
+        write(*,*)'urban_map_fbd too small, please increase to at least ', nbui_max*ndm*nf_u*(nz_um-1)
         stop
       endif
 
@@ -447,7 +532,6 @@ use module_wrf_error
          stop
       endif
 
-!
 !End of new conditions
 !
 !
@@ -458,6 +542,7 @@ use module_wrf_error
       ind_zd=0
       ind_zdf=0
       ind_zrd=0
+      ind_grd=0
       ind_bd=0
       ind_wd=0
       ind_gbd=0
@@ -505,10 +590,20 @@ use module_wrf_error
       enddo
       enddo
       enddo
+
+     iii=0
+      do iz_u=1,nz_um
+      do iw=1,ngr_u
+      do id=1,ndm
+       iii=iii+1
+       ind_grd(iz_u,iw,id)=iii
+      enddo
+      enddo
+      enddo
      
 !
 !New indexes for BEM
-!
+      
       iii=0
       do iz_u=1,nz_um
       do id=1,ndm
@@ -524,8 +619,9 @@ use module_wrf_error
          ind_bd(ibui,iz_u)=iii
       enddo !iz_u
       enddo !ibui
-      
-      
+
+
+
       iii=0
       do ibui=1,nbui_max !type of building
       do iz_u=1,nz_um !vertical levels
@@ -557,9 +653,10 @@ use module_wrf_error
       enddo !iz_u
       enddo !iw
       enddo !ibui
-!
-!End of new indexes
-!   
+
+
+      !End of new indexes
+   
       if (num_urban_hi.ge.nz_um)then
           write(*,*)'nz_um too small, please increase to at least ', num_urban_hi+1
           stop         
@@ -593,23 +690,26 @@ use module_wrf_error
       enddo
       enddo
 
+
       if (first) then                           ! True only on first call
 
          call init_para(alag_u,alaw_u,alar_u,csg_u,csw_u,csr_u,&
                 twini_u,trini_u,tgini_u,albg_u,albw_u,albr_u,albwin_u,emg_u,emw_u,&
                 emr_u,emwind_u,z0g_u,z0r_u,nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,  &
                 cop_u,pwin_u,beta_u,sw_cond_u,time_on_u,time_off_u,targtemp_u,    &
-                gaptemp_u,targhum_u,gaphum_u,perflo_u,hsesf_u,hsequip)
-
+                bldac_frc_u,cooled_frc_u,                                         &
+                gaptemp_u,targhum_u,gaphum_u,perflo_u,                            &
+                gr_frac_roof_u,pv_frac_roof_u,                   & 
+                hsesf_u,hsequip,irho,gr_flag_u,gr_type_u)
+ 
 !Initialisation of the urban parameters and calculation of the view factor
-
-       call icBEP(nd_u,h_b,d_b,ss_u,pb_u,nz_u,z_u)                                  
-
-       first=.false.
+        call icBEP(nd_u,h_b,d_b,ss_u,pb_u,nz_u,z_u)
+   
+      first=.false.
 
       endif ! first
-      
-      do ix=its,ite
+
+do ix=its,ite
       do iy=jts,jte
         if (FRC_URB2D(ix,iy).gt.0.) then    ! Calling BEP only for existing urban classes.
 	
@@ -618,6 +718,7 @@ use module_wrf_error
          hi_urb1D=0.
          do iz_u=1,nz_um
             hi_urb1D(iz_u)=hi_urb(ix,iz_u,iy)
+           
          enddo
 
          call icBEPHI_XY(iurb,hb_u,hi_urb1D,ss_urb,pb_urb,    &
@@ -657,13 +758,14 @@ use module_wrf_error
             stop
          endif
 
-       do iz= kts,kte
+
+
+do iz= kts,kte
           ua1D(iz)=u_phy(ix,iz,iy)
           va1D(iz)=v_phy(ix,iz,iy)
 	  pt1D(iz)=th_phy(ix,iz,iy)
 	  da1D(iz)=rho(ix,iz,iy)
 	  pr1D(iz)=p_phy(ix,iz,iy)
-!!	  pt01D(iz)=th_phy(ix,iz,iy)
 	  pt01D(iz)=300.
 	  z1D(iz)=z(ix,iz,iy)
           qv1D(iz)=qv_phy(ix,iz,iy)
@@ -679,12 +781,12 @@ use module_wrf_error
          enddo
 	 z1D(kte+1)=z(ix,kte+1,iy)
 
+
+
          do id=1,ndm
          do iz_u=1,nz_um
          do iw=1,nwr_u
          do ibui=1,nbui_max
-!!        tw1D(2*id-1,iz_u,iw)=tw1_u(ix,iy,ind_zwd(iz_u,iw,id))
-!!        tw1D(2*id,iz_u,iw)=tw2_u(ix,iy,ind_zwd(iz_u,iw,id))
           tw1D(2*id-1,iz_u,iw,ibui)=tw1_urb4d(ix,ind_zwd(ibui,iz_u,iw,id),iy)
           tw1D(2*id,iz_u,iw,ibui)=tw2_urb4d(ix,ind_zwd(ibui,iz_u,iw,id),iy)
          enddo
@@ -693,20 +795,30 @@ use module_wrf_error
          enddo
 	
          do id=1,ndm
-          do ig=1,ng_u
-!!          tg1D(id,ig)=tg_u(ix,iy,ind_gd(ig,id))
+           do ig=1,ng_u
             tg1D(id,ig)=tgb_urb4d(ix,ind_gd(ig,id),iy)
-          enddo
-          do iz_u=1,nz_um
-          do ir=1,nwr_u
-!!          tr1D(id,iz_u,ir)=tr_u(ix,iy,ind_zwd(iz_u,ir,id))
-            tr1D(id,iz_u,ir)=trb_urb4d(ix,ind_zrd(iz_u,ir,id),iy)
-          enddo
-          enddo
-         enddo
-!
+           enddo
+         
+           do iz_u=1,nz_um
+             do ir=1,nwr_u
+               tr1D(id,iz_u,ir)=trb_urb4d(ix,ind_zrd(iz_u,ir,id),iy)
+             enddo
+             do ir=1,ngr_u
+               if(gr_flag_u.eq.1)then
+                 trv1D(id,iz_u,ir)=trv_urb4d(ix,ind_grd(iz_u,ir,id),iy)
+                 qr1D(id,iz_u,ir)=qr_urb4d(ix,ind_grd(iz_u,ir,id),iy)
+               else
+                 trv1D(id,iz_u,ir)=0.
+                 qr1D(id,iz_u,ir)=0.
+               endif
+             enddo
+           enddo
+        enddo
+
+
+
 !Initialize variables for BEM
-!
+
          tlev1D=0.  !Indoor temperature
          qlev1D=0.  !Indoor humidity
 
@@ -717,6 +829,8 @@ use module_wrf_error
          sflev1D=0.    !Sensible heat flux from the a.c.
          lflev1D=0.    !latent heat flux from the a.c.
          consumlev1D=0.!consumption of the a.c.
+         eppvlev1D=0.  !electricity production of PV panels
+         tpvlev1D=0.
          sfvlev1D=0.   !Sensible heat flux from natural ventilation
          lfvlev1D=0.   !Latent heat flux from natural ventilation
          sfwin1D=0.    !Sensible heat flux from windows
@@ -728,6 +842,8 @@ use module_wrf_error
             qlev1D(iz_u,ibui)= qlev_urb3d(ix,ind_bd(ibui,iz_u),iy)  
          enddo !ibui
          enddo !iz_u
+
+
 
          do id=1,ndm  !direction
             do iz_u=1,nz_um !vertical levels
@@ -753,6 +869,7 @@ use module_wrf_error
                do iz_u=1,nz_um-1 !verticals levels
                   do ibui=1,nbui_max !type of building
                      tflev1D(id,iw,iz_u,ibui)=tflev_urb3d(ix,ind_fbd(ibui,iw,iz_u,id),iy)
+                     
                   enddo !ibui
                enddo ! iz_u
              enddo !iw
@@ -760,42 +877,59 @@ use module_wrf_error
 
 !
 !End initialization for BEM
-!         
+!   
 
-         do id=1,ndm
-	 do iz=1,nz_um
-         do ibui=1,nbui_max !type of building
-!!	  sfw1D(2*id-1,iz)=sfw1(ix,iy,ind_zd(iz,id))
-!!	  sfw1D(2*id,iz)=sfw2(ix,iy,ind_zd(iz,id))
-	  sfw1D(2*id-1,iz,ibui)=sfw1_urb3d(ix,ind_zd(ibui,iz,id),iy)
-	  sfw1D(2*id,iz,ibui)=sfw2_urb3d(ix,ind_zd(ibui,iz,id),iy)
-         enddo
-	 enddo
-	 enddo
-	 
+        do id=1,ndm
+          do iz=1,nz_um
+            do ibui=1,nbui_max !type of building
+          !!  sfw1D(2*id-1,iz)=sfw1(ix,iy,ind_zd(iz,id))
+          !!  sfw1D(2*id,iz)=sfw2(ix,iy,ind_zd(iz,id))
+              sfw1D(2*id-1,iz,ibui)=sfw1_urb3d(ix,ind_zd(ibui,iz,id),iy)
+              sfw1D(2*id,iz,ibui)=sfw2_urb3d(ix,ind_zd(ibui,iz,id),iy)
+            enddo
+          enddo
+        enddo
+ 
+        do id=1,ndm
+          sfg1D(id)=sfg_urb3d(ix,id,iy)
+          lfg1D(id)=lfg_urb3d(ix,id,iy)
+          dg1D(id)=dg_urb3d(ix,id,iy)
+
+        enddo
+
 	 do id=1,ndm
-!!	  sfg1D(id)=sfg(ix,iy,id)
-	  sfg1D(id)=sfg_urb3d(ix,id,iy)
-	 enddo
-	 
-	 do id=1,ndm
 	 do iz=1,nz_um
-!!	  sfr1D(id,iz)=sfr(ix,iy,ind_zd(iz,id))
+	  tpvlev1D(id,iz)=t_pv_urb3d(ix,ind_zdf(iz,id),iy)
 	  sfr1D(id,iz)=sfr_urb3d(ix,ind_zdf(iz,id),iy)
+          lfr1D(id,iz)=lfr_urb3d(ix,ind_zdf(iz,id),iy)          
+          dgr1D(id,iz)=dgr_urb3d(ix,ind_zdf(iz,id),iy)
+          if(gr_flag_u.eq.1)then
+          sfrv1D(id,iz)=sfrv_urb3d(ix,ind_zdf(iz,id),iy)
+          lfrv1D(id,iz)=lfrv_urb3d(ix,ind_zdf(iz,id),iy)
+          drain1D(id,iz)=drain_urb4d(ix,ind_zdf(iz,id),iy)
+          else
+          sfrv1D(id,iz)=0.
+          lfrv1D(id,iz)=0.
+          drain1D(id,iz)=0.
+          endif
 	 enddo
 	 enddo
-         
+
+
+
          rs1D=swdown(ix,iy)
          rld1D=glw(ix,iy)
-
+         swddir1D=swddir(ix,iy)         !_gl
+         swddif1D=swddif(ix,iy)         !_gl
          zr1D=acos(COSZ_URB2D(ix,iy))
          deltar1D=DECLIN_URB
          ah1D=OMG_URB2D(ix,iy)
+         
 
-         call BEP1D(iurb,kms,kme,kts,kte,z1D,dt,ua1D,va1D,pt1D,da1D,pr1D,pt01D,  &
+         call BEP1D(itimestep,ix,iy,iurb,kms,kme,kts,kte,z1D,dt,ua1D,va1D,pt1D,da1D,pr1D,pt01D,  &
                    zr1D,deltar1D,ah1D,rs1D,rld1D,alagb,             & 
                    alag,alaw,alar,alaf,csgb,csg,csw,csr,csf,        & 
-                   dzr,dzf,dzw,dzgb,                                &
+                   dzr,dzf,dzw,dzgb,xlat(ix,iy),swddir1D,swddif1D, &
                    albg_u(iurb),albw_u(iurb),albr_u(iurb),          &
                    albwin_u(iurb),emg_u(iurb),emw_u(iurb),          &
                    emr_u(iurb),emwind_u(iurb),fww_u,fwg_u,          &
@@ -804,17 +938,20 @@ use module_wrf_error
                    nzurban(iurb),z_u,cop_u,pwin_u,beta_u,           & 
                    sw_cond_u,time_on_u,time_off_u,targtemp_u,       &
                    gaptemp_u,targhum_u,gaphum_u,perflo_u,           &
-                   hsesf_u,hsequip,                                 &
-                   tw1D,tg1D,tr1D,sfw1D,sfg1D,sfr1D,                & 
+                   gr_frac_roof_u(iurb),pv_frac_roof_u(iurb),  & 
+                   hsesf_u,hsequip,irho,gr_flag_u,gr_type_u,        &
+                   tw1D,tg1D,tr1D,trv1D,sfw1D,sfg1D,sfr1D,    &
+                   sfrv1D,lfrv1D,    &
+                   dgr1D,dg1D,lfr1D,lfg1D,                       &
+                   drain1D,rainbl(ix,iy),qr1D,                   &
                    a_u1D,a_v1D,a_t1D,a_e1D,                         & 
                    b_u1D,b_v1D,b_t1D,b_ac1D,b_e1D,b_q1D,            & 
                    dlg1D,dl_u1D,sf1D,vl1D,rl_up(ix,iy),             &
                    rs_abs(ix,iy),emiss(ix,iy),grdflx_urb(ix,iy),    &
                    qv1D,tlev1D,qlev1D,sflev1D,lflev1D,consumlev1D,  &
-                   sfvlev1D,lfvlev1D,twlev1D,tglev1D,tflev1D,sfwin1D,&
-                   ix,iy)                            
- 
-         do ibui=1,nbui_max !type of building
+                   eppvlev1D,tpvlev1D,sfvlev1D,lfvlev1D,twlev1D,tglev1D,tflev1D,sfwin1D,tair1D,sfr_indoor1D,sfrpv1D,gfr1D) 
+           
+          do ibui=1,nbui_max !type of building
 	    do iz=1,nz_um   !vertical levels
                do id=1,ndm ! direction
 	          sfw1_urb3d(ix,ind_zd(ibui,iz,id),iy)=sfw1D(2*id-1,iz,ibui) 
@@ -824,16 +961,26 @@ use module_wrf_error
          enddo
  
 	 do id=1,ndm
-	  sfg_urb3d(ix,id,iy)=sfg1D(id) 
+	  sfg_urb3d(ix,id,iy)=sfg1D(id)
+          lfg_urb3d(ix,id,iy)=lfg1D(id)
+          dg_urb3d(ix,id,iy)=dg1D(id) 
 	 enddo
          
 	 do id=1,ndm
 	 do iz=1,nz_um
+          t_pv_urb3d(ix,ind_zdf(iz,id),iy)=tpvlev1D(id,iz) 
 	  sfr_urb3d(ix,ind_zdf(iz,id),iy)=sfr1D(id,iz)
+          dgr_urb3d(ix,ind_zdf(iz,id),iy)=dgr1D(id,iz)
+          lfr_urb3d(ix,ind_zdf(iz,id),iy)=lfr1D(id,iz)
+          if(gr_flag_u.eq.1)then 
+          sfrv_urb3d(ix,ind_zdf(iz,id),iy)=sfrv1D(id,iz)
+          lfrv_urb3d(ix,ind_zdf(iz,id),iy)=lfrv1D(id,iz)
+          drain_urb4d(ix,ind_zdf(iz,id),iy)=drain1D(id,iz)
+          endif
 	 enddo
 	 enddo
          
-         do ibui=1,nbui_max
+        do ibui=1,nbui_max
          do iz_u=1,nz_um
          do iw=1,nwr_u
          do id=1,ndm
@@ -843,17 +990,27 @@ use module_wrf_error
          enddo
          enddo
          enddo
-         
-         do id=1,ndm
+
+
+          do id=1,ndm
             do ig=1,ng_u
+              
                tgb_urb4d(ix,ind_gd(ig,id),iy)=tg1D(id,ig)
             enddo
             do iz_u=1,nz_um
                do ir=1,nwr_u
                   trb_urb4d(ix,ind_zrd(iz_u,ir,id),iy)=tr1D(id,iz_u,ir)
                enddo
+                if(gr_flag_u.eq.1)then
+               do ir=1,ngr_u
+                  trv_urb4d(ix,ind_grd(iz_u,ir,id),iy)=trv1D(id,iz_u,ir)
+                  qr_urb4d(ix,ind_grd(iz_u,ir,id),iy)=qr1D(id,iz_u,ir)
+               enddo
+                endif
             enddo
-         enddo
+          enddo
+!
+         
 !
 !Outputs of BEM
 !
@@ -884,26 +1041,31 @@ use module_wrf_error
             enddo !iw
          enddo !ibui
 
-         do ibui=1,nbui_max  !type of building  
-            do iw=1,nf_u !layer in the walls
+        do ibui=1,nbui_max !type of building 
+        do iw=1,nf_u !layer in the walls
                do iz_u=1,nz_um-1 !verticals levels
-                  do id=1,ndm   !direction
-                     tflev_urb3d(ix,ind_fbd(ibui,iw,iz_u,id),iy)=tflev1D(id,iw,iz_u,ibui)
-                  enddo !id
-               enddo !iz_u
+                 do  id=1,ndm
+                    tflev_urb3d(ix,ind_fbd(ibui,iw,iz_u,id),iy)=tflev1D(id,iw,iz_u,ibui)
+                  enddo !ibui
+               enddo ! iz_u
              enddo !iw
-         enddo !ibui
- 
+         enddo !id
+
+
+
          sf_ac_urb3d(ix,iy)=0.
          lf_ac_urb3d(ix,iy)=0.
          cm_ac_urb3d(ix,iy)=0.
+         ep_pv_urb3d(ix,iy)=0.
          sfvent_urb3d(ix,iy)=0.
          lfvent_urb3d(ix,iy)=0.
-
+         draingr_urb3d(ix,iy)=0.
+         qgr_urb3d(ix,iy)=0.
+         tgr_urb3d(ix,iy)=0.
          meso_urb=(1./4.)*FRC_URB2D(ix,iy)/((bs_urb(1,iurb)+ws_urb(1,iurb))*bs_urb(2,iurb))+ &
                   (1./4.)*FRC_URB2D(ix,iy)/((bs_urb(2,iurb)+ws_urb(2,iurb))*bs_urb(1,iurb))
-
-         
+          meso_urb_ac=meso_urb*bldac_frc_u(iurb)*cooled_frc_u(iurb)
+          roof_frac=FRC_URB2D(ix,iy)*bs_urb(1,iurb)/(bs_urb(1,iurb)+ws_urb(1,iurb))
          ibui=0
          nlev=0
          nbui=0
@@ -917,30 +1079,41 @@ use module_wrf_error
 	 endif	  
          end do  !iz
 
-         do ibui=1,nbui       !type of building   
-         do iz_u=1,nlev(ibui) !vertical levels                    
-               sf_ac_urb3d(ix,iy)=sf_ac_urb3d(ix,iy)+meso_urb*d_urb(ibui)*sflev1D(iz_u,ibui)
-               lf_ac_urb3d(ix,iy)=lf_ac_urb3d(ix,iy)+meso_urb*d_urb(ibui)*lflev1D(iz_u,ibui)
-               cm_ac_urb3d(ix,iy)=cm_ac_urb3d(ix,iy)+meso_urb*d_urb(ibui)*consumlev1D(iz_u,ibui)
-               sfvent_urb3d(ix,iy)=sfvent_urb3d(ix,iy)+meso_urb*d_urb(ibui)*sfvlev1D(iz_u,ibui)
-               lfvent_urb3d(ix,iy)=lfvent_urb3d(ix,iy)+meso_urb*d_urb(ibui)*lfvlev1D(iz_u,ibui)            
+       
+
+
+        do ibui=1,nbui       !type of building
+            ep_pv_urb3d(ix,iy)=ep_pv_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*eppvlev1D(ibui)
+         do iz_u=1,nlev(ibui) !vertical levels
+               sf_ac_urb3d(ix,iy)=sf_ac_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*sflev1D(iz_u,ibui)
+               lf_ac_urb3d(ix,iy)=lf_ac_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*lflev1D(iz_u,ibui)
+               cm_ac_urb3d(ix,iy)=cm_ac_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*consumlev1D(iz_u,ibui)
+        !if(consumlev1D(iz_u,ibui).gt.0.)then
+        !print*,'IX',ix,'IY',iy,'IZ_U',iz_u,'IBUI',ibui,'CONSUM',consumlev1D(iz_u,ibui),'D_URB',d_urb(ibui),'MESO_URB',meso_urb_ac
+
+        !endif
+               sfvent_urb3d(ix,iy)=sfvent_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*sfvlev1D(iz_u,ibui)
+               lfvent_urb3d(ix,iy)=lfvent_urb3d(ix,iy)+meso_urb_ac*d_urb(ibui)*lfvlev1D(iz_u,ibui)
          enddo !iz_u
          enddo !ibui
-
-!
-!Add the latent heat exchanged throughout the ventilation in the lf_ac_urb3d output variable. 
-!it is only a rint variable
-!
-!        lf_ac_urb3d(ix,iy)=lf_ac_urb3d(ix,iy)+lfvent_urb3d(ix,iy)
-!
-
-         lf_ac_urb3d(ix,iy)=lf_ac_urb3d(ix,iy)-lfvent_urb3d(ix,iy)        
+       
 
 
-!
+       if(gr_flag_u.eq.1)then 
+       do id=1,ndm
+       do iz=2,nz_um-1
+        draingr_urb3d(ix,iy)=draingr_urb3d(ix,iy)+d_urb(iz-1)*roof_frac*drain1D(id,iz)*1000
+       do ig=1,ngr_u
+        qgr_urb3d(ix,iy)=qgr_urb3d(ix,iy)+qr1D(id,iz,ig)/ndm/(nz_um-2)/ngr_u
+        tgr_urb3d(ix,iy)=tgr_urb3d(ix,iy)+trv1D(id,iz,ig)/ndm/(nz_um-2)/ngr_u
+        
+       enddo
+       enddo
+       enddo
+       endif
 !End outputs of bem
 !
-
+         
         sf_ac=0.
         sf(ix,kts:kte,iy)=0.
         vl(ix,kts:kte,iy)=0.
@@ -975,80 +1148,48 @@ use module_wrf_error
         sf(ix,kte+1,iy)=sf1D(kte+1)
 
          endif ! FRC_URB2D
-   
+
+
       enddo  ! iy
       enddo  ! ix
 
 
         time_bep=time_bep+dt
 
-      print*, 'ss_urb', ss_urb
-      print*, 'pb_urb', pb_urb
-      print*, 'nz_urb', nz_urb
-      print*, 'd_urb',  d_urb
-            
+!      print*, 'ss_urb', ss_urb
+!      print*, 'pb_urb', pb_urb
+!      print*, 'nz_urb', nz_urb
+!      print*, 'd_urb',  d_urb
+         
+  
       return
       end subroutine BEP_BEM
-            
+
+
 ! ===6=8===============================================================72
 
-      subroutine BEP1D(iurb,kms,kme,kts,kte,z,dt,ua,va,pt,da,pr,pt0,   &  
+      subroutine BEP1D(itimestep,ix,iy,iurb,kms,kme,kts,kte,z,dt,ua,va,pt,da,pr,pt0,   &  
                       zr,deltar,ah,rs,rld,alagb,                       & 
                       alag,alaw,alar,alaf,csgb,csg,csw,csr,csf,        & 
-                      dzr,dzf,dzw,dzgb,                                &
+                      dzr,dzf,dzw,dzgb,xlat,swddir,swddif,             &
                       albg,albw,albr,albwin,emg,emw,emr,               & 
                       emwind,fww,fwg,fgw,fsw,fws,fsg,z0,               & 
                       ndu,strd,drst,ws,bs_u,bs,ss,pb,                  & 
                       nzu,z_u,cop_u,pwin_u,beta_u,sw_cond_u,           & 
                       time_on_u,time_off_u,targtemp_u,                 &
                       gaptemp_u,targhum_u,gaphum_u,perflo_u,           &
-                      hsesf_u,hsequip,                                 &
-                      tw,tg,tr,sfw,sfg,sfr,                            & 
+                      gr_frac_roof,pv_frac_roof,        & 
+                      hsesf_u,hsequip,irho,gr_flag,gr_type,                    &
+                      tw,tg,tr,trv,sfw,sfg,sfr,            &
+                      sfrv,lfrv,dgr,dg,lfr,lfg,drain,rainbl,qr,      & 
                       a_u,a_v,a_t,a_e,                                 &
                       b_u,b_v,b_t,b_ac,b_e,b_q,                        & 
                       dlg,dl_u,sf,vl,rl_up,rs_abs,emiss,grdflx_urb,    &
                       qv,tlev,qlev,sflev,lflev,consumlev,              &
-                      sfvlev,lfvlev,twlev,tglev,tflev,sfwin,ix,iy)                             
+                      eppvlev,tpvlev,sfvlev,lfvlev,twlev,tglev,tflev,sfwin,tmp_u,sfr_indoor,sfrpv,gfr)    
+        ! print*,'SFR_AFT',sfr(id,iz)
 
-! ----------------------------------------------------------------------
-! This routine computes the effects of buildings on momentum, heat and
-!  TKE (turbulent kinetic energy) sources or sinks and on the mixing length.
-! It provides momentum, heat and TKE sources or sinks at different levels of a
-!  mesoscale grid defined by the altitude of its cell interfaces "z" and
-!  its number of levels "nz".
-! The meteorological input parameters (wind, temperature, solar radiation)
-!  are specified on the "mesoscale grid".
-! The inputs concerning the building and street charateristics are defined
-!  on a "urban grid". The "urban grid" is defined with its number of levels
-!  "nz_u" and its space step "dz_u".
-! The input parameters are interpolated on the "urban grid". The sources or sinks
-!  are calculated on the "urban grid". Finally the sources or sinks are 
-!  interpolated on the "mesoscale grid".
- 
 
-!  Mesoscale grid            Urban grid             Mesoscale grid
-!  
-! z(4)    ---                                               ---
-!          |                                                 |
-!          |                                                 |
-!          |   Interpolation                  Interpolation  |
-!          |            Sources or sinks calculation         |
-! z(3)    ---                                               ---
-!          | ua               ua_u  ---  uv_a         a_u    |
-!          | va               va_u   |   uv_b         b_u    |
-!          | pt               pt_u  ---  uh_b         a_v    |
-! z(2)    ---                        |    etc...      etc...---
-!          |                 z_u(1) ---                      |
-!          |                         |                       |
-! z(1) ------------------------------------------------------------
-
-!     
-! Reference:
-! Martilli, A., Clappier, A., Rotach, M.W.:2002, 'AN URBAN SURFACE EXCHANGE
-! PARAMETERISATION FOR MESOSCALE MODELS', Boundary-Layer Meteorolgy 104:
-! 261-304
- 
-! ----------------------------------------------------------------------
 
       implicit none
 
@@ -1059,7 +1200,7 @@ use module_wrf_error
 ! Data relative to the "mesoscale grid"
 
 !!    integer nz                 ! Number of vertical levels
-      integer kms,kme,kts,kte
+      integer kms,kme,kts,kte,ix,iy,itimestep
       real z(kms:kme)               ! Altitude above the ground of the cell interfaces.
       real ua(kms:kme)                ! Wind speed in the x direction
       real va(kms:kme)                ! Wind speed in the y direction
@@ -1074,6 +1215,9 @@ use module_wrf_error
       real ah                    ! Hour angle
       real rs                    ! Solar radiation
       real rld                   ! Downward flux of the longwave radiation
+      real xlat                  ! Latitude
+      real swddir                ! short wave direct solar radiation   !_gl
+      real swddif                ! short wave diffuse solar radiation  !_gl
 
 ! Data relative to the "urban grid"
 
@@ -1088,6 +1232,7 @@ use module_wrf_error
       real emg                   ! Emissivity of ground
       real emw                   ! Emissivity of wall
       real emr                   ! Emissivity of roof
+
 
 !    fww,fwg,fgw,fsw,fsg are the view factors used to compute the long and 
 !    short wave radation. 
@@ -1120,7 +1265,14 @@ use module_wrf_error
       real perflo_u(nurbm)
       real hsesf_u(nurbm)
       real hsequip(24)
-
+      real irho(24)
+      real gr_frac_roof
+      real pv_frac_roof
+      integer gr_flag
+      integer gr_type
+      real tpv(nbui_max)
+     real  sfpv(nbui_max)
+     real sfr_indoor(nbui_max)
 ! ----------------------------------------------------------------------
 ! INPUT-OUTPUT
 ! ----------------------------------------------------------------------
@@ -1130,15 +1282,27 @@ use module_wrf_error
       real tw(2*ndm,nz_um,nwr_u,nbui_max)  ! Temperature in each layer of the wall [K]
       real tr(ndm,nz_um,nwr_u)  ! Temperature in each layer of the roof [K]
       real tg(ndm,ng_u)          ! Temperature in each layer of the ground [K]
+      real trv(ndm,nz_um,ngr_u)  ! Temperature in each layer of the green roof [K]
       real sfw(2*ndm,nz_um,nbui_max)      ! Sensible heat flux from walls
       real sfg(ndm)              ! Sensible heat flux from ground (road)
       real sfr(ndm,nz_um)      ! Sensible heat flux from roofs
+      real sfrv(ndm,nz_um)      ! Sensible heat flux from green roofs
+      real lfrv(ndm,nz_um)      ! Latent heat flux from green roofs
+      real dg(ndm)              ! water depth ground (road)
+      real dgr(ndm,nz_um)      ! water depth roofs
+      real lfr(ndm,nz_um)      ! Latent heat flux from roofs
+      real lfg(ndm)              ! Latent heat flux from ground (road)
+      real drain(ndm,nz_um)        ! Green roof drainage
+      real rainbl              ! Rainfall 
       real gfg(ndm)             ! Heat flux transferred from the surface of the ground (road) towards the interior
       real gfr(ndm,nz_um)     ! Heat flux transferred from the surface of the roof towards the interior
       real gfw(2*ndm,nz_um,nbui_max)     ! Heat flux transfered from the surface of the walls towards the interior
+      real qr(ndm,nz_um,ngr_u)  ! Green Roof soil moisture
+
 ! ----------------------------------------------------------------------
 ! OUTPUT:
 ! ----------------------------------------------------------------------
+                         
 
 ! Data relative to the "mesoscale grid"
 
@@ -1159,14 +1323,11 @@ use module_wrf_error
       real b_q(kms:kme)              ! Explicit component of the humidity sources or sinks
       real dlg(kms:kme)              ! Height above ground (L_ground in formula (24) of the BLM paper). 
       real dl_u(kms:kme)             ! Length scale (lb in formula (22) ofthe BLM paper).
-    
-      
 ! ----------------------------------------------------------------------
 ! LOCAL:
 ! ----------------------------------------------------------------------
 
       real dz(kms:kme)               ! vertical space steps of the "mesoscale grid"
-
 ! Data interpolated from the "mesoscale grid" to the "urban grid"
 
       real ua_u(nz_um)          ! Wind speed in the x direction
@@ -1192,11 +1353,14 @@ use module_wrf_error
       real drst(ndm)            ! Street directions for the current urban class
       real ss(nz_um)          ! Probability to have a building with height h
       real pb(nz_um)          ! Probability to have a building with an height equal
+      real cdrag(nz_um)
+      real alp
 
 ! Solar radiation at each level of the "urban grid"
 
-      real rsg(ndm)             ! Short wave radiation from the ground
+     real rsg(ndm)             ! Short wave radiation from the ground
       real rsw(2*ndm,nz_um)     ! Short wave radiation from the walls
+      real rsd(2*ndm,nz_um)     ! Direct Short wave radiation received by the walls
       real rlg(ndm)             ! Long wave radiation from the ground
       real rlw(2*ndm,nz_um)     ! Long wave radiation from the walls
 
@@ -1204,9 +1368,10 @@ use module_wrf_error
 
       real ptg(ndm)             ! Ground potential temperatures 
       real ptr(ndm,nz_um)     ! Roof potential temperatures 
+      real ptrv(ndm,nz_um)     ! Roof potential temperatures 
       real ptw(2*ndm,nz_um,nbui_max)     ! Walls potential temperatures 
 
- 
+      real tg_av(ndm) 
 ! Explicit and implicit component of the momentum, temperature and TKE sources or sinks on
 ! vertical surfaces (walls) ans horizontal surfaces (roofs and street)
 ! The fluxes can be computed as follow: Fluxes of X = A*X + B
@@ -1221,7 +1386,9 @@ use module_wrf_error
       real thb_u(ndm,nz_um)   ! Temperature        Horizontal surfaces, B (explicit) term
       real tva_u(2*ndm,nz_um)   ! Temperature          Vertical surfaces, A (implicit) term
       real tvb_u(2*ndm,nz_um)   ! Temperature          Vertical surfaces, B (explicit) term
-      real tvb_ac(2*ndm,nz_um)
+
+
+ real tvb_ac(2*ndm,nz_um)
       real ehb_u(ndm,nz_um)   ! Energy (TKE)       Horizontal surfaces, B (explicit) term
       real evb_u(2*ndm,nz_um)   ! Energy (TKE)         Vertical surfaces, B (explicit) term
       real qhb_u(ndm,nz_um)     ! Humidity      Horizontal surfaces, B (explicit) term
@@ -1233,8 +1400,8 @@ use module_wrf_error
       real grdflx_urb ! ground heat flux
       real dt_int ! internal time step
       integer nt_int ! number of internal time step
-      integer iz,id, it_int
-      integer iw,ix,iy
+      integer iz,id, it_int,it
+      integer iw
 
 !---------------------------------------
 !New variables uses in BEM
@@ -1248,7 +1415,7 @@ use module_wrf_error
       real dzgb(ngb_u)      !Layer sizes in the ground below the buildings
 
       real csgb(ngb_u)      !Specific heat of the ground material below the buildings 
-                            !of the current urban class at each ground levels[J m^3 K^-1]
+
       real csf(nf_u)        !Specific heat of the floors materials in the buildings 
                             !of the current urban class at each levels[J m^3 K^-1]
       real alar(nwr_u+1)    ! Roof thermal diffusivity for the current urban class [W/m K]
@@ -1257,6 +1424,12 @@ use module_wrf_error
       real alagb(ngb_u+1)   ! Ground thermal diffusivity below the building at each wall layer [W/m K] 
 
       real sfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+      real sfrbpv(ndm,nbui_max)      ! Sensible heat flux from PV panels [W/m2]
+      real sfrpv(ndm,nz_um)          ! Sensible heat flux from PV panels [W/m2]
+      real sfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+      real lfrvb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+      real lfrb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
+  
       real gfrb(ndm,nbui_max)        ! Heat flux flowing inside the roofs [W/m2]
       real sfwb1D(2*ndm,nz_um)    !Sensible heat flux from the walls [W/m2] 
       real sfwin(2*ndm,nz_um,nbui_max)!Sensible heat flux from windows [W/m2]
@@ -1275,14 +1448,18 @@ use module_wrf_error
       real tflev(ndm,nf_u,nz_um-1,nbui_max)!Floor temperature in BEM[K]
       real tflevb1D(nf_u,nz_um-1)       !Floor temperature in BEM[K]
       real trb(ndm,nwr_u,nbui_max)         !Roof temperature in BEM [K]
-      real trb1D(nwr_u)                 !Roof temperature in BEM [K]
-      
+      real trvb(ndm,ngr_u,nbui_max)         !Roof temperature in BEM [K]
+      real trb1D(nwr_u) 
+
       real sflev(nz_um,nz_um)     ! sensible heat flux due to the air conditioning systems [W]
       real lflev(nz_um,nz_um)     ! latent heat flux due to the air conditioning systems  [W]
       real consumlev(nz_um,nz_um) ! consumption due to the air conditioning systems [W]
       real sflev1D(nz_um)         ! sensible heat flux due to the air conditioning systems [W]
       real lflev1D(nz_um)         ! latent heat flux due to the air conditioning systems  [W]
       real consumlev1D(nz_um)     ! consumption due to the air conditioning systems [W]
+      real eppvlev(nz_um)         ! Electricity production of PV panels [W]
+	   real tpvlev(ndm,nz_um)
+      real tpvlevb(ndm,nbui_max)        ! Sensible heat flux from roofs [W/m2]
       real sfvlev(nz_um,nz_um)    ! sensible heat flux due to ventilation [W]
       real lfvlev(nz_um,nz_um)    ! latent heat flux due to ventilation [W]
       real sfvlev1D(nz_um)        ! sensible heat flux due to ventilation [W]
@@ -1293,26 +1470,48 @@ use module_wrf_error
       real twlev_av(2*ndm,nz_um)     ! Averaged temperature of the windows
       real sfw_av(2*ndm,nz_um)       ! Averaged sensible heat from walls
       real sfwind_av(2*ndm,nz_um)    ! Averaged sensible heat from windows
-
+      integer flag_pvp
       integer nbui                !Total number of different type of buildings in an urban class
       integer nlev(nz_um)         !Number of levels in each different type of buildings in an urban class
       integer ibui,ily  
       real :: nhourday   ! Number of hours from midnight, local time
+      real :: st4,gamma,fp,lmr,smr,prova
+      real hfgr(ndm,nz_um)!heat flux green roof
+      real hfgrb(ndm,nbui_max)
+      real irri_per_ts
+      real irri_now 
+      real tr_av(ndm,nz_um)
+      real tr_avb(ndm,nbui_max)
+      real sfr_avb(ndm,nbui_max)
 ! ----------------------------------------------------------------------
 ! END VARIABLES DEFINITIONS
 ! ----------------------------------------------------------------------
-
+    
 ! Fix some usefull parameters for the computation of the sources or sinks
 !
 !initialize the variables inside the param routine
-!
 
+        nhourday=ah/PI*180./15.+12.
+        if (nhourday >= 24) nhourday = nhourday - 24
+        if (nhourday < 0)  nhourday = nhourday + 24
+
+
+      if(sum(irho).gt.0)then
+        irri_per_ts=h_water/sum(irho)
+       else
+        irri_per_ts=0.
+       endif
+       
+     if(irho(int(nhourday)+1).ne.0)then
+       irri_now=irri_per_ts
+     else
+       irri_now=0.
+     endif
+      
       do iz=kts,kte
          dz(iz)=z(iz+1)-z(iz)
       end do
-
 ! Interpolation on the "urban grid"
-
       call interpol(kms,kme,kts,kte,nzu,z,z_u,ua,ua_u)
       call interpol(kms,kme,kts,kte,nzu,z,z_u,va,va_u)
       call interpol(kms,kme,kts,kte,nzu,z,z_u,pt,pt_u)
@@ -1320,38 +1519,87 @@ use module_wrf_error
       call interpol(kms,kme,kts,kte,nzu,z,z_u,pr,pr_u)
       call interpol(kms,kme,kts,kte,nzu,z,z_u,da,da_u)
       call interpol(kms,kme,kts,kte,nzu,z,z_u,qv,qv_u)
-                   
 ! Compute the modification of the radiation due to the buildings
       
 
       call averaging_temp(tw,twlev,ss,pb,tw_av,twlev_av, &
-                          sfw_av,sfwind_av,sfw,sfwin)
+                           sfw_av,sfwind_av,sfw,sfwin)
+                           
+     do id=1,ndu
+       tg_av(id)=tg(id,ng_u)
+     do iz=1,nz_um
+
+       tr_av(id,iz)=((1-gr_frac_roof)*tr(id,iz,nwr_u)**4.+   &
+       gr_frac_roof*trv(id,iz,ngr_u)**4.)**(1./4.)
+
+     enddo
+     enddo
+     
      
 
-      call modif_rad(iurb,ndu,nzu,z_u,ws,           &
+
+   
+     call modif_rad(iurb,ndu,nzu,z_u,ws,           &
                     drst,strd,ss,pb,                &
-                    tw_av,tg,twlev_av,albg,albw,    &
+                    tw_av,tg_av,twlev_av,albg,albw,    &
                     emw,emg,pwin_u(iurb),albwin,    &
                     emwind,fww,fwg,fgw,fsw,fsg,     &
-                    zr,deltar,ah,                   &
-                    rs,rld,rsw,rsg,rlw,rlg)  
+                    zr,deltar,ah,xlat,swddir,swddif,      &  !_gl  
+                    rs,rld,rsw,rsd,rsg,rlw,rlg)  
+
+
+ 
 
 ! calculation of the urban albedo and the upward long wave radiation
 
-       call upward_rad(ndu,nzu,ws,bs,sigma,pb,ss,                 &
-                       tg,emg,albg,rlg,rsg,sfg,                   & 
-                       tw_av,emw,albw,rlw,rsw,sfw_av,             & 
-                       tr,emr,albr,emwind,                        &
-                       albwin,twlev_av,pwin_u(iurb),sfwind_av,rld,rs,sfr, & 
-                       rs_abs,rl_up,emiss,grdflx_urb)               
-        
-! Compute the surface temperatures
 
-      call surf_temp(ndu,pr_u,dt,                   & 
+       call upward_rad(ndu,nzu,ws,bs,sigma,pb,ss,                 &
+                       tg_av,emg,albg,rlg,rsg,sfg,lfg,                   & 
+                       tw_av,emw,albw,rlw,rsw,sfw_av,             & 
+                       tr_av,emr,albr,emwind,                        &
+                       albwin,twlev_av,pwin_u(iurb),sfwind_av,rld,rs,sfr,sfrv,lfr,lfrv, & 
+                       rs_abs,rl_up,emiss,grdflx_urb,gr_frac_roof,tpvlev,pv_frac_roof)          
+   
+    do id=1,ndu
+    if(dg(id).le.dgmax) then
+      dg(id)=dg(id)+(rainbl+(lfg(id)*dt)/latent)
+     endif
+    if (dg(id).lt.0) then
+      dg(id)=0
+    endif
+    if (dg(id).gt.dgmax) then
+      dg(id)=dgmax
+    endif
+   do iz=2,nz_um
+    if(dgr(id,iz).le.drmax) then
+     dgr(id,iz)=dgr(id,iz)+(rainbl+(lfr(id,iz)*dt)/latent)
+    endif 
+    if (dgr(id,iz).lt.0) then
+     dgr(id,iz)=0
+    endif
+    if (dgr(id,iz).gt.drmax) then
+     dgr(id,iz)=drmax
+    endif
+   enddo
+  enddo !id 
+ 
+  
+
+
+     call surf_temp(ndu,pr_u,dt,                   & 
                     rld,rsg,rlg,                    &
-                    tg,alag,csg,emg,albg,ptg,sfg,gfg)
-      
-! Call the BEM (Building Energy Model) routine 
+                    tg,alag,csg,emg,albg,ptg,sfg,lfg,gfg)
+     if(gr_flag.eq.1)then
+     if(gr_frac_roof.gt.0.)then
+     hfgr=0.
+     call roof_temp_veg(ndu,pr_u,dt,                   &
+                    rld,rs,                    &
+                    trv,ptrv,sfrv,lfrv,gfr,qr,rainbl,drain,hfgr,tr,alar(5),dzr(5),csr(5),nzu,irri_now,gr_type,pv_frac_roof,tpvlev)
+    
+     endif
+     endif
+
+
        
        do iz=1,nz_um !Compute the outdoor temperature 
 	 tmp_u(iz)=pt_u(iz)*(pr_u(iz)/p0)**(rcp_u) 
@@ -1360,8 +1608,13 @@ use module_wrf_error
        ibui=0
        nlev=0
        nbui=0
-     
+       hfgrb=0. 
        sfrb=0.     !Sensible heat flux from roof
+       sfrbpv=0.   !Sensible heat flux from PV panels
+       sfrpv=0.    !Sensible heat flux from PV panels
+       lfrvb=0.
+       lfrb=0.
+       sfrvb=0.
        gfrb=0.     !Heat flux flowing inside the roof
        sfwb1D=0.   !Sensible heat flux from walls
        sfwinb1D=0. !Sensible heat flux from windows
@@ -1371,19 +1624,21 @@ use module_wrf_error
        twb1D=0.    !Wall temperature
        twlevb1D=0. !Window temperature
        tglevb1D=0. !Ground temperature below a building
-       tflevb1D=0. !Floor temperature     
+       tflevb1D=0. !Floor temperature
+       trvb=0.     
        trb=0.      !Roof temperature
        trb1D=0.    !Roof temperature
-
+       tr_avb=0.
        qlevb1D=0. !Indoor humidity
        tlevb1D=0. !indoor temperature
 
        sflev1D=0.    !Sensible heat flux from the a.c.
        lflev1D=0.    !Latent heat flux from the a.c.
        consumlev1D=0.!Consumption from the a.c.
+       tpvlevb=0.
+       eppvlev=0.
        sfvlev1D=0.   !Sensible heat flux from the natural ventilation
        lfvlev1D=0.   !Latent heat flux from natural ventilation
-
        ptw=0.        !Wall potential temperature
        ptwin=0.      !Window potential temperature
        ptr=0.        !Roof potential temperature
@@ -1394,10 +1649,21 @@ use module_wrf_error
            nlev(ibui)=iz-1
            nbui=ibui
            do id=1,ndm
+              tr_avb(id,ibui)=tr_av(id,iz)
+	      tpvlevb(id,ibui)=tpvlev(id,iz)
+              hfgrb(id,ibui)=hfgr(id,iz)
               sfrb(id,ibui)=sfr(id,iz)
+               sfrvb(id,ibui)=sfrv(id,iz)
+              lfrvb(id,ibui)=lfrv(id,iz)
+              lfrb(id,ibui)=lfr(id,iz)
+              sfr_avb(id,ibui)=(1-gr_frac_roof)*sfr(id,iz)+gr_frac_roof*(sfrv(id,iz))
               do ily=1,nwr_u
                  trb(id,ily,ibui)=tr(id,iz,ily)
               enddo
+              do ily=1,ngr_u
+                 trvb(id,ily,ibui)=trv(id,iz,ily)
+              enddo
+
            enddo
 	 endif	  
        end do  !iz
@@ -1406,13 +1672,8 @@ use module_wrf_error
 !Loop over BEM  -----------------------------------------------------------------
 !--------------------------------------------------------------------------------
 !--------------------------------------------------------------------------------
-        nhourday=ah/PI*180./15.+12.
-        if (nhourday >= 24) nhourday = nhourday - 24
-        if (nhourday < 0)  nhourday = nhourday + 24
 
-        do ibui=1,nbui
-
-         
+       do ibui=1,nbui
           do iz=1,nz_um
              qlevb1D(iz)=qlev(iz,ibui)
              tlevb1D(iz)=tlev(iz,ibui) 
@@ -1428,9 +1689,9 @@ use module_wrf_error
              enddo
 
              do ily=1,nf_u
-             do iz=1,nz_um-1
-               tflevb1D(ily,iz)=tflev(id,ily,iz,ibui)
-             enddo
+                do iz=1,nz_um-1
+                  tflevb1D(ily,iz)=tflev(id,ily,iz,ibui)
+                enddo
              enddo
 
              do iz=1,nz_um
@@ -1449,177 +1710,41 @@ use module_wrf_error
                 twlevb1D(2*id,iz)=twlev(2*id,iz,ibui)
              enddo
           enddo
-       
-         !print*,'nz_um',nz_um
-         !print*,'nlev(ibui)',nlev(ibui)
-         !print*,'nhourday',nhourday
-         !print*,'dt',dt
-         !print*, 'bs_u(1,iurb)',bs_u(1,iurb)
-         !print*, 'bs_u(2,iurb)',bs_u(2,iurb)
-         !print*, 'dz_u',dz_u
-         !print*, 'nwr_u',nwr_u
-         !print*, 'nf_u',nf_u
-         !print*, 'nwr_u', nwr_u
-         !print*, 'ngb_u',ngb_u
-         !print*, 'sfwb1D',sfwb1D
-         !print*, 'gfwb1D',gfwb1D
-         !print*, 'sfwinb1D',sfwinb1D
-         !print*, 'sfrb(1,ibui)',sfrb(1,ibui)
-         !print*, 'gfrb(1,ibui)',gfrb(1,ibui)
-         !print*, 'latent',latent
-         !print*,  'sigma',sigma
-         !print*, 'albw_u(iurb)',albw
-         !print*, 'albwin_u(iurb)',albwin
-         !print*, 'albr_u(iurb)',albr
-         !print*, 'emr_u(iurb)',emr
-         !print*, 'emw_u(iurb)',emw
-         !print*, 'emwind_u(iurb)',emwind
-         !print*, 'rsw',rsw
-         !print*, 'rlw',rlw
-         !print*, 'r',r
-         !print*, 'cp_u',cp_u
-         !print*, 'da_u',da_u
-         !print*, 'tmp_u',tmp_u
-         !print*, 'qv_u',qv_u
-         !print*, 'pr_u',pr_u
-         !print*, 'rs',rs
-         !print*, 'rld',rld
-         !print*, 'dzw',dzw
-         !print*, 'csw',csw
-         !print*, 'alaw',alaw
-         !print*, 'pwin_u',pwin_u
-         !print*, 'cop_u(iurb)',cop_u(iurb)
-         !print*, 'beta_u(iurb)',beta_u(iurb)
-         !print*, 'sw_cond_u(iurb)',sw_cond_u(iurb)
-         !print*, 'time_on_u(iurb)',time_on_u(iurb)
-         !print*, 'time_off_u(iurb)',time_off_u(iurb)
-         !print*, 'targtemp_u(iurb)',targtemp_u(iurb)
-         !print*, 'gaptemp_u(iurb)',gaptemp_u(iurb)
-         !print*, 'targhum_u(iurb)',targhum_u(iurb)
-         !print*, 'gaphum_u(iurb)',gaphum_u(iurb)
-         !print*, 'perflo_u(iurb)',perflo_u(iurb)
-         !print*, 'hsesf_u(iurb)',hsesf_u(iurb)
-         !print*, 'hsequip',hsequip
-         !print*, 'dzf',dzf
-         !print*, 'csf',csf
-         !print*, 'alaf',alaf
-         !print*, 'dzgb',dzgb
-         !print*, 'csgb',csgb
-         !print*, 'alagb',alagb
-         !print*, 'dzr',dzr
-         !print*, 'csr',csr
-         !print*, 'alar',alar
-         !print*, 'tlevb1D',tlevb1D
-         !print*, 'qlevb1D',qlevb1D
-         !print*, 'twb1D',twb1D
-         !print*, 'twlevb1D',twlevb1D
-         !print*, 'tflevb1D',tflevb1D
-         !print*, 'tglevb1D',tglevb1D
-         !print*, 'trb1D',trb1D
-         !print*, 'sflev1D',sflev1D
-         !print*, 'lflev1D',lflev1D
-         !print*, 'consumlev1D',consumlev1D
-         !print*, 'sfvlev1D',sfvlev1D
-         !print*, 'lfvlev1D',lfvlev1D
 
+    !print*,'HFGR_BEFORE_CALLING_BEM',hfgr(nlev(ibui))
 
-
-
-     
-         
           call BEM(nz_um,nlev(ibui),nhourday,dt,bs_u(1,iurb),                &
                    bs_u(2,iurb),dz_u,nwr_u,nf_u,nwr_u,ngb_u,sfwb1D,gfwb1D,   &
-                   sfwinb1D,sfrb(1,ibui),gfrb(1,ibui),                       &
+                   sfwinb1D,sfr_avb(1,ibui),lfrb(1,ibui),gfrb(1,ibui),       &
+                   sfrbpv(1,ibui),                                           &
                    latent,sigma,albw,albwin,albr,                            &
-     	           emr,emw,emwind,rsw,rlw,r,cp_u,                            &
-     	           da_u,tmp_u,qv_u,pr_u,rs,rld,dzw,csw,alaw,pwin_u(iurb),    &
+                   emr,emw,emwind,rsw,rlw,r,cp_u,                            &
+                   da_u,tmp_u,qv_u,pr_u,rs,swddif,rld,dzw,csw,alaw,pwin_u(iurb),    &
                    cop_u(iurb),beta_u(iurb),sw_cond_u(iurb),time_on_u(iurb), &
                    time_off_u(iurb),targtemp_u(iurb),gaptemp_u(iurb),        &
                    targhum_u(iurb),gaphum_u(iurb),perflo_u(iurb),            &
+                   gr_frac_roof,pv_frac_roof,gr_flag,                        & 
+                   ua_u,va_u,                                                &
                    hsesf_u(iurb),hsequip,                                    &
-     	           dzf,csf,alaf,dzgb,csgb,alagb,dzr,csr,                     &
-     	           alar,tlevb1D,qlevb1D,twb1D,twlevb1D,tflevb1D,tglevb1D,    &
-     	           trb1D,sflev1D,lflev1D,consumlev1D,sfvlev1D,lfvlev1D)      
+                   dzf,csf,alaf,dzgb,csgb,alagb,dzr,csr,                     &
+                   alar,tlevb1D,qlevb1D,twb1D,twlevb1D,tflevb1D,tglevb1D,    &
+                   trb1D,sflev1D,lflev1D,consumlev1D,eppvlev(ibui),          &
+                   tpvlevb(1,ibui),                                          &
+                   sfvlev1D,lfvlev1D,hfgrb(1,ibui),tr_avb(1,ibui),           &
+                   tpv(ibui),sfpv(ibui),sfr_indoor(ibui))
+          
 
-         !print*,'nz_um A',nz_um
-         !print*,'nlev(ibui) A',nlev(ibui)
-         !print*,'nhourday A',nhourday
-         !print*,'dt A',dt
-         !print*, 'bs_u(1,iurb) A',bs_u(1,iurb)
-         !print*, 'bs_u(2,iurb) A',bs_u(2,iurb)
-         !print*, 'dz_u A',dz_u
-         !print*, 'nwr_u A',nwr_u
-         !print*, 'nf_u A',nf_u
-         !print*, 'nwr_u A', nwr_u
-         !print*, 'ngb_u A',ngb_u
-         !print*, 'sfwb1D A',sfwb1D
-         !print*, 'gfwb1D A',gfwb1D
-         !print*, 'sfwinb1D A',sfwinb1D
-         !print*, 'sfrb(1,ibui) A',sfrb(1,ibui)
-         !print*, 'gfrb(1,ibui) A',gfrb(1,ibui)
-         !print*, 'latent A',latent
-         !print*,  'sigma A',sigma
-         !print*, 'albw_u(iurb) A',albw
-         !print*, 'albwin_u(iurb) A',albwin
-         !print*, 'albr_u(iurb) A',albr
-         !print*, 'emr_u(iurb) A',emr
-         !print*, 'emw_u(iurb) A',emw
-         !print*, 'emwind_u(iurb) A',emwind
-         !print*, 'rsw A',rsw
-         !print*, 'rlw A',rlw
-         !print*, 'r A',r
-         !print*, 'cp_u A',cp_u
-         !print*, 'da_u A',da_u
-         !print*, 'tmp_u A',tmp_u
-         !print*, 'qv_u A',qv_u
-         !print*, 'pr_u A',pr_u
-         !print*, 'rs A',rs
-         !print*, 'rld A',rld
-         !print*, 'dzw A',dzw
-         !print*, 'csw A',csw
-         !print*, 'alaw A',alaw
-         !print*, 'pwin_u A',pwin_u
-         !print*, 'cop_u(iurb) A',cop_u(iurb)
-         !print*, 'beta_u(iurb) A',beta_u(iurb)
-         !print*, 'sw_cond_u(iurb) A',sw_cond_u(iurb)
-         !print*, 'time_on_u(iurb) A',time_on_u(iurb)
-         !!print*, 'time_off_u(iurb) A',time_off_u(iurb)
-         !print*, 'targtemp_u(iurb) A',targtemp_u(iurb)
-         !print*, 'gaptemp_u(iurb) A ',gaptemp_u(iurb)
-         !print*, 'targhum_u(iurb) A ',targhum_u(iurb)
-         !print*, 'gaphum_u(iurb) A',gaphum_u(iurb)
-         !print*, 'perflo_u(iurb) A',perflo_u(iurb)
-         !print*, 'hsesf_u(iurb) A',hsesf_u(iurb)
-         !print*, 'hsequip A',hsequip
-         !print*, 'dzf A',dzf
-         !print*, 'csf A',csf
-         !print*, 'alaf A',alaf
-         !print*, 'dzgb A',dzgb
-         !print*, 'csgb A',csgb
-         !print*, 'alagb A',alagb
-         !print*, 'dzr A',dzr
-         !print*, 'csr A',csr
-         !print*, 'alar A',alar
-         !print*, 'tlevb1D A',tlevb1D
-         !print*, 'qlevb1D A',qlevb1D
-         !print*, 'twb1D A',twb1D
-         !print*, 'twlevb1D A',twlevb1D
-         !print*, 'tflevb1D A',tflevb1D
-         !print*, 'tglevb1D A',tglevb1D
-         !print*, 'trb1D A',trb1D
-         !print*, 'sflev1D A',sflev1D
-         !print*, 'lflev1D A',lflev1D
-         !print*, 'consumlev1D A',consumlev1D
-         !print*, 'sfvlev1D A',sfvlev1D
-         !print*, 'lfvlev1D A',lfvlev1D
-
-        
 !
 !Temporal modifications
-!
+!        
+         tpvlevb(2,ibui)=tpvlevb(1,ibui)
          sfrb(2,ibui)=sfrb(1,ibui)
+         sfrvb(2,ibui)=sfrvb(1,ibui)
+         lfrvb(2,ibui)=lfrvb(1,ibui)
+         lfrb(2,ibui)=lfrb(1,ibui)
+         sfrbpv(2,ibui)=sfrbpv(1,ibui)
          gfrb(2,ibui)=gfrb(1,ibui)
-!
+         hfgrb(2,ibui)=hfgrb(1,ibui)
 !End temporal modifications  
 !        
            do iz=1,nz_um
@@ -1646,18 +1771,12 @@ use module_wrf_error
               enddo
               enddo
            
-!!            do iz=1,nz_um
-!!               sfwin(2*id-1,iz,ibui)=sfwinb1D(2*id-1,iz)
-!!               sfwin(2*id,iz,ibui)=sfwinb1D(2*id,iz)
-!!            enddo
 
              do iz=1,nz_um
                 do ily=1,nwr_u
                    tw(2*id-1,iz,ily,ibui)=twb1D(2*id-1,ily,iz)
                    tw(2*id,iz,ily,ibui)=twb1D(2*id,ily,iz)
                 enddo
-!!              sfw(2*id-1,iz,ibui)=sfwb1D(2*id-1,iz)
-!!              sfw(2*id,iz,ibui)=sfwb1D(2*id,iz)
                 gfw(2*id-1,iz,ibui)=gfwb1D(2*id-1,iz)
                 gfw(2*id,iz,ibui)=gfwb1D(2*id,iz)
                 twlev(2*id-1,iz,ibui)=twlevb1D(2*id-1,iz)
@@ -1666,7 +1785,7 @@ use module_wrf_error
            enddo       
 
         enddo !ibui   
-        
+   
 !-----------------------------------------------------------------------------
 !End loop over BEM -----------------------------------------------------------
 !-----------------------------------------------------------------------------
@@ -1674,43 +1793,67 @@ use module_wrf_error
 
        ibui=0
 
-       do iz=1,nz_um	
+        do iz=1,nzu!nz_um	
 	   
          if(ss(iz).gt.0) then		
            ibui=ibui+1	
            do id=1,ndm	
               gfr(id,iz)=gfrb(id,ibui)
+	      tpvlev(id,iz)=tpvlevb(id,ibui)
               sfr(id,iz)=sfrb(id,ibui)
+              hfgr(id,iz)=hfgrb(id,ibui)
+              sfrpv(id,iz)=-sfrbpv(id,ibui)
+              lfr(id,iz)=lfrb(id,ibui)
               do ily=1,nwr_u
                  tr(id,iz,ily)=trb(id,ily,ibui)
               enddo
               ptr(id,iz)=tr(id,iz,nwr_u)*(pr_u(iz)/p0)**(-rcp_u)
            enddo
          endif
-       enddo !iz
+        enddo !iz
 
 !Compute the potential temperature for the vertical surfaces of the buildings
 
        do id=1,ndm
-          do iz=1,nz_um
+          do iz=1,nzu!nz_um
              do ibui=1,nbui
                 ptw(2*id-1,iz,ibui)=tw(2*id-1,iz,nwr_u,ibui)*(pr_u(iz)/p0)**(-rcp_u) 
                 ptw(2*id,iz,ibui)=tw(2*id,iz,nwr_u,ibui)*(pr_u(iz)/p0)**(-rcp_u) 
                 ptwin(2*id-1,iz,ibui)=twlev(2*id-1,iz,ibui)*(pr_u(iz)/p0)**(-rcp_u) 
                 ptwin(2*id,iz,ibui)=twlev(2*id,iz,ibui)*(pr_u(iz)/p0)**(-rcp_u) 
+              
              enddo
           enddo
        enddo
+!NEW CDRAG!
+     do iz=1,nz_um
+       alp=0.
+       do id=1,ndu
+        alp=alp+bs(id)/(ws(id)+bs(id))*pb(iz)
+       enddo
+       alp=alp/ndu
+       if(alp.lt.0.29)then
+        cdrag(iz)=3.32*alp**0.47
+       else
+        cdrag(iz)=1.85
+       endif
+     enddo
+
              
         
 ! Compute the implicit and explicit components of the sources or sinks on the "urban grid"
-     
-      call buildings(iurb,ndu,nzu,z0,ua_u,va_u,                               & 
-                     pt_u,pt0_u,ptg,ptr,da_u,ptw,ptwin,pwin_u(iurb),drst,     &                      
+
+      call buildings(iurb,ndu,nzu,z0,cdrag,ua_u,va_u,                               & 
+                     pt_u,pt0_u,ptg,ptr,ptrv,da_u,qv_u,pr_u,tmp_u,ptw,ptwin,pwin_u(iurb),drst,     &                      
                      uva_u,vva_u,uvb_u,vvb_u,tva_u,tvb_u,evb_u,qvb_u,qhb_u,   & 
-                     uhb_u,vhb_u,thb_u,ehb_u,ss,dt,sfw,sfg,sfr,               &
-                     sfwin,pb,bs_u,dz_u,sflev,lflev,sfvlev,lfvlev,tvb_ac)  
+                     uhb_u,vhb_u,thb_u,ehb_u,ss,dt,sfw,sfg,sfr,sfrpv,sfrv,lfrv,   &
+                     dgr,dg,lfr,lfg,                                                                    &
+                     sfwin,pb,bs_u,dz_u,sflev,lflev,sfvlev,lfvlev,tvb_ac,ix,iy,rsg,rs,qr,gr_frac_roof,  &
+                     pv_frac_roof,gr_flag,gr_type)  
       
+
+
+
 ! Calculation of the sensible heat fluxes for the ground, the wall and roof
 ! Sensible Heat Flux = density * Cp_U * ( A* potential temperature + B )
 ! where A and B are the implicit and explicit components of the heat sources or sinks.
@@ -1940,16 +2083,12 @@ use module_wrf_error
        enddo
        do id=1,ndu
           if ((bs(id)<=1.).OR.(bs(id)>=150.)) then
-!            write(*,*) 'WARNING, WIDTH OF THE BUILDING WRONG',id,bs(id)
-!            write(*,*) 'WIDTH OF THE STREET',id,ws(id)
              bs(id)=bs_u(id,iurb)
              ws(id)=ws_u(id,iurb)
              bs_urb(id,iurb)=bs_u(id,iurb)
              ws_urb(id,iurb)=ws_u(id,iurb)
           endif
           if ((ws(id)<=1.).OR.(ws(id)>=150.)) then
-!            write(*,*) 'WARNING, WIDTH OF THE STREET WRONG',id,ws(id)
-!            write(*,*) 'WIDTH OF THE BUILDING',id,bs(id)
              ws(id)=ws_u(id,iurb)
              bs(id)=bs_u(id,iurb)
              bs_urb(id,iurb)=bs_u(id,iurb)
@@ -2095,10 +2234,10 @@ use module_wrf_error
 ! ===6=8===============================================================72    
 
       subroutine modif_rad(iurb,nd,nz_u,z,ws,drst,strd,ss,pb,    &
-                          tw,tg,twlev,albg,albw,emw,emg,pwin,albwin,   &
+                          tw,tg_av,twlev,albg,albw,emw,emg,pwin,albwin,   &
                           emwin,fww,fwg,fgw,fsw,fsg,             &
-                          zr,deltar,ah,                          &    
-                          rs,rl,rsw,rsg,rlw,rlg)                       
+                          zr,deltar,ah,xlat,swddir,swddif,           &    
+                          rs,rl,rsw,rsd,rsg,rlw,rlg)                       
  
 ! ----------------------------------------------------------------------
 ! This routine computes the modification of the short wave and 
@@ -2121,7 +2260,7 @@ use module_wrf_error
       real ss(nz_um)          ! probability to have a building with height h
       real pb(nz_um)          ! probability to have a building with an height equal
       real tw(2*ndm,nz_um)    ! Temperature in each layer of the wall [K]
-      real tg(ndm,ng_u)         ! Temperature in each layer of the ground [K]
+      real tg_av(ndm)         ! Temperature in each layer of the ground [K]
       real albg                 ! Albedo of the ground for the current urban class
       real albw                 ! Albedo of the wall for the current urban class
       real emg                  ! Emissivity of ground for the current urban class
@@ -2137,6 +2276,10 @@ use module_wrf_error
       real deltar               ! Declination of the sun
       real rs                   ! solar radiation
       real rl                   ! downward flux of the longwave radiation
+      real xlat                 ! latitudine
+      real swddir               ! short wave direct solar radiation  _gl
+      real swddif               ! short wave diffuse solar radiation _gl
+
 !
 !New variables BEM
 !
@@ -2152,6 +2295,7 @@ use module_wrf_error
       real rlw(2*ndm,nz_um)     ! Long wave radiation at the walls
       real rsg(ndm)             ! Short wave radiation at the ground
       real rsw(2*ndm,nz_um)     ! Short wave radiation at the walls
+      real rsd(2*ndm,nz_um)     ! Direct Short wave radiation at the walls
 
 ! ----------------------------------------------------------------------
 ! LOCAL:
@@ -2162,27 +2306,31 @@ use module_wrf_error
 !  Calculation of the shadow effects
 
       call shadow_mas(nd,nz_u,zr,deltar,ah,drst,ws,ss,pb,z,        &
-                     rs,rsw,rsg)
+                     swddir,rsw,rsg,xlat)
+      rsd=rsw
 
 ! Calculation of the reflection effects          
       do id=1,nd
          call long_rad(iurb,nz_u,id,emw,emg,emwin,pwin,twlev,      &
-                      fwg,fww,fgw,fsw,fsg,tg,tw,rlg,rlw,rl,pb)
+                      fwg,fww,fgw,fsw,fsg,tg_av,tw,rlg,rlw,rl,pb)
 
          alb_av=pwin*albwin+(1.-pwin)*albw
          
-         call short_rad(iurb,nz_u,id,alb_av,albg,fwg,fww,fgw,rsg,rsw,pb)
-  
+        call short_rad_dd(iurb,nz_u,id,alb_av,                        &
+                           albg,swddif,fwg,fww,fgw,fsw,fsg,rsg,rsw,pb)
+ 
+ 
       enddo
       return
       end subroutine modif_rad
+
 
 
 ! ===6=8===============================================================72  
 ! ===6=8===============================================================72     
 
       subroutine surf_temp(nd,pr,dt,rl,rsg,rlg,              &
-                           tg,alag,csg,emg,albg,ptg,sfg,gfg) 
+                           tg,alag,csg,emg,albg,ptg,sfg,lfg,gfg) 
 
 ! ----------------------------------------------------------------------
 ! Computation of the surface temperatures for walls, ground and roofs 
@@ -2213,6 +2361,8 @@ use module_wrf_error
       
       real sfg(ndm)             ! Sensible heat flux from ground (road)
 
+      real lfg(ndm)             ! Latent heat flux from ground (road)
+
       real gfg(ndm)             ! Heat flux transferred from the surface of the ground (road) toward the interior
 
       real tg(ndm,ng_u)         ! Temperature in each layer of the ground [K]
@@ -2235,6 +2385,7 @@ use module_wrf_error
       
       data dzg_u /0.2,0.12,0.08,0.05,0.03,0.02,0.02,0.01,0.005,0.0025/
 
+     
 ! ----------------------------------------------------------------------
 ! END VARIABLES DEFINITIONS
 ! ----------------------------------------------------------------------
@@ -2248,10 +2399,13 @@ use module_wrf_error
         tg_tmp(ig)=tg(id,ig)
        end do
 !	        
+!       print*,'alag','cs',alag(1),csg(1)
+
        call soil_temp(ng_u,dzg_u,tg_tmp,ptg(id),alag,csg,      &
                      rsg(id),rlg(id),pr(1),                    &
                      dt,emg,albg,                              &
-                     rtg(id),sfg(id),gfg(id))    
+                     rtg(id),sfg(id),lfg(id),gfg(id))    
+
        do ig=1,ng_u
         tg(id,ig)=tg_tmp(ig)
        end do
@@ -2260,16 +2414,198 @@ use module_wrf_error
       
       return
       end subroutine surf_temp
+
+
+! ===6=8===============================================================72  
+! ===6=8===============================================================72     
+
+
+      subroutine roof_temp_veg(nd,pr,dt,rl,rsr,              &
+                           trv,ptrv,sfrv,lfrv,gfr,qr,rainbl,drain,hfgroof,tr,alar,dzr,csr,nzu,irri_now,gr_type,pv_frac_roof,tpvlev)
+
+! ----------------------------------------------------------------------
+! Computation of the surface temperatures for walls, ground and roofs 
+! ----------------------------------------------------------------------
+
+      implicit none
+
+! ----------------------------------------------------------------------
+! INPUT:
+! ----------------------------------------------------------------------
+      real rainbl
+      integer nd                ! Number of street direction for the current urban class
+
+      integer nzu                ! Number of urban layers
+      real irho(24)                ! Which hour of irrigation\
+
+
+      real alar           ! Roof thermal diffusivity for the current urban class [m^2 s^-1] 
+      real pv_frac_roof
+      real csr
+
+      real dzr          ! Layer sizes in the roofs [m]
+
+      real dt                   ! Time step
+
+      real pr(nz_um)            ! Air pressure
+
+      real rl                   ! Downward flux of the longwave radiation
+
+      real rsr                 ! Short wave radiation at the ground
+
+     real tpvlev(ndm,nz_um)      
+
+      real sfrv(ndm,nz_um)             ! Sensible heat flux from ground (road)
+
+      real lfrv(ndm,nz_um)             ! Latent heat flux from ground (road)
+
+      real gfr(ndm,nz_um)             ! Heat flux transferred from the surface of the ground (road) toward the interior
+
+      real trv(ndm,nz_um,ngr_u)         ! Temperature in each layer of the green roof [K]
+
+      real qr(ndm,nz_um,ngr_u)         ! Humidity in each layer of the green roof
+
+      real tr(ndm,nz_um,nwr_u)         !Roof temperature in BEM [K]
+ 
+! ----------------------------------------------------------------------
+! OUTPUT:
+! ----------------------------------------------------------------------
+      real ptrv(ndm,nz_um)             ! Ground potential temperatures 
+      
+      real hfgroof(ndm,nz_um)
+! ----------------------------------------------------------------------
+! LOCAL:
+! ----------------------------------------------------------------------
+      integer id,ig,ir,iw,iz
+
+      real alagr(ngr_u)           ! Green Roof thermal diffusivity for the current urban class [m^2 s^-1] 
+
+      real rtr(ndm,nz_um)             ! Total radiation at ground(road) surface (solar+incoming long+outgoing long)
+
+      real tr_tmp(ngr_u)
+
+      real qr_tmp(ngr_u)
+      real qr_tmp_old(ngr_u)
+      real dzgr_u(ngr_u)          ! Layer sizes in the green roof
+!MODIFICA
+      data dzgr_u /0.1,0.003,0.06,0.003,0.05,0.04,0.02,0.0125,0.005,0.0025/
+      real cs(ngr_u)  ! Specific heat of the ground material
+      real cw
+      parameter(cw=4.295e6)
+      real s(ngr_u)
+      real d(ngr_u)
+      real k(ngr_u)
+      real qr_m     ! mean soil moisture between layers
+      real qrmax(ngr_u)
+      real smax(ngr_u)
+      real kmax(ngr_u)
+      real b(ngr_u)
+      real cd(ngr_u)
+      real csa(4)
+      real ka(4)
+      real qref
+      parameter(qref=0.37)
+      data qrmax /0.0,0.0,0.0,0.0,0.439,0.37,0.37,0.37,0.37,0.37/
+      data smax /0,0,0,0,-0.01,-0.1,-0.1,-0.1,-0.1,-0.1/
+      data kmax /0,0,0,0,3.32e-3,2.162e-3,2.162e-3,2.162e-3,2.162e-3,2.162e-3/
+      data b /0,0,0,0,2.7,3.9,3.9,3.9,3.9,3.9/
+      data cd /0,0,0,0,331500,1.342e6,1.342e6,1.342e6,1.342e6,1.342e6/
+      data csa /7.5e4,2.1e6,4.48e4,2.1e6/
+      data ka /0.035,0.7,0.024,0.7/
+      real em_gr(1)
+      real alb_gr(1)
+      real irri_now
+      integer gr_type
+      real drain(ndm,nz_um)
+! ----------------------------------------------------------------------
+! END VARIABLES DEFINITIONS
+
+      if(gr_type.eq.1)then
+      em_gr=0.95
+      alb_gr=0.3
+      elseif(gr_type.eq.2)then
+       em_gr=0.83
+       alb_gr=0.154
+      endif
+
+
+      do iz=2,nzu
+
+      do id=1,nd
+
+
+
+
+!      Calculation for the ground surfaces
+
+       do ig=1,ngr_u
+        tr_tmp(ig)=trv(id,iz,ig)
+        qr(id,iz,ig) = max(qr(id,iz,ig),1e-6) !cenlin, 11/4/2020
+        qr_tmp(ig)=qr(id,iz,ig)
+        qr_tmp_old(ig)=qr(id,iz,ig) 
+
+      if(ig.le.4) then
+ 
+       cs(ig)=csa(ig)
+       alagr(ig)=ka(ig)/csa(ig)
+
+      else
+ 
+ 
+        if (ig.gt.5) then
+        qr_m=(qr(id,iz,ig)*dzgr_u(ig-1)+qr(id,iz,ig-1)*dzgr_u(ig))/(dzgr_u(ig)+dzgr_u(ig-1))
+        else
+        qr_m=qr(id,iz,ig)
+        endif
+        cs(ig)=(1-qr_m)*cd(ig)+qr_m*cw
+        s(ig)=smax(ig)*(qrmax(ig)/qr_m)**b(ig)
+        k(ig)=kmax(ig)*(qr_m/qrmax(ig))**(2*b(ig)+3)
+        d(ig)=-b(ig)*kmax(ig)*smax(ig)*((qr_m/qrmax(ig))**(b(ig)+3))/qr_m
+        if (log10(abs(s(ig))).le.5.1) then
+          alagr(ig)=exp(-(log10(abs(s(ig)))+2.7))*4.186e2/cs(ig)
+        endif
+        if (log10(abs(s(ig))).gt.5.1) then
+          alagr(ig)=0.00041*4.186e2/cs(ig)
+        endif
+
+       endif
+
+        end do
+        hfgroof(id,iz)=(alar/csr+alagr(1))*(tr_tmp(1)-tr(id,iz,5))/(dzr+dzgr_u(1))
+ 
+       call soil_temp_veg(hfgroof(id,iz),ngr_u,dzgr_u,tr_tmp,ptrv(id,iz),alagr,cs,      &
+                     rsr,rl,pr(iz),                    &
+                     dt,em_gr(1),alb_gr(1),                              &
+                     rtr(id,iz),sfrv(id,iz),lfrv(id,iz),gfr(id,iz),pv_frac_roof,tpvlev(id,iz))
+       do ig=1,ngr_u
+        trv(id,iz,ig)=tr_tmp(ig)
+       end do
+        drain(id,iz)=kmax(5)*(qr(id,iz,5)/qrmax(5))**(2*b(5)+3)
+        call soil_moist(ngr_u,dzgr_u,qr_tmp,dt,lfrv(id,iz),d,k,rainbl,drain(id,iz),irri_now)
+ 
      
+        do ig=1,ngr_u
+          ! qr(id,iz,ig)=min(qr_tmp(ig),qrmax(ig))
+           qr(id,iz,ig)=max(min(qr_tmp(ig),qrmax(ig)),1e-6) !cenlin,11/4/2020
+         end do
+   
+      end do !id
+      end do !iz
+
+      return
+      end subroutine roof_temp_veg
+
 ! ===6=8===============================================================72     
 ! ===6=8===============================================================72  
 
-      subroutine buildings(iurb,nd,nz,z0,ua_u,va_u,pt_u,pt0_u,       &
-                        ptg,ptr,da_u,ptw,ptwin,pwin,                 &
+      subroutine buildings(iurb,nd,nz,z0,cdrag,ua_u,va_u,pt_u,pt0_u,       &
+                        ptg,ptr,ptrv,da_u,qv_u,pr_u,tmp_u,ptw,ptwin,pwin,                 &
                         drst,uva_u,vva_u,uvb_u,vvb_u,                &
                         tva_u,tvb_u,evb_u,qvb_u,qhb_u,               &
-                        uhb_u,vhb_u,thb_u,ehb_u,ss,dt,sfw,sfg,sfr,   &
-                        sfwin,pb,bs_u,dz_u,sflev,lflev,sfvlev,lfvlev,tvb_ac)                  
+                        uhb_u,vhb_u,thb_u,ehb_u,ss,dt,sfw,sfg,sfr,sfrpv,sfrv,lfrv,   &
+                        dgr,dg,lfr,lfg,                                               &
+                        sfwin,pb,bs_u,dz_u,sflev,lflev,sfvlev,lfvlev,tvb_ac,ix,iy,rsg,rs,qr,gr_frac_roof,  &
+                        pv_frac_roof,gr_flag,gr_type)                  
 
 ! ----------------------------------------------------------------------
 ! This routine computes the sources or sinks of the different quantities 
@@ -2284,23 +2620,34 @@ use module_wrf_error
 ! INPUT:
 ! ----------------------------------------------------------------------
       integer nd                ! Number of street direction for the current urban class
+      integer ix,iy
       integer nz                ! number of vertical space steps
       real ua_u(nz_um)          ! Wind speed in the x direction on the urban grid
       real va_u(nz_um)          ! Wind speed in the y direction on the urban grid
       real da_u(nz_um)          ! air density on the urban grid
+      real qv_u(nz_um)          ! specific humidity on the urban grid
+      real pr_u(nz_um)          ! pressure on the urban grid
+      real tmp_u(nz_um)         ! temperaure on the urban grid
       real drst(ndm)            ! Street directions for the current urban class
       real dz
       real pt_u(nz_um)          ! Potential temperature on the urban grid
       real pt0_u(nz_um)         ! reference potential temperature on the urban grid
       real ptg(ndm)             ! Ground potential temperatures 
       real ptr(ndm,nz_um)       ! Roof potential temperatures 
+      real ptrv(ndm,nz_um)      ! Green Roof potential temperatures 
       real ptw(2*ndm,nz_um,nbui_max)     ! Walls potential temperatures 
       real ss(nz_um)            ! probability to have a building with height h
       real pb(nz_um)
+      real cdrag(nz_um)
       real z0(ndm,nz_um)        ! Roughness lengths "profiles"
       real dt ! time step
       integer iurb              !Urban class
-
+      real rsg(ndm)             ! Solar Radiation
+      real rs                  ! Solar Radiation
+      real qr(ndm,nz_um,ngr_u)         ! Ground Soil Moisture
+      real trv(ndm,nz_um,ngr_u)         ! Ground Soil Moisture
+      real roof_frac
+      real road_frac
 !
 !New variables (BEM)
 !
@@ -2315,6 +2662,10 @@ use module_wrf_error
       real ptwin(2*ndm,nz_um,nbui_max)  ! window potential temperature
       real pwin
       real tvb_ac(2*ndm,nz_um)
+      real gr_frac_roof
+      real pv_frac_roof
+      integer gr_flag,gr_type
+
 ! ----------------------------------------------------------------------
 ! OUTPUT:
 ! ----------------------------------------------------------------------
@@ -2334,10 +2685,21 @@ use module_wrf_error
       real tvb_u(2*ndm,nz_um)   ! Temperature          Vertical surfaces, B (explicit) term
       real ehb_u(ndm,nz_um)   ! Energy (TKE)       Horizontal surfaces, B (explicit) term
       real evb_u(2*ndm,nz_um)   ! Energy (TKE)         Vertical surfaces, B (explicit) term
+      real uhb(2*ndm,nz_um)
+      real vhb(2*ndm,nz_um)
+      real ehb(2*ndm,nz_um)
       real sfw(2*ndm,nz_um,nbui_max)   ! sensible heat flux from walls
       real sfwin(2*ndm,nz_um,nbui_max) ! sensible heat flux form windows
       real sfr(ndm,nz_um)           ! sensible heat flux from roof
+      real sfrv(ndm,nz_um)           ! sensible heat flux from roof
+      real lfrv(ndm,nz_um)           ! Latent heat flux from roof
+      real dgr(ndm,nz_um)           ! sensible heat flux from roof
+      real dg(ndm)
+      real lfr(ndm,nz_um)           ! Latent heat flux from roof
+      real lfg(ndm)                 ! Latent heat flux from street
+      real sfrpv(ndm,nz_um)         ! sensible heat flux from PV panels
       real sfg(ndm)                 ! sensible heat flux from street
+
 
 ! ----------------------------------------------------------------------
 ! LOCAL:
@@ -2349,9 +2711,22 @@ use module_wrf_error
       real vvb_tmp 
       real evb_tmp     
       integer nlev(nz_um)
-      integer id,iz,ibui,nbui
-
-! ----------------------------------------------------------------------
+      integer id,iz,ibui,nbui,il
+      real wfg     !Ground water pool fraction
+      real wfr     !Roof water pool fraction 
+      real uhbv(2*ndm,nz_um)
+      real vhbv(2*ndm,nz_um)
+      real ehbv(2*ndm,nz_um)
+      real z0v     !Vegetation roughness
+      parameter(z0v=0.01)
+      real resg
+      real rsveg
+      real f1,f2,f3,f4
+      integer rsv(2)
+      real qr_tmp(ngr_u)
+      data rsv /0,1/
+      real fh,ric,utot
+!------------------------------------------------------------------
 ! END VARIABLES DEFINITIONS
 ! ----------------------------------------------------------------------
       dz=dz_u
@@ -2373,9 +2748,17 @@ use module_wrf_error
       evb_u=0.
       qvb_u=0.
       qhb_u=0.
+      
+      uhb=0.
+      vhb=0.
+      ehb=0.
+      uhbv=0.
+      vhbv=0.
+      ehbv=0.
+
 
       do iz=1,nz_um		   
-         if(ss(iz).gt.0) then		
+         if(ss(iz).gt.0)then		
            ibui=ibui+1
            d_urb(ibui)=ss(iz)
            nlev(ibui)=iz-1
@@ -2383,31 +2766,70 @@ use module_wrf_error
          endif
       enddo
 
-      do id=1,nd
-
 !        Calculation at the ground surfaces
-
-         call flux_flat(dz,z0(id,1),ua_u(1),va_u(1),pt_u(1),pt0_u(1),  &
-                       ptg(id),uhb_u(id,1),                            & 
-                       vhb_u(id,1),sfg(id),ehb_u(id,1),da_u(1))          
-         thb_u(id,1)=- sfg(id)/(da_u(1)*cp_u)  
-              
-!        Calculation at the roof surfaces    
-
+      do id=1,nd
+      
+          call flux_flat(dz,z0(id,1),ua_u(1),va_u(1),pt_u(1),pt0_u(1),  &
+                       ptg(id),qv_u(1),uhb(id,1),                            & 
+                       vhb(id,1),sfg(id),lfg(id),ehb(id,1),da_u(1),pr_u(1))        
+          if(dg(id).gt.0)then
+           wfg=dg(id)/dgmax
+           lfg(id)=-da_u(1)*latent*(-(wfg*lfg(id))/(da_u(1)*latent))
+          else
+           qhb_u(id,1)=0.
+           lfg(id)=0.
+          endif   
+         thb_u(id,1)=-(sfg(id))/(da_u(1)*cp_u)
+         vhb_u(id,1)=vhb(id,1)
+         uhb_u(id,1)=uhb(id,1)
+         ehb_u(id,1)=ehb(id,1)
+         qhb_u(id,1)=-lfg(id)/(da_u(1)*latent)
          do iz=2,nz
             if(ss(iz).gt.0)then
-               call flux_flat(dz,z0(id,iz),ua_u(iz),                  &              
-                       va_u(iz),pt_u(iz),pt0_u(iz),                   &   
-                       ptr(id,iz),uhb_u(id,iz),                       &   
-                       vhb_u(id,iz),sfr(id,iz),ehb_u(id,iz),da_u(iz)) 
-               thb_u(id,iz)=- sfr(id,iz)/(da_u(iz)*cp_u) 
+            
+               call flux_flat(dz,z0(id,iz),ua_u(iz),&
+                       va_u(iz),pt_u(iz),pt0_u(iz), &
+                       ptr(id,iz),qv_u(iz),uhb(id,iz),       &
+                       vhb(id,iz),sfr(id,iz),lfr(id,iz),ehb(id,iz),da_u(iz),pr_u(iz))
+         if(dgr(id,iz).gt.0)then
+          wfr=dgr(id,iz)/drmax
+          lfr(id,iz)=-da_u(iz)*latent*(-(wfr*lfr(id,iz))/(da_u(iz)*latent))
+         else
+          lfr(id,iz)=0.
+         endif
+         if(gr_flag.eq.1.and.gr_frac_roof.gt.0.)then  
+         do il=1,ngr_u
+           qr_tmp(il)=qr(id,iz,il)
+         enddo
+               call flux_flat_roof(dz,z0v,ua_u(iz),va_u(iz),pt_u(iz),pt0_u(iz),  &
+                       ptrv(id,iz),uhbv(id,iz),                            &
+                       vhbv(id,iz),sfrv(id,iz),lfrv(id,iz),ehbv(id,iz),da_u(iz),qv_u(iz),pr_u(iz),rs,qr_tmp,resg,rsveg,f1,f2,f3,f4,gr_type,pv_frac_roof)
+         sfr(id,iz)=sfr(id,iz)+pv_frac_roof*sfrpv(id,iz) 
+         thb_u(id,iz)=-((1.-gr_frac_roof)*sfr(id,iz)+gr_frac_roof*sfrv(id,iz))/(da_u(iz)*cp_u)
+         vhb_u(id,iz)=(1.-gr_frac_roof)*vhb(id,iz)+gr_frac_roof*vhbv(id,iz)
+         uhb_u(id,iz)=(1.-gr_frac_roof)*uhb(id,iz)+gr_frac_roof*uhbv(id,iz)
+         ehb_u(id,iz)=(1.-gr_frac_roof)*ehb(id,iz)+gr_frac_roof*ehbv(id,iz)
+         qhb_u(id,iz)=-(gr_frac_roof*lfrv(id,iz)+(1.-gr_frac_roof)*lfr(id,iz))/(da_u(iz)*latent)
+         sfr(id,iz)=sfr(id,iz)-pv_frac_roof*sfrpv(id,iz)
+         else
+         sfr(id,iz)=sfr(id,iz)+pv_frac_roof*sfrpv(id,iz)
+         thb_u(id,iz)=-sfr(id,iz)/(da_u(iz)*cp_u)
+         vhb_u(id,iz)=vhb(id,iz)
+         uhb_u(id,iz)=uhb(id,iz)
+         ehb_u(id,iz)=ehb(id,iz)
+         qhb_u(id,iz)=-lfr(id,iz)/(da_u(iz)*latent)
+         sfr(id,iz)=sfr(id,iz)-pv_frac_roof*sfrpv(id,iz)
+         endif
             else
                uhb_u(id,iz) = 0.0
                vhb_u(id,iz) = 0.0
                thb_u(id,iz) = 0.0
                ehb_u(id,iz) = 0.0
+               qhb_u(id,iz) = 0.0
             endif
-         end do
+         enddo
+         
+         
 
 !        Calculation at the wall surfaces        
  
@@ -2419,7 +2841,7 @@ use module_wrf_error
                         uva_tmp,vva_tmp,                                    &   
                         uvb_tmp,vvb_tmp,                                    &   
                         sfw(2*id-1,iz,ibui),sfwin(2*id-1,iz,ibui),          &   
-                        evb_tmp,drst(id),dt)      
+                        evb_tmp,drst(id),dt,cdrag(iz))      
    
             if (pb(iz+1).gt.0.) then
 
@@ -2444,7 +2866,7 @@ use module_wrf_error
                         uva_tmp,vva_tmp,                           &    
                         uvb_tmp,vvb_tmp,                           &    
                         sfw(2*id,iz,ibui),sfwin(2*id,iz,ibui),     &   
-                        evb_tmp,drst(id),dt) 
+                        evb_tmp,drst(id),dt,cdrag(iz)) 
 
             if (pb(iz+1).gt.0.) then
 
@@ -2785,7 +3207,7 @@ use module_wrf_error
 ! ===6=8===============================================================72   
 
       subroutine shadow_mas(nd,nz_u,zr,deltar,ah,drst,ws,ss,pb,z,    &
-                           rs,rsw,rsg)
+                           swddir,rsw,rsg,xlat)
         
 ! ----------------------------------------------------------------------
 !         Modification of short wave radiation to take into account
@@ -2802,13 +3224,14 @@ use module_wrf_error
       real ah                   ! Hour angle (it should come from the radiation routine)
       real deltar               ! Declination of the sun
       real drst(ndm)            ! street directions for the current urban class
-      real rs                   ! solar radiation
+      real swddir                   ! solar radiation
       real ss(nz_um)          ! probability to have a building with height h
       real pb(nz_um)          ! Probability that a building has an height greater or equal to h
       real ws(ndm)              ! Street width of the current urban class
       real z(nz_um)           ! Height of the urban grid levels
       real zr                   ! zenith angle
-
+      real xlat
+      real xlat_r
 ! ----------------------------------------------------------------------
 ! OUTPUT:
 ! ----------------------------------------------------------------------
@@ -2825,23 +3248,29 @@ use module_wrf_error
 ! END VARIABLES DEFINITIONS
 ! ----------------------------------------------------------------------
 
-      if(rs.eq.0.or.sin(zr).eq.1)then
-         do id=1,nd
-            rsg(id)=0.
-            do iz=1,nz_u
+         xlat_r=xlat*pi/180
+
+        if(swddir.eq.0.or.sin(zr).eq.1)then
+           do id=1,nd
+             rsg(id)=0.
+             do iz=1,nz_u
                rsw(2*id-1,iz)=0.
                rsw(2*id,iz)=0.
             enddo
          enddo
-      else            
+        else
 !test              
-         if(abs(sin(zr)).gt.1.e-10)then
+
+        if(abs(sin(zr)).gt.1.e-10)then
           if(cos(deltar)*sin(ah)/sin(zr).ge.1)then
            bbb=pi/2.
           elseif(cos(deltar)*sin(ah)/sin(zr).le.-1)then
            bbb=-pi/2.
           else
-           bbb=asin(cos(deltar)*sin(ah)/sin(zr))
+           bbb=asin(cos(deltar)*sin(ah)/sin(zr))                !
+           if(sin(deltar).lt.(cos(zr)*sin(xlat_r)))then         !
+           bbb=pi-bbb                                           !
+          endif
           endif
          else
           if(cos(deltar)*sin(ah).ge.0)then
@@ -2850,58 +3279,63 @@ use module_wrf_error
            bbb=-pi/2.
           endif
          endif
-
-         phix=zr
+        phix=zr
            
          do id=1,nd
-        
+         
             rsg(id)=0.
-           
+
             aae=bbb-drst(id)
             aaw=bbb-drst(id)+pi
-                    
+
             do iz=1,nz_u
                rsw(2*id-1,iz)=0.
-               rsw(2*id,iz)=0.          
-            if(pb(iz+1).gt.0.)then          
-               do jz=1,nz_u                    
+               rsw(2*id,iz)=0.
+            if(pb(iz+1).gt.0.)then
+               do jz=1,nz_u
                 if(abs(sin(aae)).gt.1.e-10)then
-                  call shade_wall(z(iz),z(iz+1),z(jz+1),phix,aae,   &    
-                      ws(id),rd)                  
-                  rsw(2*id-1,iz)=rsw(2*id-1,iz)+rs*rd*ss(jz+1)/pb(iz+1)
-                endif
-              
-                if(abs(sin(aaw)).gt.1.e-10)then
-                  call shade_wall(z(iz),z(iz+1),z(jz+1),phix,aaw,   &    
+                  call shade_wall(z(iz),z(iz+1),z(jz+1),phix,aae,   &
                       ws(id),rd)
-                  rsw(2*id,iz)=rsw(2*id,iz)+rs*rd*ss(jz+1)/pb(iz+1)                  
+                  rsw(2*id-1,iz)=rsw(2*id-1,iz)+swddir*rd*ss(jz+1)/pb(iz+1)
                 endif
-               enddo             
-            endif  
+
+                if(abs(sin(aaw)).gt.1.e-10)then
+                  call shade_wall(z(iz),z(iz+1),z(jz+1),phix,aaw,   &
+                      ws(id),rd)
+                  rsw(2*id,iz)=rsw(2*id,iz)+swddir*rd*ss(jz+1)/pb(iz+1)
+                endif
+               enddo
+            endif
             enddo
         if(abs(sin(aae)).gt.1.e-10)then
             wsd=abs(ws(id)/sin(aae))
-              
-            do jz=1,nz_u           
+
+            do jz=1,nz_u
                rd=max(0.,wsd-z(jz+1)*tan(phix))
-               rsg(id)=rsg(id)+rs*rd*ss(jz+1)/wsd          
+               rsg(id)=rsg(id)+swddir*rd*ss(jz+1)/wsd
             enddo
             rtot=0.
-           
+
             do iz=1,nz_u
                rtot=rtot+(rsw(2*id,iz)+rsw(2*id-1,iz))*            &
                          (z(iz+1)-z(iz))
             enddo
             rtot=rtot+rsg(id)*ws(id)
         else
-            rsg(id)=rs
+            rsg(id)=swddir
         endif
+
+
             
          enddo
       endif
          
       return
       end subroutine shadow_mas
+
+
+
+
          
 ! ===6=8===============================================================72     
 ! ===6=8===============================================================72     
@@ -2962,7 +3396,7 @@ use module_wrf_error
 ! ===6=8===============================================================72     
 
       subroutine long_rad(iurb,nz_u,id,emw,emg,emwin,pwin,twlev,&
-                         fwg,fww,fgw,fsw,fsg,tg,tw,rlg,rlw,rl,pb)
+                         fwg,fww,fgw,fsw,fsg,tg_av,tw,rlg,rlw,rl,pb)
 
 ! ----------------------------------------------------------------------
 ! This routine computes the effects of the reflections of long-wave 
@@ -2992,7 +3426,7 @@ use module_wrf_error
       integer nz_u                    ! Number of layer in the urban grid
       real pb(nz_um)                  ! Probability to have a building with an height equal
       real rl                         ! Downward flux of the longwave radiation
-      real tg(ndm,ng_u)               ! Temperature in each layer of the ground [K]
+      real tg_av(ndm)               ! Temperature in each layer of the ground [K]
       real tw(2*ndm,nz_um)            ! Temperature in each layer of the wall [K]
 !
 !New Variables for BEM
@@ -3038,7 +3472,7 @@ use module_wrf_error
 !!      aaa(i,2*nz_u+1)=-(1.-emg)*fgw(i,id,iurb)*pb(i+1)
         aaa(i,2*nz_u+1)=-(1.-emg)*fgw(i,id,iurb)
         
-        bbb(i)=fsw(i,id,iurb)*rl+emg*fgw(i,id,iurb)*sigma*tg(id,ng_u)**4
+        bbb(i)=fsw(i,id,iurb)*rl+emg*fgw(i,id,iurb)*sigma*tg_av(id)**4
         do j=1,nz_u
            bbb(i)=bbb(i)+pb(j+1)*sigma*fww(j,i,id,iurb)* &
                  (emw*(1.-pwin)*tw(2*id,j)**4+emwin*pwin*twlev(2*id,j)**4)+ &
@@ -3065,7 +3499,7 @@ use module_wrf_error
         aaa(i,2*nz_u+1)=-(1.-emg)*fgw(i-nz_u,id,iurb)
         
         bbb(i)=fsw(i-nz_u,id,iurb)*rl+  &     
-               emg*fgw(i-nz_u,id,iurb)*sigma*tg(id,ng_u)**4
+               emg*fgw(i-nz_u,id,iurb)*sigma*tg_av(id)**4
 
         do j=1,nz_u
          bbb(i)=bbb(i)+pb(j+1)*sigma*fww(j,i-nz_u,id,iurb)*  &   
@@ -3117,8 +3551,9 @@ use module_wrf_error
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
 
-       subroutine short_rad(iurb,nz_u,id,albw,                        & 
-                           albg,fwg,fww,fgw,rsg,rsw,pb)
+ 
+      subroutine short_rad_dd(iurb,nz_u,id,albw,                        & 
+                           albg,rsdif,fwg,fww,fgw,fsw,fsg,rsg,rsw,pb)
 
 ! ----------------------------------------------------------------------
 ! This routine computes the effects of the reflections of short-wave 
@@ -3138,9 +3573,12 @@ use module_wrf_error
 ! ----------------------------------------------------------------------
       real albg                 ! Albedo of the ground for the current urban class
       real albw                 ! Albedo of the wall for the current urban class
+      real rsdif                ! diffused short wave radiation
       real fgw(nz_um,ndm,nurbm)       ! View factors from ground to wall
       real fwg(nz_um,ndm,nurbm)       ! View factors from wall to ground
       real fww(nz_um,nz_um,ndm,nurbm) ! View factors from wall to wall
+      real fsg(ndm,nurbm)             ! View factors from sky to ground
+      real fsw(nz_um,ndm,nurbm)       ! View factors from sky to wall
       integer id                ! current street direction 
       integer iurb              ! current urban class
       integer nz_u              ! Number of layer in the urban grid
@@ -3166,67 +3604,69 @@ use module_wrf_error
       
 ! west wall
        
-      do i=1,nz_u
+         
+        do i=1,nz_u
          do j=1,nz_u
             aaa(i,j)=0.
          enddo
-         
-         aaa(i,i)=1.        
-         
+
+         aaa(i,i)=1.
+
          do j=nz_u+1,2*nz_u
             aaa(i,j)=-albw*fww(j-nz_u,i,id,iurb)*pb(j-nz_u+1)
          enddo
-         
-         aaa(i,2*nz_u+1)=-albg*fgw(i,id,iurb)
-         bbb(i)=rsw(2*id-1,i)
-         
-      enddo
-       
-! east wall
 
-      do i=1+nz_u,2*nz_u
+         aaa(i,2*nz_u+1)=-albg*fgw(i,id,iurb)
+         bbb(i)=rsw(2*id-1,i)+fsw(i,id,iurb)*rsdif
+
+      enddo
+ 
+! east wall
+       do i=1+nz_u,2*nz_u
          do j=1,nz_u
             aaa(i,j)=-albw*fww(j,i-nz_u,id,iurb)*pb(j+1)
          enddo
-         
+
          do j=1+nz_u,2*nz_u
             aaa(i,j)=0.
          enddo
-         
+
         aaa(i,i)=1.
         aaa(i,2*nz_u+1)=-albg*fgw(i-nz_u,id,iurb)
-        bbb(i)=rsw(2*id,i-nz_u)
-        
+        bbb(i)=rsw(2*id,i-nz_u)+fsw(i-nz_u,id,iurb)*rsdif
+
       enddo
 
-! ground
 
+! ground
       do j=1,nz_u
          aaa(2*nz_u+1,j)=-albw*fwg(j,id,iurb)*pb(j+1)
       enddo
-       
+
       do j=nz_u+1,2*nz_u
          aaa(2*nz_u+1,j)=-albw*fwg(j-nz_u,id,iurb)*pb(j-nz_u+1)
       enddo
-       
+
       aaa(2*nz_u+1,2*nz_u+1)=1.
-      bbb(2*nz_u+1)=rsg(id)
-       
+      bbb(2*nz_u+1)=rsg(id)+fsg(id,iurb)*rsdif
+
       call gaussj(aaa,2*nz_u+1,bbb,2*nz_um+1)
 
       do i=1,nz_u
          rsw(2*id-1,i)=bbb(i)
       enddo
-       
+
       do i=nz_u+1,2*nz_u
-         rsw(2*id,i-nz_u)=bbb(i) 
+         rsw(2*id,i-nz_u)=bbb(i)
       enddo
-       
+
       rsg(id)=bbb(2*nz_u+1)
+
        
       return
-      end subroutine short_rad
-             
+      end subroutine short_rad_dd
+
+
 
 ! ===6=8===============================================================72     
 ! ===6=8===============================================================72     
@@ -3308,7 +3748,7 @@ use module_wrf_error
          endif
          
          if(a(icol,icol).eq.0) FATAL_ERROR('singular matrix in gaussj')
- 
+         
          pivinv=1./a(icol,icol)
          a(icol,icol)=1
          
@@ -3334,12 +3774,101 @@ use module_wrf_error
       
       return
       end subroutine gaussj
+
+
+
+! ===6=8===============================================================72     
+! ===6=8===============================================================72     
+
+      subroutine soil_moist(nz,dz,qv,dt,lf,d,k,rainbl,drain,irri_now)
+
+! ----------------------------------------------------------------------
+! This routine solves the Fourier diffusion equation for heat in 
+! the material (wall, roof, or ground). Resolution is done implicitely.
+! Boundary conditions are: 
+! - fixed temperature at the interior
+! - energy budget at the surface
+! ----------------------------------------------------------------------
+
+      implicit none
+
+
+
+! ----------------------------------------------------------------------
+! INPUT:
+! ----------------------------------------------------------------------
+      integer nz                ! Number of layers
+      real dt                   ! Time step
+      real lf                   ! Latent heat flux at the surface
+      real qv(nz)               ! Moisture in each layer [K]
+      real dz(nz)               ! Layer sizes [m]
+      real rainbl               ! Rainfall [mm]
+      real d(nz)                ! Soil water diffusivity
+      real k(nz)                ! Hydraulic conductivity
+      real gr                   ! Dummy variable 
+      real drain
+      real irri_now
+! ----------------------------------------------------------------------
+! OUTPUT:
+! ----------------------------------------------------------------------
+  
+
+! ----------------------------------------------------------------------
+! LOCAL:
+! ----------------------------------------------------------------------
+      integer iz
+      real a(nz,3)
+      real alpha
+      real c(nz)
+      real cddz(nz+2)
+      real dw     !water density Kg/m3
+      parameter(dw=1000.)
+!----------------------------------------------------------------------
+! END VARIABLES DEFINITIONS
+! ----------------------------------------------------------------------
+
+      alpha=rainbl/(dw*dt)+lf/latent/dw+irri_now/dw
+      cddz(1)=0.
+      do iz=2,nz
+         cddz(iz)=2.*d(iz)/(dz(iz)+dz(iz-1))
+      enddo
+      do iz=1,4
+         a(iz,1)=0.
+         a(iz,2)=1.
+         a(iz,3)=0.
+         c(iz)=qv(iz)
+      enddo
+      do iz=6,nz-1
+         a(iz,1)=-cddz(iz)*dt/dz(iz)
+         a(iz,2)=1.+dt*(cddz(iz)+cddz(iz+1))/dz(iz)
+         a(iz,3)=-cddz(iz+1)*dt/dz(iz)
+         c(iz)=qv(iz)+dt*(k(iz+1)-k(iz))/dz(iz)
+      enddo
+         a(5,1)=0.
+         a(5,2)=1.+dt*(cddz(5+1))/dz(5)
+         a(5,3)=-cddz(5+1)*dt/dz(5)
+         c(5)=qv(5)+dt*(k(5+1)-drain)/dz(5)
+      
+
+      a(nz,1)=-dt*cddz(nz)/dz(nz)
+      a(nz,2)=1.+dt*cddz(nz)/dz(nz)
+      a(nz,3)=0.
+      c(nz)=qv(nz)+dt*alpha/dz(nz)-dt*k(nz-1)/dz(nz)
+
+      call invert(nz,a,c,qv)
+
+      return
+      end subroutine soil_moist
          
 ! ===6=8===============================================================72     
 ! ===6=8===============================================================72     
+  
+
+! ===6=8===============================================================72     
+! ===6=8===============================================================72     
        
-      subroutine soil_temp(nz,dz,temp,pt,ala,cs,                       &
-                          rs,rl,press,dt,em,alb,rt,sf,gf)
+      subroutine soil_temp_veg(heflro,nz,dz,temp,pt,ala,cs,                       &
+                          rs,rl,press,dt,em,alb,rt,sf,lf,gf,pv_frac_roof,tpv)
 
 ! ----------------------------------------------------------------------
 ! This routine solves the Fourier diffusion equation for heat in 
@@ -3366,9 +3895,107 @@ use module_wrf_error
       real rl                   ! Downward flux of the longwave radiation
       real rs                   ! Solar radiation
       real sf                   ! Sensible heat flux at the surface
+      real lf                   ! Latent heat flux at the surface
       real temp(nz)             ! Temperature in each layer [K]
       real dz(nz)               ! Layer sizes [m]
+      real heflro                ! Heat flux between roof and green roof 
+      real rs_eff
+      real rl_eff
+      real tpv
+      real pv_frac_roof
+! ----------------------------------------------------------------------
+! OUTPUT:
+! ----------------------------------------------------------------------
+      real gf                   ! Heat flux transferred from the surface toward the interior
+      real pt                   ! Potential temperature at the surface
+      real rt                   ! Total radiation at the surface (solar+incoming long+outgoing long)
 
+! ----------------------------------------------------------------------
+! LOCAL:
+! ----------------------------------------------------------------------
+      integer iz
+      real a(nz,3)
+      real alpha
+      real c(nz)
+      real cddz(nz+2)
+      real tsig
+
+! ----------------------------------------------------------------------
+! END VARIABLES DEFINITIONS
+! ----------------------------------------------------------------------
+     if(pv_frac_roof.gt.0)then 
+     rl_eff=(1-pv_frac_roof)*em*rl+em*sigma*tpv**4*pv_frac_roof
+      rs_eff=(1.-pv_frac_roof)*rs
+     else
+      rl_eff=em*rl
+      rs_eff=rs
+     endif
+      tsig=temp(nz)
+      alpha=(1.-alb)*rs_eff+rl_eff-em*sigma*(tsig**4)+sf+lf
+      cddz(1)=ala(1)/dz(1)
+      do iz=2,nz
+         cddz(iz)=2.*ala(iz)/(dz(iz)+dz(iz-1))
+      enddo
+      
+      a(1,1)=0.
+      a(1,2)=1.
+      a(1,3)=0.
+      c(1)=temp(1)-heflro*dt/dz(1)
+      do iz=2,nz-1
+         a(iz,1)=-cddz(iz)*dt/dz(iz)
+         a(iz,2)=1.+dt*(cddz(iz)+cddz(iz+1))/dz(iz)          
+         a(iz,3)=-cddz(iz+1)*dt/dz(iz)
+         c(iz)=temp(iz)
+      enddo          
+      a(nz,1)=-dt*cddz(nz)/dz(nz)
+      a(nz,2)=1.+dt*cddz(nz)/dz(nz)
+      a(nz,3)=0.
+      c(nz)=temp(nz)+dt*alpha/cs(nz)/dz(nz) 
+      
+      call invert(nz,a,c,temp)
+
+      pt=temp(nz)*(press/1.e+5)**(-rcp_u)
+
+      rt=(1.-alb)*rs_eff+rl_eff-em*sigma*(tsig**4.)
+                        
+      gf=(1.-alb)*rs_eff+rl_eff-em*sigma*(tsig**4.)+sf                                   
+      return
+      end subroutine soil_temp_veg
+      
+! ===6=8===============================================================72     
+! ===6=8===============================================================72     
+       
+      subroutine soil_temp(nz,dz,temp,pt,ala,cs,                       &
+                          rs,rl,press,dt,em,alb,rt,sf,lf,gf)
+
+! ----------------------------------------------------------------------
+! This routine solves the Fourier diffusion equation for heat in 
+! the material (wall, roof, or ground). Resolution is done implicitely.
+! Boundary conditions are: 
+! - fixed temperature at the interior
+! - energy budget at the surface
+! ----------------------------------------------------------------------
+
+      implicit none
+
+     
+                
+! ----------------------------------------------------------------------
+! INPUT:
+! ----------------------------------------------------------------------
+      integer nz                ! Number of layers
+      real ala(nz)              ! Thermal diffusivity in each layers [m^2 s^-1] 
+      real alb                  ! Albedo of the surface
+      real cs(nz)               ! Specific heat of the material [J m^3 K^-1]
+      real dt                   ! Time step
+      real em                   ! Emissivity of the surface
+      real press                ! Pressure at ground level
+      real rl                   ! Downward flux of the longwave radiation
+      real rs                   ! Solar radiation
+      real sf                   ! Sensible heat flux at the surface
+      real lf                   ! Latent heat flux at the surface
+      real temp(nz)             ! Temperature in each layer [K]
+      real dz(nz)               ! Layer sizes [m]
 
 ! ----------------------------------------------------------------------
 ! OUTPUT:
@@ -3392,47 +4019,43 @@ use module_wrf_error
 ! ----------------------------------------------------------------------
        
       tsig=temp(nz)
-      alpha=(1.-alb)*rs+em*rl-em*sigma*(tsig**4)+sf
+      alpha=(1.-alb)*rs+em*rl-em*sigma*(tsig**4)+sf+lf
 ! Compute cddz=2*cd/dz  
-        
       cddz(1)=ala(1)/dz(1)
       do iz=2,nz
          cddz(iz)=2.*ala(iz)/(dz(iz)+dz(iz-1))
       enddo
-!        cddz(nz+1)=ala(nz+1)/dz(nz)
-       
+      
       a(1,1)=0.
       a(1,2)=1.
       a(1,3)=0.
       c(1)=temp(1)
-          
       do iz=2,nz-1
          a(iz,1)=-cddz(iz)*dt/dz(iz)
-         a(iz,2)=1+dt*(cddz(iz)+cddz(iz+1))/dz(iz)          
+         a(iz,2)=1.+dt*(cddz(iz)+cddz(iz+1))/dz(iz)          
          a(iz,3)=-cddz(iz+1)*dt/dz(iz)
          c(iz)=temp(iz)
       enddo          
-                     
       a(nz,1)=-dt*cddz(nz)/dz(nz)
       a(nz,2)=1.+dt*cddz(nz)/dz(nz)
       a(nz,3)=0.
-      c(nz)=temp(nz)+dt*alpha/cs(nz)/dz(nz)
+      c(nz)=temp(nz)+dt*alpha/cs(nz)/dz(nz) 
 
       
       call invert(nz,a,c,temp)
 
-           
       pt=temp(nz)*(press/1.e+5)**(-rcp_u)
 
-      rt=(1.-alb)*rs+em*rl-em*sigma*(tsig**4)
+      rt=(1.-alb)*rs+em*rl-em*sigma*(tsig**4.)
                         
-!      gf=-cddz(nz)*(temp(nz)-temp(nz-1))*cs(nz)
-       gf=(1.-alb)*rs+em*rl-em*sigma*(tsig**4)+sf                                   
+       gf=(1.-alb)*rs+em*rl-em*sigma*(tsig**4.)+sf                                   
       return
       end subroutine soil_temp
+      
 
 ! ===6=8===============================================================72 
 ! ===6=8===============================================================72 
+
 
       subroutine invert(n,a,c,x)
 
@@ -3487,7 +4110,7 @@ use module_wrf_error
 ! ===6=8===============================================================72
   
       subroutine flux_wall(ua,va,pt,da,ptw,ptwin,uva,vva,uvb,vvb,  &
-                           sfw,sfwin,evb,drst,dt)         
+                           sfw,sfwin,evb,drst,dt,cdrag)         
        
 ! ----------------------------------------------------------------------
 ! This routine computes the surface sources or sinks of momentum, tke,
@@ -3505,7 +4128,7 @@ use module_wrf_error
       real ua                   ! wind speed
       real va                   ! wind speed
       real dt                   !time step
-
+      real cdrag
 ! OUTPUT:
 ! ------
 ! Explicit and implicit component of the momentum, temperature and TKE sources or sinks on
@@ -3582,8 +4205,8 @@ use module_wrf_error
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
 
-      subroutine flux_flat(dz,z0,ua,va,pt,pt0,ptg,                     &
-                          uhb,vhb,sf,ehb,da)
+      subroutine flux_flat_ground(dz,z0,ua,va,pt,pt0,ptg,                     &
+                          uhb,vhb,sf,ehb,da,qv,pr,rsg,qg,resg,rsveg,f1,f2,f3,f4,fh,ric,utot,gr_type)
                                 
 ! ----------------------------------------------------------------------
 !           Calculation of the flux at the ground 
@@ -3600,7 +4223,11 @@ use module_wrf_error
       real va                   ! wind speed
       real z0                   ! Roughness length
       real da                   ! air density
-      
+      real qv                   ! specific humidity
+      real pr                   ! pressure
+      real rsg                  ! solar radiation
+      real qg(ng_u)         ! Ground Soil Moisture
+
      
 
 ! ----------------------------------------------------------------------
@@ -3617,12 +4244,13 @@ use module_wrf_error
       real tvb                  ! Temperature          Vertical surfaces, B (explicit) term
       real ehb                  ! Energy (TKE)       Horizontal surfaces, B (explicit) term
       real sf
-
+      real lf
 
 ! ----------------------------------------------------------------------
 ! LOCAL:
 ! ----------------------------------------------------------------------
-      real aa
+      real aa,ah
+      real z0t
       real al
       real buu
       real c
@@ -3632,22 +4260,58 @@ use module_wrf_error
       real fm
       real ric
       real tstar
+      real qstar
       real ustar
       real utot
       real wstar
       real zz
-      
+      real qvsg,qvs,es,esa,fbqq
       real b,cm,ch,rr,tol
       parameter(b=9.4,cm=7.4,ch=5.3,rr=0.74,tol=.001)
 
+      real f
+      real f1
+      real f2
+      real f3
+      real f4
+      real ta          ! surface air temperature
+      real tmp                  ! ground temperature
+      real rsveg       ! Stomatal resistance 
+      real resg
+      real lai         ! leaf area index
+      real sdlim       ! radiation limit at which photosyntesis start W/m2
+      parameter(sdlim=100.)
+      real rsmin ! Minimum stomatal resistance 
+      real rsmax ! Maximun stomatal resistance 
+      real qw
+      parameter(qw=0.06)
+      real qref
+      parameter(qref=0.37)  
+      real hs
+      parameter(hs=36.35)
+ 
+      real dzg_u(ng_u)          ! Layer sizes in the ground
+
+      data dzg_u /0.2,0.12,0.08,0.05,0.03,0.02,0.02,0.01,0.005,0.0025/
+      
+      real gx,dzg_tot
+      integer gr_type,iz
 ! ----------------------------------------------------------------------
 ! END VARIABLES DEFINITIONS
 ! ----------------------------------------------------------------------
-
-
+      z0t=z0/10.
+      if(gr_type.eq.1)then
+      rsmin=40.
+      rsmax=5000.
+      lai=2.
+      elseif(gr_type.eq.2)then
+      rsmin=150.
+      rsmax=5000.
+      lai=3.
+      endif
 ! computation of the ground temperature
          
-      utot=(ua**2+va**2)**.5
+      utot=(ua**2.+va**2.)**.5
         
       
 !!!! Louis formulation
@@ -3669,24 +4333,59 @@ use module_wrf_error
       ric=2.*g_u*zz*(pt-ptg)/((pt+ptg)*(utot**2))
               
       aa=vk/log(zz/z0)
+      ah=vk/log(zz/z0t)
 
 ! determine the parameters fm and fh for stable, neutral and unstable conditions
 
       if(ric.gt.0)then
-         fm=1/(1+0.5*b*ric)**2
+         fm=1/(1+0.5*b*ric)**2.
          fh=fm
       else
          c=b*cm*aa*aa*(zz/z0)**.5
          fm=1-b*ric/(1+c*(-ric)**.5)
+         c=b*cm*aa*ah*(zz/z0t)**.5
          c=c*ch/cm
          fh=1-b*ric/(1+c*(-ric)**.5)
       endif
       
       fbuw=-aa*aa*utot*utot*fm
-      fbpt=-aa*aa*utot*(pt-ptg)*fh/rr
-                     
+      fbpt=-aa*ah*utot*(pt-ptg)*fh/rr
+      tmp=ptg*(pr/p0)**(rcp_u)-273.15 
+      es=6.11*(10.**(tmp*7.5/(237.7+tmp)))
+      qvsg=0.62197*es/(0.01*pr-0.378*es)
+      
+
+      f=0.55*rsg/sdlim*2./lai
+      
+      f1=(f+rsmin/rsmax)/(1.+f)
+
+      ta=pt*(pr/p0)**(rcp_u)-273.15
+      esa=6.11*(10**(ta*7.5/(237.7+ta)))
+      qvs=0.62197*esa/(0.01*pr-0.378*esa)
+
+      f2= 1./(1.+hs*(qvs-qv))
+      f3=1.-0.0016*(25.-ta)**2.
+      f4=0.
+      dzg_tot=0.
+      do iz=1,ng_u
+       gx=(qg(iz)-qw)/(qref-qw)
+       if (gx.gt.1)gx=1.
+       if (gx.lt.0)gx=0.
+       f4=f4+gx*dzg_u(iz)
+       dzg_tot=dzg_tot+dzg_u(iz)
+      enddo
+      f4=f4/dzg_tot
+
+      rsveg=min(rsmin/max(lai*f1*f2*f3*f4,1e-9),rsmax)
+      resg= rr/(aa*aa*utot*fh)
+
+
+      fbqq=-(qv-qvsg)/(resg+rsveg)
+      
+               
       ustar=(-fbuw)**.5
       tstar=-fbpt/ustar
+      qstar=-fbqq/ustar
 
       al=(vk*g_u*tstar)/(pt*ustar*ustar)                      
       
@@ -3695,20 +4394,337 @@ use module_wrf_error
       uhb=-ustar*ustar*ua/utot
       vhb=-ustar*ustar*va/utot 
       sf= ustar*tstar*da*cp_u   
+      lf= ustar*qstar*da*latent
        
 !     thb= 0.      
       ehb=buu
 !!!!!!!!!!!!!!!
          
       return
+      end subroutine flux_flat_ground
+
+! ===6=8===============================================================72
+! ===6=8===============================================================72
+      subroutine flux_flat_roof(dz,z0,ua,va,pt,pt0,ptg,                     &
+                          uhb,vhb,sf,lf,ehb,da,qv,pr,rsg,qr,resg,rsveg,f1,f2,f3,f4,gr_type,pv_frac_roof)
+
+! ----------------------------------------------------------------------
+!           Calculation of the flux at the ground 
+!           Formulation of Louis (Louis, 1979)       
+! ----------------------------------------------------------------------
+
+      implicit none
+
+      real dz                   ! first vertical level
+      real pt                   ! potential temperature
+      real pt0                  ! reference potential temperature
+      real ptg                  ! ground potential temperature
+      real ua                   ! wind speed
+      real va                   ! wind speed
+      real z0                   ! Roughness length
+      real da                   ! air density
+      real qv                   ! specific humidity
+      real pr                   ! pressure
+      real rsg                  ! solar radiation
+      real qr(ngr_u)         ! Ground Soil Moisture
+      real pv_frac_roof
+      real rs_eff
+
+! ----------------------------------------------------------------------
+! OUTPUT:
+! ----------------------------------------------------------------------
+! Explicit component of the momentum, temperature and TKE sources or sinks on horizontal 
+!  surfaces (roofs and street)
+! The fluxes can be computed as follow: Fluxes of X = B
+!  Example: Momentum fluxes on horizontal surfaces =  uhb_u
+      real uhb                  ! U (wind component) Horizontal surfaces, B (explicit) term
+      real vhb                  ! V (wind component) Horizontal surfaces, B (explicit) term
+!     real thb                  ! Temperature        Horizontal surfaces, B (explicit) term
+      real tva                  ! Temperature          Vertical surfaces, A (implicit) term
+      real tvb                  ! Temperature          Vertical surfaces, B (explicit) term
+      real ehb                  ! Energy (TKE)       Horizontal surfaces, B (explicit) term
+      real sf
+      real lf
+
+! ----------------------------------------------------------------------
+! LOCAL:
+! ----------------------------------------------------------------------
+      real aa,ah
+      real al
+      real buu
+      real c
+      real fbuw
+      real fbpt
+      real fh
+      real fm
+      real ric
+      real tstar
+      real qstar
+      real ustar
+      real utot
+      real wstar
+      real zz
+      real z0t
+      real qvsg,qvs,es,esa,fbqq
+      real b,cm,ch,rr,tol
+      parameter(b=9.4,cm=7.4,ch=5.3,rr=0.74,tol=.001)
+
+      real f
+      real f1
+      real f2
+      real f3
+      real f4
+      real ta          ! surface air temperature
+      real tmp                  ! ground temperature
+      real rsveg       ! Stomatal resistance 
+      real resg
+      real lai         ! leaft area index
+      real sdlim       ! radiation limit at which photosyntesis start W/m2
+      parameter(sdlim=100.)
+      real rsmin
+      real rsmax ! Maximun stomatal resistance 
+      real qw    ! Wilting point
+      parameter(qw=0.06) 
+      real qref  ! Field capacity
+      parameter(qref=0.37)
+      real hs
+      parameter(hs=36.35)
+
+      real dzgr_u(ngr_u)          ! Layer sizes in the ground
+
+      data dzgr_u /0.1,0.003,0.06,0.003,0.05,0.04,0.02,0.0125,0.005,0.0025/
+
+      real gx,dzgr_tot
+      integer gr_type,iz
+! ----------------------------------------------------------------------
+! END VARIABLES DEFINITIONS
+
+! ----------------------------------------------------------------------
+      z0t=z0/10.
+      if(gr_type.eq.1)then
+      rsmin=40.
+      rsmax=5000.
+      lai=2.
+      elseif(gr_type.eq.2)then
+      rsmin=150.
+      rsmax=5000.
+      lai=3.
+      endif
+     rs_eff=(1-pv_frac_roof)*rsg
+! computation of the ground temperature
+
+      utot=(ua**2.+va**2.)**.5
+
+!!!! Louis formulation
+!
+! compute the bulk Richardson Number
+
+      zz=dz/2.
+
+
+      utot=max(utot,0.01)
+
+      ric=2.*g_u*zz*(pt-ptg)/((pt+ptg)*(utot**2))
+
+      aa=vk/log(zz/z0)
+      ah=vk/log(zz/z0t)
+
+      if(ric.gt.0.)then
+         fm=1./(1.+0.5*b*ric)**2.
+         fh=fm
+      else
+         c=b*cm*aa*aa*(zz/z0)**.5
+         fm=1.-b*ric/(1.+c*(-ric)**.5)
+         c=b*cm*aa*ah*(zz/z0t)**.5
+         c=c*ch/cm
+         fh=1.-b*ric/(1+c*(-ric)**.5)
+      endif
+
+      fbuw=-aa*aa*utot*utot*fm
+      fbpt=-aa*ah*utot*(pt-ptg)*fh/rr
+      tmp=ptg*(pr/p0)**(rcp_u)-273.15
+      es=6.11*(10.**(tmp*7.5/(237.7+tmp)))
+      qvsg=0.62197*es/(0.01*pr-0.378*es)
+
+
+      f=0.55*rs_eff/sdlim*2./lai
+
+      f1=(f+rsmin/rsmax)/(1.+f)
+
+      ta=pt*(pr/p0)**(rcp_u)-273.15
+      esa=6.11*(10**(ta*7.5/(237.7+ta)))
+      qvs=0.62197*esa/(0.01*pr-0.378*esa)
+
+      f2= 1./(1.+hs*(qvs-qv))
+      f3=1.-0.0016*(25.-ta)**2.
+      f4=0.
+      dzgr_tot=0.
+      do iz=5,ngr_u
+       gx=(qr(iz)-qw)/(qref-qw)
+       if (gx.gt.1)gx=1.
+       if (gx.lt.0)gx=0.
+       f4=f4+gx*dzgr_u(iz)
+       dzgr_tot=dzgr_tot+dzgr_u(iz)
+      enddo
+      f4=f4/dzgr_tot
+
+      rsveg=min(rsmin/max(lai*f1*f2*f3*f4,1e-9),rsmax)
+
+
+      resg= rr/(aa*aa*utot*fh)
+
+
+      fbqq=-(qv-qvsg)/(resg+rsveg)
+
+      ustar=(-fbuw)**.5
+      tstar=-fbpt/ustar
+      qstar=-fbqq/ustar
+
+      al=(vk*g_u*tstar)/(pt*ustar*ustar)
+
+      buu=-g_u/pt0*ustar*tstar
+
+      uhb=-ustar*ustar*ua/utot
+      vhb=-ustar*ustar*va/utot
+      sf= ustar*tstar*da*cp_u
+      lf= ustar*qstar*da*latent
+
+      ehb=buu
+      end subroutine flux_flat_roof
+      
+!!!!!!!===============================
+
+! ===6=8===============================================================72
+! ===6=8===============================================================72
+
+      subroutine flux_flat(dz,z0,ua,va,pt,pt0,ptg,qv,                   &
+                          uhb,vhb,sf,lf,ehb,da,pr)
+                                
+! ----------------------------------------------------------------------
+!           Calculation of the flux at the ground 
+!           Formulation of Louis (Louis, 1979)       
+! ----------------------------------------------------------------------
+
+      implicit none
+      real pr
+      real dz                   ! first vertical level
+      real pt                   ! potential temperature
+      real pt0                  ! reference potential temperature
+      real ptg                  ! ground potential temperature
+      real ua                   ! wind speed
+      real va                   ! wind speed
+      real z0                   ! Roughness length
+      real da                   ! air density
+      real qv
+! ----------------------------------------------------------------------
+! OUTPUT:
+! ----------------------------------------------------------------------
+! Explicit component of the momentum, temperature and TKE sources or sinks on horizontal 
+!  surfaces (roofs and street)
+! The fluxes can be computed as follow: Fluxes of X = B
+!  Example: Momentum fluxes on horizontal surfaces =  uhb_u
+      real uhb                  ! U (wind component) Horizontal surfaces, B (explicit) term
+      real vhb                  ! V (wind component) Horizontal surfaces, B (explicit) term
+!     real thb                  ! Temperature        Horizontal surfaces, B (explicit) term
+      real tva                  ! Temperature          Vertical surfaces, A (implicit) term
+      real tvb                  ! Temperature          Vertical surfaces, B (explicit) term
+      real ehb                  ! Energy (TKE)       Horizontal surfaces, B (explicit) term
+      real sf
+      real lf
+       
+! ----------------------------------------------------------------------
+! LOCAL:
+! ----------------------------------------------------------------------
+      real aa
+      real al
+      real buu
+      real c
+      real fbuw
+      real fbpt
+      real fh
+      real fm
+      real ric
+      real tstar
+      real ustar
+      real qstar
+      real utot
+      real wstar
+      real zz
+      real qvsg,qvs,es,esa,fbqq,tmp,resg
+      real b,cm,ch,rr,tol
+      parameter(b=9.4,cm=7.4,ch=5.3,rr=0.74,tol=.001)
+
+! ----------------------------------------------------------------------
+! END VARIABLES DEFINITIONS
+! ----------------------------------------------------------------------
+
+
+! computation of the ground temperature
+         
+      utot=(ua**2+va**2)**.5
+        
+      
+!!!! Louis formulation
+!
+! compute the bulk Richardson Number
+
+      zz=dz/2.
+   
+
+      utot=max(utot,0.01)
+          
+      ric=2.*g_u*zz*(pt-ptg)/((pt+ptg)*(utot**2))
+              
+      aa=vk/log(zz/z0)
+
+
+     
+      tmp=ptg*(pr/(1.e+5))**(rcp_u)-273.15 
+      es=6.11*(10**(tmp*7.5/(237.7+tmp)))
+      qvsg=0.62197*es/(0.01*pr-0.378*es)
+
+
+
+! determine the parameters fm and fh for stable, neutral and unstable conditions
+
+      if(ric.gt.0.)then
+         fm=1./(1.+0.5*b*ric)**2
+         fh=fm
+      else
+         c=b*cm*aa*aa*(zz/z0)**.5
+         fm=1.-b*ric/(1.+c*(-ric)**.5)
+         c=c*ch/cm
+         fh=1.-b*ric/(1.+c*(-ric)**.5)
+      endif
+
+      resg= rr/(aa*aa*utot*fh)
+      fbuw=-aa*aa*utot*utot*fm
+      fbpt=-aa*aa*utot*(pt-ptg)*fh/rr
+      fbqq=-(qv-qvsg)/(resg)
+               
+      ustar=(-fbuw)**.5
+      tstar=-fbpt/ustar
+      qstar=-fbqq/ustar
+      al=(vk*g_u*tstar)/(pt*ustar*ustar)                      
+      
+      buu=-g_u/pt0*ustar*tstar
+       
+      uhb=-ustar*ustar*ua/utot
+      vhb=-ustar*ustar*va/utot 
+      sf= ustar*tstar*da*cp_u  
+      lf= ustar*qstar*da*latent 
+      ehb=buu
+!!!!!!!!!!!!!!!
+         
+      return
       end subroutine flux_flat
-
+!!!!!!!!!!!!!================!!!!!!!!!!!!!!!!!!!      
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
 
-      subroutine icBEP (nd_u,h_b,d_b,ss_u,pb_u,nz_u,z_u)                               
+      subroutine icBEP (nd_u,h_b,d_b,ss_u,pb_u,nz_u,z_u)
 
-      implicit none     
+      implicit none
 
 !    Street parameters
       integer nd_u(nurbm)     ! Number of street direction for each urban class
@@ -3720,7 +4736,7 @@ use module_wrf_error
 
       real ss_u(nz_um,nurbm)     ! The probability that a building has an height equal to z
       real pb_u(nz_um,nurbm)     ! The probability that a building has an height greater or equal to z
-        
+
 !    Grid parameters
       integer nz_u(nurbm)     ! Number of layer in the urban grid
       real z_u(nz_um)       ! Height of the urban grid levels
@@ -3741,19 +4757,20 @@ use module_wrf_error
 !
 !Initialize variables
 !
+ !
       nz_u=0
       z_u=0.
       ss_u=0.
       pb_u=0.
 
 ! Computation of the urban levels height
- 
+
       z_u(1)=0.
-     
+
       do iz_u=1,nz_um-1
          z_u(iz_u+1)=z_u(iz_u)+dz_u
       enddo
-      
+
 ! Normalisation of the building density
 
       do iurb=1,nurbm
@@ -3764,33 +4781,33 @@ use module_wrf_error
          do ilu=1,nz_um
             d_b(ilu,iurb)=d_b(ilu,iurb)/dtot
          enddo
-      enddo      
+      enddo
 
-! Compute the view factors, pb and ss 
-      
-      do iurb=1,nurbm         
+! Compute the view factors, pb and ss
+
+      do iurb=1,nurbm
          hbmax=0.
          nz_u(iurb)=0
          do ilu=1,nz_um
             if(h_b(ilu,iurb).gt.hbmax)hbmax=h_b(ilu,iurb)
          enddo
-         
+
          do iz_u=1,nz_um-1
             if(z_u(iz_u+1).gt.hbmax)go to 10
          enddo
-         
+
  10      continue
-         nz_u(iurb)=iz_u+1
+          nz_u(iurb)=iz_u+1
 
          do id=1,nd_u(iurb)
 
             do iz_u=1,nz_u(iurb)
                ss_u(iz_u,iurb)=0.
                do ilu=1,nz_um
-                  if(z_u(iz_u).le.h_b(ilu,iurb)                      &    
-                    .and.z_u(iz_u+1).gt.h_b(ilu,iurb))then            
+                  if(z_u(iz_u).le.h_b(ilu,iurb)                      &
+                    .and.z_u(iz_u+1).gt.h_b(ilu,iurb))then
                         ss_u(iz_u,iurb)=ss_u(iz_u,iurb)+d_b(ilu,iurb)
-                  endif 
+                  endif
                enddo
             enddo
 
@@ -3801,13 +4818,14 @@ use module_wrf_error
 
          enddo
       end do
-     
-                  
-      return       
+
+
+      return
       end subroutine icBEP
 
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
+    
 
       subroutine view_factors(iurb,nz_u,id,dxy,z,ws,fww,fwg,fgw,fsg,fsw,fws) 
      
@@ -3925,7 +4943,7 @@ use module_wrf_error
       enddo
 
 ! radiation from wall to sky      
-      do iz=1,nz_u
+       do iz=1,nz_u
        call fnrms(fnrm,ws,dxy,hut-z(iz))
        f12=fnrm
        call fnrms(fnrm,ws,dxy,hut-z(iz+1))
@@ -3972,6 +4990,7 @@ use module_wrf_error
 
 ! ===6=8===============================================================72
 ! ===6=8===============================================================72
+
 
       SUBROUTINE fprls (fprl,a,b,c)
 
@@ -4034,16 +5053,19 @@ use module_wrf_error
       end subroutine fnrms
   ! ===6=8===============================================================72  
      
-      SUBROUTINE init_para(alag_u,alaw_u,alar_u,csg_u,csw_u,csr_u,&
+        SUBROUTINE init_para(alag_u,alaw_u,alar_u,csg_u,csw_u,csr_u,&
         twini_u,trini_u,tgini_u,albg_u,albw_u,albr_u,albwin_u,emg_u,emw_u,&
         emr_u,emwind_u,z0g_u,z0r_u,nd_u,strd_u,drst_u,ws_u,bs_u,h_b,d_b,  &
         cop_u,pwin_u,beta_u,sw_cond_u,time_on_u,time_off_u,targtemp_u,    &
-        gaptemp_u, targhum_u,gaphum_u,perflo_u,hsesf_u,hsequip)
+        bldac_frc_u,cooled_frc_u,                                         &
+        gaptemp_u, targhum_u,gaphum_u,perflo_u,                           &
+        gr_frac_roof_u,pv_frac_roof_u,                   &
+        hsesf_u,hsequip,irho,gr_flag_u,gr_type_u)
 
+ 
 ! initialization routine, where the variables from the table are read
 
       implicit none
-      
       integer iurb            ! urban class number
 !    Building parameters      
       real alag_u(nurbm)      ! Ground thermal diffusivity [m^2 s^-1]
@@ -4082,6 +5104,8 @@ use module_wrf_error
 
       integer i,iu
       integer nurb ! number of urban classes used
+        real, intent(out) :: bldac_frc_u(nurbm)
+      real, intent(out) :: cooled_frc_u(nurbm)
       real, intent(out) :: cop_u(nurbm)
       real, intent(out) :: pwin_u(nurbm)
       real, intent(out) :: beta_u(nurbm)
@@ -4093,9 +5117,12 @@ use module_wrf_error
       real, intent(out) :: targhum_u(nurbm)
       real, intent(out) :: gaphum_u(nurbm)
       real, intent(out) :: perflo_u(nurbm)
+      real, intent(out) :: gr_frac_roof_u(nurbm)
+      real, intent(out) :: pv_frac_roof_u(nurbm)
       real, intent(out) :: hsesf_u(nurbm)
       real, intent(out) :: hsequip(24)
-
+      real, intent(out) :: irho(24)
+      integer, intent(out) :: gr_flag_u,gr_type_u
 !
 !Initialize some variables
 !  
@@ -4129,6 +5156,9 @@ use module_wrf_error
        z0g_u=Z0G_TBL
        nd_u=NUMDIR_TBL
 !FS
+     !  print*, 'g alla call', gr_frac_roof_u(iurb)
+       bldac_frc_u = bldac_frc_tbl
+       cooled_frc_u = cooled_frc_tbl
        cop_u = cop_tbl
        pwin_u = pwin_tbl
        beta_u = beta_tbl
@@ -4140,9 +5170,13 @@ use module_wrf_error
        targhum_u = targhum_tbl
        gaphum_u = gaphum_tbl
        perflo_u = perflo_tbl
+       gr_frac_roof_u =gr_frac_roof_tbl
+       gr_flag_u=gr_flag_tbl
+       pv_frac_roof_u = pv_frac_roof_tbl
        hsesf_u = hsesf_tbl
        hsequip = hsequip_tbl
-
+       irho=irho_tbl
+       gr_type_u=gr_type_tbl
        do iu=1,icate
               if(ndm.lt.nd_u(iu))then
                 write(*,*)'ndm too small in module_sf_bep_bem, please increase to at least ', nd_u(iu)
@@ -4185,12 +5219,12 @@ use module_wrf_error
 !====6=8===============================================================72         
 !====6=8===============================================================72 
 
-      subroutine upward_rad(ndu,nzu,ws,bs,sigma,pb,ss,                &
-                       tg,emg_u,albg_u,rlg,rsg,sfg,                   & 
+       subroutine upward_rad(ndu,nzu,ws,bs,sigma,pb,ss,                &
+                       tg_av,emg_u,albg_u,rlg,rsg,sfg,lfg,                   & 
                        tw,emw_u,albw_u,rlw,rsw,sfw,                   & 
-                       tr,emr_u,albr_u,emwind,albwind,twlev,pwin,     &
-                       sfwind,rld,rs, sfr,                            & 
-                       rs_abs,rl_up,emiss,grdflx_urb)
+                       tr_av,emr_u,albr_u,emwind,albwind,twlev,pwin,     &
+                       sfwind,rld,rs, sfr,sfrv,lfr,lfrv,                            & 
+                       rs_abs,rl_up,emiss,grdflx_urb,gr_frac_roof,tpvlev,pv_frac_roof)
 !
 ! IN this surboutine we compute the upward longwave flux, and the albedo
 ! needed for the radiation scheme
@@ -4207,7 +5241,12 @@ use module_wrf_error
       real rs                        ! Short wave radiation at the horizontal surface from the sun [W/m2]  
       real sfw(2*ndm,nz_um)      ! Sensible heat flux from walls [W/m2]
       real sfg(ndm)              ! Sensible heat flux from ground (road) [W/m2]
-      real sfr(ndm,nz_um)      ! Sensible heat flux from roofs [W/m2]                      
+      real lfg(ndm)
+      real sfr(ndm,nz_um)      ! Sensible heat flux from roofs [W/m2]   
+      real lfr(ndm,nz_um)
+      real lfrv(ndm,nz_um)
+      real sfrv(ndm,nz_um)
+      real gr_frac_roof
       real rld                        ! Long wave radiation from the sky [W/m2]
       real albg_u                    ! albedo of the ground/street
       real albw_u                    ! albedo of the walls
@@ -4223,8 +5262,10 @@ use module_wrf_error
       real emw_u                       ! emissivity of the wall
       real emr_u                       ! emissivity of the roof
       real tw(2*ndm,nz_um)  ! Temperature in each layer of the wall [K]
-      real tr(ndm,nz_um,nwr_u)  ! Temperature in each layer of the roof [K]
-      real tg(ndm,ng_u)          ! Temperature in each layer of the ground [K]
+      real tr_av(ndm,nz_um)  ! Temperature in each layer of the roof [K]
+      real tpvlev(ndm,nz_um)
+      real pv_frac_roof
+      real tg_av(ndm)          ! Temperature in each layer of the ground [K]
       integer id ! street direction
       integer ndu ! number of street directions
 !
@@ -4251,12 +5292,11 @@ use module_wrf_error
          iwrong=1
       do iz=1,nzu+1
       do id=1,ndu
-      do iw=1,nwr_u
-        if(tr(id,iz,iw).lt.100.)then
-              write(*,*)'in upward_rad ',iz,id,iw,tr(id,iz,iw) 
+      if(tr_av(id,iz).lt.100.)then
+              write(203,*) tr_av(id,iz)
+              write(*,*)'in upward_rad ',iz,id,iw,tr_av(id,iz)
               iwrong=0
-        endif
-      enddo
+      endif     
       enddo
       enddo
            if(iwrong.eq.0)stop
@@ -4269,18 +5309,20 @@ use module_wrf_error
       rl_emit=0.
       grdflx_urb=0.
       do id=1,ndu          
-       rl_emit=rl_emit-( emg_u*sigma*(tg(id,ng_u)**4.)+(1-emg_u)*rlg(id))*ws(id)/(ws(id)+bs(id))/ndu
+       rl_emit=rl_emit-( emg_u*sigma*(tg_av(id)**4.)+(1-emg_u)*rlg(id))*ws(id)/(ws(id)+bs(id))/ndu
        rl_inc=rl_inc+rlg(id)*ws(id)/(ws(id)+bs(id))/ndu       
        rs_abs=rs_abs+(1.-albg_u)*rsg(id)*ws(id)/(ws(id)+bs(id))/ndu
-         gfl=(1.-albg_u)*rsg(id)+emg_u*rlg(id)-emg_u*sigma*(tg(id,ng_u)**4.)+sfg(id)
+         gfl=(1.-albg_u)*rsg(id)+emg_u*rlg(id)-emg_u*sigma*(tg_av(id)**4.)+sfg(id)+lfg(id)
          grdflx_urb=grdflx_urb-gfl*ws(id)/(ws(id)+bs(id))/ndu  
  
-          do iz=2,nzu
-            rl_emit=rl_emit-(emr_u*sigma*(tr(id,iz,nwr_u)**4.)+(1-emr_u)*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu            
-            rs_abs=rs_abs+(1.-albr_u)*rs*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
-            gfl=(1.-albr_u)*rs+emr_u*rld-emr_u*sigma*(tr(id,iz,nwr_u)**4.)+sfr(id,iz)
-            grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+         do iz=2,nzu
+             rl_emit=rl_emit-(emr_u*sigma*(1.-pv_frac_roof)*tr_av(id,iz)**4.+0.79*sigma*pv_frac_roof*tpvlev(id,iz)**4+ &
+                     (1-emr_u)*rld*(1.-pv_frac_roof)+(1-0.79)*pv_frac_roof*rld)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             rl_inc=rl_inc+rld*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             rs_abs=rs_abs+((1.-albr_u)*rs*(1.-pv_frac_roof)+(1.-0.11)*rs*pv_frac_roof)*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu
+             gfl=(1.-albr_u)*rs*(1-pv_frac_roof)+emr_u*rld*(1-pv_frac_roof)+pv_frac_roof*emr_u*sigma*tpvlev(id,iz)**4 &
+                -emr_u*sigma*(tr_av(id,iz)**4.)+(1-gr_frac_roof)*sfr(id,iz)+(sfrv(id,iz)+lfrv(id,iz))*gr_frac_roof+(1.-gr_frac_roof)*lfr(id,iz)
+             grdflx_urb=grdflx_urb-gfl*ss(iz)*bs(id)/(ws(id)+bs(id))/ndu  
          enddo
            
          do iz=1,nzu 
@@ -4591,9 +5633,78 @@ use module_wrf_error
                pb_u(iz_u+1)=max(0.,pb_u(iz_u)-ss_u(iz_u,iurb))
             enddo
 
-20    continue    
-      return
-      end subroutine icBEPHI_XY
+20     continue    
+       return
+       end subroutine icBEPHI_XY
 !====================================================================72
 !====================================================================72
 END MODULE module_sf_bep_bem
+
+! ===6=8===============================================================72
+! ===6=8===============================================================72
+
+      FUNCTION bep_bem_nurbm () RESULT (bep_bem_val_nurbm)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_nurbm
+         bep_bem_val_nurbm = nurbm
+      END FUNCTION bep_bem_nurbm
+
+      FUNCTION bep_bem_ndm () RESULT (bep_bem_val_ndm)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_ndm
+         bep_bem_val_ndm = ndm
+      END FUNCTION bep_bem_ndm
+
+      FUNCTION bep_bem_nz_um () RESULT (bep_bem_val_nz_um)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_nz_um
+         bep_bem_val_nz_um = nz_um
+      END FUNCTION bep_bem_nz_um
+
+      FUNCTION bep_bem_ng_u () RESULT (bep_bem_val_ng_u)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_ng_u
+         bep_bem_val_ng_u = ng_u
+      END FUNCTION bep_bem_ng_u
+
+      FUNCTION bep_bem_nwr_u () RESULT (bep_bem_val_nwr_u)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_nwr_u
+         bep_bem_val_nwr_u = nwr_u
+      END FUNCTION bep_bem_nwr_u
+
+      FUNCTION bep_bem_nf_u () RESULT (bep_bem_val_nf_u)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_nf_u
+         bep_bem_val_nf_u = nf_u
+      END FUNCTION bep_bem_nf_u
+
+
+      FUNCTION bep_bem_ngb_u () RESULT (bep_bem_val_ngb_u)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_ngb_u
+         bep_bem_val_ngb_u = ngb_u
+      END FUNCTION bep_bem_ngb_u
+
+      FUNCTION bep_bem_nbui_max () RESULT (bep_bem_val_nbui_max)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_nbui_max
+         bep_bem_val_nbui_max = nbui_max
+      END FUNCTION bep_bem_nbui_max
+
+ 
+   FUNCTION bep_bem_ngr_u () RESULT (bep_bem_val_ngr_u)
+         USE module_sf_bep_bem
+         IMPLICIT NONE
+         INTEGER :: bep_bem_val_ngr_u
+         bep_bem_val_ngr_u = ngr_u
+      END FUNCTION bep_bem_ngr_u
+

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice.F
@@ -1,12 +1,16 @@
+!=================================================================================================================
 MODULE module_sf_noah_seaice
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_constants,only: cp,R_D=>R_d,XLF,XLV,RHOWATER=>rho_w,STBOLT
 use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
 #else
 use module_model_constants, only : CP, R_D, XLF, XLV, RHOWATER, STBOLT
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
 #endif
   use module_sf_noahlsm, only : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, &
        &                        HSTEP

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice_drv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noah_seaice_drv.F
@@ -1,12 +1,16 @@
+!=================================================================================================================
 module module_sf_noah_seaice_drv
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
-#define WRITE_MESSAGE(M) call physics_message( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
 #else
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
-#define WRITE_MESSAGE(M) call wrf_message( M )
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
+#define WRITE_MESSAGE(M) call wrf_message(M)
 #endif
   use module_sf_noah_seaice
   implicit none
@@ -77,7 +81,8 @@ contains
          &                                               RAINBL, &
          &                                             SNOALB2D, &
          &                                                 XICE, &
-         &                                                  RIB
+         &                                                  RIB, &
+         &                                                  CHS
 
     LOGICAL, INTENT (IN)      :: FRPCPN
     REAL   , INTENT (IN)      :: DT
@@ -96,25 +101,29 @@ contains
          &                                                  TSK, &
          &                                                SNOWC, &
          &                                              SNOWH2D, &
-         &                                                  CHS, &
-         &                                                 CQS2
+!        &                                                  CHS, &
+         &                                                 CQS2, &
+                                                         ACSNOW, &
+                                                         ACSNOM, &
+                                                      SFCRUNOFF
+
+    REAL,    OPTIONAL, DIMENSION( ims:ime, jms:jme )           , &
+         &   INTENT(INOUT)    ::                         POTEVP, &
+                                                         SNOPCX
 
     REAL,    DIMENSION( ims:ime, jms:jme )                     , &
          &   INTENT (OUT)     ::                            HFX, &
          &                                                   LH, &
          &                                                  QFX, &
          &                                                  ZNT, &
-         &                                               POTEVP, &
          &                                               GRDFLX, &
          &                                                 QSFC, &
-         &                                               ACSNOW, &
-         &                                               ACSNOM, &
-         &                                               SNOPCX, &
-         &                                            SFCRUNOFF, &
-         &                                              NOAHRES, &
          &                                                 CHS2
 
-    REAL,    DIMENSION( ims:ime, jms:jme )                      ,&
+    REAL,    OPTIONAL, DIMENSION( ims:ime, jms:jme )           , &
+         &   INTENT (OUT)     ::                        NOAHRES
+
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
          &   INTENT(INOUT)    ::                         SNOWSI
 
     REAL,    DIMENSION( ims:ime, jms:jme )                     , &
@@ -442,7 +451,6 @@ contains
           LH(I,J)     = ETA
           HFX(I,J)    = SHEAT
           QFX(I,J)    = ETA_KINEMATIC
-          POTEVP(I,J) = POTEVP(I,J) + ETP*FDTW
           GRDFLX(I,J) = SSOIL
 
           ! Exchange Coefficients
@@ -458,6 +466,11 @@ contains
               SNOWSI(I,J) = SNOWONSI
           ENDIF
 
+          ! Accumulated potential evaporation.
+          IF ( PRESENT(POTEVP) ) THEN
+              POTEVP(I,J) = POTEVP(I,J) + ETP*FDTW
+          ENDIF
+
           ! Accumulated snow precipitation.
           IF ( FFROZP .GT. 0.5 ) THEN
              ACSNOW(I,J) = ACSNOW(I,J) + PRCP * DT
@@ -467,7 +480,9 @@ contains
           ACSNOM(I,J) = ACSNOM(I,J) + SNOMLT * 1000.
 
           ! Accumulated snow-melt energy.
-          SNOPCX(I,J) = SNOPCX(I,J) - SNOMLT/FDTLIW
+          IF ( PRESENT(SNOPCX) ) THEN
+              SNOPCX(I,J) = SNOPCX(I,J) - SNOMLT/FDTLIW
+          ENDIF
 
           ! Surface runoff
           SFCRUNOFF(I,J) = SFCRUNOFF(I,J) + RUNOFF1 * DT * 1000.0
@@ -475,10 +490,12 @@ contains
           !
           ! Residual of surface energy balance terms
           !
-          NOAHRES(I,J) = ( SOLNET + LWDN ) &
-               &         - SHEAT + SSOIL - ETA &
-               &         - ( EMISSI * STBOLT * (T1**4) ) &
-               &         - FLX1 - FLX2 - FLX3
+          IF ( PRESENT(NOAHRES) ) THEN
+             NOAHRES(I,J) = ( SOLNET + LWDN )               &
+                            - SHEAT + SSOIL - ETA           &
+                            - ( EMISSI * STBOLT * (T1**4) ) &
+                            - FLX1 - FLX2 - FLX3
+          ENDIF
 #if defined(wrfmodel)
 #if (NMM_CORE != 1)
           IF ( ( SF_URBAN_PHYSICS == NOAHUCMSCHEME ) .OR. &

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
@@ -1,4 +1,8 @@
+!=================================================================================================================
 MODULE module_sf_noahdrv
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 
 !-------------------------------
   USE module_sf_noahlsm,  only: SFLX, XLF, XLV, CP, R_D, RHOWATER, NATURAL, SHDTBL, LUTYPE, SLTYPE, STBOLT, &
@@ -10,8 +14,7 @@ MODULE module_sf_noahdrv
       &                         SALP_DATA, REFDK_DATA, REFKDT_DATA, FRZK_DATA, ZBOT_DATA, CZIL_DATA,        &
       &                         SMLOW_DATA, SMHIGH_DATA, LVCOEF_DATA, NSLOPE, &
       &                         FRH2O,ZTOPVTBL,ZBOTVTBL, &
-      &                         LOW_DENSITY_RESIDENTIAL, HIGH_DENSITY_RESIDENTIAL, HIGH_INTENSITY_INDUSTRIAL
-
+      &                         LCZ_1,LCZ_2,LCZ_3,LCZ_4,LCZ_5,LCZ_6,LCZ_7,LCZ_8,LCZ_9,LCZ_10,LCZ_11
   USE module_sf_urban,    only: urban, oasis, IRI_SCHEME
   USE module_sf_noahlsm_glacial_only, only: sflx_glacial
   USE module_sf_bep,      only: bep
@@ -37,7 +40,8 @@ CONTAINS
 ! Urban related variable are added to arguments - urban
 !----------------------------------------------------------------
    SUBROUTINE lsm(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
-                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,GLW,SMSTAV,SMSTOT, &
+                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,SWDDIR,SWDDIF,&
+                  GLW,SMSTAV,SMSTOT, &
                   SFCRUNOFF, UDRUNOFF,IVGTYP,ISLTYP,ISURBAN,ISICE,VEGFRA,    &
                   ALBEDO,ALBBCK,ZNT,Z0,TMN,XLAND,XICE,EMISS,EMBCK,   &
                   SNOWC,QSFC,RAINBL,MMINLU,                     &
@@ -83,7 +87,17 @@ CONTAINS
                   FLXHUMR_URB2D,FLXHUMB_URB2D,FLXHUMG_URB2D,    & !H urban
                   julian, julyr,                                & !H urban
                   FRC_URB2D,UTYPE_URB2D,                        & !O
-                  num_urban_layers,                             & !I multi-layer urban
+                  num_urban_ndm,                                & !I multi-layer urban
+                  urban_map_zrd,                                & !I multi-layer urban
+                  urban_map_zwd,                                & !I multi-layer urban
+                  urban_map_gd,                                 & !I multi-layer urban
+                  urban_map_zd,                                 & !I multi-layer urban
+                  urban_map_zdf,                                & !I multi-layer urban
+                  urban_map_bd,                                 & !I multi-layer urban
+                  urban_map_wd,                                 & !I multi-layer urban
+                  urban_map_gbd,                                & !I multi-layer urban
+                  urban_map_fbd,                                & !I multi-layer urban
+                  urban_map_zgrd,                                & !I multi-layer urban
                   num_urban_hi,                                 & !I multi-layer urban
                   tsk_rural_bep,                                & !H multi-layer urban
                   trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
@@ -94,6 +108,10 @@ CONTAINS
                   sfvent_urb3d,lfvent_urb3d,                    & !H multi-layer urban
                   sfwin1_urb3d,sfwin2_urb3d,                    & !H multi-layer urban
                   sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,    & !H multi-layer urban
+                  ep_pv_urb3d,t_pv_urb3d,                         & !RMS
+                  trv_urb4d,qr_urb4d,qgr_urb3d,tgr_urb3d,         & !RMS
+                  drain_urb4d,draingr_urb3d,sfrv_urb3d,           & !RMS
+                  lfrv_urb3d,dgr_urb3d,dg_urb3d,lfr_urb3d,lfg_urb3d,& !RMS
                   lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,         & !H multi-layer urban
                   mh_urb2d,stdh_urb2d,lf_urb2d,                 & !SLUCM
                   th_phy,rho,p_phy,ust,                         & !I multi-layer urban
@@ -101,10 +119,14 @@ CONTAINS
                   a_u_bep,a_v_bep,a_t_bep,a_q_bep,              & !O multi-layer urban
                   a_e_bep,b_u_bep,b_v_bep,                      & !O multi-layer urban
                   b_t_bep,b_q_bep,b_e_bep,dlg_bep,              & !O multi-layer urban
-                  dl_u_bep,sf_bep,vl_bep,sfcheadrt,INFXSRT, soldrain      &   !O multi-layer urban         
+                  dl_u_bep,sf_bep,vl_bep                        &
+#ifdef WRF_HYDRO
+                 ,sfcheadrt,INFXSRT,soldrain                    &   !O multi-layer urban
+#endif
                  ,SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM, fasdas     &   !fasdas
-                 ,RC2,XLAI2                                               &
-                  )
+                 ,RC2,XLAI2                                         &
+                 ,IRR_CHAN                                          &
+                 )
 
 !----------------------------------------------------------------
     IMPLICIT NONE
@@ -254,12 +276,15 @@ CONTAINS
    INTEGER,  INTENT(IN   )   ::  julian, julyr                  !urban
 
 !added by Wei Yu  for routing
+#ifdef WRF_HYDRO
     REAL,    DIMENSION( ims:ime, jms:jme )                     , &
              INTENT(INOUT)  :: sfcheadrt,INFXSRT,soldrain 
     real :: etpnd1
+#endif
 !end added
 
-
+! new local vars for hydro
+   REAL :: etpnd1_hydro,sfcheadrt_hydro,infxsrt_hydro
 
    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
             INTENT(IN   )    ::                            TMN, &
@@ -274,7 +299,9 @@ CONTAINS
                                                            GLW, &
                                                         RAINBL, &
                                                         EMBCK,  &
-                                                        SR
+                                                           SR,  &
+                                                       SWDDIR,  &
+                                                       SWDDIF
 
    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
             INTENT(INOUT)    ::                         ALBBCK, &
@@ -576,30 +603,55 @@ CONTAINS
    REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
    INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
-   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+   INTEGER, INTENT(IN  ) ::                               num_urban_ndm
+   INTEGER, INTENT(IN  ) ::                               urban_map_zrd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zwd
+   INTEGER, INTENT(IN  ) ::                               urban_map_gd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zdf
+   INTEGER, INTENT(IN  ) ::                               urban_map_bd
+   INTEGER, INTENT(IN  ) ::                               urban_map_wd
+   INTEGER, INTENT(IN  ) ::                               urban_map_gbd
+   INTEGER, INTENT(IN  ) ::                               urban_map_fbd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zgrd
    INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
    REAL, OPTIONAL, DIMENSION( ims:ime,                     jms:jme ), INTENT(INOUT) :: tsk_rural_bep
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_gd , jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_bd , jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_bd , jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_gbd, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_fbd, jms:jme ), INTENT(INOUT) :: tflev_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: ep_pv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: t_pv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ),INTENT(INOUT) :: trv_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ),INTENT(INOUT) :: qr_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme ), INTENT(INOUT) :: qgr_urb3d  !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme ), INTENT(INOUT) :: tgr_urb3d  !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: drain_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: draingr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: sfrv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: lfrv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: dgr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: dg_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: lfr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: lfg_urb3d !GRZ
+
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lp_urb2d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lb_urb2d
@@ -658,6 +710,9 @@ CONTAINS
    REAL                    ::  DZQ
    REAL                    ::  HCPCT_FASDAS
 
+   REAL,OPTIONAL,INTENT(IN),DIMENSION( ims:ime, jms:jme )       :: IRR_CHAN
+   REAL       ::  IRRIGATION_CHANNEL
+   IRRIGATION_CHANNEL =0.0
    HFX_PHY = 0.0   ! initialize
    QFX_PHY = 0.0
    XQNORM  = 0.0
@@ -775,6 +830,13 @@ CONTAINS
 ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
         SOLNET=SOLDN*(1.-ALBEDO(I,J))
         PRCP=RAINBL(i,j)/DT
+        IF(PRESENT(IRR_CHAN)) THEN
+         IF(IRR_CHAN(i,j).NE.0) THEN
+           IRRIGATION_CHANNEL=IRR_CHAN(i,j)/DT
+         ELSE
+           IRRIGATION_CHANNEL=0.
+         END IF
+        ENDIF
         VEGTYP=IVGTYP(I,J)
         SOILTYP=ISLTYP(I,J)
         SHDFAC=VEGFRA(I,J)/100.
@@ -896,15 +958,20 @@ CONTAINS
 
 !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
 ! the "NATURAL" category in the VEGPARM.TBL
+                  IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                  IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                      IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                      IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                      IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
 	
-	   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
-                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                  IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
 		 VEGTYP = NATURAL
                  SHDFAC = SHDTBL(NATURAL)
                  ALBEDOK =0.2         !  0.2
                  ALBBRD  =0.2         !0.2
                  EMISSI = 0.98                                 !for VEGTYP=5
+                 LWDN   = GLW(I,J) * EMISSI
+                 SOLNET = SOLDN * (1.0 - ALBEDOK)
+
 		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
                    if(sf_urban_physics.eq.1)then
                      T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
@@ -916,10 +983,13 @@ CONTAINS
                  ENDIF
                 ENDIF
            ELSE
-                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                  IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
+            IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
                   VEGTYP = ISURBAN
-           	 ENDIF
+                 ENDIF
+
            ENDIF
 
 !===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
@@ -933,9 +1003,11 @@ CONTAINS
            if (tloc.lt.0) tloc=tloc+24
            if (tloc==0) tloc=24
            CALL cal_mon_day(julian,julyr,jmonth,jday) 
-           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
-            AOASIS = oasis  ! urban oasis effect
+             IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                 IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                 IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                 IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+                AOASIS = oasis  ! urban oasis effect
                    IF (IRIOPTION ==1) THEN
                    IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
                    IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
@@ -1018,6 +1090,15 @@ CONTAINS
 !
 !  END FASDAS
 !
+#ifdef WRF_HYDRO
+       etpnd1_hydro = 0.
+       sfcheadrt_hydro = sfcheadrt(i,j)
+       infxsrt_hydro = infxsrt(i,j)
+#else
+       etpnd1_hydro = 0.
+       sfcheadrt_hydro = 0.
+       infxsrt_hydro = 0.
+#endif
        CALL SFLX (I,J,FFROZP, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
                  LOCAL,                                            &    !L
                  LUTYPE, SLTYPE,                                   &    !CL
@@ -1040,14 +1121,18 @@ CONTAINS
                  SNOTIME1,                                         &
                  RIBB,                                             &
                  SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
-                 sfcheadrt(i,j),                                   &    !I
-                 INFXSRT(i,j),ETPND1,OPT_THCND,AOASIS              &    !O
+! WRF_HYDRO vars
+                 sfcheadrt_hydro,                                  &    !I
+                 INFXSRT_hydro,ETPND1_hydro                        &    !O
+                ,OPT_THCND,AOASIS                                  &    !O
                 ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, fasdas, HCPCT_FASDAS    &   ! fasdas
-                 )
-
+                ,IRRIGATION_CHANNEL)
 
 #ifdef WRF_HYDRO
                  soldrain(i,j) = RUNOFF2*DT*1000.0
+                 sfcheadrt(i,j) = sfcheadrt_hydro
+                 infxsrt(i,j) = INFXSRT_hydro
+                 etpnd1 = etpnd1_hydro
 #endif
     ELSEIF (ICE == -1) THEN
 
@@ -1232,9 +1317,11 @@ CONTAINS
 !--------------------------------------
 ! Input variables lsm --> urban
 
+           IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+               IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+               IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+               IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
 
-          IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-              IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL ) THEN
 
 ! Call urban
 
@@ -1251,7 +1338,7 @@ CONTAINS
             SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
             SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
             LLG_URB   = GLW(I,J)         ! [W/m/m]
-            RAIN_URB  = RAINBL(I,J)      ! [mm]
+            RAIN_URB  = RAINBL(I,J) / DT * 3600.0      ! [mm/hr]
             RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
             ZA_URB    = ZLVL             ! [m]
             DELT_URB  = DT               ! [sec]
@@ -1520,7 +1607,9 @@ CONTAINS
        CALL BEP(frc_urb2d,utype_urb2d,itimestep,dz8w,dt,u_phy,v_phy,   &
                 th_phy,rho,p_phy,swdown,glw,                           &
                 gmt,julday,xlong,xlat,declin_urb,cosz_urb2d,omg_urb2d, &
-                num_urban_layers,num_urban_hi,                         &
+           num_urban_ndm, urban_map_zrd, urban_map_zwd, urban_map_gd,  &
+            urban_map_zd, urban_map_zdf,  urban_map_bd, urban_map_wd,  &
+           urban_map_gbd, urban_map_fbd,  num_urban_hi,                &
                 trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,               &
                 sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,             &
                 lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,                  &
@@ -1553,13 +1642,20 @@ CONTAINS
        CALL BEP_BEM(frc_urb2d,utype_urb2d,itimestep,dz8w,dt,u_phy,v_phy, &
                 th_phy,rho,p_phy,swdown,glw,                           &
                 gmt,julday,xlong,xlat,declin_urb,cosz_urb2d,omg_urb2d, &
-                num_urban_layers,num_urban_hi,                         &
+                num_urban_ndm, urban_map_zrd, urban_map_zwd, urban_map_gd,  &
+                urban_map_zd, urban_map_zdf,  urban_map_bd, urban_map_wd,  &
+                urban_map_gbd, urban_map_fbd, urban_map_zgrd, num_urban_hi, &
                 trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,               &
                 tlev_urb3d,qlev_urb3d,tw1lev_urb3d,tw2lev_urb3d,       &
                 tglev_urb3d,tflev_urb3d,sf_ac_urb3d,lf_ac_urb3d,       &
                 cm_ac_urb3d,sfvent_urb3d,lfvent_urb3d,                 &
                 sfwin1_urb3d,sfwin2_urb3d,                             &
                 sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,             &
+                ep_pv_urb3d,t_pv_urb3d,                                & !RMS
+                trv_urb4d,qr_urb4d,qgr_urb3d,tgr_urb3d,                & !RMS
+                drain_urb4d,draingr_urb3d,sfrv_urb3d,                  & !RMS
+                lfrv_urb3d,dgr_urb3d,dg_urb3d,lfr_urb3d,lfg_urb3d,     & !RMS
+                rainbl,swddir,swddif,                                  & !RMS
                 lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,                  &
                 a_u_bep,a_v_bep,a_t_bep,                               &
                 a_e_bep,b_u_bep,b_v_bep,                               &
@@ -1620,7 +1716,7 @@ CONTAINS
 !           emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
 ! using the emissivity and the total longwave upward radiation estimate the averaged skin temperature
            IF (FRC_URB2D(I,J).GT.0.) THEN
-              rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emissi)*glw(i,j)
+              rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emiss_rural(i,j))*glw(i,j)
               rl_up_tot=(1.-frc_urb2d(i,j))*rl_up_rural+frc_urb2d(i,j)*rl_up_urb(i,j)   
               emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
               ts_urb2d(i,j)=(max(0.,(-rl_up_urb(i,j)-(1.-emiss_urb(i,j))*glw(i,j))/emiss_urb(i,j)/sigma_sb))**0.25
@@ -1666,18 +1762,8 @@ CONTAINS
               G_URB2D(I,J)     = 0.
               RN_URB2D(I,J)    = 0.
             endif
-!          IF( IVGTYP(I,J) == 1 .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-!                  IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
-!                    print*,'ivgtyp, qfx, hfx',ivgtyp(i,j),hfx_rural(i,j),qfx_rural(i,j)
-!                    print*,'ivgtyp,hfx,hfx_urb,hfx_rural',hfx(i,j),hfx_urb(i,j),hfx_rural(i,j)
-!                    print*,'lh,lh_rural',lh(i,j),lh_rural(i,j)
-!                    print*,'qfx',qfx(i,j)
-!                    print*,'ts_urb2d',ts_urb2d(i,j)
-!                    print*,'ust',ust(i,j)
-!          endif
         enddo
         enddo
-
 
        endif                                                           !Bep end
 
@@ -1698,9 +1784,11 @@ CONTAINS
                      SNOALB, FNDSOILW, FNDSNOWH, RDMAXALB,     &
                      num_soil_layers, restart,                 &
                      allowed_to_read ,                         &
+                     irr_rand_field,irr_ph,irr_freq,           &
                      ids,ide, jds,jde, kds,kde,                &
                      ims,ime, jms,jme, kms,kme,                &
-                     its,ite, jts,jte, kts,kte                 )
+                     its,ite, jts,jte, kts,kte                 &
+                    )
 
    INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
                                     ims,ime, jms,jme, kms,kme,  &
@@ -1747,7 +1835,10 @@ CONTAINS
                                 GRAV = 9.81, T0 = 273.15
    INTEGER                   :: errflag
    CHARACTER(LEN=80)         :: err_message
-
+   INTEGER,DIMENSION(ims:ime, jms:jme ),INTENT(INOUT):: irr_rand_field
+   INTEGER , DIMENSION(jds:jde) :: my_seeds
+   INTEGER :: irr_ph,irr_freq
+   REAL,DIMENSION(ims:ime, jms:jme ) :: rand_tmp
    character*256 :: MMINSL
         MMINSL='STAS'
 !
@@ -1772,6 +1863,22 @@ CONTAINS
 ! <--GAC
 
    IF(.not.restart)THEN
+
+#if ( EM_CORE==1 )
+   IF (irr_ph.NE.0)THEN
+   DO i = its,ite
+    DO j=jts,jte
+      my_seeds(j) =sqrt(ide*(real(j-1)**2))+sqrt(real(jde*i))
+!      PRINT*,'myseed', my_seeds(j),j,jts,jds
+    END DO
+      CALL RANDOM_SEED ( PUT = my_seeds )
+      CALL RANDOM_NUMBER ( rand_tmp(i,:) )
+      CALL RANDOM_SEED ( GET = my_seeds )
+      CALL RANDOM_NUMBER ( rand_tmp(i,:) )
+      irr_rand_field(i,:)=int(modulo(rand_tmp(i,:)*100,real(irr_freq)))
+   END DO
+   END IF
+#endif
 
    itf=min0(ite,ide-1)
    jtf=min0(jte,jde-1)
@@ -2008,14 +2115,29 @@ CONTAINS
           IF ( a_string(1:21) .EQ. 'Vegetation Parameters' ) THEN
              CALL wrf_message     ("Expected low and high density residential, and high density industrial information in VEGPARM.TBL")
              CALL wrf_error_fatal ("This could be caused by using an older VEGPARM.TBL file with a newer WRF source code.")
-          ENDIF
-          READ (19,*)LOW_DENSITY_RESIDENTIAL
-          READ (19,*)
-          READ (19,*)HIGH_DENSITY_RESIDENTIAL
-          READ (19,*)
-          READ (19,*)HIGH_INTENSITY_INDUSTRIAL
         ENDIF
-!
+         READ (19,*)LCZ_1
+          READ (19,*)
+          READ (19,*)LCZ_2
+          READ (19,*)
+          READ (19,*)LCZ_3
+          READ (19,*)
+          READ (19,*)LCZ_4
+          READ (19,*)
+          READ (19,*)LCZ_5
+          READ (19,*)
+          READ (19,*)LCZ_6
+          READ (19,*)
+          READ (19,*)LCZ_7
+          READ (19,*)
+          READ (19,*)LCZ_8
+          READ (19,*)
+          READ (19,*)LCZ_9
+          READ (19,*)
+          READ (19,*)LCZ_10
+          READ (19,*)
+          READ (19,*)LCZ_11
+        ENDIF
  2002   CONTINUE
 
         CLOSE (19)
@@ -2051,9 +2173,17 @@ CONTAINS
       CALL wrf_dm_bcast_real    ( RSMAX_DATA  , 1 )
       CALL wrf_dm_bcast_integer ( BARE    , 1 )
       CALL wrf_dm_bcast_integer ( NATURAL , 1 )
-      CALL wrf_dm_bcast_integer ( LOW_DENSITY_RESIDENTIAL , 1 )
-      CALL wrf_dm_bcast_integer ( HIGH_DENSITY_RESIDENTIAL , 1 )
-      CALL wrf_dm_bcast_integer ( HIGH_INTENSITY_INDUSTRIAL , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_1 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_2 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_3 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_4 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_5 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_6 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_7 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_8 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_9 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_10 , 1 )
+      CALL wrf_dm_bcast_integer ( LCZ_11 , 1 )
 
 !
 !-----READ IN SOIL PROPERTIES FROM SOILPARM.TBL
@@ -2276,8 +2406,19 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   DRELR_URB2D,DRELB_URB2D,DRELG_URB2D,          & !H urban
                   FLXHUMR_URB2D,FLXHUMB_URB2D,FLXHUMG_URB2D,    & !H urban
                   FRC_URB2D,UTYPE_URB2D,                        & !O
-                  num_urban_layers,                             & !I multi-layer urban
+                  num_urban_ndm,                                & !I multi-layer urban
+                  urban_map_zrd,                                & !I multi-layer urban
+                  urban_map_zwd,                                & !I multi-layer urban
+                  urban_map_gd,                                 & !I multi-layer urban
+                  urban_map_zd,                                 & !I multi-layer urban
+                  urban_map_zdf,                                & !I multi-layer urban
+                  urban_map_bd,                                 & !I multi-layer urban
+                  urban_map_wd,                                 & !I multi-layer urban
+                  urban_map_gbd,                                & !I multi-layer urban
+                  urban_map_fbd,                                & !I multi-layer urban
+                  urban_map_zgrd,                               & !I multi-layer urban
                   num_urban_hi,                                 & !I multi-layer urban
+                  use_wudapt_lcz,                               & !I wudapt
                   tsk_rural_bep,                                & !H multi-layer urban
                   trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
                   tlev_urb3d,qlev_urb3d,                        & !H multi-layer urban
@@ -2287,6 +2428,10 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   sfvent_urb3d,lfvent_urb3d,                    & !H multi-layer urban
                   sfwin1_urb3d,sfwin2_urb3d,                    & !H multi-layer urban
                   sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,    & !H multi-layer urban
+                  ep_pv_urb3d,t_pv_urb3d,                         & !RMS
+                  trv_urb4d,qr_urb4d,qgr_urb3d,tgr_urb3d,         & !RMS
+                  drain_urb4d,draingr_urb3d,sfrv_urb3d,           & !RMS
+                  lfrv_urb3d,dgr_urb3d,dg_urb3d,lfr_urb3d,lfg_urb3d,& !RMS
                   lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,         & !H multi-layer urban
                   mh_urb2d,stdh_urb2d,lf_urb2d,                 & !SLUCM
                   th_phy,rho,p_phy,ust,                         & !I multi-layer urban
@@ -2295,9 +2440,12 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   a_e_bep,b_u_bep,b_v_bep,                      & !O multi-layer urban
                   b_t_bep,b_q_bep,b_e_bep,dlg_bep,              & !O multi-layer urban
                   dl_u_bep,sf_bep,vl_bep                        & !O multi-layer urban
+#ifdef WRF_HYDRO
                  ,sfcheadrt,INFXSRT, soldrain                   & !hydro
+#endif
                  ,SDA_HFX, SDA_QFX, HFX_BOTH, QFX_BOTH, QNORM, fasdas     &   !fasdas
                  ,RC2,XLAI2                                     & !O
+                 ,IRR_CHAN                                      &
                   )
 
 !----------------------------------------------------------------
@@ -2446,10 +2594,15 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
    INTEGER,  INTENT(IN   )   ::  julian,julyr
 
 !added by Wei Yu  for routing
+#ifdef WRF_HYDRO
     REAL,    DIMENSION( ims:ime, jms:jme )                     , &
              INTENT(INOUT)  :: sfcheadrt,INFXSRT,soldrain 
     real :: etpnd1
+#endif
 !end added
+
+! new local vars for hydro
+   REAL :: etpnd1_hydro,sfcheadrt_hydro,infxsrt_hydro
 
    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
             INTENT(IN   )    ::                            TMN, &
@@ -2464,7 +2617,6 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                                                            GLW, &
                                                         RAINBL, &
                                                         SR
-
    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
             INTENT(INOUT)    ::                         ALBBCK, &
                                                             Z0, &
@@ -2767,30 +2919,55 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
    REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
    INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
-   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+   INTEGER, INTENT(IN  ) ::                               num_urban_ndm
+   INTEGER, INTENT(IN  ) ::                               urban_map_zrd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zwd
+   INTEGER, INTENT(IN  ) ::                               urban_map_gd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zdf
+   INTEGER, INTENT(IN  ) ::                               urban_map_bd
+   INTEGER, INTENT(IN  ) ::                               urban_map_wd
+   INTEGER, INTENT(IN  ) ::                               urban_map_gbd
+   INTEGER, INTENT(IN  ) ::                               urban_map_fbd
+   INTEGER, INTENT(IN  ) ::                               urban_map_zgrd
    INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
+   INTEGER, INTENT(IN  ) ::                               use_wudapt_lcz
    REAL, OPTIONAL, DIMENSION( ims:ime,                     jms:jme ), INTENT(INOUT) :: tsk_rural_bep
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zrd, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zwd, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_gd , jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_bd , jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_bd , jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_gbd, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_fbd, jms:jme ), INTENT(INOUT) :: tflev_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
-   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_wd , jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zd , jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: ep_pv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ), INTENT(INOUT) :: t_pv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ),INTENT(INOUT) :: trv_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme ),INTENT(INOUT) :: qr_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme ), INTENT(INOUT) :: qgr_urb3d  !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme ), INTENT(INOUT) :: tgr_urb3d  !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: drain_urb4d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: draingr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: sfrv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: lfrv_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: dgr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: dg_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: lfr_urb3d !GRZ
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: lfg_urb3d !GRZ
    REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lp_urb2d
    REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lb_urb2d
@@ -2889,7 +3066,9 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
    REAL                    ::  HFX_PHY, QFX_PHY
    REAL                    ::  DZQ
    REAL                    ::  HCPCT_FASDAS
-
+   REAL,OPTIONAL,DIMENSION( ims:ime, jms:jme ) :: IRR_CHAN
+   REAL               :: IRRIGATION_CHANNEL
+   IRRIGATION_CHANNEL=0.0
    HFX_PHY = 0.0   ! initialize
    QFX_PHY = 0.0
    XQNORM  = 0.0
@@ -3088,6 +3267,13 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
               SOLNET=SOLDN*(1.-ALBEDO(I,J))
               PRCP=RAINBL(i,j)/DT
+              IF(PRESENT(IRR_CHAN)) THEN
+               IF(IRR_CHAN(i,j).NE.0) THEN
+                IRRIGATION_CHANNEL=IRR_CHAN(i,j)/DT
+               ELSE
+                IRRIGATION_CHANNEL=0.
+               END IF
+              ENDIF
               VEGTYP=IVGTYP(I,J)
               SOILTYP=ISLTYP(I,J)
               SHDFAC=VEGFRA(I,J)/100.
@@ -3204,10 +3390,9 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       
       !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
       ! the "NATURAL" category in the VEGPARM.TBL
-      	
-      	!   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
-                       
-      
+
+      !   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+
            !           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
            !            IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
            !	 VEGTYP = NATURAL
@@ -3238,9 +3423,11 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
             Noah_call=.TRUE.
       
             If ( SF_URBAN_PHYSICS == 0 ) THEN   ! ONLY NOAH
-      
-                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                       IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
+             IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                 IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                 IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                 IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
                        Noah_call = .TRUE.                 
                        VEGTYP = ISURBAN
                  ENDIF
@@ -3249,16 +3436,19 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
             
             IF(SF_URBAN_PHYSICS == 1) THEN
       
-                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                       IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN   
-              	
+               IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                   IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                   IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                   IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
                        Noah_call = .TRUE.                       
               	       VEGTYP = NATURAL                                              
                        SHDFAC = SHDTBL(NATURAL)
                        ALBEDOK =0.2         !  0.2
                        ALBBRD  =0.2         !  0.2
                        EMISSI = 0.98        !  for VEGTYP=5       
-                       
+                       LWDN   = GLW(I,J) * EMISSI
+                       SOLNET = SOLDN * (1.0 - ALBEDOK)
+
       		      T1= TS_RUL2D_mosaic(I,mosaic_i,J)
                        
                  ENDIF
@@ -3276,9 +3466,12 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
            if (tloc==0) tloc=24
            CALL cal_mon_day(julian,julyr,jmonth,jday) 
 	  IF(SF_URBAN_PHYSICS == 1) THEN
-           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
-            AOASIS = oasis  ! urban oasis effect
+             IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                 IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                 IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                 IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
+                   AOASIS = oasis  ! urban oasis effect
                    IF (IRIOPTION ==1) THEN
                    IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
                    IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
@@ -3372,13 +3565,18 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                        SNOTIME1,                                         &
                        RIBB,                                             &
                        SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
-                       sfcheadrt(i,j),                                   &    !I
-                       INFXSRT(i,j),ETPND1,OPT_THCND,AOASIS              &    !O
-                ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, fasdas, HCPCT_FASDAS    & ! fasdas vars
-                       )
+! WRF_HYDRO vars
+                       sfcheadrt_hydro,                                  &    !I
+                       INFXSRT_hydro,ETPND1_hydro                        &    !O
+                      ,OPT_THCND,AOASIS                                  &    !O
+                      ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, fasdas, HCPCT_FASDAS    & ! fasdas vars
+                      ,IRRIGATION_CHANNEL  )
       
 #ifdef WRF_HYDRO
                        soldrain(i,j) = RUNOFF2*DT*1000.0
+                       sfcheadrt(i,j) = sfcheadrt_hydro
+                       infxsrt(i,j) = INFXSRT_hydro
+                       etpnd1 = etpnd1_hydro
 #endif
           ELSEIF (ICE == -1) THEN
       
@@ -3519,22 +3717,50 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       ! URBAN CANOPY MODEL START - urban
       !--------------------------------------
       ! Input variables lsm --> urban
-      
-                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                    IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL ) THEN            
-      
+                 IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                     IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                     IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                     IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
                 !  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
                 !  this need to be changed in the mosaic danli
-      
-                IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
-                IF(IVGTYP(I,J)==LOW_DENSITY_RESIDENTIAL) UTYPE_URB=1
-                IF(IVGTYP(I,J)==HIGH_DENSITY_RESIDENTIAL) UTYPE_URB=2
-                IF(IVGTYP(I,J)==HIGH_INTENSITY_INDUSTRIAL) UTYPE_URB=3
-                        
-                IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
-                IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
-                IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
-      
+                IF (use_wudapt_lcz == 1) THEN
+                  IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=5
+                  IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1
+                  IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2
+                  IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3
+                  IF(IVGTYP(I,J)==LCZ_4) UTYPE_URB=4
+                  IF(IVGTYP(I,J)==LCZ_5) UTYPE_URB=5
+                  IF(IVGTYP(I,J)==LCZ_6) UTYPE_URB=6
+                  IF(IVGTYP(I,J)==LCZ_7) UTYPE_URB=7
+                  IF(IVGTYP(I,J)==LCZ_8) UTYPE_URB=8
+                  IF(IVGTYP(I,J)==LCZ_9) UTYPE_URB=9
+                  IF(IVGTYP(I,J)==LCZ_10) UTYPE_URB=10
+                  IF(IVGTYP(I,J)==LCZ_11) UTYPE_URB=11
+
+
+                  IF(UTYPE_URB==1) FRC_URB2D(I,J)=1.
+                  IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.99
+                  IF(UTYPE_URB==3) FRC_URB2D(I,J)=1.00
+                  IF(UTYPE_URB==4) FRC_URB2D(I,J)=0.65
+                  IF(UTYPE_URB==5) FRC_URB2D(I,J)=0.7
+                  IF(UTYPE_URB==6) FRC_URB2D(I,J)=0.65
+                  IF(UTYPE_URB==7) FRC_URB2D(I,J)=0.3
+                  IF(UTYPE_URB==8) FRC_URB2D(I,J)=0.85
+                  IF(UTYPE_URB==9) FRC_URB2D(I,J)=0.3
+                  IF(UTYPE_URB==10) FRC_URB2D(I,J)=0.55
+                  IF(UTYPE_URB==11) FRC_URB2D(I,J)=1.
+                ELSE
+                  IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
+                  IF(IVGTYP(I,J)==LCZ_1) UTYPE_URB=1 ! LOW_DENSITY_RESIDENTIAL
+                  IF(IVGTYP(I,J)==LCZ_2) UTYPE_URB=2 ! HIGH_DENSITY_RESIDENTIAL
+                  IF(IVGTYP(I,J)==LCZ_3) UTYPE_URB=3 ! HIGH_INTENSITY_INDUSTRIAL
+
+                  IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
+                  IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
+                  IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
+                END IF
+
                   TA_URB    = SFCTMP           ! [K]
                   QA_URB    = Q2K              ! [kg/kg]
                   UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
@@ -3545,7 +3771,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
                   SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
                   LLG_URB   = GLW(I,J)         ! [W/m/m]
-                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RAIN_URB  = RAINBL(I,J) / DT * 3600.0      ! [mm/hr]
                   RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
                   ZA_URB    = ZLVL             ! [m]
                   DELT_URB  = DT               ! [sec]
@@ -4126,18 +4352,24 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   SNOWHK= 5.*SNEQV
                 endif
       !
-      
+
       !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
       ! the "NATURAL" category in the VEGPARM.TBL
-      	
-      	   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
-                      IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                        IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
+                 IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+
+                IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                    IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                    IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                    IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
       		 VEGTYP = NATURAL
                        SHDFAC = SHDTBL(NATURAL)
                        ALBEDOK =0.2         !  0.2
                        ALBBRD  =0.2         !0.2
                        EMISSI = 0.98                                 !for VEGTYP=5
+                       LWDN   = GLW(I,J) * EMISSI
+                       SOLNET = SOLDN * (1.0 - ALBEDOK)
+
       		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
                    if(sf_urban_physics.eq.1)then
                      T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
@@ -4149,8 +4381,10 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                        ENDIF
                       ENDIF
                  ELSE
-                       IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                        IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
+                         IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                             IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                             IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                             IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
                         VEGTYP = ISURBAN
                  	 ENDIF
                  ENDIF
@@ -4167,9 +4401,12 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
            if (tloc==0) tloc=24
            CALL cal_mon_day(julian,julyr,jmonth,jday) 
 	  IF(SF_URBAN_PHYSICS == 1) THEN
-           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
-            AOASIS = oasis  ! urban oasis effect
+                          IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                             IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                             IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                             IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
+                AOASIS = oasis  ! urban oasis effect
                    IF (IRIOPTION ==1) THEN
                    IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
                    IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
@@ -4257,13 +4494,18 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                        SNOTIME1,                                         &
                        RIBB,                                             &
                        SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
-                       sfcheadrt(i,j),                                   &    !I
-                       INFXSRT(i,j),ETPND1,OPT_THCND,AOASIS              &    !O
-                ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, fasdas, HCPCT_FASDAS    & ! fasdas vars
-                       )
+! WRF_HYDRO vars
+                       sfcheadrt_hydro,                                  &    !I
+                       INFXSRT_hydro,ETPND1_hydro                        &    !O
+                      ,OPT_THCND,AOASIS                                  &    !O
+                      ,XSDA_QFX, HFX_PHY, QFX_PHY, XQNORM, fasdas, HCPCT_FASDAS    & ! fasdas vars
+                      ,IRRIGATION_CHANNEL )
       
 #ifdef WRF_HYDRO
                        soldrain(i,j) = RUNOFF2*DT*1000.0
+                       sfcheadrt(i,j) = sfcheadrt_hydro
+                       infxsrt(i,j) = INFXSRT_hydro
+                       etpnd1 = etpnd1_hydro
 #endif
           ELSEIF (ICE == -1) THEN
       
@@ -4403,10 +4645,11 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
       ! URBAN CANOPY MODEL START - urban
       !--------------------------------------
       ! Input variables lsm --> urban
-      
-                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL .or. &
-                    IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL .or. IVGTYP(I,J) ==  HIGH_INTENSITY_INDUSTRIAL) THEN
-      
+                  IF( IVGTYP(I,J) == ISURBAN    .or. IVGTYP(I,J) == LCZ_1 .or. IVGTYP(I,J) == LCZ_2 .or. &
+                      IVGTYP(I,J) == LCZ_3      .or. IVGTYP(I,J) == LCZ_4 .or. IVGTYP(I,J) == LCZ_5 .or. &
+                      IVGTYP(I,J) == LCZ_6      .or. IVGTYP(I,J) == LCZ_7 .or. IVGTYP(I,J) == LCZ_8 .or. &
+                      IVGTYP(I,J) == LCZ_9      .or. IVGTYP(I,J) == LCZ_10 .or. IVGTYP(I,J) == LCZ_11 ) THEN
+
       ! Call urban
       !
                   UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
@@ -4421,7 +4664,7 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
                   SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
                   LLG_URB   = GLW(I,J)         ! [W/m/m]
-                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RAIN_URB  = RAINBL(I,J) / DT * 3600.0     ! [mm/hr]
                   RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
                   ZA_URB    = ZLVL             ! [m]
                   DELT_URB  = DT               ! [sec]

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm.F
@@ -1,12 +1,16 @@
+!=================================================================================================================
 MODULE module_sf_noahlsm
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_constants,only: CP=>cp,R_D=>R_d,XLF=>xlf,XLV=>xlv,RHOWATER=>rho_w,STBOLT=>stbolt,KARMAN=>karman
 use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
 #else
 USE module_model_constants, only : CP, R_D, XLF, XLV, RHOWATER, STBOLT, KARMAN
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
 #endif
 
 !ckay=KIRAN ALAPATY @ US EPA -- November 01, 2015
@@ -29,7 +33,7 @@ use module_wrf_error
 ! VEGETATION PARAMETERS
         INTEGER :: LUCATS , BARE
         INTEGER :: NATURAL
-        INTEGER :: LOW_DENSITY_RESIDENTIAL, HIGH_DENSITY_RESIDENTIAL, HIGH_INTENSITY_INDUSTRIAL
+        INTEGER :: LCZ_1,LCZ_2,LCZ_3,LCZ_4,LCZ_5,LCZ_6,LCZ_7,LCZ_8,LCZ_9,LCZ_10,LCZ_11
         integer, PARAMETER :: NLUS=50
         CHARACTER(LEN=256) LUTYPE
         INTEGER, DIMENSION(1:NLUS) :: NROTBL
@@ -96,7 +100,7 @@ CONTAINS
                        SFHEAD1RT,                                       &    !I
                        INFXS1RT,ETPND1,OPT_THCND,AOASIS                 &    !P
                       ,XSDA_QFX,HFX_PHY,QFX_PHY,XQNORM                  &    !fasdas
-                      ,fasdas,HCPCT_FASDAS                              )    !fasdas
+                      ,fasdas,HCPCT_FASDAS,IRRIGATION_CHANNEL           )    !fasdas
 
 ! ----------------------------------------------------------------------
 ! SUBROUTINE SFLX - UNIFIED NOAHLSM VERSION 1.0 JULY 2007
@@ -322,7 +326,7 @@ CONTAINS
 
       REAL, INTENT(IN)   :: SHDMIN,SHDMAX,DT,DQSDT2,LWDN,PRCP,PRCPRAIN,     &
                             Q2,Q2SAT,SFCPRS,SFCSPD,SFCTMP, SNOALB,          &
-                            SOLDN,SOLNET,TBOT,TH2,ZLVL,                     &
+                            SOLDN,SOLNET,TBOT,TH2,ZLVL,                            &
                             FFROZP,AOASIS
       REAL, INTENT(OUT)  :: EMBRD
       REAL, INTENT(OUT)  :: ALBEDO
@@ -385,6 +389,9 @@ CONTAINS
 !
 !  END FASDAS
 !
+! IRRIGATION
+  REAL, OPTIONAL,   INTENT(INOUT)  :: IRRIGATION_CHANNEL
+
 ! ----------------------------------------------------------------------
 !   INITIALIZATION
 ! ----------------------------------------------------------------------
@@ -769,7 +776,8 @@ CONTAINS
                             QUARTZ,FXEXP,CSOIL,                          &
                             BETA,DRIP,DEW,FLX1,FLX3,VEGTYP,ISURBAN,      &
                             SFHEAD1RT,INFXS1RT,ETPND1,SOILTYP,OPT_THCND  &
-                           ,XSDA_QFX,QFX_PHY,XQNORM,fasdas,HCPCT_FASDAS  ) !fasdas
+                           ,XSDA_QFX,QFX_PHY,XQNORM,fasdas,HCPCT_FASDAS,IRRIGATION_CHANNEL  ) !fasdas
+
             ETA_KINEMATIC = ETA
          ELSE
             CALL SNOPAC (ETP,ETA,PRCP,PRCPF,SNOWNG,SMC,SMCMAX,SMCWLT,    &
@@ -1908,7 +1916,8 @@ CONTAINS
                          QUARTZ,FXEXP,CSOIL,                            &
                          BETA,DRIP,DEW,FLX1,FLX3,VEGTYP,ISURBAN,        &
                          SFHEAD1RT,INFXS1RT,ETPND1,SOILTYP,OPT_THCND    &
-                        ,XSDA_QFX,QFX_PHY,XQNORM,fasdas,HCPCT_FASDAS    ) !fasdas
+                        ,XSDA_QFX,QFX_PHY,XQNORM,fasdas,HCPCT_FASDAS    &
+                        ,IRRIGATION_CHANNEL    ) !fasdas
 
 ! ----------------------------------------------------------------------
 ! SUBROUTINE NOPAC
@@ -1949,6 +1958,7 @@ CONTAINS
       REAL , DIMENSION(1:NSOIL)  ::  EFT(NSOIL), wetty(1:NSOIL)
       REAL                       ::  EFDIR, EFC, EALL_now
       REAL, INTENT(  OUT)        ::  HCPCT_FASDAS
+      REAL, INTENT(IN),OPTIONAL  ::  IRRIGATION_CHANNEL
 !
 ! END FASDAS
 !
@@ -2044,7 +2054,7 @@ CONTAINS
                       SHDFAC,CMCMAX,                                    &
                       RUNOFF1,RUNOFF2,RUNOFF3,                          &
                       EDIR1,EC1,ET1,                                    &
-                      DRIP, SFHEAD1RT,INFXS1RT)
+                      DRIP, SFHEAD1RT,INFXS1RT,IRRIGATION_CHANNEL)
 
 ! ----------------------------------------------------------------------
 ! CONVERT MODELED EVAPOTRANSPIRATION FROM  M S-1  TO  KG M-2 S-1.
@@ -2107,7 +2117,7 @@ CONTAINS
                       SHDFAC,CMCMAX,                                    &
                       RUNOFF1,RUNOFF2,RUNOFF3,                          &
                       EDIR1,EC1,ET1,                                    &
-                      DRIP, SFHEAD1RT,INFXS1RT)
+                      DRIP, SFHEAD1RT,INFXS1RT,IRRIGATION_CHANNEL)
 
 ! ----------------------------------------------------------------------
 ! CONVERT MODELED EVAPOTRANSPIRATION FROM 'M S-1' TO 'KG M-2 S-1'.
@@ -2666,7 +2676,8 @@ CONTAINS
      &                   SHDFAC,CMCMAX,                                 &
      &                   RUNOFF1,RUNOFF2,RUNOFF3,                       &
      &                   EDIR,EC,ET,                                    &
-     &                   DRIP, SFHEAD1RT,INFXS1RT)
+     &                   DRIP, SFHEAD1RT,INFXS1RT,                      &
+                         IRRIGATION_CHANNEL )
 
 ! ----------------------------------------------------------------------
 ! SUBROUTINE SMFLX
@@ -2689,11 +2700,11 @@ CONTAINS
       REAL, DIMENSION(1:NSOIL), INTENT(IN)   :: ET,ZSOIL
       REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: SMC, SH2O
       REAL, DIMENSION(1:NSOIL)             :: AI, BI, CI, STCF,RHSTS, RHSTT, &
-                                              SICE, SH2OA, SH2OFG
+                                              SICE, SH2OA, SH2OFG, SH2OIN
       REAL                  :: DUMMY, EXCESS,FRZFACT,PCPDRP,RHSCT,TRHSCT
       REAL :: FAC2
       REAL :: FLIMIT
-
+      REAL, INTENT(IN),OPTIONAL      :: IRRIGATION_CHANNEL
       REAL,    INTENT(INOUT)                 :: SFHEAD1RT,INFXS1RT
 
 ! ----------------------------------------------------------------------
@@ -2720,7 +2731,9 @@ CONTAINS
 ! ----------------------------------------------------------------------
       IF (EXCESS > CMCMAX) DRIP = EXCESS - CMCMAX
       PCPDRP = (1. - SHDFAC) * PRCP1+ DRIP / DT
-
+      IF(PRESENT(IRRIGATION_CHANNEL)) THEN
+         IF (IRRIGATION_CHANNEL.NE.0.)PCPDRP =PCPDRP+ 0.001*IRRIGATION_CHANNEL !conversion of units
+      END IF
 ! ----------------------------------------------------------------------
 ! STORE ICE CONTENT AT EACH SOIL LAYER BEFORE CALLING SRT and SSTEP
 !
@@ -2784,7 +2797,8 @@ CONTAINS
                     DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
                     SFHEAD1RT,INFXS1RT)
-         CALL SSTEP (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+         SH2OIN=SH2O
+         CALL SSTEP (SH2O,SH2OIN,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,       &
                         CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
 
       ELSE
@@ -2792,7 +2806,8 @@ CONTAINS
                     DWSAT,DKSAT,SMCMAX,BEXP,RUNOFF1,                    &
                     RUNOFF2,DT,SMCWLT,SLOPE,KDT,FRZFACT,SICE,AI,BI,CI,  &
                    SFHEAD1RT,INFXS1RT)
-         CALL SSTEP (SH2O,SH2O,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,         &
+         SH2OIN=SH2O
+         CALL SSTEP (SH2O,SH2OIN,CMC,RHSTT,RHSCT,DT,NSOIL,SMCMAX,       &
                      CMCMAX,RUNOFF3,ZSOIL,SMC,SICE,AI,BI,CI,INFXS1RT)
 !      RUNOF = RUNOFF
 

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahlsm_glacial_only.F
@@ -1,12 +1,16 @@
+!=================================================================================================================
 MODULE module_sf_noahlsm_glacial_only
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_constants
 use mpas_atmphys_utilities, only: physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
 #else
 use module_model_constants
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
 #endif
 
   USE module_sf_noahlsm, ONLY : RD, SIGMA, CPH2O, CPICE, LSUBF, EMISSI_S, ROSR12

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_urban.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_urban.F
@@ -1,12 +1,15 @@
 MODULE module_sf_urban
+
+!reference: WRF-v4.5.1
+!Laura D. Fowler (laura@ucar.edu)/2023-04-21.
 #if defined(mpas)
 use mpas_atmphys_utilities, only: physics_message,physics_error_fatal
-#define FATAL_ERROR(M) call physics_error_fatal( M )
-#define WRITE_MESSAGE(M) call physics_message( M )
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
 #else
 use module_wrf_error
-#define FATAL_ERROR(M) call wrf_error_fatal( M )
-#define WRITE_MESSAGE(M) call wrf_message( M )
+#define FATAL_ERROR(M) call wrf_error_fatal(M)
+#define WRITE_MESSAGE(M) call wrf_message(M)
 #endif
 
 !===============================================================================
@@ -35,6 +38,8 @@ use module_wrf_error
    REAL, ALLOCATABLE, DIMENSION(:) :: FRC_URB_TBL
 
    REAL, ALLOCATABLE, DIMENSION(:) :: COP_TBL
+   REAL, ALLOCATABLE, DIMENSION(:) :: BLDAC_FRC_TBL
+   REAL, ALLOCATABLE, DIMENSION(:) :: COOLED_FRC_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: PWIN_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: BETA_TBL
    INTEGER, ALLOCATABLE, DIMENSION(:) :: SW_COND_TBL
@@ -45,6 +50,11 @@ use module_wrf_error
    REAL, ALLOCATABLE, DIMENSION(:) :: TARGHUM_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: GAPHUM_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: PERFLO_TBL
+   REAL, ALLOCATABLE, DIMENSION(:) :: PV_FRAC_ROOF_TBL !GRZ
+   REAL, ALLOCATABLE, DIMENSION(:) :: GR_FRAC_ROOF_TBL !GRZ
+   INTEGER :: GR_FLAG_TBL !GRZ
+   INTEGER :: GR_TYPE_TBL !GRZ
+   REAL, DIMENSION(1:24)           :: IRHO_TBL
    REAL, ALLOCATABLE, DIMENSION(:) :: HSESF_TBL
 
    REAL, ALLOCATABLE, DIMENSION(:) :: CAPR_TBL, CAPB_TBL, CAPG_TBL
@@ -679,7 +689,7 @@ use module_wrf_error
    SIGMA_ZED = stdh_urb
 
  !Calculate Wind Direction and Assign Appropriae lf_urb
-   !WDR = (180.0/PI)*ATAN2(U10,V10)
+   WDR = (180.0/PI)*ATAN2(U10,V10)
    
    IF(WDR.ge.0.0.and.WDR.lt.22.5)THEN
      lambda_f = lf_urb(1)
@@ -691,7 +701,7 @@ use module_wrf_error
      lambda_f = lf_urb(1)
    ELSEIF(WDR.gt.22.5.and.WDR.le.67.5)THEN
      lambda_f = lf_urb(2)
-   ELSEIF(WDR.ge.-67.5.and.WDR.lt.-22.5)THEN
+   ELSEIF(WDR.ge.-157.5.and.WDR.lt.-112.5)THEN
      lambda_f = lf_urb(2)
    ELSEIF(WDR.gt.67.5.and.WDR.le.112.5)THEN
      lambda_f = lf_urb(3)
@@ -699,7 +709,7 @@ use module_wrf_error
      lambda_f = lf_urb(3)
    ELSEIF(WDR.gt.112.5.and.WDR.le.157.5)THEN
      lambda_f = lf_urb(4)
-   ELSEIF(WDR.ge.-157.5.and.WDR.lt.-112.5)THEN
+   ELSEIF(WDR.ge.-67.5.and.WDR.lt.-22.5)THEN
      lambda_f = lf_urb(4)
    ELSE
      lambda_f = lf_urb(1)
@@ -1160,7 +1170,7 @@ use module_wrf_error
      END DO
        ! Update temperature in soil layer
        CALL SHFLX (SSOILR,TGRL,SMR,SMCMAX,NGR,TGRP,DELT,YY,ZZ1,ZSOILR,       &
-                   TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR)
+                  TRLEND,ZBOT,SMCWLT,DF1,QUARTZ,CSOIL,CAPR)
    FLXTHGR=HGR/RHO/CP/100.
    FLXHUMGR=ELEGR/RHO/EL/100.
 ELSE
@@ -1940,7 +1950,7 @@ ENDIF
 !
 !===============================================================================
    SUBROUTINE urban_param_init(DZR,DZB,DZG,num_soil_layers, &
-                               sf_urban_physics)
+                               sf_urban_physics,use_wudapt_lcz)
 !                              num_roof_layers,num_wall_layers,num_road_layers)
 
    IMPLICIT NONE
@@ -1954,6 +1964,7 @@ ENDIF
    REAL, DIMENSION(1:num_soil_layers), INTENT(INOUT) :: DZB
    REAL, DIMENSION(1:num_soil_layers), INTENT(INOUT) :: DZG
    INTEGER,                            INTENT(IN)    :: SF_URBAN_PHYSICS
+   INTEGER,                            INTENT(IN)    :: USE_WUDAPT_LCZ !AndreaLCZ
 
    INTEGER :: LC, K
    INTEGER :: IOSTATUS, ALLOCATE_STATUS
@@ -1989,8 +2000,10 @@ ENDIF
    num_road_layers = num_soil_layers
 
 
-   ICATE=0
+   ICATE=0  
 
+   
+  if(USE_WUDAPT_LCZ.eq.0)then   !AndreaLCZ
    OPEN (UNIT=11,                &
          FILE='URBPARM.TBL', &
          ACCESS='SEQUENTIAL',    &
@@ -1999,9 +2012,24 @@ ENDIF
          POSITION='REWIND',      &
          IOSTAT=IOSTATUS)
 
-   IF (IOSTATUS > 0) THEN
-   FATAL_ERROR('ERROR OPEN URBPARM.TBL')
-   ENDIF
+         IF (IOSTATUS > 0) THEN
+         FATAL_ERROR('Error opening URBPARM.TBL. Make sure URBPARM.TBL (found in run/) is linked to the running directory.')
+         ENDIF
+
+ else
+   OPEN (UNIT=11,                &
+         FILE='URBPARM_LCZ.TBL', &
+         ACCESS='SEQUENTIAL',    &
+         STATUS='OLD',           &
+         ACTION='READ',          &
+         POSITION='REWIND',      &
+         IOSTAT=IOSTATUS)
+
+         IF (IOSTATUS > 0) THEN
+         FATAL_ERROR('Error opening URBPARM_LCZ.TBL. Make sure URBPARM_LCZ.TBL (found in run/) is linked to the running directory.')
+         ENDIF
+ endif
+ 
 
    READLOOP : do 
       read(11,'(A512)', iostat=iostatus) string
@@ -2109,6 +2137,10 @@ ENDIF
             if(allocate_status /= 0) FATAL_ERROR('Error allocating HPERCENT_BIN_TBL in urban_param_init')
             ALLOCATE( COP_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) FATAL_ERROR('Error allocating COP_TBL in urban_param_init')
+            ALLOCATE( BLDAC_FRC_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating BLDAC_FRC_TBL in urban_param_init')
+            ALLOCATE( COOLED_FRC_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating COOLED_FRC_TBL in urban_param_init')
             ALLOCATE( PWIN_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) FATAL_ERROR('Error allocating PWIN_TBL in urban_param_init')
             ALLOCATE( BETA_TBL(ICATE), stat=allocate_status )
@@ -2131,6 +2163,11 @@ ENDIF
             if(allocate_status /= 0) FATAL_ERROR('Error allocating PERFLO_TBL in urban_param_init')
             ALLOCATE( HSESF_TBL(ICATE), stat=allocate_status )
             if(allocate_status /= 0) FATAL_ERROR('Error allocating HSESF_TBL in urban_param_init')
+            ALLOCATE( PV_FRAC_ROOF_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating PV_FRAC_ROOF_TBL in urban_param_init')
+            ALLOCATE( GR_FRAC_ROOF_TBL(ICATE), stat=allocate_status )
+            if(allocate_status /= 0) FATAL_ERROR('Error allocating GR_FRAC_ROOF_TBL in urban_param_init')
+
          endif
          numdir_tbl = 0
          street_direction_tbl = -1.E36
@@ -2295,6 +2332,10 @@ ENDIF
          read(string(indx+1:),*) Z0R_tbl(1:icate)
       else if ( name == "COP") then
          read(string(indx+1:),*) cop_tbl(1:icate)
+      else if ( name == "BLDAC_FRC") then
+         read(string(indx+1:),*) bldac_frc_tbl(1:icate)
+      else if ( name == "COOLED_FRC") then
+         read(string(indx+1:),*) cooled_frc_tbl(1:icate)
       else if ( name == "PWIN") then
          read(string(indx+1:),*) pwin_tbl(1:icate)
       else if ( name == "BETA") then
@@ -2319,6 +2360,17 @@ ENDIF
          read(string(indx+1:),*) hsequip_tbl(1:24)
       else if (name == "HSEQUIP_SCALE_FACTOR") then
          read(string(indx+1:),*) hsesf_tbl(1:icate)
+      else if (name == "IRHO") then
+         read(string(indx+1:),*) IRHO_TBL(1:24)
+       else if ( name == "PV_FRAC_ROOF") then
+         read(string(indx+1:),*) pv_frac_roof_tbl(1:icate)
+     else if ( name == "GR_FRAC_ROOF") then
+         read(string(indx+1:),*) gr_frac_roof_tbl(1:icate)
+      else if (name == "GR_FLAG") then
+         read(string(indx+1:),*) gr_flag_tbl
+      else if (name == "GR_TYPE") then
+         read(string(indx+1:),*) gr_type_tbl
+
 !end BEP         
       else
          FATAL_ERROR('URBPARM.TBL: Unrecognized NAME = "'//trim(name)//'" in Subr URBAN_PARAM_INIT')
@@ -2410,18 +2462,25 @@ ENDIF
 !===========================================================================
    SUBROUTINE urban_var_init(ISURBAN, TSURFACE0_URB,TLAYER0_URB,TDEEP0_URB,IVGTYP,  & ! in
                              ims,ime,jms,jme,kms,kme,num_soil_layers,         & ! in
-!                             num_roof_layers,num_wall_layers,num_road_layers, & ! in
-!                              num_roof_layers,num_wall_layers,num_road_layers, & !urban
-                             LOW_DENSITY_RESIDENTIAL,                    &
-		             HIGH_DENSITY_RESIDENTIAL,                   &
-		             HIGH_INTENSITY_INDUSTRIAL,                    &
+                             LCZ_1,LCZ_2,LCZ_3,LCZ_4,LCZ_5,                &
+                             LCZ_6,LCZ_7,LCZ_8,LCZ_9,LCZ_10,LCZ_11,        & 
                              restart,sf_urban_physics,                     & !in
                              XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & ! inout
                              TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & ! inout
                              TRL_URB3D,TBL_URB3D,TGL_URB3D,                & ! inout
                              SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,           & ! inout
                              TS_URB2D,                                     & ! inout
-                             num_urban_layers,                             & ! in
+                             num_urban_ndm,                                & ! in
+                             urban_map_zrd,                                & ! in
+                             urban_map_zwd,                                & ! in
+                             urban_map_gd,                                 & ! in
+                             urban_map_zd,                                 & ! in
+                             urban_map_zdf,                                & ! in
+                             urban_map_bd,                                 & ! in
+                             urban_map_wd,                                 & ! in
+                             urban_map_gbd,                                & ! in
+                             urban_map_fbd,                                & ! in
+                             urban_map_zgrd,                                & ! in
                              num_urban_hi,                                 & ! in
                              TRB_URB4D,TW1_URB4D,TW2_URB4D,TGB_URB4D,      & ! inout
                              TLEV_URB3D,QLEV_URB3D,                        & ! inout
@@ -2431,6 +2490,11 @@ ENDIF
                              SFVENT_URB3D,LFVENT_URB3D,                    & ! inout
                              SFWIN1_URB3D,SFWIN2_URB3D,                    & ! inout
                              SFW1_URB3D,SFW2_URB3D,SFR_URB3D,SFG_URB3D,    & ! inout
+                             EP_PV_URB3D,T_PV_URB3D,                       & !GRZ
+                             TRV_URB4D,QR_URB4D,QGR_URB3D,TGR_URB3D,       & !GRZ
+                             DRAIN_URB4D,DRAINGR_URB3D,SFRV_URB3D,         & !GRZ
+                             LFRV_URB3D,DGR_URB3D,DG_URB3D,LFR_URB3D,LFG_URB3D,&!GRZ
+                             SMOIS_URB,                                    &
                              LP_URB2D,HI_URB2D,LB_URB2D,                   & ! inout
                              HGT_URB2D,MH_URB2D,STDH_URB2D,                & ! inout
                              LF_URB2D,                                     & ! inout
@@ -2441,13 +2505,23 @@ ENDIF
                              A_E_BEP,B_U_BEP,B_V_BEP,                      & ! inout multi-layer urban
                              B_T_BEP,B_Q_BEP,B_E_BEP,DLG_BEP,              & ! inout multi-layer urban
                              DL_U_BEP,SF_BEP,VL_BEP,                       & ! inout multi-layer urban
-                             FRC_URB2D, UTYPE_URB2D)                         ! inout
+                             FRC_URB2D, UTYPE_URB2D,USE_WUDAPT_LCZ)                         ! inout
    IMPLICIT NONE
 
-   INTEGER, INTENT(IN) :: ISURBAN, sf_urban_physics
-   INTEGER, INTENT(IN) :: LOW_DENSITY_RESIDENTIAL, HIGH_DENSITY_RESIDENTIAL, HIGH_INTENSITY_INDUSTRIAL
+   INTEGER, INTENT(IN) :: ISURBAN, sf_urban_physics,use_wudapt_lcz
+   INTEGER, INTENT(IN) :: LCZ_1,LCZ_2,LCZ_3,LCZ_4,LCZ_5,LCZ_6,LCZ_7,LCZ_8,LCZ_9,LCZ_10,LCZ_11
    INTEGER, INTENT(IN) :: ims,ime,jms,jme,kms,kme,num_soil_layers
-   INTEGER, INTENT(IN) :: num_urban_layers                            !multi-layer urban
+   INTEGER, INTENT(IN) :: num_urban_ndm
+   INTEGER, INTENT(IN) :: urban_map_zrd
+   INTEGER, INTENT(IN) :: urban_map_zwd
+   INTEGER, INTENT(IN) :: urban_map_gd
+   INTEGER, INTENT(IN) :: urban_map_zd
+   INTEGER, INTENT(IN) :: urban_map_zdf
+   INTEGER, INTENT(IN) :: urban_map_bd
+   INTEGER, INTENT(IN) :: urban_map_wd
+   INTEGER, INTENT(IN) :: urban_map_gbd
+   INTEGER, INTENT(IN) :: urban_map_fbd
+   INTEGER, INTENT(IN) :: urban_map_zgrd
    INTEGER, INTENT(IN) :: num_urban_hi                                !multi-layer urban
 !   INTEGER, INTENT(IN) :: num_roof_layers, num_wall_layers, num_road_layers
 
@@ -2492,28 +2566,43 @@ ENDIF
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TS_URB2D
 
 ! multi-layer UCM variables
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: TRB_URB4D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: TW1_URB4D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: TW2_URB4D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: TGB_URB4D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: TLEV_URB3D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: QLEV_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: TW1LEV_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: TW2LEV_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: TGLEV_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: TFLEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zrd, jms:jme), INTENT(INOUT) :: TRB_URB4D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zwd, jms:jme), INTENT(INOUT) :: TW1_URB4D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zwd, jms:jme), INTENT(INOUT) :: TW2_URB4D
+   REAL, DIMENSION(ims:ime, 1:urban_map_gd , jms:jme), INTENT(INOUT) :: TGB_URB4D
+   REAL, DIMENSION(ims:ime, 1:urban_map_bd , jms:jme), INTENT(INOUT) :: TLEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_bd , jms:jme), INTENT(INOUT) :: QLEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_wd , jms:jme), INTENT(INOUT) :: TW1LEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_wd , jms:jme), INTENT(INOUT) :: TW2LEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_gbd, jms:jme), INTENT(INOUT) :: TGLEV_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_fbd, jms:jme), INTENT(INOUT) :: TFLEV_URB3D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LF_AC_URB3D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SF_AC_URB3D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CM_AC_URB3D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SFVENT_URB3D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LFVENT_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: SFWIN1_URB3D
-   REAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: SFWIN2_URB3D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: SFW1_URB3D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: SFW2_URB3D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: SFR_URB3D
-   REAL, DIMENSION(ims:ime, 1:num_urban_layers, jms:jme), INTENT(INOUT) :: SFG_URB3D
-   REAL, DIMENSION( ims:ime,1:num_urban_hi, jms:jme), INTENT(INOUT) :: HI_URB2D
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd, jms:jme), INTENT(INOUT) :: SFWIN1_URB3D
+   REAL, DIMENSION( ims:ime, 1:urban_map_wd, jms:jme), INTENT(INOUT) :: SFWIN2_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zd , jms:jme), INTENT(INOUT) :: SFW1_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zd , jms:jme), INTENT(INOUT) :: SFW2_URB3D
+   REAL, DIMENSION(ims:ime, 1:urban_map_zdf, jms:jme), INTENT(INOUT) :: SFR_URB3D
+   REAL, DIMENSION(ims:ime, 1:num_urban_ndm, jms:jme), INTENT(INOUT) :: SFG_URB3D
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: EP_PV_URB3D!GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf,jms:jme ), INTENT(INOUT) :: T_PV_URB3D!GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme),INTENT(INOUT) :: TRV_URB4D ! GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zgrd, jms:jme),INTENT(INOUT) :: QR_URB4D ! GRZ
+   REAL, DIMENSION( ims:ime,jms:jme), INTENT(INOUT) :: QGR_URB3D ! GRZ
+   REAL, DIMENSION( ims:ime,jms:jme), INTENT(INOUT) :: TGR_URB3D ! GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme),INTENT(INOUT) :: DRAIN_URB4D !GRZ
+   REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRAINGR_URB3D   !GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme),INTENT(INOUT) :: SFRV_URB3D !GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme),INTENT(INOUT) :: LFRV_URB3D ! GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: DGR_URB3D !GRZ
+   REAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ),INTENT(INOUT) :: DG_URB3D !GRZ
+   REAL, DIMENSION( ims:ime, 1:urban_map_zdf, jms:jme ),INTENT(INOUT) :: LFR_URB3D !GRZ
+   REAL, DIMENSION( ims:ime, 1:num_urban_ndm, jms:jme ), INTENT(INOUT) :: LFG_URB3D !GRZ
+   REAL, DIMENSION( ims:ime, 1:num_soil_layers, jms:jme ), INTENT(IN) ::SMOIS_URB
+   REAL, DIMENSION( ims:ime,1:num_urban_hi , jms:jme), INTENT(INOUT) :: HI_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LP_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LB_URB2D
    REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: HGT_URB2D
@@ -2561,10 +2650,41 @@ ENDIF
 !m
 !FS   FRC_URB2D(I,J)=0.
       UTYPE_URB2D(I,J)=0
-      SWITCH_URB=0
+      SWITCH_URB=1
 
             IF( IVGTYP(I,J) == ISURBAN)  THEN
-               UTYPE_URB2D(I,J) = 2  ! for default. high-intensity
+               IF(use_wudapt_lcz==0) THEN
+                  UTYPE_URB2D(I,J) = 2  ! for default. high-intensity
+               ELSE
+                  UTYPE_URB2D(I,J) = 5  ! for default. high-intensity
+               ENDIF
+            ELSE IF( IVGTYP(I,J) == LCZ_1) THEN
+               UTYPE_URB2D(I,J) = 1
+            ELSE IF( IVGTYP(I,J) == LCZ_2) THEN
+               UTYPE_URB2D(I,J) = 2
+            ELSE IF( IVGTYP(I,J) == LCZ_3) THEN
+               UTYPE_URB2D(I,J) = 3
+            ELSE IF( IVGTYP(I,J) == LCZ_4) THEN
+               UTYPE_URB2D(I,J) = 4
+            ELSE IF( IVGTYP(I,J) == LCZ_5) THEN
+               UTYPE_URB2D(I,J) = 5
+            ELSE IF( IVGTYP(I,J) == LCZ_6) THEN
+               UTYPE_URB2D(I,J) = 6
+            ELSE IF( IVGTYP(I,J) == LCZ_7) THEN
+               UTYPE_URB2D(I,J) = 7
+            ELSE IF( IVGTYP(I,J) == LCZ_8) THEN
+               UTYPE_URB2D(I,J) = 8
+            ELSE IF( IVGTYP(I,J) == LCZ_9) THEN
+               UTYPE_URB2D(I,J) = 9
+            ELSE IF( IVGTYP(I,J) == LCZ_10) THEN
+               UTYPE_URB2D(I,J) = 10
+            ELSE IF( IVGTYP(I,J) == LCZ_11) THEN
+               UTYPE_URB2D(I,J) = 11
+            ELSE
+               SWITCH_URB=0
+            ENDIF
+
+            IF (SWITCH_URB == 1) THEN
                UTYPE_URB = UTYPE_URB2D(I,J)  ! for default. high-intensity
                IF (HGT_URB2D(I,J)>0.) THEN
                   CONTINUE
@@ -2594,117 +2714,7 @@ ENDIF
                   WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
                   WRITE_MESSAGE(mesg)
                   FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
-                ENDIF           
-               SWITCH_URB=1
-            ENDIF 
-
-            IF( IVGTYP(I,J) == LOW_DENSITY_RESIDENTIAL) THEN
-               UTYPE_URB2D(I,J) = 1  ! low-intensity residential
-               UTYPE_URB = UTYPE_URB2D(I,J)  ! low-intensity residential
-               IF (HGT_URB2D(I,J)>0.) THEN
-                  CONTINUE
-               ELSE
-                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
-                  WRITE_MESSAGE(mesg)
-                  LP_URB2D(I,J)=0.
-                  LB_URB2D(I,J)=0.
-                  HGT_URB2D(I,J)=0.
-                  IF ( sf_urban_physics == 1 ) THEN
-                     MH_URB2D(I,J)=0.
-                     STDH_URB2D(I,J)=0.
-                     DO K=1,4
-                       LF_URB2D(I,K,J)=0.
-                     ENDDO
-                  ELSE IF ( ( sf_urban_physics == 2 ) .or. ( sf_urban_physics == 3 ) ) THEN
-                     DO K=1,num_urban_hi
-                        HI_URB2D(I,K,J)=0.
-                     ENDDO
-                  ENDIF
-               ENDIF
-                IF (FRC_URB2D(I,J)>0.and.FRC_URB2D(I,J)<=1.) THEN
-                  CONTINUE
-                ELSE
-                  WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  WRITE_MESSAGE(mesg)
-                  WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  WRITE_MESSAGE(mesg)
-                  FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
-                ENDIF         
-              SWITCH_URB=1
-            ENDIF
-
-           IF( IVGTYP(I,J) == HIGH_DENSITY_RESIDENTIAL) THEN
-               UTYPE_URB2D(I,J) = 2  ! high-intensity
-               UTYPE_URB = UTYPE_URB2D(I,J)  ! high-intensity
-              IF (HGT_URB2D(I,J)>0.) THEN
-                  CONTINUE
-               ELSE
-                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
-                  WRITE_MESSAGE(mesg)
-                  LP_URB2D(I,J)=0.
-                  LB_URB2D(I,J)=0.
-                  HGT_URB2D(I,J)=0.
-                  IF ( sf_urban_physics == 1 ) THEN
-                     MH_URB2D(I,J)=0.
-                     STDH_URB2D(I,J)=0.
-                     DO K=1,4
-                       LF_URB2D(I,K,J)=0.
-                     ENDDO
-                  ELSE IF ( ( sf_urban_physics == 2 ) .or. ( sf_urban_physics == 3 ) ) THEN
-                     DO K=1,num_urban_hi
-                        HI_URB2D(I,K,J)=0.
-                     ENDDO
-                  ENDIF
-               ENDIF
-                IF (FRC_URB2D(I,J)>0.and.FRC_URB2D(I,J)<=1.) THEN
-                  CONTINUE
-                ELSE
-                  WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  WRITE_MESSAGE(mesg)
-                  WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  WRITE_MESSAGE(mesg)
-                  FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
                 ENDIF
-              SWITCH_URB=1
-            ENDIF
-
-            IF( IVGTYP(I,J) == HIGH_INTENSITY_INDUSTRIAL) THEN
-               UTYPE_URB2D(I,J) = 3  !  Commercial/Industrial/Transportation
-               UTYPE_URB = UTYPE_URB2D(I,J)  !  Commercial/Industrial/Transportation
-              IF (HGT_URB2D(I,J)>0.) THEN
-                  CONTINUE
-               ELSE
-                  WRITE(mesg,*) 'USING DEFAULT URBAN MORPHOLOGY'
-                  WRITE_MESSAGE(mesg)
-                  LP_URB2D(I,J)=0.
-                  LB_URB2D(I,J)=0.
-                  HGT_URB2D(I,J)=0.
-                  IF ( sf_urban_physics == 1 ) THEN
-                     MH_URB2D(I,J)=0.
-                     STDH_URB2D(I,J)=0.
-                     DO K=1,4
-                       LF_URB2D(I,K,J)=0.
-                     ENDDO
-                  ELSE IF ( ( sf_urban_physics == 2 ) .or. ( sf_urban_physics == 3 ) ) THEN
-                     DO K=1,num_urban_hi
-                        HI_URB2D(I,K,J)=0.
-                     ENDDO
-                  ENDIF
-               ENDIF
-                IF (FRC_URB2D(I,J)>0.and.FRC_URB2D(I,J)<=1.) THEN
-                  CONTINUE
-                ELSE
-                  WRITE(mesg,*) 'WARNING, FRC_URB2D = 0 BUT IVGTYP IS URBAN'
-                  WRITE_MESSAGE(mesg)
-                  WRITE(mesg,*) 'WARNING, THE URBAN FRACTION WILL BE READ FROM URBPARM.TBL'
-                  WRITE_MESSAGE(mesg)
-                  FRC_URB2D(I,J) = FRC_URB_TBL(UTYPE_URB)
-                ENDIF
-               SWITCH_URB=1
-            ENDIF
-
-            IF (SWITCH_URB==1) THEN
-                CONTINUE
             ELSE
                 FRC_URB2D(I,J)=0.
                 LP_URB2D(I,J)=0.
@@ -2796,31 +2806,21 @@ ENDIF
       END DO
       
 ! multi-layer urban
-!      IF( sf_urban_physics .EQ. 2)THEN
        IF((SF_URBAN_PHYSICS.eq.2).OR.(SF_URBAN_PHYSICS.eq.3)) THEN
-      DO k=1,num_urban_layers
-!        TRB_URB4D(I,k,J)=TSURFACE0_URB(I,J)
-!        TW1_URB4D(I,k,J)=TSURFACE0_URB(I,J)
-!        TW2_URB4D(I,k,J)=TSURFACE0_URB(I,J)
-!        TGB_URB4D(I,k,J)=TSURFACE0_URB(I,J)
-!MT        TRB_URB4D(I,K,J)=tlayer0_urb(I,1,J)
-!MT        TW1_URB4D(I,K,J)=tlayer0_urb(I,1,J)
-!MT        TW2_URB4D(I,K,J)=tlayer0_urb(I,1,J)
         IF (UTYPE_URB2D(I,J) > 0) THEN
-           TRB_URB4D(I,K,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
-           TW1_URB4D(I,K,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
-           TW2_URB4D(I,K,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
+           TRB_URB4D(I,:,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
+           TW1_URB4D(I,:,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
+           TW2_URB4D(I,:,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
         ELSE
-           TRB_URB4D(I,K,J)=tlayer0_urb(I,1,J)
-           TW1_URB4D(I,K,J)=tlayer0_urb(I,1,J)
-           TW2_URB4D(I,K,J)=tlayer0_urb(I,1,J)
+           TRB_URB4D(I,:,J)=tlayer0_urb(I,1,J)
+           TW1_URB4D(I,:,J)=tlayer0_urb(I,1,J)
+           TW2_URB4D(I,:,J)=tlayer0_urb(I,1,J)
         ENDIF
-        TGB_URB4D(I,K,J)=tlayer0_urb(I,1,J)
-        SFW1_URB3D(I,K,J)=0.
-        SFW2_URB3D(I,K,J)=0.
-        SFR_URB3D(I,K,J)=0.
-        SFG_URB3D(I,K,J)=0.
-      ENDDO
+        TGB_URB4D(I,:,J)=tlayer0_urb(I,1,J)
+        SFW1_URB3D(I,:,J)=0.
+        SFW2_URB3D(I,:,J)=0.
+        SFR_URB3D(I,:,J)=0.
+        SFG_URB3D(I,:,J)=0.
        
        ENDIF 
               
@@ -2830,22 +2830,40 @@ ENDIF
          CM_AC_URB3D(I,J)=0.
          SFVENT_URB3D(I,J)=0.
          LFVENT_URB3D(I,J)=0.
+         EP_PV_URB3D(I,J)=0.
+         T_PV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+         TGR_URB3D(I,J)=tlayer0_urb(I,1,J)
+         QR_URB4D(I,:,J)=SMOIS_URB(I,1,J)
+         DRAIN_URB4D(I,:,J)=0. !GRZ
+         SFRV_URB3D(I,:,J)=0.                !GRZ
+         LFRV_URB3D(I,:,J)=0.                !GRZ
+         DGR_URB3D(I,:,J)=0.  !GRZ
+         DG_URB3D(I,:,J)=0.
+         LFR_URB3D(I,:,J)=0.
+         LFG_URB3D(I,:,J)=0.
+         QGR_URB3D(I,J)=SMOIS_URB(I,1,J)  !GRZ
+         TGR_URB3D(I,J)=0.
+         DRAINGR_URB3D(I,J)=0. !GRZ
 
-         DO K=1,num_urban_layers
-            TLEV_URB3D(I,K,J)=tlayer0_urb(I,1,J)
-            TW1LEV_URB3D(I,K,J)=tlayer0_urb(I,1,J)
-            TW2LEV_URB3D(I,K,J)=tlayer0_urb(I,1,J)
-            TGLEV_URB3D(I,K,J)=tlayer0_urb(I,1,J)
-            TFLEV_URB3D(I,K,J)=tlayer0_urb(I,1,J)
-            QLEV_URB3D(I,K,J)=0.01
-            SFWIN1_URB3D(I,K,J)=0.
-            SFWIN2_URB3D(I,K,J)=0.
+       IF (UTYPE_URB2D(I,J) > 0) THEN
+        TRV_URB4D(I,:,J)=TBLEND_TBL(UTYPE_URB2D(I,J))
+       ELSE
+       TRV_URB4D(I,:,J)=tlayer0_urb(I,1,J) !GRZ
+      ENDIF
+
+            TLEV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+            TW1LEV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+            TW2LEV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+            TGLEV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+            TFLEV_URB3D(I,:,J)=tlayer0_urb(I,1,J)
+            QLEV_URB3D(I,:,J)=0.01
+            SFWIN1_URB3D(I,:,J)=0.
+            SFWIN2_URB3D(I,:,J)=0.
 !rm         LF_AC_URB3D(I,J)=0.
 !rm         SF_AC_URB3D(I,J)=0.
 !rm         CM_AC_URB3D(I,J)=0.
 !rm         SFVENT_URB3D(I,J)=0.
 !rm         LFVENT_URB3D(I,J)=0.
-         ENDDO
 
       endif
 
@@ -2873,6 +2891,8 @@ ENDIF
 
       IF (CHECK.EQ.0)THEN
       IF(IVGTYP(I,J).EQ.1)THEN
+        write(mesg,*) 'Sample of Urban settings'
+        WRITE_MESSAGE(mesg)
         write(mesg,*) 'TSURFACE0_URB',TSURFACE0_URB(I,J)
         WRITE_MESSAGE(mesg)
         write(mesg,*) 'TDEEP0_URB', TDEEP0_URB(I,J)


### PR DESCRIPTION
This PR updates the Noah land surface model to match what is available in the WRF v4.5 release.

Specifically, this PR makes the following changes:

* The variables `swddir`, `swddni`, and `swddif` from `module_ra_rrtmg_sw.F` are now output; these variables are only used for the urban option BEP+BEM and not the Noah LSM itself.

* In the namelist.atmosphere file, the namelist option `config lsm scheme` now uses `"sf_noah"` rather than `"noah"` to select the Noah LSM. 

* All code modules needed to run the Noah LSM have been updated to match what is available in the WRF v4.5 release. As part of this update, various code used only by urban options has also been introduced.

