### PR TITLE
Adding flag for semantics of floating-point calculations using ifort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ ifort:   # BUILDTARGET Intel Fortran, C, and C++ compiler suite
 	"CC_SERIAL = icc" \
 	"CXX_SERIAL = icpc" \
 	"FFLAGS_PROMOTION = -real-size 64" \
-	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte" \
+	"FFLAGS_OPT = -O3 -convert big_endian -free -align array64byte -fp-model precise" \
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \


### PR DESCRIPTION
This PR adds the flag "-fp-model precise" to the FFLAGS options in the master Makefile for the Intel compiler. According to the manual it "Disables optimizations that are not value-safe on floating-point data". This flag should help to improve consistency and reproducability between MPAS simulations.
