### PR TITLE
Enable the use of the more modern 'mpi_f08' module for MPI

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -39,8 +39,11 @@ module mpas_subdriver
    contains
 
 
-   subroutine mpas_init(corelist, domain_ptr, mpi_comm, namelistFileParam, streamsFileParam)
+   subroutine mpas_init(corelist, domain_ptr, external_comm, namelistFileParam, streamsFileParam)
 
+#ifdef MPAS_USE_MPI_F08
+      use mpi_f08, only : MPI_Comm
+#endif
       use mpas_stream_manager, only : MPAS_stream_mgr_init, MPAS_build_stream_filename, MPAS_stream_mgr_validate_streams
       use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
       use mpas_c_interfacing, only : mpas_f_to_c_string, mpas_c_to_f_string
@@ -53,7 +56,11 @@ module mpas_subdriver
 
       type (core_type), intent(inout), pointer :: corelist
       type (domain_type), intent(inout), pointer :: domain_ptr
-      integer, intent(in), optional :: mpi_comm
+#ifdef MPAS_USE_MPI_F08
+      type (MPI_Comm), intent(in), optional :: external_comm
+#else
+      integer, intent(in), optional :: external_comm
+#endif
       character(len=*), intent(in), optional :: namelistFileParam
       character(len=*), intent(in), optional :: streamsFileParam
 
@@ -192,7 +199,7 @@ module mpas_subdriver
       !
       ! Initialize infrastructure
       !
-      call mpas_framework_init_phase1(domain_ptr % dminfo, mpi_comm=mpi_comm)
+      call mpas_framework_init_phase1(domain_ptr % dminfo, external_comm=external_comm)
 
 
 #ifdef CORE_ATMOSPHERE
@@ -303,7 +310,11 @@ module mpas_subdriver
 
       call mpas_f_to_c_string(domain_ptr % streams_filename, c_filename)
       call mpas_f_to_c_string(mesh_stream, c_mesh_stream)
+#ifdef MPAS_USE_MPI_F08
+      c_comm = domain_ptr % dminfo % comm % mpi_val
+#else
       c_comm = domain_ptr % dminfo % comm
+#endif
       call xml_stream_get_attributes(c_filename, c_mesh_stream, c_comm, &
                                      c_mesh_filename_temp, c_ref_time_temp, &
                                      c_filename_interval_temp, c_iotype, c_ierr)

--- a/src/framework/mpas_abort.F
+++ b/src/framework/mpas_abort.F
@@ -29,10 +29,14 @@ module mpas_abort
       use mpas_kind_types, only : StrKIND
       use mpas_io_units, only : mpas_new_unit
       use mpas_threading, only : mpas_threading_get_thread_num
-   
+
 #ifdef _MPI
 #ifndef NOMPIMOD
+#ifdef MPAS_USE_MPI_F08
+      use mpi_f08
+#else
       use mpi
+#endif
 #endif
 #endif
    

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -38,6 +38,10 @@ module mpas_derived_types
    use smiolf, only : SMIOLf_context, SMIOLf_decomp, SMIOLf_file, SMIOL_offset_kind
 #endif
 
+#ifdef MPAS_USE_MPI_F08
+   use mpi_f08, only : MPI_Request, MPI_Comm, MPI_Info
+#endif
+
    use ESMF
 
 #include "mpas_attlist_types.inc"

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -31,7 +31,11 @@ module mpas_dmpar
 
 #ifdef _MPI
 #ifndef NOMPIMOD
+#ifdef MPAS_USE_MPI_F08
+   use mpi_f08
+#else
    use mpi
+#endif
 #endif
 #endif
 
@@ -42,15 +46,30 @@ module mpas_dmpar
 #ifdef NOMPIMOD
 include 'mpif.h'
 #endif
+#ifdef MPAS_USE_MPI_F08
+   type (MPI_Datatype), parameter :: MPI_INTEGERKIND = MPI_INTEGER
+   type (MPI_Datatype), parameter :: MPI_2INTEGERKIND = MPI_2INTEGER
+#else
    integer, parameter :: MPI_INTEGERKIND = MPI_INTEGER
    integer, parameter :: MPI_2INTEGERKIND = MPI_2INTEGER
+#endif
 
 #ifdef SINGLE_PRECISION
