### PR TITLE
Introduce new I/O layer option in MPAS: the Simple MPAS I/O Layer (SMIOL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -628,6 +628,7 @@ CPPINCLUDES =
 FCINCLUDES =
 LIBS =
 
+ifneq "$(PIO)" ""
 #
 # Regardless of PIO library version, look for a lib subdirectory of PIO path
 # NB: PIO_LIB is used later, so we don't just set LIBS directly
@@ -671,6 +672,11 @@ ifneq ($(wildcard $(PIO_LIB)/libpioc\.*), )
 endif
 ifneq ($(wildcard $(PIO_LIB)/libgptl\.*), )
 	LIBS += -lgptl
+endif
+
+else # Not using PIO, using SMIOL
+	LIBS += -L$(PWD)/src/external/SMIOL -lsmiolf -lsmiol
+	FCINCLUDES += -I$(PWD)/src/external/SMIOL
 endif
 
 ifneq "$(NETCDF)" ""
@@ -1175,10 +1181,10 @@ endif
 		    rm -f pio[12].f90 pio[12].x; $\
 		fi $\
 	))
-	$(if $(findstring 1,$(PIO_VERS)), $(eval PIO_MESSAGE = "Using the PIO 1.x library."), )
+	$(if $(findstring 1,$(PIO_VERS)), $(eval IO_MESSAGE = "Using the PIO 1.x library."), )
 	$(if $(findstring 1,$(PIO_VERS)), $(info PIO 1.x detected.))
 	$(if $(findstring 2,$(PIO_VERS)), $(eval override CPPFLAGS += -DUSE_PIO2), )
-	$(if $(findstring 2,$(PIO_VERS)), $(eval PIO_MESSAGE = "Using the PIO 2.x library."), )
+	$(if $(findstring 2,$(PIO_VERS)), $(eval IO_MESSAGE = "Using the PIO 2.x library."), )
 	$(if $(findstring 2,$(PIO_VERS)), $(info PIO 2.x detected.))
 	@#
 	@# A .piotest.log file exists iff no working PIO library was detected
@@ -1189,7 +1195,17 @@ endif
 	    exit 1; \
 	fi
 
-mpas_main: openmp_test openacc_test pio_test
+ifneq "$(PIO)" ""
+MAIN_DEPS = openmp_test openacc_test pio_test
+override CPPFLAGS += "-DMPAS_PIO_SUPPORT"
+else
+MAIN_DEPS = openmp_test openacc_test
+IO_MESSAGE = "Using the SMIOL library."
+override CPPFLAGS += "-DMPAS_SMIOL_SUPPORT"
+endif
+
+
+mpas_main: $(MAIN_DEPS)
 ifeq "$(AUTOCLEAN)" "true"
 	$(RM) .mpas_core_*
 endif
@@ -1233,7 +1249,7 @@ ifeq "$(AUTOCLEAN)" "true"
 endif
 	@echo $(GEN_F90_MESSAGE)
 	@echo $(TIMER_MESSAGE)
-	@echo $(PIO_MESSAGE)
+	@echo $(IO_MESSAGE)
 	@echo "*******************************************************************************"
 clean:
 	cd src; $(MAKE) clean RM="$(RM)" CORE="$(CORE)"

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -300,11 +300,15 @@ module atm_core_interface
 #else
                           'optimize')
 #endif
-      call mpas_log_write('  PIO version: ' // &
+      call mpas_log_write('  I/O layer: ' // &
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
-                          '2.x')
+                          'PIO 2.x')
 #else
-                          '1.x')
+                          'PIO 1.x')
+#endif
+#else
+                          'SMIOL')
 #endif
       call mpas_log_write('')
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -384,11 +384,15 @@ module init_atm_core_interface
 #else
                           'optimize')
 #endif
-      call mpas_log_write('  PIO version: ' // &
+      call mpas_log_write('  I/O layer: ' // &
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
-                          '2.x')
+                          'PIO 2.x')
 #else
-                          '1.x')
+                          'PIO 1.x')
+#endif
+#else
+                          'SMIOL')
 #endif
       call mpas_log_write('')
 

--- a/src/external/Makefile
+++ b/src/external/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES: .F .c .o
 
-all: esmf_time ezxml-lib
+all: esmf_time ezxml-lib smiol-lib
 
 esmf_time:
 	( cd esmf_time_f90; $(MAKE) FC="$(FC)" FFLAGS="$(FFLAGS)" CPP="$(CPP)" CPPFLAGS="$(CPPFLAGS) -DHIDE_MPI" GEN_F90=$(GEN_F90) )
@@ -8,6 +8,10 @@ esmf_time:
 ezxml-lib:
 	( cd ezxml; $(MAKE) OBJFILE="ezxml.o" )
 
+smiol-lib:
+	$(MAKE) -C SMIOL
+
 clean:
 	( cd esmf_time_f90; $(MAKE) clean )
 	( cd ezxml; $(MAKE) clean )
+	$(MAKE) -C SMIOL clean

--- a/src/external/SMIOL/Makefile
+++ b/src/external/SMIOL/Makefile
@@ -1,0 +1,23 @@
+override CPPINCLUDES += -DSMIOL_PNETCDF
+
+all: libsmiol.a libsmiolf.a
+
+libsmiol.a: smiol.o smiol_utils.o
+	ar -cr libsmiol.a smiol.o smiol_utils.o
+
+libsmiolf.a: smiolf.o
+	ar -cr libsmiolf.a smiolf.o
+
+clean:
+	$(RM) -f smiol.o smiol_utils.o libsmiol.a
+	$(RM) -f smiolf.o smiolf.mod libsmiolf.a
+
+# Cancel the built-in implicit rule for Modula-2 files (.mod) to avoid having 'make'
+# try to create .o files from Fortran .mod files
+%.o : %.mod
+
+%.o : %.F90
+	$(FC) $(CPPINCLUDES) $(FFLAGS) -c $<
+
+%.o : %.c
+	$(CC) $(CPPINCLUDES) $(CFLAGS) -c $<

