### PR TITLE
Introduce "invariant stream" capability to MPAS-Atmosphere

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -26,7 +26,7 @@ core_reg:
 core_input_gen:
 	if [ ! -e default_inputs ]; then  mkdir default_inputs; fi
 	( cd default_inputs; $(NL_GEN) ../Registry_processed.xml namelist.atmosphere in_defaults=true )
-	( cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.atmosphere stream_list.atmosphere. listed )
+	( cd default_inputs; $(ST_GEN) ../Registry_processed.xml streams.atmosphere stream_list.atmosphere. listed in_defaults=true)
 
 gen_includes: core_reg
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -407,6 +407,7 @@
                 <package name="iau" description="Incremental Analysis Update"/>
                 <package name="limited_area" description="Limited-area simulations, which have lateral boundaries"/>
                 <package name="jedi_da" description="Data Assimilation in JEDI framework"/>
+                <package name="no_invariant_stream" description="No separate invariant I/O stream is active"/>
         </packages>
 
 
@@ -498,7 +499,7 @@
                         input_interval="initial_only"
                         immutable="true">
 
-			<stream name="invariant"/>
+			<stream name="invariant" packages="no_invariant_stream"/>
 			<var name="u_init"/>
 			<var name="v_init"/>
 			<var name="t_init"/>
@@ -568,7 +569,7 @@
                         output_interval="1_00:00:00" 
                         immutable="true">
 
-			<stream name="invariant"/>
+			<stream name="invariant" packages="no_invariant_stream"/>
 			<var name="u_init"/>
 			<var name="v_init"/>
 			<var name="t_init"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -415,10 +415,10 @@
 <!-- **************************************************************************************** -->
 
 	<streams>
-		<stream name="input" 
+		<stream name="invariant" 
                         type="input" 
-                        filename_template="x1.40962.init.nc" 
-                        input_interval="initial_only"
+                        filename_template="invariant.nc" 
+                        input_interval="none"
                         immutable="true">
 
 			<var name="latCell"/>
@@ -480,10 +480,6 @@
 			<var name="zb"/>
 			<var name="zb3"/>
 			<var name="dss"/>
-			<var name="u_init"/>
-			<var name="v_init"/>
-			<var name="t_init"/>
-			<var name="qv_init"/>
 			<var name="deriv_two"/>
 			<var name="defc_a"/>
 			<var name="defc_b"/>
@@ -492,6 +488,19 @@
 			<var name="cell_gradient_coef_y"/>
 #endif
 			<var name="coeffs_reconstruct"/>
+
+                </stream>
+
+		<stream name="input" 
+                        type="input" 
+                        filename_template="x1.40962.init.nc" 
+                        input_interval="initial_only"
+                        immutable="true">
+
+			<stream name="invariant"/>
+			<var name="u_init"/>
+			<var name="v_init"/>
+			<var name="t_init"/>
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
@@ -558,77 +567,15 @@
                         output_interval="1_00:00:00" 
                         immutable="true">
 
-			<var name="latCell"/>
-			<var name="lonCell"/>
-			<var name="xCell"/>
-			<var name="yCell"/>
-			<var name="zCell"/>
-			<var name="indexToCellID"/>
-			<var name="latEdge"/>
-			<var name="lonEdge"/>
-			<var name="xEdge"/>
-			<var name="yEdge"/>
-			<var name="zEdge"/>
-			<var name="indexToEdgeID"/>
-			<var name="latVertex"/>
-			<var name="lonVertex"/>
-			<var name="xVertex"/>
-			<var name="yVertex"/>
-			<var name="zVertex"/>
-			<var name="indexToVertexID"/>
-			<var name="cellsOnEdge"/>
-			<var name="nEdgesOnCell"/>
-			<var name="nEdgesOnEdge"/>
-			<var name="edgesOnCell"/>
-			<var name="edgesOnEdge"/>
-			<var name="weightsOnEdge"/>
-			<var name="dvEdge"/>
-			<var name="dcEdge"/>
-			<var name="angleEdge"/>
-			<var name="areaCell"/>
-			<var name="areaTriangle"/>
-			<var name="edgeNormalVectors"/>
-			<var name="localVerticalUnitVectors"/>
-			<var name="cellTangentPlane"/>
-			<var name="cellsOnCell"/>
-			<var name="verticesOnCell"/>
-			<var name="verticesOnEdge"/>
-			<var name="edgesOnVertex"/>
-			<var name="cellsOnVertex"/>
-			<var name="kiteAreasOnVertex"/>
-			<var name="fEdge"/>
-			<var name="fVertex"/>
-			<var name="meshDensity"/>
-			<var name="nominalMinDc"/>
-			<var name="bdyMaskCell"/>
-			<var name="bdyMaskEdge"/>
-			<var name="bdyMaskVertex"/>
-			<var name="cf1"/>
-			<var name="cf2"/>
-			<var name="cf3"/>
-			<var name="zgrid"/>
-			<var name="rdzw"/>
-			<var name="dzu"/>
-			<var name="rdzu"/>
-			<var name="fzm"/>
-			<var name="fzp"/>
-			<var name="zxu"/>
-			<var name="zz"/>
-			<var name="zb"/>
-			<var name="zb3"/>
-			<var name="dss"/>
+			<stream name="invariant"/>
 			<var name="u_init"/>
 			<var name="v_init"/>
 			<var name="t_init"/>
 			<var name="qv_init"/>
