### PR TITLE
Add `streamInfo` argument to `setup_packages` and `get_mesh_stream` interfaces for all cores

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -337,15 +337,16 @@ module atm_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function atm_get_mesh_stream(configs, stream) result(ierr)
+   function atm_get_mesh_stream(configs, streamInfo, stream) result(ierr)
 
       use mpas_kind_types, only : StrKIND
-      use mpas_derived_types, only : mpas_pool_type
+      use mpas_derived_types, only : mpas_pool_type, MPAS_streamInfo_type
       use mpas_pool_routines, only : mpas_pool_get_config
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -99,10 +99,10 @@ module atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function atm_setup_packages(configs, packages, iocontext) result(ierr)
+   function atm_setup_packages(configs, streamInfo, packages, iocontext) result(ierr)
 
       use mpas_dmpar
-      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type
+      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type, MPAS_streamInfo_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
 
 #ifdef DO_PHYSICS
@@ -113,6 +113,7 @@ module atm_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packages
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -100,14 +100,15 @@ module init_atm_core_interface
    !>  not allocated until after this routine has been called.
    !
    !-----------------------------------------------------------------------
-   function init_atm_setup_packages(configs, packages, iocontext) result(ierr)
+   function init_atm_setup_packages(configs, streamInfo, packages, iocontext) result(ierr)
 
-      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type
+      use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type, MPAS_streamInfo_type
       use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packages
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -421,15 +421,16 @@ module init_atm_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function init_atm_get_mesh_stream(configs, stream) result(ierr)
+   function init_atm_get_mesh_stream(configs, streamInfo, stream) result(ierr)
 
       use mpas_kind_types, only : StrKIND
-      use mpas_derived_types, only : mpas_pool_type
+      use mpas_derived_types, only : mpas_pool_type, MPAS_streamInfo_type
       use mpas_pool_routines, only : mpas_pool_get_config
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -90,10 +90,11 @@ module li_core_interface
 !>   *not* allocated until after this routine is called.
 !
 !-----------------------------------------------------------------------
-   function li_setup_packages(configPool, packagePool, iocontext) result(ierr)
+   function li_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)
 
       implicit none
       type (mpas_pool_type), intent(inout) :: configPool
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr

