### PR TITLE
Add mpas_string_replace to mpas_string_utils

### DIFF
--- a/src/core_test/mpas_test_core_string_utils.F
+++ b/src/core_test/mpas_test_core_string_utils.F
@@ -16,6 +16,66 @@ module test_core_string_utils
 
     contains
 
+    subroutine mpas_test_string_replace(err)
+
+        use mpas_string_utils, only : mpas_string_replace
+
+        implicit none
+
+        ! Arguments
+        integer, intent(out) :: err
+
+        ! Local variables
+        character(len=StrKIND) :: testString
+        character(len=StrKIND) :: outString
+        character :: targetCharacter, toReplace
+
+        err = 0
+
+        ! Basic functionality
+        testString = 'Test_String'
+        targetCharacter = '-'
+        toReplace = '_'
+        outString = mpas_string_replace(testString, toReplace, targetCharacter)
+        if (trim(outString) /= 'Test-String') then
+            err = err + 1
+            call mpas_log_write('FAILED TO REPLACE STRING #1 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+
+        ! Whitespace replacement
+        testString = 'Test String'
+        targetCharacter = '-'
+        toReplace = ' '
+        outString = mpas_string_replace(testString, toReplace, targetCharacter)
+        if (trim(outString) /= 'Test-String') then
+            err = err + 1
+            call mpas_log_write('FAILED TO REPLACE STRING #2 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+
+        ! Consecutive charcters
+        testString = 'Test__String'
+        toReplace = '_'
+        outString = mpas_string_replace(testString, toReplace, targetCharacter)
+        if (trim(outString) /= 'Test--String') then
+            err = err + 1
+            call mpas_log_write('FAILED TO REPLACE STRING #3 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+
+        ! No Replacement
+        testString = 'Test String'
+        toReplace = '-'
+        outString = mpas_string_replace(testString, toReplace, targetCharacter)
+        if (trim(outString) /= 'Test String') then
+            err = err + 1
+            call mpas_log_write('FAILED TO REPLACE STRING #4 CORRECTLY', &
+                                MPAS_LOG_ERR)
+        end if
+
+    end subroutine mpas_test_string_replace
+
     subroutine mpas_test_split_string(err)
 
         use mpas_string_utils, only : mpas_split_string
@@ -108,6 +168,14 @@ module test_core_string_utils
             call mpas_log_write('   mpas_split_string: SUCCESS')
         else
             call mpas_log_write('   mpas_split_string: FAILURE', MPAS_LOG_ERR)
+        end if
+
+        call mpas_test_string_replace(err)
+        if (err == 0) then
+            call mpas_log_write('   mpas_string_replace: SUCCESS')
+        else
+            call mpas_log_write('   mpas_string_replace: FAILURE', &
+                                MPAS_LOG_ERR)
         end if
 
     end subroutine mpas_test_string_utils

--- a/src/framework/mpas_string_utils.F
+++ b/src/framework/mpas_string_utils.F
@@ -68,5 +68,39 @@ module mpas_string_utils
 
     end subroutine mpas_split_string
 
+    !-----------------------------------------------------------------------
+    !  routine mpas_string_replace
+    !
+    !> \brief Returns string with charToReplace replaced with targetChar
+    !> \author Matthew Dimond
+    !> \date   07/26/2023
+    !> \details This function replaces all characters matching charToReplace in
+    !>          "string" with the char "targetChar" after trimming "string"
+    !
+    !-----------------------------------------------------------------------
+    function mpas_string_replace(string, charToReplace, targetChar) result(stringOut)
+
+        implicit none
+
+        ! Arguments
+        character(len=*), intent(in) :: string 
+        character, intent(in) :: targetChar, charToReplace
+
+        ! Local variables
+        integer :: i
+
+        ! Result
+        character(len=len_trim(string)) :: stringOut
+
+        stringOut = trim(string)
+
+        do i = 1, len_trim(string)
+            if (string(i:i) == charToReplace) then
+                stringOut(i:i) = targetChar
+            end if
+        end do
+
+    end function mpas_string_replace
+
 end module mpas_string_utils
 


### PR DESCRIPTION
Add mpas_string_replace to replace characters in a given string.

A function to replace characters in a string with another character has been added to the mpas_string_utils module, along with tests in mpas_test_core. The function searches for a character (charToReplace) inside of an input string, and replaces any instances of that character with another character (targetCharacter). Strings are trimmed before characters are replaced to avoid potential issues with trailing whitespace when replacing spaces.

Tests include consecutive characters, whitespace characters, and attempting to replace a character that does not appear in the input string.
