### PR TITLE
Add new routine for checking consistency of dynamics options

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -98,6 +98,69 @@ module atm_time_integration
    contains
 
 
+   !***********************************************************************
+   !
+   !  routine mpas_atm_dynamics_checks
+   !
+   !> \brief   Checks compatibility of dynamics settings
+   !> \author  Michael Duda
+   !> \date    14 June 2023
+   !> \details
+   !>  This routine checks that dynamics settings are valid.
+   !>  Specifically,the following are checked by this routine:
+   !>
+   !>  1) config_positive_definite == .false.
+   !>
+   !>  At present only a warning is printed in the case of a failed check,
+   !>  and a value of 0 is always returned by the ierr argument. However,
+   !>  warnings may be escalated to errors in future.
+   !
+   !-----------------------------------------------------------------------
+   subroutine mpas_atm_dynamics_checks(dminfo, blockList, streamManager, ierr)
+
+       use mpas_log, only : mpas_log_write
+       use mpas_derived_types, only : dm_info, block_type, MPAS_LOG_WARN
+       use mpas_pool_routines, only : mpas_pool_get_config
+
+       implicit none
+
+       type (dm_info), pointer :: dminfo
+       type (block_type), pointer :: blockList
+       type (MPAS_streamManager_type), pointer :: streamManager
+       integer, intent(out) :: ierr
+
+       logical, pointer :: config_positive_definite
+
+
+       call mpas_log_write('')
+       call mpas_log_write('Checking consistency of dynamics settings...')
+
+       !
+       ! Check that config_positive_definite == .false., since the positive-definite advection
+       ! option is currently unimplemented.
+       !
+       nullify(config_positive_definite)
+       call mpas_pool_get_config(blocklist % configs, 'config_positive_definite', config_positive_definite)
+
+       if (config_positive_definite) then
+           call mpas_log_write('The positive definite advection option is currently unimplemented, and', &
+                               messageType=MPAS_LOG_WARN)
+           call mpas_log_write('setting config_positive_definite = true will enable monotonic advection.', &
+                               messageType=MPAS_LOG_WARN)
+           call mpas_log_write('Please remove the specification of config_positive_definite from the', &
+                               messageType=MPAS_LOG_WARN)
+           call mpas_log_write('&nhyd_model namelist group.', &
+                               messageType=MPAS_LOG_WARN)
+       end if
+
+       call mpas_log_write(' ----- done checking dynamics settings -----')
+       call mpas_log_write('')
+
+       ierr = 0
+
+   end subroutine mpas_atm_dynamics_checks
+
+
    !----------------------------------------------------------------------------
    !  routine MPAS_atm_dynamics_init
    !

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1442,6 +1442,7 @@ module atm_core
       use mpas_atmphys_control, only : physics_compatibility_check
 #endif
       use mpas_atm_boundaries, only : mpas_atm_bdy_checks
+      use atm_time_integration, only : mpas_atm_dynamics_checks
 
       implicit none
 
@@ -1466,6 +1467,12 @@ module atm_core
       ! Checks for limited-area simulations
       !
       call mpas_atm_bdy_checks(dminfo, blockList, streamManager, local_ierr)
+      ierr = ierr + local_ierr
+
+      !
+      ! Checks for dynamics options
+      !
+      call mpas_atm_dynamics_checks(dminfo, blockList, streamManager, local_ierr)
       ierr = ierr + local_ierr
 
    end subroutine mpas_atm_run_compatibility


### PR DESCRIPTION
This PR adds a new routine, `mpas_atm_dynamics_checks`, that checks for consistency within dynamics options at model start-up, similar in concept to what is done by the existing `physics_compatibility_check` and `mpas_atm_bdy_checks` routines.

The `mpas_atm_dynamics_checks` routine is called from the `mpas_atm_run_compatibility`, and it currently only checks that `config_positive_definite` is false in the `&nhyd_model` group; if this check fails, warnings are printed to the log file, but no errors are generated.