### PR TITLE
Introduce framework routine `mpas_framework_report_settings` for reporting compile-time options and run-time settings

### DIFF
--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -262,9 +262,7 @@ module atm_core_interface
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
-#ifdef MPAS_OPENMP
-      use mpas_threading, only : mpas_threading_get_num_threads
-#endif
+      use mpas_framework, only : mpas_framework_report_settings
 
       implicit none
 
@@ -293,53 +291,8 @@ module atm_core_interface
       call mpas_log_write('')
       call mpas_log_write('MPAS-Atmosphere Version '//trim(domain % core % modelVersion))
       call mpas_log_write('')
-      call mpas_log_write('')
-      call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
-      call mpas_log_write('')
-      call mpas_log_write('Compile-time options:')
-      call mpas_log_write('  Build target: '//trim(domain % core % build_target))
-      call mpas_log_write('  OpenMP support: ' // &
-#ifdef MPAS_OPENMP
-                          'yes')
-#else
-                          'no')
-#endif
-      call mpas_log_write('  OpenACC support: ' // &
-#ifdef MPAS_OPENACC
-                          'yes')
-#else
-                          'no')
-#endif
-      call mpas_log_write('  Default real precision: ' // &
-#ifdef SINGLE_PRECISION
-                          'single')
-#else
-                          'double')
-#endif
-      call mpas_log_write('  Compiler flags: ' // &
-#ifdef MPAS_DEBUG
-                          'debug')
-#else
-                          'optimize')
-#endif
-      call mpas_log_write('  I/O layer: ' // &
-#ifdef MPAS_PIO_SUPPORT
-#ifdef USE_PIO2
-                          'PIO 2.x')
-#else
-                          'PIO 1.x')
-#endif
-#else
-                          'SMIOL')
-#endif
-      call mpas_log_write('')
 
-      call mpas_log_write('Run-time settings:')
-      call mpas_log_write('  MPI task count: $i', intArgs=[domain % dminfo % nprocs])
-#ifdef MPAS_OPENMP
-      call mpas_log_write('  OpenMP max threads: $i', intArgs=[mpas_threading_get_max_threads()])
-#endif
-      call mpas_log_write('')
+      call mpas_framework_report_settings(domain)
 
    end function atm_setup_log!}}}
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -325,9 +325,7 @@ module init_atm_core_interface
 
       use mpas_derived_types, only : mpas_log_type, domain_type
       use mpas_log, only : mpas_log_init, mpas_log_open
-#ifdef MPAS_OPENMP
-      use mpas_threading, only : mpas_threading_get_num_threads
-#endif
+      use mpas_framework, only : mpas_framework_report_settings
 
       implicit none
 
@@ -356,53 +354,8 @@ module init_atm_core_interface
       call mpas_log_write('')
       call mpas_log_write('MPAS Init-Atmosphere Version '//trim(domain % core % modelVersion))
       call mpas_log_write('')
-      call mpas_log_write('')
-      call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
-      call mpas_log_write('')
-      call mpas_log_write('Compile-time options:')
-      call mpas_log_write('  Build target: '//trim(domain % core % build_target))
-      call mpas_log_write('  OpenMP support: ' // &
-#ifdef MPAS_OPENMP
-                          'yes')
-#else
-                          'no')
-#endif
-      call mpas_log_write('  OpenACC support: ' // &
-#ifdef MPAS_OPENACC
-                          'yes')
-#else
-                          'no')
-#endif
-      call mpas_log_write('  Default real precision: ' // &
-#ifdef SINGLE_PRECISION
-                          'single')
-#else
-                          'double')
-#endif
-      call mpas_log_write('  Compiler flags: ' // &
-#ifdef MPAS_DEBUG
-                          'debug')
-#else
-                          'optimize')
-#endif
-      call mpas_log_write('  I/O layer: ' // &
-#ifdef MPAS_PIO_SUPPORT
-#ifdef USE_PIO2
-                          'PIO 2.x')
-#else
-                          'PIO 1.x')
-#endif
-#else
-                          'SMIOL')
-#endif
-      call mpas_log_write('')
 
