### PR TITLE
Initialize sfluxzen to 0.0 to prevent junk values when nlayers = laytrop

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -3284,6 +3284,10 @@ use module_wrf_error
 
 !jm not thread safe      hvrtau = '$Revision: 1.3 $'
 
+!     Initialize sfluxzen to 0.0 to prevent junk values when nlayers = laytrop
+!     added from WRF 12 December 2021
+      sfluxzen(:) = 0.0
+
 ! Calculate gaseous optical depth and planck fractions for each spectral band.
 
       call taumol16


### PR DESCRIPTION
This PR initializes sfluxzen to 0.0 to prevent junk values when nlayers = laytrop in RRTMG_SW. This fix is copied from WRF.
