### PR TITLE
Add ability for `clean` target to check for CORE existence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -996,6 +996,7 @@ override CPPFLAGS += -DMPAS_BUILD_TARGET=$(BUILD_TARGET)
 ifeq ($(wildcard src/core_$(CORE)), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
 
 all: core_error
+clean: core_error
 
 else
 
@@ -1320,8 +1321,7 @@ clean_core:
 else # CORE IF
 
 all: error
-clean: errmsg
-	exit 1
+clean: error
 error: errmsg
 	@echo "************ ERROR ************"
 	@echo "No CORE specified. Quitting."


### PR DESCRIPTION
Previously MPAS would run the clean recipe without regard for the core actually existing. This change ensures that the clean recipe will only run if a valid value for CORE is provided.