### PR TITLE
Improve error message in MPAS I/O layer

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -6375,10 +6375,11 @@ module mpas_io
    end function MPAS_io_handle_dminfo
 
 
-   subroutine MPAS_io_err_mesg(ierr, fatal)
+   subroutine MPAS_io_err_mesg(ioContext, ierr, fatal)
 
       implicit none
 
+      type (mpas_io_context_type), intent(inout) :: ioContext
       integer, intent(in) :: ierr
       logical, intent(in) :: fatal
 
@@ -6407,6 +6408,10 @@ module mpas_io
 #ifdef MPAS_SMIOL_SUPPORT
             call mpas_log_write('MPAS IO Error: SMIOL error $i: '//trim(SMIOLf_error_string(io_global_err)), &
                                 messageType=MPAS_LOG_ERR, intArgs=[io_global_err])
+            if (io_global_err == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write('Library error message: '// &
+                                   trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            end if
 #endif
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -82,6 +82,13 @@ module mpas_io
 
 #endif
 
+#ifdef MPAS_PIO_SUPPORT
+   integer, private :: io_global_err = PIO_noerr
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+   integer, private :: io_global_err = SMIOL_SUCCESS
+#endif
+
    interface MPAS_io_get_var
       module procedure MPAS_io_get_var_int0d
       module procedure MPAS_io_get_var_int1d
@@ -425,6 +432,7 @@ module mpas_io
          endif
 #ifdef MPAS_PIO_SUPPORT
          if (pio_ierr /= PIO_noerr) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -448,6 +456,7 @@ module mpas_io
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -461,6 +470,7 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                return
             end if
@@ -585,6 +595,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -743,6 +754,7 @@ module mpas_io
 #endif
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -836,6 +848,7 @@ module mpas_io
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -847,6 +860,7 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -873,6 +887,7 @@ module mpas_io
 #ifdef MPAS_SMIOL_SUPPORT
          local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), vartype=smiol_type)
          if (local_ierr /= SMIOL_SUCCESS) then
+            io_global_err = local_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -900,6 +915,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -918,6 +934,7 @@ module mpas_io
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
 
+            io_global_err = local_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
 
             deallocate(new_fieldlist_node % fieldhandle)
@@ -935,6 +952,7 @@ module mpas_io
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -958,6 +976,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -968,6 +987,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -1310,6 +1330,7 @@ module mpas_io
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -1330,6 +1351,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -2682,6 +2704,7 @@ module mpas_io
 !      call mpas_log_write('Checking for error')
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -3055,6 +3078,7 @@ module mpas_io
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. &
              .not. (handle % external_file_desc .or. handle % preexisting_file)) then
+            io_global_err = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -3950,6 +3974,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4279,6 +4304,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4289,6 +4315,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4305,6 +4332,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
+            io_global_err = local_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -4444,6 +4472,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4455,6 +4484,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4462,6 +4492,7 @@ module mpas_io
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4607,6 +4638,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4675,6 +4707,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4686,6 +4719,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
+            io_global_err = local_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -4836,12 +4870,14 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -4883,6 +4919,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5019,6 +5056,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5029,6 +5067,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5045,6 +5084,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
+            io_global_err = local_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
@@ -5232,6 +5272,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5412,6 +5453,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5615,6 +5657,7 @@ module mpas_io
 
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5818,6 +5861,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
@@ -5983,6 +6027,7 @@ module mpas_io
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
 
+         io_global_err = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
 
          !
@@ -5994,16 +6039,19 @@ module mpas_io
          if (handle % preexisting_file .and. .not. handle % data_mode) then
             pio_ierr = PIO_redef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                return
             end if
 
             pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                return
             end if
 
             pio_ierr = PIO_enddef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
+               io_global_err = pio_ierr
                return
             end if
 
@@ -6235,6 +6283,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
+              io_global_err = pio_ierr
               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
               return
            end if
@@ -6270,6 +6319,11 @@ module mpas_io
       integer, intent(in) :: ierr
       logical, intent(in) :: fatal
 
+#ifdef MPAS_PIO_SUPPORT
+      integer :: ierr_local
+      character(len=StrKIND) :: pio_string
+#endif
+
       select case (ierr)
          case (MPAS_IO_NOERR)
             ! ... do nothing ...
@@ -6283,10 +6337,13 @@ module mpas_io
             call mpas_log_write('MPAS IO Error: Uninitialized I/O handle', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_BACKEND)
 #ifdef MPAS_PIO_SUPPORT
