### PR TITLE
Add changes for variable epssm and reference sounding option

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -197,6 +197,11 @@
                      description="Whether to advect scalar fields"
                      possible_values=".true. or .false."/>
 
+                <nml_option name="config_reference_sounding" type="logical" default_value="true"
+                     units="-"
+                     description="Whether a reference sounding is used for thermodynamic variables"
+                     possible_values=".true. or .false."/>
+
                 <nml_option name="config_positive_definite" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="Whether to enable positive-definite advection of scalars"
@@ -263,6 +268,26 @@
                      units="-"
                      description="Maximum w-damping coefficient at model top"
                      possible_values="0 $\leq$ config_xnutr $\leq$ 1"/>
+
+                <nml_option name="config_min_coeff" type="real" default_value="0.1"
+                     units="-"
+                     description="Value of epssm below transition zone"
+                     possible_values="Positive real values between 0 and 1"/>
+
+                <nml_option name="config_max_coeff" type="real" default_value="0.1"
+                     units="-"
+                     description="Value of epssm above transition zone"
+                     possible_values="Positive real values between 0 and 1"/>
+
+                <nml_option name="config_transition_lower_bound" type="real" default_value="10000."
+                     units="-"
+                     description="Height MSL of bottom of transition zone for epssm"
+                     possible_values="Positive real values"/>
+
+                <nml_option name="config_transition_upper_bound" type="real" default_value="20000."
+                     units="-"
+                     description="Height MSL of top of transition zone for epssm"
+                     possible_values="Positive real values"/>
 
                 <nml_option name="config_mpas_cam_coef" type="real" default_value="0.0" in_defaults="false"
                      units="-"
@@ -471,6 +496,10 @@
 			<var name="cf3"/>
 			<var name="zgrid"/>
 			<var name="rdzw"/>
+			<var name="etp"/>
+			<var name="etm"/>
+			<var name="ewp"/>
+			<var name="ewm"/>
 			<var name="dzu"/>
 			<var name="rdzu"/>
 			<var name="fzm"/>
@@ -607,6 +636,10 @@
 			<var name="cf3"/>
 			<var name="zgrid"/>
 			<var name="rdzw"/>
+			<var name="etp"/>
+			<var name="etm"/>
+			<var name="ewp"/>
+			<var name="ewm"/>
 			<var name="dzu"/>
 			<var name="rdzu"/>
 			<var name="fzm"/>
@@ -1352,6 +1385,18 @@
 
                 <var name="rdzw" type="real" dimensions="nVertLevels" units="unitless"
                      description="Reciprocal dzw"/>
+
+                <var name="etp" type="real" dimensions="nVertLevels" units="unitless"
+                     description="coeff for variable epssm"/>
+
+                <var name="etm" type="real" dimensions="nVertLevels" units="unitless"
+                     description="coeff for variable epssm"/>
+
+                <var name="ewp" type="real" dimensions="nVertLevelsP1" units="unitless"
+                     description="coeff for variable epssm"/>
+
+                <var name="ewm" type="real" dimensions="nVertLevelsP1" units="unitless"
+                     description="coeff for variable epssm"/>
 
                 <var name="dzu" type="real" dimensions="nVertLevels" units="unitless"
                      description="d(zeta) at w levels"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -197,11 +197,6 @@
                      description="Whether to advect scalar fields"
                      possible_values=".true. or .false."/>
 
-                <nml_option name="config_reference_sounding" type="logical" default_value="true"
-                     units="-"
-                     description="Whether a reference sounding is used for thermodynamic variables"
-                     possible_values=".true. or .false."/>
-
                 <nml_option name="config_positive_definite" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="Whether to enable positive-definite advection of scalars"
@@ -256,7 +251,8 @@
                      units="-"
                      description="Coefficient for the divergent component of the Laplacian filter of momentum in the relaxation zone"
                      possible_values="Positive real values"/>
-        </nml_record>
+
+	      </nml_record>
 
         <nml_record name="damping" in_defaults="true">
                 <nml_option name="config_zd" type="real" default_value="22000.0"
@@ -516,6 +512,7 @@
 			<var name="deriv_two"/>
 			<var name="defc_a"/>
 			<var name="defc_b"/>
+			<var name="reference_sounding_switch"/> 
 #ifdef MPAS_CAM_DYCORE
 			<var name="cell_gradient_coef_x"/>
 			<var name="cell_gradient_coef_y"/>
@@ -656,6 +653,7 @@
 			<var name="deriv_two"/>
 			<var name="defc_a"/>
 			<var name="defc_b"/>
+			<var name="reference_sounding_switch"/> 
 #ifdef MPAS_CAM_DYCORE
 			<var name="cell_gradient_coef_x"/>
 			<var name="cell_gradient_coef_y"/>
@@ -1444,6 +1442,9 @@
 
                 <var name="qv_init" type="real" dimensions="nVertLevels" units="kg kg^{-1}"
                      description="qv reference profile"/>
+
+                <var name="reference_sounding_switch" type="integer" dimensions="" units="unitless" default_value="1" 
+                     description="Switch to designate a reference sounding is used (1) or full variables (0)"/>       
 
                 <!-- Space needed for advection -->
                 <var name="deriv_two" type="real" dimensions="FIFTEEN TWO nEdges" units="unitless"

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1635,16 +1635,14 @@ module atm_time_integration
 
 !!!JBK-vepssm and reference sounding                                                    
       real (kind=RKIND), dimension(:), pointer :: etp, etm, ewp, ewm
-      logical,                         pointer :: reference_sounding
+      integer,	      	      	       pointer :: reference_sounding_switch    
       call mpas_pool_get_array(mesh, 'etp', etp)                                                                                            
       call mpas_pool_get_array(mesh, 'etm', etm)                                                                                            
       call mpas_pool_get_array(mesh, 'ewp', ewp)                                                                                            
       call mpas_pool_get_array(mesh, 'ewm', ewm)                                                                                            
-      call mpas_pool_get_config(configs, 'config_reference_sounding', reference_sounding)
-!!!JBK                                                                                                                                      
-
+      call mpas_pool_get_array(mesh, 'reference_sounding_switch', reference_sounding_switch) 
       call mpas_pool_get_config(configs, 'config_epssm', epssm)
-
+!!!JBK
       call mpas_pool_get_array(mesh, 'rdzu', rdzu)
       call mpas_pool_get_array(mesh, 'rdzw', rdzw)
       call mpas_pool_get_array(mesh, 'fzm', fzm)
@@ -1674,13 +1672,12 @@ module atm_time_integration
       call mpas_pool_get_dimension(state, 'moist_start', moist_start)
       call mpas_pool_get_dimension(state, 'moist_end', moist_end)
 
-
       call atm_compute_vert_imp_coefs_work(nCells, moist_start, moist_end, dts, epssm, &
                                    zz, cqw, p, t, rb, rtb, pb, rt, cofwr, cofwz, coftz, cofwt, &
                                    a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
                                    cellStart, cellEnd, edgeStart, edgeEnd, &
 !!!JBK
-                                   etp, etm, ewp, ewm, reference_sounding,    &
+                                   etp, etm, ewp, ewm, reference_sounding_switch,    &
 !!!JBK
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -1693,7 +1690,7 @@ module atm_time_integration
                                    a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
                                    cellStart, cellEnd, edgeStart, edgeEnd, &
 !!!JBK
-                                   etp, etm, ewp, ewm, reference_sounding,    &
+                                   etp, etm, ewp, ewm, reference_sounding_switch,    &
 !!!JBK
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
@@ -1737,7 +1734,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels  ) :: etp,etm
       real (kind=RKIND), dimension(nVertLevels+1) :: ewp,ewm
 !!!JBK Swith to use reference sounding and perturbation thermodynamic variables
-      logical :: reference_sounding
+      integer                                     :: reference_sounding_switch
 !!!JBK
 
 
@@ -1793,8 +1790,8 @@ module atm_time_integration
          coftz(nVertLevels+1,iCell) = 0.0
 !DIR$ IVDEP
 
-!!!JBK Mod to use full variables and log(p)
-       if(reference_sounding)  then
+!!!JBK Mod to use either reference sounding or full variables and log(p)
+       if(reference_sounding_switch.eq.1)  then
 !!!JBK
          do k=1,nVertLevels
 
@@ -4087,13 +4084,12 @@ module atm_time_integration
       real (kind=RKIND), pointer :: config_h_theta_eddy_visc2, config_v_theta_eddy_visc2
 
       real (kind=RKIND), pointer :: config_mpas_cam_coef