+#ifdef MPAS_USE_MPI_F08
+   type (MPI_Datatype), parameter :: MPI_REALKIND = MPI_REAL
+   type (MPI_Datatype), parameter :: MPI_2REALKIND = MPI_2REAL
+#else
    integer, parameter :: MPI_REALKIND = MPI_REAL
    integer, parameter :: MPI_2REALKIND = MPI_2REAL
+#endif
+#else
+#ifdef MPAS_USE_MPI_F08
+   type (MPI_Datatype), parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+   type (MPI_Datatype), parameter :: MPI_2REALKIND = MPI_2DOUBLE_PRECISION
 #else
    integer, parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
    integer, parameter :: MPI_2REALKIND = MPI_2DOUBLE_PRECISION
+#endif
 #endif
 #endif
 
@@ -232,12 +251,16 @@ include 'mpif.h'
 !>  It also setups of the domain information structure.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_dmpar_init(dminfo, mpi_comm)!{{{
+   subroutine mpas_dmpar_init(dminfo, external_comm)!{{{
 
       implicit none
 
       type (dm_info), intent(inout) :: dminfo !< Input/Output: Domain information
-      integer, intent(in), optional :: mpi_comm !< Input - Optional: externally-supplied MPI communicator
+#ifdef MPAS_USE_MPI_F08
+      type (MPI_Comm), intent(in), optional :: external_comm !< Input - Optional: externally-supplied MPI communicator
+#else
+      integer, intent(in), optional :: external_comm !< Input - Optional: externally-supplied MPI communicator
+#endif
 
 #ifdef _MPI
       integer :: mpi_rank, mpi_size
@@ -246,13 +269,13 @@ include 'mpif.h'
       integer :: desiredThreadLevel, threadLevel
 #endif
 
-      if ( present(mpi_comm) ) then
+      if ( present(external_comm) ) then
          dminfo % initialized_mpi = .false.
 #ifdef MPAS_OPENMP
          desiredThreadLevel = MPI_THREAD_FUNNELED
          call MPI_Query_thread(threadLevel, mpi_ierr)
 #endif
-         call MPI_Comm_dup(mpi_comm, dminfo % comm, mpi_ierr)
+         call MPI_Comm_dup(external_comm, dminfo % comm, mpi_ierr)
       else
          dminfo % initialized_mpi = .true.
 #ifdef MPAS_OPENMP
@@ -1540,7 +1563,12 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
       type (field0dInteger), pointer :: offsetCursor, ownedLimitCursor
       integer :: nOwnedBlocks, nNeededBlocks
       integer :: nOwnedList, nNeededList
-      integer :: mpi_ierr, mpi_rreq, mpi_sreq
+      integer :: mpi_ierr
+#ifdef MPAS_USE_MPI_F08
+      type (MPI_Request) :: mpi_rreq, mpi_sreq
+#else
+      integer :: mpi_rreq, mpi_sreq
+#endif
 
       type (hashtable) :: neededHash
       integer :: nUniqueNeededList, threadNum
@@ -10073,7 +10101,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             call mpas_log_write('         proc: $i', intArgs=(/commListPtr % procID/))
             call mpas_log_write('         size check: $i $i', intArgs=(/commListPtr % nlist, size( commListPtr % rbuffer )/))
             call mpas_log_write('         bufferOffset: $i', intArgs=(/commListPtr % bufferOffset/))
+#ifdef MPAS_USE_MPI_F08
+            call mpas_log_write('         reqId: $i', intArgs=(/commListPtr % reqId % mpi_val/))
+#else
             call mpas_log_write('         reqId: $i', intArgs=(/commListPtr % reqId/))
+#endif
             call mpas_log_write('         ibuffer assc: $l', logicArgs=(/ associated( commListPtr % ibuffer ) /) )
             call mpas_log_write('         rbuffer assc: $l', logicArgs=(/ associated( commListPtr % rbuffer ) /) )
             call mpas_log_write('         next assc: $l', logicArgs=(/ associated( commListPtr % next ) /) )
@@ -10092,7 +10124,11 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             call mpas_log_write('         proc: $i', intArgs=(/ commListPtr % procID /) )
             call mpas_log_write('         size check: $i $i', intArgs=(/ commListPtr % nlist, size( commListPtr % rbuffer ) /) )
             call mpas_log_write('         bufferOffset: $i', intArgs=(/ commListPtr % bufferOffset /) )
+#ifdef MPAS_USE_MPI_F08
+            call mpas_log_write('         reqId: $i', intArgs=(/ commListPtr % reqId % mpi_val /) )
+#else
             call mpas_log_write('         reqId: $i', intArgs=(/ commListPtr % reqId /) )
+#endif
             call mpas_log_write('         ibuffer assc: $l', logicArgs=(/ associated( commListPtr % ibuffer ) /) )
             call mpas_log_write('         rbuffer assc: $l', logicArgs=(/ associated( commListPtr % rbuffer ) /) )
             call mpas_log_write('         next assc: $l', logicArgs=(/ associated( commListPtr % next ) /) )

--- a/src/framework/mpas_dmpar_types.inc
+++ b/src/framework/mpas_dmpar_types.inc
@@ -7,7 +7,14 @@
    integer, parameter :: MPAS_DMPAR_BUFFER_EXISTS = 6
 
    type dm_info
-     integer :: nprocs, my_proc_id, comm, info
+#ifdef MPAS_USE_MPI_F08
+     type (MPI_Comm) :: comm
+     type (MPI_Info) :: info
+#else
+     integer :: comm
+     integer :: info
+#endif
+     integer :: nprocs, my_proc_id
      logical :: initialized_mpi
 
      ! Add variables specific to block decomposition. {{{
@@ -47,7 +54,11 @@
      integer :: bufferOffset
      real (kind=RKIND), dimension(:), pointer :: rbuffer => null()
      integer, dimension(:), pointer :: ibuffer => null()
+#ifdef MPAS_USE_MPI_F08
+     type (MPI_Request) :: reqID
+#else
      integer :: reqID
+#endif
      type (mpas_communication_list), pointer :: next => null()
      integer :: commListSize
      logical :: received

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -42,15 +42,23 @@ module mpas_framework
 !>  MPI, the log unit numbers.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_framework_init_phase1(dminfo, mpi_comm)!{{{
+   subroutine mpas_framework_init_phase1(dminfo, external_comm)!{{{
+
+#ifdef MPAS_USE_MPI_F08
+      use mpi_f08, only : MPI_Comm
+#endif
 
       implicit none
 
       type (dm_info), pointer :: dminfo
-      integer, intent(in), optional :: mpi_comm
+#ifdef MPAS_USE_MPI_F08
+      type (MPI_Comm), intent(in), optional :: external_comm
+#else
+      integer, intent(in), optional :: external_comm
+#endif
 
       allocate(dminfo)
-      call mpas_dmpar_init(dminfo, mpi_comm)
+      call mpas_dmpar_init(dminfo, external_comm)
 
    end subroutine mpas_framework_init_phase1!}}}
 

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -485,16 +485,28 @@ module mpas_halo
     !-----------------------------------------------------------------------
     subroutine mpas_halo_exch_group_full_halo_exch(domain, groupName, iErr)
 
+#ifdef MPAS_USE_MPI_F08
+        use mpi_f08
+#else
         use mpi
+#endif
         use mpas_derived_types, only : domain_type, mpas_halo_group, MPAS_HALO_REAL, MPAS_LOG_CRIT
         use mpas_pool_routines, only : mpas_pool_get_array
         use mpas_log, only : mpas_log_write
 
         ! Parameters
+#ifdef MPAS_USE_MPI_F08
+#ifdef SINGLE_PRECISION
+        type (MPI_Datatype), parameter :: MPI_REALKIND = MPI_REAL
+#else
+        type (MPI_Datatype), parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+#endif
+#else
 #ifdef SINGLE_PRECISION
         integer, parameter :: MPI_REALKIND = MPI_REAL
 #else
         integer, parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+#endif
 #endif
 
         ! Arguments
@@ -508,7 +520,12 @@ module mpas_halo
         integer :: i1, i2, j, iNeighbor, iReq
         integer :: iHalo, iEndp
         integer :: nHalos, nSendEndpts, nRecvEndpts
-        integer :: rank, comm
+        integer :: rank
+#ifdef MPAS_USE_MPI_F08
+        type (MPI_Comm) :: comm
+#else
+        integer :: comm
+#endif
         integer :: mpi_ierr
         type (mpas_halo_group), pointer :: group
         integer, dimension(:), pointer :: compactHaloInfo
@@ -550,7 +567,11 @@ module mpas_halo
         ! the group; all fields should be using the same communicator, so this should not
         ! be problematic
         !
+#ifdef MPAS_USE_MPI_F08
+        comm % mpi_val = group % fields(1) % compactHaloInfo(7)
+#else
         comm = group % fields(1) % compactHaloInfo(7)
+#endif
         rank = group % fields(1) % compactHaloInfo(8)
 
 
@@ -992,7 +1013,11 @@ module mpas_halo
         ! 7-8: Add MPI info
         !
         idx = 7
+#ifdef MPAS_USE_MPI_F08
+        compactHaloInfo(idx) = domain % dminfo % comm % mpi_val
+#else
         compactHaloInfo(idx) = domain % dminfo % comm
+#endif
         idx = idx + 1
         compactHaloInfo(idx) = domain % dminfo % my_proc_id
         idx = idx + 1

--- a/src/framework/mpas_halo_types.inc
+++ b/src/framework/mpas_halo_types.inc
@@ -47,7 +47,11 @@
         integer :: nGroupSendNeighbors = MPAS_HALO_INVALID                ! Number of unique neighbors that we send to
         integer :: groupSendBufSize = MPAS_HALO_INVALID                   ! Total number of elements to be sent in a group exchange
         real (kind=RKIND), dimension(:), pointer :: sendBuf => null()     ! Segmented buffer used for outgoing messages
-        integer, dimension(:), pointer :: sendRequests => null()          ! Used internally - MPI request IDs
+#ifdef MPAS_USE_MPI_F08
+        type (MPI_Request), dimension(:), pointer :: sendRequests => null() ! Used internally - MPI request IDs
+#else
+        integer, dimension(:), pointer :: sendRequests => null() ! Used internally - MPI request IDs
+#endif
         integer, dimension(:,:), pointer :: groupPackOffsets => null()    ! Offsets into sendBuf for each neighbor and each field
                                                                           !     dimensioned (nGroupSendNeighbors, nFields)
         integer, dimension(:), pointer :: groupSendNeighbors => null()    ! List of neighbors we send to
@@ -60,7 +64,11 @@
         integer :: nGroupRecvNeighbors = MPAS_HALO_INVALID                ! Number of unique neighbors that we recv from
         integer :: groupRecvBufSize = MPAS_HALO_INVALID                   ! Total number of elements to be recvd in a group exchange
         real (kind=RKIND), dimension(:), pointer :: recvBuf => null()     ! Segmented buffer used for incoming messages
-        integer, dimension(:), pointer :: recvRequests => null()          ! Used internally - MPI request IDs
+#ifdef MPAS_USE_MPI_F08
+        type (MPI_Request), dimension(:), pointer :: recvRequests => null() ! Used internally - MPI request IDs
+#else
+        integer, dimension(:), pointer :: recvRequests => null() ! Used internally - MPI request IDs
+#endif
         integer, dimension(:,:), pointer :: groupUnpackOffsets => null()  ! Offsets into recvBuf for each neighbor and each field
                                                                           !     dimensioned (nGroupRecvNeighbors, nFields)
         integer, dimension(:), pointer :: groupRecvNeighbors => null()    ! List of neighbors we recv from

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -193,7 +193,11 @@ module mpas_io
 #ifdef MPAS_PIO_SUPPORT
          allocate(ioContext % pio_iosystem)
          call PIO_init(ioContext % dminfo % my_proc_id, &  ! comp_rank
+#ifdef MPAS_USE_MPI_F08
+                       ioContext % dminfo % comm % mpi_val, &  ! comp_comm
+#else
                        ioContext % dminfo % comm,       &  ! comp_comm
+#endif
                        io_task_count,             &     ! num_iotasks
                        0,                         &     ! num_aggregator
                        io_task_stride,            &     ! stride
@@ -203,7 +207,11 @@ module mpas_io
 
 #ifdef MPAS_SMIOL_SUPPORT
          allocate(ioContext % smiol_context)
+#ifdef MPAS_USE_MPI_F08
+         local_ierr = SMIOLf_init(ioContext % dminfo % comm % mpi_val, &
+#else
          local_ierr = SMIOLf_init(ioContext % dminfo % comm, &
+#endif
                                   io_task_count, &
                                   io_task_stride, &
                                   iocontext % smiol_context)

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -808,7 +808,11 @@ module mpas_log
 
 #ifdef _MPI
 #ifndef NOMPIMOD
+#ifdef MPAS_USE_MPI_F08
+      use mpi_f08
+#else
       use mpi
+#endif
 #endif
 #endif
 

--- a/src/framework/mpas_stream_inquiry.F
+++ b/src/framework/mpas_stream_inquiry.F
@@ -90,18 +90,25 @@ contains
     !>  be made with the query() method.
     !
     !-----------------------------------------------------------------------
-    function streaminfo_init(this, mpi_comm, stream_filename) result(ierr)
+    function streaminfo_init(this, comm, stream_filename) result(ierr)
 
         use mpas_derived_types, only : MPAS_streamInfo_type
         use mpas_log, only : mpas_log_write
         use mpas_c_interfacing, only : mpas_f_to_c_string
         use iso_c_binding, only : c_char, c_associated
+#ifdef MPAS_USE_MPI_F08
+        use mpi_f08, only : MPI_Comm
+#endif
 
         implicit none
 
         ! Arguments
         class (MPAS_streamInfo_type) :: this
-        integer, intent(in) :: mpi_comm
+#ifdef MPAS_USE_MPI_F08
+        type (MPI_Comm), intent(in) :: comm
+#else
+        integer, intent(in) :: comm
+#endif
         character(len=*), intent(in) :: stream_filename
 
         ! Return value
@@ -111,9 +118,9 @@ contains
         character(kind=c_char), dimension(len(stream_filename)+1) :: c_stream_filename
 
         interface
-            function parse_streams_file(mpi_comm, filename) bind(C, name='parse_streams_file') result(xmltree)
+            function parse_streams_file(comm, filename) bind(C, name='parse_streams_file') result(xmltree)
                 use iso_c_binding, only : c_char, c_ptr
-                integer, intent(in), value :: mpi_comm
+                integer, intent(in), value :: comm
                 character(kind=c_char), dimension(*), intent(in) :: filename
                 type(c_ptr) :: xmltree
             end function parse_streams_file
@@ -124,7 +131,11 @@ contains
 
         call mpas_f_to_c_string(stream_filename, c_stream_filename)
         call mpas_log_write('Initializing MPAS_streamInfo from file '//trim(stream_filename))
-        this % xmltree = parse_streams_file(mpi_comm, c_stream_filename)
+#ifdef MPAS_USE_MPI_F08
+        this % xmltree = parse_streams_file(comm % mpi_val, c_stream_filename)
+#else
+        this % xmltree = parse_streams_file(comm, c_stream_filename)
+#endif
 
         if (.not. c_associated(this % xmltree)) then
             ierr = 1

--- a/src/framework/mpas_stream_inquiry_types.inc
+++ b/src/framework/mpas_stream_inquiry_types.inc
@@ -7,10 +7,17 @@
    end type MPAS_streamInfo_type
 
    abstract interface
-      function streaminfo_init_function(this, mpi_comm, stream_filename) result(ierr)
+      function streaminfo_init_function(this, comm, stream_filename) result(ierr)
+#ifdef MPAS_USE_MPI_F08
+         use mpi_f08, only : MPI_Comm
+#endif
          import MPAS_streamInfo_type
          class (MPAS_streamInfo_type) :: this
-         integer, intent(in) :: mpi_comm
+#ifdef MPAS_USE_MPI_F08
+         type (MPI_Comm), intent(in) :: comm
+#else
+         integer, intent(in) :: comm
+#endif
          character(len=*), intent(in) :: stream_filename
          integer :: ierr
       end function streaminfo_init_function


### PR DESCRIPTION
This PR enables MPAS to make use of the more modern `mpi_f08` module introduced in MPI-3.0.

The top-level `Makefile` now tries to compile a test program that uses `mpi_f08`, and if that test is
successful, the macro `MPAS_USE_MPI_F08` is defined in the `CPPFLAGS` used in the build; otherwise,
MPAS will make use of the `mpi` module as it previously did.

With the use of the `mpi_f08` module, certain MPI types are no longer integers in Fortran, but are derived
types; e.g., `MPI_Comm`, `MPI_Request`, `MPI_Datatype`, and `MPI_Info`. However, in some instances,
an integer-typed MPI type is still needed for interoperability, and the MPI standard permits this to be done
through the `mpi_val` member of all MPI derived types, e.g., `MPI_Comm % mpi_val`.