--- a/src/external/SMIOL/gen_put_get.sh
+++ b/src/external/SMIOL/gen_put_get.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env sh
+
+filename=smiolf_put_get_var.inc
+
+
+################################################################################
+#
+# gen_put_get_var
+#
+# Generate a function body for a specific "SMIOLf_put/get_var" function
+# Required variables:
+#  d = 0, 1, 2, 3
+#  io = put, get
+#  colon_list = ":,:,:"
+#  dim_list = "d1,d1,d3"
+#  type = real32, real64
+#  kind = c_float, c_double
+#  base_type = real, integer
+#  size_args = "size(buf,dim=1), size(buf,dim=2)"
+#
+################################################################################
+gen_put_get_var()
+{
+    #
+    # For non-scalars, build, e.g., " dimension(:,:,:),"
+    #
+    if [ $d -ge 1 ]; then
+        dim=" dimension(${colon_list}),"
+        c_loc_invocation="            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_${d}d_${type}(buf${size_args})"
+    else
+        dim=""
+        c_loc_invocation="            c_buf = c_loc(buf)"
+    fi
+
+    #
+    # Character variables need special copying code...
+    #
+    if [ "${kind}" = "c_char" ]; then
+
+        if [ "${io}" = "put" ]; then
+
+            char_copyin="            allocate(char_buf(len(buf)))
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do"
+
+            char_copyout="        if (associated(buf)) then
+            deallocate(char_buf)
+        end if"
+
+        else
+
+            char_copyin="            allocate(char_buf(len(buf)))
+
+            ! In case buf contains more characters than will be read from the file,
+            ! initialize char_buf with the contents of buf to preserve un-read
+            ! characters during the copy of char_buf back into buf later on
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do"
+
+            char_copyout="        if (associated(buf)) then
+            do i=1,len(buf)
+                buf(i:i) = char_buf(i)
+            end do
+
+            deallocate(char_buf)
+        end if"
+
+        fi
+
+        dummy_buf_decl="        ${base_type},${dim} pointer :: buf"
+        char_buf_decl="        character(kind=c_char), dimension(:), allocatable, target :: char_buf"
+        c_loc_invocation="            c_buf = c_loc(char_buf)"
+
+    else
+        char_copyin=""
+        char_copyout=""
+        dummy_buf_decl="        ${base_type}(kind=${kind}),${dim} pointer :: buf"
+        char_buf_decl=""
+    fi
+
+
+    #
+    # Build function documentation block
+    #
+    if [ "${io}" = "put" ]; then
+
+    header="    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d${d}_${type}
+    !
+    !> \brief Writes a ${d}-d ${type} variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------"
+
+    else
+
+    header="    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d${d}_${type}
+    !
+    !> \brief Reads a ${d}-d ${type} variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------"
+
+    fi
+
+    cat >> ${filename} << EOF
+$header
+    function SMIOLf_${io}_var_${d}d_${type}(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : ${kind}, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+${dummy_buf_decl}
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+${char_buf_decl}
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+${char_copyin}
+${c_loc_invocation}
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_${io}_var(c_file, c_varname, c_decomp, c_buf)
+
+${char_copyout}
+        deallocate(c_varname)
+
+    end function SMIOLf_${io}_var_${d}d_${type}
+
+
+EOF
+}
+
+
+################################################################################
+#
+# gen_c_loc
+#
+# Generate a function body for a specific "c_loc_assumed_shape" function
+# Required variables:
+#  d = 1, 2, 3
+#  dim_args = , d1, d1, d3
+#  dim_list = d1,d1,d3
+#  type = real32, real64
+#  kind = c_float, c_double
+#  base_type = real, integer
+#
+################################################################################
+gen_c_loc()
+{
+    #
+    # Build, e.g., " dimension(d1,d2,d3),"
+    #
+    dim=" dimension(${dim_list}),"
+
+    #
+    # Build list of dimension argument declarations
+    #
+    d_decl="integer, intent(in) :: d1"
+    i=2
+    while [ $i -le $d ]; do
+        d_decl="${d_decl}, d$i"
+        i=$(($i+1))
+    done
+
+    #
+    # Build function documentation block
+    #
+    header="    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_${d}d_${type}
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------"
+
+    cat >> ${filename} << EOF
+${header}
+    function c_loc_assumed_shape_${d}d_${type}(a${dim_args}) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, ${kind}
+
+        implicit none
+
+        ! Arguments
+        ${d_decl}
+        ${base_type}(kind=${kind}),${dim} target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_${d}d_${type}
+
+
+EOF
+}
+
+
+################################################################################
+#
+# gen_put_get.sh
+#
+################################################################################
+printf "" > ${filename}
+
+#
+# For each type, handle each dimensionality
+#
+for d in 0 1 2 3 4 5; do
+
+    #
+    # Build list of dimension formal arguments, e.g. ", d1, d2, d3"
+    #
+    dim_args=''
+    i=1
+    while [ $i -le $d ]; do
+       dim_args="${dim_args}, d$i"
+       i=$(($i+1))
+    done
+
+    #
+    # Build explicit shape list, e.g., "d1,d2,d3"
+    #
+    dim_list=''
+    i=1
+    while [ $i -le $d ]; do
+        dim_list="${dim_list}d$i"
+        if [ $i -lt $d ]; then
+            dim_list="${dim_list},"
+        fi
+        i=$(($i+1))
+    done
+
+    #
+    # Build assumed shape list, e.g., ":,:,:"
+    #
+    colon_list=''
+    i=1
+    while [ $i -le $d ]; do
+        colon_list="${colon_list}:"
+        if [ $i -lt $d ]; then
+            colon_list="${colon_list},"
+        fi
+        i=$(($i+1))
+    done
+
+    #
+    # Build array size actual arguments , e.g., "size(buf,dim=1), size(buf,dim=2)"
+    #
+    size_args=''
+    i=1
+    while [ $i -le $d ]; do
+
+        # Break long lines after three dimensions
+        if [ $i -eq 4 -a $d -ge 4 ]; then
+            size_args="${size_args}, &
+                                           size(buf,dim=$i)"
+        else
+            size_args="${size_args}, size(buf,dim=$i)"
+        fi
+
+        i=$(($i+1))
+
+    done
+
+    #
+    # Create functions for each type
+    #
+    for type in char real32 real64 int32; do
+
+        # Only up to 0-d char interfaces
+        if [ "${type}" = "char" ] && [ $d -gt 0 ]; then
+            continue
+        fi
+
+        # Only up to 4-d int32 interfaces
+        if [ "${type}" = "int32" ] && [ $d -gt 4 ]; then
+            continue
+        fi
+
+        if [ "$type" = "real32" ]; then
+            kind="c_float"
+            base_type="real"
+        elif [ "$type" = "real64" ]; then
+            kind="c_double"
+            base_type="real"
+        elif [ "$type" = "int32" ]; then
+            kind="c_int"
+            base_type="integer"
+        elif [ "$type" = "char" ]; then
+            kind="c_char"
+            base_type="character(len=:)"
+        fi
+
+        if [ $d -ge 1 ]; then
+            gen_c_loc
+        fi
+
+        for io in put get; do
+            gen_put_get_var
+        done
+
+    done
+
+done

--- a/src/external/SMIOL/smiol.c
+++ b/src/external/SMIOL/smiol.c
@@ -1,0 +1,2852 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+#include "smiol.h"
+#include "smiol_utils.h"
+
+#ifdef SMIOL_PNETCDF
+#include "pnetcdf.h"
+#define PNETCDF_DEFINE_MODE 0
+#define PNETCDF_DATA_MODE 1
+#define MAX_REQS 256
+#endif
+
+#define START_COUNT_READ 0
+#define START_COUNT_WRITE 1
+
+/*
+ * Local functions
+ */
+int build_start_count(struct SMIOL_file *file, const char *varname,
+                      const struct SMIOL_decomp *decomp,
+                      int write_or_read, size_t *element_size,
+                      size_t *basic_type_size, int *ndims,
+                      int *has_unlimited_dim,
+                      size_t **start, size_t **count);
+
+#ifdef SMIOL_PNETCDF
+int write_chunk_pnetcdf(struct SMIOL_file *file,
+                        int varidp,
+                        int ndims,
+                        int has_unlimited_dim,
+                        size_t basic_type_size,
+                        MPI_Comm io_file_comm,
+                        const void *buf_p,
+                        MPI_Offset *mpi_start,
+                        MPI_Offset *mpi_count
+                       );
+
+int read_chunk_pnetcdf(struct SMIOL_file *file,
+                       int varidp,
+                       int ndims,
+                       int has_unlimited_dim,
+                       size_t basic_type_size,
+                       MPI_Comm io_file_comm,
+                       void *buf_p,
+                       MPI_Offset *mpi_start,
+                       MPI_Offset *mpi_count
+                      );
+#endif
+
+
+/********************************************************************************
+ *
+ * SMIOL_fortran_init
+ *
+ * Initialize a SMIOL context from Fortran.
+ *
+ * This function is a simply a wrapper for the SMOIL_init routine that is intended
+ * to be called from Fortran. Accordingly, the first argument is of type MPI_Fint
+ * (a Fortran integer) rather than MPI_Comm.
+ *
+ ********************************************************************************/
+int SMIOL_fortran_init(MPI_Fint comm, int num_io_tasks, int io_stride,
+                       struct SMIOL_context **context)
+{
+	return SMIOL_init(MPI_Comm_f2c(comm), num_io_tasks, io_stride, context);
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_init
+ *
+ * Initialize a SMIOL context.
+ *
+ * Initializes a SMIOL context, within which decompositions may be defined and
+ * files may be read and written. The input argument comm is an MPI communicator,
+ * and the input arguments num_io_tasks and io_stride provide the total number
+ * of I/O tasks and the stride between those I/O tasks within the communicator.
+ *
+ * Upon successful return the context argument points to a valid SMIOL context;
+ * otherwise, it is NULL and an error code other than MPI_SUCCESS is returned.
+ *
+ * Note: It is assumed that MPI_Init has been called prior to this routine, so
+ *       that any use of the provided MPI communicator will be valid.
+ *
+ ********************************************************************************/
+int SMIOL_init(MPI_Comm comm, int num_io_tasks, int io_stride,
+               struct SMIOL_context **context)
+{
+	MPI_Comm smiol_comm;
+
+	/*
+	 * Before dereferencing context below, ensure that the pointer
+	 * the context pointer is not NULL
+	 */
+	if (context == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * We cannot check for every possible invalid argument for comm, but
+	 * at least we can verify that the communicator is not MPI_COMM_NULL
+	 */
+	if (comm == MPI_COMM_NULL) {
+		/* Nullifying (*context) here may result in a memory leak, but this
+		 * seems better than disobeying the stated behavior of returning
+		 * a NULL context upon failure
+		 */
+		(*context) = NULL;
+
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	*context = (struct SMIOL_context *)malloc(sizeof(struct SMIOL_context));
+	if ((*context) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Initialize context
+	 */
+	(*context)->lib_ierr = 0;
+	(*context)->lib_type = SMIOL_LIBRARY_UNKNOWN;
+
+	(*context)->num_io_tasks = num_io_tasks;
+	(*context)->io_stride = io_stride;
+
+
+	/*
+	 * Make a duplicate of the MPI communicator for use by SMIOL
+	 */
+	if (MPI_Comm_dup(comm, &smiol_comm) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+	(*context)->fcomm = MPI_Comm_c2f(smiol_comm);
+
+	if (MPI_Comm_size(smiol_comm, &((*context)->comm_size)) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+
+	if (MPI_Comm_rank(smiol_comm, &((*context)->comm_rank)) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_finalize
+ *
+ * Finalize a SMIOL context.
+ *
+ * Finalizes a SMIOL context and frees all memory in the SMIOL_context instance.
+ * After this routine is called, no other SMIOL routines that make reference to
+ * the finalized context should be called.
+ *
+ ********************************************************************************/
+int SMIOL_finalize(struct SMIOL_context **context)
+{
+	MPI_Comm smiol_comm;
+
+	/*
+	 * If the pointer to the context pointer is NULL, assume we have nothing
+	 * to do and declare success
+	 */
+	if (context == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	if ((*context) == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	smiol_comm = MPI_Comm_f2c((*context)->fcomm);
+	if (MPI_Comm_free(&smiol_comm) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+
+	free((*context));
+	(*context) = NULL;
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_inquire
+ *
+ * Inquire about a SMIOL context.
+ *
+ * Detailed description.
+ *
+ ********************************************************************************/
+int SMIOL_inquire(void)
+{
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_open_file
+ *
+ * Opens a file within a SMIOL context.
+ *
+ * Depending on the specified file mode, creates or opens the file specified
+ * by filename within the provided SMIOL context.
+ *
+ * The bufsize argument specifies the size in bytes of the buffer to be attached
+ * to the file by I/O tasks; at present this buffer is only used by the Parallel-
+ * NetCDF library if the file is opened with a mode of SMIOL_FILE_CREATE or
+ * SMIOL_FILE_WRITE. A bufsize of 0 will force the use of the Parallel-NetCDF
+ * blocking write interface, while a nonzero value enables the use of the
+ * non-blocking, buffered interface for writing.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned, and the file handle
+ * argument will point to a valid file handle and the current frame for the
+ * file will be set to zero. Otherwise, the file handle is NULL and an error
+ * code other than SMIOL_SUCCESS is returned.
+ *
+ ********************************************************************************/
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
+                    int mode, struct SMIOL_file **file, size_t bufsize)
+{
+	int io_group;
+	MPI_Comm io_file_comm;
+	MPI_Comm io_group_comm;
+	int ierr;
+
+
+	/*
+	 * Before dereferencing file below, ensure that the pointer
+	 * the file pointer is not NULL
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that context is valid
+	 */
+	if (context == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	*file = (struct SMIOL_file *)malloc(sizeof(struct SMIOL_file));
+	if ((*file) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Save pointer to context for this file
+	 */
+	(*file)->context = context;
+	(*file)->frame = (SMIOL_Offset) 0;
+
+
+	/*
+	 * Determine whether a task is an I/O task or not, and compute
+	 * the I/O group to which each task belongs
+	 */
+	(*file)->io_task = context->comm_rank % context->io_stride == 0 ? 1 : 0;
+	io_group = context->comm_rank / context->io_stride;
+
+	/*
+	 * If there are fewer than comm_size / io_stride I/O tasks, some
+	 * tasks that were set to I/O tasks above will actually not perform
+	 * I/O. Also, place all remainder tasks in the last I/O group
+	 */
+	if (io_group >= context->num_io_tasks) {
+		(*file)->io_task = 0;
+		io_group = context->num_io_tasks - 1;
+	}
+
+	/*
+	 * Create a communicator for communicating within a group of tasks
+	 * associated with an I/O task
+	 */
+	ierr = MPI_Comm_split(MPI_Comm_f2c(context->fcomm), io_group,
+	                      context->comm_rank, &io_group_comm);
+	if (ierr != MPI_SUCCESS) {
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+	(*file)->io_group_comm = MPI_Comm_c2f(io_group_comm);
+
+
+	/*
+	 * Create a communicator for collective file I/O operations among
+	 * I/O tasks (i.e., io_task == 1)
+	 */
+	ierr = MPI_Comm_split(MPI_Comm_f2c(context->fcomm), (*file)->io_task,
+	                      context->comm_rank, &io_file_comm);
+	if (ierr != MPI_SUCCESS) {
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+	(*file)->io_file_comm = MPI_Comm_c2f(io_file_comm);
+
+
+	if (mode & SMIOL_FILE_CREATE) {
+#ifdef SMIOL_PNETCDF
+		if ((*file)->io_task) {
+			ierr = ncmpi_create(io_file_comm, filename,
+			                    (NC_64BIT_DATA | NC_CLOBBER),
+			                    MPI_INFO_NULL,
+			                    &((*file)->ncidp));
+		}
+		(*file)->state = PNETCDF_DEFINE_MODE;
+#endif
+	} else if (mode & SMIOL_FILE_WRITE) {
+#ifdef SMIOL_PNETCDF
+		if ((*file)->io_task) {
+			ierr = ncmpi_open(io_file_comm, filename,
+			                  NC_WRITE, MPI_INFO_NULL,
+			                  &((*file)->ncidp));
+		}
+		(*file)->state = PNETCDF_DATA_MODE;
+#endif
+	} else if (mode & SMIOL_FILE_READ) {
+#ifdef SMIOL_PNETCDF
+		if ((*file)->io_task) {
+			ierr = ncmpi_open(io_file_comm, filename,
+			                  NC_NOWRITE, MPI_INFO_NULL,
+			                  &((*file)->ncidp));
+		}
+		(*file)->state = PNETCDF_DATA_MODE;
+#endif
+	} else {
+		free((*file));
+		(*file) = NULL;
+		MPI_Comm_free(&io_file_comm);
+		MPI_Comm_free(&io_group_comm);
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+#ifdef SMIOL_PNETCDF
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		free((*file));
+		(*file) = NULL;
+		MPI_Comm_free(&io_file_comm);
+		MPI_Comm_free(&io_group_comm);
+		context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	(*file)->bufsize = 0;
+	(*file)->n_reqs = 0;
+	(*file)->reqs = NULL;
+
+	if (mode & SMIOL_FILE_CREATE || mode & SMIOL_FILE_WRITE) {
+		if (bufsize > 0 && (*file)->io_task) {
+			(*file)->bufsize = bufsize;
+			ierr = ncmpi_buffer_attach((*file)->ncidp,
+			                           (MPI_Offset)bufsize);
+			(*file)->reqs = malloc(sizeof(int) * (size_t)MAX_REQS);
+		}
+
+		if (bufsize > 0) {
+			MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+			if (ierr != NC_NOERR) {
+				if ((*file)->reqs != NULL) {
+					free((*file)->reqs);
+					(*file)->reqs = NULL;
+				}
+				free((*file));
+				(*file) = NULL;
+				MPI_Comm_free(&io_file_comm);
+				MPI_Comm_free(&io_group_comm);
+				context->lib_type = SMIOL_LIBRARY_PNETCDF;
+				context->lib_ierr = ierr;
+				return SMIOL_LIBRARY_ERROR;
+			}
+		}
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_close_file
+ *
+ * Closes a file within a SMIOL context.
+ *
+ * Closes the file associated with the provided file handle. Upon successful
+ * completion, SMIOL_SUCCESS is returned, the file will be closed, and all memory
+ * that is uniquely associated with the file handle will be deallocated.
+ * Otherwise, an error code other than SMIOL_SUCCESS will be returned.
+ *
+ ********************************************************************************/
+int SMIOL_close_file(struct SMIOL_file **file)
+{
+	MPI_Comm io_file_comm;
+	MPI_Comm io_group_comm;
+#ifdef SMIOL_PNETCDF
+	int ierr;
+#endif
+
+
+	/*
+	 * If the pointer to the file pointer is NULL, assume we have nothing
+	 * to do and declare success
+	 */
+	if (file == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	io_file_comm = MPI_Comm_f2c((*file)->io_file_comm);
+	io_group_comm = MPI_Comm_f2c((*file)->io_group_comm);
+
+#ifdef SMIOL_PNETCDF
+	if ((*file)->io_task) {
+		ierr = NC_NOERR;
+		if ((*file)->n_reqs > 0) {
+			int statuses[MAX_REQS];
+
+			ierr = ncmpi_wait_all((*file)->ncidp, (*file)->n_reqs,
+			                      (*file)->reqs, statuses);
+			(*file)->n_reqs = 0;
+		}
+		if ((*file)->reqs != NULL) {
+			free((*file)->reqs);
+		}
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		((*file)->context)->lib_type = SMIOL_LIBRARY_PNETCDF;
+		((*file)->context)->lib_ierr = ierr;
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	ierr = NC_NOERR;
+	if ((*file)->io_task && (*file)->bufsize > 0) {
+		ierr = ncmpi_buffer_detach((*file)->ncidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		((*file)->context)->lib_type = SMIOL_LIBRARY_PNETCDF;
+		((*file)->context)->lib_ierr = ierr;
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	if ((*file)->io_task) {
+		ierr = ncmpi_close((*file)->ncidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		((*file)->context)->lib_type = SMIOL_LIBRARY_PNETCDF;
+		((*file)->context)->lib_ierr = ierr;
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_LIBRARY_ERROR;
+	}
+#endif
+
+	if (MPI_Comm_free(&io_file_comm) != MPI_SUCCESS) {
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+
+	if (MPI_Comm_free(&io_group_comm) != MPI_SUCCESS) {
+		free((*file));
+		(*file) = NULL;
+		return SMIOL_MPI_ERROR;
+	}
+
+	free((*file));
+	(*file) = NULL;
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_define_dim
+ *
+ * Defines a new dimension in a file.
+ *
+ * Defines a dimension with the specified name and size in the file associated
+ * with the file handle. If a negative value is provided for the size argument,
+ * the dimension will be defined as an unlimited or record dimension.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+ * code is returned.
+ *
+ ********************************************************************************/
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int dimidp;
+	int ierr;
+	MPI_Offset len;
+#endif
+
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension name is valid
+	 */
+	if (dimname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	/*
+	 * The parallel-netCDF library does not permit zero-length dimensions
+	 */
+	if (dimsize == (SMIOL_Offset)0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Handle unlimited / record dimension specifications
+	 */
+	if (dimsize < (SMIOL_Offset)0) {
+		len = NC_UNLIMITED;
+	}
+	else {
+		len = (MPI_Offset)dimsize;
+	}
+
+	/*
+	 * If the file is in data mode, then switch it to define mode
+	 */
+	if (file->state == PNETCDF_DATA_MODE) {
+		if (file->io_task) {
+			ierr = ncmpi_redef(file->ncidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		file->state = PNETCDF_DEFINE_MODE;
+	}
+
+	if (file->io_task) {
+		ierr = ncmpi_def_dim(file->ncidp, dimname, len, &dimidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_inquire_dim
+ *
+ * Inquires about an existing dimension in a file.
+ *
+ * Inquire about the size of an existing dimension and optionally inquire if the
+ * given dimension is the unlimited dimension or not. If dimsize is a non-NULL
+ * pointer then the dimension size will be returned in dimsize. For unlimited
+ * dimensions, the current size of the dimension is returned; future writes of
+ * additional records to a file can lead to different return sizes for
+ * unlimited dimensions.
+ *
+ * If is_unlimited is a non-NULL pointer and if the inquired dimension is the
+ * unlimited dimension, is_unlimited will be set to 1; if the inquired
+ * dimension is not the unlimited dimension then is_unlimited will be set to 0.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+ * code is returned.
+ *
+ ********************************************************************************/
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
+                      SMIOL_Offset *dimsize, int *is_unlimited)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int dimidp = 0;
+	int ierr;
+	MPI_Offset len = 0;
+#endif
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension name is valid
+	 */
+	if (dimname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension size is not NULL
+	 */
+	if (dimsize == NULL && is_unlimited == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (dimsize != NULL) {
+		(*dimsize) = (SMIOL_Offset)0;   /* Default dimension size if no library provides a value */
+	}
+
+	if (is_unlimited != NULL) {
+		(*is_unlimited) = 0; /* Return 0 if no library provides a value */
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	if (file->io_task) {
+		ierr = ncmpi_inq_dimid(file->ncidp, dimname, &dimidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		(*dimsize) = (SMIOL_Offset)(-1);  /* TODO: should there be a well-defined invalid size? */
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	/*
+	 * Inquire about dimsize
+	 */
+	if (dimsize != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_dimlen(file->ncidp, dimidp, &len);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			(*dimsize) = (SMIOL_Offset)(-1);  /* TODO: should there be a well-defined invalid size? */
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		(*dimsize) = (SMIOL_Offset)len;
+/* TO DO: what if SMIOL_Offset is different in size from MPI_LONG */
+		MPI_Bcast(dimsize, 1, MPI_LONG, 0, io_group_comm);
+	}
+
+
+	/*
+	 * Inquire if this dimension is the unlimited dimension
+	 */
+	if (is_unlimited != NULL) {
+		int unlimdimidp = 0;
+		if (file->io_task) {
+			ierr = ncmpi_inq_unlimdim(file->ncidp, &unlimdimidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		if (file->io_task) {
+			if (unlimdimidp == dimidp) {
+				(*is_unlimited) = 1;
+			} else {
+				(*is_unlimited) = 0; /* Not the unlimited dim */
+			}
+		}
+		MPI_Bcast(is_unlimited, 1, MPI_INT, 0, io_group_comm);
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_define_var
+ *
+ * Defines a new variable in a file.
+ *
+ * Defines a variable with the specified name, type, and dimensions in an open
+ * file pointed to by the file argument. The varname and dimnames arguments
+ * are expected to be null-terminated strings, except if the variable has zero
+ * dimensions, in which case the dimnames argument may be a NULL pointer.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+ * code is returned.
+ *
+ ********************************************************************************/
+int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, int ndims, const char **dimnames)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int *dimids;
+	int ierr;
+	int i;
+	nc_type xtype;
+	int varidp;
+#endif
+
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that variable name is valid
+	 */
+	if (varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that the variable type is valid - handled below in a library-specific way...
+	 */
+
+	/*
+	 * Check that variable dimension names are valid
+	 */
+	if (dimnames == NULL && ndims > 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	dimids = (int *)malloc(sizeof(int) * (size_t)ndims);
+	if (dimids == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Build a list of dimension IDs
+	 */
+	for (i=0; i<ndims; i++) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_dimid(file->ncidp,
+			                       dimnames[i], &dimids[i]);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			free(dimids);
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+	}
+
+	/*
+	 * Translate SMIOL variable type to parallel-netcdf type
+	 */
+	switch (vartype) {
+		case SMIOL_REAL32:
+			xtype = NC_FLOAT;
+			break;
+		case SMIOL_REAL64:
+			xtype = NC_DOUBLE;
+			break;
+		case SMIOL_INT32:
+			xtype = NC_INT;
+			break;
+		case SMIOL_CHAR:
+			xtype = NC_CHAR;
+			break;
+		default:
+			free(dimids);
+			return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * If the file is in data mode, then switch it to define mode
+	 */
+	if (file->state == PNETCDF_DATA_MODE) {
+		if (file->io_task) {
+			ierr = ncmpi_redef(file->ncidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		file->state = PNETCDF_DEFINE_MODE;
+	}
+
+	/*
+	 * Define the variable
+	 */
+	if (file->io_task) {
+		ierr = ncmpi_def_var(file->ncidp, varname, xtype, ndims, dimids,
+		                     &varidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		free(dimids);
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	free(dimids);
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_inquire_var
+ *
+ * Inquires about an existing variable in a file.
+ *
+ * Inquires about a variable in a file, and optionally returns the type
+ * of the variable, the dimensionality of the variable, and the names of
+ * the dimensions of the variable. Which properties of the variable to return
+ * (type, dimensionality, or dimension names) is indicated by the status of
+ * the pointers for the corresponding properties: if the pointer is a non-NULL
+ * pointer, the property will be set upon successful completion of this routine.
+ *
+ * If the names of a variable's dimensions are requested (by providing a non-NULL
+ * actual argument for dimnames), the size of the dimnames array must be at least
+ * the number of dimensions in the variable, and each character string pointed
+ * to by an element of dimnames must be large enough to accommodate the corresponding
+ * dimension name.
+ *
+ ********************************************************************************/
+int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int *dimids;
+	int varidp = 0;
+	int ierr;
+	int i;
+	int xtypep;
+	int ndimsp = 0;
+#endif
+
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that variable name is valid
+	 */
+	if (varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * If all output arguments are NULL, we can return early
+	 */
+	if (vartype == NULL && ndims == NULL && dimnames == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	/*
+	 * Provide default values for output arguments in case
+	 * no library-specific below is active
+	 */
+	if (vartype != NULL) {
+		*vartype = SMIOL_UNKNOWN_VAR_TYPE;
+	}
+	if (ndims != NULL) {
+		*ndims = 0;
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	/*
+	 * Get variable ID
+	 */
+	if (file->io_task) {
+		ierr = ncmpi_inq_varid(file->ncidp, varname, &varidp);
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+
+	/*
+	 * If requested, inquire about variable type
+	 */
+	if (vartype != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_vartype(file->ncidp, varidp, &xtypep);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		MPI_Bcast(&xtypep, 1, MPI_INT, 0, io_group_comm);
+
+		/* Convert parallel-netCDF variable type to SMIOL variable type */
+		switch (xtypep) {
+			case NC_FLOAT:
+				*vartype = SMIOL_REAL32;
+				break;
+			case NC_DOUBLE:
+				*vartype = SMIOL_REAL64;
+				break;
+			case NC_INT:
+				*vartype = SMIOL_INT32;
+				break;
+			case NC_CHAR:
+				*vartype = SMIOL_CHAR;
+				break;
+			default:
+				*vartype = SMIOL_UNKNOWN_VAR_TYPE;
+		}
+	}
+
+	/*
+	 * All remaining properties will require the number of dimensions
+	 */
+	if (ndims != NULL || dimnames != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_varndims(file->ncidp, varidp, &ndimsp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		MPI_Bcast(&ndimsp, 1, MPI_INT, 0, io_group_comm);
+	}
+
+	/*
+	 * If requested, inquire about dimensionality
+	 */
+	if (ndims != NULL) {
+		*ndims = ndimsp;
+	}
+
+	/*
+	 * If requested, inquire about dimension names
+	 */
+	if (dimnames != NULL) {
+		dimids = (int *)malloc(sizeof(int) * (size_t)ndimsp);
+		if (dimids == NULL) {
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		if (file->io_task) {
+			ierr = ncmpi_inq_vardimid(file->ncidp, varidp, dimids);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			free(dimids);
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		for (i = 0; i < ndimsp; i++) {
+			int len;
+
+			if (dimnames[i] == NULL) {
+				return SMIOL_INVALID_ARGUMENT;
+			}
+			if (file->io_task) {
+				ierr = ncmpi_inq_dimname(file->ncidp, dimids[i],
+				                         dimnames[i]);
+			}
+			MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+			if (ierr != NC_NOERR) {
+				file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+				file->context->lib_ierr = ierr;
+				free(dimids);
+				return SMIOL_LIBRARY_ERROR;
+			}
+
+			if (file->io_task) {
+				len = (int)strnlen(dimnames[i],
+				                   (size_t)NC_MAX_NAME);
+				len++; /* Include the terminating '\0' character */
+			}
+			MPI_Bcast(&len, 1, MPI_INT, 0, io_group_comm);
+			MPI_Bcast(dimnames[i], len, MPI_CHAR, 0, io_group_comm);
+		}
+
+		free(dimids);
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_put_var
+ *
+ * Writes a variable to a file.
+ *
+ * Given a pointer to a SMIOL file that was previously opened with write access
+ * and the name of a variable previously defined in the file with a call to
+ * SMIOL_define_var, this routine will write the contents of buf to the variable
+ * according to the decomposition described by decomp.
+ *
+ * If decomp is not NULL, the variable is assumed to be decomposed across MPI
+ * ranks, and all ranks with non-zero-sized partitions of the variable must
+ * provide a valid buffer. For decomposed variables, all MPI ranks must provide
+ * a non-NULL decomp, regardless of whether a rank has a non-zero-sized
+ * partition of the variable.
+ *
+ * If the variable is not decomposed -- that is, all ranks store identical
+ * values for the entire variable -- all MPI ranks must provide a NULL pointer
+ * for the decomp argument. As currently implemented, this routine will write
+ * the buffer for MPI rank 0 to the variable; however, this behavior should not
+ * be relied on.
+ *
+ * If the variable has been successfully written to the file, SMIOL_SUCCESS will
+ * be returned. Otherwise, an error code indicating the nature of the failure
+ * will be returned.
+ *
+ ********************************************************************************/
+int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, const void *buf)
+{
+	int ierr;
+	int ndims;
+	size_t element_size;
+	size_t basic_size;
+	int has_unlimited_dim;
+	void *out_buf = NULL;
+	size_t *start;
+	size_t *count;
+
+	void *agg_buf = NULL;
+	const void *agg_buf_cnst = NULL;
+
+
+	/*
+	 * Basic checks on arguments
+	 */
+	if (file == NULL || varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Work out the start[] and count[] arrays for writing this variable
+	 * in parallel
+	 */
+	ierr = build_start_count(file, varname, decomp,
+	                         START_COUNT_WRITE, &element_size, &basic_size, &ndims,
+	                         &has_unlimited_dim,
+	                         &start, &count);
+	if (ierr != SMIOL_SUCCESS) {
+		return ierr;
+	}
+
+	/*
+	 * Communicate elements of this field from MPI ranks that compute those
+	 * elements to MPI ranks that write those elements. This only needs to
+	 * be done for decomposed variables.
+	 */
+	if (decomp) {
+		out_buf = malloc(element_size * decomp->io_count);
+		if (out_buf == NULL) {
+			free(start);
+			free(count);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		if (decomp->agg_factor != 1) {
+			MPI_Datatype dtype;
+			MPI_Comm agg_comm;
+
+			ierr = MPI_Type_contiguous((int)element_size,
+			                           MPI_UINT8_T, &dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_contiguous failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_commit(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_commit failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_buf = malloc(element_size * decomp->n_compute_agg);
+			if (agg_buf == NULL && decomp->n_compute_agg > 0) {
+				return SMIOL_MALLOC_FAILURE;
+			}
+
+			agg_comm = MPI_Comm_f2c(decomp->agg_comm);
+
+			ierr = MPI_Gatherv((const void *)buf,
+			                   (int)decomp->n_compute, dtype,
+			                   (void *)agg_buf,
+			                   (const int *)decomp->counts,
+			                   (const int *)decomp->displs,
+			                   dtype, 0, agg_comm);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Gatherv failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_free(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_free failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_buf_cnst = agg_buf;
+		} else {
+			agg_buf_cnst = buf;
+		}
+
+		ierr = transfer_field(decomp, SMIOL_COMP_TO_IO,
+		                      element_size, agg_buf_cnst, out_buf);
+		if (ierr != SMIOL_SUCCESS) {
+			free(start);
+			free(count);
+			free(out_buf);
+			return ierr;
+		}
+
+		if (decomp->agg_factor != 1) {
+			free(agg_buf);
+		}
+	}
+
+/* TO DO: could check that out_buf has size zero if not file->io_task */
+
+	/*
+	 * Write out_buf
+	 */
+#ifdef SMIOL_PNETCDF
+	{
+		int j;
+		int varidp = 0;
+		const void *buf_p;
+		MPI_Offset *mpi_start;
+		MPI_Offset *mpi_count;
+		MPI_Comm io_group_comm;
+		MPI_Comm io_file_comm;
+
+		io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+		io_file_comm = MPI_Comm_f2c(file->io_file_comm);
+
+		if (file->state == PNETCDF_DEFINE_MODE) {
+			if (file->io_task) {
+				ierr = ncmpi_enddef(file->ncidp);
+			}
+			MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+			if (ierr != NC_NOERR) {
+				file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+				file->context->lib_ierr = ierr;
+
+				if (decomp) {
+					free(out_buf);
+				}
+				free(start);
+				free(count);
+
+				return SMIOL_LIBRARY_ERROR;
+			}
+			file->state = PNETCDF_DATA_MODE;
+		}
+
+		if (file->io_task) {
+			ierr = ncmpi_inq_varid(file->ncidp, varname, &varidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+
+			if (decomp) {
+				free(out_buf);
+			}
+			free(start);
+			free(count);
+
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		if (decomp) {
+			buf_p = out_buf;
+		} else {
+			buf_p = buf;
+		}
+
+		mpi_start = malloc(sizeof(MPI_Offset) * (size_t)ndims);
+		if (mpi_start == NULL) {
+			free(start);
+			free(count);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		mpi_count = malloc(sizeof(MPI_Offset) * (size_t)ndims);
+		if (mpi_count == NULL) {
+			free(start);
+			free(count);
+			free(mpi_start);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		for (j = 0; j < ndims; j++) {
+			mpi_start[j] = (MPI_Offset)start[j];
+			mpi_count[j] = (MPI_Offset)count[j];
+		}
+
+		if (file->io_task) {
+			ierr = write_chunk_pnetcdf(file,
+			                           varidp,
+			                           ndims,
+			                           has_unlimited_dim,
+			                           basic_size,
+			                           io_file_comm,
+			                           buf_p,
+			                           mpi_start,
+			                           mpi_count
+			                          );
+		}
+
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+
+		free(mpi_start);
+		free(mpi_count);
+
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+
+			if (decomp) {
+				free(out_buf);
+			}
+			free(start);
+			free(count);
+
+			return SMIOL_LIBRARY_ERROR;
+		}
+	}
+#endif
+
+	/*
+	 * Free up memory before returning
+	 */
+	if (decomp) {
+		free(out_buf);
+	}
+
+	free(start);
+	free(count);
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_get_var
+ *
+ * Reads a variable from a file.
+ *
+ * Given a pointer to a SMIOL file and the name of a variable previously defined
+ * in the file, this routine will read the contents of the variable into buf
+ * according to the decomposition described by decomp.
+ *
+ * If decomp is not NULL, the variable is assumed to be decomposed across MPI
+ * ranks, and all ranks with non-zero-sized partitions of the variable must
+ * provide a valid buffer. For decomposed variables, all MPI ranks must provide
+ * a non-NULL decomp, regardless of whether a rank has a non-zero-sized
+ * partition of the variable.
+ *
+ * If the variable is not decomposed -- that is, all ranks load identical
+ * values for the entire variable -- all MPI ranks must provide a NULL pointer
+ * for the decomp argument.
+ *
+ * If the variable has been successfully read from the file, SMIOL_SUCCESS will
+ * be returned. Otherwise, an error code indicating the nature of the failure
+ * will be returned.
+ *
+ ********************************************************************************/
+int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, void *buf)
+{
+	int ierr;
+	int ndims;
+	size_t element_size;
+	size_t basic_size;
+	int has_unlimited_dim;
+	void *in_buf = NULL;
+	size_t *start;
+	size_t *count;
+
+	void *agg_buf = NULL;
+
+	MPI_Comm io_group_comm;
+	MPI_Comm io_file_comm;
+
+
+	/*
+	 * Basic checks on arguments
+	 */
+	if (file == NULL || varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+	io_file_comm = MPI_Comm_f2c(file->io_file_comm);
+
+	/*
+	 * Work out the start[] and count[] arrays for reading this variable
+	 * in parallel
+	 */
+	ierr = build_start_count(file, varname, decomp,
+	                         START_COUNT_READ, &element_size, &basic_size, &ndims,
+	                         &has_unlimited_dim,
+	                         &start, &count);
+	if (ierr != SMIOL_SUCCESS) {
+		return ierr;
+	}
+
+	/*
+	 * If this variable is decomposed, allocate a buffer into which
+	 * the variable will be read using the I/O decomposition; later,
+	 * elements this buffer will be transferred to MPI ranks that compute
+	 * on those elements
+	 */
+	if (decomp) {
+		in_buf = malloc(element_size * decomp->io_count);
+		if (in_buf == NULL) {
+			free(start);
+			free(count);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+#ifndef SMIOL_PNETCDF
+		/*
+		 * If no file library provides values for the memory pointed to
+		 * by in_buf, the transfer_field call later will transfer
+		 * garbage to the output buffer; to avoid returning
+		 * non-deterministic values to the caller in this case,
+		 * initialize in_buf.
+		 */
+		memset(in_buf, 0, element_size * decomp->io_count);
+		
+#endif
+	}
+
+/* MGD TO DO: could verify that if not file->io_task, then size of in_buf is zero */
+
+	/*
+	 * Read in_buf
+	 */
+#ifdef SMIOL_PNETCDF
+	{
+		int j;
+		int varidp = 0;
+		void *buf_p;
+		MPI_Offset *mpi_start;
+		MPI_Offset *mpi_count;
+
+		if (file->state == PNETCDF_DEFINE_MODE) {
+			if (file->io_task) {
+				ierr = ncmpi_enddef(file->ncidp);
+			}
+			MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+			if (ierr != NC_NOERR) {
+				file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+				file->context->lib_ierr = ierr;
+
+				if (decomp) {
+					free(in_buf);
+				}
+				free(start);
+				free(count);
+
+				return SMIOL_LIBRARY_ERROR;
+			}
+			file->state = PNETCDF_DATA_MODE;
+		}
+
+		if (file->io_task) {
+			ierr = ncmpi_inq_varid(file->ncidp, varname, &varidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+
+			if (decomp) {
+				free(in_buf);
+			}
+			free(start);
+			free(count);
+
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		if (decomp) {
+			buf_p = in_buf;
+		} else {
+			buf_p = buf;
+		}
+
+		mpi_start = malloc(sizeof(MPI_Offset) * (size_t)ndims);
+		if (mpi_start == NULL) {
+			free(start);
+			free(count);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		mpi_count = malloc(sizeof(MPI_Offset) * (size_t)ndims);
+		if (mpi_count == NULL) {
+			free(start);
+			free(count);
+			free(mpi_start);
+
+			return SMIOL_MALLOC_FAILURE;
+		}
+
+		for (j = 0; j < ndims; j++) {
+			mpi_start[j] = (MPI_Offset)start[j];
+			mpi_count[j] = (MPI_Offset)count[j];
+		}
+
+		ierr = NC_NOERR;
+		if (file->io_task) {
+			/*
+			 * Finish and flush any pending writes to this file
+			 * before reading back a variable
+			 */
+			if (file->n_reqs > 0) {
+				int statuses[MAX_REQS];
+
+				ierr = ncmpi_wait_all(file->ncidp, file->n_reqs,
+				                      file->reqs, statuses);
+				file->n_reqs = 0;
+
+				if (ierr == NC_NOERR) {
+					ierr = ncmpi_sync(file->ncidp);
+				}
+			}
+			if (ierr == NC_NOERR) {
+				ierr = read_chunk_pnetcdf(file,
+				                          varidp,
+				                          ndims,
+				                          has_unlimited_dim,
+				                          basic_size,
+				                          io_file_comm,
+				                          buf_p,
+				                          mpi_start,
+				                          mpi_count
+				                         );
+			}
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+
+		free(mpi_start);
+		free(mpi_count);
+
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+
+			if (decomp) {
+				free(in_buf);
+			}
+			free(start);
+			free(count);
+
+			return SMIOL_LIBRARY_ERROR;
+		}
+	}
+#endif
+
+	/*
+	 * Free start/count arrays
+	 */
+	free(start);
+	free(count);
+
+	/*
+	 * Communicate elements of this field from MPI ranks that read those
+	 * elements to MPI ranks that compute those elements. This only needs to
+	 * be done for decomposed variables.
+	 */
+	if (decomp) {
+		if (decomp->agg_factor != 1) {
+			agg_buf = malloc(element_size * decomp->n_compute_agg);
+			if (agg_buf == NULL && decomp->n_compute_agg > 0) {
+				return SMIOL_MALLOC_FAILURE;
+			}
+		} else {
+			agg_buf = buf;
+		}
+
+		ierr = transfer_field(decomp, SMIOL_IO_TO_COMP,
+		                      element_size, in_buf, agg_buf);
+
+		if (decomp->agg_factor != 1) {
+			MPI_Datatype dtype = MPI_DATATYPE_NULL;
+			MPI_Comm agg_comm;
+
+			ierr = MPI_Type_contiguous((int)element_size,
+			                           MPI_UINT8_T, &dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_contiguous failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_commit(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_commit failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_comm = MPI_Comm_f2c(decomp->agg_comm);
+
+			ierr = MPI_Scatterv((const void *)agg_buf,
+			                    (const int*)decomp->counts,
+			                    (const int *)decomp->displs,
+			                    dtype, (void *)buf,
+			                    (int)decomp->n_compute,
+			                    dtype, 0, agg_comm);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Scatterv failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			free(agg_buf);
+
+			ierr = MPI_Type_free(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_free failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+		}
+
+		free(in_buf);
+
+		if (ierr != SMIOL_SUCCESS) {
+			return ierr;
+		}
+	} else {
+		/*
+		 * For non-decomposed variables, broadcast from I/O tasks
+		 * to other tasks in each I/O group
+		 */
+		MPI_Bcast(buf, (int)element_size, MPI_CHAR, 0, io_group_comm);
+	}
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_define_att
+ *
+ * Defines a new attribute in a file.
+ *
+ * Defines a new attribute for a variable if varname is not NULL,
+ * or a global attribute otherwise. The type of the attribute must be one
+ * of SMIOL_REAL32, SMIOL_REAL64, SMIOL_INT32, or SMIOL_CHAR.
+ *
+ * If the attribute has been successfully defined for the variable or file,
+ * SMIOL_SUCCESS is returned.
+ *
+ ********************************************************************************/
+int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
+                     const char *att_name, int att_type, const void *att)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int ierr;
+	int varidp = 0;
+	nc_type xtype;
+#endif
+
+	/*
+	 * Check validity of arguments
+	 */
+	if (file == NULL || att_name == NULL || att == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Checks for valid attribute type are handled in library-specific
+	 * code, below
+	 */
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	/*
+	 * If varname was provided, get the variable ID; else, the attribute
+	 * is a global attribute not associated with a specific variable
+	 */
+	if (varname != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_varid(file->ncidp, varname, &varidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+	} else {
+		varidp = NC_GLOBAL;
+	}
+
+	/*
+	 * Translate SMIOL variable type to parallel-netcdf type
+	 */
+	switch (att_type) {
+		case SMIOL_REAL32:
+			xtype = NC_FLOAT;
+			break;
+		case SMIOL_REAL64:
+			xtype = NC_DOUBLE;
+			break;
+		case SMIOL_INT32:
+			xtype = NC_INT;
+			break;
+		case SMIOL_CHAR:
+			xtype = NC_CHAR;
+			break;
+		default:
+			return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * If the file is in data mode, then switch it to define mode
+	 */
+	if (file->state == PNETCDF_DATA_MODE) {
+		if (file->io_task) {
+			ierr = ncmpi_redef(file->ncidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		file->state = PNETCDF_DEFINE_MODE;
+	}
+
+	/*
+	 * Add the attribute to the file
+	 */
+	if (file->io_task) {
+		if (att_type == SMIOL_CHAR) {
+			ierr = ncmpi_put_att(file->ncidp, varidp, att_name,
+			                     xtype, (MPI_Offset)strlen(att),
+			                     (const char *)att);
+		} else {
+			ierr = ncmpi_put_att(file->ncidp, varidp, att_name,
+			                     xtype, (MPI_Offset)1,
+			                     (const char *)att);
+		}
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_inquire_att
+ *
+ * Inquires about an attribute in a file.
+ *
+ * Inquires about a variable attribute if varname is not NULL, or a global
+ * attribute otherwise.
+ *
+ * If the requested attribute is found, SMIOL_SUCCESS is returned and the memory
+ * pointed to by the att argument will contain the attribute value.
+ *
+ * For character string attributes, no bytes beyond the length of the attribute
+ * in the file will be modified in the att argument, and no '\0' character will
+ * be added. Therefore, calling code may benefit from initializing character
+ * strings before calling this routine.
+ *
+ * If SMIOL was not compiled with support for any file library, the att_type
+ * output argument will always be set to SMIOL_UNKNOWN_VAR_TYPE, and the att_len
+ * output argument will always be set to -1; the value of the att output
+ * argument will be unchanged.
+ *
+ ********************************************************************************/
+int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,                                                                  
+                      const char *att_name, int *att_type,
+                      SMIOL_Offset *att_len, void *att)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int ierr;
+	int varidp = 0;
+	nc_type xtypep = 0;
+	MPI_Offset lenp = 0;
+#endif
+
+	/*
+	 * Check validity of arguments
+	 */
+	if (file == NULL || att_name == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Set output arguments in case no library sets them later
+	 */
+	if (att_len != NULL) {
+		*att_len = (SMIOL_Offset)-1;
+	}
+
+	if (att_type != NULL) {
+		*att_type = SMIOL_UNKNOWN_VAR_TYPE;
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	/*
+	 * If varname was provided, get the variable ID; else, the inquiry is
+	 * is for a global attribute not associated with a specific variable
+	 */
+	if (varname != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_varid(file->ncidp, varname, &varidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+	} else {
+		varidp = NC_GLOBAL;
+	}
+
+	/*
+	 * Inquire about attribute type and length
+	 */
+	if (att != NULL || att_type != NULL || att_len != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_inq_att(file->ncidp, varidp, att_name,
+			                     &xtypep, &lenp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		MPI_Bcast(&lenp, sizeof(MPI_Offset), MPI_BYTE, 0,
+		          io_group_comm);
+		MPI_Bcast(&xtypep, sizeof(nc_type), MPI_BYTE, 0,
+		          io_group_comm);
+
+		if (att_type != NULL) {
+			/* Convert parallel-netCDF type to SMIOL type */
+			switch (xtypep) {
+				case NC_FLOAT:
+					*att_type = SMIOL_REAL32;
+					break;
+				case NC_DOUBLE:
+					*att_type = SMIOL_REAL64;
+					break;
+				case NC_INT:
+					*att_type = SMIOL_INT32;
+					break;
+				case NC_CHAR:
+					*att_type = SMIOL_CHAR;
+					break;
+				default:
+					*att_type = SMIOL_UNKNOWN_VAR_TYPE;
+			}
+		}
+
+		if (att_len != NULL) {
+			*att_len = lenp;
+		}
+	}
+
+
+	/*
+	 * Inquire about attribute value if requested
+	 */
+	if (att != NULL) {
+		if (file->io_task) {
+			ierr = ncmpi_get_att(file->ncidp, varidp, att_name,
+			                     att);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+
+		switch (xtypep) {
+		case NC_FLOAT:
+			ierr = MPI_Bcast(att, 1, MPI_FLOAT, 0, io_group_comm);
+			break;
+		case NC_DOUBLE:
+			ierr = MPI_Bcast(att, 1, MPI_DOUBLE, 0, io_group_comm);
+			break;
+		case NC_INT:
+			ierr = MPI_Bcast(att, 1, MPI_INT, 0, io_group_comm);
+			break;
+		case NC_CHAR:
+			ierr = MPI_Bcast(att, (int)lenp, MPI_CHAR, 0,
+			                 io_group_comm);
+			break;
+		}
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_sync_file
+ *
+ * Forces all in-memory data to be flushed to disk.
+ *
+ * Upon success, all in-memory data for the file associatd with the file
+ * handle will be flushed to the file system and SMIOL_SUCCESS will be
+ * returned; otherwise, an error code is returned.
+ *
+ ********************************************************************************/
+int SMIOL_sync_file(struct SMIOL_file *file)
+{
+#ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
+	int ierr;
+#endif
+
+	/*
+	 * Check that file is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+#ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
+	/*
+	 * If the file is in define mode then switch it into data mode
+	 */
+	if (file->state == PNETCDF_DEFINE_MODE) {
+		if (file->io_task) {
+			ierr = ncmpi_enddef(file->ncidp);
+		}
+		MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+		if (ierr != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		file->state = PNETCDF_DATA_MODE;
+	}
+
+	if (file->io_task) {
+		ierr = NC_NOERR;
+
+		if (file->n_reqs > 0) {
+			int statuses[MAX_REQS];
+
+			ierr = ncmpi_wait_all(file->ncidp, file->n_reqs,
+			                      file->reqs, statuses);
+			file->n_reqs = 0;
+		}
+
+		if (ierr == NC_NOERR) {
+			ierr = ncmpi_sync(file->ncidp);
+		}
+	}
+	MPI_Bcast(&ierr, 1, MPI_INT, 0, io_group_comm);
+	if (ierr != NC_NOERR) {
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+#endif
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_error_string
+ *
+ * Returns an error string for a specified error code.
+ *
+ * Returns an error string corresponding to a SMIOL error code. If the error code is
+ * SMIOL_LIBRARY_ERROR and a valid SMIOL context is available, the SMIOL_lib_error_string
+ * function should be called instead. The error string is null-terminated, but it
+ * does not contain a newline character.
+ *
+ ********************************************************************************/
+const char *SMIOL_error_string(int errno)
+{
+	switch (errno) {
+	case SMIOL_SUCCESS:
+		return "Success!";
+	case SMIOL_MALLOC_FAILURE:
+		return "malloc returned a null pointer";
+	case SMIOL_INVALID_ARGUMENT:
+		return "invalid subroutine argument";
+	case SMIOL_MPI_ERROR:
+		return "internal MPI call failed";
+	case SMIOL_FORTRAN_ERROR:
+		return "Fortran wrapper detected an inconsistency in C return values";
+	case SMIOL_LIBRARY_ERROR:
+		return "bad return code from a library call";
+	case SMIOL_WRONG_ARG_TYPE:
+		return "argument is of the wrong type";
+	case SMIOL_INSUFFICIENT_ARG:
+		return "argument is of insufficient size";
+	default:
+		return "Unknown error";
+	}
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_lib_error_string
+ *
+ * Returns an error string for a third-party library called by SMIOL.
+ *
+ * Returns an error string corresponding to an error that was generated by
+ * a third-party library that was called by SMIOL. The library that was the source
+ * of the error, as well as the library-specific error code, are retrieved from
+ * a SMIOL context. If successive library calls resulted in errors, only the error
+ * string for the last of these errors will be returned. The error string is
+ * null-terminated, but it does not contain a newline character.
+ *
+ ********************************************************************************/
+const char *SMIOL_lib_error_string(struct SMIOL_context *context)
+{
+	if (context == NULL) {
+		return "SMIOL_context argument is a NULL pointer";
+	}
+
+	switch (context->lib_type) {
+#ifdef SMIOL_PNETCDF
+	case SMIOL_LIBRARY_PNETCDF:
+		return ncmpi_strerror(context->lib_ierr);
+#endif
+	default:
+		return "Could not find matching library for the source of the error";
+	}
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_set_option
+ *
+ * Sets an option for the SMIOL library.
+ *
+ * Detailed description.
+ *
+ ********************************************************************************/
+int SMIOL_set_option(void)
+{
+	return SMIOL_SUCCESS;
+}
+
+/********************************************************************************
+ *
+ * SMIOL_set_frame
+ *
+ * Set the frame for the unlimited dimension for an open file
+ *
+ * For an open SMIOL file handle, set the frame for the unlimited dimension.
+ * After setting the frame for a file, writing to a variable that is
+ * dimensioned by the unlimited dimension will write to the last set frame,
+ * overwriting any current data that maybe present in that frame.
+ *
+ * SMIOL_SUCCESS will be returned if the frame is successfully set otherwise an
+ * error will return.
+ *
+ ********************************************************************************/
+int SMIOL_set_frame(struct SMIOL_file *file, SMIOL_Offset frame)
+{
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+	file->frame = frame;
+	return SMIOL_SUCCESS;
+}
+
+/********************************************************************************
+ *
+ * SMIOL_get_frame
+ *
+ * Return the current frame of an open file
+ *
+ * Get the current frame of an open file. Upon success, SMIOL_SUCCESS will be
+ * returned, otherwise an error will be returned.
+ *
+ ********************************************************************************/
+int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame)
+{
+	if (file == NULL || frame == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+	*frame = file->frame;
+	return SMIOL_SUCCESS;
+}
+
+
+/*******************************************************************************
+ *
+ * SMIOL_create_decomp
+ *
+ * Creates a mapping between compute elements and I/O elements.
+ *
+ * Given arrays of global element IDs that each task computes, this routine
+ * works out a mapping of elements between compute and I/O tasks.
+ *
+ * The aggregation factor is used to indicate the size of subsets of ranks
+ * that will gather fields onto a single rank in each subset before transferring
+ * that field from compute to output tasks; in a symmetric way, it also
+ * indicates the size of subsets over which fields will be scattered after they
+ * are transferred from input tasks to a single compute tasks in each subset.
+ *
+ * An aggregation factor of 0 indicates that the implementation should choose
+ * a suitable aggregation factor (usually matching the size of shared-memory
+ * domains), while a positive integer specifies a specific size for task groups
+ * to be used for aggregation.
+ *
+ * If all input arguments are determined to be valid and if the routine is
+ * successful in working out a mapping, the decomp pointer is allocated and
+ * given valid contents, and SMIOL_SUCCESS is returned; otherwise a non-success
+ * error code is returned and the decomp pointer is NULL.
+ *
+ *******************************************************************************/
+int SMIOL_create_decomp(struct SMIOL_context *context,
+                        size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        int aggregation_factor,
+                        struct SMIOL_decomp **decomp)
+{
+	size_t i;
+	size_t n_io_elements, n_io_elements_global;
+	size_t io_start, io_count;
+	SMIOL_Offset *io_elements;
+	MPI_Comm comm;
+	MPI_Datatype dtype;
+	int ierr;
+
+	size_t n_compute_elements_agg;
+	SMIOL_Offset *compute_elements_agg = NULL;
+	MPI_Comm agg_comm = MPI_COMM_NULL;
+	int *counts = NULL;
+	int *displs = NULL;
+	int actual_agg_factor;
+
+
+	/*
+	 * Minimal check on the validity of arguments
+	 */
+	if (context == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (compute_elements == NULL && n_compute_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (aggregation_factor < 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	comm = MPI_Comm_f2c(context->fcomm);
+
+	/*
+	 * Figure out MPI_Datatype for size_t... there must be a better way...
+	 */
+	switch (sizeof(size_t)) {
+		case sizeof(uint64_t):
+			dtype = MPI_UINT64_T;
+			break;
+		case sizeof(uint32_t):
+			dtype = MPI_UINT32_T;
+			break;
+		case sizeof(uint16_t):
+			dtype = MPI_UINT16_T;
+			break;
+		default:
+			return SMIOL_MPI_ERROR;
+	}
+
+	/*
+	 * Based on the number of compute elements for each task, determine
+	 * the total number of elements across all tasks for I/O. The assumption
+	 * is that the number of elements to read/write is equal to the size of
+	 * the set of compute elements.
+	 */
+	n_io_elements = n_compute_elements;
+	if (MPI_SUCCESS != MPI_Allreduce((const void *)&n_io_elements,
+	                                 (void *)&n_io_elements_global,
+	                                 1, dtype, MPI_SUM, comm)) {
+		return SMIOL_MPI_ERROR;
+	}
+
+	/*
+	 * Determine the contiguous range of elements to be read/written by
+	 * this MPI task
+	 */
+	ierr = get_io_elements(context->comm_rank,
+	                       context->num_io_tasks, context->io_stride,
+	                       n_io_elements_global, &io_start, &io_count);
+
+	/*
+	 * Fill in io_elements from io_start through io_start + io_count - 1
+	 */
+	io_elements = NULL;
+	if (io_count > 0) {
+		io_elements = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset)
+		                                     * n_io_elements_global);
+		if (io_elements == NULL) {
+			return SMIOL_MALLOC_FAILURE;
+		}
+		for (i = 0; i < io_count; i++) {
+			io_elements[i] = (SMIOL_Offset)(io_start + i);
+		}
+	}
+
+	/*
+	 * If aggregation_factor != 1, aggregate the list of compute_elements
+	 * before building the mapping
+	 */
+	if (aggregation_factor != 1) {
+		int comm_rank = context->comm_rank;
+
+		/*
+		 * Create intracommunicators for aggregation
+		 */
+		if (aggregation_factor == 0) {
+			ierr = MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED,
+			                           comm_rank, MPI_INFO_NULL,
+			                           &agg_comm);
+		} else {
+			ierr = MPI_Comm_split(comm,
+			                      (comm_rank / aggregation_factor),
+			                      comm_rank,
+			                      &agg_comm);
+		}
+		if (ierr != MPI_SUCCESS) {
+			fprintf(stderr, "Error: MPI_Comm_split failed with code %i\n",
+			        ierr);
+			return SMIOL_MPI_ERROR;
+		}
+
+		ierr = MPI_Comm_size(agg_comm, &actual_agg_factor);
+		if (ierr != MPI_SUCCESS) {
+			fprintf(stderr, "Error: MPI_Comm_size failed with code %i\n",
+			        ierr);
+			return SMIOL_MPI_ERROR;
+		}
+
+		/*
+		 * Create aggregated compute_elements list if the actual
+		 * aggregation factor is > 1
+		 */
+		if (actual_agg_factor > 1) {
+			aggregate_list(agg_comm, 0, n_compute_elements,
+			               compute_elements,
+			               &n_compute_elements_agg,
+			               &compute_elements_agg, &counts, &displs);
+		} else {
+			MPI_Comm_free(&agg_comm);
+			n_compute_elements_agg = n_compute_elements;
+			compute_elements_agg = compute_elements;
+		}
+	} else {
+		actual_agg_factor = 1;
+		n_compute_elements_agg = n_compute_elements;
+		compute_elements_agg = compute_elements;
+	}
+
+	/*
+	 * Build the mapping between compute tasks and I/O tasks
+	 */
+	ierr = build_exchange(context,
+	                      n_compute_elements_agg, compute_elements_agg,
+	                      io_count, io_elements,
+	                      decomp);
+
+	free(io_elements);
+
+	if (actual_agg_factor > 1) {
+		(*decomp)->agg_factor = actual_agg_factor;
+		(*decomp)->agg_comm = MPI_Comm_c2f(agg_comm);
+		(*decomp)->n_compute = n_compute_elements;
+		(*decomp)->n_compute_agg = n_compute_elements_agg;
+		(*decomp)->counts = counts;
+		(*decomp)->displs = displs;
+
+		free(compute_elements_agg);
+	}
+
+	/*
+	 * If decomp was successfully created, add io_start and io_count values
+	 * to the decomp before returning
+	 */
+	if (ierr == SMIOL_SUCCESS) {
+		(*decomp)->io_start = io_start;
+		(*decomp)->io_count = io_count;
+	}
+
+	return ierr;
+}
+
+
+/********************************************************************************
+ *
+ * SMIOL_free_decomp
+ *
+ * Frees a mapping between compute elements and I/O elements.
+ *
+ * Free all memory of a SMIOL_decomp and returns SMIOL_SUCCESS. If decomp
+ * points to NULL, then do nothing and return SMIOL_SUCCESS. After this routine
+ * is called, no other SMIOL routines should use the freed SMIOL_decomp.
+ *
+ ********************************************************************************/
+int SMIOL_free_decomp(struct SMIOL_decomp **decomp)
+{
+	MPI_Comm comm;
+
+	if ((*decomp) == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	free((*decomp)->comp_list);
+	free((*decomp)->io_list);
+
+	comm = MPI_Comm_f2c((*decomp)->agg_comm);
+	if (comm != MPI_COMM_NULL) {
+		MPI_Comm_free(&comm);
+	}
+	if ((*decomp)->counts != NULL) {
+		free((*decomp)->counts);
+	}
+	if ((*decomp)->displs != NULL) {
+		free((*decomp)->displs);
+	}
+
+	free((*decomp));
+	*decomp = NULL;
+
+	return SMIOL_SUCCESS;
+}
+
+
+/********************************************************************************
+ *
+ * build_start_count
+ *
+ * Constructs start[] and count[] arrays for parallel I/O operations
+ *
+ * Given a pointer to a SMIOL file that was previously opened, the name of
+ * a variable in that file, and a SMIOL decomp, this function returns several
+ * items that may be used when reading or writing the variable in parallel:
+ *
+ * 1) The size of each "element" of the variable, where an element is defined as
+ *    a contiguous memory range associated with the slowest-varying, non-record
+ *    dimension of the variable; for example, a variable
+ *    float foo[nCells][nVertLevels] would have an element size of
+ *    sizeof(float) * nVertLevels if nCells were a decomposed dimension.
+ *
+ *    For non-decomposed variables, the element size is the size of one record
+ *    of the entire variable.
+ *
+ * 2) The size of the fundamental datatype for the variable; for example, a
+ *    float variable would yield sizeof(float).
+ *
+ * 3) The number of dimensions for the variable, including any unlimited/record
+ *    dimension.
+ *
+ * 4) Whether the variable has a record (unlimited) dimension.
+ *
+ * 5) The start[] and count[] arrays (each with size ndims) to be read or written
+ *    by an MPI rank using the I/O decomposition described in decomp.
+ *
+ * If the decomp argument is NULL, the variable is to be read or written as
+ * a non-decomposed variable; typically, only MPI rank 0 will write
+ * the non-decomposed variable, and all MPI ranks will read the non-decomposed
+ * variable.
+ *
+ * Depending on the value of the write_or_read argument -- either START_COUNT_READ
+ * or START_COUNT_WRITE -- the count[] values will be set so that all ranks will
+ * read the variable, or only rank 0 will write the variable if the variable is
+ * not decomposed.
+ *
+ ********************************************************************************/
+int build_start_count(struct SMIOL_file *file, const char *varname,
+                      const struct SMIOL_decomp *decomp,
+                      int write_or_read, size_t *element_size,
+                      size_t *basic_type_size, int *ndims,
+                      int *has_unlimited_dim,
+                      size_t **start, size_t **count)
+{
+	int i;
+	int ierr;
+	int vartype;
+	char **dimnames;
+	SMIOL_Offset *dimsizes;
+
+/* TO DO - define maximum string size, currently assumed to be 64 chars */
+
+	/*
+	 * Figure out type of the variable, as well as its dimensions
+	 */
+	ierr = SMIOL_inquire_var(file, varname, &vartype, ndims, NULL);
+	if (ierr != SMIOL_SUCCESS) {
+		return ierr;
+	}
+
+	dimnames = malloc(sizeof(char *) * (size_t)(*ndims));
+        if (dimnames == NULL) {
+		ierr = SMIOL_MALLOC_FAILURE;
+		return ierr;
+	}
+
+	for (i = 0; i < *ndims; i++) {
+		dimnames[i] = malloc(sizeof(char) * (size_t)64);
+	        if (dimnames[i] == NULL) {
+			int j;
+
+			for (j = 0; j < i; j++) {
+				free(dimnames[j]);
+			}
+			free(dimnames);
+
+			ierr = SMIOL_MALLOC_FAILURE;
+			return ierr;
+		}
+	}
+
+	ierr = SMIOL_inquire_var(file, varname, NULL, NULL, dimnames);
+	if (ierr != SMIOL_SUCCESS) {
+		for (i = 0; i < *ndims; i++) {
+			free(dimnames[i]);
+		}
+		free(dimnames);
+		return ierr;
+	}
+	
+	dimsizes = malloc(sizeof(SMIOL_Offset) * (size_t)(*ndims));
+        if (dimsizes == NULL) {
+		ierr = SMIOL_MALLOC_FAILURE;
+		return ierr;
+	}
+
+	/*
+	 * It is assumed that only the first dimension can be an unlimited
+	 * dimension, so by inquiring about dimensions from last to first, we
+	 * can be guaranteed that has_unlimited_dim will be set correctly at
+	 * the end of the loop over dimensions
+	 */
+	*has_unlimited_dim = 0;
+	for (i = (*ndims-1); i >= 0; i--) {
+		ierr = SMIOL_inquire_dim(file, dimnames[i], &dimsizes[i],
+		                         has_unlimited_dim);
+		if (ierr != SMIOL_SUCCESS) {
+			for (i = 0; i < *ndims; i++) {
+				free(dimnames[i]);
+			}
+			free(dimnames);
+			free(dimsizes);
+
+			return ierr;
+		}
+	}
+
+	for (i = 0; i < *ndims; i++) {
+		free(dimnames[i]);
+	}
+	free(dimnames);
+
+	/*
+	 * Set basic size of each element in the field
+	 */
+	*element_size = 1;
+	switch (vartype) {
+		case SMIOL_REAL32:
+			*basic_type_size = sizeof(float);
+			break;
+		case SMIOL_REAL64:
+			*basic_type_size = sizeof(double);
+			break;
+		case SMIOL_INT32:
+			*basic_type_size = sizeof(int);
+			break;
+		case SMIOL_CHAR:
+			*basic_type_size = sizeof(char);
+			break;
+	}
+	*element_size = *basic_type_size;
+
+	*start = malloc(sizeof(size_t) * (size_t)(*ndims));
+        if (*start == NULL) {
+		free(dimsizes);
+		ierr = SMIOL_MALLOC_FAILURE;
+		return ierr;
+	}
+
+	*count = malloc(sizeof(size_t) * (size_t)(*ndims));
+        if (*count == NULL) {
+		free(dimsizes);
+		free(start);
+		ierr = SMIOL_MALLOC_FAILURE;
+		return ierr;
+	}
+
+	/*
+	 * Build start/count description of the part of the variable to be
+	 * read or written. Simultaneously, compute the product of all
+	 * non-unlimited, non-decomposed dimension sizes, scaled by the basic
+	 * element size to get the effective size of each element to be read or
+	 * written
+	 */
+	for (i = 0; i < *ndims; i++) {
+		(*start)[i] = (size_t)0;
+		(*count)[i] = (size_t)dimsizes[i];
+
+		/*
+		 * If variable has an unlimited dimension, set start to current
+		 * frame and count to one
+		 */
+		if (*has_unlimited_dim && i == 0) {
+			(*start)[i] = (size_t)file->frame;
+			(*count)[i] = (size_t)1;
+		}
+
+		/*
+		 * If variable is decomposed, set the slowest-varying,
+		 * non-record dimension start and count based on values from
+		 * the decomp structure
+		 */
+		if (decomp) {
+			if ((!*has_unlimited_dim && i == 0) ||
+			    (*has_unlimited_dim && i == 1)) {
+				(*start)[i] = decomp->io_start;
+				(*count)[i] = decomp->io_count;
+			} else {
+				*element_size *= (*count)[i];
+			}
+		} else {
+			*element_size *= (*count)[i];
+		}
+
+		if (write_or_read == START_COUNT_WRITE) {
+			/*
+			 * If the variable is not decomposed, only MPI rank 0
+			 * will have non-zero count values so that all MPI ranks
+			 * do no try to write the same offsets
+			 */
+			if (!decomp && file->context->comm_rank != 0) {
+				(*count)[i] = 0;
+			}
+		}
+	}
+
+	free(dimsizes);
+
+	return SMIOL_SUCCESS;
+}
+
+
+#ifdef SMIOL_PNETCDF
+/********************************************************************************
+ *
+ * write_chunk_pnetcdf
+ *
+ * Write a chunk of a variable to a file using the Parallel-NetCDF library
+ *
+ * Given a file and information about a variable in the file, write a chunk of
+ * memory to the variable according to start/count arrays. If the size of the
+ * chunk to be written will fit within any buffer attached to the file, the
+ * chunk is written using the Parallel-NetCDF buffered non-blocking interface;
+ * otherwise, the chunk is written using the blocking write interface, ensuring
+ * that not more than 2 GiB is written in any single call to ncmpi_put_vara_all.
+ *
+ * The return value from this function will be NC_NOERR in case no errors
+ * occurred in calls to the Parallel-NetCDF library, or a Parallel-NetCDF error
+ * code otherwise.
+ *
+ * Within this function, return error codes from MPI calls are ignored.
+ *
+ ********************************************************************************/
+int write_chunk_pnetcdf(struct SMIOL_file *file,
+                        int varidp,
+                        int ndims,
+                        int has_unlimited_dim,
+                        size_t basic_type_size,
+                        MPI_Comm io_file_comm,
+                        const void *buf_p,
+                        MPI_Offset *mpi_start,
+                        MPI_Offset *mpi_count
+                       )
+{
+	int ierr = NC_NOERR;
+	long lusage;
+	long max_usage;
+	size_t element_size;
+	int iter_idx;
+	int i;
+
+	/*
+	 * For scalar variables (with or without an unlimited dimension),
+	 * just write with a single call to the blocking write interface.
+	 */
+	if (ndims == 0 || (has_unlimited_dim && ndims == 1)) {
+		ierr = ncmpi_bput_vara(file->ncidp,
+		                       varidp,
+		                       mpi_start, mpi_count,
+		                       buf_p,
+		                       0, MPI_DATATYPE_NULL,
+		                       &(file->reqs[(file->n_reqs++)]));
+		return ierr;
+	}
+
+	/*
+	 * Set iter_idx to be the slowest-varying non-record (non-unlimited)
+	 * dimension for the variable
+	 */
+	iter_idx = 0;
+	if (has_unlimited_dim) iter_idx++;
+
+	/*
+	 * Let element_size be the product of the fastest-varying dimension
+	 * sizes beyond the iter_idx dimension multiplied by the basic type
+	 * size for this variable.
+	 */
+	element_size = basic_type_size;
+	for (i = iter_idx + 1; i < ndims; i++) {
+		element_size *= mpi_count[i];
+	}
+
+	/*
+	 * Compute the maximum total number of bytes to be written by any MPI
+	 * task for their chunks of the variable
+	 */
+	lusage = (long)element_size * mpi_count[iter_idx];
+	MPI_Allreduce(&lusage, &max_usage, 1, MPI_LONG,
+	              MPI_MAX, io_file_comm);
+
+	/*
+	 * If the maximum size of a chunk of data to be written is larger than
+	 * the buffer size, just write through the non-buffered interface;
+	 * otherwise, the ncmpi_bput_vara call will fail.
+	 */
+	if (max_usage > file->bufsize || max_usage > ((MPI_Offset)INT_MAX)) {
+		MPI_Offset remaining_count;
+		MPI_Offset max_count;
+		long done, global_done;
+		size_t buf_offset;
+
+		max_count = ((MPI_Offset)INT_MAX) / element_size;
+		remaining_count = mpi_count[iter_idx];
+
+		/*
+		 * Bound the number of values to be written along the slowest-
+		 * varying non-record dimension to ensure that not more than
+		 * 2 GiB are written in the call to ncmpi_put_vara_all
+		 */
+		mpi_count[iter_idx] = (max_count < remaining_count)
+		                    ? max_count : remaining_count;
+		remaining_count -= mpi_count[iter_idx];
+		done = (mpi_count[iter_idx] == 0) ? 1 : 0;
+		global_done = 0;
+		buf_offset = 0;
+
+		/*
+		 * Keep calling ncmpi_put_vara_all on all I/O tasks as long as
+		 * at least one task still has data to be written, writing at
+		 * most 2 GiB at a time
+		 */
+		while (!global_done) {
+			ierr = ncmpi_put_vara_all(file->ncidp,
+			                          varidp,
+			                          mpi_start, mpi_count,
+			                          &((uint8_t *)buf_p)[buf_offset],
+			                          0, MPI_DATATYPE_NULL);
+
+			/*
+			 * Update start/count values for slowest non-record
+			 * dimension, and determine whether this task still has
+			 * data to be written
+			 */
+			if (!done) {
+				buf_offset += (size_t)mpi_count[iter_idx]
+				              * element_size;
+				mpi_start[iter_idx] += mpi_count[iter_idx];
+				mpi_count[iter_idx] = (max_count < remaining_count)
+				                    ? max_count : remaining_count;
+				remaining_count -= mpi_count[iter_idx];
+
+				done = (mpi_count[iter_idx] == 0) ? 1 : 0;
+			}
+
+			if (ierr != NC_NOERR) {
+				done = -1;
+			}
+
+			/*
+			 * Get done status across all I/O tasks
+			 */
+			MPI_Allreduce(&done, &global_done, 1, MPI_LONG, MPI_MIN,
+			              MPI_Comm_f2c(file->io_file_comm));
+		};
+
+	} else {
+		/*
+		 * If executing this else branch, assume bufsize > 0 and
+		 * that a buffer has therefore been attached to file.
+		 */
+
+		MPI_Offset usage;
+
+		/*
+		 * Check how many bytes have been used in buffer on this task
+		 */
+		ierr = ncmpi_inq_buffer_usage(file->ncidp,
+		                              &usage);
+		lusage = usage +
+		         (long)element_size * mpi_count[iter_idx];
+
+		MPI_Allreduce(&lusage, &max_usage, 1,
+		              MPI_LONG, MPI_MAX,
+		              io_file_comm);
+
+		/*
+		 * If making a buffered write would cause the remaining buffer
+		 * size to be exceeded on any task, wait for non-blocking
+		 * writes to complete
+		 */
+		if ((size_t)max_usage > file->bufsize
+		    || file->n_reqs == MAX_REQS) {
+			ierr = ncmpi_wait_all(file->ncidp, file->n_reqs,
+			                      file->reqs, NULL);  /* statuses */
+			file->n_reqs = 0;
+		}
+
+		if (ierr == NC_NOERR) {
+			ierr = ncmpi_bput_vara(file->ncidp,
+			                       varidp,
+			                       mpi_start, mpi_count,
+			                       buf_p,
+			                       0, MPI_DATATYPE_NULL,
+			                       &(file->reqs[(file->n_reqs++)]));
+		}
+	}
+
+	return ierr;
+}
+
+
+/********************************************************************************
+ *
+ * read_chunk_pnetcdf
+ *
+ * Read a chunk of a variable from a file using the Parallel-NetCDF library
+ *
+ * Given a file and information about a variable in the file, read a chunk of
+ * memory from the variable according to start/count arrays. The chunk is always
+ * read using the blocking read interface while ensuring that not more than 2
+ * GiB is read in any single call to ncmpi_get_vara_all.
+ *
+ * The return value from this function will be NC_NOERR in case no errors
+ * occurred in calls to the Parallel-NetCDF library, or a Parallel-NetCDF error
+ * code otherwise.
+ *
+ * Within this function, return error codes from MPI calls are ignored.
+ *
+ ********************************************************************************/
+int read_chunk_pnetcdf(struct SMIOL_file *file,
+                       int varidp,
+                       int ndims,
+                       int has_unlimited_dim,
+                       size_t basic_type_size,
+                       MPI_Comm io_file_comm,
+                       void *buf_p,
+                       MPI_Offset *mpi_start,
+                       MPI_Offset *mpi_count
+                      )
+{
+	int ierr = NC_NOERR;
+	int iter_idx;
+	MPI_Offset remaining_count;
+	MPI_Offset max_count;
+	long done, global_done;
+	size_t element_size;
+	size_t buf_offset;
+	int i;
+
+	/*
+	 * For scalar variables (with or without an unlimited dimension),
+	 * just read with a single call to the blocking read interface.
+	 */
+	if (ndims == 0 || (has_unlimited_dim && ndims == 1)) {
+		ierr = ncmpi_get_vara_all(file->ncidp,
+		                          varidp,
+		                          mpi_start, mpi_count,
+		                          buf_p,
+		                          0, MPI_DATATYPE_NULL);
+		return ierr;
+	}
+
+	/*
+	 * Set iter_idx to be the slowest-varying non-record (non-unlimited)
+	 * dimension for the variable
+	 */
+	iter_idx = 0;
+	if (has_unlimited_dim) iter_idx++;
+
+	/*
+	 * Let element_size be the product of the fastest-varying dimension
+	 * sizes beyond the iter_idx dimension multiplied by the basic type
+	 * size for this variable.
+	 */
+	element_size = basic_type_size;
+	for (i = iter_idx + 1; i < ndims; i++) {
+		element_size *= mpi_count[i];
+	}
+
+	max_count = ((MPI_Offset)INT_MAX) / element_size;
+	remaining_count = mpi_count[iter_idx];
+
+	/*
+	 * Bound the number of values to be read along the slowest-varying
+	 * non-record dimension to ensure that not more than 2 GiB are read
+	 * in the call to ncmpi_get_vara_all
+	 */
+	mpi_count[iter_idx] = (max_count < remaining_count)
+	                    ? max_count : remaining_count;
+
+	remaining_count -= mpi_count[iter_idx];
+	done = (mpi_count[iter_idx] == 0) ? 1 : 0;
+	global_done = 0;
+	buf_offset = 0;
+
+	/*
+	 * Keep calling ncmpi_get_vara_all on all I/O tasks as long as at least
+	 * one task still has data to be read, reading at most 2 GiB at a time
+	 */
+	while (!global_done) {
+		ierr = ncmpi_get_vara_all(file->ncidp,
+		                          varidp,
+		                          mpi_start, mpi_count,
+		                          &((uint8_t *)buf_p)[buf_offset],
+		                          0, MPI_DATATYPE_NULL);
+
+		/*
+		 * Update start/count values for slowest non-record dimension,
+		 * and determine whether this task still has data to be read
+		 */
+		if (!done) {
+			buf_offset += (size_t)mpi_count[iter_idx] * element_size;
+			mpi_start[iter_idx] += mpi_count[iter_idx];
+			mpi_count[iter_idx] = (max_count < remaining_count)
+			                    ? max_count : remaining_count;
+			remaining_count -= mpi_count[iter_idx];
+
+			done = (mpi_count[iter_idx] == 0) ? 1 : 0;
+		}
+
+		if (ierr != NC_NOERR) {
+			done = -1;
+		}
+
+		/*
+		 * Get done status across all I/O tasks
+		 */
+		MPI_Allreduce(&done, &global_done, 1, MPI_LONG, MPI_MIN,
+		              io_file_comm);
+	};
+
+	return ierr;
+}
+#endif

--- a/src/external/SMIOL/smiol.h
+++ b/src/external/SMIOL/smiol.h
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * SMIOL -- The Simple MPAS I/O Library
+ *******************************************************************************/
+#ifndef SMIOL_H
+#define SMIOL_H
+
+#include "smiol_types.h"
+
+
+/*
+ * Library methods
+ */
+int SMIOL_fortran_init(MPI_Fint comm, int num_io_tasks, int io_stride,
+                       struct SMIOL_context **context);
+int SMIOL_init(MPI_Comm comm, int num_io_tasks, int io_stride,
+               struct SMIOL_context **context);
+int SMIOL_finalize(struct SMIOL_context **context);
+int SMIOL_inquire(void);
+
+/*
+ * File methods
+ */
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
+                    int mode, struct SMIOL_file **file, size_t bufsize);
+int SMIOL_close_file(struct SMIOL_file **file);
+
+/*
+ * Dimension methods
+ */
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize);
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
+                      SMIOL_Offset *dimsize, int *is_unlimited);
+
+/*
+ * Variable methods
+ */
+int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, int ndims, const char **dimnames);
+int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames);
+int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, const void *buf);
+int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, void *buf);
+
+/*
+ * Attribute methods
+ */
+int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
+                     const char *att_name, int att_type, const void *att);
+
+int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
+                      const char *att_name, int *att_type,
+                      SMIOL_Offset *att_len, void *att);
+
+/*
+ * Control methods
+ */
+int SMIOL_sync_file(struct SMIOL_file *file);
+const char *SMIOL_error_string(int errno);
+const char *SMIOL_lib_error_string(struct SMIOL_context *context);
+int SMIOL_set_option(void);
+int SMIOL_set_frame(struct SMIOL_file *file, SMIOL_Offset frame);
+int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame);
+
+/*
+ * Decomposition methods
+ */
+int SMIOL_create_decomp(struct SMIOL_context *context,
+                        size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        int aggregation_factor,
+                        struct SMIOL_decomp **decomp);
+int SMIOL_free_decomp(struct SMIOL_decomp **decomp);
+
+#endif

--- a/src/external/SMIOL/smiol_codes.inc
+++ b/src/external/SMIOL/smiol_codes.inc
@@ -1,0 +1,21 @@
+#define SMIOL_SUCCESS             (0)
+#define SMIOL_MALLOC_FAILURE     (-1)
+#define SMIOL_INVALID_ARGUMENT   (-2)
+#define SMIOL_MPI_ERROR          (-3)
+#define SMIOL_FORTRAN_ERROR      (-4)
+#define SMIOL_LIBRARY_ERROR      (-5)
+#define SMIOL_WRONG_ARG_TYPE     (-6)
+#define SMIOL_INSUFFICIENT_ARG   (-7)
+
+#define SMIOL_FILE_CREATE         (1)
+#define SMIOL_FILE_READ           (2)
+#define SMIOL_FILE_WRITE          (4)
+
+#define SMIOL_LIBRARY_UNKNOWN  (1000)
+#define SMIOL_LIBRARY_PNETCDF  (1001)
+
+#define SMIOL_REAL32           (2000)
+#define SMIOL_REAL64           (2001)
+#define SMIOL_INT32            (2002)
+#define SMIOL_CHAR             (2003)
+#define SMIOL_UNKNOWN_VAR_TYPE (2004)

--- a/src/external/SMIOL/smiol_types.h
+++ b/src/external/SMIOL/smiol_types.h
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * SMIOL -- The Simple MPAS I/O Library
+ *******************************************************************************/
+#ifndef SMIOL_TYPES_H
+#define SMIOL_TYPES_H
+
+#include <stdint.h>
+#include "mpi.h"
+
+
+/* If SMIOL_Offset is redefined, interoperable Fortran types and interfaces must also be updated */
+typedef int64_t SMIOL_Offset;
+
+
+#define TRIPLET_SIZE ((size_t)3)
+
+
+/*
+ * Types
+ */
+struct SMIOL_context {
+	MPI_Fint fcomm;   /* Fortran handle to MPI communicator */
+	int comm_size;    /* Size of MPI communicator */
+	int comm_rank;    /* Rank within MPI communicator */
+
+	int num_io_tasks; /* The number of I/O tasks */
+	int io_stride;    /* The stride between I/O tasks in the communicator */
+
+	int lib_ierr;     /* Library-specific error code */
+	int lib_type;     /* From which library the error code originated */
+};
+
+struct SMIOL_file {
+	struct SMIOL_context *context; /* Context for this file */
+	SMIOL_Offset frame; /* Current frame of the file */
+#ifdef SMIOL_PNETCDF
+	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
+	int ncidp; /* parallel-netCDF file handle */
+	size_t bufsize; /* Size of buffer attached to this file */
+	int n_reqs;  /* Number of pending non-blocking requests */
+	int *reqs;   /* Array of pending non-blocking request handles */
+#endif
+	int io_task; /* 1 = this task performs I/O calls
+	                0 = no I/O calls on this task */
+	MPI_Fint io_file_comm;  /* Communicator shared by all tasks with
+	                           io_task == 1 */
+	MPI_Fint io_group_comm; /* Communicator shared by tasks associated with
+	                           an I/O task, usually 1 I/O task and N-1
+	                           non-I/O tasks, where N is the I/O stride */
+};
+
+struct SMIOL_decomp {
+	/*
+	 * The lists below are structured as follows:
+	 *   list[0] - the number of neighbors for which a task sends/recvs
+	 *                                                                             |
+	 *   list[n] - neighbor task ID                                                | repeated for
+	 *   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+	 *   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+	 *                                                                             |
+	 */
+	SMIOL_Offset *comp_list;   /* Elements to be sent/received from/on a compute task */
+	SMIOL_Offset *io_list;     /* Elements to be sent/received from/on an I/O task */
+
+	struct SMIOL_context *context; /* Context for this decomp */
+
+	size_t io_start;  /* The starting offset on disk for I/O by a task */
+	size_t io_count;  /* The number of elements for I/O by a task */
+
+	int agg_factor;        /* Aggregation factor, or size of aggregation group */
+	MPI_Fint agg_comm;     /* Communicator for aggregation/deaggregation operations */
+	size_t n_compute;      /* Number of un-aggregated compute elements on the task */
+	size_t n_compute_agg;  /* Number of aggregated compute elements on the task */
+	int *counts;           /* Compute element counts for tasks in aggregation group */
+	int *displs;           /* Displacements in aggregated list of elements for tasks */
+	                       /*    in aggregation group */
+};
+
+
+/*
+ * Return error codes
+ */
+#include "smiol_codes.inc"
+
+#endif

--- a/src/external/SMIOL/smiol_utils.c
+++ b/src/external/SMIOL/smiol_utils.c
@@ -1,0 +1,1263 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "smiol_utils.h"
+
+/*
+ * Prototypes for functions used only internally by SMIOL utilities
+ */
+static int comp_sort_0(const void *a, const void *b);
+static int comp_sort_1(const void *a, const void *b);
+static int comp_sort_2(const void *a, const void *b);
+static int comp_search_0(const void *a, const void *b);
+static int comp_search_1(const void *a, const void *b);
+static int comp_search_2(const void *a, const void *b);
+
+
+/*******************************************************************************
+ *
+ * sort_triplet_array
+ *
+ * Sorts an array of triplets of SMIOL_Offset values in ascending order
+ *
+ * Given a pointer to an array of SMIOL_Offset triplets, sorts the array in
+ * ascending order on the specified entry: 0 sorts on the first value in
+ * the triplets, 1 sorts on the second value, and 2 sorts on the third.
+ *
+ * If the sort_entry is 1 or 2, the relative position of two triplets whose
+ * values in that entry match will be determined by their values in the first
+ * entry.
+ *
+ * The sort is not guaranteed to be stable.
+ *
+ *******************************************************************************/
+void sort_triplet_array(size_t n_arr, SMIOL_Offset *arr, int sort_entry)
+{
+	size_t width = sizeof(SMIOL_Offset) * TRIPLET_SIZE;
+
+	switch (sort_entry) {
+	case 0:
+		qsort((void *)arr, n_arr, width, comp_sort_0);
+		break;
+	case 1:
+		qsort((void *)arr, n_arr, width, comp_sort_1);
+		break;
+	case 2:
+		qsort((void *)arr, n_arr, width, comp_sort_2);
+		break;
+	}
+}
+
+
+/*******************************************************************************
+ *
+ * search_triplet_array
+ *
+ * Searches a sorted array of triplets of SMIOL_Offset values
+ *
+ * Given a pointer to a sorted array of SMIOL_Offset triplets, searches
+ * the array on the specified entry for the key value. A search_entry value of
+ * 0 searches for the key in the first entry of each triplet, 1 searches in
+ * the second entry, and 2 searches in the third.
+ *
+ * If the key is found, the address of the triplet will be returned; otherwise,
+ * a NULL pointer is returned.
+ *
+ * If the key occurs in more than one triplet at the specified entry, there is
+ * no guarantee as to which triplet's address will be returned.
+ *
+ *******************************************************************************/
+SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
+                                   size_t n_arr, SMIOL_Offset *arr,
+                                   int search_entry)
+{
+	SMIOL_Offset *res;
+	SMIOL_Offset key3[TRIPLET_SIZE];
+	size_t width = sizeof(SMIOL_Offset) * TRIPLET_SIZE;
+
+	key3[search_entry] = key;
+
+	switch (search_entry) {
+	case 0:
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_0);
+		break;
+	case 1:
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_1);
+		break;
+	case 2:
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_2);
+		break;
+	default:
+		res = NULL;
+	}
+
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * transfer_field
+ *
+ * Transfers a field between compute and I/O tasks
+ *
+ * Given a SMIOL_decomp and a direction, which determines whether the input
+ * field is transferred from compute tasks to I/O tasks or from I/O tasks to
+ * compute tasks, this function transfers the input field to the output field.
+ *
+ * The size in bytes of the elements in the field to be transferred is given by
+ * element_size; for example, a single-precision field would set element_size
+ * to sizeof(float).
+ *
+ * The caller must have already allocated the out_field argument with sufficient
+ * space to contain the field.
+ *
+ * If no errors are detected in the input arguments or in the transfer of
+ * the input field to the output field, SMIOL_SUCCESS is returned.
+ *
+ *******************************************************************************/
+int transfer_field(const struct SMIOL_decomp *decomp, int dir,
+                   size_t element_size, const void *in_field, void *out_field)
+{
+	MPI_Comm comm;
+	int comm_rank;
+
+	SMIOL_Offset *sendlist = NULL;
+	SMIOL_Offset *recvlist = NULL;
+
+	MPI_Request *send_reqs = NULL;
+	MPI_Request *recv_reqs = NULL;
+
+	uint8_t **send_bufs = NULL;
+	uint8_t **recv_bufs = NULL;
+	uint8_t *in_bytes = NULL;
+	uint8_t *out_bytes = NULL;
+
+	size_t ii, kk;
+	size_t n_neighbors_send;
+	size_t n_neighbors_recv;
+	int64_t pos;
+	int64_t pos_src = -1;
+	int64_t pos_dst = -1;
+
+	/*
+	 * The following are ints because they correspond to MPI arguments
+	 * that are ints, or they iterate over an int bound
+	 */
+	int taskid;
+	int n_send, n_recv;
+	int j;
+
+
+	if (decomp == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	comm = MPI_Comm_f2c(decomp->context->fcomm);
+	comm_rank = decomp->context->comm_rank;
+
+	/*
+	 * Throughout this function, operate on the fields as arrays of bytes
+	 */
+	in_bytes = (uint8_t *)in_field;
+	out_bytes = (uint8_t *)out_field;
+
+	/*
+	 * Set send and recv lists based on exchange direction
+	 */
+	if (dir == SMIOL_COMP_TO_IO) {
+		sendlist = decomp->comp_list;
+		recvlist = decomp->io_list;
+	} else if (dir == SMIOL_IO_TO_COMP) {
+		sendlist = decomp->io_list;
+		recvlist = decomp->comp_list;
+	} else {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Determine how many other MPI tasks to communicate with, and allocate
+	 * request lists and buffer pointers
+	 */
+	n_neighbors_send = (size_t)(sendlist[0]);
+	n_neighbors_recv = (size_t)(recvlist[0]);
+
+	/*
+	 * Check that we have non-NULL in_field and out_field arguments
+	 * in agreement with the number of neighbors to send/recv to/from
+	 */
+	if ((in_field == NULL && n_neighbors_send != 0)
+	    || (out_field == NULL && n_neighbors_recv != 0)) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	send_reqs = (MPI_Request *)malloc(sizeof(MPI_Request)
+	                                  * n_neighbors_send);
+	recv_reqs = (MPI_Request *)malloc(sizeof(MPI_Request)
+	                                  * n_neighbors_recv);
+
+	send_bufs = (uint8_t **)malloc(sizeof(uint8_t *) * n_neighbors_send);
+	recv_bufs = (uint8_t **)malloc(sizeof(uint8_t *) * n_neighbors_recv);
+
+	/*
+	 * Post receives
+	 */
+	pos = 1;
+	for (ii = 0; ii < n_neighbors_recv; ii++) {
+		taskid = (int)recvlist[pos++];
+		n_recv = (int)recvlist[pos++];
+		if (taskid != comm_rank) {
+			recv_bufs[ii] = (uint8_t *)malloc(sizeof(uint8_t)
+			                                  * element_size
+			                                  * (size_t)n_recv);
+
+			MPI_Irecv((void *)recv_bufs[ii],
+			          n_recv * (int)element_size,
+			          MPI_BYTE, taskid, comm_rank, comm,
+			          &recv_reqs[ii]);
+		}
+		else {
+			/*
+			 * This is a receive from ourself - save position in
+			 * recvlist for local copy, below
+			 */
+			pos_dst = pos - 1; /* Offset of n_recv */
+			recv_bufs[ii] = NULL;
+		}
+		pos += n_recv;
+	}
+
+	/*
+	 * Post sends
+	 */
+	pos = 1;
+	for (ii = 0; ii < n_neighbors_send; ii++) {
+		taskid = (int)sendlist[pos++];
+		n_send = (int)sendlist[pos++];
+		if (taskid != comm_rank) {
+			send_bufs[ii] = (uint8_t *)malloc(sizeof(uint8_t)
+			                                  * element_size
+			                                  * (size_t)n_send);
+
+			/* Pack send buffer */
+			for (j = 0; j < n_send; j++) {
+				size_t out_idx = (size_t)j
+				                 * element_size;
+				size_t in_idx = (size_t)sendlist[pos]
+				                * element_size;
+
+				for (kk = 0; kk < element_size; kk++) {
+					send_bufs[ii][out_idx + kk] = in_bytes[in_idx + kk];
+				}
+				pos++;
+			}
+
+			MPI_Isend((void *)send_bufs[ii],
+			          n_send * (int)element_size,
+			          MPI_BYTE, taskid, taskid, comm,
+			          &send_reqs[ii]);
+		}
+		else {
+			/*
+			 * This is a send to ourself - save position in
+			 * sendlist for local copy, below
+			 */
+			pos_src = pos - 1; /* Offset of n_send */
+			send_bufs[ii] = NULL;
+			pos += n_send;
+		}
+	}
+
+	/*
+	 * Handle local copies
+	 */
+	if (pos_src >= 0 && pos_dst >= 0) {
+
+		/* n_send and n_recv should actually be identical */
+		n_send = (int)sendlist[pos_src++];
+		n_recv = (int)recvlist[pos_dst++];
+
+		for (j = 0; j < n_send; j++) {
+			size_t out_idx = (size_t)recvlist[pos_dst]
+			                 * element_size;
+			size_t in_idx = (size_t)sendlist[pos_src]
+			                * element_size;
+
+			for (kk = 0; kk < element_size; kk++) {
+				out_bytes[out_idx + kk] = in_bytes[in_idx + kk];
+			}
+			pos_dst++;
+			pos_src++;
+		}
+	}
+
+	/*
+	 * Wait on receives
+	 */
+	pos = 1;
+	for (ii = 0; ii < n_neighbors_recv; ii++) {
+		taskid = (int)recvlist[pos++];
+		n_recv = (int)recvlist[pos++];
+		if (taskid != comm_rank) {
+			MPI_Wait(&recv_reqs[ii], MPI_STATUS_IGNORE);
+
+			/* Unpack receive buffer */
+			for (j = 0; j < n_recv; j++) {
+				size_t out_idx = (size_t)recvlist[pos]
+				                 * element_size;
+				size_t in_idx = (size_t)j
+				                * element_size;
+
+				for (kk = 0; kk < element_size; kk++) {
+					out_bytes[out_idx + kk] = recv_bufs[ii][in_idx + kk];
+				}
+				pos++;
+			}
+		}
+		else {
+			/*
+			 * A receive from ourself - just skip to next neighbor
+			 * in the recvlist
+			 */
+			pos += n_recv;
+		}
+
+		/*
+		 * The receive buffer for the current neighbor can now be freed
+		 */
+		if (recv_bufs[ii] != NULL) {
+			free(recv_bufs[ii]);
+		}
+	}
+
+	/*
+	 * Wait on sends
+	 */
+	pos = 1;
+	for (ii = 0; ii < n_neighbors_send; ii++) {
+		taskid = (int)sendlist[pos++];
+		n_send = (int)sendlist[pos++];
+		if (taskid != comm_rank) {
+			MPI_Wait(&send_reqs[ii], MPI_STATUS_IGNORE);
+		}
+
+		/*
+		 * The send buffer for the current neighbor can now be freed
+		 */
+		if (send_bufs[ii] != NULL) {
+			free(send_bufs[ii]);
+		}
+
+		pos += n_send;
+	}
+
+	/*
+	 * Free request lists and buffer pointers
+	 */
+	free(send_reqs);
+	free(recv_reqs);
+	free(send_bufs);
+	free(recv_bufs);
+
+	return SMIOL_SUCCESS;
+}
+
+
+/*******************************************************************************
+ *
+ * aggregate_list
+ *
+ * Aggregates lists of elements from across all ranks onto a chosen root rank
+ *
+ * On entry, each MPI rank supplies a list of SMIOL_Offset values as well as the
+ * size of that input list. The input list may be zero size.
+ *
+ * Upon successful return, for the root rank, the out_list argument will point
+ * to an allocated array containing the aggregated elements from all MPI ranks
+ * in the communicator, and n_out will specify the number of elements in the
+ * output array. On all other ranks, n_out will be zero, and out_list will be a
+ * NULL pointer.
+ *
+ * Also on the root rank, the counts and displs arrays will be allocated with
+ * size equal to the size of the communicator, and they will contain the number
+ * of elements in the aggregated list from each MPI rank as well as the
+ * beginning offset in the aggregated list of elements from each rank. On all
+ * non-root ranks, counts and displs will be returned as NULL pointers.
+ *
+ * Although the number of elements in each input list is given by a size_t,
+ * the number of elements must not exceed the maximum representable value of
+ * a signed integer due to restrictions imposed by MPI argument types.
+ * Similarly, it must be ensured that the number of output elements does not
+ * exceed the maximum representable value of a signed integer.
+ *
+ * If no errors occurred, 0 is returned. Otherwise, a value of 1 is returned.
+ *
+ *******************************************************************************/
+int aggregate_list(MPI_Comm comm, int root, size_t n_in, SMIOL_Offset *in_list,
+                   size_t *n_out, SMIOL_Offset **out_list,
+                   int **counts, int **displs)
+{
+	int comm_size;
+	int comm_rank;
+	int err;
+	int i;
+	int n_in_i;
+
+
+	*n_out = 0;
+	*out_list = NULL;
+
+	*counts = NULL;
+	*displs = NULL;
+
+	n_in_i = (int)n_in;
+
+	if (MPI_Comm_size(comm, &comm_size) != MPI_SUCCESS) {
+		fprintf(stderr, "Error: MPI_Comm_size failed in aggregate_list\n");
+		return 1;
+	}
+
+	if (MPI_Comm_rank(comm, &comm_rank) != MPI_SUCCESS) {
+		fprintf(stderr, "Error: MPI_Comm_rank failed in aggregate_list\n");
+		return 1;
+	}
+
+	if (comm_rank == root) {
+		*counts = (int *)malloc(sizeof(int) * (size_t)(comm_size));
+		*displs = (int *)malloc(sizeof(int) * (size_t)(comm_size));
+	}
+
+	/*
+	 * Gather the number of input elements from all tasks onto root rank
+	 */
+	err = MPI_Gather((const void *)&n_in_i, 1, MPI_INT,
+	                 (void *)(*counts), 1, MPI_INT, root, comm);
+	if (err != MPI_SUCCESS) {
+		fprintf(stderr, "Error: MPI_Gather failed in aggregate_list\n");
+		return 1;
+	}
+
+	/*
+	 * Perform a scan of counts to get displs, and compute the number of
+	 * output elements on root rank as the sum of the number of input
+	 * elements across all tasks in the communicator
+	 */
+	if (comm_rank == root) {
+		(*displs)[0] = 0;
+		*n_out = (size_t)(*counts)[0];
+		for (i = 1; i < comm_size; i++) {
+			(*displs)[i] = (*displs)[i-1] + (*counts)[i-1];
+			*n_out += (size_t)(*counts)[i];
+		}
+
+		*out_list = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset)
+		                                   * (*n_out));
+	}
+
+	/* TO DO: Find an MPI type that is guaranteed to match SMIOL_Offset */
+	/*        For now, just return an error if MPI_LONG isn't appropriate */
+	if (sizeof(long) != sizeof(SMIOL_Offset)) {
+		fprintf(stderr, "Error: sizeof(long) != sizeof(SMIOL_Offset)\n");
+		return 1;
+	}
+
+	err = MPI_Gatherv((const void *)in_list, n_in_i, MPI_LONG,
+	                  (void *)(*out_list), (*counts), (*displs), MPI_LONG,
+	                  root, comm);
+	if (err != MPI_SUCCESS) {
+		fprintf(stderr, "Error: MPI_Gatherv failed in aggregate_list\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+
+/*******************************************************************************
+ *
+ * get_io_elements
+ *
+ * Returns a contiguous range of I/O elements for an MPI task
+ *
+ * Given the rank of a task, a description of the I/O task arrangement --
+ * the number of I/O tasks and the stride between I/O tasks -- as well as the
+ * total number of elements to read or write, compute the offset of the first
+ * I/O element as well as the number of elements to read or write for the task.
+ *
+ * If this routine is successful in producing a valid io_start and io_count,
+ * a value of 0 is returned; otherwise, a non-zero value is returned.
+ *
+ *******************************************************************************/
+int get_io_elements(int comm_rank, int num_io_tasks, int io_stride,
+                    size_t n_io_elements, size_t *io_start, size_t *io_count)
+{
+	if (io_start == NULL || io_count == NULL) {
+		return 1;
+	}
+
+	*io_start = 0;
+	*io_count = 0;
+
+	if (comm_rank % io_stride == 0) {
+		size_t io_rank = (size_t)(comm_rank / io_stride);
+		size_t elems_per_task = (n_io_elements / (size_t)num_io_tasks);
+
+		if (io_rank >= num_io_tasks) {
+			return 0;
+		}
+
+		*io_start = io_rank * elems_per_task;
+		*io_count = elems_per_task;
+
+		if (io_rank + 1 == (size_t)num_io_tasks) {
+			size_t remainder = n_io_elements
+			                   - (size_t)num_io_tasks * elems_per_task;
+			*io_count += remainder;
+		}
+	}
+
+	return 0;
+}
+
+
+/*******************************************************************************
+ *
+ * build_exchange
+ *
+ * Builds a mapping between compute elements and I/O elements.
+ *
+ * Given arrays of global element IDs that each task computes and global element
+ * IDs that each task reads/writes, this routine works out a mapping of elements
+ * between compute and I/O tasks.
+ *
+ * If all input arguments are determined to be valid and if the routine is
+ * successful in working out a mapping, the decomp pointer is allocated and
+ * given valid contents, and SMIOL_SUCCESS is returned; otherwise a non-success
+ * error code is returned and the decomp pointer is NULL.
+ *
+ *******************************************************************************/
+int build_exchange(struct SMIOL_context *context,
+                   size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                   size_t n_io_elements, SMIOL_Offset *io_elements,
+                   struct SMIOL_decomp **decomp)
+{
+	MPI_Comm comm;
+	int comm_size;
+	int comm_rank;
+	int ierr;
+	int i, j;
+	int count;
+	int nbuf_in, nbuf_out;
+	SMIOL_Offset *compute_ids;
+	SMIOL_Offset *io_ids;
+	SMIOL_Offset *buf_in, *buf_out;
+	SMIOL_Offset *io_list, *comp_list;
+	SMIOL_Offset neighbor;
+	MPI_Request req_in, req_out;
+	size_t ii;
+	size_t idx;
+	size_t n_neighbors;
+	size_t n_xfer;
+	size_t n_xfer_total;
+	size_t n_list;
+
+	const SMIOL_Offset UNKNOWN_TASK = (SMIOL_Offset)(-1);
+
+
+	if (context == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (compute_elements == NULL && n_compute_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (io_elements == NULL && n_io_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+
+	comm = MPI_Comm_f2c(context->fcomm);
+	comm_size = context->comm_size;
+	comm_rank = context->comm_rank;
+
+
+	/*
+	 * Because the count argument to MPI_Isend and MPI_Irecv is an int, at
+	 * most 2^31-1 elements can be transmitted at a time. In this routine,
+	 * arrays of pairs of SMIOL_Offset values will be transmitted as arrays
+	 * of bytes, so n_compute_elements and n_io_elements can be at most
+	 * 2^31-1 / sizeof(SMIOL_Offset) / 2.
+	 */
+	i = 0;
+	if (n_compute_elements > (((size_t)1 << 31) - 1)
+	                         / sizeof(SMIOL_Offset)
+	                         / (size_t)2) {
+		i = 1;
+	}
+	if (n_io_elements > (((size_t)1 << 31) - 1)
+	                    / sizeof(SMIOL_Offset)
+	                    / (size_t)2) {
+		i = 1;
+	}
+
+	ierr = MPI_Allreduce((const void *)&i, (void *)&j, 1, MPI_INT, MPI_MAX,
+	                     comm);
+	if (j > 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	} else if (ierr != MPI_SUCCESS) {
+		return SMIOL_MPI_ERROR;
+	}
+
+
+	/*
+	 * Allocate an array, compute_ids, with three entries for each compute
+	 * element
+	 *    [0] - element global ID
+	 *    [1] - element local ID
+	 *    [2] - I/O task that reads/writes this element
+	 */
+	compute_ids = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * TRIPLET_SIZE
+	                                     * n_compute_elements);
+	if (compute_ids == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Fill in compute_ids array with global and local IDs; rank of I/O task
+	 * is not yet known
+	 */
+	for (ii = 0; ii < n_compute_elements; ii++) {
+		compute_ids[TRIPLET_SIZE*ii] = compute_elements[ii]; /* global ID */
+		compute_ids[TRIPLET_SIZE*ii+1] = (SMIOL_Offset)ii;   /* local ID */
+		compute_ids[TRIPLET_SIZE*ii+2] = UNKNOWN_TASK;       /* I/O task rank */
+	}
+
+	/*
+	 * Sort the compute_ids array on global element ID
+	 * (first entry for each element)
+	 */
+	sort_triplet_array(n_compute_elements, compute_ids, 0);
+
+	/*
+	 * Allocate buffer with two entries for each I/O element
+	 *    [0] - I/O element global ID
+	 *    [1] - task that computes this element
+	 */
+	nbuf_out = (int)n_io_elements;
+	buf_out = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * (size_t)2
+	                                 * (size_t)nbuf_out);
+	if (buf_out == NULL) {
+		free(compute_ids);
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Fill buffer with I/O element IDs; compute task is not yet known
+	 */
+	for (ii = 0; ii < n_io_elements; ii++) {
+		buf_out[2*ii] = io_elements[ii];
+		buf_out[2*ii+1] = UNKNOWN_TASK;
+	}
+
+	/*
+	 * Iterate through all ranks in the communicator, receiving from "left"
+	 * neighbor and sending to "right" neighbor in each iteration.
+	 * The objective is to identify, for each I/O element, which MPI rank
+	 * computes that element. At the end of iteration, each rank will have
+	 * seen the I/O element list from all other ranks.
+	 */
+	for (i = 0; i < comm_size; i++) {
+		/*
+		 * Compute the rank whose buffer will be received this iteration
+		 */
+		SMIOL_Offset src_rank = (comm_rank - 1 - i + comm_size)
+		                        % comm_size;
+
+		/*
+		 * Initiate send of outgoing buffer size and receive of incoming
+		 * buffer size
+		 */
+		ierr = MPI_Irecv((void *)&nbuf_in, 1, MPI_INT,
+		                 (comm_rank - 1 + comm_size) % comm_size,
+		                 (comm_rank + i), comm, &req_in);
+
+		ierr = MPI_Isend((const void *)&nbuf_out, 1, MPI_INT,
+		                 (comm_rank + 1) % comm_size,
+		                 ((comm_rank + 1) % comm_size + i), comm,
+		                 &req_out);
+
+		/*
+		 * Wait until the incoming buffer size has been received
+		 */
+		ierr = MPI_Wait(&req_in, MPI_STATUS_IGNORE);
+
+		/*
+		 * Allocate incoming buffer
+		 */
+		buf_in = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * (size_t)2
+		                                * (size_t)nbuf_in);
+
+		/*
+		 * Initiate receive of incoming buffer
+		 */
+		count = 2 * nbuf_in;
+		count *= (int)sizeof(SMIOL_Offset);
+		ierr = MPI_Irecv((void *)buf_in, count, MPI_BYTE,
+		                 (comm_rank - 1 + comm_size) % comm_size,
+		                 (comm_rank + i), comm, &req_in);
+
+		/*
+		 * Wait until the outgoing buffer size has been sent
+		 */
+		ierr = MPI_Wait(&req_out, MPI_STATUS_IGNORE);
+
+		/*
+		 * Initiate send of outgoing buffer
+		 */
+		count = 2 * nbuf_out;
+		count *= (int)sizeof(SMIOL_Offset);
+		ierr = MPI_Isend((const void *)buf_out, count, MPI_BYTE,
+		                 (comm_rank + 1) % comm_size,
+		                 ((comm_rank + 1) % comm_size + i), comm,
+		                 &req_out);
+
+		/*
+		 * Wait until the incoming buffer has been received
+		 */
+		ierr = MPI_Wait(&req_in, MPI_STATUS_IGNORE);
+
+		/*
+		 * Loop through the incoming buffer, marking all elements that
+		 * are computed on this task
+		 */
+		for (j = 0; j < nbuf_in; j++) {
+			/*
+			 * If I/O element does not yet have a computing task...
+			 */
+			if (buf_in[2*j+1] == UNKNOWN_TASK) {
+				SMIOL_Offset *elem;
+
+				/*
+				 * and if this element is computed on this task...
+				 */
+				elem = search_triplet_array(buf_in[2*j],
+				                            n_compute_elements,
+				                            compute_ids, 0);
+				if (elem != NULL) {
+					/*
+					 * then mark the element as being
+					 * computed on this task
+					 */
+					buf_in[2*j+1] = (SMIOL_Offset)comm_rank;
+
+					/*
+					 * and note locally which task will
+					 * read/write this element
+					 */
+					elem[2] = src_rank;
+				}
+			}
+		}
+
+		/*
+		 * Wait until we have sent the outgoing buffer
+		 */
+		ierr = MPI_Wait(&req_out, MPI_STATUS_IGNORE);
+
+		/*
+		 * Free outgoing buffer and make the input buffer into
+		 * the output buffer for next iteration
+		 */
+		free(buf_out);
+		buf_out = buf_in;
+		nbuf_out = nbuf_in;
+	}
+
+	/*
+	 * The output buffer is now the initial buffer with the compute tasks
+	 * for each I/O element identified
+	 */
+
+	/*
+	 * Allocate an array, io_ids, with three entries for each I/O element
+	 *    [0] - element global ID
+	 *    [1] - element local ID
+	 *    [2] - compute task that operates on this element
+	 */
+	io_ids = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * TRIPLET_SIZE
+	                                * n_io_elements);
+	if (io_ids == NULL) {
+		free(compute_ids);
+		free(buf_out);
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Fill in io_ids array with global and local IDs, plus the rank of
+	 * the task that computes each element
+	 */
+	for (ii = 0; ii < n_io_elements; ii++) {
+		io_ids[TRIPLET_SIZE*ii] = buf_out[2*ii+0];    /* global ID */
+		io_ids[TRIPLET_SIZE*ii+1] = (SMIOL_Offset)ii; /* local ID */
+		io_ids[TRIPLET_SIZE*ii+2] = buf_out[2*ii+1];  /* computing task rank */
+	}
+
+	free(buf_out);
+
+	/*
+	 * Sort io_ids array on task ID (third entry for each element)
+	 */
+	sort_triplet_array(n_io_elements, io_ids, 2);
+
+	*decomp = (struct SMIOL_decomp *)malloc(sizeof(struct SMIOL_decomp));
+	if ((*decomp) == NULL) {
+		free(compute_ids);
+		free(io_ids);
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Initialize the SMIOL_decomp struct
+	 */
+	(*decomp)->context = context;
+	(*decomp)->comp_list = NULL;
+	(*decomp)->io_list = NULL;
+	(*decomp)->io_start = 0;
+	(*decomp)->io_count = 0;
+	(*decomp)->agg_factor = 1;   /* Group with 1 task -> no aggregation */
+	(*decomp)->agg_comm = MPI_Comm_c2f(MPI_COMM_NULL);
+	(*decomp)->n_compute = 0;
+	(*decomp)->n_compute_agg = 0;
+	(*decomp)->counts = NULL;
+	(*decomp)->displs = NULL;
+
+
+	/*
+	 * Scan through io_ids to determine number of unique neighbors that
+	 * compute elements read/written on this task, and also determine
+	 * the total number of elements
+	 * computed on other tasks that are read/written on this task
+	 */
+	ii = 0;
+	n_neighbors = 0;
+	n_xfer_total = 0;
+	while (ii < n_io_elements) {
+		/* Task that computes this element */
+		neighbor = io_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to read/write for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since io_ids is sorted on task, as long as task is unchanged,
+		 * increment n_xfer
+		 */
+		while (ii < n_io_elements
+		       && io_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			n_xfer++;
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			n_neighbors++;
+			n_xfer_total += n_xfer;
+		}
+	}
+
+	/*
+	 * Based on number of neighbors and total number of elements to transfer
+	 * allocate the io_list
+	 */
+	n_list = sizeof(SMIOL_Offset) * ((size_t)1
+	                                 + (size_t)2 * n_neighbors
+	                                 + n_xfer_total);
+	(*decomp)->io_list = (SMIOL_Offset *)malloc(n_list);
+	if ((*decomp)->io_list == NULL) {
+		free(compute_ids);
+		free(io_ids);
+		free(*decomp);
+		*decomp = NULL;
+		return SMIOL_MALLOC_FAILURE;
+	}
+	io_list = (*decomp)->io_list;
+
+	/*
+	 * Scan through io_ids a second time, filling in the io_list
+	 */
+	io_list[0] = (SMIOL_Offset)n_neighbors;
+	idx = 1; /* Index in io_list where neighbor ID will be written, followed
+	            by number of elements and element local IDs */
+
+	ii = 0;
+	while (ii < n_io_elements) {
+		/* Task that computes this element */
+		neighbor = io_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to read/write for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since io_ids is sorted on task, as long as task is unchanged,
+		 * increment n_xfer
+		 */
+		while (ii < n_io_elements
+		       && io_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			if (neighbor != UNKNOWN_TASK) {
+				/* Save local element ID in list */
+				io_list[idx+2+n_xfer] = io_ids[TRIPLET_SIZE*ii+1];
+				n_xfer++;
+			}
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			io_list[idx] = neighbor;
+			io_list[idx+1] = (SMIOL_Offset)n_xfer;
+			idx += (2 + n_xfer);
+		}
+	}
+
+	free(io_ids);
+
+	/*
+	 * Sort compute_ids array on task ID (third entry for each element)
+	 */
+	sort_triplet_array(n_compute_elements, compute_ids, 2);
+
+	/*
+	 * Scan through compute_ids to determine number of unique neighbors that
+	 * read/write elements computed on this task, and also determine
+	 * the total number of elements read/written on other tasks that are
+	 * computed on this task
+	 */
+	ii = 0;
+	n_neighbors = 0;
+	n_xfer_total = 0;
+	while (ii < n_compute_elements) {
+		/* Task that reads/writes this element */
+		neighbor = compute_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to compute for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since compute_ids is sorted on task, as long as task is
+		 * unchanged, increment n_xfer
+		 */
+		while (ii < n_compute_elements
+		       && compute_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			n_xfer++;
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			n_neighbors++;
+			n_xfer_total += n_xfer;
+		}
+	}
+
+	/*
+	 * Based on number of neighbors and total number of elements to transfer
+	 * allocate the comp_list
+	 */
+	n_list = sizeof(SMIOL_Offset) * ((size_t)1
+	                                 + (size_t)2 * n_neighbors
+	                                 + n_xfer_total);
+	(*decomp)->comp_list = (SMIOL_Offset *)malloc(n_list);
+	if ((*decomp)->comp_list == NULL) {
+		free(compute_ids);
+		free((*decomp)->io_list);
+		free(*decomp);
+		*decomp = NULL;
+		return SMIOL_MALLOC_FAILURE;
+	}
+	comp_list = (*decomp)->comp_list;
+
+	/*
+	 * Scan through compute_ids a second time, filling in the comp_list
+	 */
+	comp_list[0] = (SMIOL_Offset)n_neighbors;
+	idx = 1; /* Index in compute_list where neighbor ID will be written,
+	            followed by number of elements and element local IDs */
+
+	ii = 0;
+	while (ii < n_compute_elements) {
+		/* Task that reads/writes this element */
+		neighbor = compute_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to compute for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since compute_ids is sorted on task, as long as task is
+		 * unchanged, increment n_xfer
+		 */
+		while (ii < n_compute_elements
+		       && compute_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			if (neighbor != UNKNOWN_TASK) {
+				/* Save local element ID in list */
+				comp_list[idx+2+n_xfer] = compute_ids[TRIPLET_SIZE*ii+1];
+				n_xfer++;
+			}
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			comp_list[idx] = neighbor;
+			comp_list[idx+1] = (SMIOL_Offset)n_xfer;
+			idx += (2 + n_xfer);
+		}
+	}
+
+	free(compute_ids);
+
+	return SMIOL_SUCCESS;
+}
+
+
+/*******************************************************************************
+ *
+ * print_lists
+ *
+ * Writes the contents of comp_list and io_list arrays to a text file
+ *
+ * Given pointers to the comp_list and io_list arrays from a SMIOL_decomp
+ * structure, writes the contents of these arrays to a text file in a human-
+ * readable format.
+ *
+ * Because the comp_list and io_list arrays are unique to each MPI task, this
+ * routine takes as an argument the MPI rank of the calling task. The output
+ * text file is named list.NNNN.txt, where NNNN is the rank of the task.
+ *
+ *******************************************************************************/
+void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list)
+{
+	char filename[14];
+	FILE *f;
+	SMIOL_Offset n_neighbors;
+	SMIOL_Offset n_elems, neighbor;
+	int i, j, k;
+
+	snprintf(filename, 14, "list.%4.4i.txt", comm_rank);
+
+	f = fopen(filename, "w");
+
+	/*
+	 * The lists below are structured as follows:
+	 *   list[0] - the number of neighbors for which a task sends/recvs
+	 *                                                                             |
+	 *   list[n] - neighbor task ID                                                | repeated for
+	 *   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+	 *   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+	 *                                                                             |
+	 */
+
+	fprintf(f, "===== comp_list for MPI rank %i =====\n", comm_rank);
+	fprintf(f, "Our compute elements are read/written on %i tasks\n",
+	        (int)comp_list[0]);
+	j = 0;
+	n_neighbors = comp_list[j++];
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = comp_list[j++];
+		n_elems = comp_list[j++];
+		if (neighbor == comm_rank) {
+			fprintf(f, "----- copy %i elements -----\n",
+			        (int)n_elems);
+		} else {
+			fprintf(f, "----- send %i elements to %i -----\n",
+			        (int)n_elems, (int)neighbor);
+		}
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, "  %i\n", (int)comp_list[j+k]);
+		}
+		j += n_elems;
+	}
+
+	fprintf(f, "\n\n");
+	fprintf(f, "===== io_list for MPI rank %i =====\n", comm_rank);
+	fprintf(f, "Our I/O elements are computed on %i tasks\n",
+	        (int)io_list[0]);
+	j = 0;
+	n_neighbors = io_list[j++];
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = io_list[j++];
+		n_elems = io_list[j++];
+		if (neighbor == comm_rank) {
+			fprintf(f, "----- copy %i elements -----\n",
+			        (int)n_elems);
+		} else {
+			fprintf(f, "----- recv %i elements from %i -----\n",
+			        (int)n_elems, (int)neighbor);
+		}
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, "  %i\n", (int)io_list[j+k]);
+		}
+		j += n_elems;
+	}
+	fprintf(f, "\n\n");
+
+
+	fprintf(f, "SMIOL_Offset comp_list_correct[] = { ");
+	j = 0;
+	n_neighbors = comp_list[j++];
+	fprintf(f, "%i", (int)n_neighbors);
+
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = comp_list[j++];
+		fprintf(f, ", %i", (int)neighbor);
+
+		n_elems = comp_list[j++];
+		fprintf(f, ", %i", (int)n_elems);
+
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, ", %i", (int)comp_list[j+k]);
+		}
+		j += n_elems;
+	}
+	fprintf(f, " };\n");
+
+	fprintf(f, "SMIOL_Offset io_list_correct[] = { ");
+	j = 0;
+	n_neighbors = io_list[j++];
+	fprintf(f, "%i", (int)n_neighbors);
+
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = io_list[j++];
+		fprintf(f, ", %i", (int)neighbor);
+
+		n_elems = io_list[j++];
+		fprintf(f, ", %i", (int)n_elems);
+
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, ", %i", (int)io_list[j+k]);
+		}
+		j += n_elems;
+	}
+	fprintf(f, " };\n");
+
+	fclose(f);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_0
+ *
+ * Compares two SMIOL_Offset triplets based on their first entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_sort_0(const void *a, const void *b)
+{
+	return (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+	     - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_1
+ *
+ * Compares two SMIOL_Offset triplets based on their second entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ * If the triplets a and b have equal values in their second entry, the values
+ * in their first entry will be used to determine the result of the comparison.
+ *
+ *******************************************************************************/
+static int comp_sort_1(const void *a, const void *b)
+{
+	int res;
+
+	res = (((const SMIOL_Offset *)a)[1] > ((const SMIOL_Offset *)b)[1])
+	    - (((const SMIOL_Offset *)a)[1] < ((const SMIOL_Offset *)b)[1]);
+	if (res == 0) {
+		res = (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+		    - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
+	}
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_2
+ *
+ * Compares two SMIOL_Offset triplets based on their third entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ * If the triplets a and b have equal values in their third entry, the values
+ * in their first entry will be used to determine the result of the comparison.
+ *
+ *******************************************************************************/
+static int comp_sort_2(const void *a, const void *b)
+{
+	int res;
+
+	res = (((const SMIOL_Offset *)a)[2] > ((const SMIOL_Offset *)b)[2])
+	    - (((const SMIOL_Offset *)a)[2] < ((const SMIOL_Offset *)b)[2]);
+	if (res == 0) {
+		res = (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+		    - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
+	}
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_0
+ *
+ * Compares two SMIOL_Offset triplets based on their first entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_0(const void *a, const void *b)
+{
+	return (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+	     - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_1
+ *
+ * Compares two SMIOL_Offset triplets based on their second entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_1(const void *a, const void *b)
+{
+	return (((const SMIOL_Offset *)a)[1] > ((const SMIOL_Offset *)b)[1])
+	     - (((const SMIOL_Offset *)a)[1] < ((const SMIOL_Offset *)b)[1]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_2
+ *
+ * Compares two SMIOL_Offset triplets based on their third entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_2(const void *a, const void *b)
+{
+	return (((const SMIOL_Offset *)a)[2] > ((const SMIOL_Offset *)b)[2])
+	     - (((const SMIOL_Offset *)a)[2] < ((const SMIOL_Offset *)b)[2]);
+}

--- a/src/external/SMIOL/smiol_utils.h
+++ b/src/external/SMIOL/smiol_utils.h
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Utilities and helper functions for SMIOL
+ *******************************************************************************/
+#ifndef SMIOL_UTILS_H
+#define SMIOL_UTILS_H
+
+#include "smiol_types.h"
+
+#define SMIOL_COMP_TO_IO 1
+#define SMIOL_IO_TO_COMP 2
+
+
+/*
+ * Searching and sorting
+ */
+void sort_triplet_array(size_t n_arr, SMIOL_Offset *arr, int sort_entry);
+SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
+                                   size_t n_arr, SMIOL_Offset *arr,
+                                   int search_entry);
+
+/*
+ * Communication
+ */
+int transfer_field(const struct SMIOL_decomp *decomp, int dir,
+                   size_t element_size, const void *in_field, void *out_field);
+
+int aggregate_list(MPI_Comm comm, int root, size_t n_in, SMIOL_Offset *in_list,
+                   size_t *n_out, SMIOL_Offset **out_list,
+                   int **counts, int **displs);
+
+/*
+ * Field decomposition
+ */
+int get_io_elements(int comm_rank, int num_io_tasks, int io_stride,
+                    size_t n_io_elements, size_t *io_start, size_t *io_count);
+
+int build_exchange(struct SMIOL_context *context,
+                   size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                   size_t n_io_elements, SMIOL_Offset *io_elements,
+                   struct SMIOL_decomp **decomp);
+
+/*
+ * Debugging
+ */
+void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list);
+
+#endif

--- a/src/external/SMIOL/smiolf.F90
+++ b/src/external/SMIOL/smiolf.F90
@@ -1,0 +1,2057 @@
+#include "smiol_codes.inc"
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! SMIOL -- The Simple MPAS I/O Library
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+module SMIOLf
+
+    use iso_c_binding, only : c_int, c_size_t, c_int64_t, c_ptr
+
+    private
+
+    public :: SMIOLf_context, &
+              SMIOLf_decomp, &
+              SMIOLf_file
+
+    public :: SMIOL_offset_kind
+
+    public :: SMIOLf_init, &
+              SMIOLf_finalize, &
+              SMIOLf_inquire, &
+              SMIOLf_open_file, &
+              SMIOLf_close_file, &
+              SMIOLf_define_dim, &
+              SMIOLf_inquire_dim, &
+              SMIOLf_define_var, &
+              SMIOLf_inquire_var, &
+              SMIOLf_put_var, &
+              SMIOLf_get_var, &
+              SMIOLf_define_att, &
+              SMIOLf_inquire_att, &
+              SMIOLf_sync_file, &
+              SMIOLf_error_string, &
+              SMIOLf_lib_error_string, &
+              SMIOLf_set_option, &
+              SMIOLf_create_decomp, &
+              SMIOLf_free_decomp, &
+              SMIOLf_set_frame, &
+              SMIOLf_get_frame, &
+              SMIOLf_f_to_c_string
+
+
+    integer, parameter :: SMIOL_offset_kind = c_int64_t   ! Must match SMIOL_Offset in smiol_types.h
+
+
+    type, bind(C) :: SMIOLf_context
+        integer :: fcomm                ! Fortran handle to MPI communicator; MPI_Fint on the C side, which is supposed to match
+                                        !   a Fortran integer
+
+        integer(c_int) :: comm_size     ! Size of MPI communicator
+        integer(c_int) :: comm_rank     ! Rank within MPI communicator
+
+        integer(c_int) :: num_io_tasks  ! The number of I/O tasks
+        integer(c_int) :: io_stride     ! The stride between I/O tasks in the communicator
+
+        integer(c_int) :: lib_ierr      ! Library-specific error code
+        integer(c_int) :: lib_type      ! From which library the error code originated
+    end type SMIOLf_context
+
+    type, bind(C) :: SMIOLf_file
+        type (c_ptr) :: context      ! Pointer to (struct SMIOL_context); the context within which the file was opened
+        integer(kind=SMIOL_offset_kind) :: frame      ! Current frame of the file
+#ifdef SMIOL_PNETCDF
+        integer(c_int) :: state      ! parallel-netCDF file state (i.e. Define or data mode)
+        integer(c_int) :: ncidp      ! parallel-netCDF file handle
+        integer(c_size_t) :: bufsize ! Size of buffer attached to this file
+        integer(c_int) :: n_reqs     ! Number of pending non-blocking requests
+        type (c_ptr) :: reqs         ! Array of pending non-blocking request handles
+#endif
+        integer(c_int) :: io_task    ! 1 = this task performs I/O calls; 0 = no I/O calls on this task
+        integer :: io_file_comm      ! Communicator shared by all tasks with io_task == 1
+        integer :: io_group_comm     ! Communicator shared by tasks associated with an I/O task, usually 1 I/O task
+                                     ! and N-1 non-I/O tasks, where N is the I/O stride
+    end type SMIOLf_file
+
+    type, bind(C) :: SMIOLf_decomp
+        !
+        ! The lists below are structured (in C) as follows:
+        !   list[0] - the number of neighbors for which a task sends/recvs
+        !                                                                             |
+        !   list[n] - neighbor task ID                                                | repeated for
+        !   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+        !   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+        !                                                                             |
+        !
+        type(c_ptr) :: comp_list  ! Elements to be sent/received from/on a compute task
+        type(c_ptr) :: io_list    ! Elements to be send/received from/on an I/O task
+
+        type (c_ptr) :: context   ! Pointer to (struct SMIOL_context); the context for this decomp
+
+        integer(c_size_t) :: io_start;  ! The starting offset on disk for I/O by a task
+        integer(c_size_t) :: io_count;  ! The number of elements for I/O by a task
+
+        integer(c_int) ::  agg_factor       ! Aggregation factor, or size of aggregation group
+        integer :: agg_comm                 ! Communicator for aggregation/deaggregation operations
+        integer(c_size_t) :: n_compute      ! Number of un-aggregated compute elements on the task
+        integer(c_size_t) :: n_compute_agg  ! Number of aggregated compute elements on the task
+        type (c_ptr) :: counts              ! Compute element counts for tasks in aggregation group
+        type (c_ptr) :: displs              ! Displacements in aggregated list of elements for tasks
+                                            !    in aggregation group
+    end type SMIOLf_decomp
+
+    interface SMIOLf_define_att
+        module procedure SMIOLf_define_att_int
+        module procedure SMIOLf_define_att_float
+        module procedure SMIOLf_define_att_double
+        module procedure SMIOLf_define_att_text
+    end interface
+
+    interface SMIOLf_inquire_att
+        module procedure SMIOLf_inquire_att_int
+        module procedure SMIOLf_inquire_att_float
+        module procedure SMIOLf_inquire_att_double
+        module procedure SMIOLf_inquire_att_text
+    end interface
+
+    !
+    ! Note: The implementations of the specific SMIOLf_put_var routines
+    !       are found in the file smiolf_put_get_var.inc, which is included
+    !       in this module with a pre-processor directive
+    !
+    interface SMIOLf_put_var
+        module procedure SMIOLf_put_var_0d_char
+        module procedure SMIOLf_put_var_0d_int32
+        module procedure SMIOLf_put_var_0d_real32
+        module procedure SMIOLf_put_var_0d_real64
+        module procedure SMIOLf_put_var_1d_int32
+        module procedure SMIOLf_put_var_1d_real32
+        module procedure SMIOLf_put_var_1d_real64
+        module procedure SMIOLf_put_var_2d_int32
+        module procedure SMIOLf_put_var_2d_real32
+        module procedure SMIOLf_put_var_2d_real64
+        module procedure SMIOLf_put_var_3d_int32
+        module procedure SMIOLf_put_var_3d_real32
+        module procedure SMIOLf_put_var_3d_real64
+        module procedure SMIOLf_put_var_4d_int32
+        module procedure SMIOLf_put_var_4d_real32
+        module procedure SMIOLf_put_var_4d_real64
+        module procedure SMIOLf_put_var_5d_real32
+        module procedure SMIOLf_put_var_5d_real64
+    end interface SMIOLf_put_var
+
+    !
+    ! Note: The implementations of the specific SMIOLf_get_var routines
+    !       are found in the file smiolf_put_get_var.inc, which is included
+    !       in this module with a pre-processor directive
+    !
+    interface SMIOLf_get_var
+        module procedure SMIOLf_get_var_0d_char
+        module procedure SMIOLf_get_var_0d_int32
+        module procedure SMIOLf_get_var_0d_real32
+        module procedure SMIOLf_get_var_0d_real64
+        module procedure SMIOLf_get_var_1d_int32
+        module procedure SMIOLf_get_var_1d_real32
+        module procedure SMIOLf_get_var_1d_real64
+        module procedure SMIOLf_get_var_2d_int32
+        module procedure SMIOLf_get_var_2d_real32
+        module procedure SMIOLf_get_var_2d_real64
+        module procedure SMIOLf_get_var_3d_int32
+        module procedure SMIOLf_get_var_3d_real32
+        module procedure SMIOLf_get_var_3d_real64
+        module procedure SMIOLf_get_var_4d_int32
+        module procedure SMIOLf_get_var_4d_real32
+        module procedure SMIOLf_get_var_4d_real64
+        module procedure SMIOLf_get_var_5d_real32
+        module procedure SMIOLf_get_var_5d_real64
+    end interface SMIOLf_get_var
+
+    ! C interface definitions used in multiple routines
+    interface
+        function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+            use iso_c_binding, only : c_ptr, c_char, c_int
+            type (c_ptr), value :: file
+            type (c_ptr), value :: varname
+            character(kind=c_char), dimension(*) :: att_name
+            integer(kind=c_int), value :: att_type
+            type (c_ptr), value :: att
+            integer(kind=c_int) :: ierr
+        end function
+
+        function SMIOL_inquire_att(file, varname, att_name, att_type, att_len, att) result(ierr) bind(C, name='SMIOL_inquire_att')
+            use iso_c_binding, only : c_ptr, c_char, c_int
+            type (c_ptr), value :: file
+            type (c_ptr), value :: varname
+            character(kind=c_char), dimension(*) :: att_name
+            type (c_ptr), value :: att_type
+            type (c_ptr), value :: att_len
+            type (c_ptr), value :: att
+            integer(kind=c_int) :: ierr
+        end function
+
+        function SMIOL_put_var(file, varname, decomp, buf) result(ierr) bind(C, name='SMIOL_put_var')
+             use iso_c_binding, only : c_ptr, c_char, c_int
+             type (c_ptr), value :: file
+             character (kind=c_char), dimension(*) :: varname
+             type (c_ptr), value :: decomp
+             type (c_ptr), value :: buf
+             integer (kind=c_int) :: ierr
+        end function
+
+        function SMIOL_get_var(file, varname, decomp, buf) result(ierr) bind(C, name='SMIOL_get_var')
+             use iso_c_binding, only : c_ptr, c_char, c_int
+             type (c_ptr), value :: file
+             character (kind=c_char), dimension(*) :: varname
+             type (c_ptr), value :: decomp
+             type (c_ptr), value :: buf
+             integer (kind=c_int) :: ierr
+        end function
+    end interface
+
+
+contains
+
+
+    !
+    ! Library methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_init
+    !
+    !> \brief Initialize a SMIOL context
+    !> \details
+    !>  Initializes a SMIOL context, within which decompositions may be defined and
+    !>  files may be read and written. The input argument comm is an MPI communicator,
+    !>  and the input arguments num_io_tasks and io_stride provide the total number
+    !>  of I/O tasks and the stride between those I/O tasks within the communicator.
+    !>
+    !>  Upon successful return the context argument points to a valid SMIOL context;
+    !>  otherwise, it is NULL and an error code other than MPI_SUCCESS is returned.
+    !>
+    !>  Note: It is assumed that MPI_Init has been called prior to this routine, so
+    !>        that any use of the provided MPI communicator will be valid.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_init(comm, num_io_tasks, io_stride, context) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_f_pointer, c_null_ptr, c_associated
+
+        implicit none
+
+        integer, intent(in) :: comm
+        integer, intent(in) :: num_io_tasks
+        integer, intent(in) :: io_stride
+        type (SMIOLf_context), pointer :: context
+
+        type (c_ptr) :: c_context = c_null_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_fortran_init(comm, num_io_tasks, io_stride, context) result(ierr) bind(C, name='SMIOL_fortran_init')
+                use iso_c_binding, only : c_int, c_ptr
+                integer, value :: comm   ! MPI_Fint on the C side, which is supposed to match a Fortran integer
+                integer(c_int), value :: num_io_tasks
+                integer(c_int), value :: io_stride
+                type (c_ptr) :: context
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ierr = SMIOL_fortran_init(comm, num_io_tasks, io_stride, c_context)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (.not. c_associated(c_context)) then
+                nullify(context)
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                call c_f_pointer(c_context, context)
+            end if
+        else
+            if (.not. c_associated(c_context)) then
+                nullify(context)
+            else
+                ierr = SMIOL_FORTRAN_ERROR
+            end if
+        end if
+
+    end function SMIOLf_init
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_finalize
+    !
+    !> \brief Finalize a SMIOL context
+    !> \details
+    !>  Finalizes a SMIOL context and frees all memory in the SMIOL_context instance.
+    !>  After this routine is called, no other SMIOL routines that make reference to
+    !>  the finalized context should be called.
+    !>
+    !>  Upon return, the context argument will be unassociated if no errors occurred.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_finalize(context) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_associated, c_null_ptr
+
+        implicit none
+
+        type (SMIOLf_context), pointer :: context
+
+        type (c_ptr) :: c_context = c_null_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_finalize(context) result(ierr) bind(C, name='SMIOL_finalize')
+                use iso_c_binding, only : c_int, c_ptr
+                type (c_ptr) :: context
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        if (associated(context)) then
+            c_context = c_loc(context)
+        end if
+
+        ierr = SMIOL_finalize(c_context)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_context)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                nullify(context)
+            end if
+        else
+            if (.not. c_associated(c_context)) then
+                nullify(context)
+            end if
+        end if
+
+    end function SMIOLf_finalize
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire
+    !
+    !> \brief Inquire about a SMIOL context
+    !> \details
+    !>  Detailed description of what this routine does.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire() result(ierr)
+
+        implicit none
+
+        ierr = 0
+
+    end function SMIOLf_inquire
+
+
+    !
+    ! File methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_open_file
+    !
+    !> \brief Opens a file within a SMIOL context
+    !> \details
+    !>  Depending on the specified file mode, creates or opens the file specified
+    !>  by filename within the provided SMIOL context.
+    !>
+    !>  The optional bufsize argument specifies the size in bytes of the buffer
+    !>  to be attached to the file by I/O tasks; at present this buffer is only
+    !>  used by the Parallel-NetCDF library if the file is opened with a mode of
+    !>  SMIOL_FILE_CREATE or SMIOL_FILE_WRITE. A bufsize of 0 will force the use of
+    !>  the Parallel-NetCDF blocking write interface, while a nonzero value enables
+    !>  the use of the non-blocking, buffered interface for writing. If the bufsize
+    !>  argument is not present, a default buffer size of 128 MiB is used.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned, and the file handle argument
+    !>  will point to a valid file handle. Otherwise, the file handle is not associated
+    !>  and an error code other than SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_open_file(context, filename, mode, file, bufsize) result(ierr)
+
+        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_char, c_size_t, c_associated, c_f_pointer
+
+        implicit none
+
+        type (SMIOLf_context), pointer :: context
+        character(len=*), intent(in) :: filename
+        integer, intent(in) :: mode
+        type (SMIOLf_file), pointer :: file
+        integer(kind=c_size_t), intent(in), optional :: bufsize
+
+        ! Default buffer size to use if optional bufsize argument is not provided
+        integer (kind=c_size_t), parameter :: default_bufsize = int(128*1024*1024, kind=c_size_t)
+
+        type (c_ptr) :: c_context = c_null_ptr
+        type (c_ptr) :: c_file = c_null_ptr
+        integer(kind=c_int) :: c_mode
+        character(kind=c_char), dimension(:), pointer :: c_filename
+
+        ! C interface definitions
+        interface
+            function SMIOL_open_file(context, filename, mode, file, bufsize) result(ierr) bind(C, name='SMIOL_open_file')
+                use iso_c_binding, only : c_char, c_ptr, c_int, c_size_t
+                type (c_ptr), value :: context
+                character(kind=c_char), dimension(*) :: filename
+                integer(kind=c_int), value :: mode
+                type (c_ptr) :: file
+                integer(kind=c_size_t), value :: bufsize
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        if (associated(context)) then
+            c_context = c_loc(context)
+        end if
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_filename(len_trim(filename) + 1))
+        call SMIOLf_f_to_c_string(filename, c_filename)
+
+        c_mode = mode
+
+        if (present(bufsize)) then
+            ierr = SMIOL_open_file(c_context, c_filename, c_mode, c_file, &
+                                   bufsize)
+        else
+            ierr = SMIOL_open_file(c_context, c_filename, c_mode, c_file, &
+                                   default_bufsize)
+        end if
+
+        deallocate(c_filename)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                call c_f_pointer(c_file, file)
+            end if
+        else
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+            else
+                ierr = SMIOL_FORTRAN_ERROR
+            end if
+        end if
+
+    end function SMIOLf_open_file
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_close_file
+    !
+    !> \brief Closes a file within a SMIOL context
+    !> \details
+    !>  Closes the file associated with the provided file handle. Upon successful
+    !>  completion, SMIOL_SUCCESS is returned, the file will be closed, and all memory
+    !>  that is uniquely associated with the file handle will be deallocated.
+    !>  Otherwise, an error code other than SMIOL_SUCCESS will be returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_close_file(file) result(ierr)
+
+        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_associated
+
+        implicit none
+
+        type (SMIOLf_file), pointer :: file
+
+        type (c_ptr) :: c_file = c_null_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_close_file(file) result(ierr) bind(C, name='SMIOL_close_file')
+                use iso_c_binding, only : c_ptr, c_int
+                type (c_ptr) :: file
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        if (associated(file)) then
+            c_file = c_loc(file)
+        end if
+
+        ierr = SMIOL_close_file(c_file)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_file)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                nullify(file)
+            end if
+        else
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+            end if
+        end if
+
+    end function SMIOLf_close_file
+
+
+    !
+    ! Dimension methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_dim
+    !
+    !> \brief Defines a new dimension in a file
+    !> \details
+    !>  Defines a dimension with the specified name and size in the file associated
+    !>  with the file handle. If a negative value is provided for the size argument,
+    !>  the dimension will be defined as an unlimited or record dimension.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+    !>  code is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_dim(file, dimname, dimsize) result(ierr)
+
+        use iso_c_binding, only : c_char, c_loc, c_ptr
+
+        implicit none
+
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: dimname
+        integer(kind=SMIOL_offset_kind), intent(in) :: dimsize
+
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), pointer :: c_dimname
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_dim(file, dimname, dimsize) result(ierr) bind(C, name='SMIOL_define_dim')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                import SMIOL_offset_kind
+                type (c_ptr), value :: file
+                character(kind=c_char), dimension(*) :: dimname
+                integer(kind=SMIOL_offset_kind), value :: dimsize
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ! Get C address of file; there is no need to worry about an unassociated file here,
+        ! since the file argument is not a pointer
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_dimname(len_trim(dimname) + 1))
+        call SMIOLf_f_to_c_string(dimname, c_dimname)
+
+        ierr = SMIOL_define_dim(c_file, c_dimname, dimsize)
+
+        deallocate(c_dimname)
+
+    end function SMIOLf_define_dim
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_dim
+    !
+    !> \brief Inquires about an existing dimension in a file
+    !> \details
+    !>  Inquire about an existing dimension's size or if a dimension is the
+    !>  unlimited dimension or not. If dimsize is present, the size of the dimension
+    !>  will be returned in it; likewise, if is_unlimited is present, is_unlimited
+    !>  will return either .true. or .false. depending on whether or not the dimension
+    !>  is the unlimited dimension or not.
+    !>
+    !>  For unlimited dimensions, the current size of the dimension is returned;
+    !>  future writes of additional records to a file can lead to different return
+    !>  sizes for unlimited dimensions.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+    !>  code is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_dim(file, dimname, dimsize, is_unlimited) result(ierr)
+
+        use iso_c_binding, only : c_char, c_loc, c_ptr, c_null_ptr
+
+        implicit none
+
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: dimname
+        integer(kind=SMIOL_offset_kind), intent(out), optional :: dimsize
+        logical, intent(out), optional :: is_unlimited
+
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), pointer :: c_dimname
+        integer (kind=SMIOL_offset_kind), target :: c_dimsize
+        integer (kind=c_int), target :: c_is_unlimited
+        type (c_ptr) :: c_dimsize_ptr
+        type (c_ptr) :: c_is_unlimited_ptr
+
+
+        ! C interface definitions
+        interface
+            function SMIOL_inquire_dim(file, dimname, dimsize, is_unlimited) result(ierr) bind(C, name='SMIOL_inquire_dim')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                import SMIOL_offset_kind
+                type (c_ptr), value :: file
+                character(kind=c_char), dimension(*) :: dimname
+                type (c_ptr), value :: dimsize
+                type (c_ptr), value :: is_unlimited
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ! Get C address of file; there is no need to worry about an unassociated file here,
+        ! since the file argument is not a pointer
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_dimname(len_trim(dimname) + 1))
+        call SMIOLf_f_to_c_string(dimname, c_dimname)
+
+        !
+        ! Set C dimsize
+        !
+        if (present(dimsize)) then
+            c_dimsize_ptr = c_loc(c_dimsize)
+        else
+            c_dimsize_ptr = c_null_ptr
+        endif
+
+        !
+        ! Set C pointer for unlimited dimension inquiry argument
+        !
+        if (present(is_unlimited)) then
+            c_is_unlimited_ptr = c_loc(c_is_unlimited)
+        else
+            c_is_unlimited_ptr = c_null_ptr
+        end if
+
+        ierr = SMIOL_inquire_dim(c_file, c_dimname, c_dimsize_ptr, c_is_unlimited_ptr)
+
+        if (present(dimsize)) then
+            dimsize = c_dimsize
+        end if
+
+        if (present(is_unlimited)) then
+            if (c_is_unlimited == 1) then
+                is_unlimited = .true.
+            else
+                is_unlimited = .false.
+            end if
+        end if
+
+        deallocate(c_dimname)
+
+    end function SMIOLf_inquire_dim
+
+
+    !
+    ! Variable methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_var
+    !
+    !> \brief Defines a new variable in a file
+    !> \details
+    !>  Defines a variable with the specified name, type, and dimensions in an open
+    !>  file pointed to by the file argument. The varname and dimnames arguments
+    !>  are expected to be null-terminated strings, except if the variable has
+    !>  zero dimensions, in which case the dimnames argument is ignored.
+    !>
+    !>  Unlike the C SMIOL_define_var function, this routine assumes that
+    !>  dimnames provides the dimension names in their natural Fortran order,
+    !>  with the fastest-varying dimension given first and any unlimited
+    !>  dimension given last.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+    !>  code is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_var(file, varname, vartype, ndims, dimnames) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_null_char, c_ptr, c_loc, c_null_ptr
+
+        implicit none
+
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        integer, intent(in) :: vartype
+        integer, intent(in) :: ndims
+        character(len=*), dimension(:), intent(in) :: dimnames
+
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        integer(kind=c_int) :: c_vartype
+        integer(kind=c_int) :: c_ndims
+
+        type (c_ptr) :: c_dimnames_ptr
+        type (c_ptr), dimension(:), allocatable, target :: c_dimnames
+
+        integer :: i, j
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_var(file, varname, vartype, ndims, dimnames) result(ierr) bind(C, name='SMIOL_define_var')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                character(kind=c_char), dimension(*) :: varname
+                integer(kind=c_int), value :: vartype
+                integer(kind=c_int), value :: ndims
+                type (c_ptr), value :: dimnames
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ! Used to store an array of pointers to character arrays
+        type string_ptr
+            character(kind=c_char), dimension(:), allocatable :: str
+        end type string_ptr
+
+        type (string_ptr), dimension(:), allocatable, target :: strings
+
+        !
+        ! Check that the 'dimnames' array has at least ndims elements
+        !
+        if (size(dimnames) < ndims) then
+            ierr = SMIOL_FORTRAN_ERROR
+            return
+        end if
+
+        ! Get C address of file; there is no need to worry about an unassociated file here,
+        ! since the file argument is not a pointer
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        call SMIOLf_f_to_c_string(varname, c_varname)
+
+        !
+        ! Convert vartype and ndims
+        !
+        c_vartype = vartype
+        c_ndims = ndims
+
+        !
+        ! Convert dimnames, reversing their order
+        !
+        allocate(c_dimnames(ndims))
+        allocate(strings(ndims))
+
+        do j=1,ndims
+            allocate(strings(j) % str(len_trim(dimnames(ndims-j+1))+1))
+
+            do i=1,len_trim(dimnames(ndims-j+1))
+                strings(j) % str(i) = dimnames(ndims-j+1)(i:i)
+            end do
+            strings(j) % str(i) = c_null_char
+            c_dimnames(j) = c_loc(strings(j) % str)
+        end do
+
+        if (ndims > 0) then
+            c_dimnames_ptr = c_loc(c_dimnames)
+        else
+            c_dimnames_ptr = c_null_ptr
+        end if
+
+        ierr = SMIOL_define_var(c_file, c_varname, c_vartype, c_ndims, c_dimnames_ptr)
+
+        do j=1,ndims
+            deallocate(strings(j) % str)
+        end do
+
+        deallocate(c_varname)
+        deallocate(strings)
+        deallocate(c_dimnames)
+
+    end function SMIOLf_define_var
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_var
+    !
+    !> \brief Inquires about an existing variable in a file
+    !> \details
+    !>  Inquires about a variable in a file, and optionally returns the type
+    !>  of the variable, the dimensionality of the variable, and the names of
+    !>  the dimensions of the variable.
+    !>
+    !>  If the names of a variable's dimensions are requested (by providing an
+    !>  actual argument for dimnames), the size of the dimnames array must be at
+    !>  least the number of dimensions in the variable, and each character string
+    !>  in the dimnames array must be large enough to accommodate the corresponding
+    !>  dimension name.
+    !>
+    !>  Unlike the C SMIOL_inquire_var function, this routine returns the list of
+    !>  dimension names in its natural Fortran order, with the fastest-varying
+    !>  dimension given first and any unlimited dimension given last.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_var(file, varname, vartype, ndims, dimnames) result(ierr)
+
+        use iso_c_binding, only : c_char, c_null_char, c_loc, c_ptr, c_null_ptr, c_int
+
+        implicit none
+
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        integer, intent(out), optional :: vartype
+        integer, intent(out), optional :: ndims
+        character(len=*), dimension(:), intent(out), optional :: dimnames
+
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        integer(kind=c_int), target :: c_vartype
+        integer(kind=c_int), target :: c_ndims
+        type (c_ptr), dimension(:), allocatable, target :: c_dimnames
+
+        type (c_ptr) :: c_vartype_ptr
+        type (c_ptr) :: c_ndims_ptr
+        type (c_ptr) :: c_dimnames_ptr
+
+        integer :: i, j, ndims_in
+
+        ! C interface definitions
+        interface
+            function SMIOL_inquire_var(file, varname, vartype, ndims, dimnames) result(ierr) bind(C, name='SMIOL_inquire_var')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                character(kind=c_char), dimension(*) :: varname
+                type (c_ptr), value :: vartype
+                type (c_ptr), value :: ndims
+                type (c_ptr), value :: dimnames
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ! Used to store an array of pointers to character arrays
+        type string_ptr
+            character(kind=c_char), dimension(:), allocatable :: str
+        end type string_ptr
+
+        type (string_ptr), dimension(:), allocatable, target :: strings
+
+
+        ! Get C address of file; there is no need to worry about an unassociated file here,
+        ! since the file argument is not a pointer
+        c_file = c_loc(file)
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        call SMIOLf_f_to_c_string(varname, c_varname)
+
+        !
+        ! Set C pointer for variable type
+        !
+        if (present(vartype)) then
+            c_vartype_ptr = c_loc(c_vartype)
+        else
+            c_vartype_ptr = c_null_ptr
+        end if
+
+        !
+        ! Set C pointer for number of dimensions
+        ! This is done even if dimnames is requested but ndims is not,
+        ! since c_ndims may be used later on when copying out strings
+        ! to dimnames.
+        !
+        if (present(ndims) .or. present(dimnames)) then
+            c_ndims_ptr = c_loc(c_ndims)
+        else
+            c_ndims_ptr = c_null_ptr
+        end if
+
+        !
+        ! Set C pointers for dimension names in C order
+        !
+        if (present(dimnames)) then
+            ndims_in = size(dimnames)
+            allocate(c_dimnames(ndims_in))
+            allocate(strings(ndims_in))
+
+            do j=1,ndims_in
+                allocate(strings(j) % str(len(dimnames(ndims_in-j+1))+1))
+                c_dimnames(j) = c_loc(strings(j) % str)
+            end do
+            c_dimnames_ptr = c_loc(c_dimnames)
+        else
+            c_dimnames_ptr = c_null_ptr
+        end if
+
+
+        ierr = SMIOL_inquire_var(c_file, c_varname, c_vartype_ptr, c_ndims_ptr, c_dimnames_ptr)
+
+        deallocate(c_varname)
+
+        if (ierr /= SMIOL_SUCCESS) then
+            return
+        end if
+
+        !
+        ! Copy variable type to output argument
+        !
+        if (present(vartype)) then
+            vartype = c_vartype
+        end if
+
+        !
+        ! Copy number of dimensions to output argument
+        !
+        if (present(ndims)) then
+            ndims = c_ndims
+        end if
+
+        !
+        ! Copy dimension names to output argument, reversing their order
+        !
+        if (present(dimnames)) then
+            do j=1,c_ndims
+                do i=1,len(dimnames(c_ndims-j+1))
+                    if (strings(j) % str(i) == c_null_char) exit
+                end do
+
+                i = i - 1
+
+                dimnames(c_ndims-j+1)(1:i) = transfer(strings(j) % str(1:i), dimnames(c_ndims-j+1))
+                dimnames(c_ndims-j+1) = dimnames(c_ndims-j+1)(1:i)
+            end do
+
+            do j=1,ndims_in
+                deallocate(strings(j) % str)
+            end do
+            deallocate(strings)
+            deallocate(c_dimnames)
+        end if
+
+    end function SMIOLf_inquire_var
+
+
+#include "smiolf_put_get_var.inc"
+
+
+    !
+    ! Attribute methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_int
+    !
+    !> \brief Defines a new integer attribute
+    !> \details
+    !>  Defines a new integer attribute for a variable if varname is not
+    !>  an empty string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_int(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        integer(kind=c_int), intent(in), target :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_INT32, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_int
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_float
+    !
+    !> \brief Defines a new float attribute
+    !> \details
+    !>  Defines a new float attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_float(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_float, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_float), intent(in), target :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_REAL32, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_float
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_double
+    !
+    !> \brief Defines a new double attribute
+    !> \details
+    !>  Defines a new double attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_double(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_double, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_double), intent(in), target :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_REAL64, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_double
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_text
+    !
+    !> \brief Defines a new text attribute
+    !> \details
+    !>  Defines a new text attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_text(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        character(len=*), intent(in) :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        character(kind=c_char), dimension(:), allocatable, target :: c_att
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        allocate(c_att(len_trim(att) + 1))
+        do i=1,len_trim(att)
+            c_att(i) = att(i:i)
+        end do
+        c_att(i) = c_null_char
+
+        att_ptr = c_loc(c_att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_CHAR, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+        deallocate(c_att)
+
+    end function SMIOLf_define_att_text
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_int
+    !
+    !> \brief Inquires about an integer attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is integer-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not an integer
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_int(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        integer(kind=c_int), intent(out), target :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_INT32) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_int
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_float
+    !
+    !> \brief Inquires about a float attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is float-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a float
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_float(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_float, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_float), intent(out), target :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_REAL32) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_float
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_double
+    !
+    !> \brief Inquires about a double attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is double-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a double
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_double(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_double, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_double), intent(out), target :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_REAL64) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_double
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_text
+    !
+    !> \brief Inquires about a text attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, if it is character-valued, and if
+    !>  the att output argument is long enough to contain the attribute value,
+    !>  then SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a character
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined. If the attribute was found, and it is a character attribute,
+    !>  but the att output argument is not long enough to contain the attribute
+    !>  value, then SMIOL_INSUFFICIENT_ARG is returned, and the contents of att
+    !>  are undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_text(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        character(len=*), intent(out) :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        integer(kind=SMIOL_offset_kind), target :: att_len
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        character(kind=c_char), dimension(:), allocatable, target :: c_att
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: att_len_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+        att_len_ptr = c_loc(att_len)
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type and length
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, att_len_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_CHAR) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        if (len(att) < att_len) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            ierr = SMIOL_INSUFFICIENT_ARG
+            return
+        end if
+
+        !
+        ! Next, allocate a local c_char array
+        !
+        allocate(c_att(att_len))
+        att_ptr = c_loc(c_att)
+
+        !
+        ! Finally, inquire about the attribute itself
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        !
+        ! Copy c_char array to Fortran string
+        !
+        att(1:att_len) = transfer(c_att(1:att_len), att)
+        att = att(1:att_len)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+        deallocate(c_att)
+
+    end function SMIOLf_inquire_att_text
+
+
+    !
+    ! Control methods
+    !
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_sync_file
+    !
+    !> \brief Forces all in-memory data to be flushed to disk
+    !> \details
+    !> Upon success, all in-memory data for the file associatd with the file
+    !> handle will be flushed to the file system and SMIOL_SUCCESS will be
+    !> returned; otherwise, an error code is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_sync_file(file) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_null_ptr
+
+        implicit none
+
+        type (SMIOLf_file), pointer :: file
+        type (c_ptr) :: c_file
+
+        interface
+            function SMIOL_sync_file(file) result(ierr) bind(C, name='SMIOL_sync_file')
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr), value :: file
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_null_ptr
+
+        if (associated(file)) then
+            c_file = c_loc(file)
+        end if
+
+        ierr = SMIOL_sync_file(c_file)
+
+    end function SMIOLf_sync_file
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_error_string
+    !
+    !> \brief Returns an error string for a specified error code
+    !> \details
+    !>  Returns an error string corresponding to a SMIOL error code. If the error code is
+    !>  SMIOL_LIBRARY_ERROR and a valid SMIOL context is available, the SMIOLf_lib_error_string
+    !>  function should be called instead.
+    !>
+    !>  The error string is always of length 128, and so it is recommended to trim
+    !>  the string before it is printed.
+    !
+    !-----------------------------------------------------------------------
+    character(len=128) function SMIOLf_error_string(ierrno) result(err_mesg)
+
+        use iso_c_binding, only : c_ptr, c_char, c_null_char, c_f_pointer
+
+        implicit none
+
+        integer, intent(in) :: ierrno
+
+        type (c_ptr) :: c_mesg_ptr
+        character(kind=c_char), dimension(:), pointer :: c_mesg
+        integer :: i
+    
+        ! C interface definitions
+        interface
+            function SMIOL_error_string(errno) result(err_mesg) bind(C, name='SMIOL_error_string')
+                use iso_c_binding, only : c_int, c_ptr
+                integer(kind=c_int), value :: errno
+                type (c_ptr) :: err_mesg
+            end function
+        end interface
+
+        c_mesg_ptr = SMIOL_error_string(ierrno)
+        call c_f_pointer(c_mesg_ptr, c_mesg, shape=[len(err_mesg)])
+
+        do i=1,len(err_mesg)
+            if (c_mesg(i) == c_null_char) exit
+        end do
+
+        i = i - 1
+
+        err_mesg(1:i) = transfer(c_mesg(1:i), err_mesg)
+        err_mesg = err_mesg(1:i)
+
+    end function SMIOLf_error_string
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_lib_error_string
+    !
+    !> \brief Returns an error string for a third-party library called by SMIOL
+    !> \details
+    !>  Returns an error string corresponding to an error that was generated by
+    !>  a third-party library that was called by SMIOL. The library that was the source
+    !>  of the error, as well as the library-specific error code, are retrieved from
+    !>  a SMIOL context. If successive library calls resulted in errors, only the error
+    !>  string for the last of these errors will be returned. 
+    !>
+    !>  The error string is always of length 128, and so it is recommended to trim
+    !>  the string before it is printed.
+    !
+    !-----------------------------------------------------------------------
+    character(len=128) function SMIOLf_lib_error_string(context) result(err_mesg)
+
+        use iso_c_binding, only : c_ptr, c_null_ptr, c_char, c_null_char, c_f_pointer, c_loc
+
+        implicit none
+
+        type (SMIOLf_context), target :: context
+
+        type (c_ptr) :: c_context = c_null_ptr
+        type (c_ptr) :: c_mesg_ptr = c_null_ptr
+        character(kind=c_char), dimension(:), pointer :: c_mesg => null()
+        integer :: i
+
+        ! C interface definitions
+        interface
+            function SMIOL_lib_error_string(context) result(err_mesg) bind(C, name='SMIOL_lib_error_string')
+                use iso_c_binding, only : c_ptr
+                type(c_ptr), value :: context
+                type (c_ptr) :: err_mesg
+            end function
+        end interface
+
+        c_context = c_loc(context)
+
+        c_mesg_ptr = SMIOL_lib_error_string(c_context)
+        call c_f_pointer(c_mesg_ptr, c_mesg, shape=[len(err_mesg)])
+
+        do i=1,len(err_mesg)
+            if (c_mesg(i) == c_null_char) exit
+        end do
+
+        i = i - 1
+
+        err_mesg(1:i) = transfer(c_mesg(1:i), err_mesg)
+        err_mesg = err_mesg(1:i)
+
+    end function SMIOLf_lib_error_string
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_set_option
+    !
+    !> \brief Sets an option for the SMIOL library
+    !> \details
+    !>  Detailed description of what this routine does.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_set_option() result(ierr)
+
+        implicit none
+
+        ierr = 0
+
+    end function SMIOLf_set_option
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_set_frame
+    !
+    !> \brief Set the frame of an open file
+    !> \details
+    !> For an open SMIOL file handle, set the frame for the unlimited dimension.
+    !> After setting the frame for a file, writing to a variable that is
+    !> dimensioned by the unlimited dimension will write to the last set frame,
+    !> overwriting any current data that maybe present in that frame.
+    !>
+    !> SMIOL_SUCCESS will be returned if the frame is successfully set otherwise an
+    !> error will return.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_set_frame(file, frame) result(ierr)
+
+        use iso_c_binding, only : c_loc, c_ptr
+
+        implicit none
+
+        type (SMIOLf_file), target :: file
+        integer (kind=SMIOL_offset_kind), value, intent(in) :: frame
+
+        type (c_ptr) :: c_file
+
+        ! C interface definitions
+        interface
+            function SMIOL_set_frame(file, frame) result(ierr) bind(C, name='SMIOL_set_frame')
+                use iso_c_binding, only : c_ptr, c_int
+                import SMIOL_offset_kind
+                type (c_ptr), value :: file
+                integer (kind=SMIOL_offset_kind), value :: frame
+                integer (kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+        ierr = SMIOL_set_frame(c_file, frame)
+
+    end function SMIOLf_set_frame
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_frame
+    !
+    !> \brief Get the frame of an open file
+    !> \details
+    !> Get the current frame of an open file. Upon success, SMIOL_SUCCESS will be
+    !> returned, otherwise an error will be returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_get_frame(file, frame) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_loc
+
+        implicit none
+
+        type (SMIOLf_file), target, intent(in) :: file
+        integer (kind=SMIOL_offset_kind), target, intent(out) :: frame
+
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_frame
+
+        ! C interface definitions
+        interface
+            function SMIOL_get_frame(file, frame) result(ierr) bind(C, name='SMIOL_get_frame')
+                use iso_c_binding, only : c_ptr, c_int
+                type (c_ptr), value :: file
+                type (c_ptr), value :: frame
+                integer (kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+        c_frame = c_loc(frame)
+        ierr = SMIOL_get_frame(c_file, c_frame)
+
+    end function SMIOLf_get_frame
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_create_decomp
+    !
+    !> \brief Creates a mapping between compute elements and I/O elements
+    !> \details
+    !>  Given arrays of global element IDs that each task computes, this routine
+    !>  works out a mapping of elements between compute and I/O tasks.
+    !>
+    !>  The aggregation factor is used to indicate the size of subsets of ranks
+    !>  that will gather fields onto a single rank in each subset before transferring
+    !>  that field from compute to output tasks; in a symmetric way, it also
+    !>  indicates the size of subsets over which fields will be scattered after they
+    !>  are transferred from input tasks to a single compute tasks in each subset.
+    !>
+    !>  An aggregation factor of 0 indicates that the implementation should choose
+    !>  a suitable aggregation factor (usually matching the size of shared-memory
+    !>  domains), while a positive integer specifies a specific size for task groups
+    !>  to be used for aggregation.
+    !>
+    !>  If the optional aggregation_factor argument is not given, it defaults to
+    !>  a value of 0.
+    !>
+    !>  If all input arguments are determined to be valid and if the routine is
+    !>  successful in working out a mapping, the decomp pointer is allocated
+    !>  and given valid contents, and SMIOL_SUCCESS is returned; otherwise
+    !>  a non-success error code is returned and the decomp pointer is unassociated.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, &
+                                          aggregation_factor) result(ierr)
+
+        use iso_c_binding, only : c_int, c_size_t, c_ptr, c_null_ptr, c_loc, c_f_pointer, c_associated
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_context), target, intent(in) :: context
+        integer(kind=c_size_t), intent(in) :: n_compute_elements
+        integer(kind=SMIOL_offset_kind), dimension(n_compute_elements), target, intent(in) :: compute_elements
+        type (SMIOLf_decomp), pointer, intent(inout) :: decomp
+        integer, intent(in), optional :: aggregation_factor
+
+        ! Local variables
+        type (c_ptr) :: c_context
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_compute_elements
+        integer(kind=c_int) :: c_agg_factor
+        
+        interface
+            function SMIOL_create_decomp(context, n_compute_elements, compute_elements, aggregation_factor, decomp) &
+                                         result(ierr) bind(C, name='SMIOL_create_decomp')
+                use iso_c_binding, only : c_size_t, c_ptr, c_int
+                type (c_ptr), value :: context
+                integer(c_size_t), value :: n_compute_elements
+                type (c_ptr), value :: compute_elements
+                integer(kind=c_int), value :: aggregation_factor
+                integer(kind=c_int) :: ierr
+                type (c_ptr) :: decomp
+            end function
+        end interface
+
+
+        if (present(aggregation_factor)) then
+            c_agg_factor = aggregation_factor
+        else
+            c_agg_factor = 0    ! Let SMIOL choose its own aggregation factor
+        end if
+
+        ! Get C pointers to Fortran types
+        c_context = c_loc(context)
+        if (size(compute_elements) > 0) then
+            c_compute_elements = c_loc(compute_elements)
+        else
+            c_compute_elements = c_null_ptr
+        end if
+
+        c_decomp = c_null_ptr
+
+        ierr = SMIOL_create_decomp(c_context, n_compute_elements, c_compute_elements, c_agg_factor, c_decomp)
+
+        ! Error check and translate c_decomp pointer into a Fortran SMIOLf_decomp pointer
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_decomp)) then
+                call c_f_pointer(c_decomp, decomp)
+            else
+                nullify(decomp)
+                ierr = SMIOL_FORTRAN_ERROR
+            end if
+        else
+            nullify(decomp)
+            if (c_associated(c_decomp)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            endif
+        end if
+
+    end function SMIOLf_create_decomp
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_free_decomp
+    !
+    !> \brief Frees a mapping between compute elements and I/O elements
+    !> \details
+    !>  Frees all memory of a SMIOLf_decomp and returns SMIOL_SUCCESS. If 
+    !>  decomp is unassociated, nothing will be done and SMIOL_SUCCESS will 
+    !>  be returned. After this function has been called, no other SMIOL 
+    !>  routines should use the freed SMIOL_decomp.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_free_decomp(decomp) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_associated, c_null_ptr
+
+        implicit none
+
+        type(SMIOLF_decomp), pointer, intent(inout) :: decomp
+        type(c_ptr) :: c_decomp = c_null_ptr
+
+        interface
+            function SMIOL_free_decomp(decomp) result(ierr) bind(C, name='SMIOL_free_decomp')
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr) :: decomp
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ierr = SMIOL_SUCCESS
+
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        endif
+        ierr = SMIOL_free_decomp(c_decomp)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_decomp)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                nullify(decomp)
+            end if
+        else
+            if (.not. c_associated(c_decomp)) then
+                nullify(decomp)
+            end if
+        end if
+
+    end function SMIOLf_free_decomp
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_f_to_c_string
+    !
+    !> \brief Convert a Fortran string to a C null-terminated character array
+    !> \details
+    !>  Converts a Fortran string to a C null-terminated character array.
+    !>  The cstring output argument must be large enough to contain the trimmed
+    !>  Fortran string plus at least one c_null_char character. Any characters
+    !>  beyond len_trim(fstring) of cstring will be filled with c_null_char
+    !>  characters. If the size of cstring  is less than len_trim(fstring)+1,
+    !>  then only size(cstring)-1 characters from fstring will be copied into
+    !>  cstring before the final c_null_char character is added.
+    !
+    !-----------------------------------------------------------------------
+    subroutine SMIOLf_f_to_c_string(fstring, cstring)
+
+        use iso_c_binding, only : c_char, c_null_char
+
+        implicit none
+
+        character(len=*), intent(in) :: fstring
+        character(kind=c_char), dimension(:), intent(out) :: cstring
+
+        integer :: i
+        integer :: nchar
+
+        if (size(cstring) <= 0) then
+            return
+        end if
+
+        nchar = min(size(cstring)-1, len_trim(fstring))
+
+        do i = 1, nchar
+            cstring(i) = fstring(i:i)
+        end do
+        cstring(nchar+1:size(cstring)) = c_null_char
+
+    end subroutine SMIOLf_f_to_c_string
+
+end module SMIOLf

--- a/src/external/SMIOL/smiolf_put_get_var.inc
+++ b/src/external/SMIOL/smiolf_put_get_var.inc
@@ -1,0 +1,3994 @@
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_char
+    !
+    !> \brief Writes a 0-d char variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_char(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_char, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        character(len=:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+        character(kind=c_char), dimension(:), allocatable, target :: char_buf
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+            allocate(char_buf(len(buf)))
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do
+            c_buf = c_loc(char_buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+        if (associated(buf)) then
+            deallocate(char_buf)
+        end if
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_char
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_char
+    !
+    !> \brief Reads a 0-d char variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_char(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_char, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        character(len=:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+        character(kind=c_char), dimension(:), allocatable, target :: char_buf
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+            allocate(char_buf(len(buf)))
+
+            ! In case buf contains more characters than will be read from the file,
+            ! initialize char_buf with the contents of buf to preserve un-read
+            ! characters during the copy of char_buf back into buf later on
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do
+            c_buf = c_loc(char_buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+        if (associated(buf)) then
+            do i=1,len(buf)
+                buf(i:i) = char_buf(i)
+            end do
+
+            deallocate(char_buf)
+        end if
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_char
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_real32
+    !
+    !> \brief Writes a 0-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_real32
+    !
+    !> \brief Reads a 0-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_real64
+    !
+    !> \brief Writes a 0-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_real64
+    !
+    !> \brief Reads a 0-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_int32
+    !
+    !> \brief Writes a 0-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_int32
+    !
+    !> \brief Reads a 0-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_real32(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        real(kind=c_float), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_real32
+    !
+    !> \brief Writes a 1-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_real32
+    !
+    !> \brief Reads a 1-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_real64(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        real(kind=c_double), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_real64
+    !
+    !> \brief Writes a 1-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real64(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_real64
+    !
+    !> \brief Reads a 1-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real64(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_int32(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        integer(kind=c_int), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_int32
+    !
+    !> \brief Writes a 1-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_int32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_int32
+    !
+    !> \brief Reads a 1-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_int32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_real32(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        real(kind=c_float), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_real32
+    !
+    !> \brief Writes a 2-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_real32
+    !
+    !> \brief Reads a 2-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_real64(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        real(kind=c_double), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_real64
+    !
+    !> \brief Writes a 2-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real64(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_real64
+    !
+    !> \brief Reads a 2-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real64(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_int32(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        integer(kind=c_int), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_int32
+    !
+    !> \brief Writes a 2-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_int32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_int32
+    !
+    !> \brief Reads a 2-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_int32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_real32(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        real(kind=c_float), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_real32
+    !
+    !> \brief Writes a 3-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_real32
+    !
+    !> \brief Reads a 3-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_real64(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        real(kind=c_double), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_real64
+    !
+    !> \brief Writes a 3-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_real64
+    !
+    !> \brief Reads a 3-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_int32(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        integer(kind=c_int), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_int32
+    !
+    !> \brief Writes a 3-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_int32
+    !
+    !> \brief Reads a 3-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_real32(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        real(kind=c_float), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_real32
+    !
+    !> \brief Writes a 4-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_real32
+    !
+    !> \brief Reads a 4-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_real64(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        real(kind=c_double), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_real64
+    !
+    !> \brief Writes a 4-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_real64
+    !
+    !> \brief Reads a 4-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_int32(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        integer(kind=c_int), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_int32
+    !
+    !> \brief Writes a 4-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_int32
+    !
+    !> \brief Reads a 4-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_5d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_5d_real32(a, d1, d2, d3, d4, d5) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4, d5
+        real(kind=c_float), dimension(d1,d2,d3,d4,d5), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d5_real32
+    !
+    !> \brief Writes a 5-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_5d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d5_real32
+    !
+    !> \brief Reads a 5-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_5d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_5d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_5d_real64(a, d1, d2, d3, d4, d5) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4, d5
+        real(kind=c_double), dimension(d1,d2,d3,d4,d5), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_5d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d5_real64
+    !
+    !> \brief Writes a 5-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_5d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_5d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d5_real64
+    !
+    !> \brief Reads a 5-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_5d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_5d_real64
+
+

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -78,14 +78,20 @@ module mpas_bootstrapping
    !-----------------------------------------------------------------------
    subroutine mpas_bootstrap_framework_phase1(domain, mesh_filename, mesh_iotype, pio_file_desc) !{{{
 
+#ifdef MPAS_PIO_SUPPORT
       use pio, only : file_desc_t
+#endif
 
       implicit none
 
       type (domain_type), pointer :: domain
       character(len=*), intent(in) :: mesh_filename
       integer, intent(in) :: mesh_iotype
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, intent(inout), optional :: pio_file_desc
+#endif
 
       type (block_type), pointer :: readingBlock
 
@@ -445,12 +451,18 @@ module mpas_bootstrapping
 
       use mpas_stream_manager
       use mpas_stream_list
+#ifdef MPAS_PIO_SUPPORT
       use pio, only : file_desc_t
+#endif
 
       implicit none
 
       type (domain_type), pointer :: domain
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, intent(inout), optional :: pio_file_desc
+#endif
 
       type (mpas_pool_type), pointer :: readableDimensions
       type (mpas_pool_type), pointer :: streamDimensions

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -27,8 +27,10 @@ module mpas_derived_types
 
    use mpas_kind_types
 
+#ifdef MPAS_PIO_SUPPORT
    use pio
    use pio_types
+#endif
 
    use ESMF
 

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -32,6 +32,10 @@ module mpas_derived_types
    use pio_types
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+   use smiolf, only : SMIOLf_context, SMIOLf_decomp, SMIOLf_file, SMIOL_offset_kind
+#endif
+
    use ESMF
 
 #include "mpas_attlist_types.inc"

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -74,7 +74,11 @@ module mpas_framework
 
       type (domain_type), pointer :: domain
 
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), optional, pointer :: io_system
+#else
+      integer, optional, pointer :: io_system
+#endif
       character(len=*), intent(in), optional :: calendar
 
       character(len=StrKIND), pointer :: config_calendar_type
@@ -154,7 +158,11 @@ module mpas_framework
 
       type (dm_info), pointer :: dminfo
       type (domain_type), pointer :: domain
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), optional, pointer :: io_system
+#else
+      integer, optional, pointer :: io_system
+#endif
 
       call MPAS_io_finalize(domain % ioContext, .false.)
 

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -12,6 +12,7 @@ module mpas_io
    use mpas_dmpar
    use mpas_log
 
+#ifdef MPAS_PIO_SUPPORT
    use pio
    use piolib_mod
    use pionfatt_mod
@@ -22,7 +23,13 @@ module mpas_io
 #else
    integer, parameter :: PIO_REALKIND = PIO_DOUBLE
 #endif
+#endif
 
+#ifdef MPAS_PIO_SUPPORT
+
+   !
+   ! PIO-based fill values
+   !
 #ifdef USE_PIO2
    integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT
    character, parameter :: MPAS_CHAR_FILLVAL = achar(0)  ! TODO: To be replaced with PIO_FILL_CHAR once PIO2 provides this variable
@@ -43,6 +50,17 @@ module mpas_io
 #else
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = NF_FILL_DOUBLE
 #endif
+#endif
+
+#else
+
+   !
+   ! Default fill values
+   !
+   integer, parameter :: MPAS_INT_FILLVAL = huge(1)
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = huge(1.0_RKIND)
+
 #endif
 
    interface MPAS_io_get_var
@@ -103,7 +121,11 @@ module mpas_io
       type (mpas_io_context_type), intent(inout) :: ioContext
       integer, intent(in) :: io_task_count
       integer, intent(in) :: io_task_stride
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), optional, pointer :: io_system
+#else
+      integer, optional, pointer :: io_system
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: local_ierr
@@ -114,7 +136,9 @@ module mpas_io
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
       if (present(io_system)) then
+#ifdef MPAS_PIO_SUPPORT
          ioContext % pio_iosystem => io_system
+#endif
       else
 !call mpas_log_write('MGD PIO_init')
          if ( io_task_count < 0 .or. io_task_count > ioContext % dminfo % nprocs ) then
@@ -140,6 +164,7 @@ module mpas_io
             call mpas_log_write('Invalid PIO configuration.', MPAS_LOG_CRIT)
          end if
 
+#ifdef MPAS_PIO_SUPPORT
          allocate(ioContext % pio_iosystem)
          call PIO_init(ioContext % dminfo % my_proc_id, &  ! comp_rank
                        ioContext % dminfo % comm,       &  ! comp_comm
@@ -148,10 +173,13 @@ module mpas_io
                        io_task_stride,            &     ! stride
                        PIO_rearr_box,             &     ! rearr
                        ioContext % pio_iosystem)           ! iosystem
+#endif
   
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       call pio_seterrorhandling(ioContext % pio_iosystem, PIO_BCAST_ERROR)
+#endif
 
    end subroutine MPAS_io_init
 
@@ -223,7 +251,11 @@ module mpas_io
       type (mpas_io_context_type), pointer :: ioContext
       logical, intent(in), optional :: clobber_file
       logical, intent(in), optional :: truncate_file
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, optional :: pio_file_desc
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr, pio_iotype, pio_mode
@@ -268,6 +300,7 @@ module mpas_io
       MPAS_io_open % ioformat = ioformat
       MPAS_io_open % ioContext => ioContext
 
+#ifdef MPAS_PIO_SUPPORT
       if (ioContext % master_pio_iotype /= -999) then
          pio_iotype = ioContext % master_pio_iotype
          pio_mode = PIO_64BIT_OFFSET
@@ -290,9 +323,12 @@ module mpas_io
 #endif
          end if
       end if
+#endif
 
       if (present(pio_file_desc)) then
+#ifdef MPAS_PIO_SUPPORT
          MPAS_io_open % pio_file = pio_file_desc
+#endif
          MPAS_io_open % external_file_desc = .true.
       else
          if (mode == MPAS_IO_WRITE) then
@@ -310,10 +346,14 @@ module mpas_io
             end if
  
             if (exists .and. (.not. local_truncate)) then
+#ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_write)
+#endif
                MPAS_io_open % preexisting_file = .true.
             else
+#ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_createfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), pio_mode)
+#endif
 #ifdef MPAS_DEBUG
                if (exists) then
                   call mpas_log_write('MPAS I/O: Truncating existing data in output file '//trim(filename), MPAS_LOG_WARN)
@@ -327,17 +367,22 @@ module mpas_io
                if (present(ierr)) ierr = MPAS_IO_ERR_NOEXIST_READ
                return
             end if
+#ifdef MPAS_PIO_SUPPORT
 !call mpas_log_write('MGD PIO_openfile')
             pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
+#endif
          endif
+#ifdef MPAS_PIO_SUPPORT
          if (pio_ierr /= PIO_noerr) then
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
+#endif
          MPAS_io_open % external_file_desc = .false.
       end if
 
       if (mode == MPAS_IO_READ .or. MPAS_io_open % preexisting_file) then
+#ifdef MPAS_PIO_SUPPORT
 !MPAS_io_open % pio_unlimited_dimid = 44
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
@@ -345,17 +390,20 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
+#endif
 
          ! Here we're depending on the undocumented behavior of PIO to return a
          ! negative dimension ID when an unlimited dimension is not found.  This
          ! might change in the future, causing this code to break, though it
          ! shouldn't break for files with unlimited dimensions.
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
+#ifdef MPAS_PIO_SUPPORT
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                return
             end if
+#endif
          else
             MPAS_io_open % preexisting_records = -1
          end if
@@ -391,12 +439,14 @@ module mpas_io
          return
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_dimname(handle % pio_file, handle % pio_unlimited_dimid, dimname) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_NO_UNLIMITED_DIM
          dimname = ' '
          return
       end if
+#endif
 
    end subroutine MPAS_io_inq_unlimited_dim
 
@@ -446,6 +496,7 @@ module mpas_io
 
       new_dimlist_node % dimhandle % dimname = dimname
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_dimid(handle % pio_file, trim(dimname), new_dimlist_node % dimhandle % dimid)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_MISSING_DIM
@@ -465,6 +516,7 @@ module mpas_io
          dimsize = -1
          return
       end if
+#endif
    
       ! Keep dimension information for future reference
       if (.not. associated(handle % dimlist_head)) then
@@ -571,16 +623,22 @@ module mpas_io
       new_dimlist_node % dimhandle % dimsize = dimsize
       if (dimsize == MPAS_IO_UNLIMITED_DIM) then
          new_dimlist_node % dimhandle % is_unlimited_dim = .true.
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), PIO_unlimited, new_dimlist_node % dimhandle % dimid)
+#endif
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
+#endif
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
          return
       end if
+#endif
 
       ! Keep dimension information
       if (.not. associated(handle % dimlist_head)) then
@@ -657,6 +715,7 @@ module mpas_io
          new_fieldlist_node % fieldhandle % fieldname = fieldname
 
          ! Get variable ID
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
@@ -692,8 +751,10 @@ module mpas_io
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_CHAR
 !!!!!!!! PIO DOES NOT SUPPORT LOGICAL !!!!!!!!
          end if
+#endif
 
          ! Get number of dimensions
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -702,10 +763,12 @@ module mpas_io
             return
          end if
 !call mpas_log_write('Inquired about number of dimensions $i', intArgs=(/new_fieldlist_node % fieldhandle % ndims/) )
+#endif
 
          allocate(dimids(new_fieldlist_node % fieldhandle % ndims))
 
          ! Get dimension IDs
+#ifdef MPAS_PIO_SUPPORT
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
@@ -717,9 +780,11 @@ module mpas_io
             end if
 !call mpas_log_write('Inquired about dimension IDs $i.', intArgs=(/dimids/) )
          end if
+#endif
 
          allocate(new_fieldlist_node % fieldhandle % dims(new_fieldlist_node % fieldhandle % ndims))
 
+#ifdef MPAS_PIO_SUPPORT
          ! Get information about dimensions
          do i=1,new_fieldlist_node % fieldhandle % ndims
             new_fieldlist_node % fieldhandle % dims(i) % dimid = dimids(i)
@@ -749,6 +814,7 @@ module mpas_io
 !call mpas_log_write('Inquired about dimension name ' // trim(new_fieldlist_node % fieldhandle % dims(i) % dimname))
 
          end do
+#endif
 
          deallocate(dimids)
 
@@ -988,25 +1054,38 @@ module mpas_io
       ! Convert from MPAS type
       if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_DOUBLE) then
          if (local_precision == MPAS_IO_SINGLE_PRECISION) then
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_REAL
          else
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
+#endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_REAL) then
          if (local_precision == MPAS_IO_DOUBLE_PRECISION) then
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_DOUBLE
          else
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
+#endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_INT) then
+#ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_int
+#endif
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_CHAR) then
+#ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_char
+#endif
 !!!!!!!! PIO DOES NOT SUPPORT LOGICAL !!!!!!!!
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       if (ndims == 0) then
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, new_fieldlist_node % fieldhandle % field_desc)
       else
@@ -1016,13 +1095,16 @@ module mpas_io
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Get the varid for use by put_att routines
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       deallocate(dimids)
 
@@ -1155,6 +1237,7 @@ module mpas_io
 !if (.not. associated(decomp_cursor)) call mpas_log_write('No existing decompositions to check...')
       early_return = 0
       DECOMP_LOOP: do while (associated(decomp_cursor))
+#ifdef MPAS_PIO_SUPPORT
          if (decomp_cursor % decomphandle % field_type == field_cursor % fieldhandle % field_type) then
          if (size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims) then
 !call mpas_log_write('Number of dimensions matches...')
@@ -1165,6 +1248,7 @@ module mpas_io
                   cycle DECOMP_LOOP
                end if
             end do
+#endif
 
             if (size(decomp_cursor % decomphandle % indices) /= size(indices)) then
 !call mpas_log_write('We do not have the same number of indices in this decomposition...')
@@ -1185,6 +1269,7 @@ module mpas_io
 !call mpas_log_write('Found a matching decomposition that we can use')
             early_return = 1
             exit DECOMP_LOOP
+#ifdef MPAS_PIO_SUPPORT
          else if ((size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims - 1)  &
                   .and. field_cursor % fieldhandle % has_unlimited_dim  &
                  ) then
@@ -1220,6 +1305,7 @@ module mpas_io
             exit DECOMP_LOOP
          end if
          end if
+#endif
          decomp_cursor => decomp_cursor % next
       end do DECOMP_LOOP
 
@@ -1252,6 +1338,7 @@ module mpas_io
       new_decomp % decomphandle % indices(:) = indices(:)
 
       ! Convert from MPAS type
+#ifdef MPAS_PIO_SUPPORT
       if (field_cursor % fieldhandle % field_type == MPAS_IO_DOUBLE) then
          pio_type = PIO_double
       else if (field_cursor % fieldhandle % field_type == MPAS_IO_REAL) then
@@ -1334,6 +1421,9 @@ module mpas_io
 
       dimlist(ndims) = field_cursor % fieldhandle % dims(ndims) % dimsize
       call PIO_initdecomp(handle % ioContext % pio_iosystem, pio_type, dimlist, compdof, new_decomp % decomphandle % pio_iodesc)
+      deallocate(compdof)
+      deallocate(dimlist)
+#endif
 
       ! Add new decomposition to the list
       if (.not. associated(handle % ioContext % decomp_list)) then
@@ -1348,8 +1438,6 @@ module mpas_io
 !call mpas_log_write('Setting decomp in fieldhandle')
       field_cursor % fieldhandle % decomp => new_decomp % decomphandle
 
-      deallocate(compdof)
-      deallocate(dimlist)
 !call mpas_log_write('All finished.')
 
    end subroutine MPAS_io_set_var_indices
@@ -1438,10 +1526,12 @@ module mpas_io
 
 !      call mpas_log_write('Checking for unlimited dim')
       if (field_cursor % fieldhandle % has_unlimited_dim) then
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
 #else
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
+#endif
 #endif
          start1(1) = handle % frame_number
          count1(1) = 1
@@ -1456,36 +1546,47 @@ module mpas_io
 !         call mpas_log_write('  value is real')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, singleVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, singleVal)
             end if
+#endif
+
             realVal = real(singleVal,RKIND)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, doubleVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, doubleVal)
             end if
+#endif
+
             realVal = real(doubleVal,RKIND)
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, realVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, realVal)
             end if
+#endif
          end if
       else if (present(intVal)) then
 !         call mpas_log_write('  value is int')
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, intVal)
          else
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, intVal)
          end if
+#endif
       else if (present(charVal)) then
 !         call mpas_log_write('  value is char')
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, tempchar)
@@ -1496,8 +1597,10 @@ module mpas_io
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, tempchar)
             charVal(1:count1(1)) = tempchar(1)(1:count1(1))
          end if
+#endif
       else if (present(charArray1d)) then
 !         call mpas_log_write('  value is char1')
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             ! Can only read one string at a time, since the sizes differ so much (i.e. StrLen != StrKIND)
             do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
@@ -1541,15 +1644,19 @@ module mpas_io
                end do
             end do
          end if
+#endif
       else if (present(realArray1d)) then
 !         call mpas_log_write('  value is real1')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1561,6 +1668,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, singleArray1d)
                end if
+#endif
             end if
             realArray1d(:) = real(singleArray1d(:),RKIND)
             deallocate(singleArray1d)
@@ -1568,9 +1676,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1582,14 +1693,18 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, doubleArray1d)
                end if
+#endif
             end if
             realArray1d(:) = real(doubleArray1d(:),RKIND)
             deallocate(doubleArray1d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1601,6 +1716,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, realArray1d)
                end if
+#endif
             end if
          end if
       else if (present(realArray2d)) then
@@ -1609,9 +1725,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1625,6 +1744,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, singleArray2d)
                end if
+#endif
             end if
             realArray2d(:,:) = real(singleArray2d(:,:),RKIND)
             deallocate(singleArray2d)
@@ -1632,9 +1752,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1648,14 +1771,18 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, doubleArray2d)
                end if
+#endif
             end if
             realArray2d(:,:) = real(doubleArray2d(:,:),RKIND)
             deallocate(doubleArray2d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1669,6 +1796,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, realArray2d)
                end if
+#endif
             end if
          end if
       else if (present(realArray3d)) then
@@ -1677,9 +1805,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1695,6 +1826,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, singleArray3d)
                end if
+#endif
             end if
             realArray3d(:,:,:) = real(singleArray3d(:,:,:),RKIND)
             deallocate(singleArray3d)
@@ -1702,9 +1834,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1720,14 +1855,18 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, doubleArray3d)
                end if
+#endif
             end if
             realArray3d(:,:,:) = real(doubleArray3d(:,:,:),RKIND)
             deallocate(doubleArray3d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1743,6 +1882,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, realArray3d)
                end if
+#endif
             end if
          end if
       else if (present(realArray4d)) then
@@ -1751,9 +1891,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1771,6 +1914,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, singleArray4d)
                end if
+#endif
             end if
             realArray4d(:,:,:,:) = real(singleArray4d(:,:,:,:),RKIND)
             deallocate(singleArray4d)
@@ -1778,9 +1922,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1798,14 +1945,18 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, doubleArray4d)
                end if
+#endif
             end if
             realArray4d(:,:,:,:) = real(doubleArray4d(:,:,:,:),RKIND)
             deallocate(doubleArray4d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1823,6 +1974,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, realArray4d)
                end if
+#endif
             end if
          end if
       else if (present(realArray5d)) then
@@ -1831,9 +1983,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    singleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1853,6 +2008,7 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, singleArray5d)
                end if
+#endif
             end if
             realArray5d(:,:,:,:,:) = real(singleArray5d(:,:,:,:,:),RKIND)
             deallocate(singleArray5d)
@@ -1860,9 +2016,12 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    doubleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1882,14 +2041,18 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, doubleArray5d)
                end if
+#endif
             end if
             realArray5d(:,:,:,:,:) = real(doubleArray5d(:,:,:,:,:),RKIND)
             deallocate(doubleArray5d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    realArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1909,14 +2072,18 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, realArray5d)
                end if
+#endif
             end if
          end if
       else if (present(intArray1d)) then
 !         call mpas_log_write('  value is int1')
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray1d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start2(1) = 1
                start2(2) = handle % frame_number
@@ -1928,13 +2095,17 @@ module mpas_io
                count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, intArray1d)
             end if
+#endif
          end if
       else if (present(intArray2d)) then
 !         call mpas_log_write('  value is int2')
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray2d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start3(:) = 1
                start3(3) = handle % frame_number
@@ -1948,13 +2119,17 @@ module mpas_io
                count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, intArray2d)
             end if
+#endif
          end if
       else if (present(intArray3d)) then
 !         call mpas_log_write('  value is int3')
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray3d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start4(:) = 1
                start4(4) = handle % frame_number
@@ -1970,13 +2145,17 @@ module mpas_io
                count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, intArray3d)
             end if
+#endif
          end if
       else if (present(intArray4d)) then
 !         call mpas_log_write('  value is int4')
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray4d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start5(:) = 1
                start5(5) = handle % frame_number
@@ -1994,14 +2173,17 @@ module mpas_io
                count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, intArray4d)
             end if
+#endif
          end if
       end if
 
 !      call mpas_log_write('Checking for error')
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
    end subroutine MPAS_io_get_var_generic
 
@@ -2326,6 +2508,7 @@ module mpas_io
       if (.not. handle % data_mode) then
          handle % data_mode = .true.
 
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_enddef(handle % pio_file)
          ! If we are working with a preexisting file, we likely didn't define
          ! new dimensions or variables, in which case PIO_enddef() will return
@@ -2336,6 +2519,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
+#endif
       end if
 
 !     call mpas_log_write('Writing '//trim(fieldname))
@@ -2357,10 +2541,12 @@ module mpas_io
 
       if (field_cursor % fieldhandle % has_unlimited_dim) then
 
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
 #else
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
+#endif
 #endif
          start1(1) = handle % frame_number
          count1(1) = 1
@@ -2377,33 +2563,42 @@ module mpas_io
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             singleVal = real(realVal,R4KIND)
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, singleVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, singleVal)
             end if
+#endif
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             doubleVal = real(realVal,R8KIND)
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, doubleVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, doubleVal)
             end if
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, realVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, realVal)
             end if
+#endif
          end if
       else if (present(intVal)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, intVal)
          else
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, intVal)
          end if
+#endif
       else if (present(charVal)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, charVal(1:count2(1)))
@@ -2412,7 +2607,9 @@ module mpas_io
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, charVal(1:count1(1)))
          end if
+#endif
       else if (present(charArray1d)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             ! Write one string at a time because the sizes differ so much (i.e. StrLen != StrKIND)
             do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
@@ -2434,15 +2631,19 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, charArray1d(i)(1:count2(1)))
             end do
          end if
+#endif
       else if (present(realArray1d)) then
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray1d(size(realArray1d)))
             singleArray1d(:) = real(realArray1d(:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2454,6 +2655,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, singleArray1d)
                end if
+#endif
             end if
             deallocate(singleArray1d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2461,9 +2663,12 @@ module mpas_io
             allocate(doubleArray1d(size(realArray1d)))
             doubleArray1d(:) = real(realArray1d(:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2475,13 +2680,17 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, doubleArray1d)
                end if
+#endif
             end if
             deallocate(doubleArray1d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2493,6 +2702,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, realArray1d)
                end if
+#endif
             end if
          end if
       else if (present(realArray2d)) then
@@ -2501,9 +2711,12 @@ module mpas_io
             allocate(singleArray2d(size(realArray2d,1), size(realArray2d,2)))
             singleArray2d(:,:) = real(realArray2d(:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2518,6 +2731,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, singleArray2d)
                end if
+#endif
             end if
             deallocate(singleArray2d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2525,9 +2739,12 @@ module mpas_io
             allocate(doubleArray2d(size(realArray2d,1), size(realArray2d,2)))
             doubleArray2d(:,:) = real(realArray2d(:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2542,13 +2759,17 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, doubleArray2d)
                end if
+#endif
             end if
             deallocate(doubleArray2d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2563,6 +2784,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, realArray2d)
                end if
+#endif
             end if
          end if
       else if (present(realArray3d)) then
@@ -2571,9 +2793,12 @@ module mpas_io
             allocate(singleArray3d(size(realArray3d,1), size(realArray3d,2), size(realArray3d,3)))
             singleArray3d(:,:,:) = real(realArray3d(:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2591,6 +2816,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, singleArray3d)
                end if
+#endif
             end if
             deallocate(singleArray3d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2598,9 +2824,12 @@ module mpas_io
             allocate(doubleArray3d(size(realArray3d,1), size(realArray3d,2), size(realArray3d,3)))
             doubleArray3d(:,:,:) = real(realArray3d(:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2618,13 +2847,17 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, doubleArray3d)
                end if
+#endif
             end if
             deallocate(doubleArray3d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2642,6 +2875,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, realArray3d)
                end if
+#endif
             end if
          end if
       else if (present(realArray4d)) then
@@ -2650,9 +2884,12 @@ module mpas_io
             allocate(singleArray4d(size(realArray4d,1), size(realArray4d,2), size(realArray4d,3), size(realArray4d,4)))
             singleArray4d(:,:,:,:) = real(realArray4d(:,:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2673,6 +2910,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, singleArray4d)
                end if
+#endif
             end if
             deallocate(singleArray4d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2680,9 +2918,12 @@ module mpas_io
             allocate(doubleArray4d(size(realArray4d,1), size(realArray4d,2), size(realArray4d,3), size(realArray4d,4)))
             doubleArray4d(:,:,:,:) = real(realArray4d(:,:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2703,13 +2944,17 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, doubleArray4d)
                end if
+#endif
             end if
             deallocate(doubleArray4d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2730,6 +2975,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, realArray4d)
                end if
+#endif
             end if
          end if
       else if (present(realArray5d)) then
@@ -2738,9 +2984,12 @@ module mpas_io
             allocate(singleArray5d(size(realArray5d,1), size(realArray5d,2), size(realArray5d,3), size(realArray5d,4), size(realArray5d,5)))
             singleArray5d(:,:,:,:,:) = real(realArray5d(:,:,:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2764,6 +3013,7 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, singleArray5d)
                end if
+#endif
             end if
             deallocate(singleArray5d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2771,9 +3021,12 @@ module mpas_io
             allocate(doubleArray5d(size(realArray5d,1), size(realArray5d,2), size(realArray5d,3), size(realArray5d,4), size(realArray5d,5)))
             doubleArray5d(:,:,:,:,:) = real(realArray5d(:,:,:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2797,13 +3050,17 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, doubleArray5d)
                end if
+#endif
             end if
             deallocate(doubleArray5d)
          else
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2827,13 +3084,17 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, realArray5d)
                end if
+#endif
             end if
          end if
       else if (present(intArray1d)) then
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray1d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start2(1) = 1
                start2(2) = handle % frame_number
@@ -2845,12 +3106,16 @@ module mpas_io
                count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, intArray1d)
             end if
+#endif
          end if
       else if (present(intArray2d)) then
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray2d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start3(1) = 1
                start3(2) = 1
@@ -2865,12 +3130,16 @@ module mpas_io
                count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, intArray2d)
             end if
+#endif
          end if
       else if (present(intArray3d)) then
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray3d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start4(1) = 1
                start4(2) = 1
@@ -2888,12 +3157,16 @@ module mpas_io
                count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, intArray3d)
             end if
+#endif
          end if
       else if (present(intArray4d)) then
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray4d, pio_ierr)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start5(1) = 1
                start5(2) = 1
@@ -2914,12 +3187,15 @@ module mpas_io
                count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, intArray4d)
             end if
+#endif
          end if
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
    end subroutine MPAS_io_put_var_generic
 
@@ -3225,10 +3501,13 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -3244,6 +3523,7 @@ module mpas_io
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3366,10 +3646,13 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -3393,6 +3676,7 @@ module mpas_io
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3518,7 +3802,9 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       if (present(precision)) then
@@ -3528,45 +3814,55 @@ module mpas_io
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       if ((local_precision == MPAS_IO_SINGLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
 
+#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_REAL) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, singleVal)
+#endif
          attValue = real(singleVal,RKIND)
 
       else if ((local_precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
 
+#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_DOUBLE) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, doubleVal)
+#endif
          attValue = real(doubleVal,RKIND)
 
       else
 
+#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_DOUBLE .and. xtype /= PIO_REAL) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
+#endif
 
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3694,7 +3990,9 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       if (present(precision)) then
@@ -3704,6 +4002,7 @@ module mpas_io
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -3756,6 +4055,7 @@ module mpas_io
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3878,10 +4178,13 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -3897,6 +4200,7 @@ module mpas_io
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -4050,7 +4354,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4073,11 +4379,13 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4207,7 +4515,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4230,11 +4540,13 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       deallocate(attValueLocal)
 
@@ -4364,7 +4676,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4390,19 +4704,27 @@ module mpas_io
       if ((new_attlist_node % attHandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
          singleVal = real(attValueLocal,R4KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, singleVal) 
+#endif
       else if ((new_attlist_node % attHandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
          doubleVal = real(attValueLocal,R8KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, doubleVal) 
+#endif
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
+#endif
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4541,7 +4863,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4568,21 +4892,29 @@ module mpas_io
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
          allocate(singleVal(size(attValueLocal)))
          singleVal(:) = real(attValueLocal(:),R4KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, singleVal) 
+#endif
          deallocate(singleVal)
       else if ((new_attlist_node % attHandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
          allocate(doubleVal(size(attValueLocal)))
          doubleVal(:) = real(attValueLocal(:),R8KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, doubleVal) 
+#endif
          deallocate(doubleVal)
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
+#endif
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
+#endif
 
       deallocate(attValueLocal)
 
@@ -4714,7 +5046,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4737,6 +5071,7 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
 
@@ -4770,6 +5105,7 @@ module mpas_io
 
          return
       end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4823,7 +5159,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       call PIO_syncfile(handle % pio_file)
+#endif
 
    end subroutine MPAS_io_sync
 
@@ -4896,7 +5234,9 @@ module mpas_io
 
 !call mpas_log_write('MGD PIO_closefile')
       if (.not. handle % external_file_desc) then
+#ifdef MPAS_PIO_SUPPORT
          call PIO_closefile(handle % pio_file)
+#endif
       end if
 
    end subroutine MPAS_io_close
@@ -4924,7 +5264,9 @@ module mpas_io
 !if (.not. associated(decomp_del % decomphandle)) call mpas_log_write('OOPS... do not have decomphandle')
          deallocate(decomp_del % decomphandle % dims)
          deallocate(decomp_del % decomphandle % indices)
+#ifdef MPAS_PIO_SUPPORT
          call PIO_freedecomp(ioContext % pio_iosystem, decomp_del % decomphandle % pio_iodesc)
+#endif
          deallocate(decomp_del % decomphandle)
          deallocate(decomp_del)
       end do
@@ -4932,12 +5274,14 @@ module mpas_io
 !call mpas_log_write('MGD PIO_finalize')
       if (present(finalize_iosystem)) then
          if ( finalize_iosystem ) then
+#ifdef MPAS_PIO_SUPPORT
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
               return
            end if
            deallocate(ioContext % pio_iosystem)
+#endif
          end if
       end if
 

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -25,6 +25,12 @@ module mpas_io
 #endif
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+   use SMIOLf
+
+#include "smiol_codes.inc"
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
 
    !
@@ -54,12 +60,25 @@ module mpas_io
 
 #else
 
+#ifdef MPAS_SMIOL_SUPPORT
+
+   !
+   ! SMIOL-based fill values
+   !
+   integer, parameter :: MPAS_INT_FILLVAL = huge(0)
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = huge(0.0_RKIND)
+
+#else
+
    !
    ! Default fill values
    !
    integer, parameter :: MPAS_INT_FILLVAL = huge(1)
    character, parameter :: MPAS_CHAR_FILLVAL = achar(0)
    real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = huge(1.0_RKIND)
+
+#endif
 
 #endif
 
@@ -174,6 +193,22 @@ module mpas_io
                        PIO_rearr_box,             &     ! rearr
                        ioContext % pio_iosystem)           ! iosystem
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         allocate(ioContext % smiol_context)
+         local_ierr = SMIOLf_init(ioContext % dminfo % comm, &
+                                  io_task_count, &
+                                  io_task_stride, &
+                                  iocontext % smiol_context)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_init failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_CRIT)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_CRIT)
+            end if
+         end if
+#endif
   
       end if
 
@@ -259,8 +294,12 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr, pio_iotype, pio_mode
+      integer :: local_ierr
       logical :: local_clobber, local_truncate
       logical :: exists
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: preexisting_records
+#endif
 
 !      call mpas_log_write('Called MPAS_io_open()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -349,10 +388,18 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_write)
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                             SMIOL_FILE_WRITE, MPAS_io_open % smiol_file)
+#endif
                MPAS_io_open % preexisting_file = .true.
             else
 #ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_createfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), pio_mode)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                             SMIOL_FILE_CREATE, MPAS_io_open % smiol_file)
 #endif
 #ifdef MPAS_DEBUG
                if (exists) then
@@ -371,11 +418,25 @@ module mpas_io
 !call mpas_log_write('MGD PIO_openfile')
             pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                          SMIOL_FILE_READ, MPAS_io_open % smiol_file)
+#endif
          endif
 #ifdef MPAS_PIO_SUPPORT
          if (pio_ierr /= PIO_noerr) then
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
+         end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_open_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
          end if
 #endif
          MPAS_io_open % external_file_desc = .false.
@@ -392,21 +453,26 @@ module mpas_io
          end if
 #endif
 
+#ifdef MPAS_PIO_SUPPORT
          ! Here we're depending on the undocumented behavior of PIO to return a
          ! negative dimension ID when an unlimited dimension is not found.  This
          ! might change in the future, causing this code to break, though it
          ! shouldn't break for files with unlimited dimensions.
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
-#ifdef MPAS_PIO_SUPPORT
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                return
             end if
-#endif
          else
             MPAS_io_open % preexisting_records = -1
          end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+!MGD TODO: need a way to determine which dimension is the unlimited dimension
+         local_ierr = SMIOLf_inquire_dim(MPAS_io_open % smiol_file, 'Time', dimsize=preexisting_records)
+         MPAS_io_open % preexisting_records = preexisting_records
+#endif
       end if
 
       MPAS_io_open % initialized = .true.
@@ -448,6 +514,11 @@ module mpas_io
       end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+!MGD TODO: Do this for SMIOL once we have a way to inquire about unlimited dim by name
+      dimname = 'Time'
+#endif
+
    end subroutine MPAS_io_inq_unlimited_dim
 
 
@@ -463,6 +534,10 @@ module mpas_io
       type (dimlist_type), pointer :: new_dimlist_node
       type (dimlist_type), pointer :: dim_cursor
       integer :: pio_ierr
+      integer :: local_ierr
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: local_dimsize
+#endif
 
 !      call mpas_log_write('Called MPAS_io_inq_dim()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -517,6 +592,20 @@ module mpas_io
          return
       end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_inquire_dim(handle % smiol_file, trim(dimname), &
+                                      dimsize=local_dimsize, &
+                                      is_unlimited=new_dimlist_node % dimhandle % is_unlimited_dim)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (present(ierr)) ierr = MPAS_IO_ERR_MISSING_DIM
+         deallocate(new_dimlist_node % dimhandle)
+         deallocate(new_dimlist_node)
+         dimsize = -1
+         return
+      end if
+      new_dimlist_node % dimhandle % dimsize = local_dimsize
+#endif
    
       ! Keep dimension information for future reference
       if (.not. associated(handle % dimlist_head)) then
@@ -544,7 +633,11 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: inq_dimsize
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: local_dimsize
+#endif
       type (dimlist_type), pointer :: new_dimlist_node
       type (dimlist_type), pointer :: dim_cursor
 
@@ -626,11 +719,28 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), PIO_unlimited, new_dimlist_node % dimhandle % dimid)
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_dimsize = -1_SMIOL_offset_kind
+#endif
       else
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_dimsize = int(dimsize,kind=SMIOL_offset_kind)
+#endif
       end if
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_define_dim(handle % smiol_file, trim(dimname), local_dimsize)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_dim failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
@@ -677,6 +787,13 @@ module mpas_io
       integer, dimension(:), pointer :: dimids
       logical :: found
       integer :: pio_ierr
+      integer :: local_ierr
+      integer :: smiol_type
+      integer :: smiol_ndims
+      character(len=StrKind), dimension(:), allocatable :: smiol_dimnames
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: smiol_dimlen
+#endif
 
 
 !      call mpas_log_write('Called MPAS_io_inq_var()')
@@ -753,6 +870,32 @@ module mpas_io
          end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), vartype=smiol_type)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            deallocate(new_fieldlist_node % fieldhandle)
+            deallocate(new_fieldlist_node)
+            call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
+            return
+         end if
+         new_fieldlist_node % fieldhandle % field_type = smiol_type
+
+         ! Convert to MPAS type
+         new_fieldlist_node % fieldhandle % precision = MPAS_IO_NATIVE_PRECISION
+         if (new_fieldlist_node % fieldhandle % field_type == SMIOL_REAL64) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_DOUBLE
+            new_fieldlist_node % fieldhandle % precision = MPAS_IO_DOUBLE_PRECISION
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_REAL32) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_REAL
+            new_fieldlist_node % fieldhandle % precision = MPAS_IO_SINGLE_PRECISION
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_INT32) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_INT
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_CHAR) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_CHAR
+         end if
+#endif
+
          ! Get number of dimensions
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
@@ -763,6 +906,26 @@ module mpas_io
             return
          end if
 !call mpas_log_write('Inquired about number of dimensions $i', intArgs=(/new_fieldlist_node % fieldhandle % ndims/) )
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), ndims=smiol_ndims)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_inquire_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+
+            deallocate(new_fieldlist_node % fieldhandle)
+            deallocate(new_fieldlist_node)
+            call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
+            return
+         end if
+         new_fieldlist_node% fieldhandle % ndims = smiol_ndims
 #endif
 
          allocate(dimids(new_fieldlist_node % fieldhandle % ndims))
@@ -814,6 +977,41 @@ module mpas_io
 !call mpas_log_write('Inquired about dimension name ' // trim(new_fieldlist_node % fieldhandle % dims(i) % dimname))
 
          end do
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         new_fieldlist_node % fieldhandle % has_unlimited_dim = .false.
+         allocate(smiol_dimnames(smiol_ndims))
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), dimnames=smiol_dimnames)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_inquire_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+         end if
+         do i=1,new_fieldlist_node % fieldhandle % ndims
+            new_fieldlist_node % fieldhandle % dims(i) % dimname = smiol_dimnames(i)
+         end do
+         do i=1,new_fieldlist_node % fieldhandle % ndims
+            local_ierr = SMIOLf_inquire_dim(handle % smiol_file, trim(smiol_dimnames(i)), &
+                                            dimsize=smiol_dimlen, &
+                                            is_unlimited=new_fieldlist_node % fieldhandle % dims(i) % is_unlimited_dim)
+            if (local_ierr /= SMIOL_SUCCESS) then
+               call mpas_log_write('SMIOLf_inquire_dim failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+               if (local_ierr == SMIOL_LIBRARY_ERROR) then
+                  call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+               else
+                  call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+               end if
+            end if
+            new_fieldlist_node % fieldhandle % dims(i) % dimsize = smiol_dimlen
+            if (new_fieldlist_node % fieldhandle % dims(i) % is_unlimited_dim) then
+               new_fieldlist_node % fieldhandle % has_unlimited_dim = .true.
+            end if
+         end do
+         deallocate(smiol_dimnames)
 #endif
 
          deallocate(dimids)
@@ -902,7 +1100,9 @@ module mpas_io
 
       integer :: i
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: pio_type
+      integer :: smiol_type
       integer :: ndims
       integer :: inq_fieldtype
       integer :: inq_ndims
@@ -1057,10 +1257,16 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL32
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_REAL
          else
 #ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL64
 #endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_REAL) then
@@ -1068,19 +1274,31 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL64
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_DOUBLE
          else
 #ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL32
 #endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_INT) then
 #ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_int
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+         smiol_type = SMIOL_INT32
+#endif
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_CHAR) then
 #ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_char
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         smiol_type = SMIOL_CHAR
 #endif
 !!!!!!!! PIO DOES NOT SUPPORT LOGICAL !!!!!!!!
       end if
@@ -1094,6 +1312,17 @@ module mpas_io
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
+      end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_define_var(handle % smiol_file, trim(fieldname), smiol_type, size(dimnames), dimnames)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
       end if
 #endif
 
@@ -1192,6 +1421,11 @@ module mpas_io
       integer, dimension(:), pointer :: dimlist
       integer (kind=MPAS_IO_OFFSET_KIND), dimension(:), pointer :: compdof
       type (decomplist_type), pointer :: decomp_cursor, new_decomp
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind), dimension(:), pointer :: smiol_indices
+      integer :: local_ierr
+      integer(kind=SMIOL_offset_kind) :: smiol_n_compute_elements
+#endif
 
 !      call mpas_log_write('Called MPAS_io_set_var_indices()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1425,6 +1659,23 @@ module mpas_io
       deallocate(dimlist)
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      allocate(smiol_indices(size(indices)))
+      smiol_indices(:) = int(indices(:), kind=SMIOL_offset_kind) - 1_SMIOL_offset_kind   ! SMIOL indices are 0-based
+      smiol_n_compute_elements = size(indices,kind=SMIOL_offset_kind)
+      local_ierr = SMIOLf_create_decomp(handle % ioContext % smiol_context, smiol_n_compute_elements, smiol_indices, &
+                                        new_decomp % decomphandle % smiol_decomp)
+      deallocate(smiol_indices)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_create_decomp failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
+
       ! Add new decomposition to the list
       if (.not. associated(handle % ioContext % decomp_list)) then
          handle % ioContext % decomp_list => new_decomp
@@ -1451,22 +1702,23 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       character (len=*), intent(in) :: fieldname
-      integer, intent(out), optional :: intVal
-      integer, dimension(:), intent(out), optional :: intArray1d
-      integer, dimension(:,:), intent(out), optional :: intArray2d
-      integer, dimension(:,:,:), intent(out), optional :: intArray3d
-      integer, dimension(:,:,:,:), intent(out), optional :: intArray4d
-      real (kind=RKIND), intent(out), optional :: realVal
-      real (kind=RKIND), dimension(:), intent(out), optional :: realArray1d
-      real (kind=RKIND), dimension(:,:), intent(out), optional :: realArray2d
-      real (kind=RKIND), dimension(:,:,:), intent(out), optional :: realArray3d
-      real (kind=RKIND), dimension(:,:,:,:), intent(out), optional :: realArray4d
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(out), optional :: realArray5d
-      character (len=*), intent(out), optional :: charVal
-      character (len=*), dimension(:), intent(out), optional :: charArray1d
+      integer, intent(out), target, optional :: intVal
+      integer, dimension(:), intent(out), target, optional :: intArray1d
+      integer, dimension(:,:), intent(out), target, optional :: intArray2d
+      integer, dimension(:,:,:), intent(out), target, optional :: intArray3d
+      integer, dimension(:,:,:,:), intent(out), target, optional :: intArray4d
+      real (kind=RKIND), intent(out), target, optional :: realVal
+      real (kind=RKIND), dimension(:), intent(out), target, optional :: realArray1d
+      real (kind=RKIND), dimension(:,:), intent(out), target, optional :: realArray2d
+      real (kind=RKIND), dimension(:,:,:), intent(out), target, optional :: realArray3d
+      real (kind=RKIND), dimension(:,:,:,:), intent(out), target, optional :: realArray4d
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(out), target, optional :: realArray5d
+      character (len=*), intent(out), target, optional :: charVal
+      character (len=*), dimension(:), intent(out), target, optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer, dimension(1) :: start1
       integer, dimension(1) :: count1
       integer, dimension(2) :: start2
@@ -1484,19 +1736,44 @@ module mpas_io
 
       integer i, j
 
-      real (kind=R4KIND) :: singleVal
-      real (kind=R4KIND), dimension(:), allocatable :: singleArray1d
-      real (kind=R4KIND), dimension(:,:), allocatable :: singleArray2d
-      real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
-      real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
-      real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+      real (kind=R4KIND), pointer :: singleVal
+      real (kind=R4KIND), target :: singleVal_target
+      real (kind=R4KIND), dimension(:), pointer :: singleArray1d
+      real (kind=R4KIND), dimension(:,:), pointer :: singleArray2d
+      real (kind=R4KIND), dimension(:,:,:), pointer :: singleArray3d
+      real (kind=R4KIND), dimension(:,:,:,:), pointer :: singleArray4d
+      real (kind=R4KIND), dimension(:,:,:,:,:), pointer :: singleArray5d
 
-      real (kind=R8KIND) :: doubleVal
-      real (kind=R8KIND), dimension(:), allocatable :: doubleArray1d
-      real (kind=R8KIND), dimension(:,:), allocatable :: doubleArray2d
-      real (kind=R8KIND), dimension(:,:,:), allocatable :: doubleArray3d
-      real (kind=R8KIND), dimension(:,:,:,:), allocatable :: doubleArray4d
-      real (kind=R8KIND), dimension(:,:,:,:,:), allocatable :: doubleArray5d
+      real (kind=R8KIND), pointer :: doubleVal
+      real (kind=R8KIND), target :: doubleVal_target
+      real (kind=R8KIND), dimension(:), pointer :: doubleArray1d
+      real (kind=R8KIND), dimension(:,:), pointer :: doubleArray2d
+      real (kind=R8KIND), dimension(:,:,:), pointer :: doubleArray3d
+      real (kind=R8KIND), dimension(:,:,:,:), pointer :: doubleArray4d
+      real (kind=R8KIND), dimension(:,:,:,:,:), pointer :: doubleArray5d
+
+      integer, pointer :: intVal_p
+      integer, dimension(:), pointer :: intArray1d_p
+      integer, dimension(:,:), pointer :: intArray2d_p
+      integer, dimension(:,:,:), pointer :: intArray3d_p
+      integer, dimension(:,:,:,:), pointer :: intArray4d_p
+      real (kind=RKIND), pointer :: realVal_p
+      real (kind=RKIND), dimension(:), pointer :: realArray1d_p
+      real (kind=RKIND), dimension(:,:), pointer :: realArray2d_p
+      real (kind=RKIND), dimension(:,:,:), pointer :: realArray3d_p
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: realArray4d_p
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: realArray5d_p
+      character (len=:), pointer :: charVal_p
+      character (len=:), dimension(:), pointer :: charArray1d_p
+
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: null_decomp
+
+      nullify(null_decomp)
+#endif
+
+      singleVal => singleVal_target
+      doubleVal => doubleVal_target
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -1533,6 +1810,19 @@ module mpas_io
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
 #endif
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_set_frame(handle % smiol_file, int(handle % frame_number - 1, kind=SMIOL_offset_kind))
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_set_frame failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+         end if
+#endif
+
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -1546,6 +1836,11 @@ module mpas_io
 !         call mpas_log_write('  value is real')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleVal)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, singleVal)
@@ -1557,6 +1852,11 @@ module mpas_io
             realVal = real(singleVal,RKIND)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleVal)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, doubleVal)
@@ -1567,6 +1867,11 @@ module mpas_io
 
             realVal = real(doubleVal,RKIND)
          else
+            realVal_p => realVal
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realVal_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, realVal)
@@ -1577,6 +1882,12 @@ module mpas_io
          end if
       else if (present(intVal)) then
 !         call mpas_log_write('  value is int')
+
+         intVal_p => intVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intVal_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, intVal)
@@ -1586,6 +1897,12 @@ module mpas_io
 #endif
       else if (present(charVal)) then
 !         call mpas_log_write('  value is char')
+
+         charVal_p => charVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, charVal_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
@@ -1645,17 +1962,31 @@ module mpas_io
             end do
          end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         call mpas_log_write('1-d char variables not yet implemented in SMIOL: '//trim(fieldname), messageType=MPAS_LOG_ERR)
+#endif
+
       else if (present(realArray1d)) then
 !         call mpas_log_write('  value is real1')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray1d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray1d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray1d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
@@ -1676,11 +2007,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray1d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray1d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray1d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
@@ -1698,12 +2038,22 @@ module mpas_io
             realArray1d(:) = real(doubleArray1d(:),RKIND)
             deallocate(doubleArray1d)
          else
+            realArray1d_p => realArray1d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray1d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray1d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray1d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
@@ -1725,11 +2075,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray2d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray2d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray2d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
@@ -1752,11 +2111,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray2d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray2d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray2d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
@@ -1776,12 +2144,22 @@ module mpas_io
             realArray2d(:,:) = real(doubleArray2d(:,:),RKIND)
             deallocate(doubleArray2d)
          else
+            realArray2d_p => realArray2d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray2d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray2d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray2d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
@@ -1805,11 +2183,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray3d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray3d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray3d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
@@ -1834,11 +2221,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray3d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray3d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray3d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
@@ -1860,12 +2256,22 @@ module mpas_io
             realArray3d(:,:,:) = real(doubleArray3d(:,:,:),RKIND)
             deallocate(doubleArray3d)
          else
+            realArray3d_p => realArray3d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray3d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray3d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray3d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
@@ -1891,11 +2297,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray4d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray4d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray4d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
@@ -1922,11 +2337,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray4d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray4d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray4d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
@@ -1950,12 +2374,22 @@ module mpas_io
             realArray4d(:,:,:,:) = real(doubleArray4d(:,:,:,:),RKIND)
             deallocate(doubleArray4d)
          else
+            realArray4d_p => realArray4d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray4d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray4d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray4d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
@@ -1983,11 +2417,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray5d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    singleArray5d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray5d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
@@ -2016,11 +2459,20 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray5d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    doubleArray5d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray5d)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
@@ -2046,12 +2498,22 @@ module mpas_io
             realArray5d(:,:,:,:,:) = real(doubleArray5d(:,:,:,:,:),RKIND)
             deallocate(doubleArray5d)
          else
+            realArray5d_p => realArray5d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray5d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    realArray5d, pio_ierr)
 #endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray5d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
@@ -2077,12 +2539,22 @@ module mpas_io
          end if
       else if (present(intArray1d)) then
 !         call mpas_log_write('  value is int1')
+         intArray1d_p => intArray1d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray1d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray1d, pio_ierr)
 #endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray1d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start2(1) = 1
@@ -2099,12 +2571,22 @@ module mpas_io
          end if
       else if (present(intArray2d)) then
 !         call mpas_log_write('  value is int2')
+         intArray2d_p => intArray2d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray2d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray2d, pio_ierr)
 #endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray2d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start3(:) = 1
@@ -2123,12 +2605,22 @@ module mpas_io
          end if
       else if (present(intArray3d)) then
 !         call mpas_log_write('  value is int3')
+         intArray3d_p => intArray3d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray3d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray3d, pio_ierr)
 #endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray3d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start4(:) = 1
@@ -2149,12 +2641,22 @@ module mpas_io
          end if
       else if (present(intArray4d)) then
 !         call mpas_log_write('  value is int4')
+         intArray4d_p => intArray4d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray4d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray4d, pio_ierr)
 #endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray4d_p)
+#endif
+
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start5(:) = 1
@@ -2182,6 +2684,17 @@ module mpas_io
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
+      end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_get_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
       end if
 #endif
 
@@ -2453,22 +2966,23 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       character (len=*), intent(in) :: fieldname
-      integer, intent(in), optional :: intVal
-      integer, dimension(:), intent(in), optional :: intArray1d
-      integer, dimension(:,:), intent(in), optional :: intArray2d
-      integer, dimension(:,:,:), intent(in), optional :: intArray3d
-      integer, dimension(:,:,:,:), intent(in), optional :: intArray4d
-      real (kind=RKIND), intent(in), optional :: realVal
-      real (kind=RKIND), dimension(:), intent(in), optional :: realArray1d
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: realArray2d
-      real (kind=RKIND), dimension(:,:,:), intent(in), optional :: realArray3d
-      real (kind=RKIND), dimension(:,:,:,:), intent(in), optional :: realArray4d
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(in), optional :: realArray5d
-      character (len=*), intent(in), optional :: charVal
-      character (len=*), dimension(:), intent(in), optional :: charArray1d
+      integer, intent(in), target, optional :: intVal
+      integer, dimension(:), intent(in), target, optional :: intArray1d
+      integer, dimension(:,:), intent(in), target, optional :: intArray2d
+      integer, dimension(:,:,:), intent(in), target, optional :: intArray3d
+      integer, dimension(:,:,:,:), intent(in), target, optional :: intArray4d
+      real (kind=RKIND), intent(in), target, optional :: realVal
+      real (kind=RKIND), dimension(:), intent(in), target, optional :: realArray1d
+      real (kind=RKIND), dimension(:,:), intent(in), target, optional :: realArray2d
+      real (kind=RKIND), dimension(:,:,:), intent(in), target, optional :: realArray3d
+      real (kind=RKIND), dimension(:,:,:,:), intent(in), target, optional :: realArray4d
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(in), target, optional :: realArray5d
+      character (len=*), intent(in), target, optional :: charVal
+      character (len=*), dimension(:), intent(in), target, optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer, dimension(1) :: start1
       integer, dimension(1) :: count1
       integer, dimension(2) :: start2
@@ -2485,19 +2999,44 @@ module mpas_io
 
       integer :: i
 
-      real (kind=R4KIND) :: singleVal
-      real (kind=R4KIND), dimension(:), allocatable :: singleArray1d
-      real (kind=R4KIND), dimension(:,:), allocatable :: singleArray2d
-      real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
-      real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
-      real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+      real (kind=R4KIND), target :: singleVal_target
+      real (kind=R4KIND), pointer :: singleVal
+      real (kind=R4KIND), dimension(:), pointer :: singleArray1d
+      real (kind=R4KIND), dimension(:,:), pointer :: singleArray2d
+      real (kind=R4KIND), dimension(:,:,:), pointer :: singleArray3d
+      real (kind=R4KIND), dimension(:,:,:,:), pointer :: singleArray4d
+      real (kind=R4KIND), dimension(:,:,:,:,:), pointer :: singleArray5d
 
-      real (kind=R8KIND) :: doubleVal
-      real (kind=R8KIND), dimension(:), allocatable :: doubleArray1d
-      real (kind=R8KIND), dimension(:,:), allocatable :: doubleArray2d
-      real (kind=R8KIND), dimension(:,:,:), allocatable :: doubleArray3d
-      real (kind=R8KIND), dimension(:,:,:,:), allocatable :: doubleArray4d
-      real (kind=R8KIND), dimension(:,:,:,:,:), allocatable :: doubleArray5d
+      real (kind=R8KIND), target :: doubleVal_target
+      real (kind=R8KIND), pointer :: doubleVal
+      real (kind=R8KIND), dimension(:), pointer :: doubleArray1d
+      real (kind=R8KIND), dimension(:,:), pointer :: doubleArray2d
+      real (kind=R8KIND), dimension(:,:,:), pointer :: doubleArray3d
+      real (kind=R8KIND), dimension(:,:,:,:), pointer :: doubleArray4d
+      real (kind=R8KIND), dimension(:,:,:,:,:), pointer :: doubleArray5d
+
+      integer, pointer :: intVal_p
+      integer, dimension(:), pointer :: intArray1d_p
+      integer, dimension(:,:), pointer :: intArray2d_p
+      integer, dimension(:,:,:), pointer :: intArray3d_p
+      integer, dimension(:,:,:,:), pointer :: intArray4d_p
+      real (kind=RKIND), pointer :: realVal_p
+      real (kind=RKIND), dimension(:), pointer :: realArray1d_p
+      real (kind=RKIND), dimension(:,:), pointer :: realArray2d_p
+      real (kind=RKIND), dimension(:,:,:), pointer :: realArray3d_p
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: realArray4d_p
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: realArray5d_p
+      character (len=:), pointer :: charVal_p
+      character (len=:), dimension(:), pointer :: charArray1d_p
+
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: null_decomp
+
+      nullify(null_decomp)
+#endif
+
+      singleVal => singleVal_target
+      doubleVal => doubleVal_target
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -2548,6 +3087,19 @@ module mpas_io
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
 #endif
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_set_frame(handle % smiol_file, int(handle % frame_number - 1, kind=SMIOL_offset_kind))
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_set_frame failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+         end if
+#endif
+
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -2570,6 +3122,10 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, singleVal)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleVal)
+#endif
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             doubleVal = real(realVal,R8KIND)
@@ -2580,6 +3136,10 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, doubleVal)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleVal)
+#endif
          else
 #ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
@@ -2587,6 +3147,11 @@ module mpas_io
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, realVal)
             end if
+#endif
+
+            realVal_p => realVal
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realVal_p)
 #endif
          end if
       else if (present(intVal)) then
@@ -2596,6 +3161,11 @@ module mpas_io
          else
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, intVal)
          end if
+#endif
+
+         intVal_p => intVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intVal_p)
 #endif
       else if (present(charVal)) then
 #ifdef MPAS_PIO_SUPPORT
@@ -2607,6 +3177,11 @@ module mpas_io
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, charVal(1:count1(1)))
          end if
+#endif
+
+         charVal_p => charVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, charVal_p)
 #endif
       else if (present(charArray1d)) then
 #ifdef MPAS_PIO_SUPPORT
@@ -2632,6 +3207,9 @@ module mpas_io
             end do
          end if
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+         call mpas_log_write('1-d char variables not yet implemented in SMIOL: '//trim(fieldname), messageType=MPAS_LOG_ERR)
+#endif
       else if (present(realArray1d)) then
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
@@ -2641,6 +3219,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray1d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2656,6 +3239,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, singleArray1d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray1d)
+#endif
             end if
             deallocate(singleArray1d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2666,6 +3253,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray1d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2681,13 +3273,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, doubleArray1d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray1d)
+#endif
             end if
             deallocate(doubleArray1d)
          else
+            realArray1d_p => realArray1d
             if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray1d_p)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2703,6 +3305,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, realArray1d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray1d_p)
+#endif
             end if
          end if
       else if (present(realArray2d)) then
@@ -2714,6 +3320,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray2d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2732,6 +3343,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, singleArray2d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray2d)
+#endif
             end if
             deallocate(singleArray2d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2742,6 +3357,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray2d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2760,13 +3380,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, doubleArray2d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray2d)
+#endif
             end if
             deallocate(doubleArray2d)
          else
+            realArray2d_p => realArray2d
             if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray2d_p)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2785,6 +3415,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, realArray2d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray2d_p)
+#endif
             end if
          end if
       else if (present(realArray3d)) then
@@ -2796,6 +3430,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray3d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2817,6 +3456,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, singleArray3d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray3d)
+#endif
             end if
             deallocate(singleArray3d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2827,6 +3470,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray3d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2848,13 +3496,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, doubleArray3d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray3d)
+#endif
             end if
             deallocate(doubleArray3d)
          else
+            realArray3d_p => realArray3d
             if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray3d_p)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2876,6 +3534,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, realArray3d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray3d_p)
+#endif
             end if
          end if
       else if (present(realArray4d)) then
@@ -2887,6 +3549,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray4d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2911,6 +3578,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, singleArray4d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray4d)
+#endif
             end if
             deallocate(singleArray4d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2921,6 +3592,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray4d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2945,13 +3621,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, doubleArray4d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray4d)
+#endif
             end if
             deallocate(doubleArray4d)
          else
+            realArray4d_p => realArray4d
             if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray4d_p)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -2976,6 +3662,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, realArray4d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray4d_p)
+#endif
             end if
          end if
       else if (present(realArray5d)) then
@@ -2987,6 +3677,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray5d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -3014,6 +3709,10 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, singleArray5d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray5d)
+#endif
             end if
             deallocate(singleArray5d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -3024,6 +3723,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray5d)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -3051,13 +3755,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, doubleArray5d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray5d)
+#endif
             end if
             deallocate(doubleArray5d)
          else
+            realArray5d_p => realArray5d
             if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray5d_p)
 #endif
             else
 #ifdef MPAS_PIO_SUPPORT
@@ -3085,13 +3799,23 @@ module mpas_io
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, realArray5d)
                end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray5d_p)
+#endif
             end if
          end if
       else if (present(intArray1d)) then
+         intArray1d_p => intArray1d
          if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray1d_p)
 #endif
          else
 #ifdef MPAS_PIO_SUPPORT
@@ -3107,12 +3831,22 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, intArray1d)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray1d_p)
+#endif
          end if
       else if (present(intArray2d)) then
+         intArray2d_p => intArray2d
          if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray2d_p)
 #endif
          else
 #ifdef MPAS_PIO_SUPPORT
@@ -3131,12 +3865,22 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, intArray2d)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray2d_p)
+#endif
          end if
       else if (present(intArray3d)) then
+         intArray3d_p => intArray3d
          if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray3d_p)
 #endif
          else
 #ifdef MPAS_PIO_SUPPORT
@@ -3158,12 +3902,22 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, intArray3d)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray3d_p)
+#endif
          end if
       else if (present(intArray4d)) then
+         intArray4d_p => intArray4d
          if (associated(field_cursor % fieldhandle % decomp)) then
 #ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray4d_p)
 #endif
          else
 #ifdef MPAS_PIO_SUPPORT
@@ -3188,12 +3942,26 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, intArray4d)
             end if
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray4d_p)
+#endif
          end if
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
+      end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_put_var failed with error $i : '//trim(fieldname), intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
       end if
 #endif
 
@@ -3432,6 +4200,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: xtype
 #ifdef USE_PIO2
@@ -3525,6 +4294,23 @@ module mpas_io
       end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+            return
+         else
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            return
+         end if
+      end if
+#endif
+
       ! Keep attribute for future reference
       allocate(new_att_node)
       nullify(new_att_node % next)
@@ -3594,6 +4380,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+     call mpas_log_write('1-d integer attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       !
       ! For variable attributes, find the structure for fieldname
@@ -3730,6 +4519,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: local_precision
       real (kind=R4KIND) :: singleVal
@@ -3832,6 +4622,15 @@ module mpas_io
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, singleVal)
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), singleVal)
+         else
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), singleVal)
+         end if
+#endif
+
          attValue = real(singleVal,RKIND)
 
       else if ((local_precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -3844,6 +4643,15 @@ module mpas_io
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, doubleVal)
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), doubleVal)
+         else
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), doubleVal)
+         end if
+#endif
+
          attValue = real(doubleVal,RKIND)
 
       else
@@ -3856,11 +4664,31 @@ module mpas_io
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
+         else
+            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
+         end if
+#endif
+
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
+      end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+            return
+         else
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            return
+         end if
       end if
 #endif
 
@@ -3938,6 +4766,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d real attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       !
       ! For variable attributes, find the structure for fieldname
@@ -4109,6 +4940,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: xtype
 #ifdef USE_PIO2
@@ -4202,6 +5034,23 @@ module mpas_io
       end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+            return
+         else
+            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            return
+         end if
+      end if
+#endif
+
       ! Keep attribute for future reference
       allocate(new_att_node)
       nullify(new_att_node % next)
@@ -4253,6 +5102,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
@@ -4387,6 +5237,22 @@ module mpas_io
       end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), attValueLocal)
+      else
+         local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), attValueLocal)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
+
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
    end subroutine MPAS_io_put_att_int0d
@@ -4429,6 +5295,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d integer attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       allocate(new_attlist_node) 
       nullify(new_attlist_node % next)
@@ -4568,6 +5437,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       real (kind=RKIND) :: attValueLocal
       real (kind=R4KIND) :: singleVal
@@ -4707,15 +5577,39 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, singleVal) 
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), singleVal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), singleVal)
+         end if
+#endif
       else if ((new_attlist_node % attHandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
          doubleVal = real(attValueLocal,R8KIND)
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, doubleVal) 
 #endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), doubleVal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), doubleVal)
+         end if
+#endif
       else
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), attValueLocal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), attValueLocal)
+         end if
 #endif
       end if
 
