### PR TITLE
Eliminate the need to specify config_len_disp through the introduction of a new variable, nominalMinDc

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -142,10 +142,10 @@
                      description="Formulation of horizontal mixing"
                      possible_values="`2d_fixed' or `2d_smagorinsky'"/>
 
-                <nml_option name="config_len_disp" type="real" default_value="120000.0"
+                <nml_option name="config_len_disp" type="real" default_value="0.0" in_defaults="false"
                      units="m"
                      description="Horizontal length scale, used by the Smagorinsky formulation of horizontal diffusion and by 3-d divergence damping"
-                     possible_values="Positive real values"/>
+                     possible_values="Positive real values. A zero value implies that the length scale is prescribed by the nominalMinDc value in the input file."/>
 
                 <nml_option name="config_visc4_2dsmag" type="real" default_value="0.05"
                      units="-"
@@ -457,6 +457,7 @@
 			<var name="fEdge"/>
 			<var name="fVertex"/>
 			<var name="meshDensity"/>
+			<var name="nominalMinDc"/>
 			<var name="bdyMaskCell"/>
 			<var name="bdyMaskEdge"/>
 			<var name="bdyMaskVertex"/>
@@ -592,6 +593,7 @@
 			<var name="fEdge"/>
 			<var name="fVertex"/>
 			<var name="meshDensity"/>
+			<var name="nominalMinDc"/>
 			<var name="bdyMaskCell"/>
 			<var name="bdyMaskEdge"/>
 			<var name="bdyMaskVertex"/>
@@ -1304,6 +1306,9 @@
 
                 <var name="meshDensity" type="real" dimensions="nCells" units="unitless"
                      description="Mesh density function (used when generating the mesh) evaluated at a cell"/>
+
+                <var name="nominalMinDc" type="real" dimensions="" units="m"
+                     description="Nominal minimum dcEdge value where meshDensity == 1.0"/>
 
                 <var name="meshScalingDel2" type="real" dimensions="nEdges" units="unitless"
                      description="Scaling coefficient for $\nabla^2$ eddy viscosity"/>

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -71,6 +71,9 @@ module atm_core
       character (len=StrKIND), pointer :: initial_time1, initial_time2
       type (MPAS_Time_Type) :: startTime
 
+      real (kind=RKIND), pointer :: nominalMinDc
+      real (kind=RKIND), pointer :: config_len_disp
+
       integer, pointer :: nVertLevels, maxEdges, maxEdges2, num_scalars
       character (len=ShortStrKIND) :: init_stream_name
       real (kind=R8KIND) :: input_start_time, input_stop_time
@@ -148,6 +151,56 @@ module atm_core
       call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='input', direction=MPAS_STREAM_INPUT, ierr=ierr)
       call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', direction=MPAS_STREAM_INPUT, ierr=ierr)
       call mpas_log_write(' ----- done reading initial state -----')
+
+
+      !
+      ! Determine horizontal length scale used by horizontal diffusion and 3-d divergence damping
+      !
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', mesh)
+      nullify(nominalMinDc)
+      call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
+
+      nullify(config_len_disp)
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_len_disp', config_len_disp)
+
+      call mpas_log_write('')
+
+      !
+      ! If config_len_disp was specified as a valid value, use that
+      !
+      if (config_len_disp > 0.0_RKIND) then
+         call mpas_log_write('Setting nominalMinDc to $r based on namelist option config_len_disp', realArgs=[config_len_disp])
+
+         !
+         ! But if nominalMinDc was available in the input file and is different, print a warning
+         !
+         if (nominalMinDc > 0.0_RKIND .and. abs(nominalMinDc - config_len_disp) > 1.0e-6_RKIND * config_len_disp) then
+            call mpas_log_write('nominalMinDc was read from input file as a positive value ($r) that differs', &
+                                realArgs=[nominalMinDc], messageType=MPAS_LOG_WARN)
+            call mpas_log_write('from the specified config_len_disp value ($r)', &
+                                realArgs=[config_len_disp], messageType=MPAS_LOG_WARN)
+         end if
+
+         nominalMinDc = config_len_disp
+
+      !
+      ! Otherwise, try to use nominalMinDc
+      !
+      else
+         if (nominalMinDc > 0.0_RKIND) then
+            call mpas_log_write('Setting config_len_disp to $r based on nominalMinDc value in input file', realArgs=[nominalMinDc])
+            config_len_disp = nominalMinDc
+         else
+            call mpas_log_write('Both config_len_disp and nominalMinDc are <= 0.0.', messageType=MPAS_LOG_ERR)
+            call mpas_log_write('Please either specify config_len_disp in the &nhyd_model namelist group,', &
+                                messageType=MPAS_LOG_ERR)
+            call mpas_log_write('or use an input file that provides a valid value for the nominalMinDc variable.', &
+                                messageType=MPAS_LOG_ERR)
+            ierr = 1
+            return
+         end if
+      end if
+
 
       !
       ! Read all other inputs

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -384,6 +384,7 @@
                         <var name="cellsOnVertex"/>
                         <var name="kiteAreasOnVertex"/>
                         <var name="meshDensity"/>
