### PR TITLE
Fix MPAS field tests

### DIFF
--- a/src/core_test/mpas_test_core_field_tests.F
+++ b/src/core_test/mpas_test_core_field_tests.F
@@ -91,6 +91,7 @@ module test_core_field_tests
       integer :: threadNum
 
       iErr = 0
+      threadErrs = 0
 
       threadNum = mpas_threading_get_thread_num()
 

--- a/src/core_test/mpas_test_core_field_tests.F
+++ b/src/core_test/mpas_test_core_field_tests.F
@@ -93,9 +93,9 @@ module test_core_field_tests
       iErr = 0
       threadErrs = 0
 
-      threadNum = mpas_threading_get_thread_num()
+      threadNum = mpas_threading_get_thread_num() + 1
 
-      if ( threadNum == 0 ) then
+      if ( threadNum == 1 ) then
          allocate(srcList)
          nullify(destList)
 


### PR DESCRIPTION
This PR fixes two issues with the field test functions in the test core. Issue one arose when creating the threadErrs array, but not initializing it to 0.  setting all values to 0 before the tests run, the field tests now correctly show that they are passing.

The first issue is with the field test functions in the test core. This arose when reading in threadErrs, but not setting it to zero. This means that the field tests will inheret the error codes from the halo exchange tests above. intent(out) also allows the compiler to do whatever it desires to  the contents of that array as soon as it enters the function. This could lead to undefined behavior. The net result of this is that the field test codes are erroneously set to nonzero values while the tests are in fact passing. After setting all values to 0 before the tests run, the field tests now correctly show that they are passing.


The second issue comes from the use of mpas_threading_get_thread_num to get the thread number that the tests are running on, but only running the tests when threadNum == 0. If one of the tests does actually fail, threadErrs( threadNum ) is updated to 1. Since fortran has 1 based arrays, this led to out of bounds errors in the event that a test actually did fail. This was fixed by adding 1  to threadNum, and checking that threadNum == 1. This ensures that we still update the first element in threadErrs if there is a failed test.
