### PR TITLE
Trim strings before splitting

### DIFF
--- a/src/framework/mpas_string_utils.F
+++ b/src/framework/mpas_string_utils.F
@@ -17,50 +17,56 @@
 !-----------------------------------------------------------------------
 module mpas_string_utils
 
-  contains
+    contains
 
-   !-----------------------------------------------------------------------
-   !  routine mpas_split_string
-   !
-   !> \brief This routine splits a string on a specified delimiting character
-   !> \author Michael Duda, Doug Jacobsen
-   !> \date   07/23/2014
-   !> \details This routine splits the given "string" on the delimiter
-   !>          character, and returns an array of pointers to the substrings
-   !>          between the delimiting characters. 
-   !
-   !-----------------------------------------------------------------------
-  subroutine mpas_split_string(string, delimiter, subStrings)
+    !-----------------------------------------------------------------------
+    !  routine mpas_split_string
+    !
+    !> \brief This routine splits a string on a specified delimiting character
+    !> \author Michael Duda, Doug Jacobsen
+    !> \date   07/23/2014
+    !> \details This routine splits the given "string" on the delimiter
+    !>          character, and returns an array of pointers to the substrings
+    !>          between the delimiting characters. Strings are trimmed before
+    !>          splitting such that all trailing whitespace is ignored.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_split_string(string, delimiter, subStrings)
 
-    implicit none
+        implicit none
 
-    character(len=*), intent(in) :: string
-    character, intent(in) :: delimiter
-    character(len=*), pointer, dimension(:) :: subStrings
+        ! Arguments
+        character(len=*), intent(in) :: string
+        character, intent(in) :: delimiter
+        character(len=*), pointer, dimension(:) :: subStrings
 
-    integer :: i, start, index
+        ! Local variables
+        character(len=len_trim(string)) :: trimString
+        integer :: i, start, index
 
-    index = 1
-    do i = 1, len(string)
-      if(string(i:i) == delimiter) then
-        index = index + 1
-      end if
-    end do
+        trimString = trim(string)
+        index = 1
 
-    allocate(subStrings(1:index))
+        do i = 1, len(trimString)
+            if (trimString(i:i) == delimiter) then
+                index = index + 1
+            end if
+        end do
 
-    start = 1
-    index = 1
-    do i = 1, len(string)
-      if (string(i:i) == delimiter) then
-          subStrings(index) = string(start:i-1)
-          index = index + 1
-          start = i + 1
-      end if
-    end do
-    subStrings(index) = string(start:len(string))
+        allocate(subStrings(1:index))
 
-  end subroutine mpas_split_string
+        start = 1
+        index = 1
+        do i = 1, len(trimString)
+            if (trimString(i:i) == delimiter) then
+                subStrings(index) = trimString(start:i-1)
+                index = index + 1
+                start = i + 1
+            end if
+        end do
+        subStrings(index) = trimString(start:len(trimString))
+
+    end subroutine mpas_split_string
 
 end module mpas_string_utils
 


### PR DESCRIPTION
This commit adds a step to the mpas_split_string subroutine. In the process of adding tests, it was discovered that splitting a string while using a space as a delimiter causes the string to be split on every trailing space, leading to a splitStrings array that is equal to the size of the untrimmed input string, minus the number of non-space characters, plus one. This behavior is unwanted.

This has been solved this by trimming off trailing spaces before splitting the string. This has been tested with the new tests in PR #1107 and confirmed to pass these tests as expected. This PR should be merged prior to #1107, as the first test splits based on a space character delimiter, and will fail without these changes to the mpas_split_string routine.