+                        <var name="nominalMinDc"/>
                         <var name="bdyMaskCell"/>
                         <var name="bdyMaskEdge"/>
                         <var name="bdyMaskVertex"/>
@@ -482,6 +483,7 @@
                         <var name="cellsOnVertex"/>
                         <var name="kiteAreasOnVertex"/>
                         <var name="meshDensity"/>
+                        <var name="nominalMinDc"/>
                         <var name="bdyMaskCell"/>
                         <var name="bdyMaskEdge"/>
                         <var name="bdyMaskVertex"/>
@@ -728,6 +730,9 @@
 
                 <var name="meshDensity" type="real" dimensions="nCells" units="unitless"
                      description="Mesh density function (used when generating the mesh) evaluated at a cell"/>
+
+                <var name="nominalMinDc" type="real" dimensions="" units="m"
+                     description="Nominal minimum dcEdge value where meshDensity == 1.0"/>
 
                 <!-- coefficients for vertical extrapolation to the surface -->
                 <var name="cf1" type="real" dimensions="" units="unitless"

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -483,6 +483,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, areaTriangle
       real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real (kind=RKIND), pointer :: nominalMinDc
 
       real (kind=RKIND), dimension(:), pointer :: latCell, latVertex, lonVertex, latEdge, lonEdge
       real (kind=RKIND), dimension(:), pointer :: fEdge, fVertex
