### PR TITLE
Add missing dependency on core_physics_mmm in core_atmosphere/physics/Makefile

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -52,7 +52,7 @@ lookup_tables:
 core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
-core_physics_wrf: core_physics_init
+core_physics_wrf: core_physics_init core_physics_mmm
 	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)


### PR DESCRIPTION
This PR corrects parallel build failures in the atmosphere core by adding a missing dependency on `core_physics_mmm`
in `src/core_atmosphere/physics/Makefile`. The `core_physics_wrf` build target should depend on `core_physics_mmm`, since compilation of modules in the `physics_wrf` directory depends on successful compilation of modules in the `physics_mmm` directory.