### PR TITLE
Enable the use of mpas_halo routines for communicating halo groups in MPAS-A

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -382,7 +382,7 @@
                 <nml_option name="config_halo_exch_method" type="character" default_value="mpas_dmpar"
                      units="-"
                      description="Method to use for exchanging halos"
-                     possible_values="`mpas_dmpar'"/>
+                     possible_values="`mpas_dmpar', `mpas_halo'"/>
         </nml_record>
 
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -379,7 +379,7 @@
         </nml_record>
 
         <nml_record name="development" in_defaults="false">
-                <nml_option name="config_halo_exch_method" type="character" default_value="mpas_dmpar"
+                <nml_option name="config_halo_exch_method" type="character" default_value="mpas_halo"
                      units="-"
                      description="Method to use for exchanging halos"
                      possible_values="`mpas_dmpar', `mpas_halo'"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -378,6 +378,13 @@
                      possible_values=".true. or .false."/>
         </nml_record>
 
+        <nml_record name="development" in_defaults="false">
+                <nml_option name="config_halo_exch_method" type="character" default_value="mpas_dmpar"
+                     units="-"
+                     description="Method to use for exchanging halos"
+                     possible_values="`mpas_dmpar'"/>
+        </nml_record>
+
 <!-- **************************************************************************************** -->
 <!-- **************************************  Packages  ************************************** -->
 <!-- **************************************************************************************** -->

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -29,6 +29,22 @@ module atm_time_integration
    
    use mpas_atm_iau  
 
+   !
+   ! Abstract interface for routine used to communicate halos of fields
+   ! in a named group
+   !
+   abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+   end interface
+
    integer :: timerid, secs, u_secs
 
    ! Used to store physics tendencies for dynamics variables
@@ -124,86 +140,6 @@ module atm_time_integration
       call mpas_allocate_scratch_field(tend_ru_physicsField)
 #endif
 
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'theta_m', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'scalars', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'pressure_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'rtheta_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-
-      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
-      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % ru_p, (/ 2 /))
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rw_p', &
-                                           timeLevel=1, haloLayers=(/1/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'ru_p', &
-                                           timeLevel=1, haloLayers=(/2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rho_pp', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rtheta_pp', &
-                                           timeLevel=1, haloLayers=(/2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'w', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'pv_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'rho_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'w', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'pv_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'rho_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'scalars', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'theta_m', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'pressure_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:exner')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:tend_u')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:tend_u', 'tend_u', timeLevel=1, haloLayers=(/1/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rho_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rho_pp', 'rho_pp', timeLevel=1, haloLayers=(/1/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rtheta_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rtheta_pp', 'rtheta_pp', timeLevel=1, haloLayers=(/1/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_123')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_123', 'u', timeLevel=2, haloLayers=(/1,2,3/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_3')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_3', 'u', timeLevel=2, haloLayers=(/3/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars', 'scalars', timeLevel=2, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars_old')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars_old', 'scalars', timeLevel=1, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w', 'w', timeLevel=2, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scale')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scale', 'scale', timeLevel=1, haloLayers=(/1,2/))
-
    end subroutine mpas_atm_dynamics_init
 
 
@@ -249,27 +185,10 @@ module atm_time_integration
       call mpas_deallocate_scratch_field(tend_ru_physicsField)
 #endif
 
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
-
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:exner')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:tend_u')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rho_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rtheta_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_123')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_3')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars_old')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scale')
-
    end subroutine mpas_atm_dynamics_finalize
 
 
-   subroutine atm_timestep(domain, dt, nowTime, itimestep)
+   subroutine atm_timestep(domain, dt, nowTime, itimestep, exchange_halo_group)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step
    !
@@ -285,6 +204,7 @@ module atm_time_integration
       real (kind=RKIND), intent(in) :: dt
       type (MPAS_Time_type), intent(in) :: nowTime
       integer, intent(in) :: itimestep
+      procedure (halo_exchange_routine) :: exchange_halo_group
 
 
       type (MPAS_Time_type) :: currTime
@@ -302,7 +222,7 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs)
 
       if (trim(config_time_integration) == 'SRK3') then