@@ -517,6 +518,7 @@ module init_atm_cases
       call mpas_pool_get_array(mesh, 'areaCell', areaCell)
       call mpas_pool_get_array(mesh, 'areaTriangle', areaTriangle)
       call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
       call mpas_pool_get_config(mesh, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
 
@@ -534,6 +536,7 @@ module init_atm_cases
       areaCell(:) = areaCell(:) * sphere_radius**2.0
       areaTriangle(:) = areaTriangle(:) * sphere_radius**2.0
       kiteAreasOnVertex(:,:) = kiteAreasOnVertex(:,:) * sphere_radius**2.0
+      nominalMinDc = nominalMinDc * sphere_radius
 
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
@@ -1403,6 +1406,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, areaTriangle
       real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real (kind=RKIND), pointer :: nominalMinDc
       logical, pointer :: on_a_sphere
       real (kind=RKIND), pointer :: sphere_radius
 
@@ -1425,6 +1429,7 @@ module init_atm_cases
       call mpas_pool_get_array(mesh, 'areaCell', areaCell)
       call mpas_pool_get_array(mesh, 'areaTriangle', areaTriangle)
       call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
 
       call mpas_pool_get_config(mesh, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
@@ -1450,6 +1455,7 @@ module init_atm_cases
       areaCell(:) = areaCell(:) * a_scale**2.0
       areaTriangle(:) = areaTriangle(:) * a_scale**2.0
       kiteAreasOnVertex(:,:) = kiteAreasOnVertex(:,:) * a_scale**2.0
+      nominalMinDc = nominalMinDc * a_scale
 
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
@@ -2005,6 +2011,7 @@ module init_atm_cases
       real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, areaTriangle
       real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real (kind=RKIND), pointer :: nominalMinDc
       logical, pointer :: on_a_sphere
       real (kind=RKIND), pointer :: sphere_radius
       real (kind=RKIND), pointer :: config_coef_3rd_order
@@ -2031,6 +2038,7 @@ module init_atm_cases
       call mpas_pool_get_array(mesh, 'areaCell', areaCell)
       call mpas_pool_get_array(mesh, 'areaTriangle', areaTriangle)
       call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
 
       call mpas_pool_get_config(mesh, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
@@ -2072,6 +2080,7 @@ module init_atm_cases
       areaCell(:) = areaCell(:) * a_scale**2.0
       areaTriangle(:) = areaTriangle(:) * a_scale**2.0
       kiteAreasOnVertex(:,:) = kiteAreasOnVertex(:,:) * a_scale**2.0
+      nominalMinDc = nominalMinDc * a_scale
 
       
       call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
@@ -5857,6 +5866,7 @@ call mpas_log_write('Done with soil consistency check')
       real(kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
       real(kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, areaTriangle
       real(kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real(kind=RKIND), pointer :: nominalMinDc
 
       real(kind=RKIND), dimension(:), pointer :: fEdge, fVertex
       real(kind=RKIND), dimension(:), pointer :: latEdge
@@ -5943,6 +5953,7 @@ call mpas_log_write('Done with soil consistency check')
       call mpas_pool_get_array(mesh, 'areaCell', areaCell)
       call mpas_pool_get_array(mesh, 'areaTriangle', areaTriangle)
       call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
       call mpas_pool_get_config(mesh, 'on_a_sphere', on_a_sphere)
       call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
 
@@ -5960,6 +5971,7 @@ call mpas_log_write('Done with soil consistency check')
       areaCell(:) = areaCell(:) * sphere_radius**2
       areaTriangle(:) = areaTriangle(:) * sphere_radius**2
       kiteAreasOnVertex(:,:) = kiteAreasOnVertex(:,:) * sphere_radius**2
+      nominalMinDc = nominalMinDc * sphere_radius
 
 
       !

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -165,6 +165,7 @@
  real (kind=RKIND), dimension(:), pointer :: latVertex, lonVertex
  real (kind=RKIND), dimension(:), pointer :: latEdge, lonEdge
  real (kind=RKIND), dimension(:), pointer :: fEdge, fVertex
+ real (kind=RKIND), pointer :: nominalMinDc
 
  integer (kind=I8KIND), dimension(:,:), pointer :: greenfrac_int
  real (kind=RKIND), dimension(:), pointer :: snoalb
@@ -274,6 +275,8 @@
  call mpas_pool_get_dimension(dims, 'nVertices', nVertices)
  call mpas_pool_get_dimension(dims, 'maxEdges', maxEdges)
 
+ call mpas_pool_get_array(mesh, 'nominalMinDc', nominalMinDc)
+
  xCell = xCell * sphere_radius
  yCell = yCell * sphere_radius
  zCell = zCell * sphere_radius
@@ -288,6 +291,8 @@
  areaCell = areaCell * sphere_radius**2.0
  areaTriangle = areaTriangle * sphere_radius**2.0
  kiteAreasOnVertex = kiteAreasOnVertex * sphere_radius**2.0
+
+ nominalMinDc = nominalMinDc * sphere_radius
 
 !
 ! Set max squared distance for k-d tree search to twice the squared cell diameter


### PR DESCRIPTION
This PR eliminates the need for users to specify `config_len_disp` in their `namelist.atmosphere` files
by introducing a new scalar variable, `nominalMinDc`, which specifies the nominal minimum
grid distance where meshDensity == 1.0. The `nominalMinDc` variable is read from the "input" stream by
the init_atmosphere core and scaled along with other mesh fields like `dcEdge` and `dvEdge`; the `nominalMinDc`
variable is then written to the "output" stream by the init_atmosphere core, making it available to the atmoshere core.

At start-up, the atmosphere core attempts to read both the `config_len_disp` namelist variable and the `nominalMinDc`
variable, both of which default to 0.0.

1) If both `config_len_disp` and `nominalMinDc` are provided (in the namelist and input file, respectively) as positive values, the `config_len_disp` value is used as the horizontal length scale for horizontal diffusion and 3-d divergence damping; `nominalMinDc` is set to this value as well. Additionally, if `config_len_disp` and `nominalMinDc` differ
(by more than ~1.0e-6 relative difference), a warning is printed to the log file; e.g.:
```
WARNING: nominalMinDc was read from input file as a positive value (120000.) that differs
WARNING: from the specified config_len_disp value (125000.)
```

2) If only one of `config_len_disp` and `nominalMinDc` is provided as a positive value, that positive value is used in the model (and in any case, `nominalMinDc` takes that value when written to model restart files).

3) If neither `config_len_disp` nor `nominalMinDc` are provided, the atmosphere core stops with an error:
```
      ERROR: Both config_len_disp and nominalMinDc are <= 0.0.
      ERROR: Please either specify config_len_disp in the &nhyd_model namelist group,
      ERROR: or use an input file that provides a valid value for the nominalMinDc variable.
```

The changes in this PR are backwards-compatible, in the sense that old mesh files that lack the `nominalMinDc` variable can still be used, in which case the user must supply the `config_len_disp` option in their `namelist.atmosphere` file.