### PR TITLE
Reduce static field interpolation memory usage

### DIFF
--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -338,8 +338,10 @@ module mpas_geotile_manager
         do i = 0, mgr % nTileX
             do j = 0, mgr % nTileY
                 if (associated(mgr % hash(i, j) % ptr)) then
+                  if (associated(mgr % hash(i, j) % ptr % tile)) then
                     deallocate(mgr % hash(i, j) % ptr % tile)
-                    deallocate(mgr % hash(i, j) % ptr)
+                  endif
+                  deallocate(mgr % hash(i, j) % ptr)
                 endif
             enddo
         enddo

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -561,7 +561,7 @@
                     end if
                 end do
             end do
-
+            deallocate(tile % tile)
             tile % is_processed = .true.
 
             if (.not. all_pixels_mapped_to_halo_cells) then
@@ -795,7 +795,7 @@
                     end if
                 end do
             end do
-
+            deallocate(tile % tile)
             tile % is_processed = .true.
 
             if (.not. all_pixels_mapped_to_halo_cells) then
@@ -1028,7 +1028,7 @@
                     end if
                 end do
             end do
-
+            deallocate(tile % tile)
             tile % is_processed = .true.
 
             if (.not. all_pixels_mapped_to_halo_cells) then
@@ -1341,9 +1341,8 @@
                     end if
                 end do
             end do
-
-            tile % is_processed = .true.
-
+            deallocate(tile % tile)
+            tile % is_processed = .true. 
             !
             ! If at least one pixel maps to an owned cell (i.e. <= nCellsSolve) then
             ! it is possible that the neighboring tiles might contain pixels that map


### PR DESCRIPTION
This pull request aims to reduce the memory usage of static field interpolation by deallocating tiles as they are used.

Static field interpolation occasionally failed by overflowing the memory of the compute nodes when running core_init_atmosphere. Running valgrind revealed that this was not due to a memory leak, but simply loading all of the required geotiles in to memory during the depth first search for candidate tiles, and only deallocating them once the interpolation was finished. This pull request deallocates the memory associated with the geotile each time that we process a tile, leading to significant memory use reductions- on an x1.40962 grid, static field interpolation peak memory useage has dropped from ~43GiB to ~6GiB. 

