### PR TITLE
Add new mpas_stream_inquiry infrastructure module for querying contents of streams files

### DIFF
--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -10,6 +10,7 @@ OBJS = mpas_test_core.o \
        mpas_halo_testing.o \
        mpas_test_core_string_utils.o \
        mpas_test_core_dmpar.o \
+       mpas_test_core_stream_inquiry.o
 
 all: core_test
 
@@ -39,7 +40,8 @@ mpas_test_core_interface.o: mpas_test_core.o
 mpas_test_core.o: mpas_test_core_halo_exch.o mpas_test_core_streams.o \
                   mpas_test_core_field_tests.o mpas_test_core_timekeeping_tests.o \
                   mpas_test_core_sorting.o mpas_halo_testing.o \
-                  mpas_test_core_string_utils.o mpas_test_core_dmpar.o
+                  mpas_test_core_string_utils.o mpas_test_core_dmpar.o \
+                  mpas_test_core_stream_inquiry.o
 
 mpas_test_core_halo_exch.o:
 

--- a/src/core_test/Registry.xml
+++ b/src/core_test/Registry.xml
@@ -71,6 +71,19 @@
 			<var name="cellsOnVertex"/>
 			<var name="kiteAreasOnVertex"/>
 		</stream>
+
+                <!-- A mutable stream used for testing the stream inquiry functionality -->
+                <!-- This stream is never actually read by the test core -->
+		<stream name="mutable_test"
+		        type="input"
+		        filename_template="mutable_test.nc"
+		        filename_interval="none"
+		        input_interval="none"
+		        immutable="false"
+                        runtime_format="single_file">
+
+			<var name="xtime"/>
+		</stream>
 	</streams>
 	<var_struct name="model" time_levs="1">
 		<var name="xtime"                             type="text"     dimensions="Time"/>

--- a/src/core_test/mpas_test_core.F
+++ b/src/core_test/mpas_test_core.F
@@ -95,6 +95,7 @@ module test_core
       use mpas_halo_testing, only : mpas_halo_tests
       use test_core_string_utils, only : mpas_test_string_utils
       use mpas_test_core_dmpar, only : mpas_test_dmpar
+      use mpas_test_core_stream_inquiry, only : mpas_test_stream_inquiry
 
       implicit none
    
@@ -179,6 +180,18 @@ module test_core
       !
       call mpas_log_write('')
       iErr = mpas_test_dmpar(domain % dminfo)
+      if (iErr == 0) then
+          call mpas_log_write('All tests PASSED')
+      else
+          call mpas_log_write('$i tests FAILED', intArgs=[iErr])
+      end if
+      call mpas_log_write('')
+
+      !
+      ! Run mpas_stream_inquiry tests
+      !
+      call mpas_log_write('')
+      iErr = mpas_test_stream_inquiry(domain % dminfo)
       if (iErr == 0) then
           call mpas_log_write('All tests PASSED')
       else

