### PR TITLE
Add `-std=f2008` to `FFLAGS_DEBUG` for the `gnu` build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ gnu:   # BUILDTARGET GNU Fortran, C, and C++ compilers
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -g -ffree-line-length-none -fconvert=big-endian -ffree-form -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"FFLAGS_DEBUG = -std=f2008 -g -ffree-line-length-none -fconvert=big-endian -ffree-form -fcheck=all -fbacktrace -ffpe-trap=invalid,zero,overflow" \
 	"CFLAGS_DEBUG = -g" \
 	"CXXFLAGS_DEBUG = -g" \
 	"LDFLAGS_DEBUG = -g" \


### PR DESCRIPTION
This PR adds the `-std=f2008` option to `FFLAGS_DEBUG` for the `gnu` build target.

For the `gnu` target, `FFLAGS_OPT` contained `-std=f2008` to check for Fortran 2008 conformance, but the debug build flags in `FFLAGS_DEBUG` lacked this option. This PR simply adds `-std=f2008` to `FFLAGS_DEBUG` so that both optimized and debug builds check that code conforms to the Fortran 2008 standard.