### PR TITLE
bug fix for the Thompson parameterization of the cloud fraction

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_cloudiness.F
@@ -51,7 +51,10 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2016-07-05.
 ! * since we removed the local variable radt_cld_scheme from mpas_atmphys_vars.F, now defines radt_cld_scheme
 !   as a pointer to config_radt_cld_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2917-02-16.
+!   Laura D. Fowler (laura@ucar.edu) / 2017-02-16.
+! * this is a bug fix. dx_p is converted from meters to kilometers prior to calling the thompson parameterization
+!   of the cloud fraction.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-03-23.
 
 
  contains
@@ -119,6 +122,8 @@
  do j = jts,jte
     do i = its,ite
        dx_p(i,j)    = len_disp / meshDensity(i)**0.25
+       !conversion of dx_p from meters to kilometers.
+       dx_p(i,j)    = dx_p(i,j)*0.001
        xland_p(i,j) = xland(i)
     enddo
 


### PR DESCRIPTION
This PR is a bug fix when calling the Thompson parameterization of the cloud fraction. This bug was first brought to our attention by Brett Wilt back in February 2022 but never corrected in subsequent bug fix releases.

The input to the Thompson scheme is expecting the grid scale to be in units of km, but in mpas_atmphys_driver_cloudiness.F source, dx_p is in units of meters. The unit of dx_p has been corrected to be kilometers.
