### PR TITLE
Add mpas_dmpar_sum_int8 to mpas_dmpar

### DIFF
--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -8,7 +8,8 @@ OBJS = mpas_test_core.o \
        mpas_test_core_timekeeping_tests.o \
        mpas_test_core_sorting.o \
        mpas_halo_testing.o \
-       mpas_test_core_string_utils.o
+       mpas_test_core_string_utils.o \
+       mpas_test_core_dmpar.o \
 
 all: core_test
 
@@ -38,7 +39,7 @@ mpas_test_core_interface.o: mpas_test_core.o
 mpas_test_core.o: mpas_test_core_halo_exch.o mpas_test_core_streams.o \
                   mpas_test_core_field_tests.o mpas_test_core_timekeeping_tests.o \
                   mpas_test_core_sorting.o mpas_halo_testing.o \
-                  mpas_test_core_string_utils.o
+                  mpas_test_core_string_utils.o mpas_test_core_dmpar.o
 
 mpas_test_core_halo_exch.o:
 

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -94,6 +94,7 @@ module test_core
       use test_core_sorting, only : test_core_test_sorting
       use mpas_halo_testing, only : mpas_halo_tests
       use test_core_string_utils, only : mpas_test_string_utils
+      use mpas_test_core_dmpar, only : mpas_test_dmpar
 
       implicit none
    
@@ -171,6 +172,18 @@ module test_core
       ! Run string util tests
       call mpas_log_write('')
       call mpas_test_string_utils(iErr)
+      call mpas_log_write('')
+
+      !
+      ! Run mpas_dmpar tests
+      !
+      call mpas_log_write('')
+      iErr = mpas_test_dmpar(domain % dminfo)
+      if (iErr == 0) then
+          call mpas_log_write('All tests PASSED')
+      else
+          call mpas_log_write('$i tests FAILED', intArgs=[iErr])
+      end if
       call mpas_log_write('')
 
       call test_core_test_intervals(domain, threadErrs, iErr)

