### PR TITLE
Merge the halo adjoint exchange code for real_2d fields

### DIFF
--- a/src/core_test/mpas_test_core_halo_exch.F
+++ b/src/core_test/mpas_test_core_halo_exch.F
@@ -81,6 +81,16 @@ module test_core_halo_exch
          err = ior(err, iErr)
       end if
 
+      if ( threadNum == 0 ) then
+         call mpas_log_write(' - Performing halo exchange adjoint tests')
+      end if
+      call test_halo_adj_exch_fields(domain, threadErrs, iErr)
+      call mpas_threading_barrier()
+      if ( threadNum == 0 ) then
+         call mpas_log_write('    -- Return code: $i', intArgs=(/iErr/))
+         err = ior(err, iErr)
+      end if
+
       call mpas_timer_stop('halo exch tests')
 
    end subroutine test_core_halo_exch_test!}}}
@@ -252,8 +262,6 @@ module test_core_halo_exch
       call test_core_halo_exch_validate_fields(domain, threadErrs, iErr)
       err = ior(err, iErr)
 
-      call test_halo_adj_exch_fields(domain, threadErrs, iErr)
-      err = ior(err, iErr)
    end subroutine test_core_halo_exch_full_test!}}}
 
 

--- a/src/core_test/mpas_test_core_halo_exch.F
+++ b/src/core_test/mpas_test_core_halo_exch.F
@@ -7,6 +7,7 @@
 !
 
 !#define HALO_EXCH_DEBUG
+!#define HALO_EXCH_DEBUG_VERBOSE
 
 module test_core_halo_exch
 
@@ -51,7 +52,7 @@ module test_core_halo_exch
 
       call mpas_timer_start('halo exch tests')
       if ( threadNum == 0 ) then
-         call mpas_log_write(' - Performing exchange group tests')
+         call mpas_log_write(' - Performing group halo exchange tests')
       end if
       call test_core_halo_exch_group_test(domain, threadErrs, iErr)
       call mpas_threading_barrier()
@@ -115,6 +116,7 @@ module test_core_halo_exch
       type (field2DInteger), pointer :: int2DField
       type (field1DInteger), pointer :: int1DField
 
+      integer :: iErr
       integer :: threadNum
 
       threadNum = mpas_threading_get_thread_num() + 1
@@ -247,8 +249,11 @@ module test_core_halo_exch
 
       call mpas_threading_barrier()
 
-      call test_core_halo_exch_validate_fields(domain, threadErrs, err)
+      call test_core_halo_exch_validate_fields(domain, threadErrs, iErr)
+      err = ior(err, iErr)
 
+      call test_halo_adj_exch_fields(domain, threadErrs, iErr)
+      err = ior(err, iErr)
    end subroutine test_core_halo_exch_full_test!}}}
 
 
@@ -983,6 +988,7 @@ module test_core_halo_exch
    !-----------------------------------------------------------------------
    function computeErrors(nColumns, expectedValues, real5D, real4D, real3D, real2D, real1D, &
                           int3d, int2d, int1d) result(errorCode)
+
       integer, intent(in) :: nColumns !< the outermost dimension size to be checked
       integer, dimension(:), pointer, intent(in) :: expectedValues !< an array of expected values
       !< the following are multi-dimension arrays whose elements are checked
@@ -1370,5 +1376,224 @@ module test_core_halo_exch
 
    end subroutine test_core_halo_exch_validate_fields!}}}
 