-         call atm_srk3(domain, dt, itimestep)
+         call atm_srk3(domain, dt, itimestep, exchange_halo_group)
       else
          call mpas_log_write('Unknown time integration option '//trim(config_time_integration), messageType=MPAS_LOG_ERR)
          call mpas_log_write('Currently, only ''SRK3'' is supported.', messageType=MPAS_LOG_CRIT)
@@ -319,7 +239,7 @@ module atm_time_integration
    end subroutine atm_timestep
 
 
-   subroutine atm_srk3(domain, dt, itimestep)
+   subroutine atm_srk3(domain, dt, itimestep, exchange_halo_group)
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
    ! Advance model state forward in time by the specified time step using 
    !   time-split RK3 scheme
@@ -338,6 +258,7 @@ module atm_time_integration
       type (domain_type), intent(inout) :: domain
       real (kind=RKIND), intent(in) :: dt
       integer, intent(in) :: itimestep
+      procedure (halo_exchange_routine) :: exchange_halo_group
 
       integer :: thread
       integer :: iCell, k, iEdge
@@ -551,7 +472,7 @@ module atm_time_integration
       !
       ! Communicate halos for theta_m, scalars, pressure_p, and rtheta_p
       !
-      call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+      call exchange_halo_group(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
 
       call mpas_timer_start('atm_rk_integration_setup')
 
@@ -589,18 +510,10 @@ module atm_time_integration
       call mpas_timer_start('physics_get_tend')
       rk_step = 1
       dynamics_substep = 1
-      call physics_get_tend( block, &
-                              mesh, &
-                             state, &     
-                              diag, &
-                              tend, &
-                      tend_physics, &
-                   block % configs, &
-                           rk_step, &
-                  dynamics_substep, &
-                   tend_ru_physics, &
-               tend_rtheta_physics, &
-                  tend_rho_physics )
+      call physics_get_tend( block, mesh, state, diag, tend, tend_physics, &
+                             block % configs, rk_step, dynamics_substep, &
+                             tend_ru_physics, tend_rtheta_physics, tend_rho_physics, &
+                             exchange_halo_group )
       call mpas_timer_stop('physics_get_tend')
 #else
 #ifndef MPAS_CAM_DYCORE
@@ -640,7 +553,7 @@ module atm_time_integration
 !$OMP END PARALLEL DO
          call mpas_timer_stop('atm_compute_vert_imp_coefs')
 
-         call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:exner')
+         call exchange_halo_group(domain, 'dynamics:exner')
 
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
@@ -713,7 +626,7 @@ module atm_time_integration
             !***********************************
 
 ! tend_u
-            call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:tend_u')
+            call exchange_halo_group(domain, 'dynamics:tend_u')
    
             call mpas_timer_start('small_step_prep')
    
@@ -790,7 +703,7 @@ module atm_time_integration
 
             do small_step = 1, number_sub_steps(rk_step)
 
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:rho_pp')
+               call exchange_halo_group(domain, 'dynamics:rho_pp')
 
                call mpas_timer_start('atm_advance_acoustic_step')
 
@@ -813,7 +726,7 @@ module atm_time_integration
 ! rtheta_pp
 ! This is the only communications needed during the acoustic steps because we solve for u on all edges of owned cells
 
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:rtheta_pp')
+               call exchange_halo_group(domain, 'dynamics:rtheta_pp')
 
 !  complete update of horizontal momentum by including 3d divergence damping at the end of the acoustic step
 
@@ -833,7 +746,7 @@ module atm_time_integration
             !
             ! Communicate halos for rw_p[1,2], ru_p[1,2], rho_pp[1,2], rtheta_pp[2]
             !
-            call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+            call exchange_halo_group(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
 
             call mpas_timer_start('atm_recover_large_step_variables')
 
@@ -894,10 +807,9 @@ module atm_time_integration
             
             ! u
             if (config_apply_lbcs) then
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:u_123')
+               call exchange_halo_group(domain, 'dynamics:u_123')
             else
-               !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % state % time_levs(2) % state % u, (/ 3 /))
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:u_3')
+               call exchange_halo_group(domain, 'dynamics:u_3')
             end if
 
             ! scalar advection: RK3 scheme of Skamarock and Gassmann (2011). 
@@ -906,11 +818,11 @@ module atm_time_integration
             if (config_scalar_advection .and. (.not. config_split_dynamics_transport) ) then
 
                call advance_scalars('scalars', domain, rk_step, rk_timestep, config_monotonic, config_positive_definite, &
-                                    config_time_integration_order, config_split_dynamics_transport)
+                                    config_time_integration_order, config_split_dynamics_transport, exchange_halo_group)
 
                if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS scalar transport
 
-                  call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:scalars')
+                  call exchange_halo_group(domain, 'dynamics:scalars')
 
                   allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
@@ -981,12 +893,12 @@ module atm_time_integration
                !
                ! Communicate halos for w[1,2], pv_edge[1,2], rho_edge[1,2], scalars[1,2]
                !
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+               call exchange_halo_group(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
             else
                !
                ! Communicate halos for w[1,2], pv_edge[1,2], rho_edge[1,2]
                !
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:w,pv_edge,rho_edge')
+               call exchange_halo_group(domain, 'dynamics:w,pv_edge,rho_edge')
             end if
 
             ! set the zero-gradient condition on w for regional_MPAS
@@ -1001,7 +913,7 @@ module atm_time_integration
 !$OMP END PARALLEL DO
 
               ! w halo values needs resetting after regional boundary update
-              call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:w')
+              call exchange_halo_group(domain, 'dynamics:w')
 
             end if ! end of regional_MPAS addition 
 
@@ -1012,7 +924,7 @@ module atm_time_integration
             !
             ! Communicate halos for theta_m[1,2], pressure_p[1,2], and rtheta_p[1,2]
             !
-            call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+            call exchange_halo_group(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
 
             !
             ! Note: A halo exchange for 'exner' here as well as after the call
@@ -1072,12 +984,12 @@ module atm_time_integration
 
 
             call advance_scalars('scalars', domain, rk_step, rk_timestep, config_monotonic, config_positive_definite, &
-                                 config_time_integration_order, config_split_dynamics_transport)
+                                 config_time_integration_order, config_split_dynamics_transport, exchange_halo_group)
 
             if (config_apply_lbcs) then  ! adjust boundary tendencies for regional_MPAS scalar transport
 
                ! need to fill halo for horizontal filter
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:scalars')
+               call exchange_halo_group(domain, 'dynamics:scalars')
    
                allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
@@ -1124,7 +1036,7 @@ module atm_time_integration
 !------------------------------------------------------------------------------------------------------------------------
 
             if (rk_step < 3) then
-               call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:scalars')
+               call exchange_halo_group(domain, 'dynamics:scalars')
             end if
 
          end do RK3_SPLIT_TRANSPORT
@@ -1226,7 +1138,7 @@ module atm_time_integration
 
       if (config_apply_lbcs) then  ! adjust boundary values for regional_MPAS scalar transport
 
-         call mpas_dmpar_exch_group_full_halo_exch(domain, 'dynamics:scalars')
+         call exchange_halo_group(domain, 'dynamics:scalars')
 
          allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
@@ -1301,7 +1213,7 @@ module atm_time_integration
    !
    !-----------------------------------------------------------------------
    subroutine advance_scalars(field_name, domain, rk_step, rk_timestep, config_monotonic, config_positive_definite, &
-                              config_time_integration_order, config_split_dynamics_transport)
+                              config_time_integration_order, config_split_dynamics_transport, exchange_halo_group)
 
       implicit none
 
@@ -1314,6 +1226,7 @@ module atm_time_integration
       logical, intent(in) :: config_positive_definite
       integer, intent(in) :: config_time_integration_order
       logical, intent(in) :: config_split_dynamics_transport
+      procedure (halo_exchange_routine) :: exchange_halo_group
 
       ! Local variables
       integer :: thread
@@ -1414,6 +1327,7 @@ module atm_time_integration
                                           cellSolveThreadStart(thread), cellSolveThreadEnd(thread), &
                                           scalar_old_arr, scalar_new_arr, s_max_arr, s_min_arr, wdtn_arr, &
                                           flux_array, flux_upwind_tmp_arr, flux_tmp_arr, &
+                                          exchange_halo_group, &
                                           advance_density=config_split_dynamics_transport, rho_zz_int=rho_zz_int)
          end if
       end do