-      logical, pointer :: config_rayleigh_damp_u
+      logical,           pointer :: config_rayleigh_damp_u
       real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale_days
-      integer, pointer :: config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels
-!!!JBK - Mod for reference sounding switch
-      logical,           pointer :: reference_sounding
+      integer,           pointer :: config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels
+!!!JBK - Mod for reference sounding
+      integer,           pointer :: reference_sounding_switch
 !!!JBK end
-
 
       call mpas_pool_get_config(mesh, 'sphere_radius', r_earth)
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', coef_3rd_order)
@@ -4114,9 +4110,7 @@ module atm_time_integration
       call mpas_pool_get_config(configs, 'config_rayleigh_damp_u_timescale_days', config_rayleigh_damp_u_timescale_days)
       call mpas_pool_get_config(configs, 'config_number_rayleigh_damp_u_levels', config_number_rayleigh_damp_u_levels)
       call mpas_pool_get_config(configs, 'config_number_cam_damping_levels', config_number_cam_damping_levels)
-!!!JBK Mod foe reference sounding switch
-      call mpas_pool_get_config(configs, 'config_reference_sounding', reference_sounding)
-!!!JBK end
+
       call mpas_pool_get_array(state, 'rho_zz', rho_zz, 2)
       call mpas_pool_get_array(state, 'u', u, 2)
       call mpas_pool_get_array(state, 'w', w, 2)
@@ -4146,7 +4140,9 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'exner', exner)
 
       call mpas_pool_get_array(tend_physics, 'rthdynten', rthdynten)
-
+!!!JBK Mod for reference_sounding_switch
+      call mpas_pool_get_array(mesh, 'reference_sounding_switch', reference_sounding_switch)   
+!!!
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(mesh, 'cellsOnCell', cellsOnCell)
@@ -4239,8 +4235,8 @@ module atm_time_integration
          config_mpas_cam_coef, &
          config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, & 
          config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels, &
-!!!JBK - Mod for reference sounding switch
-         reference_sounding,  &
+!!!JBK - Mod for reference sounding
+         reference_sounding_switch,  &
 !!!JBK end
          rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
@@ -4267,8 +4263,8 @@ module atm_time_integration
       config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, &
       config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels, &
 
-!!!JBK - Mod for reference sounding switch
-      reference_sounding,  &
+!!!JBK - Mod for reference sounding
+      reference_sounding_switch,  &
 !!!JBK end
       rthdynten, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
@@ -4428,11 +4424,11 @@ module atm_time_integration
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
 
 !!!JBK - mod for reference sounding switch
-      logical           :: reference_sounding
-!     Declaration for plog                                                                                                                                     
+      integer           :: reference_sounding_switch
+!     Declaration for plog                      
       real (kind=RKIND) :: p0
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: plog
-!!!JBK end                                                                                                                                                        
+!!!JBK end                       
       flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
                 ua*( 7.*(q_i + q_im1) - (q_ip1 + q_im2) )/12.0
 
@@ -4449,10 +4445,10 @@ module atm_time_integration
 
       if (rk_step == 1) then
 
-        p0 = 1.0e+05  ! this should come from somewhere else...                                                                                                
+        p0 = 1.0e+05  ! this should come from somewhere else...              
 
 !!!JBK - Temporary mod to print reference_sounding
-        call mpas_log_write('reference_sounding = $l ', logicArgs=(/reference_sounding/))
+        call mpas_log_write('reference_sounding_switch = $i ', intArgs=(/reference_sounding_switch/))
 !!!JBK end
 
 !         tend_u_euler(1:nVertLevels,edgeStart:edgeEnd) = 0.0
@@ -4556,7 +4552,7 @@ module atm_time_integration
           do k = 1,nVertLevels
              tend_rho(k,iCell) = -h_divergence(k,iCell)-rdzw(k)*(rw(k+1,iCell)-rw(k,iCell)) + tend_rho_physics(k,iCell)
           end do
-          if(reference_sounding)  then
+          if(reference_sounding_switch.eq.1)  then
              do k = 1,nVertLevels
                 dpdz(k,iCell) = -gravity*(rb(k,iCell)*(qtot(k,iCell)) + rr_save(k,iCell)*(1.+qtot(k,iCell)))
              end do
@@ -4591,7 +4587,7 @@ module atm_time_integration
 !               tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*( (pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)/(.5*(zz(k,cell2)+zz(k,cell1))) &
 !                                              -0.5*zxu(k,iEdge)*(dpdz(k,cell1)+dpdz(k,cell2)) )
 !            end do
-            if(reference_sounding)  then
+            if(reference_sounding_switch.eq.1)  then
                do k=1,nVertLevels
                   tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*((pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)  &
                                                       /(.5*(zz(k,cell2)+zz(k,cell1)))                  &
@@ -5017,7 +5013,7 @@ module atm_time_integration
 !                                         - (fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )  ! dpdz is the buoyancy term here.
 !            end do
 
-            if(reference_sounding)  then
+            if(reference_sounding_switch.eq.1)  then
                do k=2,nVertLevels
                   tend_w_euler(k,iCell) = tend_w_euler(k,iCell)                             - cqw(k,iCell)     &
                                                                       *(rdzu(k)*(pp(k,iCell)-pp(k-1,iCell))    & 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -94,6 +94,8 @@ module atm_time_integration
    ! if damping in the model changed with the simulation calendar
    real (kind=RKIND), parameter, private :: seconds_per_day = 86400.0_RKIND
 
+   !WCM_epssm                                                                                                                                   
+!   real (kind=RKIND), dimension(:), allocatable :: ewp, ewm, etp, etm ! variable_epssm                                                          
 
    contains
 
@@ -376,6 +378,11 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:), pointer :: rqvdynten, rthdynten, theta_m
       real (kind=RKIND) :: theta_local, fac_m
 
+!--------------------------                                                                                                                     
+!SK_epssm: wrote this to retrieve rdzw                                                                                                          
+      real (kind=RKIND), dimension(:), pointer:: rdzw
+!--------------------------                                                                                                                     
+
 #ifndef MPAS_CAM_DYCORE
       ! Used in allocating scratch fields for physics tendencies
       type (field2DReal), pointer :: tend_ru_physicsField, tend_rtheta_physicsField, tend_rho_physicsField
@@ -415,6 +422,15 @@ module atm_time_integration
 #ifdef DO_PHYSICS
       call mpas_pool_get_subpool(block % structs, 'diag_physics', diag_physics)
 #endif
+!----------------------                                                                                                                         
+!SK_epssm: setting the 'mesh' pool pointer                                                                                                      
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', mesh)                                                                    
+!----------------------------                                                                                                                   
+
+!------------------------                                                                                                                       
+!SK_epssm: added this to retrieve the pointer for rdzw                                                                                          
+      call mpas_pool_get_array(mesh, 'rdzw', rdzw)
+!------------------                                                                                                                             
 
       !
       ! Retrieve dimensions
@@ -486,6 +502,14 @@ module atm_time_integration
       tend_rho_physics(:,nCells+1) = 0.0_RKIND
       call mpas_pool_get_array(tend_physics, 'tend_ru_physics', tend_ru_physics)
       tend_ru_physics(:,nEdges+1) = 0.0_RKIND
+
+      ! WCS_epssm                                                                                                                               
+      ! allocate storage for epssm column arrays and set values                                                                                 
+!      allocate(ewp(nVertLevels+1))
+!      allocate(ewm(nVertLevels+1))
+!      allocate(etp(nVertLevels))
+!      allocate(etm(nVertLevels))
+!      call set_epssm(ewp,ewm,etp,etm,nVertLevels,rdzw)
 
       !
       ! Initialize RK weights
@@ -1257,6 +1281,12 @@ module atm_time_integration
 
       end if  ! regional_MPAS addition
 
+      ! WCS_epssm                                                                                                                               
+!      deallocate(ewp)
+!      deallocate(ewm)
+!      deallocate(etp)
+!      deallocate(etm)
+
       call summarize_timestep(domain)
 
    end subroutine atm_srk3
@@ -1603,6 +1633,15 @@ module atm_time_integration
 
       integer, pointer :: nCells, moist_start, moist_end
 
+!!!JBK-vepssm and reference sounding                                                    
+      real (kind=RKIND), dimension(:), pointer :: etp, etm, ewp, ewm
+      logical,                         pointer :: reference_sounding
+      call mpas_pool_get_array(mesh, 'etp', etp)                                                                                            
+      call mpas_pool_get_array(mesh, 'etm', etm)                                                                                            
+      call mpas_pool_get_array(mesh, 'ewp', ewp)                                                                                            
+      call mpas_pool_get_array(mesh, 'ewm', ewm)                                                                                            
+      call mpas_pool_get_config(configs, 'config_reference_sounding', reference_sounding)
+!!!JBK                                                                                                                                      
 
       call mpas_pool_get_config(configs, 'config_epssm', epssm)
 
@@ -1640,6 +1679,9 @@ module atm_time_integration
                                    zz, cqw, p, t, rb, rtb, pb, rt, cofwr, cofwz, coftz, cofwt, &
                                    a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
                                    cellStart, cellEnd, edgeStart, edgeEnd, &
+!!!JBK
+                                   etp, etm, ewp, ewm, reference_sounding,    &
+!!!JBK
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
 
@@ -1650,6 +1692,9 @@ module atm_time_integration
                                    zz, cqw, p, t, rb, rtb, pb, rt, cofwr, cofwz, coftz, cofwt, &
                                    a_tri, alpha_tri, gamma_tri, cofrz, rdzw, fzm, fzp, rdzu, scalars, &
                                    cellStart, cellEnd, edgeStart, edgeEnd, &
+!!!JBK
+                                   etp, etm, ewp, ewm, reference_sounding,    &
+!!!JBK
                                    cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd)
 
       use mpas_atm_dimensions