--- a/src/core_test/mpas_test_core_dmpar.F
+++ b/src/core_test/mpas_test_core_dmpar.F
@@ -1,0 +1,160 @@
+! Copyright (c) 2023 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+module mpas_test_core_dmpar
+
+    use mpas_derived_types, only : dm_info
+    use mpas_log, only : mpas_log_write
+
+    private
+
+    public :: mpas_test_dmpar
+
+
+    contains
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_test_dmpar
+    !
+    !> \brief Main driver for tests of the mpas_dmpar module
+    !> \author Michael Duda
+    !> \date   14 November 2023
+    !> \details
+    !>  This routine invokes tests for individual routines in the mpas_dmpar
+    !>  module, and reports PASSED/FAILED for each of those tests.
+    !>
+    !>  Return value: The total number of test that failed on any MPI rank.
+    !
+    !-----------------------------------------------------------------------
+    function mpas_test_dmpar(dminfo) result(ierr_count)
+
+        use mpas_dmpar, only : mpas_dmpar_max_int
+        use mpas_kind_types, only : StrKIND
+
+        implicit none
+
+        ! Arguments
+        type (dm_info), intent(inout) :: dminfo
+
+        ! Return value
+        integer :: ierr_count
+
+        ! Local variables
+        integer :: ierr, ierr_global
+        character(len=StrKIND) :: routine_name
+
+
+        ierr_count = 0
+
+        call mpas_log_write('--- Begin dmpar tests')
+
+        !
+        ! Test mpas_dmpar_sum_int8 routine
+        !
+        routine_name = 'mpas_dmpar_sum_int8'
+        ierr = test_sum_int8(dminfo)
+        call mpas_dmpar_max_int(dminfo, ierr, ierr_global)
+        if (ierr_global == 0) then
+            call mpas_log_write('    '//trim(routine_name)//' - PASSED')
+        else
+            ierr_count = ierr_count + 1
+            call mpas_log_write('    '//trim(routine_name)//' - FAILED')
+        end if
+
+    end function mpas_test_dmpar
+
+
+    !-----------------------------------------------------------------------
+    !  routine test_sum_int8
+    !
+    !> \brief Tests the mpas_dmpar_sum_int8 routine
+    !> \author Michael Duda
+    !> \date   14 November 2023
+    !> \details
+    !>  This routine tests the mpas_dmpar_sum_int8 routine.
+    !>
+    !>  Return value: The total number of test that failed on the calling rank.
+    !
+    !-----------------------------------------------------------------------
+    function test_sum_int8(dminfo) result(ierr_count)
+
+        use mpas_dmpar, only : mpas_dmpar_sum_int8
+        use mpas_kind_types, only : I8KIND
+
+        implicit none
+
+        ! Arguments
+        type (dm_info), intent(inout) :: dminfo
+
+        ! Return value
+        integer :: ierr_count
+
+        ! Local variables
+        integer(kind=I8KIND) :: ival, ival_sum
+        integer :: nranks, myrank
+
+        ierr_count = 0
+
+        myrank = dminfo % my_proc_id
+        nranks = dminfo % nprocs
+
+        !
+        ! Compute sum(huge(ival) / nranks)
+        ! Correct result should be at least (huge(ival) - nranks) when accounting
+        ! for truncation in the integer division operation
+        !
+        ival = huge(ival) / nranks
+        call mpas_dmpar_sum_int8(dminfo, ival, ival_sum)
+        if (ival_sum >= huge(ival) - nranks) then
+            call mpas_log_write('        int8 sum to HUGE() - PASSED')
+        else
+            call mpas_log_write('        int8 sum to HUGE() - FAILED')
+            ierr_count = 1
+        end if
+
+        !
+        ! Compute sum(-huge(ival) / nranks)
+        ! Correct result should be at most (-huge(ival) + nranks) when accounting
+        ! for truncation in the integer division operation
+        !
+        ival = -huge(ival) / nranks
+        call mpas_dmpar_sum_int8(dminfo, ival, ival_sum)
+        if (ival_sum <= -huge(ival) + nranks) then
+            call mpas_log_write('        int8 sum to -HUGE() - PASSED')
+        else
+            call mpas_log_write('        int8 sum to -HUGE() - FAILED')
+            ierr_count = 1
+        end if
+
+        !
+        ! Compute sum of N alternating positive and negative values, where N is
+        ! the largest even number not greater than the number of ranks.
+        ! The magnitude of the values to be summed is (huge(ival) / nranks) to
+        ! avoid overflow for any order of summation.
+        !
+        ival = huge(ival) / nranks
+        if (mod(myrank, 2) == 1) then
+            ival = -ival
+        end if
+
+        ! If we have an odd number of ranks, set value on rank 0 to zero
+        if (mod(nranks, 2) /= 0) then
+            if (myrank == 0) then
+                ival = 0
+            end if
+        end if
+        call mpas_dmpar_sum_int8(dminfo, ival, ival_sum)
+        if (ival_sum == 0_I8KIND) then
+            call mpas_log_write('        int8 sum to zero - PASSED')
+        else
+            call mpas_log_write('        int8 sum to zero - FAILED')
+            ierr_count = 1
+        end if
+
+    end function test_sum_int8
+
+end module mpas_test_core_dmpar

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -76,6 +76,7 @@ include 'mpif.h'
    public :: mpas_dmpar_bcast_char
    public :: mpas_dmpar_bcast_chars
    public :: mpas_dmpar_sum_int
+   public :: mpas_dmpar_sum_int8
    public :: mpas_dmpar_sum_real
    public :: mpas_dmpar_min_int
    public :: mpas_dmpar_min_real
@@ -749,6 +750,39 @@ include 'mpif.h'
       end if
 
    end subroutine mpas_dmpar_sum_int!}}}
+
+!-----------------------------------------------------------------------
+!  routine mpas_dmpar_sum_int8
+!
+!> \brief MPAS dmpar sum 8 byte integer routine.
+!> \author Matthew Dimond
+!> \date   11/07/2023
+!> \details
+!>  This routine sums (Allreduce) int(8) values across all processors in a communicator.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_dmpar_sum_int8(dminfo, i, isum)!{{{
+
+      implicit none
+
+      type (dm_info), intent(in) :: dminfo !< Input: Domain information
+      integer(kind=I8KIND), intent(in) :: i !< Input: Integer value input
+      integer(kind=I8KIND), intent(out) :: isum !< Output: Integer sum for output
+
+      integer :: mpi_ierr
+      integer :: threadNum
+
+      threadNum = mpas_threading_get_thread_num()
+
+      if ( threadNum == 0 ) then
+#ifdef _MPI
+         call MPI_Allreduce(i, isum, 1, MPI_INTEGER8, MPI_SUM, dminfo % comm, mpi_ierr)
+#else
+         isum = i
+#endif
+      end if
+
+   end subroutine mpas_dmpar_sum_int8!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_sum_real


### PR DESCRIPTION
This PR adds a function to sum the values of an 8-byte integer across all MPI ranks. It is functionally identical to mpas_dmpar_sum_int, but returns an integer(kind=I8KIND) instead of a standard 4-byte integer.

