### PR TITLE
Initial implementation of the CCPP-compliant parameterization of the MM5 revised surface layer

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -72,6 +72,8 @@
 ! * modified logic in subroutine physics_tables_init so that the Thompson microphysics tables are read in each
 !   MPI task.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-12-30.
+! * added the option sf_monin_obukhov_rev to run the revised surface layer scheme with the YSU PBL scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
 
 
  contains
@@ -255,9 +257,10 @@
  endif
 
 !surface-layer scheme:
- if(.not. (config_sfclayer_scheme .eq. 'off'     .or. &
-           config_sfclayer_scheme .eq. 'sf_mynn' .or. &
-           config_sfclayer_scheme .eq. 'sf_monin_obukhov')) then
+ if(.not. (config_sfclayer_scheme .eq. 'off'              .or. &
+           config_sfclayer_scheme .eq. 'sf_mynn'          .or. &
+           config_sfclayer_scheme .eq. 'sf_monin_obukhov' .or. &
+           config_sfclayer_scheme .eq. 'sf_monin_obukhov_rev')) then
  
     write(mpas_err_message,'(A,A10)') 'illegal value for surface layer scheme: ', &
           trim(config_sfclayer_scheme)
@@ -266,7 +269,12 @@
     if(config_pbl_scheme == 'bl_mynn') then
        config_sfclayer_scheme = 'sf_mynn'
     elseif(config_pbl_scheme == 'bl_ysu') then
-       config_sfclayer_scheme = 'sf_monin_obukhov'
+       if(config_sfclayer_scheme /= 'sf_monin_obukhov' .and. &
+          config_sfclayer_scheme /= 'sf_monin_obukhov_rev') then
+          write(mpas_err_message,'(A,A10)') 'wrong choice for surface layer scheme with YSU PBL: ', &
+                trim(config_sfclayer_scheme)
+          call physics_error_fatal(mpas_err_message)
+       endif
     endif
  endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -200,9 +200,16 @@
           if(.not.allocated(fm_sea)) allocate(fm_sea(ims:ime,jms:jme))
        endif
 
-       if(.not.allocated(waterdepth_p)) allocate(waterdepth_p(ims:ime,jms:jme))
-       if(.not.allocated(lakedepth_p) ) allocate(lakedepth_p(ims:ime,jms:jme) )
-       if(.not.allocated(lakemask_p)  ) allocate(lakemask_p(ims:ime,jms:jme)  )
+       sfclayer2_select: select case(sfclayer_scheme)
+
+          case("sf_monin_obukhov_rev")
+             if(.not.allocated(waterdepth_p)) allocate(waterdepth_p(ims:ime,jms:jme))
+             if(.not.allocated(lakedepth_p) ) allocate(lakedepth_p(ims:ime,jms:jme) )
+             if(.not.allocated(lakemask_p)  ) allocate(lakemask_p(ims:ime,jms:jme)  )
+
+          case default
+
+       end select sfclayer2_select
 
     case("sf_mynn")
        if(.not.allocated(snowh_p)) allocate(snowh_p(ims:ime,jms:jme))
@@ -321,9 +328,16 @@
           if(allocated(fm_sea)) deallocate(fm_sea)
        endif
 
-       if(allocated(waterdepth_p)) deallocate(waterdepth_p)
-       if(allocated(lakedepth_p) ) deallocate(lakedepth_p )
-       if(allocated(lakemask_p)  ) deallocate(lakemask_p  )
+       sfclayer2_select: select case(sfclayer_scheme)
+
+          case("sf_monin_obukhov_rev")
+             if(allocated(waterdepth_p)) deallocate(waterdepth_p)
+             if(allocated(lakedepth_p) ) deallocate(lakedepth_p )
+             if(allocated(lakemask_p)  ) deallocate(lakemask_p  )
+
+          case default
+
+       end select sfclayer2_select
 
     case("sf_mynn")
        if(allocated(snowh_p)) deallocate(snowh_p)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -558,12 +558,24 @@
              fh_sea(i,j) = fh(i)
              fm_sea(i,j) = fm(i)
           endif
+       enddo
+       enddo
 
-          waterdepth_p(i,j) = 0._RKIND
-          lakedepth_p(i,j)  = 0._RKIND
-          lakemask_p(i,j)   = 0._RKIND
-       enddo
-       enddo
+       sfclayer2_select: select case(sfclayer_scheme)
+
+          case("sf_monin_obukhov_rev")
+
+             do j = jts,jte
+             do i = its,ite
+                waterdepth_p(i,j) = 0._RKIND
+                lakedepth_p(i,j)  = 0._RKIND
+                lakemask_p(i,j)   = 0._RKIND
+             enddo
+             enddo
+
+          case default
+
+       end select sfclayer2_select
 
     case("sf_mynn")
        !input variables:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_sfclayer.F
@@ -17,6 +17,8 @@
 !wrf physics:
  use module_sf_mynn
  use module_sf_sfclay
+ use module_sf_sfclayrev,only: sfclayrev
+ use sf_sfclayrev,only: sf_sfclayrev_init
 
  implicit none
  private
@@ -78,7 +80,13 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-18.
 ! * since we removed the local variable sfclayer_scheme from mpas_atmphys_vars.F, now defines sfclayer_scheme
 !   as a pointer to config_sfclayer_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * in subroutine driver_sfclayer, replaced the call to sfclay with a call to sfclayrev to use the revised
+!   version of the MONIN-OBUKHOV surface layer scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
+! * added the option sf_monin_obukhov_rev to run the revised surface layer scheme with the YSU PBL scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
+
 
 
  contains
@@ -184,13 +192,17 @@
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
-    case("sf_monin_obukhov")
+    case("sf_monin_obukhov","sf_monin_obukhov_rev")
        if(.not.allocated(fh_p)) allocate(fh_p(ims:ime,jms:jme))
        if(.not.allocated(fm_p)) allocate(fm_p(ims:ime,jms:jme))
        if(config_frac_seaice) then
           if(.not.allocated(fh_sea)) allocate(fh_sea(ims:ime,jms:jme))
           if(.not.allocated(fm_sea)) allocate(fm_sea(ims:ime,jms:jme))
        endif
+
+       if(.not.allocated(waterdepth_p)) allocate(waterdepth_p(ims:ime,jms:jme))
+       if(.not.allocated(lakedepth_p) ) allocate(lakedepth_p(ims:ime,jms:jme) )
+       if(.not.allocated(lakemask_p)  ) allocate(lakemask_p(ims:ime,jms:jme)  )
 
     case("sf_mynn")
        if(.not.allocated(snowh_p)) allocate(snowh_p(ims:ime,jms:jme))
@@ -301,13 +313,17 @@
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
-    case("sf_monin_obukhov")
+    case("sf_monin_obukhov","sf_monin_obukhov_rev")
        if(allocated(fh_p)) deallocate(fh_p)
        if(allocated(fm_p)) deallocate(fm_p)
        if(config_frac_seaice) then
           if(allocated(fh_sea)) deallocate(fh_sea)
           if(allocated(fm_sea)) deallocate(fm_sea)
        endif
+
+       if(allocated(waterdepth_p)) deallocate(waterdepth_p)
+       if(allocated(lakedepth_p) ) deallocate(lakedepth_p )
+       if(allocated(lakemask_p)  ) deallocate(lakemask_p  )
 
     case("sf_mynn")
        if(allocated(snowh_p)) deallocate(snowh_p)
@@ -516,7 +532,7 @@
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
-    case("sf_monin_obukhov")
+    case("sf_monin_obukhov","sf_monin_obukhov_rev")
        call mpas_pool_get_array(diag_physics,'fh',fh)
        call mpas_pool_get_array(diag_physics,'fm',fm)
 
@@ -528,6 +544,10 @@
              fh_sea(i,j) = fh(i)
              fm_sea(i,j) = fm(i)
           endif
+
+          waterdepth_p(i,j) = 0._RKIND
+          lakedepth_p(i,j)  = 0._RKIND
+          lakemask_p(i,j)   = 0._RKIND
        enddo
        enddo
 
@@ -733,7 +753,7 @@
 
  sfclayer_select: select case (trim(sfclayer_scheme))
 
-    case("sf_monin_obukhov")
+    case("sf_monin_obukhov","sf_monin_obukhov_rev")
        call mpas_pool_get_array(diag_physics,'fh',fh)
        call mpas_pool_get_array(diag_physics,'fm',fm)
 
@@ -791,7 +811,15 @@
  logical, parameter:: allowed_to_read = .false. !actually not used in subroutine sfclayinit.
  character(len=StrKIND),pointer:: sfclayer_scheme
 
+!CCPP-compliant flags:
+ character(len=StrKIND):: errmsg
+ integer:: errflg
+
 !-----------------------------------------------------------------------------------------------------------------
+
+!initialization of CCPP-compliant flags:
+ errmsg = ' '
+ errflg = 0
 
  call mpas_pool_get_config(configs,'config_sfclayer_scheme',sfclayer_scheme)
 
@@ -799,6 +827,9 @@
 
     case("sf_monin_obukhov")
        call sfclayinit(allowed_to_read)
+
+    case("sf_monin_obukhov_rev")
+       call sf_sfclayrev_init(errmsg,errflg)
 
     case("sf_mynn")
        call mynn_sf_init_driver(allowed_to_read)
@@ -833,9 +864,17 @@
  integer:: initflag
  real(kind=RKIND):: dx
 
+!CCPP-compliant flags:
+ character(len=StrKIND):: errmsg
+ integer:: errflg
+
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('')
 !call mpas_log_write('--- enter subroutine driver_sfclayer:')
+
+!initialization of CCPP-compliant flags:
+ errmsg = ' '
+ errflg = 0
 
  call mpas_pool_get_config(configs,'config_do_restart'     ,config_do_restart )
  call mpas_pool_get_config(configs,'config_frac_seaice'    ,config_frac_seaice)
@@ -854,12 +893,12 @@
  sfclayer_select: select case (trim(sfclayer_scheme))
 
     case("sf_monin_obukhov")