--- a/src/core_landice/mode_forward/mpas_li_core_interface.F
+++ b/src/core_landice/mode_forward/mpas_li_core_interface.F
@@ -237,11 +237,12 @@ module li_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function li_get_mesh_stream(configs, stream) result(ierr)
+   function li_get_mesh_stream(configs, streamInfo, stream) result(ierr)
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -530,7 +530,7 @@ module ocn_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function ocn_get_mesh_stream(configs, stream) result(ierr)!{{{
+   function ocn_get_mesh_stream(configs, streamInfo, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -538,6 +538,7 @@ module ocn_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_ocean/driver/mpas_ocn_core_interface.F
+++ b/src/core_ocean/driver/mpas_ocn_core_interface.F
@@ -95,11 +95,12 @@ module ocn_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function ocn_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
+   function ocn_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
 
       use ocn_analysis_driver
 
       type (mpas_pool_type), intent(inout) :: configPool
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
 

--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -88,13 +88,14 @@ module seaice_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function seaice_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
+   function seaice_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
 
       use mpas_derived_types
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configPool
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
 

--- a/src/core_seaice/model_forward/mpas_seaice_core_interface.F
+++ b/src/core_seaice/model_forward/mpas_seaice_core_interface.F
@@ -719,7 +719,7 @@ module seaice_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function seaice_get_mesh_stream(configs, stream) result(ierr)!{{{
+   function seaice_get_mesh_stream(configs, streamInfo, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -727,6 +727,7 @@ module seaice_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -89,13 +89,14 @@ module sw_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function sw_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
+   function sw_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
 
       use mpas_derived_types
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configPool
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr

--- a/src/core_sw/mpas_sw_core_interface.F
+++ b/src/core_sw/mpas_sw_core_interface.F
@@ -235,7 +235,7 @@ module sw_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function sw_get_mesh_stream(configs, stream) result(ierr)!{{{
+   function sw_get_mesh_stream(configs, streamInfo, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -243,6 +243,7 @@ module sw_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -89,13 +89,14 @@ module test_core_interface
    !>   *not* allocated until after this routine is called.
    !
    !-----------------------------------------------------------------------
-   function test_setup_packages(configPool, packagePool, iocontext) result(ierr)!{{{
+   function test_setup_packages(configPool, streamInfo, packagePool, iocontext) result(ierr)!{{{
 
       use mpas_derived_types
 
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configPool
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       type (mpas_pool_type), intent(inout) :: packagePool
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -269,7 +269,7 @@ module test_core_interface
    !>  are available.
    !
    !-----------------------------------------------------------------------
-   function test_get_mesh_stream(configs, stream) result(ierr)!{{{
+   function test_get_mesh_stream(configs, streamInfo, stream) result(ierr)!{{{
 
       use mpas_derived_types
       use mpas_pool_routines
@@ -277,6 +277,7 @@ module test_core_interface
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
+      type (MPAS_streamInfo_type), intent(inout) :: streamInfo
       character(len=StrKIND), intent(out) :: stream
       integer :: ierr
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -297,7 +297,7 @@ module mpas_subdriver
       ! Using information from the namelist, a graph.info file, and a file containing
       !    mesh fields, build halos and allocate blocks in the domain
       !
-      ierr = domain_ptr % core % get_mesh_stream(domain_ptr % configs, mesh_stream)
+      ierr = domain_ptr % core % get_mesh_stream(domain_ptr % configs, domain_ptr % streamInfo, mesh_stream)
       if ( ierr /= 0 ) then
          call mpas_log_write('Failed to find mesh stream for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
       end if

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -267,7 +267,8 @@ module mpas_subdriver
          call mpas_log_write('Package definition failed for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
       end if
 
-      ierr = domain_ptr % core % setup_packages(domain_ptr % configs, domain_ptr % packages, domain_ptr % iocontext)
+      ierr = domain_ptr % core % setup_packages(domain_ptr % configs, domain_ptr % streamInfo, domain_ptr % packages, &
+                                                domain_ptr % iocontext)
       if ( ierr /= 0 ) then
          call mpas_log_write('Package setup failed for core '//trim(domain_ptr % core % coreName), messageType=MPAS_LOG_CRIT)
       end if

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -21,11 +21,13 @@
    end interface
 
    abstract interface
-      function mpas_setup_packages_function(configs, packages, iocontext) result(iErr)
+      function mpas_setup_packages_function(configs, streamInfo, packages, iocontext) result(iErr)
          import mpas_pool_type
          import mpas_io_context_type
+         import mpas_streaminfo_type
 
          type (mpas_pool_type), intent(inout) :: configs
+         type (mpas_streaminfo_type), intent(inout) :: streamInfo
          type (mpas_pool_type), intent(inout) :: packages
          type (mpas_io_context_type), intent(inout) :: iocontext
          integer :: iErr

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -44,11 +44,13 @@
    end interface
 
    abstract interface
-      function mpas_get_mesh_stream_function(configs, stream) result(iErr)
+      function mpas_get_mesh_stream_function(configs, streamInfo, stream) result(iErr)
          use mpas_kind_types
          import mpas_pool_type
+         import mpas_streaminfo_type
 
          type (mpas_pool_type), intent(inout) :: configs
+         type (mpas_streaminfo_type), intent(inout) :: streamInfo
          character (len=StrKIND), intent(out) :: stream
          integer :: iErr
       end function mpas_get_mesh_stream_function


### PR DESCRIPTION
This PR adds the `domain % streamInfo` instance of an `MPAS_streamInfo_type` type
as an argument to the `setup_packages` and `get_mesh_stream` core interface routines for
all cores. Before the calls to these two core interface routines in `mpas_init`, the `streamInfo`
instance has been initialized with the core's streams XML file, enabling cores to make decisions
based on the streams XML file regarding packages and the stream to provide the mesh
information for a core.