+   !***********************************************************************
+   !> \brief   Identify cells which are adjacent to the cells with the provided cellMask/
+   !> \Author Michael Duda
+   !> \details 
+   !>  This function identifies cells which are adjacent to cells with the provided mask.
+   !>  Such cells will be marked with with cellMask+1.
+   !>  Only cells which have no mask are considered.
+   !-----------------------------------------------------------------------
+   function mark_interior_cells(cellMask, sentinelValue, cellsOnCell, nEdgesOnCell) result(nCellsMarked)
+
+      !< array of masks, where a value of zero means the cell won't be updated by the halo adjoint exchange
+      integer, dimension(:), intent(inout) :: cellMask
+      integer, intent(in) :: sentinelValue !< the value to look for being adjacent to
+      integer, dimension(:,:), intent(in) :: cellsOnCell   !< array containing adjacent cells for each cell
+      integer, dimension(:), intent(in) :: nEdgesOnCell  !< array containing edges for each cell
+
+      integer :: iCell, j, nCellsMarked
+
+      nCellsMarked = 0
+      do iCell = 1, size(cellMask)
+         if (cellMask(iCell) == 0) then
+            do j = 1, nEdgesOnCell(iCell)
+               if (cellMask(cellsOnCell(j, iCell)) == sentinelValue) then
+                  cellMask(iCell) = sentinelValue + 1
+                  nCellsMarked = nCellsMarked + 1
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+                  call mpas_log_write(' mark_interior iCell:$i abuts:$i', &
+                          intArgs = (/iCell, cellsOnCell(j,iCell)/))
+#endif
+                   exit
+               end if
+            end do
+         end if
+      end do
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write(' mark_interior nCellsMarked:$i sentinel:$i', &
+          intArgs=(/nCellsMarked, sentinelValue/))
+#endif
+
+   end function mark_interior_cells
+
+   !***********************************************************************
+   !> \brief   Identify interior and edge cells
+   !> \Author Michael Duda, Jim Wittig
+   !> \details 
+   !>  This function identifies cells which are on the interior, vs cells on the edge
+   !>  (cells with neighbors which aren't in this block).
+   !>  Returns a vector of flags corresponding to the array of cells, where a value of zero indicates
+   !>  the cell is interior, and a value of non-zero indicates
+   !>    1. the cell is a halo cell (not owned by this block)
+   !>    2. the cell is on an edge of this block (adjacent to a halo cell), or
+   !>    3. the cell is adjacent to an edge cell, or
+   !>    4. the cell is adjacent to a cell which is adjacent to an edge
+   !>  This identifies cells which should be updated via the halo adjoint exchange.
+   !>  Cells marked with a 2 should get updated via halo layer 1.
+   !>  Cells marked with a 3 should get updated via halo layer 2, etc.
+   !>  
+   !-----------------------------------------------------------------------
+   function findExteriorCells(nCellsSolve, nCells, cellsOnCell, edgesOnCell, nHaloLayers) &
+      result(exteriorCells)
+
+      integer, intent(in) :: nCellsSolve !< the number of cells in this block
+      integer, intent(in) :: nCells !< total number of cells (cells in this block plus halo cells)
+      integer, dimension(:,:), intent(in) :: cellsOnCell !< array with adjacent cells for each cell
+      integer, dimension(:), intent(in) :: edgesOnCell !< array with edges for each cell
+      integer, intent(in) :: nHaloLayers  !< the number of halo layers
+
+      integer, dimension(:), allocatable :: exteriorCells
+      integer nInterior, nEdge, nLayers
+
+      allocate(exteriorCells(nCells))
+      exteriorCells(1:nCellsSolve) = 0 !< mark all owned cells as interior
+      exteriorCells(nCellsSolve+1:nCells) = 1 !< mark all halo cells as edge
+      nInterior = 0
+      nEdge = 0
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write(' halo cellsOnCell($i x $i)', &
+         intArgs=(/size(cellsOnCell, dim=1), size(cellsOnCell, dim=2)/))
+#endif
+      
+      ! At this point, only halo cells are marked 1, and all owned cells are marked 0
+      ! for each halo layer, mark cells adjacent to already marked cells with next highest marker
+      do nLayers = 1, nHaloLayers
+         nEdge = nEdge + mark_interior_cells(exteriorCells(1:nCells), nLayers, cellsOnCell, edgesOnCell)
+      end do
+
+      nInterior = nCellsSolve - nEdge
+
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write(' halo nInterior:$i nEdge:$i', intArgs=(/nInterior, nEdge/))
+#endif
+   end function findExteriorCells
+
+   !***********************************************************************
+   !> \brief   MPAS Test Core halo adjoint exchange
+   !> \details 
+   !>  This routine applies the halo adjoint function to a 2D array and verifies
+   !>  interior cell's values don't change, and border cell's values are modified.
+   !>  It assumes a halo exchange has already been applied.
+   !>  Returns 0 on success, non-0 on failure.
+   !-----------------------------------------------------------------------
+   subroutine test_halo_adj_exch_fields(domain, threadErrs, err)
+
+      type (domain_type), intent(inout) :: domain
+      integer, dimension(:), intent(out) :: threadErrs
+      integer, intent(out) :: err
+
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: meshPool, haloExchTestPool
+      type (field2DReal), pointer :: real2DField
+      real (kind=RKIND), dimension(:, :), pointer :: real2D
+      real (kind=RKIND), dimension(:, :), allocatable :: real2Dorig
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:), allocatable :: exteriorCells
+      integer, pointer :: nCells, nCellsSolve
+      integer :: iCell, iEdgeOnCell, nInterior, nEdge, nHaloLayers
+
+      err = 0
+      ! get a variable to call the adjoint halo on
+      block => domain % blocklist
+
+      call mpas_pool_get_subpool(block % structs, 'haloExchTest', haloExchTestPool)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_field(haloExchTestPool, 'cellPersistReal2D', real2DField)
+      call mpas_pool_get_dimension(haloExchTestPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(haloExchTestPool, 'nCellsSolve', nCellsSolve)
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write(' test_halo_adj_exch_fields nCellsSolve:$i nCells:$i', &
+         intArgs=(/nCellsSolve, nCells/))
+#endif
+
+      ! make a copy of the data before applying the adjoint halo
+      call mpas_pool_get_array(haloExchTestPool, 'cellPersistReal2D', real2D)
+      allocate(real2Dorig(size(real2D, 2), size(real2D, 1)))
+      real2Dorig = real2D
+
+      ! find cells with adjoining ghost cells
+      call MPAS_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call MPAS_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write(' halo_adj_ cellsOnCell size:$ix$i', &
+         intArgs=(/size(cellsOnCell,2), size(cellsOnCell, 1)/))
+#endif
+
+      nHaloLayers = size(real2DField % sendList % halos)
+      exteriorCells = findExteriorCells(nCellsSolve, nCells, cellsOnCell, nEdgesOnCell, nHaloLayers)
+
+      ! run the adjoint halo, this will update owned cells
+      call mpas_dmpar_exch_halo_adj_field(real2DField)
+
+      do while ( associated(block) )
+
+         ! get the real2D array after calling mpas_dmpar_exch_halo_adj_field
+         call mpas_pool_get_array(haloExchTestPool, 'cellPersistReal2D', real2D)
+
+         ! check the adjoint halo operation populated fields correctly
+         err = check_adjoint_values(nCellsSolve, real2Dorig, real2D, exteriorCells)
+         block => block % next
+      end do
+   end subroutine test_halo_adj_exch_fields
+
+   !***********************************************************************
+   !> \brief   MPAS Test check pre & post adjoint exchange values
+   !> \details 
+   !>  This routine checks the pre-adjoint halo exchange values aganst
+   !>  post-adjoint halo exhange values.
+   !>  Interior cell's values aren't expected to change, and border cell's values are 
+   !> expected to change.
+   !>  Returns 0 on success, non-0 on failure.
+   !-----------------------------------------------------------------------
+   integer function check_adjoint_values(nCellsSolve, orig, adjoint, exteriorCells) 
+
+      integer, pointer, intent(in) :: nCellsSolve !< the number of local owned cells
+      real (kind=RKIND), dimension(:,:), intent(in) :: orig !< values of the cells before applying the adjoint exchange
+      real (kind=RKIND), dimension(:,:), intent(in) :: adjoint !< values of cells after applying the adjoint exchange
+      integer, dimension(:), intent(in) :: exteriorCells !< array indicating a cell is interior or on the edge
+
+      integer :: i, j, nError, nInterior, nEdge
+      integer :: iDim1, iDim2
+
+      nError = 0
+      iDim1 = nCellsSolve
+      iDim2 = size(orig, dim=1)
+      nInterior = 0
+      nEdge = 0
+
+      do i = 1, iDim1
+         do j = 1, iDim2
+            if (exteriorCells(i) == 0) then
+               if (j == 1) then
+                  nInterior = nInterior + 1
+                  ! interior cells shouldn't have changed
+                  if (orig(j, i) /= adjoint(j, i)) then
+                     call mpas_log_write(' halo changed value for interior cell at:$i:$i orig:$r new:$r', &
+                        intArgs=(/j,i/), realArgs=(/orig(j,i), adjoint(j,i)/))
+                     nError = nError + 1
+                  end if
+               end if
+            else
+               if (j == 1) then
+                  nEdge = nEdge + 1
+                  ! edge cells should change
+                  if (orig(j, i) == adjoint(j, i)) then
+                     call mpas_log_write(' halo unchanged value for edge cell at:$i:$i $r vs $r', &
+                        intArgs=(/i,j/), realArgs=(/orig(j, i), adjoint(j, i)/))
+                     nError = nError + 1
+                  end if
+               end if
+            end if
+         end do
+      end do
+#ifdef HALO_EXCH_DEBUG_VERBOSE
+      call mpas_log_write('  halo nInterior:$i nEdge:$i, nError:$i', &
+         intArgs=(/nInterior, nEdge, nError/))
+#endif
+
+      check_adjoint_values = nError
+   end function check_adjoint_values
 
 end module test_core_halo_exch

--- a/src/core_test/mpas_test_core_halo_exch.F
+++ b/src/core_test/mpas_test_core_halo_exch.F
@@ -1385,24 +1385,37 @@ module test_core_halo_exch
    end subroutine test_core_halo_exch_validate_fields!}}}
 
    !***********************************************************************
