### PR TITLE
Always use geog_data_path with trailing slash in mpas_init_atm_static

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -374,7 +374,7 @@
  end select
 
  call mpas_log_write('--- start interpolate TER')
- call interp_terrain(mesh, tree, trim(config_geog_data_path)//trim(geog_sub_path))
+ call interp_terrain(mesh, tree, trim(geog_data_path)//trim(geog_sub_path))
  call mpas_log_write('--- end interpolate TER')
 
 
@@ -398,7 +398,7 @@
  end select surface_input_select1
 
  call mpas_log_write('--- start interpolate LU_INDEX')
- call interp_landuse(mesh, tree, trim(config_geog_data_path)//trim(geog_sub_path), isice_lu, iswater_lu)
+ call interp_landuse(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), isice_lu, iswater_lu)
  call mpas_log_write('--- end interpolate LU_INDEX')
 
 !
@@ -407,7 +407,7 @@
  geog_sub_path = 'soiltype_top_30s/'
 
  call mpas_log_write('--- start interpolate SOILCAT_TOP')
- call interp_soilcat(mesh, tree, trim(config_geog_data_path)//trim(geog_sub_path), iswater_soil)
+ call interp_soilcat(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), iswater_soil)
  call mpas_log_write('--- end interpolate SOILCAT_TOP')
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -461,7 +461,7 @@
        call mpas_log_write('   Dataset will be supersampled by a factor of $i', intArgs=(/supersample_fac/))
     end if
 
-    ierr = mgr % init(trim(config_geog_data_path)//trim(geog_sub_path))
+    ierr = mgr % init(trim(geog_data_path)//trim(geog_sub_path))
     if (ierr /= 0) then
        call mpas_log_write('Error occurred when initializing the interpolation of snow albedo (snoalb)', &
                             messageType=MPAS_LOG_CRIT)
@@ -706,7 +706,7 @@
 
     geog_sub_path = 'greenfrac_fpar_modis/'
 
-    ierr = mgr % init(trim(config_geog_data_path)//trim(geog_sub_path))
+    ierr = mgr % init(trim(geog_data_path)//trim(geog_sub_path))
     if (ierr /= 0) then
        call mpas_log_write('Error occurred when initalizing the interpolation of monthly vegetation fraction (greenfrac)', &
                             messageType=MPAS_LOG_CRIT)
@@ -938,7 +938,7 @@
 
     geog_sub_path = 'albedo_modis/'
 
-    ierr = mgr % init(trim(config_geog_data_path)//trim(geog_sub_path))
+    ierr = mgr % init(trim(geog_data_path)//trim(geog_sub_path))
     if (ierr /= 0) then
        call mpas_log_write('Error occurred when initalizing the interpolation of monthly albedo (albedo12m)', &
                             messageType=MPAS_LOG_CRIT)


### PR DESCRIPTION
This PR corrects an issue in which static field processing would fail when the `config_geog_data_path` option
was specified in a namelist without a trailing '/' character. In such cases, trying to build paths to geographical data tiles at various points in the `mpas_init_atm_static` module would fail to produce a valid path. A local variable, `geog_data_path`, that is the same as `config_geog_data_path` but guaranteed to have a trailing '/' was already being set near the beginning of the `init_atm_static()` routine, and this PR simply uses that variable in place of the user-provided `config_geog_data_path`.

With the changes in this PR, static field processing can work with a geographical data path from the namelist that either does or does not have a trailing '/'.