### PR TITLE
Include OpenACC device info in mpas_framework_report_settings output

### DIFF
--- a/src/framework/mpas_framework.F
+++ b/src/framework/mpas_framework.F
@@ -27,6 +27,8 @@ module mpas_framework
    use mpas_io_units
    use mpas_block_decomp
 
+   private :: report_acc_devices
+
 
    contains
 
@@ -256,6 +258,63 @@ module mpas_framework
 #endif
       call mpas_log_write('')
 
+#ifdef MPAS_OPENACC
+      call report_acc_devices()
+#endif
+
    end subroutine mpas_framework_report_settings
+
+
+#ifdef MPAS_OPENACC
+   !***********************************************************************
+   !
+   !  function report_acc_devices
+   !
+   !> \brief   Queries OpenACC devices and reports device info to log file
+   !> \author  Michael G. Duda
+   !> \date    28 March 2024
+   !> \details
+   !>  This routine makes use of the OpenACC runtime library to obtain
+   !>  information about how many and which kind of OpenACC devices are
+   !>  available to the current MPI rank.
+   !>
+   !>  NB: This routine is only compiled and only called if OPENACC=true.
+   !
+   !-----------------------------------------------------------------------
+   subroutine report_acc_devices()
+
+      use mpas_c_interfacing, only : mpas_sanitize_string
+      use openacc, only : acc_get_property_string, acc_get_property, acc_get_num_devices, acc_get_device_num, &
+                          acc_get_device_type, acc_device_kind, acc_device_property, acc_property_vendor, &
+                          acc_property_name, acc_property_driver
+
+      implicit none
+
+      integer(kind=acc_device_kind) :: device
+      character(len=StrKIND) :: device_vendor, device_name, driver_vers
+      integer :: ndevices, device_num
+
+
+      device = acc_get_device_type()
+      ndevices = acc_get_num_devices(device)
+      device_num = acc_get_device_num(device_num)
+      call acc_get_property_string(device_num, device, acc_property_vendor, device_vendor)
+      call acc_get_property_string(device_num, device, acc_property_name, device_name)
+      call acc_get_property_string(device_num, device, acc_property_driver, driver_vers)
+
+      call mpas_sanitize_string(device_vendor)
+      call mpas_sanitize_string(device_name)
+      call mpas_sanitize_string(driver_vers)
+
+      call mpas_log_write('OpenACC configuration:')
+      call mpas_log_write('  Number of visible devices: $i', intArgs=[ndevices])
+      call mpas_log_write('  Device # for this MPI task: $i', intArgs=[device_num])
+      call mpas_log_write('  Device vendor: '//trim(device_vendor))
+      call mpas_log_write('  Device name: '//trim(device_name))
+      call mpas_log_write('  Device driver version: '//trim(driver_vers))
+      call mpas_log_write('')
+
+   end subroutine report_acc_devices
+#endif
 
 end module mpas_framework


### PR DESCRIPTION
This PR introduces changes to include OpenACC device information in the log output from the `mpas_framework_report_settings` routine.

If MPAS is compiled with `OPENACC=true`, the `mpas_framework_report_settings` routine now calls a new private routine, `report_acc_devices`, in `mpas_framework` to report information about OpenACC devices to the log. The `report_acc_devices` routine uses the OpenACC runtime library to inquire about the number of available devices, the device number for the calling MPI task, and info about the device type and driver. As an example from Derecho with the NVHPC 24.3 compilers, the following information is reported in the log file:
```
 OpenACC configuration:
   Number of visible devices: 1
   Device # for this MPI task: 0
   Device vendor: NVIDIA
   Device name: NVIDIA A100-SXM4-40GB
   Device driver version: 12020
```
If MPAS is not compiled with `OPENACC=true`, then the `report_acc_devices` routine, and the call to it from `mpas_framework_report_settings`, are pre-processed out.
