### PR TITLE
Fix units and description for rt_diabatic_tend in atmosphere core Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1791,8 +1791,8 @@
                 <var name="tend_theta" name_in_code="theta_m" type="real" dimensions="nVertLevels nCells Time" units="kg K m^{-3} s^{-1}"
                      description="tendency of coupled potential temperature rho*theta_m/zz from dynamics and physics, updated each RK step"/>
 
-                <var name="rt_diabatic_tend" type="real" dimensions="nVertLevels nCells Time" units="kg K s^{-1}"
-                     description="Tendency of coupled potential temperature from physics"/>
+                <var name="rt_diabatic_tend" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="Tendency of modified potential temperature due to cloud microphysics"/>
 
                 <var name="euler_tend_u" name_in_code="u_euler" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
                      description="Tendency of u from dynamics"/>


### PR DESCRIPTION
This PR corrects the units and description for the `rt_diabatic_tend` field in the atmosphere `Registry.xml`.

The `rt_diabatic_tend` field represents the tendency of the modified potential temperature due to cloud microphysics in K/s; accordingly, this commit corrects the units and description attributes for `rt_diabatic_tend` in the atmosphere core's `Registry.xml` file.