### PR TITLE
Fix memory leak in deallocate_microphysics for recloud_p, reice_p, and resnow_p (v8.0.1)

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -214,9 +214,9 @@
        if(allocated(graupelncv_p) ) deallocate(graupelncv_p )
 
        !cloud water,cloud ice,and snow effective radii:
-       if(.not.allocated(recloud_p) ) allocate(recloud_p(ims:ime,kms:kme,jms:jme) )
-       if(.not.allocated(reice_p)   ) allocate(reice_p(ims:ime,kms:kme,jms:jme)   )
-       if(.not.allocated(resnow_p)  ) allocate(resnow_p(ims:ime,kms:kme,jms:jme)  )
+       if(allocated(recloud_p) ) deallocate(recloud_p )
+       if(allocated(reice_p)   ) deallocate(reice_p   )
+       if(allocated(resnow_p)  ) deallocate(resnow_p  )
 
     microp2_select: select case(microp_scheme)
 


### PR DESCRIPTION
This PR fixes a memory leak in the deallocate_microphysics routine for the recloud_p,
reice_p, and resnow_p arrays.

The logic for deallocating the recloud_p, reice_p, and resnow_p fields was incorrect,
leading to a memory leak at the end of a simulation. Rather than checking if these arrays
are allocated and allocating them if they are not, the code now checks whether these
arrays are allocated and deallocates them if they are.

This PR mirrors PR #989 but targets the `hotfix-v8.0.1` branch.