@@ -3143,7 +3057,7 @@ module atm_time_integration
                                        cellStart, cellEnd, edgeStart, edgeEnd, &
                                        cellSolveStart, cellSolveEnd, &
                                        scalar_old, scalar_new, s_max, s_min, wdtn, flux_arr, &
-                                       flux_upwind_tmp, flux_tmp, advance_density, rho_zz_int)
+                                       flux_upwind_tmp, flux_tmp, exchange_halo_group, advance_density, rho_zz_int)
 
       implicit none
 
@@ -3164,6 +3078,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), intent(inout) :: wdtn
       real (kind=RKIND), dimension(:,:), intent(inout) :: flux_arr
       real (kind=RKIND), dimension(:,:), intent(inout) :: flux_upwind_tmp, flux_tmp
+      procedure (halo_exchange_routine) :: exchange_halo_group
       logical, intent(in), optional :: advance_density
       real (kind=RKIND), dimension(:,:), intent(inout), optional :: rho_zz_int
 
@@ -3242,7 +3157,7 @@ module atm_time_integration
                                    advCellsForEdge, adv_coefs, adv_coefs_3rd, scalar_old, scalar_new, s_max, s_min, &
                                    wdtn, scale_arr, flux_arr, flux_upwind_tmp, flux_tmp, &
                                    bdyMaskCell, bdyMaskEdge, &
-                                   advance_density, rho_zz_int)
+                                   exchange_halo_group, advance_density, rho_zz_int)
 
       call mpas_deallocate_scratch_field(scale)
 
@@ -3290,7 +3205,7 @@ module atm_time_integration
                                    advCellsForEdge, adv_coefs, adv_coefs_3rd, scalar_old, scalar_new, s_max, s_min, &
                                    wdtn, scale_arr, flux_arr, flux_upwind_tmp, flux_tmp, &
                                    bdyMaskCell, bdyMaskEdge, &
-                                   advance_density, rho_zz_int)
+                                   exchange_halo_group, advance_density, rho_zz_int)
 
       use mpas_atm_dimensions, only : nVertLevels
 
@@ -3304,6 +3219,7 @@ module atm_time_integration
       real (kind=RKIND), intent(in)        :: dt
       integer, intent(in) :: cellStart, cellEnd, edgeStart, edgeEnd
       integer, intent(in) :: cellSolveStart, cellSolveEnd
+      procedure (halo_exchange_routine) :: exchange_halo_group
       logical, intent(in), optional :: advance_density
       real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout), optional :: rho_zz_int
 
@@ -3399,7 +3315,7 @@ module atm_time_integration
 
 !$OMP BARRIER
 !$OMP MASTER
-      call mpas_dmpar_exch_group_full_halo_exch(block % domain, 'dynamics:scalars_old')
+      call exchange_halo_group(block % domain, 'dynamics:scalars_old')
 !$OMP END MASTER
 !$OMP BARRIER
 
@@ -3723,7 +3639,7 @@ module atm_time_integration
          !
 !$OMP BARRIER
 !$OMP MASTER
-         call mpas_dmpar_exch_group_full_halo_exch(block % domain, 'dynamics:scale')
+         call exchange_halo_group(block % domain, 'dynamics:scale')
 !$OMP END MASTER
 !$OMP BARRIER
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -31,9 +31,11 @@ module atm_core
 
    type (MPAS_Clock_type), pointer :: clock
    procedure (halo_exchange_routine), pointer :: exchange_halo_group
+   character(len=StrKIND), pointer :: config_halo_exch_method
 
    private :: exchange_halo_group
    private :: atm_build_halo_groups, atm_destroy_halo_groups
+   private :: config_halo_exch_method
 
 
    contains
@@ -1437,117 +1439,138 @@ module atm_core
       type (domain_type), intent(inout) :: domain
       integer, intent(inout) :: ierr
 
-
       !
-      ! Set up halo exchange groups used during atmosphere core initialization
+      ! Determine from the namelist option config_halo_exch_method which halo exchange method to employ
       !
-      call mpas_dmpar_exch_group_create(domain, 'initialization:u')
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:u', 'u', timeLevel=1, haloLayers=(/1,2,3/))
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_halo_exch_method', config_halo_exch_method)
 
