### PR TITLE
Update descriptions of fzp and fzm in init_atmosphere and atmosphere core Registry files

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1360,10 +1360,10 @@
                      description="Reciprocal dzu"/>
 
                 <var name="fzm" type="real" dimensions="nVertLevels" units="unitless"
-                     description="Weight for linear interpolation to w(k) point for u(k) level variable"/>
+                     description="Weight for interpolation to w(k) point for u(k) level variable"/>
 
                 <var name="fzp" type="real" dimensions="nVertLevels" units="unitless"
-                     description="Weight for linear interpolation to w(k) point for u(k-1) level variable"/>
+                     description="Weight for interpolation to w(k) point for u(k-1) level variable"/>
 
                 <var name="zxu" type="real" dimensions="nVertLevels nEdges" units="unitless"
                      description="dz/dx on horizontal coordinate surfaces at u levels"/>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -855,11 +855,11 @@
                      packages="vertical_stage_out;met_stage_out"/>
 
                 <var name="fzm" type="real" dimensions="nVertLevels" units="unitless"
-                     description="Weight for linear interpolation to w(k) point for u(k) level variable"
+                     description="Weight for interpolation to w(k) point for u(k) level variable"
                      packages="vertical_stage_out;met_stage_out"/>
 
                 <var name="fzp" type="real" dimensions="nVertLevels" units="unitless"
-                     description="Weight for linear interpolation to w(k) point for u(k-1) level variable"
+                     description="Weight for interpolation to w(k) point for u(k-1) level variable"
                      packages="vertical_stage_out;met_stage_out"/>
 
                 <var name="zxu" type="real" dimensions="nVertLevels nEdges" units="unitless"


### PR DESCRIPTION
I've removed "linear" from the descriptions for fzp and fzm to be consistent with new option to either interpolate linearly or via a layer integration
