### PR TITLE
Add mpas_modify_att() subroutines to mpas_attlist

### DIFF
--- a/src/core_test/mpas_test_core_field_tests.F
+++ b/src/core_test/mpas_test_core_field_tests.F
@@ -82,11 +82,12 @@ module test_core_field_tests
       integer, intent(out) :: ierr
 
       type ( att_list_type ), pointer :: srcList, destList
-      integer :: srcInt, destInt
-      integer, dimension(:), pointer :: srcIntA, destIntA
-      real (kind=RKIND) :: srcReal, destReal
+      integer :: srcInt, destInt, modifyInt
+      integer, dimension(:), pointer :: srcIntA, destIntA, modifyIntA
+      real (kind=RKIND) :: srcReal, destReal, modifyReal
       real (kind=RKIND), dimension(:), pointer :: srcRealA, destRealA
-      character (len=StrKIND) :: srcText, destText
+      real (kind=RKIND), dimension(:), pointer :: modifyRealA
+      character (len=StrKIND) :: srcText, destText, modifyText
 
       integer :: threadNum
 
@@ -154,9 +155,61 @@ module test_core_field_tests
             call mpas_log_write('      Duplicate string does not match', MPAS_LOG_ERR)
          end if
 
+         deallocate(destIntA)
+         deallocate(destRealA)
+         allocate(modifyIntA(3))
+         allocate(modifyRealA(5))
+
+         modifyInt = 2
+         modifyIntA(:) = 2
+         modifyReal = 2.0_RKIND
+         modifyRealA(:) = 2.0_RKIND
+         modifyText = 'Modified'
+
+         call mpas_modify_att(srcList, 'testInt', modifyInt)
+         call mpas_modify_att(srcList, 'testIntA', modifyIntA)
+         call mpas_modify_att(srcList, 'testReal', modifyReal)
+         call mpas_modify_att(srcList, 'testRealA', modifyRealA)
+         call mpas_modify_att(srcList, 'testText', modifyText)
+
+         call mpas_get_att(srcList, 'testInt', destInt)
+         call mpas_get_att(srcList, 'testIntA', destIntA)
+         call mpas_get_att(srcList, 'testReal', destReal)
+         call mpas_get_att(srcList, 'testRealA', destRealA)
+         call mpas_get_att(srcList, 'testText', destText)
+
+         if ( destInt /= modifyInt ) then
+            threadErrs( threadNum ) = 1
+            call mpas_log_write('     Int not modified correctly', MPAS_LOG_ERR)
+         end if
+
+         if (sum(destIntA) /= sum(modifyIntA)) then  
+            threadErrs( threadNum ) = 1
+            call mpas_log_write('     IntA not modified correctly', MPAS_LOG_ERR)
+         end if
+
+         if ( destReal /= modifyReal ) then
+            threadErrs( threadNum ) = 1
+            call mpas_log_write('     Real not modified correctly', MPAS_LOG_ERR)
+         end if
+
+         if ( sum(destRealA) /= sum(modifyRealA) ) then
+            threadErrs( threadNum ) = 1
+            call mpas_log_write('     RealA not modified correctly', MPAS_LOG_ERR)
+         end if
+
+         if ( trim(destText) /= trim(modifyText)  ) then
+            threadErrs( threadNum ) = 1
+            call mpas_log_write('     Text not modified correctly', MPAS_LOG_ERR)
+         end if
+
          call mpas_deallocate_attlist(srcList)
          call mpas_deallocate_attlist(destList)
-
+        
+         deallocate(destIntA)
+         deallocate(destRealA)
+         deallocate(modifyRealA)
+         deallocate(modifyIntA)
          deallocate(srcIntA)
          deallocate(srcRealA)
       end if

--- a/src/framework/mpas_attlist.F
+++ b/src/framework/mpas_attlist.F
@@ -30,6 +30,14 @@ module mpas_attlist
       module procedure mpas_add_att_text
    end interface mpas_add_att
 
+   interface mpas_modify_att
+     module procedure mpas_modify_att_int0d
+     module procedure mpas_modify_att_int1d
+     module procedure mpas_modify_att_real0d
+     module procedure mpas_modify_att_real1d
+     module procedure mpas_modify_att_text
+   end interface mpas_modify_att
+
    interface mpas_get_att
       module procedure mpas_get_att_int0d
       module procedure mpas_get_att_int1d
@@ -252,6 +260,216 @@ contains
       write(cursor % attValueText,'(a)') trim(attValue)
 
    end subroutine mpas_add_att_text!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_text
+!
+! > \brief  MPAS modify text attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a text attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_text(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    character (len=*), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_TEXT) then
+          if (present(ierr)) ierr = 0
+          write(cursor % attValueText,'(a)') trim(attValue)
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_text!}}}
+
+
+!***********************************************************************
+!
+! routine mpas_modify_att_int0d
+!
+! > \brief  MPAS modify 0D integer attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 0d integer attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_int0d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    integer, intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_INT) then
+          if (present(ierr)) ierr = 0
+          cursor % attValueInt = attValue
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_int0d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_int1d
+!
+! > \brief  MPAS modify 1D integer attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 1d integer attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_int1d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    integer, dimension(:), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_INTA) then
+          if (size(cursor % attValueIntA) == size(attValue)) then
+            if (present(ierr)) ierr = 0
+            cursor % attValueIntA(:) = attValue(:)
+          end if
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_int1d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_real0d
+!
+! > \brief  MPAS modify 0D real attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 0d real attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_real0d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    real (kind=RKIND), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_REAL) then
+          if (present(ierr)) ierr = 0
+          cursor % attValueReal = attValue
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_real0d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_real1d
+!
+! > \brief  MPAS modify 1D real attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 1d real attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_real1d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    real (kind=RKIND), dimension(:), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_REALA) then
+          if (size(cursor % attValueRealA) == size(attValue)) then
+            if (present(ierr)) ierr = 0
+            cursor % attValueRealA(:) = attValue(:)
+          end if
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_real1d!}}}
 
 !***********************************************************************
 !


### PR DESCRIPTION
CF compliance requires certain attributes to be updated periodically throughout a run, or at the beginning of a run after compilation. The current attlist module only supports creation and retrieval of attributes. This commit adds the functionality to modify attributes and some basic tests for those routines. The subroutines work by traversing the linked list until they find a node who's attName matches the attName to be changes. It then checks the attType of the node to make sure that the correct type of value is being passed in to the attribute. The error code is then set to 0 and the subroutine exits.

It is also noted that these procedures are not currently threadsafe. Future work may include threadsafe attribute modification and a more comprehensive test suite for all of the attlist procedures.
