### PR TITLE
Allow real-valued attributes to be read with different precision using SMIOL

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -4603,77 +4603,45 @@ module mpas_io
          local_precision = MPAS_IO_NATIVE_PRECISION
       end if
 
-      ! Query attribute value
 #ifdef MPAS_PIO_SUPPORT
+      ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
-#endif
 
       if ((local_precision == MPAS_IO_SINGLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
 
-#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_REAL) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, singleVal)
-#endif
-
-#ifdef MPAS_SMIOL_SUPPORT
-         if (present(fieldname)) then
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), singleVal)
-         else
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), singleVal)
-         end if
-#endif
 
          attValue = real(singleVal,RKIND)
 
       else if ((local_precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
 
-#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_DOUBLE) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, doubleVal)
-#endif
-
-#ifdef MPAS_SMIOL_SUPPORT
-         if (present(fieldname)) then
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), doubleVal)
-         else
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), doubleVal)
-         end if
-#endif
 
          attValue = real(doubleVal,RKIND)
 
       else
 
-#ifdef MPAS_PIO_SUPPORT
          if (xtype /= PIO_DOUBLE .and. xtype /= PIO_REAL) then
             if (present(ierr)) ierr=MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
-#endif
-
-#ifdef MPAS_SMIOL_SUPPORT
-         if (present(fieldname)) then
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
-         else
-            local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
-         end if
-#endif
 
       end if
-#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
@@ -4681,14 +4649,65 @@ module mpas_io
 #endif
 
 #ifdef MPAS_SMIOL_SUPPORT
+      !
+      ! Try to read the attribute in the MPAS native precision
+      !
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                         trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                         trim(attName), attValue)
+      end if
+
+      !
+      ! If that fails, perhaps the attribute is in a different precision from
+      ! the native MPAS precision
+      !
+      if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+         if (MPAS_IO_NATIVE_PRECISION == MPAS_IO_DOUBLE_PRECISION) then
+
+            !
+            ! Try again, but read a single-precision value
+            !
+            if (present(fieldname)) then
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                               trim(attName), singleVal)
+            else
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                               trim(attName), singleVal)
+            end if
+            attValue = real(singleVal,RKIND)
+
+         else
+
+            !
+            ! Try again, but read a double-precision value
+            !
+            if (present(fieldname)) then
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                               trim(attName), doubleVal)
+            else
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                               trim(attName), doubleVal)
+            end if
+            attValue = real(doubleVal,RKIND)
+
+         end if
+      end if
+
+      !
+      ! If all of the above were unsuccessful, set attValue to a fill value
+      ! and return an error
+      !
       if (local_ierr /= SMIOL_SUCCESS) then
+         attValue = MPAS_REAL_FILLVAL
          if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
-            return
          else
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
-            return
          end if
+         return
       end if
 #endif
 


### PR DESCRIPTION
This PR allows real-valued attributes to be read with a different precision from
MPAS's native precision when using SMIOL.

Previously, the `mpas_io_get_att_real0d()` routine relied on its 'precision'
optional argument to determine whether to attempt to read real-valued attributes
in a precision different from MPAS's native precision. However, in some parts of
the MPAS framework (specifically, in `mpas_bootstrap_framework_phase1()`), the 
`MPAS_io_get_att()` routine is called without the 'precision' argument, leading to
problems in reading, e.g., 'sphere_radius' when the precision of the input file
is not the MPAS native precision.
    
Now, the `mpas_io_get_att_real0d()` routine first tries to read an attribute in
MPAS's native precision; if that fails, a second attempt is made to read the 
attribute using the opposite precision (single vs. double). If both attempts
fail, the attribute argument is set to a fill value and an error code is
returned. This allows MPAS to read real-valued attributes using SMIOL during the 
bootstrapping process regardless of the precision of the input file.