### PR TITLE
Add arbitrary registry attributes

### DIFF
--- a/src/tools/registry/gen_inc.h
+++ b/src/tools/registry/gen_inc.h
@@ -9,6 +9,10 @@
 
 #include "ezxml.h"
 
+void escape_quotes(const char *string_in, char *string_out);
+void add_attribute_if_not_ignored(FILE *fd, char* index, char *att_name, char *pointer_name_arr, char *temp_str);
+void fortprint_add_attribute(FILE *fd, char* index, char *att_name, char *pointer_name_arr, char *temp_str);
+int find_string_in_array(char *input_string, const char *array[]);
 void write_model_variables(ezxml_t registry);
 int write_field_pointer_arrays(FILE* fd);
 int set_pointer_name(int type, int ndims, char *pointer_name, int time_levs);


### PR DESCRIPTION
This PR allows the addition of arbitrary attributes to variables defined in Registry.xml.

In pursuit of CF compliance, certain attributes will need to be added to variables. To make this easier, this pull request allows for the addition of arbitrary attributes by looping over all attributes in a variable, as opposed to hardcoding them in. Some support functions were also created to filter out attributes that aren't used in output files and to allow for the modification of attribute names if they have a different name in the code (namely, description vs. long_name). 
