### PR TITLE
Generalize mpas_sphere_angle function to work for non-unit-radius spheres

### DIFF
--- a/src/operators/mpas_geometry_utils.F
+++ b/src/operators/mpas_geometry_utils.F
@@ -42,9 +42,10 @@ module mpas_geometry_utils
       real (kind=RKIND) :: s                ! Semiperimeter of the triangle
       real (kind=RKIND) :: sin_angle
 
-      a = acos(max(min(bx*cx + by*cy + bz*cz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (3)
-      b = acos(max(min(ax*cx + ay*cy + az*cz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (2)
-      c = acos(max(min(ax*bx + ay*by + az*bz,1.0_RKIND),-1.0_RKIND))      ! Eqn. (1)
+
+      a = mpas_arc_length(bx, by, bz, cx, cy, cz)
+      b = mpas_arc_length(ax, ay, az, cx, cy, cz)
+      c = mpas_arc_length(ax, ay, az, bx, by, bz)
 
       ABx = bx - ax
       ABy = by - ay


### PR DESCRIPTION
This PR generalizes the `mpas_sphere_angle` function so that provides correct results for non-unit-radius spheres.

The methods previously employed in the `mpas_sphere_angle` function for computing the side lengths of a spherical triangle were only applicable to unit-radius spheres. This PR generalizes the computation of these side lengths so that the `mpas_sphere_angle` function can be used to compute spherical angles on spheres of arbitrary radius.
