### PR TITLE
Remove debugging prints from lsm_from_MPAS() and ysu()

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -478,7 +478,6 @@
     ust_urb_p(i,j)    = 0._RKIND
     utype_urb_p(i,j)  = 0
 
-    if(swddir_p(i,j).gt.0.) call mpas_log_write('--- sw: $i $r $r',intArgs=(/i/),realArgs=(/swddir_p(i,j),swddif_p(i,j)/))
  enddo
  enddo
 

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -308,9 +308,6 @@
                                                              frcurb_hv
 
 
-   call mpas_log_write(' ')
-   call mpas_log_write('--- enter subroutine ysu:')
-
    do j = jts,jte
 !
       !  Assign input data to local tile-sized arrays.


### PR DESCRIPTION
This PR removes a couple of debugging print statements from `lsm_from_mpas()` and `ysu()`.