-            call mpas_log_write('MPAS IO Error: Bad return value from PIO', MPAS_LOG_ERR)
+            ierr_local = PIO_strerror(io_global_err, pio_string)
+            call mpas_log_write('MPAS IO Error: PIO error $i: '//trim(pio_string), &
+                                messageType=MPAS_LOG_ERR, intArgs=[io_global_err])
 #endif
 #ifdef MPAS_SMIOL_SUPPORT
-            call mpas_log_write('MPAS IO Error: Bad return value from SMIOL', MPAS_LOG_ERR)
+            call mpas_log_write('MPAS IO Error: SMIOL error $i: '//trim(SMIOLf_error_string(io_global_err)), &
+                                messageType=MPAS_LOG_ERR, intArgs=[io_global_err])
 #endif
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -445,6 +445,10 @@ module mpas_io
             else
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
          end if
 #endif
          MPAS_io_open % external_file_desc = .false.
@@ -750,6 +754,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 #ifdef MPAS_PIO_SUPPORT
@@ -1010,6 +1018,10 @@ module mpas_io
             else
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
          end if
          do i=1,new_fieldlist_node % fieldhandle % ndims
             new_fieldlist_node % fieldhandle % dims(i) % dimname = smiol_dimnames(i)
@@ -1025,6 +1037,10 @@ module mpas_io
                else
                   call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
                end if
+
+               io_global_err = local_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+               return
             end if
             new_fieldlist_node % fieldhandle % dims(i) % dimsize = smiol_dimlen
             if (new_fieldlist_node % fieldhandle % dims(i) % is_unlimited_dim) then
@@ -1344,6 +1360,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -1695,6 +1715,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -1842,6 +1866,10 @@ module mpas_io
             else
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
          end if
 #endif
 
@@ -2718,6 +2746,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -3121,6 +3153,10 @@ module mpas_io
             else
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
          end if
 #endif
 
@@ -3987,6 +4023,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -5291,6 +5331,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -5670,6 +5714,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -6076,6 +6124,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -6146,6 +6198,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -6235,6 +6291,10 @@ module mpas_io
          else
             call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
          end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
       end if
 #endif
 
@@ -6293,6 +6353,9 @@ module mpas_io
             local_ierr = SMIOLf_finalize(ioContext % smiol_context)
             if (local_ierr /= SMIOL_SUCCESS) then
                call mpas_log_write('SMIOLf_free_decomp failed with code $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+               io_global_err = local_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+               return
             end if
 #endif
          end if

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -425,7 +425,7 @@ module mpas_io
          endif
 #ifdef MPAS_PIO_SUPPORT
          if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
 #endif
@@ -448,7 +448,7 @@ module mpas_io
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
 #endif
@@ -461,7 +461,7 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                return
             end if
          else
@@ -585,7 +585,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
          dimsize = -1
@@ -692,7 +692,7 @@ module mpas_io
       !
       if (handle % preexisting_file) then
          call MPAS_io_inq_dim(handle, dimname, inq_dimsize, ierr=pio_ierr)
-         if (pio_ierr /= MPAS_IO_ERR_PIO) then
+         if (pio_ierr /= MPAS_IO_ERR_BACKEND) then
 
             ! Verify that the dimsize matches...
             if (dimsize /= inq_dimsize .and. dimsize /= MPAS_IO_UNLIMITED_DIM) then
@@ -743,7 +743,7 @@ module mpas_io
 #endif
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
          return
@@ -836,7 +836,7 @@ module mpas_io
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
@@ -847,7 +847,7 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             return
@@ -873,7 +873,7 @@ module mpas_io
 #ifdef MPAS_SMIOL_SUPPORT
          local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), vartype=smiol_type)
          if (local_ierr /= SMIOL_SUCCESS) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
@@ -900,7 +900,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             return
@@ -918,7 +918,7 @@ module mpas_io
                call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
             end if
 
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
 
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -935,7 +935,7 @@ module mpas_io
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -958,7 +958,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -968,7 +968,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -1173,7 +1173,7 @@ module mpas_io
       !
       if (handle % preexisting_file) then
          call MPAS_io_inq_var(handle, fieldname, inq_fieldtype, inq_ndims, inq_dimnames, ierr=pio_ierr)
-         if (pio_ierr /= MPAS_IO_ERR_PIO) then
+         if (pio_ierr /= MPAS_IO_ERR_BACKEND) then
 
             ! Verify that the type and dimensions match...
             if (fieldtype == MPAS_IO_DOUBLE) then