-      call mpas_dmpar_exch_group_create(domain, 'initialization:pv_edge,ru,rw')
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'pv_edge', timeLevel=1, haloLayers=(/1,2,3/))
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'ru', timeLevel=1, haloLayers=(/1,2,3/))
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'rw', timeLevel=1, haloLayers=(/1,2/))
+      if (trim(config_halo_exch_method) == 'mpas_dmpar') then
+         call mpas_log_write('')
+         call mpas_log_write('*** Using ''mpas_dmpar'' routines for exchanging halos')
+         call mpas_log_write('')
 
-      !
-      ! Set up halo exchange groups used by dynamics
-      !
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'theta_m', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'scalars', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'pressure_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'rtheta_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
+         !
+         ! Set up halo exchange groups used during atmosphere core initialization
+         !
+         call mpas_dmpar_exch_group_create(domain, 'initialization:u')
+         call mpas_dmpar_exch_group_add_field(domain, 'initialization:u', 'u', timeLevel=1, haloLayers=(/1,2,3/))
 
-      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
-      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % ru_p, (/ 2 /))
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rw_p', &
-                                           timeLevel=1, haloLayers=(/1/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'ru_p', &
-                                           timeLevel=1, haloLayers=(/2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rho_pp', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rtheta_pp', &
-                                           timeLevel=1, haloLayers=(/2/))
+         call mpas_dmpar_exch_group_create(domain, 'initialization:pv_edge,ru,rw')
+         call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'pv_edge', timeLevel=1, haloLayers=(/1,2,3/))
+         call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'ru', timeLevel=1, haloLayers=(/1,2,3/))
+         call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'rw', timeLevel=1, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'w', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'pv_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'rho_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
+         !
+         ! Set up halo exchange groups used by dynamics
+         !
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'theta_m', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'scalars', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'pressure_p', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'rtheta_p', &
+                                              timeLevel=1, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'w', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'pv_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'rho_edge', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'scalars', &
-                                           timeLevel=2, haloLayers=(/1,2/))
+         !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
+         !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % ru_p, (/ 2 /))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rw_p', &
+                                              timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'ru_p', &
+                                              timeLevel=1, haloLayers=(/2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rho_pp', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rtheta_pp', &
+                                              timeLevel=1, haloLayers=(/2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'theta_m', &
-                                           timeLevel=2, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'pressure_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
-                                           timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'w', &
+                                              timeLevel=2, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'pv_edge', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'rho_edge', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'w', &
+                                              timeLevel=2, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'pv_edge', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'rho_edge', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'scalars', &
+                                              timeLevel=2, haloLayers=(/1,2/))
+
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'theta_m', &
+                                              timeLevel=2, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'pressure_p', &
+                                              timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
+                                              timeLevel=1, haloLayers=(/1,2/))
 
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:exner')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:exner')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:tend_u')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:tend_u', 'tend_u', timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:tend_u')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:tend_u', 'tend_u', timeLevel=1, haloLayers=(/1/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rho_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rho_pp', 'rho_pp', timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:rho_pp')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rho_pp', 'rho_pp', timeLevel=1, haloLayers=(/1/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:rtheta_pp')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rtheta_pp', 'rtheta_pp', timeLevel=1, haloLayers=(/1/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:rtheta_pp')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rtheta_pp', 'rtheta_pp', timeLevel=1, haloLayers=(/1/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_123')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_123', 'u', timeLevel=2, haloLayers=(/1,2,3/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:u_123')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_123', 'u', timeLevel=2, haloLayers=(/1,2,3/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_3')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_3', 'u', timeLevel=2, haloLayers=(/3/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:u_3')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_3', 'u', timeLevel=2, haloLayers=(/3/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars', 'scalars', timeLevel=2, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars', 'scalars', timeLevel=2, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars_old')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars_old', 'scalars', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars_old')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars_old', 'scalars', timeLevel=1, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:w')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w', 'w', timeLevel=2, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:w')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w', 'w', timeLevel=2, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'dynamics:scale')
-      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scale', 'scale', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'dynamics:scale')
+         call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scale', 'scale', timeLevel=1, haloLayers=(/1,2/))
 
 #ifdef DO_PHYSICS
-      !
-      ! Set up halo exchange groups used by physics
-      !
-      call mpas_dmpar_exch_group_create(domain, 'physics:blten')
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rublten', timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rvblten', timeLevel=1, haloLayers=(/1,2/))
+         !
+         ! Set up halo exchange groups used by physics
+         !
+         call mpas_dmpar_exch_group_create(domain, 'physics:blten')
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rublten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rvblten', timeLevel=1, haloLayers=(/1,2/))
 
-      call mpas_dmpar_exch_group_create(domain, 'physics:cuten')
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_create(domain, 'physics:cuten')
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
 #endif
 
-      !
-      ! Set routine to exchange a halo group
-      !
-      exchange_halo_group => mpas_dmpar_exch_group_full_halo_exch
+         !
+         ! Set routine to exchange a halo group
+         !
+         exchange_halo_group => mpas_dmpar_exch_group_full_halo_exch
+
+      else
+
+         !
+         ! Invalid method for exchanging halos
+         !
+         ierr = 1
+         call mpas_log_write('Invalid method for exchanging halos specified by ''config_halo_exch_method'': ' // &
+                             trim(config_halo_exch_method), messageType=MPAS_LOG_ERR)
+         return
+
+      end if
 
       ierr = 0
 
@@ -1575,39 +1598,50 @@ module atm_core
       integer, intent(inout) :: ierr
 
 
