### PR TITLE
Adding seaice thickness data from HYCOM for use in LSM sea ice module

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -498,6 +498,7 @@
 			<var name="tmn"/>
 			<var name="vegfra"/>
 			<var name="seaice"/>
+			<var name="icedepth"/>
 			<var name="xice"/>
 			<var name="xland"/>
 			<var name="u10"/>
@@ -823,6 +824,7 @@
 			<var name="tmn"/>
 			<var name="vegfra"/>
 			<var name="seaice"/>
+			<var name="icedepth"/>
 			<var name="xice"/>
 			<var name="xland"/>
 			<var name="dzs"/>
@@ -1076,6 +1078,7 @@
 			<var name="h_oml_initial"/>
 			<var name="hu_oml"/>
 			<var name="hv_oml"/>
+			<var name="icedepth"/>
 		</stream>
 
 		<stream name="surface" 
@@ -2062,6 +2065,11 @@
                      units="s"
                      description="Relaxation time to initial values in 1-d OML"
                      possible_values="Non-negative real values"/>
+
+                <nml_option name="icedepth_external" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="Whether sea ice thickness from external data sets is used"
+                     possible_values="`.true. or .false."/>
         </nml_record>
 
         <var_struct name="diag_physics" time_levs="1">
@@ -3037,6 +3045,9 @@
 
                 <var name="tmn" type="real" dimensions="nCells Time" units="K"
                      description="deep soil temperature"/>
+
+                <var name="icedepth" type="real" dimensions="nCells Time" units="m"
+                     description="Sea ice thickness"/>
 
                 <var name="vegfra" type="real" dimensions="nCells Time" units="unitless"
                      description="vegetation fraction"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2069,7 +2069,7 @@
                 <nml_option name="icedepth_external" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="Whether sea ice thickness from external data sets is used"
-                     possible_values="`.true. or .false."/>
+                     possible_values=".true. or .false."/>
         </nml_record>
 
         <var_struct name="diag_physics" time_levs="1">

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -307,7 +307,7 @@
  logical,pointer:: config_frac_seaice
 
  character(len=StrKIND),pointer:: config_microp_scheme,    &
-                                  config_convection_scheme
+                                  config_convection_scheme, icedepth_external
 
  integer,dimension(:),pointer:: isltyp,ivgtyp
 
@@ -317,7 +317,7 @@
                                            sfcrunoff,smstav,smstot,snotime,snopcx,sr,udrunoff,   &
                                            z0,znt
  real(kind=RKIND),dimension(:),pointer  :: shdmin,shdmax,snoalb,sfc_albbck,snow,snowc,snowh,tmn, &
-                                           skintemp,vegfra,xice,xland
+                                           skintemp,vegfra,xice,xland, icedepth
  real(kind=RKIND),dimension(:),pointer  :: t2m,th2m,q2
  real(kind=RKIND),dimension(:),pointer  :: raincv,rainncv
  real(kind=RKIND),dimension(:,:),pointer:: sh2o,smcrel,smois,tslb,dzs
@@ -332,6 +332,7 @@
  call mpas_pool_get_config(configs,'config_frac_seaice'      ,config_frac_seaice      )
  call mpas_pool_get_config(configs,'config_convection_scheme',config_convection_scheme)
  call mpas_pool_get_config(configs,'config_microp_scheme'    ,config_microp_scheme    )
+ call mpas_pool_get_config(configs,'icedepth_external'    ,icedepth_external    )
 
  call mpas_pool_get_array(diag_physics,'acsnom'           ,acsnom           )
  call mpas_pool_get_array(diag_physics,'acsnow'           ,acsnow           )
@@ -388,6 +389,7 @@
  call mpas_pool_get_array(sfc_input,'smcrel'    ,smcrel    )
  call mpas_pool_get_array(sfc_input,'smois'     ,smois     )
  call mpas_pool_get_array(sfc_input,'tslb'      ,tslb      )
+ call mpas_pool_get_array(sfc_input,'icedepth'  ,icedepth  )
 
 !In Registry.xml, dzs is a function of nCells. In the Noah lsm scheme, dzs is independent
 !of cell locations:
@@ -508,7 +510,11 @@
     do j = jts,jte
     do i = its,ite
        albsi_p(i,j)    = sfc_albedo_seaice(i)
+      IF(icedepth_external) THEN
+       icedepth_p(i,j) = icedepth(i)
+      ELSE
        icedepth_p(i,j) = seaice_thickness_default
+      ENDIF
        snowsi_p(i,j)   = seaice_snowdepth_min
     enddo
     enddo

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -547,6 +547,7 @@
                         <var name="snowh" packages="met_stage_out"/>
                         <var name="xice" packages="met_stage_out"/>
                         <var name="seaice" packages="met_stage_out"/>
+                        <var name="icedepth" packages="met_stage_out"/>
                         <var name="vegfra" packages="met_stage_out"/>
                         <var name="sfc_albbck" packages="met_stage_out"/>
                         <var name="xland" packages="met_stage_out"/>
@@ -1036,6 +1037,9 @@
 
                 <var name="xice" type="real" dimensions="nCells Time" units="unitless"
                      description="fractional area coverage of sea-ice"/>
+
+                <var name="icedepth" type="real" dimensions="nCells Time" units="m" default_value="0."
+                     description="Sea ice thickness in initial field, e.g.,from HYCOM"/>
 
                 <var name="seaice" type="real" dimensions="nCells Time" units="unitless"
                      description="sea-ice flag (0=no seaice; =1 otherwise)"/>

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2712,6 +2712,7 @@ module init_atm_cases
 
       real (kind=RKIND), dimension(:), pointer :: sst
       real (kind=RKIND), dimension(:), pointer :: seaice
