### PR TITLE
Bug fix in call to the parameterization of the gravity wave drag over orography

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_gwdo.F
@@ -311,7 +311,7 @@
        call gwdo ( &
                   p3d       = pres_hydd_p , p3di      = pres2_hydd_p , pi3d    = pi_p      , &
                   u3d       = u_p         , v3d       = v_p          , t3d     = t_p       , & 
-                  qv3d      = qv_p        , z         = z_p          , rublten = rublten_p , &
+                  qv3d      = qv_p        , z         = zmid_p       , rublten = rublten_p , &
                   rvblten   = rvblten_p   , dtaux3d   = dtaux3d_p    , dtauy3d = dtauy3d_p , &
                   dusfcg    = dusfcg_p    , dvsfcg    = dvsfcg_p     , kpbl2d  = kpbl_p    , &
                   itimestep = itimestep   , dt        = dt_pbl       , dx      = dx_p      , & 


### PR DESCRIPTION
This PR corrects a bug discovered by Wei Wang in the call to the subroutine gwdo in mpas_atmphys_driver_gwdo.F.  In the earlier version, the variable z was erroneously defined as the height at the interface between layers, or z = z_p where
z_p is equal to zgrid. In the corrected version, the variable z is now defined as the height defined at the middle of layers, or z = zmid_p, as needed by subroutine gwdo.  