-      !
-      ! Destroy halo exchange groups used only during initialization
-      !
-      call mpas_dmpar_exch_group_destroy(domain, 'initialization:u')
-      call mpas_dmpar_exch_group_destroy(domain, 'initialization:pv_edge,ru,rw')
+      if (trim(config_halo_exch_method) == 'mpas_dmpar') then
+         !
+         ! Destroy halo exchange groups used only during initialization
+         !
+         call mpas_dmpar_exch_group_destroy(domain, 'initialization:u')
+         call mpas_dmpar_exch_group_destroy(domain, 'initialization:pv_edge,ru,rw')
 
-      !
-      ! Destroy halo exchange groups used by dynamics
-      !
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+         !
+         ! Destroy halo exchange groups used by dynamics
+         !
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
 
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:exner')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:tend_u')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rho_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rtheta_pp')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_123')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_3')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars_old')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w')
-      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scale')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:exner')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:tend_u')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rho_pp')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rtheta_pp')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_123')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_3')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars_old')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w')
+         call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scale')
 
 #ifdef DO_PHYSICS
-      !
-      ! Destroy halo exchange groups used by physics
-      !
-      call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
-      call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
+         !
+         ! Destroy halo exchange groups used by physics
+         !
+         call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
+         call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
 #endif
+
+      else
+
+         !
+         ! Invalid method for exchanging halos - an error should have already occurred in atm_build_halo_groups()
+         !
+         ierr = 1
+         return
+
+      end if
 
       ierr = 0
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1436,6 +1436,9 @@ module atm_core
    !-----------------------------------------------------------------------
    subroutine atm_build_halo_groups(domain, ierr)
 
+      use mpas_halo, only : mpas_halo_init, mpas_halo_exch_group_create, mpas_halo_exch_group_add_field, &
+                            mpas_halo_exch_group_complete, mpas_halo_exch_group_full_halo_exch
+
       type (domain_type), intent(inout) :: domain
       integer, intent(inout) :: ierr
 
@@ -1560,6 +1563,139 @@ module atm_core
          !
          exchange_halo_group => mpas_dmpar_exch_group_full_halo_exch
 
+      else if (trim(config_halo_exch_method) == 'mpas_halo') then
+
+         call mpas_log_write('')
+         call mpas_log_write('*** Using ''mpas_halo'' routines for exchanging halos')
+         call mpas_log_write('')
+
+         call mpas_halo_init(domain)
+
+         !
+         ! Set up halo exchange groups used during atmosphere core initialization
+         !
+         call mpas_halo_exch_group_create(domain, 'initialization:u')
+         call mpas_halo_exch_group_add_field(domain, 'initialization:u', 'u', timeLevel=1, haloLayers=(/1,2,3/))
+         call mpas_halo_exch_group_complete(domain, 'initialization:u')
+
+         call mpas_halo_exch_group_create(domain, 'initialization:pv_edge,ru,rw')
+         call mpas_halo_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'pv_edge', timeLevel=1, haloLayers=(/1,2,3/))
+         call mpas_halo_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'ru', timeLevel=1, haloLayers=(/1,2,3/))
+         call mpas_halo_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'rw', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'initialization:pv_edge,ru,rw')
+
+         !
+         ! Set up halo exchange groups used by dynamics
+         !
+         call mpas_halo_exch_group_create(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'theta_m', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'scalars', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'pressure_p', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'rtheta_p', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rw_p', &
+                                             timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'ru_p', &
+                                             timeLevel=1, haloLayers=(/2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rho_pp', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rtheta_pp', &
+                                             timeLevel=1, haloLayers=(/2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'w', timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'pv_edge', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'rho_edge', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:w,pv_edge,rho_edge')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'w', &
+                                             timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'pv_edge', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'rho_edge', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'scalars', &
+                                             timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'theta_m', &
+                                             timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'pressure_p', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
+                                             timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:exner')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:exner')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:tend_u')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:tend_u', 'tend_u', timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:tend_u')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:rho_pp')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rho_pp', 'rho_pp', timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:rho_pp')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:rtheta_pp')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:rtheta_pp', 'rtheta_pp', timeLevel=1, haloLayers=(/1/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:rtheta_pp')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:u_123')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:u_123', 'u', timeLevel=2, haloLayers=(/1,2,3/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:u_123')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:u_3')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:u_3', 'u', timeLevel=2, haloLayers=(/3/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:u_3')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:scalars')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:scalars', 'scalars', timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:scalars')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:scalars_old')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:scalars_old', 'scalars', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:scalars_old')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:w')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:w', 'w', timeLevel=2, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:w')
+
+         call mpas_halo_exch_group_create(domain, 'dynamics:scale')
+         call mpas_halo_exch_group_add_field(domain, 'dynamics:scale', 'scale', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'dynamics:scale')
+
+#ifdef DO_PHYSICS
+         !
+         ! Set up halo exchange groups used by physics
+         !
+         call mpas_halo_exch_group_create(domain, 'physics:blten')
+         call mpas_halo_exch_group_add_field(domain, 'physics:blten', 'rublten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:blten', 'rvblten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'physics:blten')
+
+         call mpas_halo_exch_group_create(domain, 'physics:cuten')
+         call mpas_halo_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
+         call mpas_halo_exch_group_complete(domain, 'physics:cuten')
+#endif
+
+         !
+         ! Set routine to exchange a halo group
+         !
+         exchange_halo_group => mpas_halo_exch_group_full_halo_exch
+
       else
 
          !
@@ -1593,6 +1729,8 @@ module atm_core
    !
    !-----------------------------------------------------------------------
    subroutine atm_destroy_halo_groups(domain, ierr)
+
+      use mpas_halo, only : mpas_halo_exch_group_destroy, mpas_halo_finalize
 
       type (domain_type), intent(inout) :: domain
       integer, intent(inout) :: ierr
@@ -1632,6 +1770,44 @@ module atm_core
          call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
          call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
 #endif
+
+      else if (trim(config_halo_exch_method) == 'mpas_halo') then
+
+         !
+         ! Destroy halo exchange groups used only during initialization
+         !
+         call mpas_halo_exch_group_destroy(domain, 'initialization:u')
+         call mpas_halo_exch_group_destroy(domain, 'initialization:pv_edge,ru,rw')
+
+         !
+         ! Destroy halo exchange groups used by dynamics
+         !
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:exner')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:tend_u')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:rho_pp')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:rtheta_pp')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:u_123')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:u_3')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:scalars')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:scalars_old')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:w')
+         call mpas_halo_exch_group_destroy(domain, 'dynamics:scale')
+
+#ifdef DO_PHYSICS
+         !
+         ! Destroy halo exchange groups used by physics
+         !
+         call mpas_halo_exch_group_destroy(domain, 'physics:blten')
+         call mpas_halo_exch_group_destroy(domain, 'physics:cuten')
+#endif
+
+         call mpas_halo_finalize(domain)
 
       else
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -13,7 +13,27 @@ module atm_core
    use mpas_log, only : mpas_log_write, mpas_log_info
    use mpas_io_units, only : mpas_new_unit, mpas_release_unit
 
