### PR TITLE
Update module_sf_sfclay.F to WRF version 4.5

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F
@@ -138,14 +138,12 @@ CONTAINS
                                                             XLAND, &
                                                               TSK
 
-!
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)               ::             REGIME, &
                                                               HFX, &
                                                               QFX, &
                                                                LH, &
                                                           MOL,RMOL
-!m the following 5 are change to memory size
 !
       REAL,     DIMENSION( ims:ime, jms:jme )                    , &
                 INTENT(INOUT)   ::                 GZ1OZ0,WSPD,BR, &
@@ -326,13 +324,12 @@ CONTAINS
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(INOUT)   ::                                 &
-                                                              QGH
+                                                         QSFC,QGH
 
       REAL,     DIMENSION( ims:ime )                             , &
                 INTENT(OUT)     ::                        U10,V10, &
-                                                TH2,T2,Q2,QSFC,LH
+                                                     TH2,T2,Q2,LH
 
-                                    
       REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV
 
       REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::      DX


### PR DESCRIPTION
This PR updates ./src/core_atmosphere/physics/physics_wrf/module_sf_sfclay.F to that availabel in the WRF release 4.5. The main update is changing the intent of the variable QSFC from intent(out) to intent(inout).


