### PR TITLE
Revised approach to initialize snowh from sneqv instead of a fixed value

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -167,7 +167,10 @@
     else
        snowc(iCell) = 0._RKIND
     endif
-    snowh(iCell) = snow(iCell) * 5.0_RKIND / 1000._RKIND
+    IF(snowh(iCell) .eq. 0. .and. snow(iCell) > 0.)THEN
+    call mpas_log_write('--- caluculate snow depth based on Hill et al.,2019, The Cryosphere, 13-----')
+    snowh(iCell) = (10.**(((log10(snow(icell))-log10(0.146_RKIND))/1.102_RKIND)))/1000._RKIND
+    ENDIF
  enddo
 
 !initialization of soil layers properties:


### PR DESCRIPTION
This PR adds a different approach to initialize "snowh" from "snow" field in case _no_ information about physical snow depth is available from, e.g., GFS or ECMWF analysis. The approach is based on the work from Hill et al., 2019, The Cryosphere, 13: [https://doi.org/10.5194/tc-13-1767-2019](url)