+   !
+   ! Abstract interface for routine used to communicate halos of fields
+   ! in a named group
+   !
+   abstract interface
+      subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+         use mpas_derived_types, only : domain_type
+
+         type (domain_type), intent(inout) :: domain
+         character(len=*), intent(in) :: halo_group
+         integer, intent(out), optional :: ierr
+
+      end subroutine halo_exchange_routine
+   end interface
+
    type (MPAS_Clock_type), pointer :: clock
+   procedure (halo_exchange_routine), pointer :: exchange_halo_group
+
+   private :: exchange_halo_group
+   private :: atm_build_halo_groups, atm_destroy_halo_groups
 
 
    contains
@@ -83,32 +103,16 @@ module atm_core
       mpas_log_info => domain % logInfo
 
       !
-      ! Set up halo exchange groups used during atmosphere core initialization
+      ! Build halo exchange groups and set method for exchanging halos in a group
       !
-      call mpas_dmpar_exch_group_create(domain, 'initialization:u')
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:u', 'u', timeLevel=1, haloLayers=(/1,2,3/))
-
-      call mpas_dmpar_exch_group_create(domain, 'initialization:pv_edge,ru,rw')
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'pv_edge', timeLevel=1, haloLayers=(/1,2,3/))
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'ru', timeLevel=1, haloLayers=(/1,2,3/))
-      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'rw', timeLevel=1, haloLayers=(/1,2/))
-
-#ifdef DO_PHYSICS
-      !
-      ! Set up halo exchange groups used by physics
-      !
-      call mpas_dmpar_exch_group_create(domain, 'physics:blten')
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rublten', timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rvblten', timeLevel=1, haloLayers=(/1,2/))
-
-      call mpas_dmpar_exch_group_create(domain, 'physics:cuten')
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
-      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
-#endif
+      call atm_build_halo_groups(domain, ierr)
+      if (ierr /= 0) then
+         call mpas_log_write('Failed to build halo exchange groups.', messageType=MPAS_LOG_ERR)
+         return
+      end if
 
       call mpas_pool_get_config(domain % blocklist % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', dt)
-
 
       !
       ! If this is a restart run, read the restart stream, else read the input
@@ -180,7 +184,7 @@ module atm_core
       startTime = mpas_get_clock_time(clock, MPAS_START_TIME, ierr)
       call mpas_get_time(startTime, dateTimeString=startTimeStamp) 
 
-      call mpas_dmpar_exch_group_full_halo_exch(domain, 'initialization:u')
+      call exchange_halo_group(domain, 'initialization:u')
 
 
       !
@@ -213,16 +217,10 @@ module atm_core
          block => block % next
       end do
 
-      call mpas_dmpar_exch_group_full_halo_exch(domain, 'initialization:pv_edge,ru,rw')
+      call exchange_halo_group(domain, 'initialization:pv_edge,ru,rw')
 
       call mpas_atm_diag_setup(domain % streamManager, domain % blocklist % configs, &
                                domain % blocklist % structs, domain % clock, domain % dminfo)
-
-      !
-      ! Destroy halo exchange groups used only during initialization
-      !
-      call mpas_dmpar_exch_group_destroy(domain, 'initialization:u')
-      call mpas_dmpar_exch_group_destroy(domain, 'initialization:pv_edge,ru,rw')
 
       !
       ! Prepare the dynamics for integration
@@ -934,7 +932,7 @@ module atm_core
       endif
 #endif
 
-      call atm_timestep(domain, dt, currTime, itimestep)
+      call atm_timestep(domain, dt, currTime, itimestep, exchange_halo_group)
 
    end subroutine atm_do_timestep
    
@@ -979,13 +977,15 @@ module atm_core
 
             block_ptr => block_ptr%next
          end do
-
-         !
-         ! Destroy halo exchange groups used by physics
-         !
-         call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
-         call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
 #endif
+
+      !
+      ! Destroy halo exchange groups
+      !
+      call atm_destroy_halo_groups(domain, ierr)
+      if (ierr /= 0) then
+         call mpas_log_write('Failed to destroy halo exchange groups.', messageType=MPAS_LOG_ERR)
+      end if
 
       !
       ! Finalize threading
@@ -1415,6 +1415,203 @@ module atm_core
 
    end subroutine mpas_atm_run_compatibility
 
+
+   !-----------------------------------------------------------------------
+   !  routine atm_build_halo_groups
+   !
+   !> \brief Builds halo exchange groups used throughout atmosphere core
+   !> \author Michael Duda
+   !> \date   5 June 2023
+   !> \details
+   !>  This routine builds the halo exchange groups that are used throughout
+   !>  the atmosphere core, and it sets a function pointer,
+   !>  exchange_halo_group, to the routine that may be used to exchange the
+   !>  halos for all fields in a named group.
+   !>
+   !>  A value of 0 is returned if halo exchange groups have been
+   !>  successfully set up and a non-zero value is returned otherwise.
+   !
+   !-----------------------------------------------------------------------
+   subroutine atm_build_halo_groups(domain, ierr)
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(inout) :: ierr
+
+
+      !
+      ! Set up halo exchange groups used during atmosphere core initialization
+      !
+      call mpas_dmpar_exch_group_create(domain, 'initialization:u')
+      call mpas_dmpar_exch_group_add_field(domain, 'initialization:u', 'u', timeLevel=1, haloLayers=(/1,2,3/))
+
+      call mpas_dmpar_exch_group_create(domain, 'initialization:pv_edge,ru,rw')
+      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'pv_edge', timeLevel=1, haloLayers=(/1,2,3/))
+      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'ru', timeLevel=1, haloLayers=(/1,2,3/))
+      call mpas_dmpar_exch_group_add_field(domain, 'initialization:pv_edge,ru,rw', 'rw', timeLevel=1, haloLayers=(/1,2/))
+
+      !
+      ! Set up halo exchange groups used by dynamics
+      !
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'theta_m', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'scalars', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'pressure_p', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p', 'rtheta_p', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+
+      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % rw_p, (/ 1 /))
+      !CR: SMALLER STENCIL?: call mpas_dmpar_exch_halo_field(block % diag % ru_p, (/ 2 /))
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rw_p', &
+                                           timeLevel=1, haloLayers=(/1/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'ru_p', &
+                                           timeLevel=1, haloLayers=(/2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rho_pp', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp', 'rtheta_pp', &
+                                           timeLevel=1, haloLayers=(/2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'w', &
+                                           timeLevel=2, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'pv_edge', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge', 'rho_edge', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'w', &
+                                           timeLevel=2, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'pv_edge', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'rho_edge', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w,pv_edge,rho_edge,scalars', 'scalars', &
+                                           timeLevel=2, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'theta_m', &
+                                           timeLevel=2, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'pressure_p', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:theta_m,pressure_p,rtheta_p', 'rtheta_p', &
+                                           timeLevel=1, haloLayers=(/1,2/))
+
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:exner')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:exner', 'exner', timeLevel=1, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:tend_u')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:tend_u', 'tend_u', timeLevel=1, haloLayers=(/1/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:rho_pp')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rho_pp', 'rho_pp', timeLevel=1, haloLayers=(/1/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:rtheta_pp')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:rtheta_pp', 'rtheta_pp', timeLevel=1, haloLayers=(/1/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_123')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_123', 'u', timeLevel=2, haloLayers=(/1,2,3/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:u_3')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:u_3', 'u', timeLevel=2, haloLayers=(/3/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars', 'scalars', timeLevel=2, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:scalars_old')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scalars_old', 'scalars', timeLevel=1, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:w')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:w', 'w', timeLevel=2, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'dynamics:scale')
+      call mpas_dmpar_exch_group_add_field(domain, 'dynamics:scale', 'scale', timeLevel=1, haloLayers=(/1,2/))
+
+#ifdef DO_PHYSICS
+      !
+      ! Set up halo exchange groups used by physics
+      !
+      call mpas_dmpar_exch_group_create(domain, 'physics:blten')
+      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rublten', timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'physics:blten', 'rvblten', timeLevel=1, haloLayers=(/1,2/))
+
+      call mpas_dmpar_exch_group_create(domain, 'physics:cuten')
+      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rucuten', timeLevel=1, haloLayers=(/1,2/))
+      call mpas_dmpar_exch_group_add_field(domain, 'physics:cuten', 'rvcuten', timeLevel=1, haloLayers=(/1,2/))
+#endif
+
+      !
+      ! Set routine to exchange a halo group
+      !
+      exchange_halo_group => mpas_dmpar_exch_group_full_halo_exch
+
+      ierr = 0
+
+   end subroutine atm_build_halo_groups
+
+
+   !-----------------------------------------------------------------------
+   !  routine atm_destroy_halo_groups
+   !
+   !> \brief Destroys halo exchange groups used throughout atmosphere core
+   !> \author Michael Duda
+   !> \date   5 June 2023
+   !> \details
+   !>  This routine destroys the halo exchange groups that are used throughout
+   !>  the atmosphere core, freeing up any resources that were used by these
+   !>  halo exchange groups.
+   !>
+   !>  A value of 0 is returned if halo exchange groups have been
+   !>  successfully destroyed and a non-zero value is returned otherwise.
+   !
+   !-----------------------------------------------------------------------
+   subroutine atm_destroy_halo_groups(domain, ierr)
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(inout) :: ierr
+
+
+      !
+      ! Destroy halo exchange groups used only during initialization
+      !
+      call mpas_dmpar_exch_group_destroy(domain, 'initialization:u')
+      call mpas_dmpar_exch_group_destroy(domain, 'initialization:pv_edge,ru,rw')
+
+      !
+      ! Destroy halo exchange groups used by dynamics
+      !
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,scalars,pressure_p,rtheta_p')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rw_p,ru_p,rho_pp,rtheta_pp')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w,pv_edge,rho_edge,scalars')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:theta_m,pressure_p,rtheta_p')
+
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:exner')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:tend_u')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rho_pp')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:rtheta_pp')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_123')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:u_3')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scalars_old')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:w')
+      call mpas_dmpar_exch_group_destroy(domain, 'dynamics:scale')
+
+#ifdef DO_PHYSICS
+      !
+      ! Destroy halo exchange groups used by physics
+      !
+      call mpas_dmpar_exch_group_destroy(domain, 'physics:blten')
+      call mpas_dmpar_exch_group_destroy(domain, 'physics:cuten')
+#endif
+
+      ierr = 0
+
+   end subroutine atm_destroy_halo_groups
 
 end module atm_core
 

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -51,17 +51,32 @@
 ! * in subroutine physics_get_tend_work, added the option cu_ntiedtke in the calculation of rucuten_Edge.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-28.
 
