### PR TITLE
Updated and user defined GHG concentrations for RRTMG

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2031,6 +2031,21 @@
                      description="configuration for long-wave radiation schemes"
                      possible_values="`suite',`rrtmg_lw',`cam_lw',`off'"/>
 
+                <nml_option name="co2_content" type="real" default_value="410.E-06" in_defaults="false"
+                     units="ppm"
+                     description="Mean CO2 content in the atmosphere for RRTMG"
+                     possible_values="Positive real values"/>
+
+                <nml_option name="n2o_content" type="real" default_value="330.E-09" in_defaults="false"
+                     units="ppb"
+                     description="Mean N2O content in the atmosphere for RRTMG"
+                     possible_values="Positive real values"/>
+
+                <nml_option name="ch4_content" type="real" default_value="1850.E-09" in_defaults="false"
+                     units="ppb"
+                     description="Mean CH4 content in the atmosphere for RRTMG"
+                     possible_values="Positive real values"/>
+
                 <nml_option name="config_radt_sw_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for short-wave radiation schemes"

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -886,7 +886,7 @@
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,      &
-            co2_local = co2_local , n2o_local = n2o_local, ch4_local = ch4_local         )                       )
+            co2_local = co2_local , n2o_local = n2o_local, ch4_local = ch4_local         )
        call mpas_timer_stop('RRTMG_lw')
 
     case ("cam_lw")

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -818,6 +818,9 @@
 
  integer,intent(in):: time_lev
  real(kind=RKIND),intent(in):: xtime_s
+ real(kind=RKIND),pointer:: co2_content
+ real(kind=RKIND),pointer:: ch4_content
+ real(kind=RKIND),pointer:: n2o_content
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: state
@@ -833,12 +836,16 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real :: co2_local, ch4_local, n2o_local
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_lw: ')
 
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme      )
+ call mpas_pool_get_config(configs,'co2_content', co2_content     )
+ call mpas_pool_get_config(configs,'n2o_content', n2o_content     )
+ call mpas_pool_get_config(configs,'ch4_content', ch4_content     )
 
 !copy MPAS arrays to local arrays:
  call radiation_lw_from_MPAS(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input,sfc_input,its,ite)
@@ -849,6 +856,14 @@
     case ("rrtmg_lw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2_local = co2_content
+       n2o_local = n2o_content
+       ch4_local = ch4_content
+!!$OMP SINGLE
+!call mpas_log_write('co2_local $r',realArgs=(/co2_local/))
+!call mpas_log_write('ch4_local $r',realArgs=(/ch4_local/))
+!call mpas_log_write('n2o_local $r',realArgs=(/n2o_local/))
+!!$OMP END SINGLE
 
        call mpas_timer_start('RRTMG_lw')
        call rrtmg_lwrad( &
@@ -870,8 +885,8 @@
             lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p     , lwdnbc   = lwdnbc_p , &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
-            its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &
-                       )
+            its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,      &
+            co2_local = co2_local , n2o_local = n2o_local, ch4_local = ch4_local         )                       )
        call mpas_timer_stop('RRTMG_lw')
 
     case ("cam_lw")

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -686,6 +686,9 @@
  integer,intent(in):: time_lev
 
  real(kind=RKIND),intent(in):: xtime_s
+ real(kind=RKIND),pointer:: co2_content
+ real(kind=RKIND),pointer:: n2o_content
+ real(kind=RKIND),pointer:: ch4_content
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: state
@@ -702,12 +705,16 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real :: co2_local, ch4_local, n2o_local
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_sw: $i',intArgs=(/itimestep/))
 
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme      )
+ call mpas_pool_get_config(configs,'co2_content', co2_content     )
+ call mpas_pool_get_config(configs,'n2o_content', n2o_content     )
+ call mpas_pool_get_config(configs,'ch4_content', ch4_content     )
 
  xtime_m = xtime_s/60.
 
@@ -739,6 +746,9 @@
     case ("rrtmg_sw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2_local = co2_content
+       n2o_local = n2o_content
+       ch4_local = ch4_content
 
        call mpas_timer_start('RRTMG_sw')
        call rrtmg_swrad( &
@@ -762,8 +772,8 @@
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
-              its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &
-                       )
+              its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,        &
+              co2_local = co2_local, n2o_local = n2o_local, ch4_local = ch4_local            )
        call mpas_timer_stop('RRTMG_sw')
 
     case ("cam_sw")

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_cam_support.F
@@ -263,7 +263,7 @@ real(r8) :: gdst(ndstsz, nspint) ! dust asymmetry parameter
       real(r8) cplol    ! constant for ozone path length integral
 
 !From ghg_surfvals.F90 module
-   real(r8) :: co2vmr = 3.550e-4         ! co2   volume mixing ratio
+   real(r8) :: co2vmr = 3.950e-4         ! co2   volume mixing ratio
    real(r8) :: n2ovmr = 0.311e-6         ! n2o   volume mixing ratio
    real(r8) :: ch4vmr = 1.714e-6         ! ch4   volume mixing ratio
    real(r8) :: f11vmr = 0.280e-9         ! cfc11 volume mixing ratio

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -11484,8 +11484,8 @@ CONTAINS
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
-                       its,ite, jts,jte, kts,kte                  &
-                       )
+                       its,ite, jts,jte, kts,kte,                 &
+                       co2_local, n2o_local, ch4_local)
 
  implicit none
 
@@ -11565,13 +11565,13 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+ real :: co2_local
 !methane (1774 ppbv)
  real :: ch4
- data ch4 / 1774.e-9 / 
+ real :: ch4_local
 !nitrous oxide (319 ppbv)
  real :: n2o
- data n2o / 319.e-9 / 
+ real :: n2o_local
 !cfc-11 (251 ppt)
  real :: cfc11
  data cfc11 / 0.251e-9 / 
@@ -11642,6 +11642,9 @@ CONTAINS
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1
+ co2 = co2_local
+ n2o = n2o_local
+ ch4 = ch4_local
 
 !--- initialize option for the calculation of the cloud optical properties:
  icld     = 2 ! with clouds using maximum/random cloud overlap in subroutine mcica_subcol_lw. 

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9878,8 +9878,8 @@ CONTAINS
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
-                       its,ite, jts,jte, kts,kte                       &
-                       )
+                       its,ite, jts,jte, kts,kte,                      &
+                       co2_local, n2o_local, ch4_local)
 
  implicit none
 
@@ -9970,13 +9970,13 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+ real :: co2_local
 !methane (1774 ppbv)
  real :: ch4
- data ch4 / 1774.e-9 / 
+ real :: ch4_local
 !nitrous oxide (319 ppbv)
  real :: n2o
- data n2o / 319.e-9 / 
+ real :: n2o_local
 
 !--- set oxygen volume mixing ratio (for o2mmr=0.23143):
  real :: o2
@@ -10004,6 +10004,9 @@ CONTAINS
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1
+ co2 = co2_local
+ n2o = n2o_local
+ ch4 = ch4_local
 
 !--- initialize option for the calculation of the cloud optical properties:
  icld     = 2 ! with clouds using maximum/random cloud overlap in subroutine mcica_subcol_lw. 


### PR DESCRIPTION
This PR updates the initial GHG concentrations in RRTMG SW+LW to more recent values. In addition, the user can specifiy the values by setting co2_content, n2o_content, and ch4_content to the desired values in the physics section of namelist.atmosphere.
New default values are 410 ppmv for CO2, 330 ppbv for N2O, and 1850 ppbv for CH4.