-   !> \brief   Identify cells which are adjacent to the cells with the provided cellMask/
-   !> \Author Michael Duda
+   !> \brief  Identify cells that are adjacent to other marked cells
+   !> \author Michael Duda
+   !> \date   24 January 2024
    !> \details 
-   !>  This function identifies cells which are adjacent to cells with the provided mask.
-   !>  Such cells will be marked with with cellMask+1.
-   !>  Only cells which have no mask are considered.
+   !>  Given a cell mask field, cellMask, and a specified (positive) non-zero mask
+   !>  value, sentinelValue, this routine sets the cell mask field to (sentinelValue+1)
+   !>  for all cells that are (1) adjacent to cells with the sentinelValue mask value
+   !>  and (2) that have an initial cellMask value of zero.
+   !>
+   !>  Cell adjacency is determined by the cellsOnCell and nEdgesOnCell fields.
+   !>
+   !>  This routine returns the total number of cells that were marked as being
+   !>  adjacent to cells with the sentinelValue mask value.
    !-----------------------------------------------------------------------
    function mark_interior_cells(cellMask, sentinelValue, cellsOnCell, nEdgesOnCell) result(nCellsMarked)
 
-      !< array of masks, where a value of zero means the cell won't be updated by the halo adjoint exchange
-      integer, dimension(:), intent(inout) :: cellMask
-      integer, intent(in) :: sentinelValue !< the value to look for being adjacent to
-      integer, dimension(:,:), intent(in) :: cellsOnCell   !< array containing adjacent cells for each cell
-      integer, dimension(:), intent(in) :: nEdgesOnCell  !< array containing edges for each cell
+      ! Arguments
+      integer, dimension(:), intent(inout) :: cellMask !< mask field
+      integer, intent(in) :: sentinelValue             !< value in mask field for which adjacent cells are marked
+      integer, dimension(:,:), intent(in) :: cellsOnCell !< indices of cell neighbors for each cell
+      integer, dimension(:), intent(in) :: nEdgesOnCell  !< number of cell neighbors for each cell
 