@@ -1310,7 +1310,7 @@ module mpas_io
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -1330,7 +1330,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -2682,7 +2682,7 @@ module mpas_io
 !      call mpas_log_write('Checking for error')
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -3055,7 +3055,7 @@ module mpas_io
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. &
              .not. (handle % external_file_desc .or. handle % preexisting_file)) then
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
 #endif
@@ -3950,7 +3950,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -4279,7 +4279,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
       if (xtype /= PIO_int) then
@@ -4289,7 +4289,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -4305,7 +4305,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
       end if
@@ -4444,7 +4444,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
@@ -4455,14 +4455,14 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -4607,7 +4607,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -4675,7 +4675,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -4686,7 +4686,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
       end if
@@ -4836,13 +4836,13 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
@@ -4883,7 +4883,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5019,7 +5019,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
       if (xtype /= PIO_char) then
@@ -5029,7 +5029,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5045,7 +5045,7 @@ module mpas_io
             if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
             return
          else
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
       end if
@@ -5232,7 +5232,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5412,7 +5412,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5615,7 +5615,7 @@ module mpas_io
 
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5818,7 +5818,7 @@ module mpas_io
       end if
 #ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 #endif
@@ -5983,7 +5983,7 @@ module mpas_io
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
 
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
 
          !
          ! If we are working with a pre-existing file and the text attribute is larger than in the file, we need 
@@ -6235,7 +6235,7 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
-              if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+              if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
               return
            end if
            deallocate(ioContext % pio_iosystem)
@@ -6281,8 +6281,13 @@ module mpas_io
             call mpas_log_write('MPAS IO Error: Filename too long', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_UNINIT_HANDLE)
             call mpas_log_write('MPAS IO Error: Uninitialized I/O handle', MPAS_LOG_ERR)
-         case (MPAS_IO_ERR_PIO)
+         case (MPAS_IO_ERR_BACKEND)
+#ifdef MPAS_PIO_SUPPORT
             call mpas_log_write('MPAS IO Error: Bad return value from PIO', MPAS_LOG_ERR)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            call mpas_log_write('MPAS IO Error: Bad return value from SMIOL', MPAS_LOG_ERR)
+#endif
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_NOWRITE)

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -118,7 +118,7 @@ module mpas_io_streams
       end if
 
       ! General error
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -1704,7 +1704,7 @@ module mpas_io_streams
 !call mpas_log_write('... defining dimension '// trim(dimNames(idim))//" $i", intArgs=(/ dimSizes(idim)/))
             write(dimNamesLocal(idim),'(a)') dimNames(idim)
             call MPAS_io_def_dim(stream % fileHandle, trim(dimNames(idim)), dimSizes(idim), io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1729,7 +1729,7 @@ module mpas_io_streams
          if (ndims > 0) then
 !call mpas_log_write('... defining dimension '// trim(dimNames(idim))//" $i", intArgs=(/ globalDimSize/))
             call MPAS_io_def_dim(stream % fileHandle, trim(dimNames(idim)), globalDimSize, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1743,7 +1743,7 @@ module mpas_io_streams
          if (hasTimeDimension) then
 !call mpas_log_write('... defining Time dimension ')
             call MPAS_io_def_dim(stream % fileHandle, 'Time', MPAS_IO_UNLIMITED_DIM, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1759,7 +1759,7 @@ module mpas_io_streams
 !call mpas_log_write('... defining var to low-level interface with ndims $i', intArgs=(/ndims/))
 
          call MPAS_io_def_var(stream % fileHandle, trim(fieldName), fieldType, dimNamesLocal(1:ndims), precision=precision, ierr=io_err)
-         call MPAS_io_err_mesg(io_err, .false.)
+         call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -1772,7 +1772,7 @@ module mpas_io_streams
          call MPAS_io_inq_var(stream % fileHandle, trim(fieldName), dimnames=dimNamesInq, dimsizes=dimSizesInq, ierr=io_err)
          ! If the field does not exist in the input file, we should handle this situation gracefully at higher levels
          !   without printing disconcerting error messages
-         !call MPAS_io_err_mesg(io_err, .false.)
+         !call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -1830,7 +1830,7 @@ module mpas_io_streams
       !
       if (ndims > 0 .and. isDecomposed) then
          call MPAS_io_set_var_indices(stream % fileHandle, trim(fieldName), indices, io_err)
-         call MPAS_io_err_mesg(io_err, .false.)
+         call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -2479,7 +2479,7 @@ module mpas_io_streams
       ! Set time frame to real
       !
       call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -2500,7 +2500,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % int0dField % fieldName, int0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -2532,7 +2532,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int1dField % fieldName, int1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (.not. field_cursor % int1dField % isVarArray) then
@@ -2608,7 +2608,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int2dField % fieldName, int2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % int2dField % isVarArray) then
@@ -2690,7 +2690,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int3dField % fieldName, int3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % int3dField % isVarArray) then
@@ -2760,7 +2760,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % real0dField % fieldName, real0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -2792,7 +2792,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real1dField % fieldName, real1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (.not. field_cursor % real1dField % isVarArray) then
@@ -2869,7 +2869,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real2dField % fieldName, real2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real2dField % isVarArray) then
@@ -2954,7 +2954,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real3dField % isVarArray) then
@@ -3041,7 +3041,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real4dField % fieldName, real4d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real4dField % isVarArray) then
@@ -3131,7 +3131,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real5dField % fieldName, real5d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real5dField % isVarArray) then
@@ -3202,7 +3202,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % char0dField % fieldName, field_cursor % char0dField % scalar, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -3225,7 +3225,7 @@ module mpas_io_streams
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             allocate(char1d_temp(field_cursor % char1dField % dimSizes(1)))
             call MPAS_io_get_var(stream % fileHandle, field_cursor % char1dField % fieldName, char1d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 deallocate(char1d_temp)
@@ -3302,7 +3302,7 @@ module mpas_io_streams
       ! Set time frame to write
       !
       call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -3344,7 +3344,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % int0dField % fieldName, int0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_INT) then