+      real (kind=RKIND), dimension(:), pointer :: icedepth
       real (kind=RKIND), dimension(:), pointer :: xice
       real (kind=RKIND), dimension(:,:), pointer :: u
       real (kind=RKIND), dimension(:,:), pointer :: w
@@ -2864,6 +2865,7 @@ module init_atm_cases
       call mpas_pool_get_array(fg, 'sst', sst)
       call mpas_pool_get_array(fg, 'xice', xice)
       call mpas_pool_get_array(fg, 'seaice', seaice)
+      call mpas_pool_get_array(fg, 'icedepth', icedepth)
       call mpas_pool_get_array(fg, 'st_fg', st_fg)
       call mpas_pool_get_array(fg, 'sm_fg', sm_fg)
       call mpas_pool_get_array(fg, 'psfc', psfc)
@@ -6260,6 +6262,95 @@ call mpas_log_write('Done with soil consistency check')
          deallocate(field % slab)
          call read_next_met_field(field, istatus)
       end do
+
+      call read_met_close()
+
+      !
+      ! Get sea ice thickness  from a separate file
+      !
+      call read_met_init('ICET', .true., config_start_time(1:13), istatus)
+
+      if (istatus /= 0) then
+         call mpas_log_write('ICET file not found...')
+      end if
+
+      if (istatus == 0) then
+         call read_next_met_field(field, istatus)
+         do while (istatus == 0)
+            if (index(field % field, 'ICETHICK') /= 0) then
+
+               call mpas_log_write('PROCESSING sea ice thickness')
+
+               !
+               ! Set up projection
+               !
+               call map_init(proj)
+          
+               if (field % iproj == PROJ_LATLON) then
+                  call map_set(PROJ_LATLON, proj, &
+                               latinc = real(field % deltalat,RKIND), &
+                               loninc = real(field % deltalon,RKIND), &
+                               knowni = 1.0_RKIND, &
+                               knownj = 1.0_RKIND, &
+                               lat1 = real(field % startlat,RKIND), &
+                               lon1 = real(field % startlon,RKIND))
+               else
+                  call mpas_log_write('We were expecting sea ice thickness field to be on a lat-lon projection...', messageType=MPAS_LOG_CRIT)
+               end if
+
+               if (index(field % field, 'ICETHICK') /= 0) then
+                  nInterpPoints = nCells
+                  latPoints => latCell
+                  lonPoints => lonCell
+                  ndims = 1
+               end if
+   
+               interp_list(1) = n_neighbor
+               interp_list(2) = 0
+   
+               masked = 1
+               fillval = 0.
+               msgval = -30000. !Thomas default was 0.0
+               mask_array => landmask
+
+               allocate(rslab(field % nx, field % ny))
+               rslab(:,:) = field % slab(:,:)
+               do i=1,nInterpPoints
+                  if (mask_array(i) /= masked) then
+                     lat = latPoints(i)*DEG_PER_RAD
+                     lon = lonPoints(i)*DEG_PER_RAD
+                     call latlon_to_ij(proj, lat, lon, x, y)
+                     if (x < 0.5) then
+                        lon = lon + 360.0
+                        call latlon_to_ij(proj, lat, lon, x, y)
+                     else if (x >= real(field%nx)+0.5) then
+                        lon = lon - 360.0
+                        call latlon_to_ij(proj, lat, lon, x, y)
+                     end if
+                     if (y < 0.5) then
+                        y = 1.0
+                     else if (y >= real(field%ny)+0.5) then
+                        y = real(field%ny)
+                     end if
+                     if (ndims == 1) then
+                        icedepth(i) = interp_sequence(x, y, 1, rslab, 1, field % nx, 1, field % ny, 1, 1, msgval, interp_list, 1)
+                        if (icedepth(i) == msgval) icedepth(i) = fillval
+                        if (icedepth(i) < 0. ) icedepth(i) = 0.
+                     end if
+                  else
+                     if (ndims == 1) then
+                        icedepth(i) = fillval
+                     end if
+                  end if
+               end do
+               deallocate(rslab)
+               call mpas_log_write('PROCESSED sea ice thickness')
+            end if
+      
+            deallocate(field % slab)
+            call read_next_met_field(field, istatus)
+         end do
+      end if
 
       call read_met_close()
 

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -6310,7 +6310,7 @@ call mpas_log_write('Done with soil consistency check')
    
                masked = 1
                fillval = 0.
-               msgval = -30000. !Thomas default was 0.0
+               msgval = -30000.
                mask_array => landmask
 
                allocate(rslab(field % nx, field % ny))


### PR DESCRIPTION
This PR adds modifications to the code so that sea ice thickness information from HYCOM can be used in the LSM sea ice module. If no sea ice depth information is available, the default depth of 3m is used which can be unrealistically high in certain areas.

Sea ice depth data from HYCOM can be downloaded from https://ncss.hycom.org/thredds/ncss/grid/GLBy0.08/expt_93.0/ice/dataset.html (choose the "sih" variable). These data have to be written to WPS intermediate format with file prefix "ICET" and the name of the variable which is read in is called "ICETHICK".

To activate, users need to explicitly set _icedepth_external=.true._ in the physics section of namelist.atmosphere.
