### PR TITLE
Initialization of the f_* flags in physics parameterizations

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -400,7 +400,7 @@
                 <package name="mp_wsm6_in" description="parameterization of WSM6 cloud microphysics."/>
                 <package name="cu_grell_freitas_in" description="parameterization of Grell-Freitas convection."/>
                 <package name="cu_kain_fritsch_in" description="parameterization of Kain-Fritsch convection."/>
-                <package name="cu_tiedtke_in" description="parameterization of Tiedtke convection."/>
+                <package name="cu_ntiedtke_in" description="parameterization of Tiedtke convection."/>
                 <package name="bl_ysu_in" description="parameterization of YSU Planetary Boundary Layer."/>
                 <package name="bl_mynn_in" description="parameterization of MYNN Planetary Boundary Layer."/>
 
@@ -1458,7 +1458,7 @@
 
                         <var name="qc" array_group="moist" units="kg kg^{-1}"
                              description="Cloud water mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"
@@ -1466,7 +1466,7 @@
 
                         <var name="qi" array_group="moist" units="kg kg^{-1}"
                              description="Ice mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in"/>
 
                         <var name="qs" array_group="moist" units="kg kg^{-1}"
                              description="Snow mixing ratio"
@@ -1780,7 +1780,7 @@
 
                         <var name="tend_qc" name_in_code="qc" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of cloud water mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
 
                         <var name="tend_qr" name_in_code="qr" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of rain water mass per unit volume divided by d(zeta)/dz"
@@ -1788,7 +1788,7 @@
 
                         <var name="tend_qi" name_in_code="qi" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of ice mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in"/>
 
                         <var name="tend_qs" name_in_code="qs" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of snow mass per unit volume divided by d(zeta)/dz"
@@ -1843,13 +1843,13 @@
                         <var name="lbc_qv" name_in_code="qv" array_group="moist" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of water vapor mixing ratio"/>
 
-                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;cu_tiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of cloud water mixing ratio"/>
 
                         <var name="lbc_qr" name_in_code="qr" array_group="moist"  packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of rain water mixing ratio"/>
 
-                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_tiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of ice mixing ratio"/>
 
                         <var name="lbc_qs" name_in_code="qs" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
@@ -2213,19 +2213,19 @@
 
                 <var name="i_rainc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated convective precipitation greater than config_bucket_rainc"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="cuprec" type="real" dimensions="nCells Time" units="mm s^{-1}"
                      description="convective precipitation rate"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="rainc" type="real" dimensions="nCells Time" units="mm"
                      description="accumulated convective precipitation"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="raincv" type="real" dimensions="nCells Time" units="mm"
                      description="time-step convective precipitation"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
 
                 <!-- ... KAIN_FRITSCH ONLY: -->
@@ -2937,19 +2937,19 @@
 
                 <var name="rthcuten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
                      description="tendency of potential temperature due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="rqvcuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of water vapor mixing ratio due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="rqccuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud water mixing ratio due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
                 <var name="rqicuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of cloud ice mixing ratio due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_kain_fritsch_in;cu_ntiedtke_in"/>
 
 
                 <!-- KAIN_FRITSCH: -->
@@ -2964,15 +2964,15 @@
                 <!-- TIEDTKE AND GRELL -->
                 <var name="rqvdynten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
                      description="tendency of water vapor due to horizontal and vertical advections"
-                     packages="cu_grell_freitas_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_ntiedtke_in"/>
 
                 <var name="rucuten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of zonal wind due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_ntiedtke_in"/>
 
                 <var name="rvcuten" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1} s^{-1}"
                      description="tendency of meridional wind due to cumulus convection"
-                     packages="cu_grell_freitas_in;cu_tiedtke_in"/>
+                     packages="cu_grell_freitas_in;cu_ntiedtke_in"/>
 
 	        <!-- MGD should we add packages to the field below? -->
 	        <var name="rucuten_Edge" type="real"     dimensions="nVertLevels nEdges Time"/>
