### PR TITLE
Add Cf compliant time to core_atmosphere

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -495,6 +495,7 @@
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
+			<var name="Time"/>
 			<var name="u"/>
 			<var name="w"/>
 			<var name="rho"/>
@@ -631,6 +632,7 @@
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
+			<var name="Time"/>
 			<var name="u"/>
 			<var name="w"/>
 			<var name="rho_zz"/>
@@ -922,6 +924,7 @@
 			<var name="zz"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
+			<var name="Time"/>
 			<var name="u"/>
 			<var name="w"/>
 			<var name="pressure"/>
@@ -1006,6 +1009,7 @@
 
 			<var name="initial_time"/>
 			<var name="xtime"/>
+			<var name="Time"/>
 
                         <!-- Begin isobaric diagnostics defined in diagnostics/Registry_isobaric.xml -->
 			<var name="mslp"/>
@@ -1477,6 +1481,9 @@
 
                 <var name="xtime" type="text" dimensions="Time" units="YYYY-MM-DD_hh:mm:ss"
                      description="Model valid time"/>
+
+                <var name="Time" type="real" dimensions="Time" units="seconds since YYYY-MM-DD hh:mm:ss"
+                    description="CF-compliant valid time" standard_name="time"/>
 
                 <!-- Prognostic variables: read from input, saved in restart, and written to output -->
                 <var name="u" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -274,6 +274,8 @@ module atm_time_integration
       type (MPAS_TimeInterval_type) :: dtInterval
       character (len=StrKIND), pointer :: xtime
       character (len=StrKIND) :: xtime_new
+      real (kind=RKIND), pointer :: Time
+      real (kind=RKIND) :: Time_new
       type (mpas_pool_type), pointer :: state
       character (len=StrKIND), pointer :: config_time_integration
 
@@ -298,6 +300,14 @@ module atm_time_integration
       call mpas_pool_get_subpool(block % structs, 'state', state)
       call mpas_pool_get_array(state, 'xtime', xtime, 2)
       xtime = xtime_new
+
+      ! Get CF-compliant time at current timestep
+      call mpas_pool_get_array(state, 'Time', Time, 1)
+      Time_new = Time + dt
+
+      ! Write CF-compliant time for advanced timestep
+      call mpas_pool_get_array(state, 'Time', Time, 2)
+      Time = Time_new
 
    end subroutine atm_timestep
 

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -51,6 +51,8 @@ module atm_core
       use mpas_atm_threading, only : mpas_atm_threading_init
       use atm_time_integration, only : mpas_atm_dynamics_init
       use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+      use mpas_attlist, only : mpas_modify_att
+      use mpas_string_utils, only : mpas_string_replace
 
       implicit none
 
@@ -67,12 +69,14 @@ module atm_core
       type (mpas_pool_type), pointer :: mesh
       type (mpas_pool_type), pointer :: diag
       type (field2DReal), pointer :: u_field, pv_edge_field, ru_field, rw_field
+      type (field0DReal), pointer :: Time_field
       character (len=StrKIND), pointer :: xtime
       character (len=StrKIND), pointer :: initial_time1, initial_time2
       type (MPAS_Time_Type) :: startTime
 
       real (kind=RKIND), pointer :: nominalMinDc
       real (kind=RKIND), pointer :: config_len_disp
+      real (kind=RKIND), pointer :: Time
 
       integer, pointer :: nVertLevels, maxEdges, maxEdges2, num_scalars
       character (len=ShortStrKIND) :: init_stream_name
@@ -269,7 +273,12 @@ module atm_core
          call mpas_pool_get_array(state, 'initial_time', initial_time2, 2)
          initial_time2 = initial_time1
 
-         block => block % next
+         ! Set the units to be cf compliant 'seconds since <cf-timestamp>'
+         call mpas_pool_get_field(state, 'Time', Time_field)
+         call mpas_modify_att(Time_field % attLists(1) % attList, 'units', &
+              'seconds since ' // mpas_string_replace(initial_time1, '_', ' '))
+
+          block => block % next
       end do
 
       call exchange_halo_group(domain, 'initialization:pv_edge,ru,rw')

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -452,6 +452,7 @@
 
                         <var name="initial_time" packages="met_stage_out"/>
                         <var name="xtime"/>
+                        <var name="Time"/>
                         <var name="latCell"/>
                         <var name="lonCell"/>
                         <var name="xCell"/>
@@ -588,6 +589,7 @@
                         immutable="true">
 
 			<var name="xtime"/>
+			<var name="Time"/>
 			<var name="sst"/>
 			<var name="xice"/>
 		</stream>
@@ -601,6 +603,7 @@
                         immutable="true">
 
 			<var name="xtime"/>
+			<var name="Time"/>
 			<var_struct name="lbc_state"/>
 		</stream>
 
@@ -939,6 +942,9 @@
 
                 <var name="xtime" type="text" dimensions="Time" units="YYYY-MM-DD_hh:mm:ss"
                      description="Model valid time"/>
+
+                <var name="Time" type="real" dimensions="Time" units="seconds since YYYY-MM-DD hh:mm:ss"
+                     description="CF-compliant valid time" standard_name="time"/>
 
                 <var name="u" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
                      description="Horizontal normal velocity at edges"

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -72,9 +72,12 @@ module init_atm_cases
 
       character(len=StrKIND), pointer :: mminlu
       character(len=StrKIND), pointer :: xtime
+      real (kind=RKIND) :: dt
+      real (kind=RKIND), pointer :: Time
 
-      type (MPAS_Time_type)  :: curr_time, stop_time
+      type (MPAS_Time_type)  :: curr_time, stop_time, start_time
       type (MPAS_TimeInterval_type)  :: clock_interval, lbc_stream_interval, surface_stream_interval
+      type (MPAS_TimeInterval_type)  :: time_since_start
       character(len=StrKIND) :: timeString
 
       integer, pointer :: nCells
@@ -297,6 +300,7 @@ module init_atm_cases
 
          curr_time = mpas_get_clock_time(domain % clock, MPAS_NOW)
          stop_time = mpas_get_clock_time(domain % clock, MPAS_STOP_TIME)
+         start_time = mpas_get_clock_time(domain % clock, MPAS_START_TIME)
 
          do while (curr_time <= stop_time)
 
@@ -309,6 +313,7 @@ module init_atm_cases
                call mpas_pool_get_subpool(block_ptr % structs, 'lbc_state', lbc_state)
 
                call mpas_pool_get_array(state, 'xtime', xtime)
+               call mpas_pool_get_array(state, 'Time', Time)
 
                call mpas_pool_get_dimension(block_ptr % dimensions, 'nCells', nCells)
                call mpas_pool_get_dimension(block_ptr % dimensions, 'nEdges', nEdges)
@@ -316,6 +321,9 @@ module init_atm_cases
 
                call mpas_get_time(curr_time, dateTimeString=timeString)
                xtime = timeString   ! Set field valid time, xtime, to the current time in the time loop
+               time_since_start = curr_time - start_time
+               call mpas_get_TimeInterval(time_since_start, dt=dt)
+               Time = dt
 
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)