@@ -4723,6 +5617,16 @@ module mpas_io
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
+      end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
       end if
 #endif
 
@@ -4772,6 +5676,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d real attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       allocate(new_attlist_node) 
       nullify(new_attlist_node % next)
@@ -4935,6 +5842,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: valLen
       character (len=StrKind) :: attValueLocal, trimmedVal
@@ -5107,6 +6015,22 @@ module mpas_io
       end if
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), trim(attValueLocal))
+      else
+         local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), trim(attValueLocal))
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
+
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
    end subroutine MPAS_io_put_att_text
@@ -5150,6 +6074,8 @@ module mpas_io
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       integer, intent(out), optional :: ierr
 
+      integer :: local_ierr
+
 !      call mpas_log_write('Called MPAS_io_sync()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -5163,6 +6089,18 @@ module mpas_io
       call PIO_syncfile(handle % pio_file)
 #endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_sync_file(handle % smiol_file)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_sync_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
+
    end subroutine MPAS_io_sync
 
 
@@ -5172,6 +6110,8 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       integer, intent(out), optional :: ierr
+
+      integer :: local_ierr
 
       type (dimlist_type), pointer :: dimlist_ptr, dimlist_del
       type (fieldlist_type), pointer :: fieldlist_ptr, fieldlist_del
@@ -5238,6 +6178,17 @@ module mpas_io
          call PIO_closefile(handle % pio_file)
 #endif
       end if
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_close_file(handle % smiol_file)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_close_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+      end if
+#endif
 
    end subroutine MPAS_io_close
 
@@ -5251,6 +6202,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       type (decomplist_type), pointer :: decomp_cursor, decomp_del
 
 !      call mpas_log_write('Called MPAS_io_finalize()')
@@ -5267,6 +6219,12 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          call PIO_freedecomp(ioContext % pio_iosystem, decomp_del % decomphandle % pio_iodesc)
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_free_decomp(decomp_del % decomphandle % smiol_decomp)
+         if (local_ierr /= SMIOL_SUCCESS) then
+             call mpas_log_write('SMIOLf_free_decomp failed with code $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         end if
+#endif
          deallocate(decomp_del % decomphandle)
          deallocate(decomp_del)
       end do
@@ -5281,6 +6239,12 @@ module mpas_io
               return
            end if
            deallocate(ioContext % pio_iosystem)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_finalize(ioContext % smiol_context)
+            if (local_ierr /= SMIOL_SUCCESS) then
+               call mpas_log_write('SMIOLf_free_decomp failed with code $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            end if
 #endif
          end if
       end if

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -91,7 +91,11 @@ module mpas_io_streams
       logical, intent(in), optional :: clobberRecords
       logical, intent(in), optional :: clobberFiles
       logical, intent(in), optional :: truncateFiles
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, optional :: pio_file_desc
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: io_err

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -4,8 +4,14 @@
 #else
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET
 #endif
+
+#else
+
+#ifdef MPAS_SMIOL_SUPPORT
+   integer, parameter :: MPAS_IO_OFFSET_KIND = SMIOL_offset_kind
 #else
    integer, parameter :: MPAS_IO_OFFSET_KIND = I8KIND
+#endif
 #endif
 
    ! File access modes
@@ -69,6 +75,9 @@
 #ifdef MPAS_PIO_SUPPORT
       type (file_desc_t) :: pio_file
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_file), pointer :: smiol_file => null()
+#endif
       character (len=StrKIND) :: filename
       integer :: iomode
       integer :: ioformat
@@ -90,6 +99,9 @@
       integer, dimension(:), pointer :: indices
 #ifdef MPAS_PIO_SUPPORT
       type (io_desc_t) :: pio_iodesc
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: smiol_decomp => null()
 #endif
    end type decomphandle_type
 
@@ -151,6 +163,9 @@
       type (decomplist_type), pointer :: decomp_list => null()
 #ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), pointer :: pio_iosystem => null()
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_context), pointer :: smiol_context => null()
 #endif
       integer :: master_pio_iotype = -999
       type (dm_info), pointer :: dminfo => null()

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -1,7 +1,11 @@
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET_KIND
 #else
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET
+#endif
+#else
+   integer, parameter :: MPAS_IO_OFFSET_KIND = I8KIND
 #endif
 
    ! File access modes
@@ -62,7 +66,9 @@
       logical :: preexisting_file = .false.
       logical :: data_mode = .false.
       logical :: external_file_desc = .false.
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t) :: pio_file
+#endif
       character (len=StrKIND) :: filename
       integer :: iomode
       integer :: ioformat