@@ -1688,6 +1733,12 @@ module atm_time_integration
 
       integer, intent(in) :: cellStart, cellEnd, edgeStart, edgeEnd
       integer, intent(in) :: cellSolveStart, cellSolveEnd, edgeSolveStart, edgeSolveEnd
+!!!JBK
+      real (kind=RKIND), dimension(nVertLevels  ) :: etp,etm
+      real (kind=RKIND), dimension(nVertLevels+1) :: ewp,ewm
+!!!JBK Swith to use reference sounding and perturbation thermodynamic variables
+      logical :: reference_sounding
+!!!JBK
 
 
       !
@@ -1697,6 +1748,15 @@ module atm_time_integration
       real (kind=RKIND) :: dtseps, c2, qtotal, rcv
       real (kind=RKIND), dimension( nVertLevels ) :: b_tri, c_tri
 
+!  temporary print to check etm and ewm
+
+      integer :: iprint=0      
+      if(iprint.eq.0) then
+         do k=1,nVertLevels
+            call mpas_log_write(' k, etp(k), ewp(k) = $i $r $r', intArgs=(/k/), realArgs=(/etp(k),ewp(k)/)) 
+         end do
+         iprint = 1
+      end if 
 
       !  set coefficients
       dtseps = .5*dts*(1.+epssm)
@@ -1705,24 +1765,37 @@ module atm_time_integration
 
 ! MGD bad to have all threads setting this variable?
       do k=1,nVertLevels
-         cofrz(k) = dtseps*rdzw(k)
+         ! WCS_epssm                                                                                                                            
+         ! cofrz(k) = dtseps*rdzw(k)                                                                                                            
+         cofrz(k) = rdzw(k)
       end do
 
       do iCell = cellSolveStart,cellSolveEnd  !  we only need to do cells we are solving for, not halo cells
 
 !DIR$ IVDEP
          do k=2,nVertLevels
-            cofwr(k,iCell) =.5*dtseps*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))
+          
+  ! WCS_epssm                                                                                                                         
+            ! cofwr(k,iCell) =.5*dtseps*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))                                                       
+            cofwr(k,iCell) = 0.5*gravity*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))                                                              
          end do
          coftz(1,iCell) = 0.0
 !DIR$ IVDEP
          do k=2,nVertLevels
-            cofwz(k,iCell) = dtseps*c2*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))  &
-                 *rdzu(k)*cqw(k,iCell)*(fzm(k)*p (k,iCell)+fzp(k)*p (k-1,iCell))
-            coftz(k,iCell) = dtseps*   (fzm(k)*t (k,iCell)+fzp(k)*t (k-1,iCell))
+            ! WCS_epssm                                                                                                                         
+            ! cofwz(k,iCell) = dtseps*c2*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))  &                                                           
+            !      *rdzu(k)*cqw(k,iCell)*(fzm(k)*p (k,iCell)+fzp(k)*p (k-1,iCell))                                                              
+            ! coftz(k,iCell) = dtseps*   (fzm(k)*t (k,iCell)+fzp(k)*t (k-1,iCell))                                                              
+            cofwz(k,iCell) = c2*(fzm(k)*zz(k,iCell)+fzp(k)*zz(k-1,iCell))  &                                                                    
+                 *rdzu(k)*cqw(k,iCell)*(fzm(k)*p (k,iCell)+fzp(k)*p (k-1,iCell))                                                                
+            coftz(k,iCell) = (fzm(k)*t (k,iCell)+fzp(k)*t (k-1,iCell))
          end do
          coftz(nVertLevels+1,iCell) = 0.0
 !DIR$ IVDEP
+
+!!!JBK Mod to use full variables and log(p)
+       if(reference_sounding)  then
+!!!JBK
          do k=1,nVertLevels
 
 !            qtotal = 0.
@@ -1731,10 +1804,22 @@ module atm_time_integration
 !            end do
             qtotal = qtot(k,iCell)
 
-            cofwt(k,iCell) = .5*dtseps*rcv*zz(k,iCell)*gravity*rb(k,iCell)/(1.+qtotal)  &
-                                *p(k,iCell)/((rtb(k,iCell)+rt(k,iCell))*pb(k,iCell))
+            ! WCS_epssm                                                                                                                         
+            ! cofwt(k,iCell) = .5*dtseps*rcv*zz(k,iCell)*gravity*rb(k,iCell)/(1.+qtotal)  &                                                     
+            !                     *p(k,iCell)/((rtb(k,iCell)+rt(k,iCell))*pb(k,iCell))                                                          
+            cofwt(k,iCell) = .5*rcv*zz(k,iCell)*gravity*rb(k,iCell)/(1.+qtotal)  &                                                              
+                                *p(k,iCell)/((rtb(k,iCell)+rt(k,iCell))*pb(k,iCell))                                                            
+
 !            cofwt(k,iCell) = 0.
          end do
+!!!JBK Mod to use full variables and log(p)
+      else
+         do k=1,nVertLevels
+             cofwt(k,iCell) = .5*rcv*zz(k,iCell)*gravity/t(k,iCell)
+             cofwt(k,iCell) = 0.
+         end do
+      end if
+!!!JBK end
 
          a_tri(1,iCell) = 0.  ! note, this value is never used
          b_tri(1) = 1.    ! note, this value is never used
@@ -1744,23 +1829,45 @@ module atm_time_integration
 
 !DIR$ IVDEP
          do k=2,nVertLevels
-            a_tri(k,iCell) = -cofwz(k  ,iCell)* coftz(k-1,iCell)*rdzw(k-1)*zz(k-1,iCell)   &
-                         +cofwr(k  ,iCell)* cofrz(k-1  )                       &
+           a_tri(k,iCell) = -cofwz(k  ,iCell)* coftz(k-1,iCell)*rdzw(k-1)*zz(k-1,iCell)   &                                                     
+                         +cofwr(k  ,iCell)* cofrz(k-1  )                       &                                                                
                          -cofwt(k-1,iCell)* coftz(k-1,iCell)*rdzw(k-1)