@@ -3183,13 +3183,13 @@
                      <var name="qv_amb"  name_in_code="qv" array_group="moist" units="kg kg^{-1}"
                           description="Water vapor mixing ratio increment"/>
 
-                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
                           description="Cloud water mixing ratio increment"/>
 
                      <var name="qr_amb"  name_in_code="qr" array_group="moist" packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
                           description="Rain water mixing ratio increment"/>
 
-                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_tiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
                           description="Ice mixing ratio increment"/>
 
                      <var name="qs_amb"  name_in_code="qs" array_group="moist" packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -148,7 +148,8 @@ mpas_atmphys_init.o: \
 	mpas_atmphys_driver_radiation_sw.o \
 	mpas_atmphys_driver_sfclayer.o \
 	mpas_atmphys_landuse.o \
-	mpas_atmphys_o3climatology.o
+	mpas_atmphys_o3climatology.o \
+	mpas_atmphys_vars.o
 
 mpas_atmphys_interface.o: \
 	mpas_atmphys_constants.o \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -90,7 +90,10 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-18.
 ! * since we removed the local variable convection_scheme from mpas_atmphys_vars.F, now defines convection_scheme
 !   as a pointer to config_convection_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * removed f_qv,f_qr,and f_qs in the calls to cu_tiedtke and cu_ntiedtke. removed f_qv and f_qc in the call to
