### PR TITLE
Update test Registry.xml to have numeric missing_values

### DIFF
--- a/src/core_test/Registry.xml
+++ b/src/core_test/Registry.xml
@@ -76,7 +76,7 @@
 		<var name="xtime"                             type="text"     dimensions="Time"/>
 	</var_struct>
 	<var_struct name="mesh" time_levs="1">
-		<var_array name="arrTest" type="real" dimensions="nCells" missing_value="FILLVAL">
+		<var_array name="arrTest" type="real" dimensions="nCells" missing_value="0.0">
 			<var name="test1" units="units1" description="Test var 1 in a var_array" array_group="arrTest"/>
 			<var name="test2" units="units2" description="Test var 2 in a var_array" array_group="arrTest"/>
 		</var_array>
@@ -85,7 +85,7 @@
 		<var name="xCell"                             type="real"     dimensions="nCells"/>
 		<var name="yCell"                             type="real"     dimensions="nCells"/>
 		<var name="zCell"                             type="real"     dimensions="nCells"/>
-		<var name="indexToCellID"                     type="integer"  dimensions="nCells" missing_value="FILLVAL"/>
+		<var name="indexToCellID"                     type="integer"  dimensions="nCells" missing_value="-999"/>
 		<var name="latEdge"                           type="real"     dimensions="nEdges"/>
 		<var name="lonEdge"                           type="real"     dimensions="nEdges"/>
 		<var name="xEdge"                             type="real"     dimensions="nEdges"/>


### PR DESCRIPTION
PR #1101 created a new array of names of numeric attributes, one of which is the "missing_value" attribute. In the test core, however, the only uses of "missing_value" assign it to the string "FILLVAL". This is nonnumeric, and causes compiler errors on that branch. This PR updates the two uses of "FILLVAL" to numeric values- 0.0 in the case of the one real valued field, and -999 in the case of the integer valued field to match other variables in the registry.

The test core compiles and runs properly with these modifications.