+ !
+ ! Abstract interface for routine used to communicate halos of fields
+ ! in a named group
+ !
+ abstract interface
+    subroutine halo_exchange_routine(domain, halo_group, ierr)
+
+       use mpas_derived_types, only : domain_type
+
+       type (domain_type), intent(inout) :: domain
+       character(len=*), intent(in) :: halo_group
+       integer, intent(out), optional :: ierr
+
+    end subroutine halo_exchange_routine
+ end interface
+
 
  contains
 
  
 !=================================================================================================================
  subroutine physics_get_tend( block, mesh, state, diag, tend, tend_physics, configs, rk_step, dynamics_substep, &
-                              tend_ru_physics, tend_rtheta_physics, tend_rho_physics )
+                              tend_ru_physics, tend_rtheta_physics, tend_rho_physics, exchange_halo_group )
 !=================================================================================================================
    
  use mpas_atm_dimensions
- use mpas_dmpar, only : mpas_dmpar_exch_group_full_halo_exch
 
 !input variables:
  type(block_type),intent(in),target:: block
@@ -70,6 +85,7 @@
  type(mpas_pool_type),intent(in):: configs
  integer, intent(in):: rk_step
  integer, intent(in):: dynamics_substep
+ procedure (halo_exchange_routine) :: exchange_halo_group
 
 !inout variables:
  type(mpas_pool_type),intent(inout):: diag