-      integer :: iCell, j, nCellsMarked
+      ! Return value
+      integer :: nCellsMarked
+
+      ! Local variables
+      integer :: iCell, j
+
 
       nCellsMarked = 0
+
       do iCell = 1, size(cellMask)
          if (cellMask(iCell) == 0) then
             do j = 1, nEdgesOnCell(iCell)
@@ -1418,6 +1431,7 @@ module test_core_halo_exch
             end do
          end if
       end do
+
 #ifdef HALO_EXCH_DEBUG_VERBOSE
       call mpas_log_write(' mark_interior nCellsMarked:$i sentinel:$i', &
           intArgs=(/nCellsMarked, sentinelValue/))
@@ -1426,32 +1440,40 @@ module test_core_halo_exch
    end function mark_interior_cells
 
    !***********************************************************************
-   !> \brief   Identify interior and edge cells
-   !> \Author Michael Duda, Jim Wittig
+   !> \brief  Identify cells in the outermost N layers of owned cells in a block
+   !> \author Jim Wittig, Michael Duda
+   !> \date   29 January 2024
    !> \details 
-   !>  This function identifies cells which are on the interior, vs cells on the edge
-   !>  (cells with neighbors which aren't in this block).
-   !>  Returns a vector of flags corresponding to the array of cells, where a value of zero indicates
-   !>  the cell is interior, and a value of non-zero indicates
+   !>  This function identifies cells that are in the outermost N layers of owned
+   !>  cells in a block, where N is the number of halo layers (nHaloLayers). The
+   !>  function returns an array of values indicating the location of a cell.
+   !>  In the returned array, a value of zero indicates that the cell is not in
+   !>  the outermost N layers of owned cells, and non-zero values indicate:
    !>    1. the cell is a halo cell (not owned by this block)
-   !>    2. the cell is on an edge of this block (adjacent to a halo cell), or
-   !>    3. the cell is adjacent to an edge cell, or
-   !>    4. the cell is adjacent to a cell which is adjacent to an edge
-   !>  This identifies cells which should be updated via the halo adjoint exchange.
-   !>  Cells marked with a 2 should get updated via halo layer 1.
-   !>  Cells marked with a 3 should get updated via halo layer 2, etc.
+   !>    2. the cell is a distance of 1 away from a halo cell (i.e., adjacent to a halo cell)
+   !>    3. the cell is a distance of 2 away from a halo cell (i.e., adjacent to a cell marked '2')
+   !>    4. the cell is a distance of 3 away from a halo cell (i.e., adjacent to a cell marked '3')
+   !>
+   !>  The result of this routine may be used to determine which cells will be modified
+   !>  by the adjoint of a halo exchange; for example:
+   !>   - cells marked with a 2 will be updated from halo layer 1,
+   !>   - cells marked with a 3 will be updated from halo layer 2, etc.
    !>  
    !-----------------------------------------------------------------------
    function findExteriorCells(nCellsSolve, nCells, cellsOnCell, edgesOnCell, nHaloLayers) &
       result(exteriorCells)
 
+      ! Arguments
       integer, intent(in) :: nCellsSolve !< the number of cells in this block
       integer, intent(in) :: nCells !< total number of cells (cells in this block plus halo cells)
       integer, dimension(:,:), intent(in) :: cellsOnCell !< array with adjacent cells for each cell
       integer, dimension(:), intent(in) :: edgesOnCell !< array with edges for each cell
       integer, intent(in) :: nHaloLayers  !< the number of halo layers
 
+      ! Return value
       integer, dimension(:), allocatable :: exteriorCells
+
+      ! Local variables
       integer nInterior, nEdge, nLayers
 
       allocate(exteriorCells(nCells))
@@ -1475,22 +1497,33 @@ module test_core_halo_exch
 #ifdef HALO_EXCH_DEBUG_VERBOSE
       call mpas_log_write(' halo nInterior:$i nEdge:$i', intArgs=(/nInterior, nEdge/))
 #endif
+
    end function findExteriorCells
 
    !***********************************************************************
-   !> \brief   MPAS Test Core halo adjoint exchange
+   !> \brief  MPAS Test Core halo adjoint exchange
+   !> \author Jim Wittig
+   !> \date   29 January 2024
    !> \details 
-   !>  This routine applies the halo adjoint function to a 2D array and verifies
-   !>  interior cell's values don't change, and border cell's values are modified.
-   !>  It assumes a halo exchange has already been applied.
-   !>  Returns 0 on success, non-0 on failure.
+   !>  This routine applies the adjoint of a halo exchangeto a 2-d array and
+   !>  verifies that (1) the values for cells more than a distance N away from
+   !>  a halo cell do not change (where N is the number of halo layers), and
+   !>  (2) cells within a distance of N from a halo cell are updated.
+   !>
+   !>  This routine assumes that a halo exchange has already been applied to
+   !>  the cellPersistReal2D field before this routine has been called.
+   !>
+   !>  Upon success, a value of 0 is returned; otherwise, a non-zero status
+   !>  code is returned.
    !-----------------------------------------------------------------------
    subroutine test_halo_adj_exch_fields(domain, threadErrs, err)
 
+      ! Arguments
       type (domain_type), intent(inout) :: domain
       integer, dimension(:), intent(out) :: threadErrs
       integer, intent(out) :: err
 
+      ! Local variables
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: meshPool, haloExchTestPool
       type (field2DReal), pointer :: real2DField
@@ -1503,6 +1536,7 @@ module test_core_halo_exch
       integer :: iCell, iEdgeOnCell, nInterior, nEdge, nHaloLayers
 
       err = 0
+
       ! get a variable to call the adjoint halo on
       block => domain % blocklist
 
@@ -1544,15 +1578,18 @@ module test_core_halo_exch
          err = check_adjoint_values(nCellsSolve, real2Dorig, real2D, exteriorCells)
          block => block % next
       end do
+
    end subroutine test_halo_adj_exch_fields
 
    !***********************************************************************
-   !> \brief   MPAS Test check pre & post adjoint exchange values
+   !> \brief  MPAS Test check pre and post adjoint exchange values
+   !> \author Jim Wittig
+   !> \date   29 January 2024
    !> \details 
    !>  This routine checks the pre-adjoint halo exchange values aganst
    !>  post-adjoint halo exhange values.
    !>  Interior cell's values aren't expected to change, and border cell's values are 
-   !> expected to change.
+   !>  expected to change.
    !>  Returns 0 on success, non-0 on failure.
    !-----------------------------------------------------------------------
    integer function check_adjoint_values(nCellsSolve, orig, adjoint, exteriorCells) 
@@ -1602,6 +1639,7 @@ module test_core_halo_exch
 #endif
 
       check_adjoint_values = nError
+
    end function check_adjoint_values
 
 end module test_core_halo_exch

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -151,6 +151,14 @@ include 'mpif.h'
       module procedure mpas_dmpar_exch_halo_field5d_real
    end interface
 
+   interface mpas_dmpar_exch_halo_adj_field
+      module procedure mpas_dmpar_exch_halo_adj_field2d_real
+   end interface
+
+   public :: mpas_dmpar_exch_halo_adj_field
+
+   private :: mpas_dmpar_exch_halo_adj_field2d_real
+
    public :: mpas_dmpar_exch_halo_field
 
    private :: mpas_dmpar_exch_halo_field1d_integer
@@ -5458,6 +5466,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           end do
         else
           nHaloLayers = size(field % sendList % halos)
+          DMPAR_DEBUG_WRITE('exch_halo nHaloLayers:$i destList halos:$i' COMMA intArgs=(/nHaloLayers COMMA size(field%recvList%halos)/))
           allocate(haloLayers(nHaloLayers))
           do iHalo = 1, nHaloLayers
             haloLayers(iHalo) = iHalo
@@ -6166,6 +6175,193 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
      end if
 
    end subroutine mpas_dmpar_exch_halo_field5d_real!}}}