-			<var name="deriv_two"/>
-			<var name="defc_a"/>
-			<var name="defc_b"/>
 #ifdef MPAS_CAM_DYCORE
 			<var name="cell_gradient_coef_x"/>
 			<var name="cell_gradient_coef_y"/>
 #endif
-			<var name="coeffs_reconstruct"/>
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -419,7 +419,8 @@
                         type="input" 
                         filename_template="invariant.nc" 
                         input_interval="none"
-                        immutable="true">
+                        immutable="true"
+                        in_defaults="false">
 
 			<var name="latCell"/>
 			<var name="lonCell"/>

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -119,6 +119,15 @@ module atm_core
       call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', dt)
 
       !
+      ! By default, the 'invariant' stream has an input_interval of "none", so
+      ! the following stream read has no effect. However, in case the 'invariant'
+      ! stream is defined with an input_interval of "initial_only", we read
+      ! time-invariant fields first.
+      !
+      call MPAS_stream_mgr_read(domain % streamManager, streamID='invariant', whence=MPAS_STREAM_NEAREST, ierr=ierr)
+      call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='invariant', direction=MPAS_STREAM_INPUT, ierr=ierr)
+
+      !
       ! If this is a restart run, read the restart stream, else read the input
       ! stream.
       ! Regardless of which stream we read for initial conditions, reset the

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -123,6 +123,7 @@ module atm_core_interface
       logical, pointer :: limited_areaActive
       logical, pointer :: config_apply_lbcs
       logical, pointer :: config_jedi_da, jedi_daActive
+      logical, pointer :: no_invariant_streamActive
       integer :: local_ierr
 
       ierr = 0
@@ -173,6 +174,20 @@ module atm_core_interface
          call mpas_log_write('Package setup failed for ''jedi_da''. '// &
               'Either ''jedi_da'' is not a package, or ''config_jedi_da'' is not a namelist option.', &
               messageType=MPAS_LOG_ERR)
+      end if
+
+      !
+      ! Separate time-invariant stream
+      !
+      nullify(no_invariant_streamActive)
+      call mpas_pool_get_package(packages, 'no_invariant_streamActive', no_invariant_streamActive)
+
+      if (associated(no_invariant_streamActive)) then
+         no_invariant_streamActive = .true.
+      else
+         ierr = ierr + 1
+         call mpas_log_write("Package setup failed for 'no_invariant_stream'. 'no_invariant_stream' is not a package.", &
+                             messageType=MPAS_LOG_ERR)
       end if
 
 #ifdef DO_PHYSICS

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -124,6 +124,7 @@ module atm_core_interface
       logical, pointer :: config_apply_lbcs
       logical, pointer :: config_jedi_da, jedi_daActive
       logical, pointer :: no_invariant_streamActive
+      character(len=StrKIND) :: attvalue
       integer :: local_ierr
 
       ierr = 0
@@ -184,6 +185,11 @@ module atm_core_interface
 
       if (associated(no_invariant_streamActive)) then
          no_invariant_streamActive = .true.
+         if (streamInfo % query('invariant', attname='input_interval', attvalue=attvalue)) then
+            if (trim(attvalue) == 'initial_only') then
+               no_invariant_streamActive = .false.
+            end if
+         end if
       else
          ierr = ierr + 1
          call mpas_log_write("Package setup failed for 'no_invariant_stream'. 'no_invariant_stream' is not a package.", &
@@ -366,8 +372,21 @@ module atm_core_interface
       integer :: ierr
 
       logical, pointer :: config_do_restart
+      character(len=StrKIND) :: attvalue
 
       ierr = 0
+
+      !
+      ! If the 'invariant' stream is defined in the streams XML file with an
+      ! input_interval of 'initial_only', then use the 'invariant' stream to
+      ! get mesh information
+      !
+      if (streamInfo % query('invariant', attname='input_interval', attvalue=attvalue)) then
+         if (trim(attvalue) == 'initial_only') then
+            write(stream,'(a)') 'invariant'
+            return
+         end if
+      end if
 
       call mpas_pool_get_config(configs, 'config_do_restart', config_do_restart)
 


### PR DESCRIPTION
This PR introduces the capability to store time-invariant fields in a separate file, thereby avoiding the need to store copies of these fields in every time-varying initial conditions or restart file.

Without any changes in workflow, MPAS-A will appear to a user to work as before. However, if a definition of the `"invariant"` input stream is added to the `streams.atmosphere` file at runtime, and if the `input_interval` is set to `"initial_only"`, e.g.,
```xml
<immutable_stream name="invariant"
                  type="input"
                  filename_template="x1.40962.L32.invariant.nc"
                  input_interval="initial_only" />
```
, the model will read all time-invariant fields from the designated file when starting up -- either from a cold-start or a restart; additionally, when restart files are periodically written during a simulation, time-invariant fields will be omitted from those restart output streams.

A file containing time-invariant fields can be produced while running the `init_atmosphere_model` program by setting `config_vertical_grid = true` while also setting `config_met_interp = false` in the `namelist.init_atmosphere` file for the real-data initialization case (init case 7). The invariant file can be used as input to the `init_atmosphere_model` program when interpolating real-data ICs with `config_met_interp = true`, and this same invariant file is suitable for use in the "invariant" stream in the `streams.atmosphere` file.