@@ -218,7 +234,8 @@
                            tend_u_phys, tend_rtheta_adv, tend_diabatic, &
                            theta_m, scalars, &
                            tend_rtheta_physics, &
-                           tend_theta_euler &
+                           tend_theta_euler, &
+                           exchange_halo_group &
                            )
 
  !
@@ -273,7 +290,8 @@
                                  rthcuten, rqvcuten, rqccuten, rqrcuten, rqicuten, rqscuten, &
                                  rthratenlw, rthratensw, rthdynten, &
                                  tend_u_phys, tend_rtheta_adv, tend_diabatic, &
-                                 theta_m, scalars, tend_theta, tend_theta_euler &
+                                 theta_m, scalars, tend_theta, tend_theta_euler, &
+                                 exchange_halo_group &
                                 )
 !==================================================================================================
 
@@ -322,6 +340,7 @@
     real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1), intent(in) :: scalars
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout) :: tend_theta
     real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: tend_theta_euler
+    procedure (halo_exchange_routine) :: exchange_halo_group
 
     integer :: i, k
     real (kind=RKIND) :: coeff
@@ -329,7 +348,7 @@
     !add coupled tendencies due to PBL processes:
     if (config_pbl_scheme .ne. 'off') then
        if (rk_step == 1 .and. dynamics_substep == 1) then
-          call mpas_dmpar_exch_group_full_halo_exch(block % domain, 'physics:blten')
+          call exchange_halo_group(block % domain, 'physics:blten')
           call tend_toEdges(block,mesh,rublten,rvblten,rublten_Edge)
 
           !MGD for PV budget? should a similar line be in the cumulus section below?
@@ -390,7 +409,7 @@
     
            case('cu_tiedtke','cu_ntiedtke')
               if (rk_step == 1 .and. dynamics_substep == 1) then
-                 call mpas_dmpar_exch_group_full_halo_exch(block % domain, 'physics:cuten')
+                 call exchange_halo_group(block % domain, 'physics:cuten')
                  call tend_toEdges(block,mesh,rucuten,rvcuten,rucuten_Edge)
                  
                  tend_u_phys(1:nVertLevels,1:nEdges) = tend_u_phys(1:nVertLevels,1:nEdges) &


### PR DESCRIPTION
This PR adds the ability to use the `mpas_halo` routines for communicating halo groups in MPAS-A.

As an alternative to the group halo routines from the `mpas_dmpar` module, MPAS-A can now make
use of the routines from the `mpas_halo` module. Which module to use is runtime configurable
through a new namelist option, `config_halo_exch_method` in a new `&development` namelist group.
The `&development` group is hidden by default, and the `config_halo_exch_method` defaults to `'mpas_halo'`.
To switch to the `mpas_dmpar` halo routines, the `config_halo_exch_method` namelist option may be set
to `'mpas_dmpar'`.

The specific choice of halo exchange module (`mpas_dmpar` or `mpas_halo`) should have no impact on
simulation results, all else being equal.

In order to make the setup and use of different halo exchange methods cleaner and more modular, this PR
includes refactoring of the calls to create and destroy halo exchange groups as well as the use of procedure
arguments to supply specific halo exchange routines to the dynamics and physics-dynamics coupling code.