### PR TITLE
Units of adv_coefs?

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1404,10 +1404,10 @@
                 <var name="deriv_two" type="real" dimensions="FIFTEEN TWO nEdges" units="unitless"
                      description="weights for cell-centered second derivative, normal to edge, for transport scheme"/>
 
-                <var name="adv_coefs" type="real" dimensions="FIFTEEN nEdges" units="unitless"
+                <var name="adv_coefs" type="real" dimensions="FIFTEEN nEdges" units="m^{3}"
                      description="Weighting coefficients used for reconstructing cell-based fields at edges"/>
 
-                <var name="adv_coefs_3rd" type="real" dimensions="FIFTEEN nEdges" units="unitless"
+                <var name="adv_coefs_3rd" type="real" dimensions="FIFTEEN nEdges" units="m^{3}"
                      description="Weighting coefficients used for reconstructing cell-based fields at edges"/>
 
                 <var name="advCellsForEdge" type="integer" dimensions="FIFTEEN nEdges" units="-"


### PR DESCRIPTION
I've been trying to track units through the dynamics procedure in mpas_atm_time_integration and have found it difficult as several of the units for variables in the Registry are set to unitless when they apparently aren't. 

The units for adv_coefs and adv_coefs_3rd are a great example of ambiguous units, which––assuming that they are unitless––leads to terms in the tend_w calculation that seemingly cannot be added owing to differing units. Having dug through the code, I think that the units of these terms should be m^3 since the coefficient values are multiplied by dcEdge**2 and dvEdge in mpas_atm_core.F. However, I am not confident about this, so I've included it as a separate pull request from my other suggested corrections about units. 

As a general issue/request, it would be great if someone more knowledgable than me could check the units for the variables in the Registry files because their ambiguity makes it really hard for members of the community to contribute to the model!

