### PR TITLE
updated the use of mpas_atmphys_lsm_shared.F

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -36,6 +36,7 @@ OBJS = \
 	mpas_atmphys_interface.o           \
 	mpas_atmphys_landuse.o             \
 	mpas_atmphys_lsm_noahinit.o        \
+	mpas_atmphys_lsm_shared.o          \
 	mpas_atmphys_manager.o             \
 	mpas_atmphys_o3climatology.o       \
 	mpas_atmphys_packages.o            \
@@ -104,6 +105,7 @@ mpas_atmphys_driver_lsm.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_landuse.o \
 	mpas_atmphys_lsm_noahinit.o \
+	mpas_atmphys_lsm_shared.o \
 	mpas_atmphys_vars.o
 
 mpas_atmphys_driver_microphysics.o: \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -14,6 +14,7 @@
  use mpas_atmphys_constants
  use mpas_atmphys_landuse, only: isurban
  use mpas_atmphys_lsm_noahinit
+ use mpas_atmphys_lsm_shared,only: correct_tsk_over_seaice
  use mpas_atmphys_vars
 
 !wrf physics
@@ -911,44 +912,6 @@
 !call mpas_log_write('--- end subroutine driver_lsm.')
 
  end subroutine driver_lsm
-
-!=================================================================================================================
- subroutine correct_tsk_over_seaice(ims,ime,jms,jme,its,ite,jts,jte,xice_thresh,xice,tsk,tsk_sea,tsk_ice)
-!=================================================================================================================
-
-!input arguments:
- integer,intent(in):: ims,ime,its,ite,jms,jme,jts,jte
- real(kind=RKIND),intent(in):: xice_thresh
- real(kind=RKIND),intent(in),dimension(ims:ime,jms:jme):: tsk,xice
-
-!inout arguments:
- real(kind=RKIND),intent(inout),dimension(ims:ime,jms:jme):: tsk_sea,tsk_ice
-
-!local variables:
- integer:: i,j
-
-!-----------------------------------------------------------------------------------------------------------------
-
-!initialize the local sea-surface temperature and local sea-ice temperature to the local surface
-!temperature:
- do j = jts,jte
- do i = its,ite
-    tsk_sea(i,j) = tsk(i,j)
-    tsk_ice(i,j) = tsk(i,j)
-
-    if(xice(i,j).ge.xice_thresh .and. xice(i,j).le.1._RKIND) then
-       !over sea-ice grid cells, limit sea-surface temperatures to temperatures warmer than 271.4:
-       tsk_sea(i,j) = max(tsk_sea(i,j),271.4_RKIND)
-
-       !over sea-ice grid cells, avoids unphysically too cold sea-ice temperatures for grid cells
-       !with small sea-ice fractions:
-       if(xice(i,j).lt.0.2_RKIND .and. tsk_ice(i,j).lt.253.15_RKIND) tsk_ice(i,j) = 253.15_RKIND
-       if(xice(i,j).lt.0.1_RKIND .and. tsk_ice(i,j).lt.263.15_RKIND) tsk_ice(i,j) = 263.15_RKIND
-    endif
- enddo
- enddo
-
- end subroutine correct_tsk_over_seaice
 
 !=================================================================================================================
  end module mpas_atmphys_driver_lsm

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_shared.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_shared.F
@@ -6,7 +6,7 @@
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
 !=================================================================================================================
- module mpas_atmphys_driver_lsm_shared
+ module mpas_atmphys_lsm_shared
  use mpas_kind_types
 
 
@@ -57,7 +57,7 @@
  end subroutine correct_tsk_over_seaice
 
 !=================================================================================================================
- end module mpas_atmphys_driver_lsm_shared
+ end module mpas_atmphys_lsm_shared
 !=================================================================================================================
 
 


### PR DESCRIPTION
In the release v8.0, we added mpas_atmphys_driver_lsm.F in ./src/core_atmosphere/physics, but this file as actually not used. In this PR, we modified the LSM driver to call subroutine correct_tsk_over_seaice using that module instead.