-      call mpas_log_write('Run-time settings:')
-      call mpas_log_write('  MPI task count: $i', intArgs=[domain % dminfo % nprocs])
-#ifdef MPAS_OPENMP
-      call mpas_log_write('  OpenMP max threads: $i', intArgs=[mpas_threading_get_max_threads()])
-#endif
-      call mpas_log_write('')
+      call mpas_framework_report_settings(domain)
 
    end function init_atm_setup_log!}}}
 

--- a/src/core_test/mpas_test_core_interface.F
+++ b/src/core_test/mpas_test_core_interface.F
@@ -227,6 +227,7 @@ module test_core_interface
 
       use mpas_derived_types
       use mpas_log
+      use mpas_framework, only : mpas_framework_report_settings
 
       implicit none
 
@@ -251,6 +252,8 @@ module test_core_interface
       ! After core has had a chance to modify log defaults, open the output log
       call mpas_log_open(err=local_err)
       iErr = ior(iErr, local_err)
+
+      call mpas_framework_report_settings(domain)
 
    end function test_setup_log!}}}
 

--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -184,4 +184,78 @@ module mpas_framework
 
    end subroutine mpas_framework_finalize!}}}
 
+
+!-----------------------------------------------------------------------
+!  routine mpas_framework_report_settings
+!
+!> \brief Report information about compile- and run-time settings to the log file
+!> \author Michael Duda
+!> \date 1 May 2024
+!> \details
+!>  This routine writes information about compile-time and run-time settings for
+!>  an MPAS core to the log file.
+!
+!-----------------------------------------------------------------------  
+   subroutine mpas_framework_report_settings(domain)
+
+#ifdef MPAS_OPENMP
+      use mpas_threading, only : mpas_threading_get_num_threads
+#endif
+  
+      implicit none
+
+      type (domain_type), pointer :: domain
+
+
+      call mpas_log_write('')
+      call mpas_log_write('Output from ''git describe --dirty'': '//trim(domain % core % git_version))
+
+      call mpas_log_write('')
+      call mpas_log_write('Compile-time options:')
+      call mpas_log_write('  Build target: '//trim(domain % core % build_target))
+      call mpas_log_write('  OpenMP support: ' // &
+#ifdef MPAS_OPENMP
+                          'yes')
+#else
+                          'no')
+#endif
+      call mpas_log_write('  OpenACC support: ' // &
+#ifdef MPAS_OPENACC
+                          'yes')
+#else
+                          'no')
+#endif
+      call mpas_log_write('  Default real precision: ' // &
+#ifdef SINGLE_PRECISION
+                          'single')
+#else
+                          'double')
+#endif
+      call mpas_log_write('  Compiler flags: ' // &
+#ifdef MPAS_DEBUG
+                          'debug')
+#else
+                          'optimize')
+#endif
+      call mpas_log_write('  I/O layer: ' // &
+#ifdef MPAS_PIO_SUPPORT
+#ifdef USE_PIO2
+                          'PIO 2.x')
+#else
+                          'PIO 1.x')
+#endif
+#else
+                          'SMIOL')
+#endif
+      call mpas_log_write('')
+
+      call mpas_log_write('Run-time settings:')
+      call mpas_log_write('  MPI task count: $i', intArgs=[domain % dminfo % nprocs])
+#ifdef MPAS_OPENMP
+      call mpas_log_write('  OpenMP max threads: $i', intArgs=[mpas_threading_get_max_threads()])
+#endif
+      call mpas_log_write('')
+
+   end subroutine mpas_framework_report_settings
+
 end module mpas_framework


### PR DESCRIPTION
This PR introduces a new framework routine, `mpas_framework_report_settings`, that reports compile-time options and run-time settings to the log file. For example, the following is written by the routine when MPAS is compiled with the `nvhpc` build target with `OPENACC=true`:
```
 Output from 'git describe --dirty': v8.1.0-dirty

 Compile-time options:
   Build target: nvhpc
   OpenMP support: no
   OpenACC support: yes
   Default real precision: single
   Compiler flags: optimize
   I/O layer: SMIOL

 Run-time settings:
   MPI task count: 4
```
The output is core-independent, and any core can therefore invoke the `mpas_framework_report_settings`, for example, in its `setup_log` routine.

As part of this PR, a call to `mpas_framework_report_settings` has been added to the test core's `test_setup_log` routine, and copy-and-paste code for writing the same compile-time option and run-time setting information in the init_atmosphere and atmosphere cores has been replaced with calls to `mpas_framework_report_settings`.