### PR TITLE
Update gen_inc.c to compile with Intel compilers

### DIFF
--- a/src/tools/registry/gen_inc.c
+++ b/src/tools/registry/gen_inc.c
@@ -139,8 +139,8 @@ const char * modify_attr(const char *attr, const char *array[][2], size_t rows) 
 // characters. Returns 1 if the buffer is too small for the result. 
 int escape_quotes(const char * stringIn, char * result, size_t bufferSize){
 	size_t resultIndex = 0;
-	
-	for (size_t i = 0; i < strlen(stringIn) + 1; i++) {
+	size_t i;
+	for (i = 0; i < strlen(stringIn) + 1; i++) {
 		if ( stringIn[i] == '\'' ) {
 			if (resultIndex >= bufferSize) return 1;
 			result[resultIndex++] = '\'';


### PR DESCRIPTION
The Intel C compiler does not default to C99 standards. Introduced in C99 was the addition of variable declarations within 'for' loops. As a result, when compiling with the default Intel compiler flags, the variable declaration in the 'for' loop on line 143 failed to compile. This commit updates the file to declare the variable the line before, like the other 'for' loops in the file. 

The code is now verified to be compliant with C99 standards, and compiles with the Intel Make target.