-            b_tri(k) = 1.                                                  &
-                         +cofwz(k  ,iCell)*(coftz(k  ,iCell)*rdzw(k  )*zz(k  ,iCell)   &
-                                      +coftz(k  ,iCell)*rdzw(k-1)*zz(k-1,iCell))   &
-                         -coftz(k  ,iCell)*(cofwt(k  ,iCell)*rdzw(k  )             &
-                                       -cofwt(k-1,iCell)*rdzw(k-1))            &
-                         +cofwr(k,  iCell)*(cofrz(k    )-cofrz(k-1))
-            c_tri(k) =   -cofwz(k  ,iCell)* coftz(k+1,iCell)*rdzw(k  )*zz(k  ,iCell)   &
-                         -cofwr(k  ,iCell)* cofrz(k    )                       &
+
+            ! WCS_epssm                                                                                                                         
+            a_tri(k,iCell) = a_tri(k,iCell)*etp(k-1)*ewp(k-1)
+
+            ! WiCS_epssm                                                                                                                        
+            ! b_tri(k) = 1.                                                  &                                                                  
+            !              +cofwz(k  ,iCell)*(coftz(k  ,iCell)*rdzw(k  )*zz(k  ,iCell)   &                                                      
+            !                           +coftz(k  ,iCell)*rdzw(k-1)*zz(k-1,iCell))   &                                                          
+            !              -coftz(k  ,iCell)*(cofwt(k  ,iCell)*rdzw(k  )             &                                                          
+            !                            -cofwt(k-1,iCell)*rdzw(k-1))            &                                                              
+            !              +cofwr(k,  iCell)*(cofrz(k    )-cofrz(k-1))                                                                          
+            b_tri(k) =   +cofwz(k  ,iCell)*coftz(k,iCell)*                           &                                                          
+                             ( etp(k  )*rdzw(k  )*zz(k  ,iCell)                      &                                                          
+                              +etp(k-1)*rdzw(k-1)*zz(k-1,iCell))                     &                                                          
+                         -coftz(k  ,iCell)*( etp(k  )*cofwt(k  ,iCell)*rdzw(k  )     &                                                          
+                                            -etp(k-1)*cofwt(k-1,iCell)*rdzw(k-1))    &                                                          
+                         +cofwr(k,  iCell)*(etp(k)*cofrz(k    )-etp(k-1)*cofrz(k-1))                                                            
+            ! WCS_epssm                                                                                                                         
+            b_tri(k) =   b_tri(k)*ewp(k)
+
+            c_tri(k) =   -cofwz(k  ,iCell)* coftz(k+1,iCell)*rdzw(k  )*zz(k  ,iCell)   &                                                        
+                         -cofwr(k  ,iCell)* cofrz(k    )                       &                                                                
                          +cofwt(k  ,iCell)* coftz(k+1,iCell)*rdzw(k  )
+
+            ! WCS_epssm                                                                                                                         
+            c_tri(k) =   c_tri(k)*etp(k)*ewp(k+1)
          end do
+         ! WCS_epssm                                                                                                                            
+         c_tri(nVertLevels) = 0.0
 !MGD VECTOR DEPENDENCE
          do k=2,nVertLevels
-            alpha_tri(k,iCell) = 1./(b_tri(k)-a_tri(k,iCell)*gamma_tri(k-1,iCell))
-            gamma_tri(k,iCell) = c_tri(k)*alpha_tri(k,iCell)
+            ! WCS_epssm                                                                                                                         
+            ! alpha_tri(k,iCell) = 1./(b_tri(k)-a_tri(k,iCell)*gamma_tri(k-1,iCell))                                                            
+            ! gamma_tri(k,iCell) = c_tri(k)*alpha_tri(k,iCell)                                                                                  
+            alpha_tri(k,iCell) = 1./(1.0+(dts**2)*(b_tri(k)-a_tri(k,iCell)*gamma_tri(k-1,iCell)))                                               
+            gamma_tri(k,iCell) = (dts**2)*c_tri(k)*alpha_tri(k,iCell)
          end do
 
       end do ! loop over cells
@@ -2001,6 +2108,14 @@ module atm_time_integration
 
       integer, pointer :: nEdges, nCellsSolve
 
+!!!JBK-vepssm                                                                                                                               
+      real (kind=RKIND), dimension(:), pointer :: etp, etm, ewp, ewm
+      call mpas_pool_get_array(mesh, 'etp', etp)                                                                                            
+      call mpas_pool_get_array(mesh, 'etm', etm)                                                                                            
+      call mpas_pool_get_array(mesh, 'ewp', ewp)                                                                                            
+      call mpas_pool_get_array(mesh, 'ewm', ewm)                                                                                            
+!!!JBK                                                                                                                                      
+
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(mesh, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
@@ -2075,6 +2190,7 @@ module atm_time_integration
                                    tend_rw, zgrid, cofwr, cofwz, w, ru, ru_save, rw, rw_save, fzm, fzp, rdzw, dcEdge, invDcEdge, &
                                    invAreaCell, cofrz, dvEdge, nEdgesOnCell, cellsOnEdge, edgesOnCell, edgesOnCell_sign, &
                                    dts, small_step, epssm, cf1, cf2, cf3, &
+                                   etp, etm, ewp, ewm,    &
                                    specZoneMaskEdge, specZoneMaskCell &
                                    )
 
@@ -2088,6 +2204,7 @@ module atm_time_integration
                                    tend_rw, zgrid, cofwr, cofwz, w, ru, ru_save, rw, rw_save, fzm, fzp, rdzw, dcEdge, invDcEdge, &
                                    invAreaCell, cofrz, dvEdge, nEdgesOnCell, cellsOnEdge, edgesOnCell, edgesOnCell_sign, &
                                    dts, small_step, epssm, cf1, cf2, cf3, &
+                                   etp, etm, ewp, ewm,    &
                                    specZoneMaskEdge, specZoneMaskCell &
                                    )
 
@@ -2159,8 +2276,10 @@ module atm_time_integration
       integer, intent(in) :: small_step
       real (kind=RKIND), intent(in) :: dts, epssm,cf1, cf2, cf3
       real (kind=RKIND), dimension(nVertLevels) :: ts, rs
-
-  
+!!!JBK
+      real (kind=RKIND), dimension(nVertLevels  ) :: etp,etm
+      real (kind=RKIND), dimension(nVertLevels+1) :: ewp,ewm
+!!!JBK
       !
       ! Local variables
       !
@@ -2168,6 +2287,16 @@ module atm_time_integration
       real (kind=RKIND) :: c2, rcv, rtheta_pp_tmp
       real (kind=RKIND) :: pgrad, flux, resm, rdts
 
+
+!  temporary print to check etm and ewm
+
+      integer :: iprint=0      
+      if(iprint.eq.0) then
+         do k=1,nVertLevels
+            call mpas_log_write(' k, etm(k), ewm(k) = $i $r $r', intArgs=(/k/), realArgs=(/etm(k),ewm(k)/)) 
+         end do
+         iprint = 1
+      end if 
 
       rcv = rgas / (cp - rgas)
       c2 = cp * rcv
@@ -2281,36 +2410,60 @@ module atm_time_integration
 
 !DIR$ IVDEP
          do k=1, nVertLevels
-            rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &
-                            - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell)) 
-            ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &
-                               - resm*rdzw(k)*( coftz(k+1,iCell)*rw_p(k+1,iCell)     &
-                                               -coftz(k,iCell)*rw_p(k,iCell))
+            ! WCS_epssm                                                                                                                         
+            ! rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &                                                        
+            !                 - cofrz(k)*resm*(rw_p(k+1,iCell)-rw_p(k,iCell))                                                                   
+            rs(k) = rho_pp(k,iCell) + dts*tend_rho(k,iCell) + rs(k)                  &                                                          
+                            - dts*cofrz(k)*(ewm(k+1)*rw_p(k+1,iCell)-ewm(k)*rw_p(k,iCell))                                                      
+            ! WCS_epssm                                                                                                                         
+            ! ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &                                                        
+            !                    - resm*rdzw(k)*( coftz(k+1,iCell)*rw_p(k+1,iCell)     &                                                        
+            !                                    -coftz(k,iCell)*rw_p(k,iCell))                                                                 
+            ts(k) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell) + ts(k)                &                                                          
+                                    - dts*rdzw(k)*( ewm(k+1)*coftz(k+1,iCell)*rw_p(k+1,iCell) &                                                 
+                                                   -ewm(k  )*coftz(k,iCell)*rw_p(k,iCell))                                                      
          end do
 
 !DIR$ IVDEP
          do k=2, nVertLevels
-            wwavg(k,iCell) = wwavg(k,iCell) + 0.5*(1.0-epssm)*rw_p(k,iCell)
+            ! WCS_epssm                                                                                                                         
+            ! wwavg(k,iCell) = wwavg(k,iCell) + 0.5*(1.0-epssm)*rw_p(k,iCell)                                                                   
+            wwavg(k,iCell) = wwavg(k,iCell) + ewm(k)*rw_p(k,iCell)
          end do
 
 !DIR$ IVDEP
          do k=2, nVertLevels