--- a/src/core_test/mpas_test_core_stream_inquiry.F
+++ b/src/core_test/mpas_test_core_stream_inquiry.F
@@ -1,0 +1,225 @@
+! Copyright (c) 2023 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+module mpas_test_core_stream_inquiry
+
+    use mpas_derived_types, only : dm_info, MPAS_streamInfo_type
+    use mpas_log, only : mpas_log_write
+
+    private
+
+    public :: mpas_test_stream_inquiry
+
+
+    contains
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_test_stream_inquiry
+    !
+    !> \brief Main driver for tests of the mpas_stream_inquiry module
+    !> \author Michael Duda
+    !> \date   17 November 2023
+    !> \details
+    !>  This routine invokes tests for individual routines in the
+    !>  mpas_stream_inquiry module, and reports PASSED/FAILED for each of
+    !>  those tests.
+    !>
+    !>  Return value: The total number of test that failed on any MPI rank.
+    !
+    !-----------------------------------------------------------------------
+    function mpas_test_stream_inquiry(dminfo) result(ierr_count)
+
+        use mpas_kind_types, only : StrKIND
+        use mpas_dmpar, only : mpas_dmpar_max_int
+        use mpas_stream_inquiry, only : MPAS_stream_inquiry_new_streaminfo
+
+        implicit none
+
+        ! Arguments
+        type (dm_info), intent(inout) :: dminfo
+
+        ! Return value
+        integer :: ierr_count
+
+        ! Local variables
+        integer :: ierr, ierr_global
+        character(len=StrKIND) :: routine_name
+        type (MPAS_streamInfo_type), pointer :: streamInfo
+
+        ierr_count = 0
+
+        call mpas_log_write('--- Begin stream_inquiry tests')
+
+        !
+        ! Create a new instance of the MPAS_streamInfo_type derived type
+        !
+        nullify(streamInfo)
+        streamInfo => MPAS_stream_inquiry_new_streaminfo()
+
+        !
+        ! Initialize the instance with the streams.test file
+        ! A failure here on any task causes this routine to return early
+        !
+        routine_name = 'streamInfo % init'
+        ierr = streamInfo % init(dminfo % comm, 'streams.test')
+        call mpas_dmpar_max_int(dminfo, ierr, ierr_global)
+        if (ierr_global == 0) then
+            call mpas_log_write('    '//trim(routine_name)//' - PASSED')
+        else
+            ierr_count = ierr_count + 1
+            call mpas_log_write('    '//trim(routine_name)//' - FAILED')
+            deallocate(streamInfo)
+            return
+        end if
+
+        !
+        ! Test streamInfo % query routine
+        !
+        routine_name = 'streamInfo % query'
+        ierr = test_streaminfo_query(streamInfo)
+        call mpas_dmpar_max_int(dminfo, ierr, ierr_global)
+        if (ierr_global == 0) then
+            call mpas_log_write('    '//trim(routine_name)//' - PASSED')
+        else
+            ierr_count = ierr_count + 1
+            call mpas_log_write('    '//trim(routine_name)//' - FAILED')
+        end if
+
+        !
+        ! Finalize the MPAS_streamInfo_type instance
+        !
+        routine_name = 'streamInfo % finalize'
+        ierr = streamInfo % finalize()
+        call mpas_dmpar_max_int(dminfo, ierr, ierr_global)
+        if (ierr_global == 0) then
+            call mpas_log_write('    '//trim(routine_name)//' - PASSED')
+        else
+            ierr_count = ierr_count + 1
+            call mpas_log_write('    '//trim(routine_name)//' - FAILED')
+        end if
+
+        deallocate(streamInfo)
+
+    end function mpas_test_stream_inquiry
+
+
+    !-----------------------------------------------------------------------
+    !  routine test_streaminfo_query
+    !
+    !> \brief Tests the streaminfo_query / streamInfo % query routine
+    !> \author Michael Duda
+    !> \date   17 November 2023
+    !> \details
+    !>  This routine tests the streaminfo_query routine.
+    !>
+    !>  Return value: The total number of test that failed on the calling rank.
+    !
+    !-----------------------------------------------------------------------
+    function test_streaminfo_query(streamInfo) result(ierr_count)
+
+        use mpas_kind_types, only : StrKIND
+
+        implicit none
+
+        ! Arguments
+        type (MPAS_streamInfo_type), intent(inout) :: streamInfo
+
+        ! Return value
+        integer :: ierr_count
+
+        ! Local variables
+        logical :: success
+        character(len=StrKIND) :: attvalue
+
+        ierr_count = 0
+
+
+        !
+        ! Query about the existence of an immutable stream that exists
+        !
+        if (streamInfo % query('input')) then
+            call mpas_log_write('        query existence of an immutable stream that exists - PASSED')
+        else
+            call mpas_log_write('        query existence of an immutable stream that exists - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query about the existence of a mutable stream that exists
+        !
+        if (streamInfo % query('mutable_test')) then
+            call mpas_log_write('        query existence of a mutable stream that exists - PASSED')
+        else
+            call mpas_log_write('        query existence of a mutable stream that exists - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query about the existence of a stream that does not exist
+        !
+        if (.not. streamInfo % query('foobar')) then
+            call mpas_log_write('        query existence of a stream that does not exist - PASSED')
+        else
+            call mpas_log_write('        query existence of a stream that does not exist - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query about the existence of an attribute that exists (immutable stream)
+        !
+        if (streamInfo % query('input', attname='filename_template')) then
+            call mpas_log_write('        query existence of an attribute that exists (immutable stream) - PASSED')
+        else
+            call mpas_log_write('        query existence of an attribute that exists (immutable stream) - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query about the existence of an attribute that exists (mutable stream)
+        !
+        if (streamInfo % query('mutable_test', attname='type')) then
+            call mpas_log_write('        query existence of an attribute that exists (mutable stream) - PASSED')
+        else
+            call mpas_log_write('        query existence of an attribute that exists (mutable stream) - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query about the existence of an attribute that does not exist
+        !
+        if (.not. streamInfo % query('input', attname='input_start_time')) then
+            call mpas_log_write('        query existence of an attribute that does not exist - PASSED')
+        else
+            call mpas_log_write('        query existence of an attribute that does not exist - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query the value of an attribute (immutable stream)
+        !
+        success = streamInfo % query('input', attname='input_interval', attvalue=attvalue)
+        if (success .and. trim(attvalue) == 'initial_only') then
+            call mpas_log_write('        query value of an attribute (immutable stream) - PASSED')
+        else
+            call mpas_log_write('        query value of an attribute (immutable stream) - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+        !
+        ! Query the value of an attribute (mutable stream)
+        !
+        success = streamInfo % query('mutable_test', attname='filename_template', attvalue=attvalue)
+        if (success .and. trim(attvalue) == 'mutable_test.nc') then
+            call mpas_log_write('        query value of an attribute (mutable stream) - PASSED')
+        else
+            call mpas_log_write('        query value of an attribute (mutable stream) - FAILED')
+            ierr_count = ierr_count + 1
+        end if
+
+    end function test_streaminfo_query
+
+end module mpas_test_core_stream_inquiry

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -413,6 +413,7 @@ module mpas_subdriver
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
       use mpas_log, only : mpas_log_finalize, mpas_log_info
+      use mpas_derived_types, only : MPAS_streamInfo_type
 
       implicit none
 
@@ -420,6 +421,7 @@ module mpas_subdriver
       type (domain_type), intent(inout), pointer :: domain_ptr
 
       integer :: iErr
+      type (MPAS_streamInfo_type), pointer :: streamInfo
 
 
       !
@@ -440,7 +442,8 @@ module mpas_subdriver
       !
       call MPAS_stream_mgr_finalize(domain_ptr % streamManager)
 
-      if (domain_ptr % streamInfo % finalize() /= 0) then
+      streamInfo => domain_ptr % streamInfo
+      if (streamInfo % finalize() /= 0) then
          call mpas_log_write('Finalization of streamInfo object failed for core '//trim(domain_ptr % core % coreName), &
                              messageType=MPAS_LOG_ERR)
       end if

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -47,6 +47,7 @@ module mpas_subdriver
       use mpas_timekeeping, only : mpas_get_clock_time, mpas_get_time
       use mpas_bootstrapping, only : mpas_bootstrap_framework_phase1, mpas_bootstrap_framework_phase2
       use mpas_log
+      use mpas_stream_inquiry, only : MPAS_stream_inquiry_new_streaminfo
  
       implicit none
 
@@ -248,6 +249,19 @@ module mpas_subdriver
 
       call mpas_framework_init_phase2(domain_ptr)
 
+      !
+      ! Before defining packages, initialize the stream inquiry instance for the domain
+      !
+      domain_ptr % streamInfo => MPAS_stream_inquiry_new_streaminfo()
+      if (.not. associated(domain_ptr % streamInfo)) then
+         call mpas_log_write('Failed to instantiate streamInfo object for core '//trim(domain_ptr % core % coreName), &
+                             messageType=MPAS_LOG_CRIT)
+      end if
+      if (domain_ptr % streamInfo % init(domain_ptr % dminfo % comm, domain_ptr % streams_filename) /= 0) then
+         call mpas_log_write('Initialization of streamInfo object failed for core '//trim(domain_ptr % core % coreName), &
+                             messageType=MPAS_LOG_CRIT)
+      end if
+
       ierr = domain_ptr % core % define_packages(domain_ptr % packages)
       if ( ierr /= 0 ) then
          call mpas_log_write('Package definition failed for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
@@ -425,6 +439,12 @@ module mpas_subdriver
       ! Finalize infrastructure
       !
       call MPAS_stream_mgr_finalize(domain_ptr % streamManager)
+
+      if (domain_ptr % streamInfo % finalize() /= 0) then
+         call mpas_log_write('Finalization of streamInfo object failed for core '//trim(domain_ptr % core % coreName), &
+                             messageType=MPAS_LOG_ERR)
+      end if
+      deallocate(domain_ptr % streamInfo)
 
       ! Print out log stats and close log file
       !   (Do this after timer stats are printed and stream mgr finalized,

--- a/src/framework/Makefile
+++ b/src/framework/Makefile
@@ -35,7 +35,9 @@ OBJS = mpas_kind_types.o \
        regex_matching.o \
        mpas_log.o \
        mpas_halo.o \
-       mpas_string_utils.o
+       mpas_string_utils.o \
+       mpas_stream_inquiry.o \
+       stream_inquiry.o
 
 all: framework $(DEPS)
 
@@ -109,6 +111,8 @@ xml_stream_parser.o: xml_stream_parser.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(CPPINCLUDES) -I../external/ezxml -c xml_stream_parser.c
 
 mpas_halo.o: mpas_derived_types.o mpas_pool_routines.o mpas_log.o
+
+mpas_stream_inquiry.o : mpas_derived_types.o mpas_log.o mpas_c_interfacing.o
 
 clean:
 	$(RM) *.o *.mod *.f90 libframework.a

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -25,6 +25,8 @@
 !-----------------------------------------------------------------------
 module mpas_derived_types
 
+   use iso_c_binding, only : c_ptr, c_null_ptr
+
    use mpas_kind_types
 
 #ifdef MPAS_PIO_SUPPORT
@@ -69,6 +71,8 @@ module mpas_derived_types
 #include "mpas_block_types.inc"
 
 #include "mpas_decomp_types.inc"
+
+#include "mpas_stream_inquiry_types.inc"
 
 #include "mpas_domain_types.inc"
 

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -9,6 +9,8 @@
       type (mpas_decomp_list), pointer :: decompositions => null()
       type (mpas_io_context_type), pointer :: ioContext => null()
 
+      type (MPAS_streamInfo_type), pointer :: streamInfo => null()
+
       ! Also store parallelization info here
       type (dm_info), pointer :: dminfo
 

--- a/src/framework/mpas_stream_inquiry.F
+++ b/src/framework/mpas_stream_inquiry.F
@@ -1,0 +1,264 @@
+! Copyright (c) 2023 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+!-----------------------------------------------------------------------
+!  mpas_stream_inquiry
+!
+!> \brief Enables inquiries of the contents of the streams.<core> file
+!> \author Michael Duda
+!> \date   15 November 2023
+!> \details
+!>  This module provides a method for instantiating a new MPAS_streamInfo_type
+!>  type, as well as routines that may be invoked from that instance to query
+!>  the contents of a streams XML file.
+!>
+!>  Example usage to determine the value of the "input_interval" attribute
+!>  for the "foo" stream:
+!>
+!>     type (MPAS_streamInfo_type), pointer :: streamInfo
+!>     character(len=StrKIND) :: attvalue
+!>     integer :: ierr
+!>
+!>     streamInfo => MPAS_stream_inquiry_new_streaminfo()
+!>
+!>     ierr = streamInfo % init(dminfo % comm, 'streams.test')
+!>
+!>     if (streamInfo % query('foo', attname='input_interval', attvalue=attvalue)) then
+!>        call mpas_log_write('input_interval = '//trim(attvalue))
+!>     end if
+!>
+!>     ierr = streamInfo % finalize()
+!>
+!>     deallocate(streamInfo)
+!>
+!
+!-----------------------------------------------------------------------
+module mpas_stream_inquiry
+
+    public :: MPAS_stream_inquiry_new_streaminfo
+
+
+contains
+
+
+    !-----------------------------------------------------------------------
+    !  routine MPAS_stream_inquiry_new_streaminfo
+    !
+    !> \brief Returns a pointer to a new MPAS_streamInfo_type instance
+    !> \author Michael Duda
+    !> \date   15 November 2023
+    !> \details
+    !>  This routine returns a pointer to a newly allocated instance of an
+    !>  MPAS_streamInfo_type. The new instance has valid methods init(), query(),
+    !>  and finalize() that may be called.
+    !>
+    !>  After all queries via the MPAS_streamInfo_type instance have been
+    !>  completed, the instance finalize() method should be called before the
+    !>  instance is deallocated.
+    !
+    !-----------------------------------------------------------------------
+    function MPAS_stream_inquiry_new_streaminfo() result(new_streaminfo)
+
+        use mpas_derived_types, only : MPAS_streamInfo_type
+
+        implicit none
+
+        ! Return value
+        type (MPAS_streamInfo_type), pointer :: new_streaminfo
+
+        allocate(new_streaminfo)
+        new_streaminfo % init => streaminfo_init
+        new_streaminfo % finalize => streaminfo_finalize
+        new_streaminfo % query => streaminfo_query
+
+    end function MPAS_stream_inquiry_new_streaminfo
+
+
+    !-----------------------------------------------------------------------
+    !  routine streaminfo_init
+    !
+    !> \brief Initializes an MPAS_streamInfo_type instance from a streams XML file
+    !> \author Michael Duda
+    !> \date   15 November 2023
+    !> \details
+    !>  This routine should be called as a method within an MPAS_streamInfo_type
+    !>  instance, e.g., streaminfo % init(...). Given the name of an MPAS streams
+    !>  XML file, this method initializes the instance so that later queries may
+    !>  be made with the query() method.
+    !
+    !-----------------------------------------------------------------------
+    function streaminfo_init(this, mpi_comm, stream_filename) result(ierr)
+
+        use mpas_derived_types, only : MPAS_streamInfo_type
+        use mpas_log, only : mpas_log_write
+        use mpas_c_interfacing, only : mpas_f_to_c_string
+        use iso_c_binding, only : c_char, c_associated
+
+        implicit none
+
+        ! Arguments
+        class (MPAS_streamInfo_type) :: this
+        integer, intent(in) :: mpi_comm
+        character(len=*), intent(in) :: stream_filename
+
+        ! Return value
+        integer :: ierr
+
+        ! Local variables
+        character(kind=c_char), dimension(len(stream_filename)+1) :: c_stream_filename
+
+        interface
+            function parse_streams_file(mpi_comm, filename) bind(C, name='parse_streams_file') result(xmltree)
+                use iso_c_binding, only : c_char, c_ptr
+                integer, intent(in), value :: mpi_comm
+                character(kind=c_char), dimension(*), intent(in) :: filename
+                type(c_ptr) :: xmltree
+            end function parse_streams_file
+        end interface
+
+
+        ierr = 0
+
+        call mpas_f_to_c_string(stream_filename, c_stream_filename)
+        call mpas_log_write('Initializing MPAS_streamInfo from file '//trim(stream_filename))
+        this % xmltree = parse_streams_file(mpi_comm, c_stream_filename)
+
+        if (.not. c_associated(this % xmltree)) then
+            ierr = 1
+        end if
+    end function streaminfo_init
+
+
+    !-----------------------------------------------------------------------
+    !  routine streaminfo_finalize
+    !
+    !> \brief Finalizes an instance of the MPAS_streamInfo_type type
+    !> \author Michael Duda
+    !> \date   15 November 2023
+    !> \details
+    !>  This routine finalizes an instance of the MPAS_streamInfo_type type
+    !>  after all queries about the contents of the streams XML file associated
+    !>  with the instance have been completed. This routine should be called as
+    !>  a method within an MPAS_streamInfo_type type, e.g.,
+    !>  streaminfo % finalize().
+    !
+    !-----------------------------------------------------------------------
+    function streaminfo_finalize(this) result(ierr)
+
+        use mpas_derived_types, only : MPAS_streamInfo_type
+        use iso_c_binding, only : c_null_ptr, c_associated
+
+        implicit none
+
+        ! Arguments
+        class (MPAS_streamInfo_type) :: this
+
+        ! Return value
+        integer :: ierr
+
+        interface
+            subroutine free_streams_file(xmltree) bind(C, name='free_streams_file')
+                use iso_c_binding, only : c_ptr
+                type(c_ptr), value :: xmltree
+            end subroutine free_streams_file
+        end interface
+
+
+        ierr = 0
+
+        if (c_associated(this % xmltree)) then
+            call free_streams_file(this % xmltree)
+            this % xmltree = c_null_ptr
+        end if
+
+    end function streaminfo_finalize
+
+
+    !-----------------------------------------------------------------------
+    !  routine streaminfo_query
+    !
+    !> \brief Makes inquiries about the contents of a streams XML file
+    !> \author Michael Duda
+    !> \date   15 November 2023
+    !> \details
+    !>  For an instance of the MPAS_streamInfo_type type that has previously
+    !>  been allocated and initialized from an MPAS streams XML file, this
+    !>  routine allows for inquiries about the contents of the associated
+    !>  streams file. This routine should be called as a method within an
+    !>  instance of the MPAS_streamInfo_type type, e.g., as
+    !>  streaminfo % query(...).
+    !>
+    !>  If only the required streamname attribute is given, this routine returns
+    !>  .TRUE. if that stream exists, and .FALSE. otherwise. If the optional
+    !>  attname attribute is given, and if that attribute exists for the
+    !>  specified stream, .TRUE. is returned and .FALSE is returned otherwise;
+    !>  further, if the optional attvalue argument is given, the value of the
+    !>  attribute will assigned to the attvalue argument if the attribute
+    !>  exists.
+    !
+    !-----------------------------------------------------------------------
+    function streaminfo_query(this, streamname, attname, attvalue) result(success)
+
+        use mpas_derived_types, only : MPAS_streamInfo_type
+        use mpas_c_interfacing, only : mpas_f_to_c_string, mpas_c_to_f_string
+        use iso_c_binding, only : c_char, c_ptr, c_null_ptr, c_loc, c_associated, c_f_pointer
+
+        implicit none
+
+        ! Arguments
+        class (MPAS_streamInfo_type) :: this
+        character(len=*), intent(in) :: streamname
+        character(len=*), intent(in), optional :: attname
+        character(len=*), intent(out), optional :: attvalue
+
+        ! Return value
+        logical :: success
+
+        ! Local variables
+        character(kind=c_char), dimension(len(streamname)+1) :: c_streamname
+        character(kind=c_char), dimension(:), pointer :: c_attname, c_attvalue
+        type (c_ptr) :: c_attname_ptr, c_attvalue_ptr
+
+        interface
+            function query_streams_file(xmltree, streamname, attname, attvalue) bind(C, name='query_streams_file') result(found)
+                use iso_c_binding, only : c_ptr, c_int, c_char
+                type (c_ptr), value :: xmltree
+                character(kind=c_char), dimension(*), intent(in) :: streamname
+                type (c_ptr), value :: attname
+                type (c_ptr) :: attvalue
+                integer(kind=c_int) :: found
+            end function query_streams_file
+        end interface
+
+
+        success = .true.
+        call mpas_f_to_c_string(streamname, c_streamname)
+
+        if (present(attname)) then
+            allocate(c_attname(len(attname)))
+            call mpas_f_to_c_string(attname, c_attname)
+            c_attname_ptr = c_loc(c_attname)
+        else
+            c_attname_ptr = c_null_ptr
+        end if
+        c_attvalue_ptr = c_null_ptr
+        if (query_streams_file(this % xmltree, c_streamname, c_attname_ptr, c_attvalue_ptr) /= 1) then
+            success = .false.
+        end if
+        if (present(attname)) then
+            deallocate(c_attname)
+        end if
+        if (success .and. present(attname) .and. present(attvalue)) then
+            if (c_associated(c_attvalue_ptr)) then
+                call c_f_pointer(c_attvalue_ptr, c_attvalue, shape=[len(attvalue)])
+                call mpas_c_to_f_string(c_attvalue, attvalue)
+            else
+            end if
+        end if
+
+    end function streaminfo_query
+
+end module mpas_stream_inquiry

--- a/src/framework/mpas_stream_inquiry_types.inc
+++ b/src/framework/mpas_stream_inquiry_types.inc
@@ -1,0 +1,32 @@
+   type MPAS_streamInfo_type
+      type (c_ptr) :: xmltree = c_null_ptr
+
+      procedure (streaminfo_init_function), pass, pointer :: init => null()
+      procedure (streaminfo_finalize_function), pass, pointer :: finalize => null()
+      procedure (streaminfo_query_function), pass, pointer :: query => null()
+   end type MPAS_streamInfo_type
+
+   abstract interface
+      function streaminfo_init_function(this, mpi_comm, stream_filename) result(ierr)
+         import MPAS_streamInfo_type
+         class (MPAS_streamInfo_type) :: this
+         integer, intent(in) :: mpi_comm
+         character(len=*), intent(in) :: stream_filename
+         integer :: ierr
+      end function streaminfo_init_function
+
+      function streaminfo_finalize_function(this) result(ierr)
+         import MPAS_streamInfo_type
+         class (MPAS_streamInfo_type) :: this
+         integer :: ierr
+      end function streaminfo_finalize_function
+
+      function streaminfo_query_function(this, streamname, attname, attvalue) result(success)
+         import MPAS_streamInfo_type
+         class (MPAS_streamInfo_type) :: this
+         character(len=*), intent(in) :: streamname
+         character(len=*), intent(in), optional :: attname
+         character(len=*), intent(out), optional :: attvalue
+         logical :: success
+      end function streaminfo_query_function
+   end interface

--- a/src/framework/stream_inquiry.c
+++ b/src/framework/stream_inquiry.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2023, The University Corporation for Atmospheric Research (UCAR).
+ *
+ * Unless noted otherwise source code is licensed under the BSD license.
+ * Additional copyright and license information can be found in the LICENSE file
+ * distributed with this code, or at http://mpas-dev.github.com/license.html
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string.h>
+#include "ezxml.h"
+
+#ifdef _MPI
+#include "mpi.h"
+#endif
+
+#define MSGSIZE 256
+
+
+/*
+ *  Interface routines for writing log messages; defined in mpas_log.F
+ *  messageType_c may be any of "MPAS_LOG_OUT", "MPAS_LOG_WARN", "MPAS_LOG_ERR", or "MPAS_LOG_CRIT"
+ */
+void mpas_log_write_c(const char *message_c, const char *messageType_c);
+
+
+/*********************************************************************************
+ *
+ *  Function: read_and_broadcast
+ *
+ *  Reads the contents of a file into a buffer in distributed-memory parallel code.
+ *
+ *  The buffer buf is allocated with size bufsize, which will be exactly the
+ *  number of bytes in the file fname. Only the master task will actually read the
+ *  file, and the contents are broadcast to all other tasks. The mpi_comm argument
+ *  is a Fortran MPI communicator used to determine which task is the master task.
+ *
+ *  A return code of 0 indicates the file was successfully read and broadcast to
+ *  all MPI tasks that belong to the communicator.
+ *
+ *********************************************************************************/
+int read_and_broadcast(const char *fname, int mpi_comm, char **buf, size_t *bufsize)
+{
+	int iofd;
+	int rank;
+	struct stat s;
+	char msgbuf[MSGSIZE];
+
+#ifdef _MPI
+	MPI_Comm comm;
+
+	comm = MPI_Comm_f2c((MPI_Fint)mpi_comm);
+	if (MPI_Comm_rank(comm, &rank) != MPI_SUCCESS) {
+		snprintf(msgbuf, MSGSIZE, "Error getting MPI rank in read_and_broadcast");
+		mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+		return 1;
+	}
+#else
+	rank = 0;
+#endif
+
+	if (rank == 0) {
+		iofd = open(fname, O_RDONLY);
+		if (iofd <= 0) {
+			snprintf(msgbuf, MSGSIZE, "Could not open file %s in read_and_broadcast", fname);
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			return 1;
+		}
+
+		fstat(iofd, &s);
+		*bufsize = (size_t)s.st_size;
+#ifdef _MPI
+		if (MPI_Bcast((void *)bufsize, (int)sizeof(size_t), MPI_BYTE, 0, comm) != MPI_SUCCESS) {
+			snprintf(msgbuf, MSGSIZE, "Error from MPI_Bcast in read_and_broadcast");
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			return 1;
+		}
+#endif
+	
+		*buf = (char *)malloc(*bufsize);
+
+		if (read(iofd, (void *)(*buf), *bufsize) < 0) {
+			snprintf(msgbuf, MSGSIZE, "Error reading from %s in read_and_broadcast", fname);
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			free(*buf);
+			*buf = NULL;
+			return 1;
+		}
+
+#ifdef _MPI
+		if (MPI_Bcast((void *)(*buf), (int)(*bufsize), MPI_CHAR, 0, comm) != MPI_SUCCESS) {
+			snprintf(msgbuf, MSGSIZE, "Error from MPI_Bcast in read_and_broadcast");
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			free(*buf);
+			*buf = NULL;
+			return 1;
+		}
+#endif
+	}
+	else {
+#ifdef _MPI
+		if (MPI_Bcast((void *)bufsize, (int)sizeof(size_t), MPI_BYTE, 0, comm) != MPI_SUCCESS) {
+			snprintf(msgbuf, MSGSIZE, "Error from MPI_Bcast in read_and_broadcast");
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			return 1;
+		}
+#endif
+		*buf = (char *)malloc(*bufsize);
+
+#ifdef _MPI
+		if (MPI_Bcast((void *)(*buf), (int)(*bufsize), MPI_CHAR, 0, comm) != MPI_SUCCESS) {
+			snprintf(msgbuf, MSGSIZE, "Error from MPI_Bcast in read_and_broadcast");
+			mpas_log_write_c(msgbuf, "MPAS_LOG_ERR");
+			free(*buf);
+			*buf = NULL;
+			return 1;
+		}
+#endif
+	}
+
+	return 0;
+}
+
+/********************************************************************************
+ *
+ * parse_streams_file
+ *
+ * Parses an MPAS streams file into an XML tree
+ *
+ * Given the name of an MPAS streams XML file as well as an MPI communicator,
+ * this routine reads and broadcasts the file contents to all MPI tasks in the
+ * communicator, then parses the file into an ezxml_t struct.
+ *
+ * Upon success, a valid pointer to a root ezxml_t struct is returned;
+ * otherwise, a NULL ezxml_t is returned.
+ *
+ ********************************************************************************/
+ezxml_t parse_streams_file(int mpi_comm, const char *filename)
+{
+	char *xml_buf;
+	size_t bufsize;
+
+	if (read_and_broadcast(filename, mpi_comm, &xml_buf, &bufsize) != 0) {
+		return NULL;
+	}
+
+	return ezxml_parse_str(xml_buf, bufsize);
+}
+
+/********************************************************************************
+ *
+ * free_streams_file
+ *
+ * Frees memory associated with an ezxml_t struct.
+ *
+ ********************************************************************************/
+void free_streams_file(ezxml_t xmltree)
+{
+	ezxml_free(xmltree);
+}
+
+
+/********************************************************************************
+ *
+ * query_streams_file
+ *
+ * Returns information about the contents of a previously read streams XML file
+ *
+ * Given an ezxml_t holding the contents of a streams XML file -- typically from
+ * a previous call to parse_streams_file -- returns a 1 if the specified stream
+ * (and, optionally, attribute) exists in the file. If the stream and optionally
+ * specified attribute are found, and if the attvalue argument is not a NULL
+ * pointer, the value of the attribute is also returned.
+ *
+ * Both immutable and mutable streams can be queried.
+ *
+ * If the specified stream does not exist, a value of 0 is returned. If the
+ * stream is found, but the specified attribute is not defined for the stream, a
+ * value of 0 is returned.
+ *
+ ********************************************************************************/
+int query_streams_file(ezxml_t xmltree, const char *streamname, const char *attname, const char **attvalue)
+{
+	ezxml_t stream_xml;
+	const char *streamID;
+	const char *attval_local;
+
+	for (stream_xml = ezxml_child(xmltree, "immutable_stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
+		streamID = ezxml_attr(stream_xml, "name");
+
+		if (strcmp(streamID, streamname) == 0) {
+	                if (attname != NULL) {
+				attval_local = ezxml_attr(stream_xml, attname);
+				if (attval_local != NULL) {
+					*attvalue = attval_local;
+				} else {
+					return 0;
+				}
+			}
+			return 1;
+		}
+	}
+
+	for (stream_xml = ezxml_child(xmltree, "stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
+		streamID = ezxml_attr(stream_xml, "name");
+
+		if (strcmp(streamID, streamname) == 0) {
+	                if (attname != NULL) {
+				attval_local = ezxml_attr(stream_xml, attname);
+				if (attval_local != NULL) {
+					*attvalue = attval_local;
+				} else {
+					return 0;
+				}
+			}
+			return 1;
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds a new infrastructure module, `mpas_stream_inquiry`, for querying 
the contents of streams XML files. The new module operates on instances of a new
derived type, `MPAS_streamInfo_type`, to determine whether a streams XML file
contains a definition of a given stream, whether a stream provides a
specification for a given attribute, and the values for any attributes present 
in the XML file.

The `mpas_stream_inquiry` module can only return information that was explicitly 
provided in a streams XML file, but it cannot, for example, return the
Registry-specified default value for an attribute unless that default value was
expressed in the XML file. However, being only dependent on the contents of a
streams XML file, the `mpas_stream_inquiry` module can be employed even before
the MPAS stream manager has been initialized.

The domain type now includes a pointer to an `MPAS_streamInfo_type` type, which 
is allocated and initialized with a core's streams file from within the
`mpas_init` routine, after `mpas_framework_init_phase2` but before defining
packages. This will allow cores to make queries concerning the stream
definitions provided by a user during the MPAS start-up process.

Also included in this PR are unit tests for the stream inquiry functionality.