@@ -3401,7 +3401,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % fieldName, int1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3464,7 +3464,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % fieldName, int2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3531,7 +3531,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % fieldName, int3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3552,7 +3552,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % real0dField % fieldName, real0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_REAL) then
@@ -3609,7 +3609,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % fieldName, real1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3672,7 +3672,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % fieldName, real2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3739,7 +3739,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3808,7 +3808,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % fieldName, real4d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3879,7 +3879,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % fieldName, real5d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3898,7 +3898,7 @@ module mpas_io_streams
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % char0dField % fieldName, field_cursor % char0dField % scalar, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_CHAR) then
@@ -3910,7 +3910,7 @@ module mpas_io_streams
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % char1dField % fieldName, field_cursor % char1dField % array, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
 
@@ -3949,7 +3949,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_0dInteger
@@ -3977,7 +3977,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_1dInteger
@@ -4013,7 +4013,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_0dReal
@@ -4049,7 +4049,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_1dReal
@@ -4077,7 +4077,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_text
@@ -4106,7 +4106,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dInteger
@@ -4135,7 +4135,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dInteger
@@ -4172,7 +4172,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dReal
@@ -4209,7 +4209,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dReal
@@ -4238,7 +4238,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_text
@@ -4265,7 +4265,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_close(stream % fileHandle, io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
 !call mpas_log_write('Deallocating global attribute list')

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -49,7 +49,7 @@
                          MPAS_IO_ERR_INVALID_FORMAT = -2, &
                          MPAS_IO_ERR_LONG_FILENAME  = -3, &
                          MPAS_IO_ERR_UNINIT_HANDLE  = -4, &
-                         MPAS_IO_ERR_PIO            = -5, &
+                         MPAS_IO_ERR_BACKEND        = -5, &
                          MPAS_IO_ERR_DATA_MODE      = -6, &
                          MPAS_IO_ERR_NOWRITE        = -7, &
                          MPAS_IO_ERR_REDEF_DIM      = -8, &


### PR DESCRIPTION
This PR modifies the `mpas_io` and `mpas_io_streams` modules to provide more helpful error messages
in cases where errors occur in the PIO or SMIOL libraries. Prior to the changes in this PR, an error in
the PIO or SMIOL library would generally result in the following less-than-helpful message in the MPAS
log file:
```
MPAS IO Error: Bad return value from PIO
```
Now, for example, the error messages give further details about the nature of the error in PIO or SMIOL:
```
MPAS IO Error: PIO error -62: NetCDF: One or more variable sizes violate format constraints
```

Also included in this PR are changes to clean up several parts of the `mpas_io` module, for example,
replacing the PIO-specific error code `MPAS_IO_ERR_PIO` with a more generic name (`MPAS_IO_ERR_BACKEND`)
and adding code to properly set the error code in various places when the SMIOL library is used.