+!   kf_eta_cps.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
 
 
  contains

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -553,23 +553,22 @@
     case("cu_tiedtke")
        call mpas_timer_start('Tiedtke')
        call cu_tiedtke( &
-             pcps        = pres_hyd_p    , p8w       = pres2_hyd_p   ,               &
-             znu         = znu_hyd_p     , t3d       = t_p           ,               &
-             dt          = dt_dyn        , itimestep = initflag      ,               &
-             stepcu      = n_cu          , raincv    = raincv_p      ,               &
-             pratec      = pratec_p      , qfx       = qfx_p         ,               &
-             u3d         = u_p           , v3d       = v_p           ,               &
-             w           = w_p           , qv3d      = qv_p          ,               &
-             qc3d        = qc_p          , qi3d      = qi_p          ,               &
-             pi3d        = pi_p          , rho3d     = rho_p         ,               &
-             qvften      = rqvdynten_p   , qvpblten  = rqvdynblten_p ,               &
-             dz8w        = dz_p          , xland     = xland_p       ,               &
-             cu_act_flag = cu_act_flag   , f_qv      = f_qv          ,               &
-             f_qc        = f_qc          , f_qr      = f_qr          ,               &
-             f_qi        = f_qi          , f_qs      = f_qs          ,               &
-             rthcuten    = rthcuten_p    , rqvcuten  = rqvcuten_p    ,               &
-             rqccuten    = rqccuten_p    , rqicuten  = rqicuten_p    ,               &
-             rucuten     = rucuten_p     , rvcuten   = rvcuten_p     ,               &
+             pcps        = pres_hyd_p  , p8w       = pres2_hyd_p   ,                 &
+             znu         = znu_hyd_p   , t3d       = t_p           ,                 &
+             dt          = dt_dyn      , itimestep = initflag      ,                 &
+             stepcu      = n_cu        , raincv    = raincv_p      ,                 &
+             pratec      = pratec_p    , qfx       = qfx_p         ,                 &
+             u3d         = u_p         , v3d       = v_p           ,                 &
+             w           = w_p         , qv3d      = qv_p          ,                 &
+             qc3d        = qc_p        , qi3d      = qi_p          ,                 &
+             pi3d        = pi_p        , rho3d     = rho_p         ,                 &
+             qvften      = rqvdynten_p , qvpblten  = rqvdynblten_p ,                 &
+             dz8w        = dz_p        , xland     = xland_p       ,                 &
+             cu_act_flag = cu_act_flag , f_qc      = f_qc          ,                 &
+             f_qi        = f_qi        , rthcuten  = rthcuten_p    ,                 &
+             rqvcuten    = rqvcuten_p  , rqccuten  = rqccuten_p    ,                 &
+             rqicuten    = rqicuten_p  , rucuten   = rucuten_p     ,                 &
+             rvcuten   = rvcuten_p     ,                                             &
              ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde , &
              ims = ims , ime = ime , jms = jms , jme = jme , kms = kds , kme = kme , &
              its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
@@ -579,28 +578,27 @@
     case("cu_ntiedtke")
        call mpas_timer_start('cu_ntiedtke')
        call cu_ntiedtke_driver( &
-             pcps      = pres_hyd_p  , p8w         = pres2_hyd_p ,                   &
-             t3d       = t_p         , dz8w        = dz_p        ,                   &
-             dt        = dt_dyn      , itimestep   = initflag    ,                   &
-             stepcu    = n_cu        , raincv      = raincv_p    ,                   & 
-             pratec    = pratec_p    , qfx         = qfx_p       ,                   &
-             hfx       = hfx_p       , xland       = xland_p     ,                   &
-             dx        = dx_p        , u3d         = u_p         ,                   &
-             v3d       = v_p         , w           = w_p         ,                   &
-             qv3d      = qv_p        , qc3d        = qc_p        ,                   &
-             qi3d      = qi_p        , pi3d        = pi_p        ,                   &
-             rho3d     = rho_p       , qvften      = rqvften_p   ,                   &
-             thften    = rthften_p   , cu_act_flag = cu_act_flag ,                   &
-             f_qv      = f_qv        , f_qc        = f_qc        ,                   &
-             f_qr      = f_qr        , f_qi        = f_qi        ,                   &
-             f_qs      = f_qs        , rthcuten    = rthcuten_p  ,                   &
-             rqvcuten  = rqvcuten_p  , rqccuten    = rqccuten_p  ,                   &
-             rqicuten  = rqicuten_p  , rucuten     = rucuten_p   ,                   &
-             rvcuten   = rvcuten_p   , grav        = gravity     ,                   &
-             xlf       = xlf         , xls         = xls         ,                   &
-             xlv       = xlv         , rd          = R_d         ,                   &
-             rv        = R_v         , cp          = cp          ,                   &
-             errmsg    = errmsg      , errflg      = errflg      ,                   &
+             pcps     = pres_hyd_p , p8w         = pres2_hyd_p ,                     &
+             t3d      = t_p        , dz8w        = dz_p        ,                     &
+             dt       = dt_dyn     , itimestep   = initflag    ,                     &
+             stepcu   = n_cu       , raincv      = raincv_p    ,                     &
+             pratec   = pratec_p   , qfx         = qfx_p       ,                     &
+             hfx      = hfx_p      , xland       = xland_p     ,                     &
+             dx       = dx_p       , u3d         = u_p         ,                     &
+             v3d      = v_p        , w           = w_p         ,                     &
+             qv3d     = qv_p       , qc3d        = qc_p        ,                     &
+             qi3d     = qi_p       , pi3d        = pi_p        ,                     &
+             rho3d    = rho_p      , qvften      = rqvften_p   ,                     &
+             thften   = rthften_p  , cu_act_flag = cu_act_flag ,                     &
+             f_qc     = f_qc       , f_qi        = f_qi        ,                     &
+             rthcuten = rthcuten_p , rqvcuten    = rqvcuten_p  ,                     &
+             rqccuten = rqccuten_p , rqicuten    = rqicuten_p  ,                     &
+             rucuten  = rucuten_p  , rvcuten     = rvcuten_p   ,                     &
+             grav     = gravity    , xlf         = xlf         ,                     &
+             xls      = xls        , xlv         = xlv         ,                     &
+             rd       = R_d        , rv          = R_v         ,                     &
+             cp       = cp         ,                                                 &
+             errmsg   = errmsg     , errflg      = errflg      ,                     &
              ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde , &
              ims = ims , ime = ime , jms = jms , jme = jme , kms = kds , kme = kme , &
              its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_convection.F
@@ -538,8 +538,7 @@
              svpt0           = svpt0           , stepcu    = n_cu       ,            &
              cu_act_flag     = cu_act_flag     , warm_rain = warm_rain  ,            &
              cutop           = cutop_p         , cubot     = cubot_p    ,            &
-             qv              = qv_p            , f_qv      = f_qv       ,            &
-             f_qc            = f_qc            , f_qr      = f_qr       ,            &
+             qv              = qv_p            , f_qr      = f_qr       ,            &
              f_qi            = f_qi            , f_qs      = f_qs       ,            &
              rthcuten        = rthcuten_p      , rqvcuten  = rqvcuten_p ,            &
              rqccuten        = rqccuten_p      , rqrcuten  = rqrcuten_p ,            &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -73,6 +73,8 @@
 !   errmsg and errflg in the call to subroutine ysu for compliance with the CCPP framework. also removed local
 !   variable regime_p which is no longer needed in the call to subroutine ysu.
 !   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
+! * in the call to subroutine mynn_bl_driver,renamed f_qnc to f_nc, and f_qni to f_ni.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-24.
 
 
  contains
@@ -659,8 +661,8 @@
                  qi       = qi_p        , qni      = ni_p        , rho      = rho_p      , &
                  du       = rublten_p   , dv       = rvblten_p   , dth      = rthblten_p , &
                  dqv      = rqvblten_p  , dqc      = rqcblten_p  , dqi      = rqiblten_p , &
-                 dqni     = rniblten_p  , flag_qc  = f_qc        , flag_qnc = f_qnc      , &
-                 flag_qi  = f_qi        , flag_qni = f_qni       , kpbl     = kpbl_p     , &
+                 dqni     = rniblten_p  , flag_qc  = f_qc        , flag_qnc = f_nc       , &
+                 flag_qi  = f_qi        , flag_qni = f_ni        , kpbl     = kpbl_p     , &
                  pblh     = hpbl_p      , xland    = xland_p     , ts       = tsk_p      , &
                  hfx      = hfx_p       , qfx      = qfx_p       , ch       = ch_p       , &
                  sh3d     = sh3d_p      , tsq      = tsq_p       , qsq      = qsq_p      , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -91,7 +91,9 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-10.
 ! * since we removed the local variable radt_lw_scheme from mpas_atmphys_vars.F, now defines radt_lw_scheme
 !   as a pointer to config_radt_lw_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * removed the variables f_qv and f_qg in the call to subroutine camrad.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
 
 
  contains
@@ -912,10 +914,9 @@
                 rho_phy       = rho_p         , qv3d          = qv_p          ,              & 
                 qc3d          = qc_p          , qr3d          = qr_p          ,              &
                 qi3d          = qi_p          , qs3d          = qs_p          ,              &
-                qg3d          = qg_p          , f_qv          = f_qv          ,              &
-                f_qc          = f_qc          , f_qr          = f_qr          ,              &
-                f_qi          = f_qi          , f_qs          = f_qs          ,              &
-                f_qg          = f_qg          , f_ice_phy     = f_ice         ,              &
+                qg3d          = qg_p          , f_qc          = f_qc          ,              &
+                f_qr          = f_qr          , f_qi          = f_qi          ,              &
+                f_qs          = f_qs          , f_ice_phy     = f_ice         ,              &
                 f_rain_phy    = f_rain        , cldfra        = cldfrac_p     ,              &
                 xland         = xland_p       , xice          = xice_p        ,              &
                 num_months    = num_months    , levsiz        = num_oznlevels ,              & 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -85,6 +85,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
 ! * added the variables swddir,swddni,swddif for use in the updated version of the Noah LSM.
 !   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
+! * removed the variables f_qv and f_qg in the call to subroutine camrad.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
 
 
  contains
@@ -821,10 +823,9 @@
                 rho_phy       = rho_p         , qv3d          = qv_p          ,              & 
                 qc3d          = qc_p          , qr3d          = qr_p          ,              &
                 qi3d          = qi_p          , qs3d          = qs_p          ,              &
-                qg3d          = qg_p          , f_qv          = f_qv          ,              &
-                f_qc          = f_qc          , f_qr          = f_qr          ,              &
-                f_qi          = f_qi          , f_qs          = f_qs          ,              &
-                f_qg          = f_qg          , f_ice_phy     = f_ice         ,              &
+                qg3d          = qg_p          , f_qc          = f_qc          ,              &
+                f_qr          = f_qr          , f_qi          = f_qi          ,              &
+                f_qs          = f_qs          , f_ice_phy     = f_ice         ,              &
                 f_rain_phy    = f_rain        , cldfra        = cldfrac_p     ,              &
                 xland         = xland_p       , xice          = xice_p        ,              &
                 num_months    = num_months    , levsiz        = num_oznlevels ,              & 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -17,6 +17,7 @@
  use mpas_atmphys_driver_radiation_lw, only: init_radiation_lw
  use mpas_atmphys_driver_radiation_sw, only: init_radiation_sw
  use mpas_atmphys_driver_sfclayer
+ use mpas_atmphys_vars,only: f_qc,f_qr,f_qi,f_qs,f_qg,f_nc,f_ni
 
  use mpas_atmphys_landuse
  use mpas_atmphys_o3climatology
@@ -64,6 +65,8 @@
 ! * removed the calculation of the variable dcEdge_m which is no longer needed in the different physics
 !   parameterizations.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-18.
+! * added the subroutine init_physics_flags to initialize f_qc,f_qr,f_qi,f_qs,f_qg,f_nc,and f_ni.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-14.
 
 
  contains
@@ -213,6 +216,9 @@
 !initialization of east-north directions to convert u-tendencies from cell centers to cell
 !edges:
  call init_dirs_forphys(mesh)
+
+!initialization of logical flags for cloud mixing ratios:
+ call init_physics_flags(state,f_qc,f_qr,f_qi,f_qs,f_qg,f_nc,f_ni)
 
 !initialization of counters i_rainc and i_rainnc. i_rainc and i_rainnc track the number of
 !times the accumulated convective (rainc) and grid-scale (rainnc) rain exceed the prescribed
@@ -396,6 +402,51 @@
 ! call mpas_log_write('')
 
  end subroutine physics_init
+
+!=================================================================================================================
+ subroutine init_physics_flags(state,f_qc,f_qr,f_qi,f_qs,f_qg,f_nc,f_ni)
+!=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: state
+
+!output arguments:
+ logical,intent(out):: f_qc,f_qr,f_qi,f_qs,f_qg
+ logical,intent(out):: f_nc,f_ni
+
+!local pointers:
+ integer,pointer:: index_qc,index_qr,index_qi,index_qs,index_qg
+ integer,pointer:: index_ni
+
+!-----------------------------------------------------------------------------------------------------------------
+
+!initializes the logicals assigned to mixing ratios:
+ f_qc = .false.
+ f_qr = .false.
+ f_qi = .false.
+ f_qs = .false.
+ f_qg = .false.
+ call mpas_pool_get_dimension(state,'index_qc',index_qc)
+ call mpas_pool_get_dimension(state,'index_qr',index_qr)
+ call mpas_pool_get_dimension(state,'index_qi',index_qi)
+ call mpas_pool_get_dimension(state,'index_qs',index_qs)
+ call mpas_pool_get_dimension(state,'index_qg',index_qg)
+
+ if(index_qc .gt. -1) f_qc = .true.
+ if(index_qr .gt. -1) f_qr = .true.
+ if(index_qi .gt. -1) f_qi = .true.
+ if(index_qs .gt. -1) f_qs = .true.
+ if(index_qg .gt. -1) f_qg = .true.
+
+!initializes the logical assigned to number concentrations: note that for now, the number concentration of cloud
+!water droplets (nc) is not defined in Registry.xml. therefore f_nc is set to false by default.
+ f_nc = .false.
+ f_ni = .false.
+ call mpas_pool_get_dimension(state,'index_ni',index_ni)
+
+ if(index_ni .gt. -1) f_ni = .true.
+
+ end subroutine init_physics_flags
 
 !=================================================================================================================
  subroutine init_dirs_forphys(mesh)

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -37,7 +37,7 @@
  character(len=StrKIND),pointer:: config_convection_scheme
  character(len=StrKIND),pointer:: config_pbl_scheme
  logical,pointer:: mp_kessler_in,mp_thompson_in,mp_wsm6_in
- logical,pointer:: cu_grell_freitas_in,cu_kain_fritsch_in,cu_tiedtke_in
+ logical,pointer:: cu_grell_freitas_in,cu_kain_fritsch_in,cu_ntiedtke_in
  logical,pointer:: bl_mynn_in,bl_ysu_in
 
  integer :: ierr
@@ -100,12 +100,12 @@
  nullify(cu_kain_fritsch_in)
  call mpas_pool_get_package(packages,'cu_kain_fritsch_inActive',cu_kain_fritsch_in)
 
- nullify(cu_tiedtke_in)
- call mpas_pool_get_package(packages,'cu_tiedtke_inActive',cu_tiedtke_in)
+ nullify(cu_ntiedtke_in)
+ call mpas_pool_get_package(packages,'cu_ntiedtke_inActive',cu_ntiedtke_in)
 
  if(.not.associated(cu_grell_freitas_in) .or. &
     .not.associated(cu_kain_fritsch_in)  .or. &
-    .not.associated(cu_tiedtke_in)     ) then
+    .not.associated(cu_ntiedtke_in)    ) then
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
     call mpas_log_write('* Error while setting up packages for convection options in atmosphere core.',        messageType=MPAS_LOG_ERR)
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
@@ -115,7 +115,7 @@
 
  cu_grell_freitas_in = .false.
  cu_kain_fritsch_in  = .false.
- cu_tiedtke_in       = .false.
+ cu_ntiedtke_in      = .false.
 
  if(config_convection_scheme=='cu_grell_freitas') then
     cu_grell_freitas_in = .true.
@@ -123,12 +123,12 @@
     cu_kain_fritsch_in = .true.
  elseif(config_convection_scheme == 'cu_tiedtke' .or. &
         config_convection_scheme == 'cu_ntiedtke') then
-    cu_tiedtke_in = .true.
+    cu_ntiedtke_in = .true.
  endif
 
  call mpas_log_write('    cu_grell_freitas_in     = $l', logicArgs=(/cu_grell_freitas_in/))
  call mpas_log_write('    cu_kain_fritsch_in      = $l', logicArgs=(/cu_kain_fritsch_in/))
- call mpas_log_write('    cu_tiedtke_in           = $l', logicArgs=(/cu_tiedtke_in/))
+ call mpas_log_write('    cu_ntiedtke_in          = $l', logicArgs=(/cu_ntiedtke_in/))
 
 !--- initialization of all packages for parameterizations of surface layer and planetary boundary layer:
 

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -41,7 +41,7 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2014-09-18.
 ! * renamed "tiedtke" with "cu_tiedtke".
 !   Laura D. Fowler (laura@ucar.edu) / 2016-03-22.
-! * modified the sourcecode to accomodate the packages "cu_kain_fritsch_in" and "cu_tiedtke_in".
+! * modified the sourcecode to accomodate the packages "cu_kain_fritsch_in" and "cu_ntiedtke_in".
 !   Laura D. Fowler (laura@ucar.edu) / 2016-03-24.
 ! * added the option bl_mynn for the calculation of the tendency for the cloud ice number concentration.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-04-11.

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -122,6 +122,8 @@
 ! * added the local variables swddir,swddni,and swddif which are output to subroutine rrtmg_swrad and now input
 !   to the updated module_sf_noahdrv.F.
 !   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
+! * removed the variable f_qv which is not used in any of the ./physics_wrf modules.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
 
 
 !=================================================================================================================
@@ -229,7 +231,7 @@
 !          that the ice phase is included (except for the Kessler scheme which includes water
 !          clouds only.
 
-!    f_qv,f_qc,f_qr,f_qi,f_qs,f_qg: These logicals were initially defined in WRF to determine
+!    f_qc,f_qr,f_qi,f_qs,f_qg: These logicals were initially defined in WRF to determine
 !          which kind of hydrometeors are present. Here, we assume that all six water species
 !          are present, even if their mixing ratios and number concentrations are zero.
 
@@ -239,7 +241,6 @@
     warm_rain=.false.  !warm-phase cloud microphysics only (used in WRF).
 
  logical,parameter:: &
-    f_qv = .true.,    &!
     f_qc = .true.,    &!
     f_qr = .true.,    &!
     f_qi = .true.,    &!

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -124,6 +124,10 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
 ! * removed the variable f_qv which is not used in any of the ./physics_wrf modules.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
+! * removed the definition of f_qc,f_qr,f_qi,f_qs,f_qg,f_nc,and f_ni as parameters. these variables are now
+!   initialized in mpas_atmphys_init.F (see subroutine init_physics_flags). also renamed f_qnc to f_nc, and f_qni
+!   to f_ni.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-02-14.
 
 
 !=================================================================================================================
@@ -231,25 +235,21 @@
 !          that the ice phase is included (except for the Kessler scheme which includes water
 !          clouds only.
 
-!    f_qc,f_qr,f_qi,f_qs,f_qg: These logicals were initially defined in WRF to determine
-!          which kind of hydrometeors are present. Here, we assume that all six water species
-!          are present, even if their mixing ratios and number concentrations are zero.
-
 !=================================================================================================================
 
  logical,parameter:: &
     warm_rain=.false.  !warm-phase cloud microphysics only (used in WRF).
 
- logical,parameter:: &
-    f_qc = .true.,    &!
-    f_qr = .true.,    &!
-    f_qi = .true.,    &!
-    f_qs = .true.,    &!
-    f_qg = .true.      !
+ logical:: &
+    f_qc,             &!parameter set to true to include the cloud water mixing ratio.
+    f_qr,             &!parameter set to true to include the rain mixing ratio.
+    f_qi,             &!parameter set to true to include the cloud ice mixing ratio.
+    f_qs,             &!parameter set to true to include the snow minxg ratio.
+    f_qg               !parameter set to true to include the graupel mixing ratio.
 
- logical,parameter:: &
-    f_qnc = .true.,   &!
-    f_qni = .true.     !
+ logical:: &
+    f_nc,             &!parameter set to true to include the cloud water droplet number concentration.
+    f_ni               !parameter set to true to include the cloud ice crystal number concentration.
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     f_ice,            &!fraction of cloud ice (used in WRF only).

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_kfeta.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_kfeta.F
@@ -28,7 +28,7 @@ CONTAINS
              ,STEPCU,CU_ACT_FLAG,warm_rain,CUTOP,CUBOT               &
              ,QV                                                     &
             ! optionals
-             ,F_QV    ,F_QC    ,F_QR    ,F_QI    ,F_QS               &
+             ,F_QR    ,F_QI    ,F_QS                                 &
              ,RTHCUTEN,RQVCUTEN,RQCCUTEN,RQRCUTEN                    &
              ,RQICUTEN,RQSCUTEN                                      &
                                                              )
@@ -45,7 +45,7 @@ CONTAINS
              ,STEPCU,CU_ACT_FLAG,warm_rain,CUTOP,CUBOT       &
              ,QV                                             &
             ! optionals
-             ,F_QV    ,F_QC    ,F_QR    ,F_QI    ,F_QS       &
+             ,F_QR    ,F_QI    ,F_QS                         &
              ,RTHCUTEN,RQVCUTEN,RQCCUTEN,RQRCUTEN            &
              ,RQICUTEN,RQSCUTEN                              &
                                                              )
@@ -138,9 +138,7 @@ CONTAINS
 ! use or not.
 !
    LOGICAL, OPTIONAL ::                                      &
-                                                   F_QV      &
-                                                  ,F_QC      &
-                                                  ,F_QR      &
+                                                   F_QR      &
                                                   ,F_QI      &
                                                   ,F_QS
 

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_ntiedtke.F
@@ -24,7 +24,7 @@
                 ,u3d,v3d,w,t3d,qv3d,qc3d,qi3d,pi3d,rho3d &
                 ,qvften,thften                           &
                 ,dz8w,pcps,p8w,xland,cu_act_flag,dx      &
-                ,f_qv,f_qc,f_qr,f_qi,f_qs                &
+                ,f_qc,f_qi                               &
                 ,grav,xlf,xls,xlv,rd,rv,cp               &
                 ,rthcuten,rqvcuten,rqccuten,rqicuten     &
                 ,rucuten,rvcuten                         &
@@ -86,7 +86,7 @@
 !-----------------------------------------------------------------------------------------------------------------
 
 !--- input arguments:
- logical,intent(in),optional:: f_qv,f_qc,f_qr,f_qi,f_qs
+ logical,intent(in),optional:: f_qc,f_qi
 
  integer,intent(in):: ids,ide,jds,jde,kds,kde, &
                       ims,ime,jms,jme,kms,kme, &

--- a/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_cu_tiedtke.F
@@ -142,7 +142,7 @@ contains
                 ,its,ite, jts,jte, kts,kte                      &
                 ,rthcuten,rqvcuten,rqccuten,rqicuten            &
                 ,rucuten, rvcuten                               &
-                ,f_qv    ,f_qc    ,f_qr    ,f_qi    ,f_qs       &
+                ,f_qc ,f_qi                                     &
                                                                 )
 
 !-------------------------------------------------------------------