--- a/src/core_init_atmosphere/mpas_init_atm_core.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core.F
@@ -16,6 +16,8 @@ module init_atm_core
       use mpas_derived_types
       use mpas_stream_manager
       use mpas_io_streams, only : MPAS_STREAM_NEAREST
+      use mpas_attlist, only : mpas_modify_att
+      use mpas_string_utils, only : mpas_string_replace
       use init_atm_cases
    
       implicit none
@@ -25,6 +27,7 @@ module init_atm_core
 
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: state, mesh 
+      type (field0DReal), pointer :: Time_field
       character (len=StrKIND), pointer :: xtime
       character (len=StrKIND), pointer :: initial_time
       character (len=StrKIND), pointer :: config_start_time
@@ -38,6 +41,7 @@ module init_atm_core
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'state', state)
          call mpas_pool_get_subpool(block % structs, 'mesh', mesh)
+         call mpas_pool_get_field(state, 'Time', Time_field)
          call mpas_pool_get_array(state, 'xtime', xtime)
          call mpas_pool_get_array(state, 'initial_time', initial_time)
          call mpas_pool_get_config(mesh, 'sphere_radius', sphere_radius)
@@ -48,6 +52,10 @@ module init_atm_core
          initial_time = config_start_time
          domain % sphere_radius = a      ! Appears in output files
          sphere_radius = a               ! Used in setting up test cases
+
+         ! Set Time units to be cf compliant 'seconds since <cf-timestamp>'
+         call mpas_modify_att(Time_field % attLists(1) % attlist, 'units', &
+             'seconds since ' // mpas_string_replace(initial_time, '_', ' '))
 
          block => block % next
       end do 

--- a/src/core_init_atmosphere/mpas_init_atm_surface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_surface.F
@@ -44,13 +44,16 @@
  type (mpas_pool_type), intent(in)    :: configs
 
 !local variables:
- type (MPAS_Time_type)  :: curr_time, stop_time
+ type (MPAS_Time_type)  :: curr_time, stop_time, start_time
+ type (MPAS_TimeInterval_type) :: time_since_start
  character(len=StrKIND) :: timeString
+ real (kind=RKIND) :: dt
 
  character(len=StrKIND), pointer :: config_sfc_prefix
  character(len=StrKIND), pointer :: xtime
+ real (kind=RKIND), pointer :: Time
  integer :: ierr
- 
+
 
 !==================================================================================================
 
@@ -58,14 +61,20 @@
  call mpas_pool_get_config(configs, 'config_sfc_prefix', config_sfc_prefix)
 
  call mpas_pool_get_array(state, 'xtime', xtime)
+ call mpas_pool_get_array(state, 'Time', Time)
 
 !loop over all times:
  curr_time = mpas_get_clock_time(domain % clock, MPAS_NOW) 
  stop_time = mpas_get_clock_time(domain % clock, MPAS_STOP_TIME) 
+ start_time = mpas_get_clock_time(domain % clock, MPAS_START_TIME)
 
  do while (curr_time <= stop_time)
     call mpas_get_time(curr_time, dateTimeString=timeString)
     xtime = timeString
+
+    time_since_start = curr_time - start_time
+    call mpas_get_timeInterval(time_since_start, dt=dt)
+    Time = dt
 
 !   call mpas_log_write('Processing '//trim(config_sfc_prefix)//':'//timeString(1:13))
 


### PR DESCRIPTION
CF compliance in time axis requires a unit of '<time unit> since YYYY-MM-DD hh:mm:ss'. This commit creates the 'Time' variable in the core_atmosphere Registry.xml, initializes it to 0, and changes the 'units' attribute to 'seconds since <start_timestamp>'. The start timestamp is modified from the initial xtime format to remove the underscore and replace it with a space to match the CF compliant time string format.

We can then start to update the Time variable at the same time as the xtime variable by adding 'dt' to the Time at time level 1, and saving it to time level 2. This produces a CF-compliant time variable that tracks xtime at each step.