@@ -82,7 +88,9 @@
       integer :: field_type
       integer, dimension(:), pointer :: dims
       integer, dimension(:), pointer :: indices
+#ifdef MPAS_PIO_SUPPORT
       type (io_desc_t) :: pio_iodesc
+#endif
    end type decomphandle_type
 
    type atthandle_type
@@ -106,7 +114,9 @@
    type fieldhandle_type
       character (len=StrKIND) :: fieldname
       integer :: fieldid
+#ifdef MPAS_PIO_SUPPORT
       type (Var_desc_t) :: field_desc
+#endif
       integer :: field_type
       logical :: has_unlimited_dim = .false.
       integer :: ndims
@@ -139,7 +149,9 @@
 
    type mpas_io_context_type
       type (decomplist_type), pointer :: decomp_list => null()
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), pointer :: pio_iosystem => null()
+#endif
       integer :: master_pio_iotype = -999
       type (dm_info), pointer :: dminfo => null()
    end type mpas_io_context_type


### PR DESCRIPTION
This PR introduces a new I/O layer into MPAS: the Simple MPAS I/O Layer (SMIOL).

SMIOL provides a subset of the parallel I/O functionality of PIO, but with a simplified design that minimizes external dependencies to just the Parallel-NetCDF library. All SMIOL code is included directly in the MPAS-Model source tree in `src/external/SMIOL`, and the use of SMIOL in place of PIO is activated at build time by *not* setting the `PIO` environment variable.

If MPAS the use of SMIOL was activated at build time (by *not* setting the `PIO` environment variable), the message
```
Using the SMIOL library.
```
will appear in the build summary (rather than `Using the PIO 2.x library.` or `Using the PIO 1.x library.`).

At present, all output files written by SMIOL are in 64-bit data (CDF-5) format, and so the `io_type` attribute in streams is effectively ignored.

Although a snapshot of the SMIOL code is included under `src/external/SMIOL` in this PR, SMIOL itself is developed in a separate repository (https://github.com/MPAS-Dev/SMIOL), and in future it may be possible to pull the SMIOL code directly from its repository into MPAS.