@@ -254,12 +254,9 @@ contains
 ! to determine at run-time whether a particular tracer is in
 ! use or not.
 !
-     logical, optional ::                                    &
-                                                   f_qv      &
-                                                  ,f_qc      &
-                                                  ,f_qr      &
-                                                  ,f_qi      &
-                                                  ,f_qs
+     logical, optional ::                               &
+                                        f_qc                            &
+                                       ,f_qi
  
 !--------------------------- local vars ------------------------------
 

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_cam.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_cam.F
@@ -204,7 +204,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,                           &
                      GSW,GLW,XLAT,XLONG,                           &
                      ALBEDO,t_phy,TSK,EMISS,                       &
                      QV3D,QC3D,QR3D,QI3D,QS3D,QG3D,                &
-                     F_QV,F_QC,F_QR,F_QI,F_QS,F_QG,                &
+                     F_QC,F_QR,F_QI,F_QS,                          &
                      f_ice_phy,f_rain_phy,                         &
                      p_phy,p8w,z,pi_phy,rho_phy,dz8w,               &
                      CLDFRA,XLAND,XICE,SNOW,                        &
@@ -233,7 +233,7 @@ subroutine camrad(RTHRATENLW,RTHRATENSW,                           &
    INTEGER,    INTENT(IN   ) ::        ids,ide, jds,jde, kds,kde, &
                                        ims,ime, jms,jme, kms,kme, &
                                        its,ite, jts,jte, kts,kte
-   LOGICAL,    INTENT(IN   ) ::        F_QV,F_QC,F_QR,F_QI,F_QS,F_QG
+   LOGICAL,    INTENT(IN   ) ::        F_QC,F_QR,F_QI,F_QS
    LOGICAL,    INTENT(INout) ::        doabsems
    LOGICAL,    INTENT(IN   ) ::        dolw,dosw
 


### PR DESCRIPTION
I revised the initialization of the flags f_qc, f_qi, f_qr, f_qs, f_qg, f_ni, and f_nc which control which cloud condensate mixing ratios (qc, qr, qi, qs, qg) and cloud number concentrations (nc, ni) are used in the physics parameterizations. Note that the flag f_qv was removed from all physics parameterizations because the mixing ratio qv is always needed.

In the original sourcecode, the flags were defined and set to true (or false) manually in mpas_atmphys_vars.F. In the updated sourcecode, the flags are now initialized in subroutine init_physics_flags in mpas_atmphys_init.F. Flags are set to true if the corresponding cloud condensates and number concentrations are actually allocated at run time.


