### PR TITLE
Start mpas_string_utils

### DIFF
--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -34,7 +34,8 @@ OBJS = mpas_kind_types.o \
        xml_stream_parser.o \
        regex_matching.o \
        mpas_log.o \
-       mpas_halo.o
+       mpas_halo.o \
+       mpas_string_utils.o
 
 all: framework $(DEPS)
 
@@ -78,7 +79,7 @@ mpas_dmpar.o: mpas_sort.o mpas_kind_types.o mpas_derived_types.o mpas_hash.o mpa
 
 mpas_sort.o: mpas_kind_types.o mpas_log.o
 
-mpas_timekeeping.o: mpas_kind_types.o mpas_derived_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
+mpas_timekeeping.o: mpas_string_utils.o mpas_kind_types.o mpas_derived_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
 
 mpas_timer.o: mpas_kind_types.o mpas_dmpar.o mpas_threading.o mpas_log.o
 

--- a/src/framework/framework.cmake
+++ b/src/framework/framework.cmake
@@ -32,4 +32,5 @@ list(APPEND COMMON_RAW_SOURCES
   framework/regex_matching.c
   framework/mpas_field_accessor.F
   framework/mpas_log.F
+  framework/mpas_string_utils.F
 )

--- a/src/framework/mpas_string_utils.F
+++ b/src/framework/mpas_string_utils.F
@@ -1,0 +1,66 @@
+! Copyright (c) 2023 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+!-----------------------------------------------------------------------
+!  mpas_string_utils
+!
+!> \brief Collection of functions used for string manipulation
+!> \author Matthew Dimond
+!> \date   25 July 2023
+!> \details
+!>  This module provides functions and subroutines used for string
+!>  manipulations and utilities.
+!
+!-----------------------------------------------------------------------
+module mpas_string_utils
+
+  contains
+
+   !-----------------------------------------------------------------------
+   !  routine mpas_split_string
+   !
+   !> \brief This routine splits a string on a specified delimiting character
+   !> \author Michael Duda, Doug Jacobsen
+   !> \date   07/23/2014
+   !> \details This routine splits the given "string" on the delimiter
+   !>          character, and returns an array of pointers to the substrings
+   !>          between the delimiting characters. 
+   !
+   !-----------------------------------------------------------------------
+  subroutine mpas_split_string(string, delimiter, subStrings)
+
+    implicit none
+
+    character(len=*), intent(in) :: string
+    character, intent(in) :: delimiter
+    character(len=*), pointer, dimension(:) :: subStrings
+
+    integer :: i, start, index
+
+    index = 1
+    do i = 1, len(string)
+      if(string(i:i) == delimiter) then
+        index = index + 1
+      end if
+    end do
+
+    allocate(subStrings(1:index))
+
+    start = 1
+    index = 1
+    do i = 1, len(string)
+      if (string(i:i) == delimiter) then
+          subStrings(index) = string(start:i-1)
+          index = index + 1
+          start = i + 1
+      end if
+    end do
+    subStrings(index) = string(start:len(string))
+
+  end subroutine mpas_split_string
+
+end module mpas_string_utils
+

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -12,6 +12,7 @@ module mpas_timekeeping
    use mpas_dmpar
    use mpas_threading
    use mpas_log
+   use mpas_string_utils, only : mpas_split_string
 
    use ESMF
 
@@ -2107,40 +2108,6 @@ module mpas_timekeeping
 !      mod % ti = mod(ti1 % ti, ti2 % ti)
 !
 !   end function mod
-
-
-   subroutine mpas_split_string(string, delimiter, subStrings)   
-      
-      implicit none
-      
-      character(len=*), intent(in) :: string
-      character, intent(in) :: delimiter
-      character(len=*), pointer, dimension(:) :: subStrings
-      
-      integer :: i, start, index
-
-      index = 1
-      do i = 1, len(string)
-         if(string(i:i) == delimiter) then
-            index = index + 1
-         end if
-      end do
-
-      allocate(subStrings(1:index))
-
-      start = 1
-      index = 1
-      do i = 1, len(string)
-         if(string(i:i) == delimiter) then
-               subStrings(index) = string(start:i-1) 
-               index = index + 1
-               start = i + 1
-         end if
-      end do
-      subStrings(index) = string(start:len(string)) 
-      
-   end subroutine mpas_split_string
-
 
     subroutine mpas_get_month_day(YYYY, DoY, month, day)
        


### PR DESCRIPTION
Create mpas_string_utils file

Throughout the MPAS code, there are a number of utility functions and subroutines that deal with the manipulation of strings. As more procedures are added, it begins to make sense to have a common space for these things to be contained in. To this effect, we have added the "mpas_string_utils" module, and moved the "mpas_split_string" subroutine from mpas_timekeeping.F to this module. Future updates will include more functions and subroutines that allow further manipulation of strings.