+
+   !-----------------------------------------------------------------------
+   !  routine mpas_dmpar_exch_halo_adj_field2d_real
+   !
+   !> \brief MPAS dmpar halo exchange adjoint 2D real field
+   !> \author BJ Jung
+   !> \date   09/2020
+   !> \details
+   !>  This routine handles the adjoint of halo exchange communication of an input field across all processors.
+   !>  It accumulates the values of owned point with the values of halos. It is based on mpas_dmpar_exch_halo_field2d_real.
+   !
+   !> Note the number of halo layers impacts the number of cells which will be updated by this routine:
+   !> The first halo layer will update the owned 'edge' cells, where 'edge' cells are adjacent to ghost cells.
+   !> The second halo layer will update owned cells which are adjacent to the 'edge' cells.
+   !> The third halo layer will update owned cells which are adjacent to the cells updated by the seconds halo layer, etc.
+   !-----------------------------------------------------------------------
+   subroutine mpas_dmpar_exch_halo_adj_field2d_real(field, haloLayersIn)!{{{
+
+      implicit none
+
+      type (field2dReal), pointer, intent(inout) :: field !< Input: Field to communicate
+      integer, dimension(:), intent(in), optional :: haloLayersIn !< Input: List of halo layers to communicate. Defaults to all
+      type (dm_info), pointer :: dminfo
+      type (field2dReal), pointer :: fieldCursor, fieldCursor2
+      type (mpas_exchange_list), pointer :: exchListPtr
+      type (mpas_communication_list), pointer :: sendList, recvList, commListPtr
+      integer :: mpi_ierr, threadNum
+      integer :: nHaloLayers, iHalo, i, j
+      integer :: bufferOffset, nAdded
+      integer, dimension(:), pointer :: haloLayers
+
+      if ( .not. field % isActive ) then
+         DMPAR_DEBUG_WRITE(' -- Skipping halo exchange for deactivated field: ' // trim(field % fieldName))
+         return
+      end if
+
+      do i = 1, 2
+        if(field % dimSizes(i) <= 0) then
+          return
+        end if
+      end do
+
+      dminfo => field % block % domain % dminfo
+      threadNum = mpas_threading_get_thread_num()
+
+      if ( threadNum == 0 ) then
+        if(present(haloLayersIn)) then
+          nHaloLayers = size(haloLayersIn)
+          allocate(haloLayers(nHaloLayers))
+          do iHalo = 1, nHaloLayers
+            haloLayers(iHalo) = haloLayersIn(iHalo)
+          end do
+        else
+          nHaloLayers = size(field % sendList % halos)
+          DMPAR_DEBUG_WRITE('exch_halo_adjoint nHaloLayers:$i destList halos:$i' COMMA intArgs=(/nHaloLayers COMMA size(field%recvList%halos)/))
+          allocate(haloLayers(nHaloLayers))
+          do iHalo = 1, nHaloLayers
+            haloLayers(iHalo) = iHalo
+          end do
+        end if
+
+#ifdef _MPI
+        ! Setup Communication Lists
+        call mpas_dmpar_build_comm_lists(field % sendList, field % recvList, haloLayers, field % dimsizes, sendList, recvList)
+
+        ! Allocate space in recv lists, and initiate mpi_irecv calls
+        commListPtr => sendList
+        do while(associated(commListPtr))
+          allocate(commListPtr % rbuffer(commListPtr % nList))
+          nullify(commListPtr % ibuffer)
+          call MPI_Irecv(commListPtr % rbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, commListPtr % procID, dminfo % comm, commListPtr % reqID, mpi_ierr)
+
+          commListPtr => commListPtr % next
+        end do
+
+        ! Allocate space in send lists, copy data into buffer, and initiate mpi_isend calls
+        commListPtr => recvList
+        do while(associated(commListPtr))
+          allocate(commListPtr % rbuffer(commListPtr % nList))
+          nullify(commListPtr % ibuffer)
+          bufferOffset = 0
+          do iHalo = 1, nHaloLayers
+            nAdded = 0
+            fieldCursor => field
+            do while(associated(fieldCursor))
+              exchListPtr => fieldCursor % recvList % halos(haloLayers(iHalo)) % exchList
+              do while(associated(exchListPtr))
+                if(exchListPtr % endPointID == commListPtr % procID) then
+                  do  i = 1, exchListPtr % nList
+                    do j = 1, fieldCursor % dimSizes(1)
+                      commListPtr % rbuffer((exchListPtr % srcList(i)-1) * fieldCursor % dimSizes(1) + j + bufferOffset) = fieldCursor % array(j, exchListPtr % destList(i))
+                      ! update halo cell
+                      fieldCursor % array(j, exchListPtr % destList(i)) = 0.0_RKIND
+                      nAdded = nAdded + 1
+                    end do
+                  end do
+                end if
+
+                exchListPtr => exchListPtr % next
+              end do
+
+              fieldCursor => fieldCursor % next
+            end do
+            bufferOffset = bufferOffset + nAdded
+          end do
+
+          call MPI_Isend(commListPtr % rbuffer, commListPtr % nList, MPI_REALKIND, commListPtr % procID, dminfo % my_proc_id, dminfo % comm, commListPtr % reqID, mpi_ierr)
+          commListPtr => commListPtr % next
+        end do
+#endif
+
+        ! Handle local copy. If MPI is off, then only local copies are performed.
+        fieldCursor => field
+        do while(associated(fieldCursor))
+          do iHalo = 1, nHaloLayers
+            exchListPtr => fieldCursor % copyList % halos(haloLayers(iHalo)) % exchList
+
+            do while(associated(exchListPtr))
+              fieldCursor2 => field
+              do while(associated(fieldCursor2))
+                if(exchListPtr % endPointID == fieldCursor2 % block % localBlockID) then
+                  do i = 1, exchListPtr % nList
+                    !fieldCursor2 % array(:, exchListPtr % destList(i)) = fieldCursor % array(:, exchListPtr % srcList(i))
+                    fieldCursor % array(:, exchListPtr % srcList(i)) = fieldCursor % array(:, exchListPtr % srcList(i)) + fieldCursor2 % array(:, exchListPtr % destList(i))
+                    fieldCursor2 % array(:, exchListPtr % destList(i)) = 0.0_RKIND
+                  end do
+                end if
+
+                fieldCursor2 => fieldCursor2 % next
+              end do
+
+              exchListPtr => exchListPtr % next
+            end do
+          end do
+
+          fieldCursor => fieldCursor % next
+        end do
+
+#ifdef _MPI
+
+        ! Wait for mpi_irecv to finish, and unpack data from buffer
+        commListPtr => sendList
+        do while(associated(commListPtr))
+          call MPI_Wait(commListPtr % reqID, MPI_STATUS_IGNORE, mpi_ierr)
+          bufferOffset = 0
+          do iHalo = 1, nHaloLayers
+            nAdded = 0
+            fieldCursor => field
+            do while(associated(fieldCursor))
+              exchListPtr => fieldCursor % sendList % halos(haloLayers(iHalo)) % exchList
+              do while(associated(exchListPtr))
+                if(exchListPtr % endPointID == commListPtr % procID) then
+                  do i = 1, exchListPtr % nList
+                    do j = 1, fieldCursor % dimSizes(1)
+                      ! update cell in our block
+                      fieldCursor % array(j, exchListPtr % srcList(i)) = fieldCursor % array(j, exchListPtr % srcList(i)) + commListPtr % rbuffer((exchListPtr % destList(i)-1) * fieldCursor % dimSizes(1) + j + bufferOffset)
+                      commListPtr % rbuffer((exchListPtr % destList(i)-1) * fieldCursor % dimSizes(1) + j + bufferOffset) = 0.0_RKIND
+                    end do
+                  end do
+                  nAdded = max(nAdded, maxval(exchListPtr % destList) * fieldCursor % dimSizes(1))
+                end if
+                exchListPtr => exchListPtr % next
+              end do
+
+              fieldCursor => fieldCursor % next
+            end do
+            bufferOffset = bufferOffset + nAdded
+          end do
+          commListPtr => commListPtr % next
+        end do
+
+        ! wait for mpi_isend to finish.
+        commListPtr => recvList
+        do while(associated(commListPtr))
+          call MPI_Wait(commListPtr % reqID, MPI_STATUS_IGNORE, mpi_ierr)
+          commListPtr => commListPtr % next
+        end do
+
+       ! Destroy commLists.
+       call mpas_dmpar_destroy_communication_list(sendList)
+       call mpas_dmpar_destroy_communication_list(recvList)
+#endif
+
+       deallocate(haloLayers)
+     end if
+
+   end subroutine mpas_dmpar_exch_halo_adj_field2d_real!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_init_multihalo_exchange_list

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -6185,11 +6185,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
    !> \details
    !>  This routine handles the adjoint of halo exchange communication of an input field across all processors.
    !>  It accumulates the values of owned point with the values of halos. It is based on mpas_dmpar_exch_halo_field2d_real.
-   !
-   !> Note the number of halo layers impacts the number of cells which will be updated by this routine:
-   !> The first halo layer will update the owned 'edge' cells, where 'edge' cells are adjacent to ghost cells.
-   !> The second halo layer will update owned cells which are adjacent to the 'edge' cells.
-   !> The third halo layer will update owned cells which are adjacent to the cells updated by the seconds halo layer, etc.
+   !>
+   !>  Note the number of halo layers impacts the number of cells which will be updated by this routine:
+   !>  The first halo layer will update the owned 'edge' cells, where 'edge' cells are adjacent to ghost cells.
+   !>  The second halo layer will update owned cells which are adjacent to the 'edge' cells.
+   !>  The third halo layer will update owned cells which are adjacent to the cells updated by the seconds halo layer, etc.
    !-----------------------------------------------------------------------
    subroutine mpas_dmpar_exch_halo_adj_field2d_real(field, haloLayersIn)!{{{
 


### PR DESCRIPTION
This PR merges the mpas_dmpar_exch_halo_adj_field2d_real() function from the JCSDA-internal/MPAS-Model repository. Additionally, add unit tests to verify the routine.

The routine handles the adjoint of halo exchange communication of an input field across all processors.
 It accumulates the values of owned point with the values of halos.

The test verifies that owned cells which should not have their values changed by the adjoint function do remain unchanged. The test also verifies that cells which should have their values updated by the adjoint function are updated.