-            rw_p(k,iCell) = rw_p(k,iCell) +  dts*tend_rw(k,iCell)                       &
-                       - cofwz(k,iCell)*((zz(k  ,iCell)*ts(k)                           &
-                                     -zz(k-1,iCell)*ts(k-1))                            &
-                               +resm*(zz(k  ,iCell)*rtheta_pp(k  ,iCell)                &
-                                     -zz(k-1,iCell)*rtheta_pp(k-1,iCell)))              &
-                       - cofwr(k,iCell)*((rs(k)+rs(k-1))                                &
-                               +resm*(rho_pp(k,iCell)+rho_pp(k-1,iCell)))               &
-                       + cofwt(k  ,iCell)*(ts(k  )+resm*rtheta_pp(k  ,iCell))           &
-                       + cofwt(k-1,iCell)*(ts(k-1)+resm*rtheta_pp(k-1,iCell))
+           ! WCS_epssm                                                                                                                          
+            ! rw_p(k,iCell) = rw_p(k,iCell) +  dts*tend_rw(k,iCell)                       &                                                     
+            !            - cofwz(k,iCell)*((zz(k  ,iCell)*ts(k)                           &                                                     
+            !                          -zz(k-1,iCell)*ts(k-1))                            &                                                     
+            !                    +resm*(zz(k  ,iCell)*rtheta_pp(k  ,iCell)                &                                                     
+            !                          -zz(k-1,iCell)*rtheta_pp(k-1,iCell)))              &                                                     
+            !            - cofwr(k,iCell)*((rs(k)+rs(k-1))                                &                                                     
+            !                    +resm*(rho_pp(k,iCell)+rho_pp(k-1,iCell)))               &                                                     
+            !            + cofwt(k  ,iCell)*(ts(k  )+resm*rtheta_pp(k  ,iCell))           &                                                     
+            !            + cofwt(k-1,iCell)*(ts(k-1)+resm*rtheta_pp(k-1,iCell))                                                                 
+            rw_p(k,iCell) = rw_p(k,iCell) +  dts*(tend_rw(k,iCell)                          &                                                   
+                       - cofwz(k,iCell)*(( etp(k  )*zz(k  ,iCell)*ts(k)                     &                                                   
+                                          -etp(k-1)*zz(k-1,iCell)*ts(k-1))                  &                                                   
+                                 + ( etm(k  )*zz(k  ,iCell)*rtheta_pp(k  ,iCell)            &                                                   
+                                    -etm(k-1)*zz(k-1,iCell)*rtheta_pp(k-1,iCell)))          &                                                   
+                       - cofwr(k,iCell)*((etp(k)*rs(k)+etp(k-1)*rs(k-1))                    &                                                   
+                                        +( etm(k  )*rho_pp(k  ,iCell)                       &                                                   
+                                          +etm(k-1)*rho_pp(k-1,iCell)))                     &                                                   
+                       + cofwt(k  ,iCell)*(etp(k  )*ts(k  )+etm(k  )*rtheta_pp(k  ,iCell))  &                                                   
+                       + cofwt(k-1,iCell)*(etp(k-1)*ts(k-1)+etm(k-1)*rtheta_pp(k-1,iCell)))                                                     
+
          end do
 
          ! tridiagonal solve sweeping up and then down the column
 
 !MGD VECTOR DEPENDENCE
          do k=2,nVertLevels
-            rw_p(k,iCell) = (rw_p(k,iCell)-a_tri(k,iCell)*rw_p(k-1,iCell))*alpha_tri(k,iCell)
+           ! WCS_epssm                                                                                                                          
+            ! rw_p(k,iCell) = (rw_p(k,iCell)-a_tri(k,iCell)*rw_p(k-1,iCell))*alpha_tri(k,iCell)                                                 
+            rw_p(k,iCell) = (rw_p(k,iCell)-(dts**2)*a_tri(k,iCell)*rw_p(k-1,iCell))*alpha_tri(k,iCell)                                          
+
          end do
 
 !MGD VECTOR DEPENDENCE
@@ -2332,16 +2485,23 @@ module atm_time_integration
          ! accumulate (rho*omega)' for use later in scalar transport
 !DIR$ IVDEP
          do k=2,nVertLevels
-            wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)
+           ! WCS_epssm                                                                                                                          
+            ! wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)                                                                   
+            wwAvg(k,iCell) = wwAvg(k,iCell) + ewp(k)*rw_p(k,iCell)
          end do
 
          ! update rho_pp and theta_pp given updated rw_p
 
 !DIR$ IVDEP
          do k=1,nVertLevels
-            rho_pp(k,iCell) = rs(k) - cofrz(k) *(rw_p(k+1,iCell)-rw_p(k  ,iCell))
-            rtheta_pp(k,iCell) = ts(k) - rdzw(k)*(coftz(k+1,iCell)*rw_p(k+1,iCell)  &
-                               -coftz(k  ,iCell)*rw_p(k  ,iCell))
+           ! WCS_epssm                                                                                                                          
+            ! rho_pp(k,iCell) = rs(k) - cofrz(k) *(rw_p(k+1,iCell)-rw_p(k  ,iCell))                                                             
+            ! rtheta_pp(k,iCell) = ts(k) - rdzw(k)*(coftz(k+1,iCell)*rw_p(k+1,iCell)  &                                                         
+            !                    -coftz(k  ,iCell)*rw_p(k  ,iCell))                                                                             
+            rho_pp(k,iCell) = rs(k) - dts*cofrz(k) *( ewp(k+1)*rw_p(k+1,iCell)  &                                                               
+                                                     -ewp(k  )*rw_p(k  ,iCell))                                                                 
+            rtheta_pp(k,iCell) = ts(k) - dts*rdzw(k)*( ewp(k+1)*coftz(k+1,iCell)*rw_p(k+1,iCell)  &                                             
+                                                      -ewp(k  )*coftz(k  ,iCell)*rw_p(k  ,iCell))                                               
          end do
 
          else ! specifed zone in regional_MPAS
@@ -2350,7 +2510,9 @@ module atm_time_integration
                rho_pp(k,iCell) = rho_pp(k,iCell) + dts*tend_rho(k,iCell)
                rtheta_pp(k,iCell) = rtheta_pp(k,iCell) + dts*tend_rt(k,iCell)
                rw_p(k,iCell) = rw_p(k,iCell) + dts*tend_rw(k,iCell)
-               wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)
+               ! WCS_epssm                                                                                                                      
+               ! wwAvg(k,iCell) = wwAvg(k,iCell) + 0.5*(1.0+epssm)*rw_p(k,iCell)                                                                
+               wwAvg(k,iCell) = wwAvg(k,iCell) + ewp(k)*rw_p(k,iCell)
             end do
 
          end if
@@ -3928,6 +4090,9 @@ module atm_time_integration
       logical, pointer :: config_rayleigh_damp_u
       real (kind=RKIND), pointer :: config_rayleigh_damp_u_timescale_days
       integer, pointer :: config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels
+!!!JBK - Mod for reference sounding switch
+      logical,           pointer :: reference_sounding
+!!!JBK end
 
 
       call mpas_pool_get_config(mesh, 'sphere_radius', r_earth)
@@ -3949,7 +4114,9 @@ module atm_time_integration
       call mpas_pool_get_config(configs, 'config_rayleigh_damp_u_timescale_days', config_rayleigh_damp_u_timescale_days)
       call mpas_pool_get_config(configs, 'config_number_rayleigh_damp_u_levels', config_number_rayleigh_damp_u_levels)
       call mpas_pool_get_config(configs, 'config_number_cam_damping_levels', config_number_cam_damping_levels)
-
+!!!JBK Mod foe reference sounding switch
+      call mpas_pool_get_config(configs, 'config_reference_sounding', reference_sounding)
+!!!JBK end
       call mpas_pool_get_array(state, 'rho_zz', rho_zz, 2)
       call mpas_pool_get_array(state, 'u', u, 2)
       call mpas_pool_get_array(state, 'w', w, 2)
@@ -4072,6 +4239,9 @@ module atm_time_integration
          config_mpas_cam_coef, &
          config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, & 
          config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels, &
+!!!JBK - Mod for reference sounding switch
+         reference_sounding,  &
+!!!JBK end
          rthdynten, &
          cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
          cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
@@ -4096,6 +4266,10 @@ module atm_time_integration
       config_mpas_cam_coef, &
       config_rayleigh_damp_u, config_rayleigh_damp_u_timescale_days, &
       config_number_rayleigh_damp_u_levels, config_number_cam_damping_levels, &
+
+!!!JBK - Mod for reference sounding switch
+      reference_sounding,  &
+!!!JBK end
       rthdynten, &
       cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
       cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd)
@@ -4253,6 +4427,12 @@ module atm_time_integration
       real (kind=RKIND) :: flux3, flux4
       real (kind=RKIND) :: q_im2, q_im1, q_i, q_ip1, ua, coef3
 
+!!!JBK - mod for reference sounding switch
+      logical           :: reference_sounding
+!     Declaration for plog                                                                                                                                     
+      real (kind=RKIND) :: p0
+      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: plog
+!!!JBK end                                                                                                                                                        
       flux4(q_im2, q_im1, q_i, q_ip1, ua) =                     &
                 ua*( 7.*(q_i + q_im1) - (q_ip1 + q_im2) )/12.0
 
