### PR TITLE
Adding 3D temperature to history output

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1680,6 +1680,9 @@
                 <var name="pressure" type="real" dimensions="nVertLevels nCells Time" units="Pa"
                      description="Pressure"/>
 
+                <var name="temperature_k" type="real" dimensions="nVertLevels nCells Time" units="K"
+                     description="Temperature"/>
+
                 <var name="pressure_base" type="real" dimensions="nVertLevels nCells Time" units="Pa"
                      description="Base state pressure"/>
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -837,6 +837,7 @@ module atm_core
       integer, pointer :: nCells, nVertLevels, index_qv
       real (kind=RKIND), dimension(:,:), pointer :: theta, rho, theta_m, rho_zz, zz
       real (kind=RKIND), dimension(:,:), pointer :: pressure_base, pressure_p, pressure
+      real (kind=RKIND), dimension(:,:), pointer :: temperature_k
       real (kind=RKIND), dimension(:,:,:), pointer :: scalars
 
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
@@ -852,6 +853,7 @@ module atm_core
       call mpas_pool_get_array(diag, 'pressure_p', pressure_p)
       call mpas_pool_get_array(diag, 'pressure_base', pressure_base)
       call mpas_pool_get_array(diag, 'pressure', pressure)
+      call mpas_pool_get_array(diag, 'temperature_k', temperature_k)
 
       call mpas_pool_get_array(mesh, 'zz', zz)
 
@@ -860,6 +862,7 @@ module atm_core
             theta(k,iCell) = theta_m(k,iCell) / (1._RKIND + rvord * scalars(index_qv,k,iCell))
             rho(k,iCell) = rho_zz(k,iCell) * zz(k,iCell)
             pressure(k,iCell) = pressure_base(k,iCell) + pressure_p(k,iCell)
+            temperature_k(k,iCell) = theta(k,iCell)/(100000./pressure(k,iCell))**0.286 
          end do
       end do
 


### PR DESCRIPTION
This PR adds 3D temperature output to the history files. 

In case temperature is needed for evaluation purposes, this does not require to calculate 3D temperature from Theta and pressure of the output files. This becomes relevant at, e.g., the 3 km mesh or even higher resolutions.
