### PR TITLE
Fix OpenMP error in deallocation of rthdynten without certain cumulus schemes

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2962,6 +2962,9 @@
                      description="Total dry air tendency from physics"
                      persistence="scratch" />
 
+                <var name="rthdynten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="tendency of temperature due to horizontal and vertical advections"/>
+
                 <!-- Scratch variables used when propagating cell-centered winds to edges -->
                 <var name="tend_uzonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="Total cell-centered zonal wind tendency from physics"
@@ -3005,10 +3008,6 @@
                 <!-- TIEDTKE AND GRELL -->
                 <var name="rqvdynten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of water vapor due to horizontal and vertical advections"
-                     packages="cu_grell_freitas_in;cu_tiedtke_in"/>
-
-                <var name="rthdynten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="tendency of temperature due to horizontal and vertical advections"
                      packages="cu_grell_freitas_in;cu_tiedtke_in"/>
 
                 <var name="rucuten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1142,9 +1142,7 @@ module atm_time_integration
          call mpas_pool_get_array(tend_physics, 'rqvdynten', rqvdynten)
          call mpas_pool_get_array(state, 'theta_m', theta_m, 2)
 
-         if (associated(tend_physics)) then
-            call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
-         end if
+         call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
 
          !NOTE: The calculation of the tendency due to horizontal and vertical advection for the water vapor mixing ratio
          !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
@@ -3888,7 +3886,7 @@ module atm_time_integration
 
       real (kind=RKIND), dimension(:,:), pointer :: rr_save
 
-      real (kind=RKIND), dimension(:,:), pointer :: rthdynten => null()
+      real (kind=RKIND), dimension(:,:), pointer :: rthdynten
 
       real (kind=RKIND), dimension(:,:,:), pointer :: scalars
 
@@ -3930,8 +3928,6 @@ module atm_time_integration
       logical, pointer :: config_rayleigh_damp_u
       real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale_days
       integer, pointer :: config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels
-
-      logical :: inactive_rthdynten
 
 
       call mpas_pool_get_config(mesh, 'sphere_radius', r_earth)
@@ -3982,9 +3978,7 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'h_divergence', h_divergence)
       call mpas_pool_get_array(diag, 'exner', exner)
 
-      if (associated(tend_physics)) then
-         call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
-      end if
+      call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
 
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
@@ -4061,18 +4055,6 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'cf2', cf2)
       call mpas_pool_get_array(mesh, 'cf3', cf3)
 
-      !
-      ! rthdynten is currently associated with packages, and if those packages
-      ! are not active at run-time, we need to produce an rthdynten array for
-      ! use in the atm_compute_dyn_tend_work routine
-      !
-      inactive_rthdynten = .false.
-      if (.not. associated(rthdynten)) then
-         allocate(rthdynten(nVertLevels,nCells+1))
-         rthdynten(:,nCells+1) = 0.0_RKIND
-         inactive_rthdynten = .true.
-      end if
-
       call atm_compute_dyn_tend_work(nCells, nEdges, nVertices, nVertLevels, &
          nCellsSolve, nEdgesSolve, vertexDegree, maxEdges, maxEdges2, num_scalars, moist_start, moist_end, &
          fEdge, dvEdge, dcEdge, invDcEdge, invDvEdge, invAreaCell, invAreaTriangle, meshScalingDel2, meshScalingDel4, &
@@ -4093,10 +4075,6 @@ module atm_time_integration
          rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
          cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
-
-      if (inactive_rthdynten) then
-         deallocate(rthdynten)
-      end if
 
    end subroutine atm_compute_dyn_tend
 


### PR DESCRIPTION
This PR fixes an OpenMP error in the deallocation of `rthdynten` when certain cumulus schemes are not used.

When neither the Grell-Freitas nor the Tiedtke/nTiedtke cumulus schemes were used, the `rthdynten` array was allocated locally in the `compute_dyn_tend(...)` routine, since it is a required argument to the `compute_dyn_tend_work(...)` routine. The local `rthdynten` pointer was initialized and therefore implicitly had the `SAVE` attribute, which, according to 2.15.1.2 of the OpenMP 4.5 standard, made the `rthdynten` pointer shared:
```
  Local variables declared in called routines in the region and that have the
  save attribute, or that are data initialized, are shared unless they appear in
  a threadprivate directive.
```
The allocation and deallocation of `rthdynten` happened inside of a threaded region, leading to potential model failures when multiple threads attempted to deallocate the same shared `rthdynten` pointer.

The simple solution is to remove packages from the `rthdynten` field in the atmosphere core's `Registry.xml` file, and to remove the additional code that handled selective local allocation of this array in the `compute_dyn_tend(...)` routine.

Since `rthdynten` is allocated by the `compute_dyn_tend(...)` routine if it is not otherwise allocated due to packages, simply removing packages from the `rthdynten` field in the atmosphere core's `Registry.xml` file should have little impact on the memory usage of the dynamics, only increasing memory use outside of the dynamics in cases where neither
the Grell-Freitas nor the Tiedtke/nTiedtke schemes are used. However, this potentially larger memory use comes with the benefit of significantly simplified logic in the dynamics.