-       call mpas_timer_start('Monin-Obukhov')
+       call mpas_timer_start('sf_monin_obukhov')
        call sfclay( &
                    p3d      = pres_hyd_p , psfc     = psfc_p     , t3d      = t_p        , &
                    u3d      = u_p        , v3d      = v_p        , qv3d     = qv_p       , &
                    dz8w     = dz_p       , cp       = cp         , g        = gravity    , &
-                   rovcp    = rcp        , R        = R_d        , xlv      = xlv        , & 
+                   rovcp    = rcp        , R        = R_d        , xlv      = xlv        , &
                    chs      = chs_p      , chs2     = chs2_p     , cqs2     = cqs2_p     , &
                    cpm      = cpm_p      , znt      = znt_p      , ust      = ust_p      , &
                    pblh     = hpbl_p     , mavail   = mavail_p   , zol      = zol_p      , &
@@ -912,7 +951,76 @@
                       its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
                      )
        endif
-       call mpas_timer_stop('Monin-Obukhov')
+       call mpas_timer_stop('sf_monin_obukhov')
+
+    case("sf_monin_obukhov_rev")
+       call mpas_timer_start('sf_monin_obukhov_rev')
+       call mpas_log_write('--- enter subroutine sfclayrev:')
+       call sfclayrev( &
+               p3d         = pres_hyd_p   , psfc           = psfc_p         , t3d      = t_p                    , &
+               u3d         = u_p          , v3d            = v_p            , qv3d     = qv_p                   , &
+               dz8w        = dz_p         , cp             = cp             , g        = gravity                , &
+               rovcp       = rcp          , R              = R_d            , xlv      = xlv                    , &
+               chs         = chs_p        , chs2           = chs2_p         , cqs2     = cqs2_p                 , &
+               cpm         = cpm_p        , znt            = znt_p          , ust      = ust_p                  , &
+               pblh        = hpbl_p       , mavail         = mavail_p       , zol      = zol_p                  , &
+               mol         = mol_p        , regime         = regime_p       , psim     = psim_p                 , &
+               psih        = psih_p       , fm             = fm_p           , fh       = fh_p                   , &
+               xland       = xland_p      , hfx            = hfx_p          , qfx      = qfx_p                  , &
+               lh          = lh_p         , tsk            = tsk_p          , flhc     = flhc_p                 , &
+               flqc        = flqc_p       , qgh            = qgh_p          , qsfc     = qsfc_p                 , &
+               rmol        = rmol_p       , u10            = u10_p          , v10      = v10_p                  , &
+               th2         = th2m_p       , t2             = t2m_p          , q2       = q2_p                   , &
+               gz1oz0      = gz1oz0_p     , wspd           = wspd_p         , br       = br_p                   , &
+               isfflx      = isfflx       , dx             = dx_p           , svp1     = svp1                   , &
+               svp2        = svp2         , svp3           = svp3           , svpt0    = svpt0                  , &
+               ep1         = ep_1         , ep2            = ep_2           , karman   = karman                 , &
+               eomeg       = eomeg        , stbolt         = stbolt         , P1000mb  = P0                     , &
+               ustm        = ustm_p       , ck             = ck_p           , cka      = cka_p                  , &
+               cd          = cd_p         , cda            = cda_p          , isftcflx = isftcflx               , &
+               iz0tlnd     = iz0tlnd      , shalwater_z0   = shalwater_flag , shalwater_depth = shalwater_depth , &
+               water_depth = waterdepth_p , scm_force_flux = scm_force_flux                                     , &
+               errmsg      = errmsg       , errflg         = errflg                                             , &
+               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,                            &
+               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,                            &
+               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte                              &
+                     )
+       call mpas_log_write('--- end subroutine sfclayrev:')
+
+       if(config_frac_seaice) then
+          call mpas_log_write('--- enter subroutine sfclayrev seaice:')
+          call sfclayrev( &
+                  p3d         = pres_hyd_p   , psfc           = psfc_p         , t3d             = t_p             , &
+                  u3d         = u_p          , v3d            = v_p            , qv3d            = qv_p            , &
+                  dz8w        = dz_p         , cp             = cp             , g               = gravity         , &
+                  rovcp       = rcp          , R              = R_d            , xlv             = xlv             , &
+                  chs         = chs_sea      , chs2           = chs2_sea       , cqs2            = cqs2_sea        , &
+                  cpm         = cpm_sea      , znt            = znt_sea        , ust             = ust_sea         , &
+                  pblh        = hpbl_p       , mavail         = mavail_sea     , zol             = zol_sea         , &
+                  mol         = mol_sea      , regime         = regime_sea     , psim            = psim_sea        , &
+                  psih        = psih_sea     , fm             = fm_sea         , fh              = fh_sea          , &
+                  xland       = xland_sea    , hfx            = hfx_sea        , qfx             = qfx_sea         , &
+                  lh          = lh_sea       , tsk            = tsk_sea        , flhc            = flhc_sea        , &
+                  flqc        = flqc_sea     , qgh            = qgh_sea        , qsfc            = qsfc_sea        , &
+                  rmol        = rmol_sea     , u10            = u10_sea        , v10             = v10_sea         , &
+                  th2         = th2m_sea     , t2             = t2m_sea        , q2              = q2_sea          , &
+                  gz1oz0      = gz1oz0_sea   , wspd           = wspd_sea       , br              = br_sea          , &
+                  isfflx      = isfflx       , dx             = dx_p           , svp1            = svp1            , &
+                  svp2        = svp2         , svp3           = svp3           , svpt0           = svpt0           , &
+                  ep1         = ep_1         , ep2            = ep_2           , karman          = karman          , &
+                  eomeg       = eomeg        , stbolt         = stbolt         , P1000mb         = P0              , &
+                  ustm        = ustm_sea     , ck             = ck_sea         , cka             = cka_sea         , &
+                  cd          = cd_sea       , cda            = cda_sea        , isftcflx        = isftcflx        , &
+                  iz0tlnd     = iz0tlnd      , shalwater_z0   = shalwater_flag , shalwater_depth = shalwater_depth , &
+                  water_depth = waterdepth_p , scm_force_flux = scm_force_flux                                     , &
+                  errmsg      = errmsg       , errflg         = errflg                                             , &
+                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde , &
+                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme , &
+                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
+                        )
+          call mpas_log_write('--- end subroutine sfclayrev seaice:')
+       endif
+       call mpas_timer_stop('sf_monin_obukhov_rev')
 
     case("sf_mynn")
        call mpas_timer_start('MYNN_sfclay')

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -116,6 +116,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2022-05-10.
 ! * added the local parameters flag_bep and idiff in the call to subroutine ysu to update the YSU PBL scheme to
 !   that of WRF version 4.4.1.
+! * added local flags and variables needed to initialize and run the revised version of the MONIN-OBUKHOV surface
+!   layer scheme from the WRF version 4.4.1.
 !   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
 
 
@@ -489,6 +491,26 @@
  real(kind=RKIND),dimension(:,:),allocatable:: &
     fh_p,             &!integrated stability function for heat                                                 [-]
     fm_p               !integrated stability function for momentum                                             [-]
