### PR TITLE
Add basic string utils tests

### DIFF
--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -7,7 +7,8 @@ OBJS = mpas_test_core.o \
        mpas_test_core_field_tests.o \
        mpas_test_core_timekeeping_tests.o \
        mpas_test_core_sorting.o \
-       mpas_halo_testing.o
+       mpas_halo_testing.o \
+       mpas_test_core_string_utils.o
 
 all: core_test
 
@@ -36,7 +37,8 @@ mpas_test_core_interface.o: mpas_test_core.o
 
 mpas_test_core.o: mpas_test_core_halo_exch.o mpas_test_core_streams.o \
                   mpas_test_core_field_tests.o mpas_test_core_timekeeping_tests.o \
-                  mpas_test_core_sorting.o mpas_halo_testing.o
+                  mpas_test_core_sorting.o mpas_halo_testing.o \
+                  mpas_test_core_string_utils.o
 
 mpas_test_core_halo_exch.o:
 

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -93,7 +93,8 @@ module test_core
       use test_core_streams, only : test_core_streams_test
       use test_core_sorting, only : test_core_test_sorting
       use mpas_halo_testing, only : mpas_halo_tests
-   
+      use test_core_string_utils, only : mpas_test_string_utils
+
       implicit none
    
       type (domain_type), intent(inout) :: domain
@@ -167,6 +168,10 @@ module test_core
          call mpas_log_write('Stream I/O tests: FAILURE', MPAS_LOG_ERR)
       end if
 
+      ! Run string util tests
+      call mpas_log_write('')
+      call mpas_test_string_utils(iErr)
+      call mpas_log_write('')
 
       call test_core_test_intervals(domain, threadErrs, iErr)
 

--- a/src/core_test/mpas_test_core_string_utils.F
+++ b/src/core_test/mpas_test_core_string_utils.F
@@ -1,0 +1,115 @@
+! Copyright (c) 2023, University Corporation for Atmospheric Research (UCAR)
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the 
+! LICENSE file distributed with this code, or at 
+! http://mpas-dev.github.com/license.html .
+!
+module test_core_string_utils
+
+    use mpas_derived_types
+    use mpas_log
+
+    private
+
+    public :: mpas_test_string_utils
+
+    contains
+
+    subroutine mpas_test_split_string(err)
+
+        use mpas_string_utils, only : mpas_split_string
+
+        implicit none
+
+        character(len=StrKIND) :: testString
+        character :: delimiter
+        character(len=StrKIND), pointer, dimension(:) :: splitStrings
+        integer, intent(out) :: err
+        integer :: i
+
+        err = 0
+
+        ! Test a basic case
+        delimiter = ' '
+        testString = 'This is a basic test'
+        call mpas_split_string(testString, delimiter, splitStrings)
+        
+        if (size(splitStrings) /= 5) then
+            err = err + 1
+            call mpas_log_write('FAILED TO SPLIT STRING #1 CORRECTLY: WRONG'//&
+            ' SUBSTRING COUNT', MPAS_LOG_ERR)
+            return
+        end if
+
+        if (trim(splitStrings(1)) /= 'This' .or. &
+                 trim(splitStrings(2)) /= 'is' .or. &
+                 trim(splitStrings(3)) /= 'a' .or. &
+                 trim(splitStrings(4)) /= 'basic' .or. &
+                 trim(splitStrings(5)) /= 'test') then
+             err = err + 1
+             call mpas_log_write('FAILED TO SPLIT STRING #1 CORRECTLY', &
+                                 MPAS_LOG_ERR)
+        end if
+
+        ! Test a string without delimiters 
+        testString = 'This-is-a-test'
+        call mpas_split_string(testString, delimiter, splitStrings)
+        
+        if (size(splitStrings) /= 1) then
+            err = err + 1
+            call mpas_log_write('FAILED TO SPLIT STRING #2 CORRECTLY: WRONG'//&
+            ' SUBSTRING COUNT', MPAS_LOG_ERR)
+            return
+        end if
+        
+        if (trim(splitStrings(1)) /= 'This-is-a-test') then
+            err = err + 1
+            call mpas_log_write('FAILED TO SPLIT STRING #2 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+        
+        ! Test a string with consecutive delimiters
+        testString = 'This--is-a-test'
+        delimiter = '-'
+        call mpas_split_string(testString, delimiter, splitStrings)
+        
+        if (size(splitStrings) /= 5) then
+            err = err + 1
+            call mpas_log_write('FAILED TO SPLIT STRING #3 CORRECTLY: WRONG'//&
+            ' SUBSTRING COUNT', MPAS_LOG_ERR)
+            return
+        end if
+        
+        if (trim(splitStrings(1)) /= 'This' .or. &
+            trim(splitStrings(2)) /= '' .or. &
+            trim(splitStrings(3)) /= 'is' .or. &
+            trim(splitStrings(4)) /= 'a' .or. & 
+            trim(splitStrings(5)) /= 'test') then
+            err = err + 1
+            call mpas_log_write('FAILED TO SPLIT STRING #3 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+
+    end subroutine mpas_test_split_string
+
+    subroutine mpas_test_string_utils(err)
+
+        implicit none
+
+        integer, intent(out) :: err
+
+        err = 0
+
+        call mpas_log_write('String Utils Tests')
+
+        call mpas_test_split_string(err)
+        if (err == 0) then
+            call mpas_log_write('   mpas_split_string: SUCCESS')
+        else
+            call mpas_log_write('   mpas_split_string: FAILURE', MPAS_LOG_ERR)
+        end if
+
+    end subroutine mpas_test_string_utils
+
+end module test_core_string_utils


### PR DESCRIPTION
This commit adds the infrastructure required to test the new mpas_string_utils function. This includes adding a test file, adding some minimal tests, and adding these files to the Makefile for the test core. The tests as they stand simply test basic string splitting capability.