@@ -4268,6 +4448,12 @@ module atm_time_integration
        v_theta_eddy_visc2 = config_v_theta_eddy_visc2
 
       if (rk_step == 1) then
+
+        p0 = 1.0e+05  ! this should come from somewhere else...                                                                                                
+
+!!!JBK - Temporary mod to print reference_sounding
+        call mpas_log_write('reference_sounding = $l ', logicArgs=(/reference_sounding/))
+!!!JBK end
 
 !         tend_u_euler(1:nVertLevels,edgeStart:edgeEnd) = 0.0
 
@@ -4360,10 +4546,27 @@ module atm_time_integration
         do iCell = cellStart,cellEnd
 
 !DIR$ IVDEP
+
+!!!JBK - Mods to use log(p)
+!          do k = 1,nVertLevels
+!            tend_rho(k,iCell) = -h_divergence(k,iCell)-rdzw(k)*(rw(k+1,iCell)-rw(k,iCell)) + tend_rho_physics(k,iCell)
+!            dpdz(k,iCell) = -gravity*(rb(k,iCell)*(qtot(k,iCell)) + rr_save(k,iCell)*(1.+qtot(k,iCell)))
+!          end do
+
           do k = 1,nVertLevels
-            tend_rho(k,iCell) = -h_divergence(k,iCell)-rdzw(k)*(rw(k+1,iCell)-rw(k,iCell)) + tend_rho_physics(k,iCell)
-            dpdz(k,iCell) = -gravity*(rb(k,iCell)*(qtot(k,iCell)) + rr_save(k,iCell)*(1.+qtot(k,iCell)))
+             tend_rho(k,iCell) = -h_divergence(k,iCell)-rdzw(k)*(rw(k+1,iCell)-rw(k,iCell)) + tend_rho_physics(k,iCell)
           end do
+          if(reference_sounding)  then
+             do k = 1,nVertLevels
+                dpdz(k,iCell) = -gravity*(rb(k,iCell)*(qtot(k,iCell)) + rr_save(k,iCell)*(1.+qtot(k,iCell)))
+             end do
+          else
+             do k = 1,nVertLevels
+                dpdz(k,iCell) = -gravity*rr_save(k,iCell)/pp(k,iCell)
+                plog(k,iCell) = alog(pp(k,iCell)/p0)
+             end do
+          end if
+!!!JBK end
         end do
       end if
 
@@ -4382,11 +4585,27 @@ module atm_time_integration
 
          if(rk_step == 1) then
 !DIR$ IVDEP
-            do k=1,nVertLevels
-               tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*( (pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)/(.5*(zz(k,cell2)+zz(k,cell1))) &
-                                              -0.5*zxu(k,iEdge)*(dpdz(k,cell1)+dpdz(k,cell2)) )
-            end do
 
+!!!JBK - Mods to use log(p)
+!            do k=1,nVertLevels
+!               tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*( (pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)/(.5*(zz(k,cell2)+zz(k,cell1))) &
+!                                              -0.5*zxu(k,iEdge)*(dpdz(k,cell1)+dpdz(k,cell2)) )
+!            end do
+            if(reference_sounding)  then
+               do k=1,nVertLevels
+                  tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*((pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)  &
+                                                      /(.5*(zz(k,cell2)+zz(k,cell1)))                  &
+                                     -0.5*zxu(k,iEdge)*(dpdz(k,cell2)+dpdz(k,cell1)) )
+               end do
+            else
+               do k=1,nVertLevels
+                  tend_u_euler(k,iEdge) =         - .5*(pp  (k,cell2)+pp  (k,cell1))*                  &
+                                         (cqu(k,iEdge)*(plog(k,cell2)-plog(k,cell1))*invDcEdge(iEdge)  &
+                                                  /(.5*(zz  (k,cell2)+zz  (k,cell1)))                  &
+                                     -0.5*zxu(k,iEdge)*(dpdz(k,cell2)+dpdz(k,cell1)) )
+               end do
+            end if
+!!!JBK end
          end if
 
          ! vertical transport of u
@@ -4789,11 +5008,30 @@ module atm_time_integration
 
          if(rk_step == 1) then
 !DIR$ IVDEP