+
+!... variables and arrays only in the revised version of monin_obukhov (module_sf_sfclayrev.F) to include the
+!    shallow water roughness scheme:
+ integer,parameter:: &
+    bathymetry_flag = 0!this flag is set to 1 if input bathymetry data is available (this option is not available
+                       !in MPAS and therefore set to 0 by default.
+ integer,parameter:: &
+    shalwater_flag  = 0!this flag is set to 1 to run the shallow water roughness scheme (this option is not
+                       !available in MPAS and therefore set to 0 by default.
+ integer,parameter:: &
+    lakemodel_flag  = 0!this flag is set to 1 to run the lake model physics (this option is not available in MPAS
+                       !and therefore set to 0 by default.
+
+ real(kind=RKIND),parameter:: &
+    shalwater_depth = 0!constant shallow water depth needed to run the shallow water roughness scheme.
+
+ real(kind=RKIND),dimension(:,:),allocatable:: &
+    waterdepth_p,     &!depth of water needed to run the shallow water roughness scheme.
+    lakedepth_p,      &!depth of lakes needed to run the lake model physics.
+    lakemask_p         !mask needed to detect the location of lakes to run the lake model physics.
 
 !... arrays only in mynn surface layer scheme (module_sf_mynn.F):
  real(kind=RKIND),dimension(:,:),allocatable:: &

--- a/src/core_atmosphere/physics/physics_mmm/Makefile
+++ b/src/core_atmosphere/physics/physics_mmm/Makefile
@@ -8,7 +8,8 @@ dummy:
 OBJS = \
 	bl_gwdo.o \
 	bl_ysu.o \
-	cu_ntiedtke.o
+	cu_ntiedtke.o \
+	sf_sfclayrev.o
 
 physics_mmm: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)

--- a/src/core_atmosphere/physics/physics_mmm/sf_sfclayrev.F
+++ b/src/core_atmosphere/physics/physics_mmm/sf_sfclayrev.F
@@ -1,0 +1,1156 @@
+!=================================================================================================================
+ module sf_sfclayrev
+ use mpas_log
+ use ccpp_kinds,only: kind_phys
+
+ implicit none
+ private
+ public:: sf_sfclayrev_run,           &
+          sf_sfclayrev_init,          &
+          sf_sfclayrev_final,         &
+          sf_sfclayrev_timestep_init, &
+          sf_sfclayrev_timestep_final
+
+
+ real(kind=kind_phys),parameter:: vconvc= 1.
+ real(kind=kind_phys),parameter:: czo   = 0.0185
+ real(kind=kind_phys),parameter:: ozo   = 1.59e-5
+
+ real(kind=kind_phys),dimension(0:1000 ),save:: psim_stab,psim_unstab,psih_stab,psih_unstab
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine sf_sfclayrev_timestep_init(dz2d,u2d,v2d,qv2d,p2d,t2d,dz1d,u1d,v1d,qv1d,p1d,t1d, &
+                                       its,ite,kts,kte,errmsg,errflg)
+!=================================================================================================================
+
+!--- input arguments:
+ integer,intent(in):: its,ite,kts,kte
+
+ real(kind=kind_phys),intent(in),dimension(its:ite,kts:kte):: &
+    dz2d,u2d,v2d,qv2d,p2d,t2d
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+ real(kind=kind_phys),intent(out),dimension(its:ite):: &
+    dz1d,u1d,v1d,qv1d,p1d,t1d
+
+!--- local variables:
+ integer:: i
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ do i = its,ite
+    dz1d(i) = dz2d(i,kts)
+    u1d(i)  = u2d(i,kts)
+    v1d(i)  = v2d(i,kts)
+    qv1d(i) = qv2d(i,kts)
+    p1d(i)  = p2d(i,kts)
+    t1d(i)  = t2d(i,kts)
+ enddo
+
+ errmsg = 'sf_sfclayrev_timestep_init OK'
+ errflg = 0
+
+ end subroutine sf_sfclayrev_timestep_init
+
+!=================================================================================================================
+ subroutine sf_sfclayrev_timestep_final(errmsg,errflg)
+!=================================================================================================================
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ errmsg = 'sf_sfclayrev_timestep_final OK'
+ errflg = 0
+
+ end subroutine sf_sfclayrev_timestep_final
+
+!=================================================================================================================
+ subroutine sf_sfclayrev_init(errmsg,errflg)
+!=================================================================================================================
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+!local variables:
+ integer:: n
+ real(kind=kind_phys):: zolf
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ do n = 0,1000
+! stable function tables
+    zolf = float(n)*0.01
+    psim_stab(n)=psim_stable_full(zolf)
+    psih_stab(n)=psih_stable_full(zolf)
+
+! unstable function tables
+    zolf = -float(n)*0.01
+    psim_unstab(n)=psim_unstable_full(zolf)
+    psih_unstab(n)=psih_unstable_full(zolf)
+ enddo
+
+ errmsg = 'sf_sfclayrev_init OK'
+ errflg = 0
+
+ end subroutine sf_sfclayrev_init
+
+!=================================================================================================================
+ subroutine sf_sfclayrev_final(errmsg,errflg)
+!=================================================================================================================
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ errmsg = 'sf_sfclayrev_final OK'
+ errflg = 0
+
+ end subroutine sf_sfclayrev_final
+
+!=================================================================================================================
+ subroutine sf_sfclayrev_run(ux,vx,t1d,qv1d,p1d,dz8w1d,                &
+                             cp,g,rovcp,r,xlv,psfcpa,chs,chs2,cqs2,    &
+                             cpm,pblh,rmol,znt,ust,mavail,zol,mol,     &
+                             regime,psim,psih,fm,fh,                   &
+                             xland,hfx,qfx,tsk,                        &
+                             u10,v10,th2,t2,q2,flhc,flqc,qgh,          &
+                             qsfc,lh,gz1oz0,wspd,br,isfflx,dx,         &
+                             svp1,svp2,svp3,svpt0,ep1,ep2,             &
+                             karman,eomeg,stbolt,p1000mb,              &
+                             shalwater_z0,water_depth,shalwater_depth, & 
+                             isftcflx,iz0tlnd,scm_force_flux,          &
+                             ustm,ck,cka,cd,cda,                       &
+                             its,ite,errmsg,errflg                     &
+                            )
+!=================================================================================================================
+
+!--- input arguments:
+ integer,intent(in):: its,ite
+
+ integer,intent(in):: isfflx
+ integer,intent(in):: shalwater_z0 
+ integer,intent(in),optional:: isftcflx, iz0tlnd
+ integer,intent(in),optional:: scm_force_flux
+
+ real(kind=kind_phys),intent(in):: svp1,svp2,svp3,svpt0
+ real(kind=kind_phys),intent(in):: ep1,ep2,karman,eomeg,stbolt
+ real(kind=kind_phys),intent(in):: P1000mb
+ real(kind=kind_phys),intent(in):: cp,g,rovcp,r,xlv
+ real(kind=kind_phys),intent(in):: shalwater_depth 
+
+ real(kind=kind_phys),intent(in),dimension(its:ite):: &
+    mavail,     &
+    pblh,       &
+    psfcpa,     &
+    tsk,        &
+    xland,      &
+    water_depth
+
+ real(kind=kind_phys),intent(in),dimension(its:ite):: &
+    dx,         &
+    dz8w1d,     &    
+    ux,         &
+    vx,         &
+    qv1d,       &
+    p1d,        &
+    t1d
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+ real(kind=kind_phys),intent(out),dimension(its:ite):: &
+    lh,         &
+    u10,        &
+    v10,        &
+    th2,        &
+    t2,         &
+    q2
+
+ real(kind=kind_phys),intent(out),dimension(its:ite),optional:: &
+    ck,         &
+    cka,        &
+    cd,         &
+    cda
+
+!--- inout arguments:
+ real(kind=kind_phys),intent(inout),dimension(its:ite):: &
+    regime,     &
+    hfx,        &
+    qfx,        &
+    qsfc,       &
+    mol,        &
+    rmol,       &
+    gz1oz0,     &
+    wspd,       &
+    br,         &
+    psim,       &
+    psih,       &
+    fm,         &
+    fh,         &
+    znt,        &
+    zol,        &
+    ust,        &
+    cpm,        &
+    chs2,       &
+    cqs2,       &
+    chs,        &
+    flhc,       &
+    flqc,       &
+    qgh
+
+ real(kind=kind_phys),intent(inout),dimension(its:ite),optional:: &
+    ustm
+
+!--- local variables:
+ integer:: n,i,k,kk,l,nzol,nk,nzol2,nzol10
+
+ real(kind=kind_phys),parameter:: xka = 2.4e-5
+ real(kind=kind_phys),parameter:: prt = 1.
+
+ real(kind=kind_phys):: pl,thcon,tvcon,e1
+ real(kind=kind_phys):: zl,tskv,dthvdz,dthvm,vconv,rzol,rzol2,rzol10,zol2,zol10
+ real(kind=kind_phys):: dtg,psix,dtthx,psix10,psit,psit2,psiq,psiq2,psiq10
+ real(kind=kind_phys):: fluxc,vsgd,z0q,visc,restar,czil,gz0ozq,gz0ozt
+ real(kind=kind_phys):: zw,zn1,zn2
+ real(kind=kind_phys):: zolzz,zol0
+ real(kind=kind_phys):: zl2,zl10,z0t
+
+ real(kind=kind_phys),dimension(its:ite):: &
+    za,         &
+    thvx,       &
+    zqkl,       &
+    zqklp1,     &
+    thx,        &
+    qx,         &
+    psih2,      &
+    psim2,      &
+    psih10,     &
+    psim10,     &
+    denomq,     &
+    denomq2,    &
+    denomt2,    &
+    wspdi,      &
+    gz2oz0,     &
+    gz10oz0,    &
+    rhox,       &
+    govrth,     &
+    tgdsa,      &
+    scr3,       &
+    scr4,       &
+    thgb,       &
+    psfc
+
+ real(kind=kind_phys),dimension(its:ite):: &
+    pq,         &
+    pq2,        &
+    pq10
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ do i = its,ite
+!PSFC cb
+    psfc(i)=psfcpa(i)/1000.
+ enddo
+!                                                      
+!----CONVERT GROUND TEMPERATURE TO POTENTIAL TEMPERATURE:  
+!                                                            
+ do 5 i = its,ite                                   
+    tgdsa(i)=tsk(i)                                    
+!PSFC cb
+!   thgb(i)=tsk(i)*(100./psfc(i))**rovcp                
+    thgb(i)=tsk(i)*(p1000mb/psfcpa(i))**rovcp   
+ 5 continue                                               
+!                                                            
+!-----DECOUPLE FLUX-FORM VARIABLES TO GIVE U,V,T,THETA,THETA-VIR.,
+!     T-VIR., QV, AND QC AT CROSS POINTS AND AT KTAU-1.  
+!                                                                 
+!     *** NOTE ***                                           
+!         THE BOUNDARY WINDS MAY NOT BE ADEQUATELY AFFECTED BY FRICTION,         
+!         SO USE ONLY INTERIOR VALUES OF UX AND VX TO CALCULATE 
+!         TENDENCIES.                             
+!                                                           
+ 10 continue                                                     
+
+!do 24 i = its,ite
+!   ux(i)=u1d(i)
+!   vx(i)=v1d(i)
+!24 continue                                             
+                                                             
+ 26 continue                                               
+
+!.....SCR3(I,K) STORE TEMPERATURE,                           
+!     SCR4(I,K) STORE VIRTUAL TEMPERATURE.                                       
+                                                                                 
+ do 30 i = its,ite
+!PL cb
+    pl=p1d(i)/1000.
+    scr3(i)=t1d(i)                                                   
+!   thcon=(100./pl)**rovcp                                                 
+    thcon=(p1000mb*0.001/pl)**rovcp
+    thx(i)=scr3(i)*thcon                                               
+    scr4(i)=scr3(i)                                                    
+    thvx(i)=thx(i)                                                     
+    qx(i)=0.                                                             
+ 30 continue                                                                 
+!                                                                                
+ do i = its,ite
+    qgh(i)=0.                                                                
+    flhc(i)=0.                                                               
+    flqc(i)=0.                                                               
+    cpm(i)=cp                                                                
+ enddo
+!                                                                                
+!if(idry.eq.1)goto 80                                                   
+ do 50 i = its,ite
+    qx(i)=qv1d(i)                                                    
+    tvcon=(1.+ep1*qx(i))                                      
+    thvx(i)=thx(i)*tvcon                                               
+    scr4(i)=scr3(i)*tvcon                                              
+ 50 continue                                                                 
+!                                                                                
+ do 60 i=its,ite
+    e1=svp1*exp(svp2*(tgdsa(i)-svpt0)/(tgdsa(i)-svp3))                       
+    !for land points qsfc can come from previous time step
+    if(xland(i).gt.1.5.or.qsfc(i).le.0.0)qsfc(i)=ep2*e1/(psfc(i)-e1)                                                 
+!QGH CHANGED TO USE LOWEST-LEVEL AIR TEMP CONSISTENT WITH MYJSFC CHANGE
+!Q2SAT = QGH IN LSM
+    e1=svp1*exp(svp2*(t1d(i)-svpt0)/(t1d(i)-svp3))                       
+    pl=p1d(i)/1000.
+    qgh(i)=ep2*e1/(pl-e1)                                                 
+    cpm(i)=cp*(1.+0.8*qx(i))                                   
+ 60 continue                                                                   
+ 80 continue
+                                                                                 
+!-----COMPUTE THE HEIGHT OF FULL- AND HALF-SIGMA LEVELS ABOVE GROUND             
+!     LEVEL, AND THE LAYER THICKNESSES.                                          
+                                                                                 
+ do 90 i = its,ite
+    zqklp1(i)=0.
+    rhox(i)=psfc(i)*1000./(r*scr4(i))                                       
+ 90 continue                                                                   
+!                                                                                
+ do 110 i = its,ite                                                   
+    zqkl(i)=dz8w1d(i)+zqklp1(i)
+ 110 continue                                                                 
+!                                                                                
+ do 120 i = its,ite
+    za(i)=0.5*(zqkl(i)+zqklp1(i))                                        
+ 120 continue                                                                 
+!                                                                                
+ do 160 i=its,ite
+    govrth(i)=g/thx(i)                                                    
+ 160 continue                                                                   
+                                                                                 
+!-----CALCULATE BULK RICHARDSON NO. OF SURFACE LAYER, ACCORDING TO               
+!     AKB(1976), EQ(12).                                                                            
+ do 260 i = its,ite
+    gz1oz0(i)=alog((za(i)+znt(i))/znt(i))   ! log((z+z0)/z0)                                     
+    gz2oz0(i)=alog((2.+znt(i))/znt(i))      ! log((2+z0)/z0)                           
+    gz10oz0(i)=alog((10.+znt(i))/znt(i))    ! log((10+z0)z0)                    
+    if((xland(i)-1.5).ge.0)then                                            
+       zl=znt(i)                                                            
+    else                                                                     
+       zl=0.01                                                                
+    endif                                                                    
+    wspd(i)=sqrt(ux(i)*ux(i)+vx(i)*vx(i))                        
+
+    tskv=thgb(i)*(1.+ep1*qsfc(i))                     
+    dthvdz=(thvx(i)-tskv)                                                 
+!-----CONVECTIVE VELOCITY SCALE VC AND SUBGRID-SCALE VELOCITY VSG
+!     FOLLOWING BELJAARS (1994, QJRMS) AND MAHRT AND SUN (1995, MWR)
+!                         ... HONG AUG. 2001
+!
+!   vconv = 0.25*sqrt(g/tskv*pblh(i)*dthvm)
+!   USE BELJAARS OVER LAND, OLD MM5 (WYNGAARD) FORMULA OVER WATER
+    if(xland(i).lt.1.5) then
+       fluxc = max(hfx(i)/rhox(i)/cp                    &
+             + ep1*tskv*qfx(i)/rhox(i),0.)
+       vconv = vconvc*(g/tgdsa(i)*pblh(i)*fluxc)**.33
+    else
+       if(-dthvdz.ge.0)then
+          dthvm=-dthvdz
+       else
+          dthvm=0.
+       endif
+!      vconv = 2.*sqrt(dthvm)
+! V3.7: REDUCING CONTRIBUTION IN CALM CONDITIONS
+       vconv = sqrt(dthvm)
+    endif
+! MAHRT AND SUN LOW-RES CORRECTION
+    vsgd = 0.32 * (max(dx(i)/5000.-1.,0.))**.33
+    wspd(i)=sqrt(wspd(i)*wspd(i)+vconv*vconv+vsgd*vsgd)
+    wspd(i)=amax1(wspd(i),0.1)
+    br(i)=govrth(i)*za(i)*dthvdz/(wspd(i)*wspd(i))                        
+!-----IF PREVIOUSLY UNSTABLE, DO NOT LET INTO REGIMES 1 AND 2
+    if(mol(i).lt.0.)br(i)=amin1(br(i),0.0)
+    rmol(i)=-govrth(i)*dthvdz*za(i)*karman
+ 260 continue
+
+!                                                                                
+!-----DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATED STABILITY CLASS:            
+!                                                                                
+!                                                                                
+!     THE STABILITY CLASSES ARE DETERMINED BY BR (BULK RICHARDSON NO.)           
+!     AND HOL (HEIGHT OF PBL/MONIN-OBUKHOV LENGTH).                              
+!                                                                                
+!     CRITERIA FOR THE CLASSES ARE AS FOLLOWS:                                   
+!                                                                                
+!        1. BR .GE. 0.0;                                                         
+!               REPRESENTS NIGHTTIME STABLE CONDITIONS (REGIME=1),               
+!                                                                                
+!        3. BR .EQ. 0.0                                                          
+!               REPRESENTS FORCED CONVECTION CONDITIONS (REGIME=3),              
+!                                                                                
+!        4. BR .LT. 0.0                                                          
+!               REPRESENTS FREE CONVECTION CONDITIONS (REGIME=4).                
+!                                                                                
+
+ do 320 i = its,ite
+!                                                                           
+    if(br(i).gt.0) then
+       if(br(i).gt.250.0) then
+          zol(i)=zolri(250.0,za(i),znt(i))
+       else
+          zol(i)=zolri(br(i),za(i),znt(i))
+       endif
+    endif
+!
+    if(br(i).lt.0) then
+       if(ust(i).lt.0.001)then
+          zol(i)=br(i)*gz1oz0(i)
+       else
+          if(br(i).lt.-250.0) then
+             zol(i)=zolri(-250.0,za(i),znt(i))
+           else
+              zol(i)=zolri(br(i),za(i),znt(i))
+           endif
+       endif
+    endif
+!
+! ... paj: compute integrated similarity functions.
+!
+    zolzz=zol(i)*(za(i)+znt(i))/za(i) ! (z+z0/L
+    zol10=zol(i)*(10.+znt(i))/za(i)   ! (10+z0)/L
+    zol2=zol(i)*(2.+znt(i))/za(i)     ! (2+z0)/L
+    zol0=zol(i)*znt(i)/za(i)          ! z0/L
+    zl2=(2.)/za(i)*zol(i)             ! 2/L     
+    zl10=(10.)/za(i)*zol(i)           ! 10/L
+
+    if((xland(i)-1.5).lt.0.)then
+       zl=(0.01)/za(i)*zol(i)         ! (0.01)/L     
+    else
+       zl=zol0                        ! z0/L
+    endif
+
+    if(br(i).lt.0.)goto 310  ! go to unstable regime (class 4)
+    if(br(i).eq.0.)goto 280  ! go to neutral regime (class 3)
+!                                                                                
+!-----CLASS 1; STABLE (NIGHTTIME) CONDITIONS:                                    
+!
+    regime(i)=1.
+!
+! ... paj: psim and psih. follows cheng and brutsaert 2005 (cb05).
+!
+    psim(i)=psim_stable(zolzz)-psim_stable(zol0)
+    psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+!
+    psim10(i)=psim_stable(zol10)-psim_stable(zol0)
+    psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+!
+    psim2(i)=psim_stable(zol2)-psim_stable(zol0)
+    psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+!
+! ... paj: preparations to compute psiq. follows cb05+carlson boland jam 1978.
+!
+    pq(i)=psih_stable(zol(i))-psih_stable(zl)
+    pq2(i)=psih_stable(zl2)-psih_stable(zl)
+    pq10(i)=psih_stable(zl10)-psih_stable(zl)
+!
+!   1.0 over monin-obukhov length
+    rmol(i)=zol(i)/za(i) 
+!                                                                                
+    goto 320                                                                 
+!                                                                                
+!-----CLASS 3; FORCED CONVECTION:                                                
+!                                                                                
+ 280 regime(i)=3.                                                           
+     psim(i)=0.0                                                              
+     psih(i)=psim(i)                                                          
+     psim10(i)=0.                                                   
+     psih10(i)=psim10(i)                                           
+     psim2(i)=0.                                                  
+     psih2(i)=psim2(i)                                           
+!
+! paj: preparations to compute PSIQ.
+!
+     pq(i)=psih(i)
+     pq2(i)=psih2(i)
+     pq10(i)=0.
+!
+     zol(i)=0.                                             
+     rmol(i) = zol(i)/za(i)  
+
+     goto 320                                                                 
+!                                                                                
+!-----CLASS 4; FREE CONVECTION:                                                  
+!                                                                                
+ 310 continue                                                                 
+     regime(i)=4.                                                           
+!
+! ... paj: PSIM and PSIH ...
+!
+     psim(i)=psim_unstable(zolzz)-psim_unstable(zol0)
+     psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+!
+     psim10(i)=psim_unstable(zol10)-psim_unstable(zol0)
+     psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+!
+     psim2(i)=psim_unstable(zol2)-psim_unstable(zol0)
+     psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+!
+! ... paj: preparations to compute PSIQ 
+!
+     pq(i)=psih_unstable(zol(i))-psih_unstable(zl)
+     pq2(i)=psih_unstable(zl2)-psih_unstable(zl)
+     pq10(i)=psih_unstable(zl10)-psih_unstable(zl)
+!
+!-----LIMIT PSIH AND PSIM IN THE CASE OF THIN LAYERS AND HIGH ROUGHNESS            
+!-----THIS PREVENTS DENOMINATOR IN FLUXES FROM GETTING TOO SMALL                 
+     psih(i)=amin1(psih(i),0.9*gz1oz0(i))
+     psim(i)=amin1(psim(i),0.9*gz1oz0(i))
+     psih2(i)=amin1(psih2(i),0.9*gz2oz0(i))
+     psim10(i)=amin1(psim10(i),0.9*gz10oz0(i))
+!
+! AHW: mods to compute ck, cd
+     psih10(i)=amin1(psih10(i),0.9*gz10oz0(i))
+     rmol(i) = zol(i)/za(i)  
+
+ 320 continue                                                                   
+!                                                                                
+!-----COMPUTE THE FRICTIONAL VELOCITY:                                           
+!     ZA(1982) EQS(2.60),(2.61).                                                 
+!                                                                                
+ do 330 i = its,ite
+    dtg=thx(i)-thgb(i)                                                   
+    psix=gz1oz0(i)-psim(i)                                                   
+    psix10=gz10oz0(i)-psim10(i)
+
+!   LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
+!   ACTIVATES IN UNSTABLE CONDITIONS WITH THIN LAYERS OR HIGH Z0
+!   PSIT=AMAX1(GZ1OZ0(I)-PSIH(I),2.)
+    psit=gz1oz0(i)-psih(i)
+    psit2=gz2oz0(i)-psih2(i)
+!
+    if((xland(i)-1.5).ge.0)then                                            
+       zl=znt(i)                                                            
+    else                                                                     
+       zl=0.01                                                                
+    endif                                                                    
+!
+    psiq=alog(karman*ust(i)*za(i)/xka+za(i)/zl)-pq(i)
+    psiq2=alog(karman*ust(i)*2./xka+2./zl)-pq2(i)
+
+! AHW: mods to compute ck, cd
+    psiq10=alog(karman*ust(i)*10./xka+10./zl)-pq10(i)
+
+! v3.7: using fairall 2003 to compute z0q and z0t over water:
+!       adapted from module_sf_mynn.f
+    if((xland(i)-1.5).ge.0.) then
+       visc=(1.32+0.009*(scr3(i)-273.15))*1.e-5
+       restar=ust(i)*znt(i)/visc
+       z0t = (5.5e-5)*(restar**(-0.60))
+       z0t = min(z0t,1.0e-4)
+       z0t = max(z0t,2.0e-9)
+       z0q = z0t
+
+! following paj:
+       zolzz=zol(i)*(za(i)+z0t)/za(i) ! (z+z0t)/L
+       zol10=zol(i)*(10.+z0t)/za(i)   ! (10+z0t)/L
+       zol2=zol(i)*(2.+z0t)/za(i)     ! (2+z0t)/L
+       zol0=zol(i)*z0t/za(i)          ! z0t/L
+!
+       if(zol(i).gt.0.) then
+          psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+          psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+          psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+       else
+          if(zol(i).eq.0) then
+             psih(i)=0.
+             psih10(i)=0.
+             psih2(i)=0.
+          else
+             psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+             psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+             psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+          endif
+       endif
+       psit=alog((za(i)+z0t)/z0t)-psih(i)
+       psit2=alog((2.+z0t)/z0t)-psih2(i)
+
+       zolzz=zol(i)*(za(i)+z0q)/za(i)    ! (z+z0q)/L
+       zol10=zol(i)*(10.+z0q)/za(i)   ! (10+z0q)/L
+       zol2=zol(i)*(2.+z0q)/za(i)     ! (2+z0q)/L
+       zol0=zol(i)*z0q/za(i)          ! z0q/L
+!
+       if(zol(i).gt.0.) then
+          psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+          psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+          psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+       else
+          if(zol(i).eq.0) then
+             psih(i)=0.
+             psih10(i)=0.
+             psih2(i)=0.
+          else
+             psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+             psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+             psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+             endif
+          endif
+!
+          psiq=alog((za(i)+z0q)/z0q)-psih(i)
+          psiq2=alog((2.+z0q)/z0q)-psih2(i)
+          psiq10=alog((10.+z0q)/z0q)-psih10(i)
+       endif
+
+       if(present(isftcflx)) then
+          if(isftcflx.eq.1 .and. (xland(i)-1.5).ge.0.) then
+! v3.1
+!            z0q = 1.e-4 + 1.e-3*(max(0.,ust(i)-1.))**2
+! hfip1
+!            z0q = 0.62*2.0e-5/ust(i) + 1.e-3*(max(0.,ust(i)-1.5))**2
+! v3.2
+             z0q = 1.e-4
+!
+! ... paj: recompute psih for z0q
+!
+          zolzz=zol(i)*(za(i)+z0q)/za(i) ! (z+z0q)/L
+          zol10=zol(i)*(10.+z0q)/za(i)   ! (10+z0q)/L
+          zol2=zol(i)*(2.+z0q)/za(i)     ! (2+z0q)/L
+          zol0=zol(i)*z0q/za(i)          ! z0q/L
+!
+          if(zol(i).gt.0.) then
+             psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+             psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+             psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+          else
+             if(zol(i).eq.0) then
+                psih(i)=0.
+                psih10(i)=0.
+                psih2(i)=0.
+             else
+                psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+                psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+             endif
+          endif
+!
+          psiq=alog((za(i)+z0q)/z0q)-psih(i)
+          psit=psiq
+          psiq2=alog((2.+z0q)/z0q)-psih2(i)
+          psiq10=alog((10.+z0q)/z0q)-psih10(i)
+          psit2=psiq2
+       endif
+       if(isftcflx.eq.2 .and. (xland(i)-1.5).ge.0.) then
+! AHW: Garratt formula: Calculate roughness Reynolds number
+!        Kinematic viscosity of air (linear approc to
+!        temp dependence at sea level)
+! GZ0OZT and GZ0OZQ are based off formulas from Brutsaert (1975), which
+! Garratt (1992) used with values of k = 0.40, Pr = 0.71, and Sc = 0.60
+          visc=(1.32+0.009*(scr3(i)-273.15))*1.e-5
+!         visc=1.5e-5
+          restar=ust(i)*znt(i)/visc
+          gz0ozt=0.40*(7.3*sqrt(sqrt(restar))*sqrt(0.71)-5.)
+!
+! ... paj: compute psih for z0t for temperature ...
+!
+          z0t=znt(i)/exp(gz0ozt)
+!
+          zolzz=zol(i)*(za(i)+z0t)/za(i) ! (z+z0t)/L
+          zol10=zol(i)*(10.+z0t)/za(i)   ! (10+z0t)/L
+          zol2=zol(i)*(2.+z0t)/za(i)     ! (2+z0t)/L
+          zol0=zol(i)*z0t/za(i)          ! z0t/L
+!
+          if(zol(i).gt.0.) then
+             psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+             psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+             psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+          else
+             if(zol(i).eq.0) then
+                psih(i)=0.
+                psih10(i)=0.
+                psih2(i)=0.
+             else
+                psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+                psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+             endif
+          endif
+!
+!         psit=gz1oz0(i)-psih(i)+restar2
+!         psit2=gz2oz0(i)-psih2(i)+restar2
+          psit=alog((za(i)+z0t)/z0t)-psih(i)
+          psit2=alog((2.+z0t)/z0t)-psih2(i)
+!
+          gz0ozq=0.40*(7.3*sqrt(sqrt(restar))*sqrt(0.60)-5.)
+          z0q=znt(i)/exp(gz0ozq)
+!
+          zolzz=zol(i)*(za(i)+z0q)/za(i) ! (z+z0q)/L
+          zol10=zol(i)*(10.+z0q)/za(i)   ! (10+z0q)/L
+          zol2=zol(i)*(2.+z0q)/za(i)     ! (2+z0q)/L
+          zol0=zol(i)*z0q/za(i)          ! z0q/L
+!
+          if(zol(i).gt.0.) then
+             psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+             psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+             psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+          else
+             if(zol(i).eq.0) then
+                psih(i)=0.
+                psih10(i)=0.
+                psih2(i)=0.
+             else
+                psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+                psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+             endif
+          endif
+!
+          psiq=alog((za(i)+z0q)/z0q)-psih(i)
+          psiq2=alog((2.+z0q)/z0q)-psih2(i)
+          psiq10=alog((10.+z0q)/z0q)-psih10(i)
+!         psiq=gz1oz0(i)-psih(i)+2.28*sqrt(sqrt(restar))-2.
+!         psiq2=gz2oz0(i)-psih2(i)+2.28*sqrt(sqrt(restar))-2.
+!         psiq10=gz10oz0(i)-psih(i)+2.28*sqrt(sqrt(restar))-2.
+       endif
+    endif
+    if(present(ck) .and. present(cd) .and. present(cka) .and. present(cda)) then
+       ck(i)=(karman/psix10)*(karman/psiq10)
+       cd(i)=(karman/psix10)*(karman/psix10)
+       cka(i)=(karman/psix)*(karman/psiq)
+       cda(i)=(karman/psix)*(karman/psix)
+    endif
+    if(present(iz0tlnd)) then
+       if(iz0tlnd.ge.1 .and. (xland(i)-1.5).le.0.) then
+          zl=znt(i)
+!         CZIL RELATED CHANGES FOR LAND
+          visc=(1.32+0.009*(scr3(i)-273.15))*1.e-5
+          restar=ust(i)*zl/visc
+!         Modify CZIL according to Chen & Zhang, 2009 if iz0tlnd = 1
+!         If iz0tlnd = 2, use traditional value
+
+          if(iz0tlnd.eq.1) then
+             czil = 10.0 ** ( -0.40 * ( zl / 0.07 ) )
+          elseif(iz0tlnd.eq.2) then
+             czil = 0.1 
+          endif
+!
+! ... paj: compute phish for z0t over land
+!
+          z0t=znt(i)/exp(czil*karman*sqrt(restar))
+!
+          zolzz=zol(i)*(za(i)+z0t)/za(i) ! (z+z0t)/L
+          zol10=zol(i)*(10.+z0t)/za(i)   ! (10+z0t)/L
+          zol2=zol(i)*(2.+z0t)/za(i)     ! (2+z0t)/L
+          zol0=zol(i)*z0t/za(i)          ! z0t/L
+!
+          if(zol(i).gt.0.) then
+             psih(i)=psih_stable(zolzz)-psih_stable(zol0)
+             psih10(i)=psih_stable(zol10)-psih_stable(zol0)
+             psih2(i)=psih_stable(zol2)-psih_stable(zol0)
+          else
+             if(zol(i).eq.0) then
+                psih(i)=0.
+                psih10(i)=0.
+                psih2(i)=0.
+             else
+                psih(i)=psih_unstable(zolzz)-psih_unstable(zol0)
+                psih10(i)=psih_unstable(zol10)-psih_unstable(zol0)
+                psih2(i)=psih_unstable(zol2)-psih_unstable(zol0)
+             endif
+          endif
+!
+          psiq=alog((za(i)+z0t)/z0t)-psih(i)
+          psiq2=alog((2.+z0t)/z0t)-psih2(i)
+          psit=psiq
+          psit2=psiq2
+!
+!         psit=gz1oz0(i)-psih(i)+czil*karman*sqrt(restar)
+!         psiq=gz1oz0(i)-psih(i)+czil*karman*sqrt(restar)
+!         psit2=gz2oz0(i)-psih2(i)+czil*karman*sqrt(restar)
+!         psiq2=gz2oz0(i)-psih2(i)+czil*karman*sqrt(restar)
+       endif
+    endif
+! TO PREVENT OSCILLATIONS AVERAGE WITH OLD VALUE 
+    ust(i)=0.5*ust(i)+0.5*karman*wspd(i)/psix                                             
+! TKE coupling: compute ust without vconv for use in tke scheme
+    wspdi(i)=sqrt(ux(i)*ux(i)+vx(i)*vx(i))
+    if(present(ustm)) then
+       ustm(i)=0.5*ustm(i)+0.5*karman*wspdi(i)/psix
+    endif
+
+    u10(i)=ux(i)*psix10/psix                                    
+    v10(i)=vx(i)*psix10/psix                                   
+    th2(i)=thgb(i)+dtg*psit2/psit                                
+    q2(i)=qsfc(i)+(qx(i)-qsfc(i))*psiq2/psiq                   
+    t2(i) = th2(i)*(psfcpa(i)/p1000mb)**rovcp                     
+!                                                                                
+    if((xland(i)-1.5).lt.0.)then                                            
+       ust(i)=amax1(ust(i),0.001)
+    endif                                                                    
+    mol(i)=karman*dtg/psit/prt                              
+    denomq(i)=psiq
+    denomq2(i)=psiq2
+    denomt2(i)=psit2
+    fm(i)=psix
+    fh(i)=psit
+ 330 continue                                                                   
+!                                                                                
+ 335 continue                                                                   
+                                                                                  
+!-----COMPUTE THE SURFACE SENSIBLE AND LATENT HEAT FLUXES:                       
+ if(present(scm_force_flux) ) then
+    if(scm_force_flux.eq.1) goto 350
+    endif
+    do i = its,ite
+       qfx(i)=0.                                                              
+       hfx(i)=0.                                                              
+    enddo
+ 350 continue                                                                   
+
+ if(isfflx.eq.0) goto 410                                                
+                                                                                 
+!-----OVER WATER, ALTER ROUGHNESS LENGTH (ZNT) ACCORDING TO WIND (UST).          
+ do 360 i = its,ite
+    if((xland(i)-1.5).ge.0)then                                            
+!      znt(i)=czo*ust(i)*ust(i)/g+ozo                                   
+       ! PSH - formulation for depth-dependent roughness from
+       ! ... Jimenez and Dudhia, 2018
+       if(shalwater_z0 .eq. 1) then
+          znt(i) = depth_dependent_z0(water_depth(i),znt(i),ust(i))
+       else
+          !Since V3.7 (ref: EC Physics document for Cy36r1)
+          znt(i)=czo*ust(i)*ust(i)/g+0.11*1.5e-5/ust(i)
+          ! v3.9: add limit as in isftcflx = 1,2
+          znt(i)=min(znt(i),2.85e-3)
+       endif
+! COARE 3.5 (Edson et al. 2013)
+!      czc = 0.0017*wspd(i)-0.005
+!      czc = min(czc,0.028)
+!      znt(i)=czc*ust(i)*ust(i)/g+0.11*1.5e-5/ust(i)
+! AHW: change roughness length, and hence the drag coefficients Ck and Cd
+       if(present(isftcflx)) then
+          if(isftcflx.ne.0) then
+!            znt(i)=10.*exp(-9.*ust(i)**(-.3333))
+!            znt(i)=10.*exp(-9.5*ust(i)**(-.3333))
+!            znt(i)=znt(i) + 0.11*1.5e-5/amax1(ust(i),0.01)
+!            znt(i)=0.011*ust(i)*ust(i)/g+ozo
+!            znt(i)=max(znt(i),3.50e-5)
+! AHW 2012:
+             zw  = min((ust(i)/1.06)**(0.3),1.0)
+             zn1 = 0.011*ust(i)*ust(i)/g + ozo
+             zn2 = 10.*exp(-9.5*ust(i)**(-.3333)) + &
+                   0.11*1.5e-5/amax1(ust(i),0.01)
+             znt(i)=(1.0-zw) * zn1 + zw * zn2
+             znt(i)=min(znt(i),2.85e-3)
+             znt(i)=max(znt(i),1.27e-7)
+          endif
+       endif
+       zl = znt(i)
+    else
+       zl = 0.01
+    endif                                                                    
+    flqc(i)=rhox(i)*mavail(i)*ust(i)*karman/denomq(i)
+!   flqc(i)=rhox(i)*mavail(i)*ust(i)*karman/(   &
+!           alog(karman*ust(i)*za(i)/xka+za(i)/zl)-psih(i))
+    dtthx=abs(thx(i)-thgb(i))                                            
+    if(dtthx.gt.1.e-5)then                                                   
+       flhc(i)=cpm(i)*rhox(i)*ust(i)*mol(i)/(thx(i)-thgb(i))          
+!      write(*,1001)flhc(i),cpm(i),rhox(i),ust(i),mol(i),thx(i),thgb(i),i
+ 1001  format(f8.5,2x,f12.7,2x,f12.10,2x,f12.10,2x,f13.10,2x,f12.8,f12.8,2x,i3)
+    else                                                                     
+       flhc(i)=0.                                                             
+    endif                                                                    
+ 360 continue                                                                   
+
+!                                                                                
+!-----COMPUTE SURFACE MOIST FLUX:                                                
+!                                                                                
+!IF(IDRY.EQ.1)GOTO 390                                                
+!                                                                                
+ if(present(scm_force_flux)) then
+    if(scm_force_flux.eq.1) goto 405
+    endif
+
+    do 370 i = its,ite
+       qfx(i)=flqc(i)*(qsfc(i)-qx(i))                                     
+       qfx(i)=amax1(qfx(i),0.)                                            
+       lh(i)=xlv*qfx(i)
+    370 continue                                                                 
+                                                                                
+!-----COMPUTE SURFACE HEAT FLUX:                                                 
+!                                                                                
+    390 continue                                                                 
+    do 400 i = its,ite
+       if(xland(i)-1.5.gt.0.)then                                           
+          hfx(i)=flhc(i)*(thgb(i)-thx(i)) 
+!         if(present(isftcflx)) then
+!            if(isftcflx.ne.0) then
+! AHW: add dissipative heating term (commented out in 3.6.1)
+!               hfx(i)=hfx(i)+rhox(i)*ustm(i)*ustm(i)*wspdi(i)
+!            endif
+!         endif 
+       elseif(xland(i)-1.5.lt.0.)then                                       
+          hfx(i)=flhc(i)*(thgb(i)-thx(i))                                
+          hfx(i)=amax1(hfx(i),-250.)                                       
+       endif                                                                  
+   400 continue                                                                 
+
+   405 continue                                                                 
+         
+   do i = its,ite
+      if((xland(i)-1.5).ge.0)then
+         zl=znt(i)
+      else
+         zl=0.01
+      endif
+!v3.1.1
+!     chs(i)=ust(i)*karman/(alog(karman*ust(i)*za(i) &
+!           /xka+za(i)/zl)-psih(i))
+      chs(i)=ust(i)*karman/denomq(i)
+!     gz2oz0(i)=alog(2./znt(i))
+!     psim2(i)=-10.*gz2oz0(i)
+!     psim2(i)=amax1(psim2(i),-10.)
+!     psih2(i)=psim2(i)
+! v3.1.1
+!     cqs2(i)=ust(i)*karman/(alog(karman*ust(i)*2.0  &
+!            /xka+2.0/zl)-psih2(i))
+!     chs2(i)=ust(i)*karman/(gz2oz0(i)-psih2(i))
+      cqs2(i)=ust(i)*karman/denomq2(i)
+         chs2(i)=ust(i)*karman/denomt2(i)
+   enddo
+                                                                        
+   410 continue                                                                   
+
+!jdf
+!  do i = its,ite
+!     if(ust(i).ge.0.1) then
+!        rmol(i)=rmol(i)*(-flhc(i))/(ust(i)*ust(i)*ust(i))
+!     else
+!        rmol(i)=rmol(i)*(-flhc(i))/(0.1*0.1*0.1)
+!     endif
+!  enddo
+!jdf
+
+ errmsg = 'sf_sfclayrev_run OK'
+ errflg = 0
+
+ end subroutine sf_sfclayrev_run
+
+!=================================================================================================================
+ real(kind=kind_phys) function zolri(ri,z,z0)
+ real(kind=kind_phys),intent(in):: ri,z,z0
+ real(kind=kind_phys):: fx1,fx2,x1,x2
+
+ if(ri.lt.0.)then
+    x1=-5.
+    x2=0.
+ else
+    x1=0.
+    x2=5.
+ endif
+
+ fx1=zolri2(x1,ri,z,z0)
+ fx2=zolri2(x2,ri,z,z0)
+ do while (abs(x1 - x2) > 0.01)
+!check added for potential divide by zero (2019/11)
+    if(fx1.eq.fx2)return
+    if(abs(fx2).lt.abs(fx1))then
+       x1=x1-fx1/(fx2-fx1)*(x2-x1)
+       fx1=zolri2(x1,ri,z,z0)
+       zolri=x1
+    else
+       x2=x2-fx2/(fx2-fx1)*(x2-x1)
+       fx2=zolri2(x2,ri,z,z0)
+       zolri=x2
+    endif
+ enddo
+
+ return
+ end function zolri
+
+!=================================================================================================================
+ real(kind=kind_phys) function zolri2(zol2,ri2,z,z0)
+ real(kind=kind_phys),intent(in):: ri2,z,z0
+ real(kind=kind_phys),intent(inout):: zol2
+ real(kind=kind_phys):: psih2,psix2,zol20,zol3
+
+ if(zol2*ri2 .lt. 0.)zol2=0.  ! limit zol2 - must be same sign as ri2
+
+ zol20=zol2*z0/z ! z0/L
+ zol3=zol2+zol20 ! (z+z0)/L
+
+ if(ri2.lt.0) then
+    psix2=log((z+z0)/z0)-(psim_unstable(zol3)-psim_unstable(zol20))
+    psih2=log((z+z0)/z0)-(psih_unstable(zol3)-psih_unstable(zol20))
+ else
+    psix2=log((z+z0)/z0)-(psim_stable(zol3)-psim_stable(zol20))
+    psih2=log((z+z0)/z0)-(psih_stable(zol3)-psih_stable(zol20))
+ endif
+
+ zolri2=zol2*psih2/psix2**2-ri2
+
+ return
+ end function zolri2
+
+!=================================================================================================================
+!
+! ... integrated similarity functions ...
+!
+ real(kind=kind_phys) function psim_stable_full(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**(1./2.5))
+
+ return
+ end function psim_stable_full
+
+!=================================================================================================================
+ real(kind=kind_phys) function psih_stable_full(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**(1./1.1))
+
+ return
+ end function psih_stable_full
+
+!=================================================================================================================
+ real(kind=kind_phys) function psim_unstable_full(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ real(kind=kind_phys):: psimc,psimk,x,y,ym
+ x=(1.-16.*zolf)**.25
+ psimk=2*ALOG(0.5*(1+X))+ALOG(0.5*(1+X*X))-2.*ATAN(X)+2.*ATAN(1.)
+
+ ym=(1.-10.*zolf)**0.33
+ psimc=(3./2.)*log((ym**2.+ym+1.)/3.)-sqrt(3.)*ATAN((2.*ym+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+
+ psim_unstable_full=(psimk+zolf**2*(psimc))/(1+zolf**2.)
+
+ return
+ end function psim_unstable_full
+
+!=================================================================================================================
+ real(kind=kind_phys) function psih_unstable_full(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ real(kind=kind_phys):: psihc,psihk,y,yh
+ y=(1.-16.*zolf)**.5
+ psihk=2.*log((1+y)/2.)
+
+ yh=(1.-34.*zolf)**0.33
+ psihc=(3./2.)*log((yh**2.+yh+1.)/3.)-sqrt(3.)*ATAN((2.*yh+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+
+ psih_unstable_full=(psihk+zolf**2*(psihc))/(1+zolf**2.)
+
+ return
+ end function psih_unstable_full
+
+!=================================================================================================================
+! ... look-up table functions ...
+ real(kind=kind_phys) function psim_stable(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ integer:: nzol
+ real(kind=kind_phys):: rzol
+ nzol = int(zolf*100.)
+ rzol = zolf*100. - nzol
+ if(nzol+1 .lt. 1000)then
+    psim_stable = psim_stab(nzol) + rzol*(psim_stab(nzol+1)-psim_stab(nzol))
+ else
+    psim_stable = psim_stable_full(zolf)
+ endif
+
+ return
+ end function psim_stable
+
+!=================================================================================================================
+ real(kind=kind_phys) function psih_stable(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ integer:: nzol
+ real(kind=kind_phys):: rzol
+ nzol = int(zolf*100.)
+ rzol = zolf*100. - nzol
+ if(nzol+1 .lt. 1000)then
+    psih_stable = psih_stab(nzol) + rzol*(psih_stab(nzol+1)-psih_stab(nzol))
+ else
+    psih_stable = psih_stable_full(zolf)
+ endif
+
+ return
+ end function psih_stable
+
+!=================================================================================================================
+ real(kind=kind_phys) function psim_unstable(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ integer:: nzol
+ real(kind=kind_phys):: rzol
+ nzol = int(-zolf*100.)
+ rzol = -zolf*100. - nzol
+ if(nzol+1 .lt. 1000)then
+    psim_unstable = psim_unstab(nzol) + rzol*(psim_unstab(nzol+1)-psim_unstab(nzol))
+ else
+    psim_unstable = psim_unstable_full(zolf)
+ endif
+
+ return
+ end function psim_unstable
+
+!=================================================================================================================
+ real(kind=kind_phys) function psih_unstable(zolf)
+ real(kind=kind_phys),intent(in):: zolf
+ integer:: nzol
+ real(kind=kind_phys):: rzol
+ nzol = int(-zolf*100.)
+ rzol = -zolf*100. - nzol
+ if(nzol+1 .lt. 1000)then
+    psih_unstable = psih_unstab(nzol) + rzol*(psih_unstab(nzol+1)-psih_unstab(nzol))
+ else
+    psih_unstable = psih_unstable_full(zolf)
+ endif
+
+ return
+ end function psih_unstable
+
+!=================================================================================================================
+ real(kind=kind_phys) function depth_dependent_z0(water_depth,z0,ust)
+ real(kind=kind_phys),intent(in):: water_depth,z0,ust
+ real(kind=kind_phys):: depth_b
+ real(kind=kind_phys):: effective_depth
+ if(water_depth .lt. 10.0) then
+    effective_depth = 10.0
+ elseif(water_depth .gt. 100.0) then
+    effective_depth = 100.0
+ else
+    effective_depth = water_depth
+ endif
+ 
+ depth_b = 1 / 30.0 * log (1260.0 / effective_depth)
+ depth_dependent_z0 = exp((2.7 * ust - 1.8 / depth_b) / (ust + 0.17 / depth_b) )
+ depth_dependent_z0 = MIN(depth_dependent_z0,0.1)
+
+ return
+ end function depth_dependent_z0
+
+!=================================================================================================================
+ end module sf_sfclayrev
+!=================================================================================================================

--- a/src/core_atmosphere/physics/physics_mmm/sf_sfclayrev.F
+++ b/src/core_atmosphere/physics/physics_mmm/sf_sfclayrev.F
@@ -964,7 +964,10 @@
 !=================================================================================================================
  real(kind=kind_phys) function zolri(ri,z,z0)
  real(kind=kind_phys),intent(in):: ri,z,z0
+
+ integer:: iter
  real(kind=kind_phys):: fx1,fx2,x1,x2
+
 
  if(ri.lt.0.)then
     x1=-5.
@@ -976,7 +979,9 @@
 
  fx1=zolri2(x1,ri,z,z0)
  fx2=zolri2(x2,ri,z,z0)
+ iter = 0
  do while (abs(x1 - x2) > 0.01)
+ if (iter .eq. 10) return
 !check added for potential divide by zero (2019/11)
     if(fx1.eq.fx2)return
     if(abs(fx2).lt.abs(fx1))then
@@ -988,6 +993,7 @@
        fx2=zolri2(x2,ri,z,z0)
        zolri=x2
     endif
+    iter = iter + 1
  enddo
 
  return

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -39,6 +39,7 @@ OBJS = \
         module_sf_noah_seaice_drv.o    \
 	module_sf_oml.o                \
 	module_sf_sfclay.o             \
+	module_sf_sfclayrev.o          \
 	module_sf_urban.o
 
 physics_wrf: $(OBJS)

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclayrev.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclayrev.F
@@ -1,0 +1,276 @@
+!=================================================================================================================
+ module module_sf_sfclayrev
+ use mpas_log
+ use ccpp_kinds,only: kind_phys
+
+ use sf_sfclayrev,only: sf_sfclayrev_run, &
+                        sf_sfclayrev_timestep_init
+
+
+ implicit none
+ private
+ public:: sfclayrev
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine sfclayrev(u3d,v3d,t3d,qv3d,p3d,dz8w,                    &
+                      cp,g,rovcp,r,xlv,psfc,chs,chs2,cqs2,cpm,      &
+                      znt,ust,pblh,mavail,zol,mol,regime,psim,psih, &
+                      fm,fh,                                        &
+                      xland,hfx,qfx,lh,tsk,flhc,flqc,qgh,qsfc,rmol, &
+                      u10,v10,th2,t2,q2,                            &
+                      gz1oz0,wspd,br,isfflx,dx,                     &
+                      svp1,svp2,svp3,svpt0,ep1,ep2,                 &
+                      karman,eomeg,stbolt,                          &
+                      p1000mb,                                      &
+                      ids,ide,jds,jde,kds,kde,                      &
+                      ims,ime,jms,jme,kms,kme,                      &
+                      its,ite,jts,jte,kts,kte,                      &
+                      ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,          &
+                      shalwater_z0,water_depth,shalwater_depth,     &
+                      scm_force_flux,errmsg,errflg)
+!=================================================================================================================
+                                                               
+!--- input arguments:
+ integer,intent(in):: ids,ide,jds,jde,kds,kde, &
+                      ims,ime,jms,jme,kms,kme, &
+                      its,ite,jts,jte,kts,kte
+
+ integer,intent(in):: isfflx
+ integer,intent(in):: shalwater_z0 
+ integer,intent(in),optional:: isftcflx, iz0tlnd
+ integer,intent(in),optional:: scm_force_flux
+
+ real(kind=kind_phys),intent(in):: svp1,svp2,svp3,svpt0
+ real(kind=kind_phys),intent(in):: ep1,ep2,karman,eomeg,stbolt
+ real(kind=kind_phys),intent(in):: P1000mb
+ real(kind=kind_phys),intent(in):: cp,g,rovcp,r,xlv
+ real(kind=kind_phys),intent(in):: shalwater_depth 
+
+ real(kind=kind_phys),intent(in),dimension(ims:ime,jms:jme):: &
+    dx,         &
+    mavail,     &
+    pblh,       &
+    psfc,       &
+    tsk,        &
+    xland,      &
+    water_depth
+
+ real(kind=kind_phys),intent(in),dimension(ims:ime,kms:kme,jms:jme):: &
+    dz8w,       &
+    qv3d,       &
+    p3d,        &
+    t3d,        &
+    u3d,        &
+    v3d
+
+!--- output arguments:
+ character(len=*),intent(out):: errmsg
+ integer,intent(out):: errflg
+
+ real(kind=kind_phys),intent(out),dimension(ims:ime,jms:jme):: &
+    lh,         &
+    u10,        &
+    v10,        &
+    th2,        &
+    t2,         &
+    q2
+
+ real(kind=kind_phys),intent(out),dimension(ims:ime,jms:jme),optional:: &
+    ck,         &
+    cka,        &
+    cd,         &
+    cda
+
+!--- inout arguments:
+ real(kind=kind_phys),intent(inout),dimension(ims:ime,jms:jme):: &
+    regime,     &
+    hfx,        &
+    qfx,        &
+    qsfc,       &
+    mol,        &
+    rmol,       &
+    gz1oz0,     &
+    wspd,       &
+    br,         &
+    psim,       &
+    psih,       &
+    fm,         &
+    fh,         &
+    znt,        &
+    zol,        &
+    ust,        &
+    cpm,        &
+    chs2,       &
+    cqs2,       &
+    chs,        &
+    flhc,       &
+    flqc,       &
+    qgh
+
+ real(kind=kind_phys),intent(inout),dimension(ims:ime,jms:jme),optional:: &
+    ustm
+
+!--- local variables and arrays:
+ integer:: i,j,k
+ real(kind=kind_phys),dimension(its:ite):: dz1d,u1d,v1d,qv1d,p1d,t1d
+
+ real(kind=kind_phys),dimension(its:ite):: &
+    dx_hv,mavail_hv,pblh_hv,psfc_hv,tsk_hv,xland_hv,water_depth_hv
+ real(kind=kind_phys),dimension(its:ite,kts:kte):: &
+    dz_hv,u_hv,v_hv,qv_hv,p_hv,t_hv
+
+ real(kind=kind_phys),dimension(its:ite):: &
+    lh_hv,u10_hv,v10_hv,th2_hv,t2_hv,q2_hv
+ real(kind=kind_phys),dimension(its:ite):: &
+    ck_hv,cka_hv,cd_hv,cda_hv
+
+ real(kind=kind_phys),dimension(its:ite):: &
+    regime_hv,hfx_hv,qfx_hv,qsfc_hv,mol_hv,rmol_hv,gz1oz0_hv,wspd_hv, &
+    br_hv,psim_hv,psih_hv,fm_hv,fh_hv,znt_hv,zol_hv,ust_hv,cpm_hv,    &
+    chs2_hv,cqs2_hv,chs_hv,flhc_hv,flqc_hv,qgh_hv
+ real(kind=kind_phys),dimension(its:ite):: &
+    ustm_hv
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ do j = jts,jte
+
+    do i = its,ite
+       !input arguments:
+       dx_hv(i) = dx(i,j)
+       mavail_hv(i)      = mavail(i,j)
+       pblh_hv(i)        = pblh(i,j)
+       psfc_hv(i)        = psfc(i,j)
+       tsk_hv(i)         = tsk(i,j)
+       xland_hv(i)       = xland(i,j)
+       water_depth_hv(i) = water_depth(i,j)
+
+       do k = kts,kte
+          dz_hv(i,k) = dz8w(i,k,j)
+          u_hv(i,k)  = u3d(i,k,j)
+          v_hv(i,k)  = v3d(i,k,j)
+          qv_hv(i,k) = qv3d(i,k,j)
+          p_hv(i,k)  = p3d(i,k,j)
+          t_hv(i,k)  = t3d(i,k,j)
+       enddo
+
+       !inout arguments:
+       regime_hv(i) = regime(i,j)
+       hfx_hv(i)    = hfx(i,j)
+       qfx_hv(i)    = qfx(i,j)
+       qsfc_hv(i)   = qsfc(i,j)
+       mol_hv(i)    = mol(i,j)
+       rmol_hv(i)   = rmol(i,j)
+       gz1oz0_hv(i) = gz1oz0(i,j)
+       wspd_hv(i)   = wspd(i,j)
+       br_hv(i)     = br(i,j)
+       psim_hv(i)   = psim(i,j)
+       psih_hv(i)   = psih(i,j)
+       fm_hv(i)     = fm(i,j)
+       fh_hv(i)     = fh(i,j)
+       znt_hv(i)    = znt(i,j)
+       zol_hv(i)    = zol(i,j)
+       ust_hv(i)    = ust(i,j)
+       cpm_hv(i)    = cpm(i,j)
+       chs2_hv(i)   = chs2(i,j)
+       cqs2_hv(i)   = cqs2(i,j)
+       chs_hv(i)    = chs(i,j)
+       flhc_hv(i)   = flhc(i,j)
+       flqc_hv(i)   = flqc(i,j)
+       qgh_hv(i)    = qgh(i,j)
+    enddo
+
+    if(present(ustm)) then
+       do i = its,ite
+          ustm_hv(i) = ustm(i,j)
+       enddo
+    endif
+
+    call sf_sfclayrev_timestep_init(dz2d=dz_hv,u2d=u_hv,v2d=v_hv,qv2d=qv_hv,p2d=p_hv,t2d=t_hv,     &
+                                    dz1d=dz1d,u1d=u1d,v1d=v1d,qv1d=qv1d,p1d=p1d,t1d=t1d,           &
+                                    its=its,ite=ite,kts=kts,kte=kte,errmsg=errmsg,errflg=errflg)
+
+    call sf_sfclayrev_run(ux=u1d,vx=v1d,t1d=t1d,qv1d=qv1d,p1d=p1d,dz8w1d=dz1d,                     &
+                          cp=cp,g=g,rovcp=rovcp,r=r,xlv=xlv,psfcpa=psfc_hv,chs=chs_hv,             &
+                          chs2=chs2_hv,cqs2=cqs2_hv,cpm=cpm_hv,pblh=pblh_hv,                       &
+                          rmol=rmol_hv,znt=znt_hv,ust=ust_hv,mavail=mavail_hv,                     &
+                          zol=zol_hv,mol=mol_hv,regime=regime_hv,psim=psim_hv,                     &
+                          psih=psih_hv,fm=fm_hv,fh=fh_hv,xland=xland_hv,                           &
+                          hfx=hfx_hv,qfx=qfx_hv,tsk=tsk_hv,u10=u10_hv,                             &
+                          v10=v10_hv,th2=th2_hv,t2=t2_hv,q2=q2_hv,flhc=flhc_hv,                    &
+                          flqc=flqc_hv,qgh=qgh_hv,qsfc=qsfc_hv,lh=lh_hv,                           &
+                          gz1oz0=gz1oz0_hv,wspd=wspd_hv,br=br_hv,isfflx=isfflx,dx=dx_hv,           &
+                          svp1=svp1,svp2=svp2,svp3=svp3,svpt0=svpt0,ep1=ep1,ep2=ep2,karman=karman, &
+                          eomeg=eomeg,stbolt=stbolt,p1000mb=p1000mb,                               &
+                          shalwater_z0=shalwater_z0,water_depth=water_depth_hv,                    &
+                          shalwater_depth=shalwater_depth,                                         &
+                          its=its,ite=ite,errmsg=errmsg,errflg=errflg                              &
+#if ( ( EM_CORE == 1 ) || ( defined(mpas) ) )
+                          ,isftcflx=isftcflx,iz0tlnd=iz0tlnd,scm_force_flux=scm_force_flux,        &
+                          ustm=ustm_hv,ck=ck_hv,cka=cka_hv,cd=cd_hv,cda=cda_hv                     &
+#endif
+                         )
+
+    do i = its,ite
+       !output arguments:
+       lh(i,j)  = lh_hv(i)
+       u10(i,j) = u10_hv(i)
+       v10(i,j) = v10_hv(i)
+       th2(i,j) = th2_hv(i)
+       t2(i,j)  = t2_hv(i)
+       q2(i,j)  = q2_hv(i)
+
+       !inout arguments:
+       regime(i,j) = regime_hv(i)
+       hfx(i,j)    = hfx_hv(i)
+       qfx(i,j)    = qfx_hv(i)
+       qsfc(i,j)   = qsfc_hv(i)
+       mol(i,j)    = mol_hv(i)
+       rmol(i,j)   = rmol_hv(i)
+       gz1oz0(i,j) = gz1oz0_hv(i)
+       wspd(i,j)   = wspd_hv(i)
+       br(i,j)     = br_hv(i)
+       psim(i,j)   = psim_hv(i)
+       psih(i,j)   = psih_hv(i)
+       fm(i,j)     = fm_hv(i)
+       fh(i,j)     = fh_hv(i)
+       znt(i,j)    = znt_hv(i)
+       zol(i,j)    = zol_hv(i)
+       ust(i,j)    = ust_hv(i)
+       cpm(i,j)    = cpm_hv(i)
+       chs2(i,j)   = chs2_hv(i)
+       cqs2(i,j)   = cqs2_hv(i)
+       chs(i,j)    = chs_hv(i)
+       flhc(i,j)   = flhc_hv(i)
+       flqc(i,j)   = flqc_hv(i)
+       qgh(i,j)    = qgh_hv(i)
+    enddo
+
+    !optional output arguments:
+    if(present(ck) .and. present(cka) .and. present(cd) .and. present(cda)) then
+       do i = its,ite
+          ck(i,j)  = ck_hv(i)
+          cka(i,j) = cka_hv(i)
+          cd(i,j)  = cd_hv(i)
+          cda(i,j) = cda_hv(i)
+       enddo
+    endif
+
+    !optional inout arguments:
+    if(present(ustm)) then
+       do i = its,ite
+          ustm(i,j) = ustm_hv(i)
+       enddo
+    endif
+
+ enddo
+
+ end subroutine sfclayrev
+
+!=================================================================================================================
+ end module module_sf_sfclayrev
+!=================================================================================================================


### PR DESCRIPTION
1. In this PR, we added the directory physics_mmm. In its initial implementation, physics_mmm contains parameterizations of moist physics (surface layer scheme, planetary boundary layer scheme, convection scheme, and cloud microphysics scheme) for the mesoscale reference suite.
2.  Parameterizations in physics_mmm are CCPP-compliant (initial versions) and are shared between MPAS, WRF, and CM1.
3.  The initial version of module_sf_sfclayrev.F is split in two separate files: sf_sfclayrev.F in physics_mmm contains the actual parameterization of the MM5 revised surface layer scheme whereas the modified version of module_sf_sfclayrev.F reduces to a buffer between the parameterization and the MPAS physics driver.