-            do k=2,nVertLevels
-              tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - cqw(k,iCell)*(   &
-                                           rdzu(k)*(pp(k,iCell)-pp(k-1,iCell)) &
-                                         - (fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )  ! dpdz is the buoyancy term here.
-            end do
+
+!!!JBK - Mods for using log(p)
+
+!            do k=2,nVertLevels
+!              tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - cqw(k,iCell)*(   &
+!                                           rdzu(k)*(pp(k,iCell)-pp(k-1,iCell)) &
+!                                         - (fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )  ! dpdz is the buoyancy term here.
+!            end do
+
+            if(reference_sounding)  then
+               do k=2,nVertLevels
+                  tend_w_euler(k,iCell) = tend_w_euler(k,iCell)                             - cqw(k,iCell)     &
+                                                                      *(rdzu(k)*(pp(k,iCell)-pp(k-1,iCell))    & 
+                                                          - (fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )
+!                 dpdz is the buoyancy term here.                                                                                                              
+               end do
+            else
+               do k=2,nVertLevels
+                  tend_w_euler(k,iCell) = tend_w_euler(k,iCell) - (fzm(k)*pp(k,iCell)+fzp(k)*pp(k-1,iCell))    &
+                                                     *(cqw(k,iCell)*rdzu(k)*(plog(k,iCell)-plog(k-1,iCell))    &
+                                                           -(fzm(k)*dpdz(k,iCell) + fzp(k)*dpdz(k-1,iCell)) )
+               end do
+            end if
+!!!JBK end
           end if
 
       end do
@@ -6603,5 +6841,148 @@ module atm_time_integration
       end if
 
    end subroutine summarize_timestep
+
+!----------------------                                                                                                                         
+!-----------------------                                                                                                                        
+   subroutine set_epssm(ewp,ewm,etp,etm,n,rdzw)
+   implicit none
+   integer :: n
+   real (kind=RKIND), dimension(n+1) :: ewp, ewm
+   real (kind=RKIND), dimension(n  ) :: etp, etm
+!-----------------------                                                                                                                        
+!SK_epssm: added rdzw to the function call                                                                                                      
+   real (kind=RKIND), dimension(n) :: rdzw
+
+!----------------------------------                                                                                                             
+!SK_epssm: created local variables                                                                                                              
+   real(kind=RKIND), dimension(n):: height_u_levels
+   real(kind=RKIND), dimension(n+1):: height_w_levels
+   real (kind=RKIND), dimension(n) :: epssm_coeff_u
+   real (kind=RKIND), dimension(n+1):: epssm_coeff_w
+   real (kind=RKIND) :: max_coeff, min_coeff, transition_width, transition_point                                                                
+   integer :: ilevel
+!--------------------                                                                                                                           
+! SK_epssm: commented this out since we are transitiong to height based epssm                                                                   
+!   real (kind=RKIND), parameter :: epssm_b = 0.1                                                                                               
+
+!------------------                                                                                                                             
+!SK_epssm: intialization                                                                                                                        
+   epssm_coeff_u = 0.0_RKIND
+   epssm_coeff_w = 0.0_RKIND
+   height_u_levels = 0.0_RKIND
+   height_w_levels= 0.0_RKIND
+
+!!!   transition_point = 60000.0_RKIND ! Changed the value for WACCM simulations                                          
+   transition_point = 10500.0_RKIND ! (Model top 21K) ! Height of center of transition zone                                         
+!!!   transition_width  =20000.0_RKIND ! Changed the value for WACCM simulations                                         
+   transition_width  = 5000.0_RKIND ! (Model top 21K) ! Width of transition zone                                        
+   min_coeff = 0.1_RKIND ! Value of epssm below transition zone                        
+   max_coeff = 0.5_RKIND ! Value of epssm above transition zone
+!---------------------                                                                                                                          
+!---------------------                                                                                                                          
+!SK_epssm                                                                                                                                       
+! calculate height at levels                                                                                                                    
+   call calculate_computational_height(n, rdzw, height_u_levels, height_w_levels)                                                               
+! call the ramping function                                                                                                                     
+  call calculate_coef_height(n,height_u_levels, min_coeff,&
+                             & max_coeff, transition_width, transition_point,epssm_coeff_u)                                                     
+  call calculate_coef_height(n+1,height_w_levels, min_coeff,&
+                             & max_coeff, transition_width, transition_point,epssm_coeff_w)                                                     
+!--------------------------------                                                                                                               
+!SK_epssm: commented the lines below so that we can have epssm varying with height                                                              
+!   etp(:) = 0.5*(1.0+epssm_b)                                                                                                                  
+!   etm(:) = 0.5*(1.0-epssm_b)                                                                                                                  
+!   ewp(:) = 0.5*(1.0+epssm_b)                                                                                                                  
+!   ewm(:) = 0.5*(1.0-epssm_b)                                                                                                                  
+! SK_epssm: Not sure about the epssm_coeff value I am using for ewp and ewm                                                                     
+    do ilevel =1, n
+      etp(ilevel) = 0.5*(1.0 + epssm_coeff_u(ilevel))
+      etm(ilevel) = 0.5*(1.0 - epssm_coeff_u(ilevel))
+      ewp(ilevel) = 0.5*(1.0 + epssm_coeff_w(ilevel))
+      ewm(ilevel) = 0.5*(1.0 - epssm_coeff_w(ilevel))
+
+      call mpas_log_write('ilevel, height_u_levels, etp, etm, height_w_levels, ewp, ewm $i $r $r $r $r $r $r', intARgs=(/ilevel/),   &
+                                                                       realArgs=(/height_u_levels(ilevel),etp(ilevel),etm(ilevel),   &   
+                                                                                  height_w_levels(ilevel),ewp(ilevel),ewm(ilevel)/))   
+    enddo
+    ewp(n+1) = 0.5*(1.0 + epssm_coeff_w(n+1))
+    ewm(n+1) = 0.5*(1.0 - epssm_coeff_w(n+1))
+
+   end subroutine set_epssm
+
+!----------------                                                                                                                               
+!SK_epssm                                                                                                                                       
+  subroutine calculate_computational_height(nVertLevels,rdzw,height_u_levels, height_w_levels)                                                  
+     integer, intent(in) ::  nVertLevels
+     real (kind=RKIND), dimension( nVertLevels ), intent(in) ::  rdzw
+     real (kind=RKIND), dimension( nVertLevels ), intent(inout) :: height_u_levels                                                              
+     real (kind=RKIND), dimension( nVertLevels+1 ), intent(inout) :: height_w_levels                                                            
+
+!define variables                                                                                                                               
+     integer k
+!initialization                                                                                                                                 
+     height_w_levels(:) = 0.0_RKIND
+
+!calculate the computational height at u and w levels                                                                                           
+!DIR$ IVDEP                                                                                                                                     
+     do k =1, nVertLevels
+       height_w_levels(k+1) = height_w_levels(k) + 1.0_RKIND/rdzw(k)
+       height_u_levels(k) = 0.5*(height_w_levels(k+1) + height_w_levels(k))                                                                     
+!       call mpas_log_write('test $i $r', intARgs=(/k/),realArgs=(/rdzw(k)/))                                                                   
+     enddo
+
+!   do k =1, nVertLevels                                                                                                                        
+!       call mpas_log_write('test1 $i $r $r $r', intARgs=(/k/),realArgs=(/height_u_levels(k),&                                                  
+!                         height_w_levels(k),height_w_levels(k+1)/))                                                                            
+!  enddo                                                                                                                                        
+
+  end subroutine calculate_computational_height
+
+! ramp a value base on height                                                                                                                   
+   subroutine calculate_coef_height(nVertLevels,height_levels, min_coeff,&                                                                      
+                             & max_coeff, transition_width, transition_point,damp_coeff)                                                        
+         integer, intent(in)::nVertLevels
+         real (kind=RKIND) :: max_coeff, min_coeff, transition_width, transition_point                                                          
+         real (kind=RKIND), dimension(nVertLevels), intent (in) :: height_levels                                                                
+         real (kind=RKIND), dimension(nVertLevels), intent (out) :: damp_coeff                                                                  
+! local parameters                                                                                                                              
+         integer :: k, counter_transition
+         real (kind=RKIND) :: dx,x, transition_lower_bound, transition_upper_bound                                                              
+! initialization                                                                                                                                
+         damp_coeff = 0.0_RKIND
+         counter_transition = 0
+         dx = 0.0_RKIND
+         x = -pii/2.0_RKIND
+         transition_lower_bound = transition_point - transition_width*0.5_RKIND                                                                 
+         transition_upper_bound = transition_point + transition_width*0.5_RKIND                                                                 
+
+! calculate how many levels are in the transition region                                                                                        
+         do k =1, nVertLevels
+            if(((height_levels(k)-transition_lower_bound)>= 0.0_RKIND).and.((height_levels(k)-transition_upper_bound)<=0.0_RKIND)) then         
+                  counter_transition = counter_transition +1
+            endif
+         enddo
+         dx = pii/REAL(counter_transition-1)
+!         call mpas_log_write('check $i $r $r $r $r', intARgs=(/counter_transition/),realArgs=(/dx,x,transition_lower_bound,transition_upper_bound/))
+! start calculating the coefficient                                                                                                             
+         do k =1, nVertLevels
+           if((height_levels(k)-transition_lower_bound) < 0.0_RKIND ) then                                                                      
+               damp_coeff(k)= min_coeff
+           elseif((height_levels(k)-transition_upper_bound) > 0.0_RKIND ) then                                                                  
+               damp_coeff(k) =max_coeff
+           else
+!!!JK_epssm
+!              alternative calculation of damp_coeff in transition zone
+!              damp_coeff(k) = min_coeff+ (sin(x)+1)*0.5_RKIND*(max_coeff-min_coeff)                                                            
+!              x = x + dx
+!
+               x = (height_levels(k)-transition_lower_bound)/transition_width
+               damp_coeff(k) = min_coeff + sin(0.5_RKIND*pii*x)**2*(max_coeff-min_coeff)
+!!!JK_epssm  end 
+           endif
+!           call mpas_log_write('damping factor $i $r $r', intARgs=(/k/),realArgs=(/damp_coeff(k), height_levels(k)/))                          
+         enddo
+
+   end subroutine calculate_coef_height
 
 end module atm_time_integration

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -1284,7 +1284,7 @@ module atm_core
 
      enddo
  
-! Height dependent values of epssm
+! Height dependent values of epssm; profiles stored in etp, etm, ewp, and ewm, 
 
      do k = 1,nVertLevels
         if(height_u_levels(k).le.transition_lower_bound) then

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -551,7 +551,7 @@ module atm_core
    
       call atm_compute_mesh_scaling(mesh, block % configs)
 
-      call atm_compute_damping_coefs(mesh, block % configs)
+      call atm_compute_damping_coefs(mesh, block % configs, nVertLevels)
 
       !
       ! Set up mask fields used in limited-area simulations
@@ -1205,31 +1205,50 @@ module atm_core
    end subroutine atm_compute_signs
 
 
-   subroutine atm_compute_damping_coefs(mesh, configs)
+   subroutine atm_compute_damping_coefs(mesh, configs, nVertLevels)
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: mesh
       type (mpas_pool_type), intent(in) :: configs
 
-      integer :: iCell, k
-      integer, pointer :: nCells, nVertLevels
+      integer :: iCell, k, nVertLevels
+      integer, pointer :: nCells
       real (kind=RKIND), pointer :: config_xnutr, config_zd
       real (kind=RKIND) :: z, zt, m1, pii
       real (kind=RKIND), dimension(:,:), pointer :: dss, zgrid
       real (kind=RKIND), dimension(:), pointer :: meshDensity
       real (kind=RKIND) :: dx_scale_power
 
+!!!JBK-vepssm
+      real (kind=RKIND), dimension(:), pointer :: rdzw, etp, etm, ewp, ewm
+      real (kind=RKIND), dimension(nVertLevels)          :: height_u_levels, epssm_coeff_u            
+      real (kind=RKIND), dimension(nVertLevels+1)        :: height_w_levels, epssm_coeff_w
+      real (kind=RKIND), pointer  :: max_coeff, min_coeff, transition_lower_bound, transition_upper_bound
+      real (kind=RKIND)  ::  transition_width 
+!!!JBK
+
       m1 = -1.0
       pii = acos(m1)
 
       call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+!      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
 
       call mpas_pool_get_array(mesh, 'meshDensity', meshDensity)
       call mpas_pool_get_array(mesh, 'dss', dss)
       call mpas_pool_get_array(mesh, 'zgrid', zgrid)
 
+!!!JBK-vepssm
+      call mpas_pool_get_array(mesh, 'rdzw', rdzw)
+      call mpas_pool_get_array(mesh, 'etp', etp)
+      call mpas_pool_get_array(mesh, 'etm', etm)
+      call mpas_pool_get_array(mesh, 'ewp', ewp)
+      call mpas_pool_get_array(mesh, 'ewm', ewm)
+      call mpas_pool_get_config(configs, 'config_min_coeff', min_coeff)
+      call mpas_pool_get_config(configs, 'config_max_coeff', max_coeff)
+      call mpas_pool_get_config(configs, 'config_transition_lower_bound', transition_lower_bound)
+      call mpas_pool_get_config(configs, 'config_transition_upper_bound', transition_upper_bound)
+!!!JBK
       call mpas_pool_get_config(configs, 'config_zd', config_zd)
       call mpas_pool_get_config(configs, 'config_xnutr', config_xnutr)
 
@@ -1245,6 +1264,53 @@ module atm_core
             end if
          end do
       end do
+
+!!!JBK-vepssm - code to compute variable epssm profiles at model startup
+
+!      min_coeff = 0.1_RKIND
+!      max_coeff = 0.5_RKIND
+!      transition_lower_bound =  8000._RKIND
+!      transition_upper_bound = 13000._RKIND
+      transition_width = transition_upper_bound - transition_lower_bound
+
+! initialization for heights of coordinate at u and w levels  
+
+     height_w_levels(:) = 0.0_RKIND
+     do k =1, nVertLevels
+       height_w_levels(k+1) = height_w_levels(k) + 1.0_RKIND/rdzw(k)
+       height_u_levels(k) = 0.5*(height_w_levels(k+1) + height_w_levels(k)) 
+
+!       call mpas_log_write('test $i $r', intARgs=(/k/),realArgs=(/rdzw(k)/))
+
+     enddo
+ 
+! Height dependent values of epssm
+
+     do k = 1,nVertLevels
+        if(height_u_levels(k).le.transition_lower_bound) then
+           epssm_coeff_u(k) = min_coeff
+        else if(height_u_levels(k).ge.transition_upper_bound)  then
+           epssm_coeff_u(k) = max_coeff
+        else   
+           z = (height_u_levels(k)-transition_lower_bound)/transition_width
+           epssm_coeff_u(k) = min_coeff + sin(0.5_RKIND*pii*z)**2*(max_coeff-min_coeff)
+        end if 
+        etp(k) = 0.5*(1.0 + epssm_coeff_u(k)) 
+        etm(k) = 0.5*(1.0 - epssm_coeff_u(k)) 
+     end do
+     do k= 1,nVertlevels+1
+        if(height_w_levels(k).le.transition_lower_bound) then
+           epssm_coeff_w(k) = min_coeff
+        else if(height_w_levels(k).ge.transition_upper_bound)  then
+           epssm_coeff_w(k) = max_coeff
+        else   
+           z = (height_w_levels(k)-transition_lower_bound)/transition_width
+           epssm_coeff_w(k) = min_coeff + sin(0.5_RKIND*pii*z)**2*(max_coeff-min_coeff)
+        end if 
+        ewp(k) = 0.5*(1.0 + epssm_coeff_w(k)) 
+        ewm(k) = 0.5*(1.0 - epssm_coeff_w(k)) 
+     end do
+!!!JBK
 
    end subroutine atm_compute_damping_coefs
 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -99,6 +99,11 @@
                      description="projecting layer values to the interface, linear vertical interpolation or integral" 
                      possible_values="'linear_interpolation' or 'layer_integral' (layer average value)"/>
 
+                <nml_option name="config_reference_sounding" type="logical" default_value="true"
+                     units="-"
+                     description="Whether a reference sounding is used for thermodynamic variables"
+                     possible_values="true or false"/>
+
         </nml_record>
 
         <nml_record name="dimensions" in_defaults="true">
@@ -540,6 +545,7 @@
                         <var name="zb" packages="vertical_stage_out;met_stage_out"/>
                         <var name="zb3" packages="vertical_stage_out;met_stage_out"/>
                         <var name="dss" packages="vertical_stage_out;met_stage_out"/>
+                        <var name="reference_sounding_switch" packages="vertical_stage_out;met_stage_out"/>
                         <var name="u_init" packages="met_stage_out"/>
                         <var name="v_init" packages="met_stage_out"/>
                         <var name="t_init" packages="met_stage_out"/>
@@ -738,6 +744,9 @@
 
                 <var name="nominalMinDc" type="real" dimensions="" units="m"
                      description="Nominal minimum dcEdge value where meshDensity == 1.0"/>
+
+                <var name="reference_sounding_switch" type="integer" dimensions="" units="unitless" default_value="1"
+                     description="Switch to designate a reference sounding is used (1) or full variables (0)"/>
 
                 <!-- coefficients for vertical extrapolation to the surface -->
                 <var name="cf1" type="real" dimensions="" units="unitless"

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2380,6 +2380,19 @@ module init_atm_cases
             rr (k,i) = p (k,i)**(1./rcv)/((rgas/p0)*t (k,i)*zz(k,i))-rb(k,i)
             cqw(k,i) = 1.
          end do
+!
+!!!JBK Mods to removed reference state
+!
+         do k=1,nz1
+            rr (k,i) = rb(k,i)+rr(k,i)
+            rb (k,i) = 0.
+            rtb(k,i) = 0.
+            pb (k,i) = 0.
+            tb (k,i) = 0.
+         end do
+!
+!!!JBK
+!
       end do
 
        call mpas_log_write(' ***** base state sounding ***** ')

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -2005,7 +2005,10 @@ module init_atm_cases
 
       integer, dimension(nCells, 2) :: next_cell
       logical, parameter :: terrain_smooth = .false.
-
+!!!JBK reference sounding
+      logical,                         pointer :: config_reference_sounding
+      integer,                         pointer :: reference_sounding_switch
+!!!
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
       real (kind=RKIND), dimension(:), pointer :: xEdge, yEdge, zEdge
       real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
@@ -2046,7 +2049,10 @@ module init_atm_cases
       call mpas_pool_get_config(configs, 'config_coef_3rd_order', config_coef_3rd_order)
       call mpas_pool_get_config(configs, 'config_theta_adv_order', config_theta_adv_order)
       call mpas_pool_get_config(configs, 'config_interface_projection', config_interface_projection)
-
+!!!JBK reference sounding switch
+      call mpas_pool_get_config(configs, 'config_reference_sounding', config_reference_sounding)
+      call mpas_pool_get_array(mesh, 'reference_sounding_switch', reference_sounding_switch)
+!!!      
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
       call mpas_pool_get_array(mesh, 'edgesOnEdge', edgesOnEdge)
@@ -2135,7 +2141,13 @@ module init_atm_cases
 
       call atm_initialize_advection_rk(mesh, nCells, nEdges, maxEdges, on_a_sphere, sphere_radius )
       call atm_initialize_deformation_weights(mesh, nCells, on_a_sphere, sphere_radius)
-
+!!!JBK
+      if(config_reference_sounding)  then
+         reference_sounding_switch = 1
+      else
+         reference_sounding_switch = 0
+      end if
+!!!      
       xnutr = 0.1
       zd = 10500.
 
@@ -2381,15 +2393,17 @@ module init_atm_cases
             cqw(k,i) = 1.
          end do
 !
-!!!JBK Mods to removed reference state
+!!!JBK Mods to remove reference state
 !
-         do k=1,nz1
-            rr (k,i) = rb(k,i)+rr(k,i)
-            rb (k,i) = 0.
-            rtb(k,i) = 0.
-            pb (k,i) = 0.
-            tb (k,i) = 0.
-         end do
+         if(reference_sounding_switch.eq.0)  then    
+            do k=1,nz1
+               rr (k,i) = rb(k,i)+rr(k,i)
+               rb (k,i) = 0.
+               rtb(k,i) = 0.
+               pb (k,i) = 0.
+               tb (k,i) = 0.
+            end do
+         end if
 !
 !!!JBK
 !


### PR DESCRIPTION
1) Code added to ../src/core_atmosphere/mpas_atm_core.F to compute
vertical profiles of epssm that vary with height at the start of the
time integration. These profiles are determined by the parameters
config_min_coeff, config_max_coeff, config_transition_lower_bound,
and config_transition_upper_bound, and are specified in namelist.atmosphere.

2) Code added to allow thermodynamic variables to be represented either
as perurbations from a specified reference state or as the full
variables without a reference state. This option is controlled by the
logical config_reference_sounding as specified in namelist.init_atmosphere.
When configured using the full variables, the horizontal and vertical
pressure gradients computed on the large time steps are written in terms
of log(p).