### PR TITLE
Added support for building the atmosphere and init atmosphere cores with CMake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ restart_timestamp
 
 # Text files (For statistical output from ocean model)
 *.txt
+!CMakeLists.txt
 
 # Directories with individual .gitignore files are:
 # src/external (Externals might have a different compilation method)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,160 @@
+## MPAS-Model
+cmake_minimum_required(VERSION 3.12)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Functions/MPAS_Functions.cmake)
+get_mpas_version(MPAS_VERSION)
+project(MPAS LANGUAGES C Fortran VERSION ${MPAS_VERSION} DESCRIPTION "MPAS - Model for Prediction Across Scales")
+
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
+include(GNUInstallDirs)
+
+# Options
+set(MPAS_ALL_CORES atmosphere init_atmosphere)
+set(MPAS_CORES atmosphere CACHE STRING "MPAS cores to build. Options: ${MPAS_ALL_CORES}")
+if(MPAS_CORES MATCHES " ") #Convert strings separated with spaces to CMake list separated with ';'
+    string(REPLACE " " ";" MPAS_CORES ${MPAS_CORES})
+    set(MPAS_CORES ${MPAS_CORES} CACHE STRING "MPAS cores to build. Options: ${MPAS_ALL_CORES}" FORCE)
+endif()
+option(DO_PHYSICS "Use built-in physics schemes." TRUE)
+option(MPAS_DOUBLE_PRECISION "Use double precision 64-bit Floating point." TRUE)
+option(MPAS_PROFILE "Enable GPTL profiling" OFF)
+option(MPAS_OPENMP "Enable OpenMP" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+message(STATUS "[OPTION] MPAS_CORES: ${MPAS_CORES}")
+message(STATUS "[OPTION] MPAS_DOUBLE_PRECISION: ${MPAS_DOUBLE_PRECISION}")
+message(STATUS "[OPTION] MPAS_PROFILE: ${MPAS_PROFILE}")
+message(STATUS "[OPTION] MPAS_OPENMP: ${MPAS_OPENMP}")
+message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+
+# Build product output locations
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+# Set default build type to RelWithDebInfo
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting default build type to Release.  Specify CMAKE_BUILD_TYPE to override.")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "CMake Build type" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Detect MPAS git version
+if(NOT MPAS_GIT_VERSION)
+    find_package(Git QUIET)
+    if(GIT_FOUND)
+        execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty
+                        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                        OUTPUT_VARIABLE _mpas_git_version
+                        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+        set(_mpas_git_version "Unknown")
+    endif()
+    set(MPAS_GIT_VERSION ${_mpas_git_version} CACHE STRING "MPAS-Model git version")
+endif()
+
+### Dependencies
+find_package(OpenMP COMPONENTS Fortran)
+find_package(MPI REQUIRED COMPONENTS Fortran)
+find_package(NetCDF REQUIRED COMPONENTS Fortran C)
+find_package(PnetCDF REQUIRED COMPONENTS Fortran)
+find_package(PIO REQUIRED COMPONENTS Fortran C)
+if(MPAS_PROFILE)
+    find_package(GPTL REQUIRED)
+endif()
+
+# Find C pre-processor
+if(CMAKE_C_COMPILER_ID MATCHES GNU)
+    find_program(CPP_EXECUTABLE NAMES cpp REQUIRED)
+    set(CPP_EXTRA_FLAGS -traditional)
+elseif(CMAKE_C_COMPILER_ID MATCHES "(Apple)?Clang" )
+    find_program(CPP_EXECUTABLE NAMES cpp REQUIRED)
+else()
+    message(STATUS "Unknown compiler: ${CMAKE_C_COMPILER_ID}")
+    set(CPP_EXECUTABLE ${CMAKE_C_COMPILER})
+endif()
+
+## Common Variables
+
+# Fortran module output directory for build interface
+set(MPAS_MODULE_DIR ${PROJECT_NAME}/module/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+# Install Fortran module directory
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MPAS_MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MPAS_MODULE_DIR}/)
+
+# Location of common subdriver module compiled by each cores
+set(MPAS_MAIN_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas.F)
+set(MPAS_SUBDRIVER_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas_subdriver.F)
+
+## Create targets
+add_subdirectory(src/external/ezxml) # Target: MPAS::external::ezxml
+if(ESMF_FOUND)
+  message(STATUS "Configure MPAS for external ESMF")
+  add_definitions(-DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT)
+  add_library(${PROJECT_NAME}::external::esmf ALIAS esmf)
+else()
+  message(STATUS "Configure MPAS for internal ESMF")
+  add_subdirectory(src/external/esmf_time_f90) # Target: MPAS::external::esmf_time
+endif()
+add_subdirectory(src/tools/input_gen) # Targets: namelist_gen, streams_gen
+add_subdirectory(src/tools/registry) # Targets: mpas_parse_<core_name>
+add_subdirectory(src/framework) # Target: MPAS::framework
+add_subdirectory(src/operators) # Target: MPAS::operators
+
+foreach(_core IN LISTS MPAS_CORES)
+    add_subdirectory(src/core_${_core}) # Target: MPAS::core::<core_name>
+endforeach()
+
+### Package config
+include(CMakePackageConfigHelpers)
+
+# Build-tree target exports
+export(EXPORT ${PROJECT_NAME}ExportsExternal NAMESPACE ${PROJECT_NAME}::external:: FILE ${PROJECT_NAME}-targets-external.cmake)
+export(EXPORT ${PROJECT_NAME}Exports NAMESPACE ${PROJECT_NAME}:: FILE ${PROJECT_NAME}-targets.cmake)
+export(EXPORT ${PROJECT_NAME}ExportsCore NAMESPACE ${PROJECT_NAME}::core:: FILE ${PROJECT_NAME}-targets-core.cmake)
+
+# CMake Config file install location
+set(CONFIG_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+# Install MPAS-supplied Find<Pkg>.cmake modules for use by downstream CMake dependencies
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+## <pkgname>-config.cmake: build-tree
+# Variables to export for use from build-tree
+set(BINDIR ${CMAKE_BINARY_DIR}/bin)
+set(CORE_DATADIR_ROOT ${CMAKE_BINARY_DIR}/${PROJECT_NAME})
+set(CMAKE_MODULE_INSTALL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
+configure_package_config_file(cmake/PackageConfig.cmake.in ${PROJECT_NAME_LOWER}-config.cmake
+                              INSTALL_DESTINATION .
+                              INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+                              PATH_VARS BINDIR CORE_DATADIR_ROOT CMAKE_MODULE_INSTALL_PATH)
+
+## <pkgname>-config.cmake: install-tree
+# Variables to export for use from install-tree
+set(BINDIR ${CMAKE_INSTALL_BINDIR})
+set(CORE_DATADIR_ROOT ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+set(CMAKE_MODULE_INSTALL_PATH ${CONFIG_INSTALL_DESTINATION}/Modules)
+configure_package_config_file(cmake/PackageConfig.cmake.in install/${PROJECT_NAME_LOWER}-config.cmake
+                              INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION}
+                              PATH_VARS BINDIR CORE_DATADIR_ROOT CMAKE_MODULE_INSTALL_PATH)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/${PROJECT_NAME_LOWER}-config.cmake
+        DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+## <pkgname>-config-version.cmake
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake
+        DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+## package-targets.cmake and package-targets-<build-type>.cmake
+install(EXPORT ${PROJECT_NAME}ExportsExternal NAMESPACE ${PROJECT_NAME}::external::
+        FILE ${PROJECT_NAME_LOWER}-targets-external.cmake
+        DESTINATION ${CONFIG_INSTALL_DESTINATION})
+install(EXPORT ${PROJECT_NAME}Exports NAMESPACE ${PROJECT_NAME}::
+        FILE ${PROJECT_NAME_LOWER}-targets.cmake
+        DESTINATION ${CONFIG_INSTALL_DESTINATION})
+install(EXPORT ${PROJECT_NAME}ExportsCore NAMESPACE ${PROJECT_NAME}::core::
+        FILE ${PROJECT_NAME_LOWER}-targets-core.cmake
+        DESTINATION ${CONFIG_INSTALL_DESTINATION})

--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -1,0 +1,215 @@
+##
+# get_mpas_version( <mpas_version> )
+#
+# Extracts the MPAS-Model project's version from the README.md file.
+# The extracted version is a string following the format "X.Y.Z", where
+# "X", "Y", and "Z" correspond to the major, minor, and patch versions
+# respectively.
+#
+# Precondition:
+# * README.md file needs to be in the current source directory.
+# * README.md file should contain the project version formatted
+#   as "MPAS-vX.Y.Z".
+#
+# Postcondition:
+# * If a match is found, <output_var> will contain the version string,
+#   else it will be empty.
+#
+# Args:
+# <mpas_version> - The name of the variable that will hold the extracted version
+#                string.
+#
+# Example usage:
+# get_mpas_version(MPAS_VERSION)
+# message("MPAS Version: ${MPAS_VERSION}")
+##
+function(get_mpas_version mpas_version)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/README.md" readme_contents)
+    string(REGEX MATCH "MPAS-v([0-9]+\\.[0-9]+\\.[0-9]+)" _ ${readme_contents})
+    set(${mpas_version} ${CMAKE_MATCH_1} PARENT_SCOPE)
+endfunction()
+
+##
+# mpas_fortran_target( <target-name> )
+#
+# Fortran configuration and options common to all MPAS Fortran targets
+#
+# * Installs common Fortan modules to a per-compiler-version directory
+# * General Fortran formatting and configuration options
+# * Per-compiler configuration and options
+#   * MPAS_DOUBLE_PRECISION related flags
+#
+# Args:
+#  <target_name> - The name of the target to prepare
+#
+
+function(mpas_fortran_target target)
+    # Fortran modules include path
+    set_target_properties(${target} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MPAS_MODULE_DIR})
+    target_include_directories(${target} INTERFACE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MPAS_MODULE_DIR}>
+            $<INSTALL_INTERFACE:${MPAS_MODULE_DIR}>)
+    #Relocatable, portable, runtime dynamic linking
+    set_target_properties(${target} PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+
+    # Global Fortran configuration
+    set_target_properties(${target} PROPERTIES Fortran_FORMAT FREE)
+    set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
+        _MPI=1
+        USE_PIO2=1
+    )
+    # Enable OpenMP support
+    if(MPAS_OPENMP)
+        target_link_libraries(${target} PUBLIC OpenMP::OpenMP_Fortran)
+    endif()
+
+    # Compiler-specific options and flags
+    if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+        list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                $<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>
+        )
+        list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PUBLIC
+                $<$<COMPILE_LANGUAGE:Fortran>:-fconvert=big-endian>
+        )
+
+        if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+            list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>
+                    $<$<COMPILE_LANGUAGE:Fortran>:-fallow-invalid-boz>
+            )
+        endif()
+        if(MPAS_DOUBLE_PRECISION)
+            list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                    $<$<COMPILE_LANGUAGE:Fortran>:-fdefault-real-8> $<$<COMPILE_LANGUAGE:Fortran>:-fdefault-double-8>
+            )
+        else()
+            list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS SINGLE_PRECISION)
+        endif()
+    elseif(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+        list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PUBLIC
+                $<$<COMPILE_LANGUAGE:Fortran>:-align array64byte>
+                $<$<COMPILE_LANGUAGE:Fortran>:-convert big_endian>
+        )
+        if(MPAS_DOUBLE_PRECISION)
+            list(APPEND MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE
+                $<$<COMPILE_LANGUAGE:Fortran>:-real-size 64>
+            )
+        else()
+            list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS SINGLE_PRECISION)
+        endif()
+    endif()
+    target_compile_definitions(${target} PRIVATE ${MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS})
+    target_compile_options(${target} PRIVATE ${MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PRIVATE})
+    target_compile_options(${target} PUBLIC ${MPAS_FORTRAN_TARGET_COMPILE_OPTIONS_PUBLIC})
+endfunction()
+
+
+# mpas_core_target(CORE <core-name> TARGET <cmake-target-name> INCLUDE <file1.inc, ...> )
+#
+# Common configuration and properties for `MPAS::core::<core_name>` targets.
+# * Calls mpas_fortran_target() for common Fortran target configuration.
+# * Installs Fortran modules to a per-core directory and adds target include directories
+#   appropriate for build and install trees.
+# * XML Processing, parsing and generation of includes, namelists and streams
+#   * Each core uses a core-specific parser executable
+# * Links to MPAS::framework and MPAS::operators
+# * Exports MPAS::core::<core_name> target alias for use by external dependencies
+# * Installs core libraries modules and generated files.
+#
+#  Args:
+#   CORE - Name of core
+#   TARGET - Name of core_target (without namespace)
+#   INCLUDES - List of generated include files
+#
+function(mpas_core_target)
+    cmake_parse_arguments(ARG "" "CORE;TARGET" "INCLUDES" ${ARGN})
+
+    mpas_fortran_target(${ARG_TARGET})
+
+    set_property(TARGET ${ARG_TARGET} APPEND PROPERTY SOURCES ${MPAS_SUBDRIVER_SRC})
+
+    string(TOUPPER "${ARG_TARGET}" TARGET)
+    set_target_properties(${ARG_TARGET} PROPERTIES OUTPUT_NAME mpas_${ARG_CORE})
+
+    #Fortran modules output location
+    set(CORE_MODULE_DIR ${MPAS_MODULE_DIR}/${ARG_TARGET})
+    set_target_properties(${ARG_TARGET} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${CORE_MODULE_DIR})
+    target_include_directories(${ARG_TARGET} INTERFACE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${CORE_MODULE_DIR}>
+            $<INSTALL_INTERFACE:${CORE_MODULE_DIR}>)
+
+    #MPAS Specific option
+    target_compile_definitions(${ARG_TARGET} PRIVATE ${TARGET}=1)
+
+    #Generated includes are included from either ./inc/ or ./ so we create a symlink in the build directory
+    #To handle the inc/ variety (sw, test, seaice) uniformly with the ./ variety (atmosphere, init_atmosphere)
+    add_custom_target(${ARG_CORE}_include_link ALL
+            COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/inc)
+    add_dependencies(${ARG_TARGET} ${ARG_CORE}_include_link)
+    target_include_directories(${ARG_TARGET} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+    #Core-independent library dependencies
+    target_link_libraries(${ARG_TARGET} PUBLIC ${PROJECT_NAME}::operators ${PROJECT_NAME}::framework)
+
+    #Define alias for external use
+    add_library(${PROJECT_NAME}::core::${ARG_CORE} ALIAS ${ARG_TARGET})
+
+    #Create main executable
+    add_executable(mpas_${ARG_CORE} ${MPAS_MAIN_SRC})
+    mpas_fortran_target(mpas_${ARG_CORE})
+    target_link_libraries(mpas_${ARG_CORE} PUBLIC ${PROJECT_NAME}::core::${ARG_CORE})
+
+    #Per-core generated output and tables directory location
+    set(CORE_DATADIR ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${ARG_TARGET})
+    file(MAKE_DIRECTORY ${CORE_DATADIR})
+
+    #Process registry and generate includes, namelists, and streams
+    if(${ARG_CORE} STREQUAL "atmosphere" AND ${DO_PHYSICS})
+            set(CPP_EXTRA_FLAGS ${CPP_EXTRA_FLAGS} -DDO_PHYSICS)
+    endif()
+    add_custom_command(OUTPUT Registry_processed.xml
+            COMMAND ${CPP_EXECUTABLE} -E -P ${CPP_EXTRA_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/Registry.xml > Registry_processed.xml
+            COMMENT "CORE ${ARG_CORE}: Pre-Process Registry"
+            DEPENDS Registry.xml)
+    add_custom_command(OUTPUT ${ARG_INCLUDES}
+            COMMAND mpas_parse_${ARG_CORE} Registry_processed.xml
+            COMMENT "CORE ${ARG_CORE}: Parse Registry"
+            DEPENDS mpas_parse_${ARG_CORE} Registry_processed.xml)
+    add_custom_command(OUTPUT namelist.${ARG_CORE}
+            WORKING_DIRECTORY ${CORE_DATADIR}
+            COMMAND mpas_namelist_gen ${CMAKE_CURRENT_BINARY_DIR}/Registry_processed.xml namelist.${ARG_CORE} in_defaults=true
+            COMMENT "CORE ${ARG_CORE}: Generate Namelist"
+            DEPENDS mpas_namelist_gen Registry_processed.xml)
+    add_custom_command(OUTPUT streams.${ARG_CORE}
+            WORKING_DIRECTORY ${CORE_DATADIR}
+            COMMAND mpas_streams_gen ${CMAKE_CURRENT_BINARY_DIR}/Registry_processed.xml streams.${ARG_CORE} stream_list.${ARG_CORE}. listed
+            COMMENT "CORE ${ARG_CORE}: Generate Streams"
+            DEPENDS mpas_streams_gen Registry_processed.xml)
+    add_custom_target(gen_${ARG_CORE} DEPENDS ${ARG_INCLUDES} namelist.${ARG_CORE} streams.${ARG_CORE})
+    add_dependencies(${ARG_TARGET} gen_${ARG_CORE})
+
+    #Install data and target library and executable
+    install(DIRECTORY ${CORE_DATADIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/${ARG_TARGET}
+            FILES_MATCHING PATTERN "namelist.*" PATTERN "streams.*" PATTERN "stream_list.*" )
+    install(TARGETS ${ARG_TARGET} EXPORT ${PROJECT_NAME}ExportsCore
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(TARGETS mpas_${ARG_CORE}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endfunction()
+
+##
+# set_MPAS_DEBUG_flag( <target> )
+#
+# Sets the MPAS_DEBUG compile definition for a given target when the build type is Debug.
+#
+# Args:
+# <target> - The target for which the compile definition will be set
+#
+# Usage example:
+# set_MPAS_DEBUG_flag(TARGET)
+# This will define MPAS_DEBUG for the target TARGET during a Debug build
+##
+function(set_MPAS_DEBUG_flag target)
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+        target_compile_definitions(${target} PRIVATE MPAS_DEBUG)
+    endif()
+endfunction()

--- a/cmake/Modules/FindGPTL.cmake
+++ b/cmake/Modules/FindGPTL.cmake
@@ -1,0 +1,175 @@
+# FindGPTL.cmake
+#
+# Copyright UCAR 2020
+#
+# Find the GPTL: General Purpose Timing Library (https://jmrosinski.github.io/GPTL/)
+#
+# This find module sets the following variables and targets:
+#
+# Variables:
+#  GPTL_FOUND - True if GPTL was found
+#  GPTL_VERSION_STRING - Version of installed GPTL
+#  GPTL_BIN_DIR - GPTL binary directory
+#  GPTL_HAS_PKG_CONFIG - GPTL was found with installed `gptl.pc` and pkg-config.  This indicates full support
+#                        for compiler and linker flags as exported by GPTL.
+# Targets:
+#  GPTL::GPTL - Imported interface target to pass to target_link_libraries()
+#
+# NOTE: This find modules uses `pkg-config` to locate GPTL and glean the appropriate flags, directories,
+# and link dependency ordering.  For this to work, both a `pkg-config` executable and a `gptl.pc`
+# config file need to be found.
+# * To find the `pkg-config` executable, ensure it is on your PATH.
+#   * For non-standard locations the official CMake FindPkgConfig uses Cmake variable `PKG_CONFIG_EXECUTABLE`
+#     or environment variable `PKG_CONFIG`. See: https://cmake.org/cmake/help/latest/module/FindPkgConfig.html
+# * To find `gptl.pc` ensure it is on the (colon-separated) directories listed in standard pkg-config
+#   environment variable `PKG_CONFIG_PATH`.
+#    * See: https://linux.die.net/man/1/pkg-config
+# * A working GPTL pkg-config install can be confirmed on the command line, e.g.,
+#   ```
+#   $ pkg-config --modversion gptl
+#   8.0.2
+#   ```
+# To set a non-standard location for GPTL, ensure the correct `gptl.pc` pkg config file is found first
+# on the environment's `PKG_CONFIG_PATH`. This can be checked with the pkg-config executable, e.g.,
+#  ```
+#  $ pkg-config --variable=prefix gptl
+#  /usr/local
+#  ```
+# Only when pkg-config is not supported or available, GPTL will be searched by the standard CMake search procedures.
+# Set environment or CMake variable GPTL_ROOT to control this search.  The GPTL_ROOT variable will have no effect
+# if GPTL_HAS_PKG_CONFIG=True.
+#
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    message(DEBUG "[FindGPTL] Using PKG_CONFIG_EXECUTABLE:${PKG_CONFIG_EXECUTABLE}")
+endif()
+
+#Helper:
+#check_pkg_config(ret_var pcname pcflags...)
+# Check if pcname is known to pkg-config
+# Returns:
+#  Boolean: true if ${pcname}.pc file is found by pkg-config).
+# Args:
+#  ret_var: return variable name.
+#  pcname: pkg-config name to look for (.pc file)
+function(check_pkg_config ret_var pcname)
+    if(NOT PKG_CONFIG_FOUND OR NOT EXISTS ${PKG_CONFIG_EXECUTABLE})
+        set(${ret_var} False PARENT_SCOPE)
+    else()
+        execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --exists ${pcname} RESULT_VARIABLE _found)
+        if(_found EQUAL 0)
+            set(${ret_var} True PARENT_SCOPE)
+        else()
+            set(${ret_var} False PARENT_SCOPE)
+        endif()
+    endif()
+endfunction()
+
+#Helper:
+#get_pkg_config(ret_var pcname pcflags...)
+# Get the output of pkg-config
+# Args:
+#  ret_var: return variable name
+#  pcname: pkg-config name to look for (.pc file)
+#  pcflags: pkg-config flags to pass
+function(get_pkg_config ret_var pcname pcflags)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} ${ARGN} ${pcname} ${pcflags} OUTPUT_VARIABLE _out RESULT_VARIABLE _ret OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_ret EQUAL 0)
+        separate_arguments(_out)
+        set(${ret_var} ${_out} PARENT_SCOPE)
+    else()
+        set(${ret_var} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+check_pkg_config(GPTL_HAS_PKG_CONFIG gptl)
+if(GPTL_HAS_PKG_CONFIG)
+    #Use pkg-config to find the prefix, flags, directories, executables, and libraries
+    get_pkg_config(GPTL_VERSION_STRING gptl --modversion)
+    get_pkg_config(GPTL_PREFIX gptl --variable=prefix)
+    get_pkg_config(GPTL_INCLUDE_DIR gptl --cflags-only-I)
+    if(EXISTS GPTL_INCLUDE_DIR)
+        string(REGEX REPLACE "-I([^ ]+)" "\\1;" GPTL_INCLUDE_DIR ${GPTL_INCLUDE_DIR}) #Remove -I
+    else()
+        find_path(GPTL_INCLUDE_DIR NAMES gptl.h PATH_SUFFIXES include include/gptl PATHS ${GPTL_PREFIX} NO_DEFAULT_PATH)
+    endif()
+    find_path(GPTL_MODULE_DIR NAMES gptl.mod PATH_SUFFIXES include include/gptl module module/gptl PATHS ${GPTL_PREFIX} NO_DEFAULT_PATH)
+    get_pkg_config(GPTL_COMPILE_OPTIONS gptl --cflags-only-other)
+    get_pkg_config(GPTL_LINK_LIBRARIES gptl --libs-only-l)
+    get_pkg_config(GPTL_LINK_DIRECTORIES gptl --libs-only-L)
+    if(GPTL_LINK_DIRECTORIES)
+        string(REGEX REPLACE "-L([^ ]+)" "\\1;" GPTL_LINK_DIRECTORIES ${GPTL_LINK_DIRECTORIES}) #Remove -L
+    endif()
+    get_pkg_config(GPTL_LINK_OPTIONS gptl --libs-only-other)
+    find_library(GPTL_LIBRARY NAMES gptl PATH_SUFFIXES lib lib64 PATHS ${GPTL_PREFIX} NO_DEFAULT_PATH)
+    find_path(GPTL_BIN_DIR NAMES gptl_avail PATH_SUFFIXES bin PATHS ${GPTL_PREFIX} NO_DEFAULT_PATH)
+else()
+    #Attempt to find GPTL without pkg-config as last resort.
+    message(WARNING "\
+FindGPTL: The `pkg-config` executable was not found. Ensure it is on your path or set \
+environment variable PKG_CONFIG to your pkg-config executable. \
+Attempting to find GPTL without pkg-config support may cause some required compiler and linker options to be unset.")
+
+    find_path(GPTL_INCLUDE_DIR NAMES gptl.h PATH_SUFFIXES include include/gptl)
+    find_path(GPTL_MODULE_DIR NAMES gptl.mod PATH_SUFFIXES include include/gptl module module/gptl)
+    find_library(GPTL_LIBRARY NAMES gptl PATH_SUFFIXES lib lib64)
+    find_path(GPTL_BIN_DIR NAMES gptl_avail PATH_SUFFIXES bin)
+endif()
+
+#Hide non-documented cache variables reserved for internal/advanced usage
+mark_as_advanced( GPTL_INCLUDE_DIR
+                  GPTL_MODULE_DIR
+                  GPTL_LIBRARY )
+
+#Debugging output
+message(DEBUG "[FindGPTL] GPTL_FOUND: ${GPTL_FOUND}")
+message(DEBUG "[FindGPTL] GPTL_VERSION_STRING: ${GPTL_VERSION_STRING}")
+message(DEBUG "[FindGPTL] GPTL_HAS_PKG_CONFIG: ${GPTL_HAS_PKG_CONFIG}")
+message(DEBUG "[FindGPTL] GPTL_PREFIX: ${GPTL_PREFIX}")
+message(DEBUG "[FindGPTL] GPTL_BIN_DIR: ${GPTL_BIN_DIR}")
+message(DEBUG "[FindGPTL] GPTL_INCLUDE_DIR: ${GPTL_INCLUDE_DIR}")
+message(DEBUG "[FindGPTL] GPTL_MODULE_DIR: ${GPTL_MODULE_DIR}")
+message(DEBUG "[FindGPTL] GPTL_LIBRARY: ${GPTL_LIBRARY}")
+message(DEBUG "[FindGPTL] GPTL_LINK_LIBRARIES: ${GPTL_LINK_LIBRARIES}")
+message(DEBUG "[FindGPTL] GPTL_LINK_DIRECTORIES: ${GPTL_LINK_DIRECTORIES}")
+message(DEBUG "[FindGPTL] GPTL_LINK_OPTIONS: ${GPTL_LINK_OPTIONS}")
+
+#Check package has been found correctly
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  GPTL
+  REQUIRED_VARS
+    GPTL_LIBRARY
+    GPTL_INCLUDE_DIR
+    GPTL_MODULE_DIR
+    GPTL_BIN_DIR
+  VERSION_VAR
+    GPTL_VERSION_STRING
+)
+
+#Create GPTL::GPTL imported interface target
+if(GPTL_FOUND AND NOT TARGET GPTL::GPTL)
+    add_library(GPTL::GPTL INTERFACE IMPORTED)
+    set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GPTL_INCLUDE_DIR})
+    if(GPTL_MODULE_DIR)
+        set_property(TARGET GPTL::GPTL APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GPTL_MODULE_DIR})
+    endif()
+    if(GPTL_COMPILE_OPTIONS)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_COMPILE_OPTIONS ${GPTL_COMPILE_OPTIONS})
+    endif()
+    if(GPTL_LINK_DIRECTORIES)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_DIRECTORIES ${GPTL_LINK_DIRECTORIES})
+    endif()
+    if(GPTL_LINK_OPTIONS)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_OPTIONS ${GPTL_LINK_OPTIONS})
+    endif()
+    if(GPTL_LINK_LIBRARIES)
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_LIBRARIES ${GPTL_LINK_LIBRARIES})
+    else()
+        set_property(TARGET GPTL::GPTL PROPERTY INTERFACE_LINK_LIBRARIES ${GPTL_LIBRARY})
+        get_filename_component(_lib_dir ${GPTL_LIBRARY} DIRECTORY)
+        set_property(TARGET GPTL::GPTL APPEND PROPERTY INTERFACE_LINK_DIRECTORIES ${_lib_dir})
+        unset(_lib_dir)
+    endif()
+endif()

--- a/cmake/Modules/FindNetCDF.cmake
+++ b/cmake/Modules/FindNetCDF.cmake
@@ -1,0 +1,343 @@
+# (C) Copyright 2017-2020 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+#
+# Try to find NetCDF includes and library.
+# Supports static and shared libaries and allows each component to be found in sepearte prefixes.
+#
+# This module defines
+#
+#   - NetCDF_FOUND                - System has NetCDF
+#   - NetCDF_INCLUDE_DIRS         - the NetCDF include directories
+#   - NetCDF_VERSION              - the version of NetCDF
+#   - NetCDF_CONFIG_EXECUTABLE    - the netcdf-config executable if found
+#   - NetCDF_PARALLEL             - Boolean True if NetCDF4 has parallel IO support via hdf5 and/or pnetcdf
+#   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
+#
+# Deprecated Defines
+#   - NetCDF_LIBRARIES            - [Deprecated] Use NetCDF::NetCDF_<LANG> targets instead.
+#
+#
+# Following components are available:
+#
+#   - C                           - C interface to NetCDF          (netcdf)
+#   - CXX                         - CXX4 interface to NetCDF       (netcdf_c++4)
+#   - Fortran                     - Fortran interface to NetCDF    (netcdff)
+#
+# For each component the following are defined:
+#
+#   - NetCDF_<comp>_FOUND         - whether the component is found
+#   - NetCDF_<comp>_LIBRARIES     - the libraries for the component
+#   - NetCDF_<comp>_LIBRARY_SHARED - Boolean is true if libraries for component are shared
+#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specified component
+#   - NetCDF::NetCDF_<comp>       - target of component to be used with target_link_libraries()
+#
+# The following paths will be searched in order if set in CMake (first priority) or environment (second priority)
+#
+#   - NetCDF_ROOT                 - root of NetCDF installation
+#   - NetCDF_PATH                 - root of NetCDF installation
+#
+# The search process begins with locating NetCDF Include headers.  If these are in a non-standard location,
+# set one of the following CMake or environment variables to point to the location:
+#
+#  - NetCDF_INCLUDE_DIR or NetCDF_${comp}_INCLUDE_DIR
+#  - NetCDF_INCLUDE_DIRS or NetCDF_${comp}_INCLUDE_DIR
+#
+# Notes:
+#
+#   - Use "NetCDF::NetCDF_<LANG>" targets only.  NetCDF_LIBRARIES exists for backwards compatibility and should not be used.
+#     - These targets have all the knowledge of include directories and library search directories, and a single
+#       call to target_link_libraries will provide all these transitive properties to your target.  Normally all that is
+#       needed to build and link against NetCDF is, e.g.:
+#           target_link_libraries(my_c_tgt PUBLIC NetCDF::NetCDF_C)
+#   - "NetCDF" is always the preferred naming for this package, its targets, variables, and environment variables
+#     - For compatibility, some variables are also set/checked using alternate names NetCDF4, NETCDF, or NETCDF4
+#     - Environments relying on these older environment variable names should move to using a "NetCDF_ROOT" environment variable
+#   - Preferred component capitalization follows the CMake LANGUAGES variables: i.e., C, Fortran, CXX
+#     - For compatibility, alternate capitalizations are supported but should not be used.
+#   - If no components are defined, all components will be searched
+#
+
+list( APPEND _possible_components C CXX Fortran )
+
+## Include names for each component
+set( NetCDF_C_INCLUDE_NAME          netcdf.h )
+set( NetCDF_CXX_INCLUDE_NAME        netcdf )
+set( NetCDF_Fortran_INCLUDE_NAME    netcdf.mod )
+
+## Library names for each component
+set( NetCDF_C_LIBRARY_NAME          netcdf )
+set( NetCDF_CXX_LIBRARY_NAME        netcdf_c++4 )
+set( NetCDF_Fortran_LIBRARY_NAME    netcdff )
+
+## Enumerate search components
+foreach( _comp ${_possible_components} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  set( _name_${_COMP} ${_comp} )
+endforeach()
+
+set( _search_components C)
+foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  list( APPEND _search_components ${_name_${_COMP}} )
+  if( NOT _name_${_COMP} )
+    message(SEND_ERROR "Find${CMAKE_FIND_PACKAGE_NAME}: COMPONENT ${_comp} is not a valid component. Valid components: ${_possible_components}" )
+  endif()
+endforeach()
+list( REMOVE_DUPLICATES _search_components )
+
+## Search hints for finding include directories and libraries
+foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
+  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+    foreach( _var IN ITEMS ROOT PATH )
+      list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
+      list(APPEND _include_search_hints
+                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}
+                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS} )
+    endforeach()
+  endforeach()
+endforeach()
+#Old-school HPC module env variable names
+foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+  foreach( _comp IN ITEMS "_C" "_Fortran" "_CXX" )
+    list(APPEND _search_hints ${${_name}}         $ENV{${_name}})
+    list(APPEND _search_hints ${${_name}${_comp}} $ENV{${_name}${_comp}})
+  endforeach()
+endforeach()
+
+## Find headers for each component
+set(NetCDF_INCLUDE_DIRS)
+set(_new_search_components)
+foreach( _comp IN LISTS _search_components )
+  if(NOT ${PROJECT_NAME}_NetCDF_${_comp}_FOUND)
+      list(APPEND _new_search_components ${_comp})
+  endif()
+  find_file(NetCDF_${_comp}_INCLUDE_FILE
+    NAMES ${NetCDF_${_comp}_INCLUDE_NAME}
+    DOC "NetCDF ${_comp} include directory"
+    HINTS ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES include include/netcdf
+  )
+  mark_as_advanced(NetCDF_${_comp}_INCLUDE_FILE)
+  message(DEBUG "NetCDF_${_comp}_INCLUDE_FILE: ${NetCDF_${_comp}_INCLUDE_FILE}")
+  if( NetCDF_${_comp}_INCLUDE_FILE )
+    get_filename_component(NetCDF_${_comp}_INCLUDE_FILE ${NetCDF_${_comp}_INCLUDE_FILE} ABSOLUTE)
+    get_filename_component(NetCDF_${_comp}_INCLUDE_DIR ${NetCDF_${_comp}_INCLUDE_FILE} DIRECTORY)
+    list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
+  endif()
+endforeach()
+if(NetCDF_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+endif()
+set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
+
+## Find n*-config executables for search components
+foreach( _comp IN LISTS _search_components )
+  if( _comp MATCHES "^(C)$" )
+    set(_conf "c")
+  elseif( _comp MATCHES "^(Fortran)$" )
+    set(_conf "f")
+  elseif( _comp MATCHES "^(CXX)$" )
+    set(_conf "cxx4")
+  endif()
+  find_program( NetCDF_${_comp}_CONFIG_EXECUTABLE
+      NAMES n${_conf}-config
+      HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
+      PATH_SUFFIXES bin Bin ../bin ../../bin
+      DOC "NetCDF n${_conf}-config helper" )
+    message(DEBUG "NetCDF_${_comp}_CONFIG_EXECUTABLE: ${NetCDF_${_comp}_CONFIG_EXECUTABLE}")
+endforeach()
+
+set(_C_libs_flag --libs)
+set(_Fortran_libs_flag --flibs)
+set(_CXX_libs_flag --libs)
+set(_C_includes_flag --includedir)
+set(_Fortran_includes_flag --includedir)
+set(_CXX_includes_flag --includedir)
+function(netcdf_config exec flag output_var)
+  set(${output_var} False PARENT_SCOPE)
+  if( exec )
+    execute_process( COMMAND ${exec} ${flag} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
+    if( _ret EQUAL 0 )
+      string( STRIP ${_val} _val )
+      set( ${output_var} ${_val} PARENT_SCOPE )
+    endif()
+  endif()
+endfunction()
+
+## Find libraries for each component
+set( NetCDF_LIBRARIES )
+foreach( _comp IN LISTS _search_components )
+  string( TOUPPER "${_comp}" _COMP )
+
+  find_library( NetCDF_${_comp}_LIBRARY
+    NAMES ${NetCDF_${_comp}_LIBRARY_NAME}
+    DOC "NetCDF ${_comp} library"
+    HINTS ${NetCDF_${_comp}_INCLUDE_DIRS} ${_search_hints}
+    PATH_SUFFIXES lib64 lib ../lib64 ../lib ../../lib64 ../../lib )
+  mark_as_advanced( NetCDF_${_comp}_LIBRARY )
+  get_filename_component(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} ABSOLUTE)
+  set(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} CACHE STRING "NetCDF ${_comp} library" FORCE)
+  message(DEBUG "NetCDF_${_comp}_LIBRARY: ${NetCDF_${_comp}_LIBRARY}")
+
+
+  if( NetCDF_${_comp}_LIBRARY )
+    if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
+      set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
+      set( _library_type STATIC)
+    else()
+      if( NOT ${NetCDF_${_comp}_LIBRARY} IN_LIST NetCDF_LIBRARIES )
+        list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+        message(DEBUG "Adding new netcdf library [${_comp}]: ${NetCDF_${_comp}_LIBRARY}")
+      endif()
+      set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
+      set( _library_type SHARED)
+    endif()
+  endif()
+
+  #Use nc-config to set per-component LIBRARIES variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} _val )
+  if( _val )
+    set( NetCDF_${_comp}_LIBRARIES ${_val} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND) #Static targets should use nc_config to get a proper link line with all necessary static targets.
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  else()
+    set( NetCDF_${_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED)
+      message(SEND_ERROR "Unable to properly find NetCDF.  Found static libraries at: ${NetCDF_${_comp}_LIBRARY} but could not run nc-config: ${NetCDF_CONFIG_EXECUTABLE}")
+    endif()
+  endif()
+
+  #Use nc-config to set per-component INCLUDE_DIRS variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_includes_flag} _val )
+  if( _val )
+    string( REPLACE " " ";" _val ${_val} )
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${_val} )
+  else()
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR} )
+  endif()
+
+  if( NetCDF_${_comp}_LIBRARIES AND NetCDF_${_comp}_INCLUDE_DIRS )
+    set( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND TRUE )
+    if (NOT TARGET NetCDF::NetCDF_${_comp})
+      add_library(NetCDF::NetCDF_${_comp} ${_library_type} IMPORTED)
+      set_target_properties(NetCDF::NetCDF_${_comp} PROPERTIES
+        IMPORTED_LOCATION ${NetCDF_${_comp}_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_${_comp}_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  endif()
+endforeach()
+set(NetCDF_LIBRARIES "${NetCDF_LIBRARIES}" CACHE STRING "NetCDF library targets" FORCE)
+
+## Find version via netcdf-config if possible
+if (NetCDF_INCLUDE_DIRS)
+  if( NetCDF_C_CONFIG_EXECUTABLE )
+    netcdf_config( ${NetCDF_C_CONFIG_EXECUTABLE} --version _vers )
+    if( _vers )
+      string(REGEX REPLACE ".* ((([0-9]+)\\.)+([0-9]+)).*" "\\1" NetCDF_VERSION "${_vers}" )
+    endif()
+  else()
+    foreach( _dir IN LISTS NetCDF_INCLUDE_DIRS)
+      if( EXISTS "${_dir}/netcdf_meta.h" )
+        file(STRINGS "${_dir}/netcdf_meta.h" _netcdf_version_lines
+        REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+        string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+        set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+        unset(_netcdf_version_major)
+        unset(_netcdf_version_minor)
+        unset(_netcdf_version_patch)
+        unset(_netcdf_version_note)
+        unset(_netcdf_version_lines)
+      endif()
+    endforeach()
+  endif()
+endif ()
+
+## Detect additional package properties
+netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel4 _val)
+if( NOT _val MATCHES "^(yes|no)$" )
+  netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel _val)
+endif()
+if( _val MATCHES "^(yes)$" )
+  set(NetCDF_PARALLEL TRUE CACHE STRING "NetCDF has parallel IO capability via pnetcdf or hdf5." FORCE)
+else()
+  set(NetCDF_PARALLEL FALSE CACHE STRING "NetCDF has no parallel IO capability." FORCE)
+endif()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+if(NOT NetCDF_FOUND OR _new_search_components)
+    find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+        VERSION_VAR NetCDF_VERSION
+        HANDLE_COMPONENTS )
+endif()
+
+foreach( _comp IN LISTS _search_components )
+    if( NetCDF_${_comp}_FOUND )
+        #Record found components to avoid duplication in NetCDF_LIBRARIES for static libraries
+        set(NetCDF_${_comp}_FOUND ${NetCDF_${_comp}_FOUND} CACHE BOOL "NetCDF ${_comp} Found" FORCE)
+        #Set a per-package, per-component found variable to communicate between multiple calls to find_package()
+        set(${PROJECT_NAME}_NetCDF_${_comp}_FOUND True)
+    endif()
+endforeach()
+
+if( ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_search_components)
+  message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME} [${CMAKE_CURRENT_LIST_DIR}/FindNetCDF.cmake]:" )
+  message( STATUS "  - NetCDF_VERSION [${NetCDF_VERSION}]")
+  message( STATUS "  - NetCDF_PARALLEL [${NetCDF_PARALLEL}]")
+  foreach( _comp IN LISTS _new_search_components )
+    string( TOUPPER "${_comp}" _COMP )
+    message( STATUS "  - NetCDF_${_comp}_CONFIG_EXECUTABLE [${NetCDF_${_comp}_CONFIG_EXECUTABLE}]")
+    if( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND )
+      get_filename_component(_root ${NetCDF_${_comp}_INCLUDE_DIR}/.. ABSOLUTE)
+      if( NetCDF_${_comp}_LIBRARY_SHARED )
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [SHARED] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      else()
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [STATIC] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      endif()
+    endif()
+  endforeach()
+endif()
+
+foreach( _prefix NetCDF NetCDF4 NETCDF NETCDF4 ${CMAKE_FIND_PACKAGE_NAME} )
+  set( ${_prefix}_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} )
+  set( ${_prefix}_LIBRARIES    ${NetCDF_LIBRARIES})
+  set( ${_prefix}_VERSION      ${NetCDF_VERSION} )
+  set( ${_prefix}_FOUND        ${${CMAKE_FIND_PACKAGE_NAME}_FOUND} )
+  set( ${_prefix}_CONFIG_EXECUTABLE ${NetCDF_CONFIG_EXECUTABLE} )
+  set( ${_prefix}_PARALLEL ${NetCDF_PARALLEL} )
+
+  foreach( _comp ${_search_components} )
+    string( TOUPPER "${_comp}" _COMP )
+    set( _arg_comp ${_arg_${_COMP}} )
+    set( ${_prefix}_${_comp}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_COMP}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_arg_comp}_FOUND ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+
+    set( ${_prefix}_${_comp}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_COMP}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_arg_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+
+    set( ${_prefix}_${_comp}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_COMP}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_arg_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIRS} )
+  endforeach()
+endforeach()

--- a/cmake/Modules/FindPIO.cmake
+++ b/cmake/Modules/FindPIO.cmake
@@ -1,0 +1,181 @@
+# FindPIO.cmake
+#
+# Copyright UCAR 2020
+#
+# Find PIO: A high-level Parallel I/O Library for structured grid applications
+# https://github.com/NCAR/ParallelIO
+#
+# Components available for query:
+#  C - Has C support
+#  Fortran - Has Fortran support
+#  STATIC - Has static targets for supported LANG
+#  SHARED - Has shared targets for supported LANG
+#
+# Variables provided:
+#  PIO_FOUND - True if PIO was found
+#  PIO_VERSION - Version of installed PIO
+#
+# Targets provided:
+#  PIO::PIO_Fortran_STATIC - Fortran interface target for static libraries
+#  PIO::PIO_Fortran_SHARED - Fortran interface target for shared libraries
+#  PIO::PIO_Fortran - Fortran interface target alias to shared libraries if available else static libraries
+#  PIO::PIO_C_STATIC - C interface target for static libraries
+#  PIO::PIO_C_SHARED - C interface target for shared libraries
+#  PIO::PIO_C - C interface target alias to shared libraries if available else static libraries
+#
+# To control finding of this package, set PIO_ROOT environment variable to the full path to the prefix
+# under which PIO was installed (e.g., /usr/local)
+#
+
+## Find libraries and paths, and determine found components
+find_path(PIO_INCLUDE_DIR NAMES pio.h HINTS "${PIO_PREFIX}" PATH_SUFFIXES include include/pio)
+if(PIO_INCLUDE_DIR)
+    string(REGEX REPLACE "/include(/.+)?" "" PIO_PREFIX ${PIO_INCLUDE_DIR})
+    set(PIO_PREFIX ${PIO_PREFIX} CACHE STRING "")
+    find_path(PIO_MODULE_DIR NAMES pio.mod PATHS "${PIO_PREFIX}"
+              PATH_SUFFIXES include include/pio lib/pio/module module module/pio NO_DEFAULT_PATH)
+    if(APPLE)
+        set(_SHARED_LIB_EXT .dylib)
+    else()
+        set(_SHARED_LIB_EXT .so)
+    endif()
+    find_library(PIO_C_STATIC_LIB libpioc.a PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_C_SHARED_LIB libpioc${_SHARED_LIB_EXT} PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_Fortran_STATIC_LIB libpiof.a PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    find_library(PIO_Fortran_SHARED_LIB libpiof${_SHARED_LIB_EXT} PATHS "${PIO_PREFIX}" PATH_SUFFIXES lib lib64 NO_DEFAULT_PATH)
+    unset(_SHARED_LIB_EXT)
+
+    #Check for Fortran components
+    if(PIO_MODULE_DIR)
+        if(PIO_Fortran_STATIC_LIB)
+            set(PIO_Fortran_STATIC_FOUND 1)
+        endif()
+        if(PIO_Fortran_SHARED_LIB)
+            set(PIO_Fortran_SHARED_FOUND 1)
+        endif()
+        if(PIO_Fortran_STATIC_FOUND OR PIO_Fortran_SHARED_FOUND)
+            set(PIO_Fortran_FOUND 1)
+        endif()
+    endif()
+    #Check for C components
+    if(PIO_C_STATIC_LIB)
+        set(PIO_C_STATIC_FOUND 1)
+    endif()
+    if(PIO_C_SHARED_LIB)
+        set(PIO_C_SHARED_FOUND 1)
+    endif()
+    if(PIO_C_STATIC_FOUND OR PIO_C_SHARED_FOUND)
+        set(PIO_C_FOUND 1)
+    endif()
+    if(PIO_C_SHARED_FOUND AND (NOT PIO_Fortran_FOUND OR PIO_Fortran_SHARED_FOUND))
+        set(PIO_SHARED_FOUND 1)
+    endif()
+    if(PIO_C_STATIC_FOUND AND (NOT PIO_Fortran_FOUND OR PIO_Fortran_STATIC_FOUND))
+        set(PIO_STATIC_FOUND 1)
+    endif()
+endif()
+
+## Debugging output
+message(DEBUG "[FindPIO] PIO_INCLUDE_DIR: ${PIO_INCLUDE_DIR}")
+message(DEBUG "[FindPIO] PIO_PREFIX: ${PIO_PREFIX}")
+message(DEBUG "[FindPIO] PIO_MODULE_DIR: ${PIO_MODULE_DIR}")
+message(DEBUG "[FindPIO] PIO_Fortran_STATIC_LIB: ${PIO_Fortran_STATIC_LIB}")
+message(DEBUG "[FindPIO] PIO_Fortran_SHARED_LIB: ${PIO_Fortran_SHARED_LIB}")
+message(DEBUG "[FindPIO] PIO_C_STATIC_LIB: ${PIO_C_STATIC_LIB}")
+message(DEBUG "[FindPIO] PIO_C_SHARED_LIB: ${PIO_C_SHARED_LIB}")
+message(DEBUG "[FindPIO] PIO_Fortran_FOUND: ${PIO_Fortran_FOUND}")
+message(DEBUG "[FindPIO] PIO_C_FOUND: ${PIO_C_FOUND}")
+message(DEBUG "[FindPIO] PIO_SHARED_FOUND: ${PIO_SHARED_FOUND}")
+message(DEBUG "[FindPIO] PIO_STATIC_FOUND: ${PIO_STATIC_FOUND}")
+
+## Check package has been found correctly
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  PIO
+  REQUIRED_VARS
+    PIO_PREFIX
+    PIO_INCLUDE_DIR
+  HANDLE_COMPONENTS
+)
+message(DEBUG "[FindPIO] PIO_FOUND: ${PIO_FOUND}")
+
+## Create targets
+set(_new_components)
+
+
+# PIO::PIO_Fortran_STATIC imported interface target
+if(PIO_Fortran_FOUND AND PIO_STATIC_FOUND AND NOT TARGET PIO::PIO_Fortran_STATIC)
+    add_library(PIO::PIO_Fortran_STATIC INTERFACE IMPORTED)
+    set_target_properties(PIO::PIO_Fortran_STATIC PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                            INTERFACE_LINK_LIBRARIES ${PIO_Fortran_STATIC_LIB}
+                            IMPORTED_GLOBAL True )
+    if(PIO_MODULE_DIR AND NOT PIO_MODULE_DIR STREQUAL PIO_INCLUDE_DIR )
+        set_property(TARGET PIO::PIO_Fortran_STATIC APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PIO_MODULE_DIR})
+    endif()
+    target_link_libraries(PIO::PIO_Fortran_STATIC INTERFACE NetCDF::NetCDF_C)
+    set(_new_components 1)
+endif()
+
+# PIO::PIO_Fortran_SHARED imported interface target
+if(PIO_Fortran_FOUND AND PIO_SHARED_FOUND AND NOT TARGET PIO::PIO_Fortran_SHARED)
+    add_library(PIO::PIO_Fortran_SHARED INTERFACE IMPORTED)
+    set_target_properties(PIO::PIO_Fortran_SHARED PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                            INTERFACE_LINK_LIBRARIES ${PIO_Fortran_SHARED_LIB}
+                            IMPORTED_GLOBAL True )
+    if(PIO_MODULE_DIR AND NOT PIO_MODULE_DIR STREQUAL PIO_INCLUDE_DIR )
+        set_property(TARGET PIO::PIO_Fortran_SHARED APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PIO_MODULE_DIR})
+    endif()
+    set(_new_components 1)
+endif()
+
+# PIO::PIO_C_STATIC imported interface target
+if(PIO_C_FOUND AND PIO_STATIC_FOUND AND NOT TARGET PIO::PIO_C_STATIC)
+    add_library(PIO::PIO_C_STATIC INTERFACE IMPORTED)
+    set_target_properties(PIO::PIO_C_STATIC PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                            INTERFACE_LINK_LIBRARIES ${PIO_C_STATIC_LIB}
+                            IMPORTED_GLOBAL True )
+    target_link_libraries(PIO::PIO_C_STATIC INTERFACE NetCDF::NetCDF_C)
+    set(_new_components 1)
+endif()
+
+# PIO::PIO_C_SHARED imported interface target
+if(PIO_C_FOUND AND PIO_SHARED_FOUND AND NOT TARGET PIO::PIO_C_SHARED)
+    add_library(PIO::PIO_C_SHARED INTERFACE IMPORTED)
+    set_target_properties(PIO::PIO_C_SHARED PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES ${PIO_INCLUDE_DIR}
+                            INTERFACE_LINK_LIBRARIES ${PIO_C_SHARED_LIB}
+                            IMPORTED_GLOBAL True )
+    set(_new_components 1)
+endif()
+
+# PIO::PIO_Fortran - Shared libraries if available, static otherwise
+if(TARGET PIO::PIO_Fortran_SHARED)
+    add_library(PIO::PIO_Fortran ALIAS PIO::PIO_Fortran_SHARED)
+elseif(TARGET PIO::PIO_Fortran_STATIC)
+    add_library(PIO::PIO_Fortran ALIAS PIO::PIO_Fortran_STATIC)
+endif()
+
+# PIO::PIO_C - Shared libraries if available, static otherwise
+if(TARGET PIO::PIO_C_SHARED)
+    add_library(PIO::PIO_C ALIAS PIO::PIO_C_SHARED)
+elseif(TARGET PIO::PIO_C_STATIC)
+    add_library(PIO::PIO_C ALIAS PIO::PIO_C_STATIC)
+endif()
+
+## Print status
+if(${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_components)
+    message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME}:" )
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME}_PREFIX [${${CMAKE_FIND_PACKAGE_NAME}_PREFIX}]")
+    set(_found_comps)
+    foreach( _comp IN ITEMS Fortran C STATIC SHARED )
+        if( ${CMAKE_FIND_PACKAGE_NAME}_${_comp}_FOUND )
+            list(APPEND _found_comps ${_comp})
+        endif()
+    endforeach()
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME} Components Found: ${_found_comps}")
+    unset(_found_comps)
+endif()
+unset(_new_components)

--- a/cmake/Modules/FindPnetCDF.cmake
+++ b/cmake/Modules/FindPnetCDF.cmake
@@ -1,0 +1,174 @@
+# FindPnetCDF.cmake
+#
+# Copyright UCAR 2020
+#
+# Find PnetCDF: A Parallel I/O Library for NetCDF File Access
+# https://parallel-netcdf.github.io/
+#
+# Components available for query:
+#  C - Has C support
+#  CXX - Has CXX support
+#  Fortran - Has Fortran support
+#  NetCDF4 - Has NetCDF4 output support
+#  GPTL - Has profiling support with GPTL enabled
+#  Threads - Has thread safety enabled
+#
+# Variables provided:
+#  PnetCDF_FOUND - True if PnetCDFL was found
+#  PnetCDF_CONFIG_EXE - pnetcdf-config executable if found
+#  PnetCDF_VERSION - Version of installed PnetCDF
+#  PnetCDF_BIN_DIR - PnetCDF binary directory
+#  PnetCDF_DEBUG - True if PnetCDF is built in debug mode
+#
+# Targets provided:
+#  PnetCDF::PnetCDF_Fortran - Fortran interface target
+#  PnetCDF::PnetCDF_C - C interface target
+#  PnetCDF::PnetCDF_CXX - CXX interface target
+#
+# Functions provided:
+#  pnetcdf_get_config(ret_var flags) - Call `pnetcdf-config` with flags and set ret_var with output on execution success.
+#
+#
+# This module requires the `pnetcdf-config` executable to detect the directories and compiler and linker flags
+# necessary for the PnetCDF::PnetCDF target.  To control where PnetCDF is found:
+# * Option 1: Set an environment or cmake variable `PnetCDF_ROOT` to the install prefix for PnetCDF (e.g. /usr/local)
+# * Option 2: Set an environment or cmake variable `PnetCDF_CONFIG_EXE` to the full path to the `pnetcdf-config`
+#              (e.g., /usr/local/bin/pnetcdf-config)
+#
+
+find_program(PnetCDF_CONFIG_EXE NAMES pnetcdf-config PATH_SUFFIXES bin bin64 PATHS
+             $ENV{PnetCDF_CONFIG_EXE} ${PnetCDF_ROOT} $ENV{PnetCDF_ROOT} ${PNETCDF_ROOT} $ENV{PNETCDF_ROOT})
+message(DEBUG "[FindPnetCDF] Using PnetCDF_CONFIG_EXE:${PnetCDF_CONFIG_EXE}")
+
+# pnetcdf_get_config(ret_var flags...)
+#  Get the output of pnetcdf-config
+#  Args:
+#   ret_var: return variable name
+#   flags: flags to pass to pnetcdf-config
+function(pnetcdf_get_config ret_var pcflags)
+    execute_process(COMMAND ${PnetCDF_CONFIG_EXE} ${pcflags} OUTPUT_VARIABLE _out RESULT_VARIABLE _ret OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_ret EQUAL 0)
+        separate_arguments(_out)
+        set(${ret_var} ${_out} PARENT_SCOPE)
+    else()
+        set(${ret_var} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+## Find libraries and paths, and determine found components
+if(EXISTS ${PnetCDF_CONFIG_EXE})
+    #Use pnetcdf-config to find the prefix, flags, directories, executables, and libraries
+    pnetcdf_get_config(PnetCDF_VERSION --version)
+    string(REGEX MATCH "([0-9.]+)" PnetCDF_VERSION "${PnetCDF_VERSION}") #Match only version actual number
+
+    pnetcdf_get_config(PnetCDF_PREFIX --prefix)
+    pnetcdf_get_config(PnetCDF_CXX_FOUND --has-c++)
+    pnetcdf_get_config(PnetCDF_Fortran_FOUND --has-fortran)
+    pnetcdf_get_config(PnetCDF_NetCDF4_FOUND --netcdf4)
+    pnetcdf_get_config(PnetCDF_GPTL_FOUND --profiling)
+    pnetcdf_get_config(PnetCDF_Threads_FOUND --thread-safe)
+    pnetcdf_get_config(PnetCDF_DEBUG --debug)
+    pnetcdf_get_config(PnetCDF_INCLUDE_DIR --includedir)
+    pnetcdf_get_config(PnetCDF_LIB_DIR --libdir)
+
+    #Translate boolean variables from pnetcdf-config enabled/disabled to True/False
+    foreach(_var IN ITEMS PnetCDF_CXX_FOUND PnetCDF_Fortran_FOUND PnetCDF_NetCDF4_FOUND PnetCDF_GPTL_FOUND PnetCDF_Threads_FOUND PnetCDF_DEBUG)
+        if( ${_var} MATCHES "(enabled)|([Yy][Ee][Ss])")
+            set(${_var} True)
+        else()
+            set(${_var} False)
+        endif()
+    endforeach()
+
+    find_path(PnetCDF_MODULE_DIR NAMES pnetcdf.mod HINTS ${PnetCDF_PREFIX} ${PnetCDF_INCLUDE_DIR}
+              PATH_SUFFIXES include include/pnetcdf module module/pnetcdf lib/pnetcdf/module NO_DEFAULT_PATH)
+    if(PnetCDF_Fortran_FOUND AND NOT EXISTS ${PnetCDF_MODULE_DIR})
+        message(WARNING "[PnetCDF] pnetcdf-config --has-fortran=yes, but could not find pnetcdf.mod.  Set PnetCDF_MODULE_DIR to path containing pnetcdf.mod")
+        set(PnetCDF_Fortran_FOUND NO)
+    endif()
+
+    if(PnetCDF_INCLUDE_DIR AND PnetCDF_LIB_DIR)
+        set(PnetCDF_C_FOUND True)
+    endif()
+
+    find_path(PnetCDF_BIN_DIR NAMES pnetcdf-config PATH_SUFFIXES bin PATHS ${PnetCDF_PREFIX} NO_DEFAULT_PATH)
+    find_library(PnetCDF_LIBRARY NAMES pnetcdf PATH_SUFFIXES lib lib64 PATHS ${PnetCDF_PREFIX} NO_DEFAULT_PATH)
+    #Hide non-documented cache variables reserved for internal/advanced usage
+    mark_as_advanced( PnetCDF_MODULE_DIR PnetCDF_LIBRARY )
+endif()
+
+## Debugging output
+message(DEBUG "[FindPnetCDF] PnetCDF_CONFIG_EXE: ${PnetCDF_CONFIG_EXE}")
+message(DEBUG "[FindPnetCDF] PnetCDF_VERSION: ${PnetCDF_VERSION}")
+message(DEBUG "[FindPnetCDF] PnetCDF_C_FOUND: ${PnetCDF_C_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_CXX_FOUND: ${PnetCDF_CXX_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_Fortran_FOUND: ${PnetCDF_Fortran_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_NetCDF4_FOUND: ${PnetCDF_NetCDF4_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_GPTL_FOUND: ${PnetCDF_GPTL_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_Threads_FOUND: ${PnetCDF_Threads_FOUND}")
+message(DEBUG "[FindPnetCDF] PnetCDF_DEBUG: ${PnetCDF_DEBUG}")
+message(DEBUG "[FindPnetCDF] PnetCDF_PREFIX: ${PnetCDF_PREFIX}")
+message(DEBUG "[FindPnetCDF] PnetCDF_BIN_DIR: ${PnetCDF_BIN_DIR}")
+message(DEBUG "[FindPnetCDF] PnetCDF_INCLUDE_DIR: ${PnetCDF_INCLUDE_DIR}")
+message(DEBUG "[FindPnetCDF] PnetCDF_MODULE_DIR: ${PnetCDF_MODULE_DIR}")
+message(DEBUG "[FindPnetCDF] PnetCDF_LIB_DIR: ${PnetCDF_LIB_DIR}")
+
+## Check package has been found correctly
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  PnetCDF
+  REQUIRED_VARS
+    PnetCDF_CONFIG_EXE
+    PnetCDF_PREFIX
+  VERSION_VAR
+    PnetCDF_VERSION
+  HANDLE_COMPONENTS
+)
+message(DEBUG "[FindPnetCDF] PnetCDF_FOUND: ${PnetCDF_FOUND}")
+
+## Create targets
+set(_new_components)
+
+# PnetCDF::PnetCDF_Fortran imported interface target
+if(PnetCDF_Fortran_FOUND AND NOT TARGET PnetCDF::PnetCDF_Fortran)
+    add_library(PnetCDF::PnetCDF_Fortran INTERFACE IMPORTED)
+    set_target_properties(PnetCDF::PnetCDF_Fortran PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
+                                                              INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+    if(PnetCDF_MODULE_DIR AND NOT PnetCDF_MODULE_DIR STREQUAL PnetCDF_INCLUDE_DIR )
+        set_property(TARGET PnetCDF::PnetCDF_Fortran APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_MODULE_DIR})
+    endif()
+    set(_new_components 1)
+    target_link_libraries(PnetCDF::PnetCDF_Fortran INTERFACE -lpnetcdf)
+endif()
+
+# PnetCDF::PnetCDF_C imported interface target
+if(PnetCDF_C_FOUND AND NOT TARGET PnetCDF::PnetCDF_C)
+    add_library(PnetCDF::PnetCDF_C INTERFACE IMPORTED)
+    set_target_properties(PnetCDF::PnetCDF_C PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
+                                                        INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+    set(_new_components 1)
+endif()
+
+# PnetCDF::PnetCDF_CXX imported interface target
+if(PnetCDF_CXX_FOUND AND NOT TARGET PnetCDF::PnetCDF_CXX)
+    add_library(PnetCDF::PnetCDF_CXX INTERFACE IMPORTED)
+    set_target_properties(PnetCDF::PnetCDF_CXX PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${PnetCDF_INCLUDE_DIR}
+                                                          INTERFACE_LINK_DIRECTORIES ${PnetCDF_LIB_DIR})
+    set(_new_components 1)
+endif()
+
+## Print status
+if(${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_components)
+    message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME}:" )
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME}_VERSION [${${CMAKE_FIND_PACKAGE_NAME}_VERSION}]")
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME}_PREFIX [${${CMAKE_FIND_PACKAGE_NAME}_PREFIX}]")
+    set(_found_comps)
+    foreach( _comp IN ITEMS Fortran C CXX NetCDF4 GPTL Threads )
+        if( ${CMAKE_FIND_PACKAGE_NAME}_${_comp}_FOUND )
+            list(APPEND _found_comps ${_comp})
+        endif()
+    endforeach()
+    message( STATUS "  - ${CMAKE_FIND_PACKAGE_NAME} Components Found: ${_found_comps}")
+    unset(_found_comps)
+endif()
+unset(_new_components)

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,0 +1,121 @@
+@PACKAGE_INIT@
+
+# @PROJECT_NAME@-config.cmake
+#
+# Valid Find COMPONENTS:
+#  * SHARED - Require shared libraries.
+#  * STATIC - Require static libraries.
+#  * DOUBLE_PRECISION - Find double precision libraries
+#  * PROFILE - True if GPTL profiling is enabled
+#  * OpenMP - True if OpenMP support is enabled
+#  * core_atmosphere - Find atmosphere core
+#  * core_init_atmosphere - Find init_atmosphere core
+#  * core_ocean - Find ocean core
+#  * core_landice - Find landice core
+#  * core_seaice - Find seaice core
+#  * core_sw - Find sw core
+#  * core_test - Find test core
+#
+#
+# Output variables set:
+#  * @PROJECT_NAME@_VERSION - Version of install package
+#  * @PROJECT_NAME@_VERSION_MAJOR - Major version of install package
+#  * @PROJECT_NAME@_VERSION_MINOR - Minor version of install package
+#  * @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID - Compiler used to generate Fortran Modules
+#  * @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION - Compiler version used to generate Fortran Modules
+#  * @PROJECT_NAME@_CORE_<CORE>_DATADIR - Location for data files for core (namelist, streams, data tables, etc.)
+#  * @PROJECT_NAME@_BINDIR - Location for installed auxiliary binaries.
+#
+
+# Imported interface targets provided:
+#  * @PROJECT_NAME@::core::<core> - Core targets
+#  * @PROJECT_NAME@::operators - Operators library target
+#  * @PROJECT_NAME@::framework - Framework library target
+#  * @PROJECT_NAME@::external::esmf - exmf_time library target
+#  * @PROJECT_NAME@::external::ezxml - ezxml library target
+#
+
+#  * @PROJECT_NAME@::@PROJECT_NAME@_shared - shared library target:
+
+#Include targets file.  This will create IMPORTED target @PROJECT_NAME@
+string(TOLOWER @PROJECT_NAME@ _project_name_lower)
+if(NOT TARGET @PROJECT_NAME@::framework)
+    include("${CMAKE_CURRENT_LIST_DIR}/${_project_name_lower}-targets-external.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/${_project_name_lower}-targets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/${_project_name_lower}-targets-core.cmake")
+endif()
+
+set(@PROJECT_NAME@_VERSION @PROJECT_VERSION@)
+set(@PROJECT_NAME@_VERSION_MAJOR @PROJECT_VERSION_MAJOR@)
+set(@PROJECT_NAME@_VERSION_MINOR @PROJECT_VERSION_MINOR@)
+
+#Export Fortran compiler version and check module compatibility
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@)
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION @CMAKE_Fortran_COMPILER_VERSION@)
+if(NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILER_ID
+   OR NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION VERSION_EQUAL CMAKE_Fortran_COMPILER_VERSION)
+    message(SEND_ERROR "Package @PROJECT_NAME@ provides Fortran modules built with "
+            "${@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID}-${@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION} "
+            "but this build for ${PROJECT_NAME} uses incompatible compiler ${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}")
+endif()
+
+set_and_check(@PROJECT_NAME@_BINDIR @PACKAGE_BINDIR@)
+set_and_check(@PROJECT_NAME@_CMAKE_MODULE_PATH @PACKAGE_CMAKE_MODULE_INSTALL_PATH@)
+set(CMAKE_MODULE_PATH ${@PROJECT_NAME@_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
+
+include(CMakeFindDependencyMacro)
+if(@OpenMP_Fortran_FOUND@) #OpenMP_Fortran_FOUND
+    if(NOT OpenMP_Fortran_FOUND)
+        find_package(OpenMP REQUIRED COMPONENTS Fortran)
+    endif()
+    set(@PROJECT_NAME@_OpenMP_FOUND True)
+endif()
+if(NOT MPI_Fortran_FOUND)
+    find_package(MPI REQUIRED COMPONENTS Fortran)
+endif()
+if(NOT NetCDF_Fortran_FOUND)
+    find_package(NetCDF REQUIRED COMPONENTS Fortran)
+endif()
+find_package(PnetCDF REQUIRED COMPONENTS Fortran)
+find_package(PIO REQUIRED COMPONENTS Fortran C)
+if(@MPAS_PROFILE@) #MPAS_PROFILE
+    if(NOT GPTL_FOUND)
+        find_dependency(GPTL REQUIRED)
+    endif()
+    set(@PROJECT_NAME@_PROFILE_FOUND)
+endif()
+
+if(@BUILD_SHARED_LIBS@) #BUILD_SHARED_LIBS
+    set(@PROJECT_NAME@_SHARED_FOUND True)
+else()
+    set(@PROJECT_NAME@_STATIC_FOUND True)
+endif()
+if(@MPAS_DOUBLE_PRECISION@) #MPAS_DOUBLE_PRECISION
+    set(@PROJECT_NAME@_DOUBLE_PRECISION_FOUND True)
+else()
+    set(@PROJECT_NAME@_DOUBLE_PRECISION_FOUND False)
+endif()
+set(MPAS_CORES @MPAS_CORES@)
+foreach(_core IN LISTS MPAS_CORES)
+    string(TOUPPER ${_core} _CORE)
+    set_and_check(@PROJECT_NAME@_CORE_${_CORE}_DATADIR @PACKAGE_CORE_DATADIR_ROOT@/core_${_core})
+    set(@PROJECT_NAME@_core_${_core}_FOUND True)
+endforeach()
+
+check_required_components("@PROJECT_NAME@")
+
+## Print status
+if(NOT @PROJECT_NAME@_FIND_QUIETLY)
+    #Get list of all found components for printing
+    set(_found_components)
+    set(_all_components SHARED STATIC PROFILE OpenMP DOUBLE_PRECISION core_atmosphere core_init_atmosphere core_landice core_ocean core_sw core_test)
+    foreach(_cmp IN LISTS _all_components)
+        if(@PROJECT_NAME@_${_cmp}_FOUND)
+            list(APPEND _found_components ${_cmp})
+        endif()
+    endforeach()
+
+    message(STATUS "Found @PROJECT_NAME@: (version: \"@PROJECT_VERSION@\") (components: ${_found_components})")
+    unset(_found_components)
+    unset(_all_components)
+endif()

--- a/src/core_atmosphere/CMakeLists.txt
+++ b/src/core_atmosphere/CMakeLists.txt
@@ -1,0 +1,200 @@
+
+## Source files
+# physics/
+set(ATMOSPHERE_CORE_PHYSICS_SOURCES
+        ccpp_kinds.F
+        mpas_atmphys_camrad_init.F
+        mpas_atmphys_constants.F
+        mpas_atmphys_control.F
+        mpas_atmphys_date_time.F
+        mpas_atmphys_driver_cloudiness.F
+        mpas_atmphys_driver_microphysics.F
+        mpas_atmphys_driver_oml.F
+        mpas_atmphys_finalize.F
+        mpas_atmphys_functions.F
+        mpas_atmphys_init_microphysics.F
+        mpas_atmphys_interface.F
+        mpas_atmphys_landuse.F
+        mpas_atmphys_lsm_noahinit.F
+        mpas_atmphys_manager.F
+        mpas_atmphys_o3climatology.F
+        mpas_atmphys_rrtmg_lwinit.F
+        mpas_atmphys_rrtmg_swinit.F
+        mpas_atmphys_update.F
+        mpas_atmphys_update_surface.F
+        mpas_atmphys_utilities.F
+        mpas_atmphys_driver.F
+        mpas_atmphys_driver_convection.F
+        mpas_atmphys_driver_gwdo.F
+        mpas_atmphys_driver_lsm.F
+        mpas_atmphys_driver_pbl.F
+        mpas_atmphys_driver_radiation_lw.F
+        mpas_atmphys_driver_radiation_sw.F
+        mpas_atmphys_driver_seaice.F
+        mpas_atmphys_driver_sfclayer.F
+        mpas_atmphys_init.F
+        mpas_atmphys_lsm_shared.F
+        mpas_atmphys_packages.F
+        mpas_atmphys_todynamics.F
+        mpas_atmphys_vars.F
+)
+list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_SOURCES PREPEND physics/)
+
+## Unused
+# physics/physics_wrf/
+set(ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES
+        libmassv.F
+        module_bep_bem_helper.F
+        module_bl_gwdo.F
+        module_bl_ysu.F
+        module_cam_error_function.F
+        module_cam_shr_kind_mod.F
+        module_cam_support.F
+        module_cu_gf.mpas.F
+        module_mp_kessler.F
+        module_mp_radar.F
+        module_mp_thompson.F
+        module_mp_thompson_cldfra3.F
+        module_mp_wsm6.F
+        module_ra_cam_support.F
+        module_ra_rrtmg_lw.F
+        module_ra_rrtmg_sw.F
+        module_ra_rrtmg_vinterp.F
+        module_sf_bem.F
+        module_sf_bep.F
+        module_sf_bep_bem.F
+        module_sf_noah_seaice.F
+        module_sf_noah_seaice_drv.F
+        module_sf_noahdrv.F
+        module_sf_noahlsm.F
+        module_sf_noahlsm_glacial_only.F
+        module_sf_oml.F
+        module_sf_sfcdiags.F
+        module_sf_sfclay.F
+        module_sf_sfclayrev.F
+        module_sf_urban.F
+        bl_mynn_post.F
+        bl_mynn_pre.F
+        module_bl_mynn.F
+        module_cu_kfeta.F
+        module_cu_ntiedtke.F
+        module_cu_tiedtke.F
+        module_ra_cam.F
+        module_sf_mynn.F
+        sf_mynn_pre.F
+)
+
+list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES PREPEND physics/physics_wrf/)
+
+set(ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES
+        bl_gwdo.F
+        bl_ysu.F
+        cu_ntiedtke.F
+        module_libmassv.F
+        mp_wsm6.F
+        mp_wsm6_effectRad.F
+        bl_mynn.F
+        bl_mynn_subroutines.F
+        mp_radar.F
+        mynn_shared.F
+        sf_mynn.F
+        sf_sfclayrev.F
+)
+
+list(TRANSFORM ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES PREPEND physics/physics_mmm/)
+
+# diagnostics/
+set(ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES
+        mpas_atm_diagnostic_template.F
+        mpas_atm_diagnostics_manager.F
+        mpas_atm_diagnostics_utils.F
+        mpas_cloud_diagnostics.F
+        mpas_convective_diagnostics.F
+        mpas_isobaric_diagnostics.F
+        mpas_pv_diagnostics.F
+        mpas_soundings.F
+)
+
+list(TRANSFORM ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES PREPEND diagnostics/)
+
+# dynamics/
+set(ATMOSPHERE_CORE_DYNAMICS_SOURCES
+        mpas_atm_boundaries.F
+        mpas_atm_iau.F
+        mpas_atm_time_integration.F)
+list(TRANSFORM ATMOSPHERE_CORE_DYNAMICS_SOURCES PREPEND dynamics/)
+
+# utils/
+set(ATMOSPHERE_CORE_UTILS_SOURCES
+        atmphys_build_tables_thompson.F
+        build_tables.F)
+list(TRANSFORM ATMOSPHERE_CORE_UTILS_SOURCES PREPEND utils/)
+
+# core_atosphere
+set(ATMOSPHERE_CORE_SOURCES
+        mpas_atm_dimensions.F
+        mpas_atm_threading.F
+        mpas_atm_core.F
+        mpas_atm_core_interface.F
+        mpas_atm_halos.F
+)
+
+## Generated includes
+set(ATMOSPHERE_CORE_INCLUDES
+        block_dimension_routines.inc
+        core_variables.inc
+        define_packages.inc
+        domain_variables.inc
+        namelist_call.inc
+        namelist_defines.inc
+        setup_immutable_streams.inc
+        structs_and_variables.inc)
+
+
+add_library(core_atmosphere ${ATMOSPHERE_CORE_SOURCES}
+        ${ATMOSPHERE_CORE_PHYSICS_SOURCES}
+        ${ATMOSPHERE_CORE_PHYSICS_MMM_SOURCES}
+        ${ATMOSPHERE_CORE_PHYSICS_WRF_SOURCES}
+        ${ATMOSPHERE_CORE_DIAGNOSTIC_SOURCES}
+        ${ATMOSPHERE_CORE_DYNAMICS_SOURCES})
+
+set(CORE_ATMOSPHERE_COMPILE_DEFINITIONS
+        mpas=1
+        MPAS_NATIVE_TIMERS
+)
+if (${DO_PHYSICS})
+    list(APPEND CORE_ATMOSPHERE_COMPILE_DEFINITIONS DO_PHYSICS)
+endif ()
+target_compile_definitions(core_atmosphere PRIVATE ${CORE_ATMOSPHERE_COMPILE_DEFINITIONS})
+set_MPAS_DEBUG_flag(core_atmosphere)
+mpas_core_target(CORE atmosphere TARGET core_atmosphere INCLUDES ${ATMOSPHERE_CORE_INCLUDES})
+
+#Get physics_wrf tables from MPAS-Data
+include(FetchContent)
+if (${PROJECT_VERSION} VERSION_GREATER_EQUAL 7.0)
+    set(MPAS_DATA_GIT_TAG v${PROJECT_VERSION_MAJOR}.0)
+else ()
+    set(MPAS_DATA_GIT_TAG master)
+endif ()
+
+FetchContent_Declare(mpas_data
+        GIT_REPOSITORY https://github.com/MPAS-Dev/MPAS-Data.git
+        GIT_TAG ${MPAS_DATA_GIT_TAG}
+        GIT_PROGRESS True
+        GIT_SHALLOW True)
+FetchContent_Populate(mpas_data)
+message(STATUS "MPAS-Data source dir: ${mpas_data_SOURCE_DIR}")
+set(PHYSICS_WRF_DATA_DIR ${mpas_data_SOURCE_DIR}/atmosphere/physics_wrf/files)
+file(GLOB PHYSICS_WRF_DATA RELATIVE ${PHYSICS_WRF_DATA_DIR} "${PHYSICS_WRF_DATA_DIR}/*")
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere)
+foreach (data_file IN LISTS PHYSICS_WRF_DATA)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PHYSICS_WRF_DATA_DIR}/${data_file}
+            ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/core_atmosphere/${data_file})
+endforeach ()
+install(DIRECTORY ${PHYSICS_WRF_DATA_DIR}/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/core_atmosphere)
+
+add_executable(mpas_atmosphere_build_tables ${ATMOSPHERE_CORE_UTILS_SOURCES})
+target_link_libraries(mpas_atmosphere_build_tables PUBLIC core_atmosphere)
+mpas_fortran_target(mpas_atmosphere_build_tables)
+install(TARGETS mpas_atmosphere_build_tables EXPORT ${PROJECT_NAME}ExportsCore
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/core_init_atmosphere/CMakeLists.txt
+++ b/src/core_init_atmosphere/CMakeLists.txt
@@ -1,0 +1,78 @@
+# MPAS/src/core_init_atmosphere
+#
+# Targets
+#   MPAS::core::init_atmosphere
+
+## Generated includes
+set(init_atm_core_inc
+        block_dimension_routines.inc
+        core_variables.inc
+        define_packages.inc
+        domain_variables.inc
+        namelist_call.inc
+        namelist_defines.inc
+        setup_immutable_streams.inc
+        structs_and_variables.inc)
+
+## core_init_atosphere
+set(init_atm_core_srcs
+        mpas_atm_advection.F
+        mpas_atmphys_constants.F
+        mpas_atmphys_date_time.F
+        mpas_atmphys_functions.F
+        mpas_atmphys_initialize_real.F
+        mpas_atmphys_utilities.F
+        mpas_geotile_manager.F
+        mpas_init_atm_bitarray.F
+        mpas_init_atm_cases.F
+        mpas_init_atm_core.F
+        mpas_init_atm_core_interface.F
+        mpas_init_atm_gwd.F
+        mpas_init_atm_hinterp.F
+        mpas_init_atm_llxy.F
+        mpas_init_atm_queue.F
+        mpas_init_atm_read_met.F
+        mpas_init_atm_static.F
+        mpas_init_atm_surface.F
+        mpas_init_atm_vinterp.F
+        mpas_kd_tree.F
+        mpas_parse_geoindex.F
+        mpas_stack.F
+        read_geogrid.c)
+
+add_library(core_init_atmosphere ${init_atm_core_srcs})
+if (${DO_PHYSICS})
+    target_compile_definitions(core_init_atmosphere PRIVATE DO_PHYSICS)
+endif ()
+if (MPAS_DOUBLE_PRECISION)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-double-8")
+else ()
+    target_compile_definitions(core_init_atmosphere PRIVATE SINGLE_PRECISION)
+endif ()
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    target_compile_definitions(core_init_atmosphere PRIVATE MPAS_DEBUG)
+endif ()
+if (${PIO_FOUND})
+    FILE(STRINGS ${PIO_PREFIX}/lib/libpio.settings PIO_SETTINGS)
+    foreach (setting ${PIO_SETTINGS})
+        string(FIND ${setting} "PIO Version" found)
+        if (${found} GREATER -1)
+            string(FIND ${setting} "2." pos)
+            if (${pos} GREATER -1)
+                set(PIO_VERSION 2)
+            else ()
+                set(PIO_VERSION 1)
+            endif ()
+            break()
+        endif ()
+    endforeach ()
+    if (${PIO_VERSION} EQUAL 1)
+        target_compile_definitions(core_init_atmosphere PRIVATE USE_PIO1)
+    else ()
+        target_compile_definitions(core_init_atmosphere PRIVATE USE_PIO2)
+    endif ()
+    target_compile_definitions(core_init_atmosphere PRIVATE MPAS_PIO_SUPPORT)
+endif ()
+target_compile_definitions(core_init_atmosphere PRIVATE mpas=1)
+target_compile_definitions(framework PRIVATE MPAS_NATIVE_TIMERS)
+mpas_core_target(CORE init_atmosphere TARGET core_init_atmosphere INCLUDES ${init_atm_core_inc})

--- a/src/external/esmf_time_f90/CMakeLists.txt
+++ b/src/external/esmf_time_f90/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+set(_esmf_time_src
+    ESMF_AlarmClockMod.F90
+    ESMF_AlarmMod.F90
+    ESMF_BaseMod.F90
+    ESMF_BaseTimeMod.F90
+    ESMF_CalendarMod.F90
+    ESMF_ClockMod.F90
+    ESMF.F90
+    ESMF_FractionMod.F90
+    ESMF_Macros.inc
+    ESMF_ShrTimeMod.F90
+    ESMF_Stubs.F90
+    ESMF_TimeIntervalMod.F90
+    ESMF_TimeMgr.inc
+    ESMF_TimeMod.F90
+    MeatMod.F90
+    wrf_error_fatal.F90
+    wrf_message.F90)
+
+add_library(esmf ${_esmf_time_src})
+mpas_fortran_target(esmf)
+add_library(${PROJECT_NAME}::external::esmf ALIAS esmf)
+
+target_compile_definitions(esmf PRIVATE HIDE_MPI=1)
+
+target_include_directories(esmf PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+target_link_libraries(esmf PUBLIC MPI::MPI_Fortran)
+
+install(TARGETS esmf EXPORT ${PROJECT_NAME}ExportsExternal
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+

--- a/src/external/ezxml/CMakeLists.txt
+++ b/src/external/ezxml/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+add_library(ezxml ezxml.c)
+add_library(${PROJECT_NAME}::external::ezxml ALIAS ezxml)
+target_include_directories(ezxml PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+install(TARGETS ezxml EXPORT ${PROJECT_NAME}ExportsExternal
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -1,0 +1,70 @@
+
+set(MPAS_FRAMEWORK_SOURCES
+        mpas_block_creator.F
+        mpas_block_decomp.F
+        mpas_bootstrapping.F
+        mpas_c_interfacing.F
+        mpas_constants.F
+        mpas_decomp.F
+        mpas_domain_routines.F
+        mpas_field_routines.F
+        mpas_forcing.F
+        mpas_hash.F
+        mpas_io_units.F
+        mpas_kind_types.F
+        mpas_pool_routines.F
+        mpas_sort.F
+        mpas_stream_list.F
+        mpas_threading.F
+        mpas_timer.F
+        mpas_abort.F
+        mpas_attlist.F
+        mpas_derived_types.F
+        mpas_dmpar.F
+        mpas_framework.F
+        mpas_halo.F
+        mpas_io.F
+        mpas_io_streams.F
+        mpas_log.F
+        mpas_stream_inquiry.F
+        mpas_stream_manager.F
+        mpas_string_utils.F
+        mpas_timekeeping.F
+        pool_hash.c
+        random_id.c
+        regex_matching.c
+        xml_stream_parser.c
+        stream_inquiry.c)
+
+add_library(framework ${MPAS_FRAMEWORK_SOURCES})
+set_MPAS_DEBUG_flag(framework)
+set(FRAMEWORK_COMPILE_DEFINITIONS
+        USE_PIO2
+        MPAS_PIO_SUPPORT
+        mpas=1
+        MPAS_NATIVE_TIMERS)
+target_compile_definitions(framework PRIVATE ${FRAMEWORK_COMPILE_DEFINITIONS})
+
+mpas_fortran_target(framework)
+add_library(${PROJECT_NAME}::framework ALIAS framework)
+
+set_target_properties(framework PROPERTIES OUTPUT_NAME mpas_framework)
+
+set(FRAMEWORK_LINK_LIBRARIES
+        ${PROJECT_NAME}::external::esmf
+        ${PROJECT_NAME}::external::ezxml
+        PIO::PIO_Fortran
+        PIO::PIO_C
+        PnetCDF::PnetCDF_Fortran
+        NetCDF::NetCDF_Fortran
+        NetCDF::NetCDF_C
+        MPI::MPI_Fortran)
+
+if (MPAS_PROFILE)
+    list(APPEND FRAMEWORK_LINK_LIBRARIES GPTL::GPTL)
+endif ()
+target_link_libraries(framework PUBLIC ${FRAMEWORK_LINK_LIBRARIES})
+
+install(TARGETS framework EXPORT ${PROJECT_NAME}Exports
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -1,0 +1,24 @@
+list(APPEND _mpas_operators_src
+    mpas_geometry_utils.F
+    mpas_matrix_operations.F
+    mpas_rbf_interpolation.F
+    mpas_spline_interpolation.F
+    mpas_tensor_operations.F
+    mpas_tracer_advection_helpers.F
+    mpas_tracer_advection_mono.F
+    mpas_tracer_advection_std.F
+    mpas_vector_operations.F
+    mpas_vector_reconstruction.F)
+
+add_library(operators ${_mpas_operators_src})
+
+mpas_fortran_target(operators)
+
+add_library(${PROJECT_NAME}::operators ALIAS operators)
+
+set_target_properties(operators PROPERTIES OUTPUT_NAME mpas_operators)
+target_link_libraries(operators PUBLIC ${PROJECT_NAME}::framework)
+
+install(TARGETS operators EXPORT ${PROJECT_NAME}Exports
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,0 +1,30 @@
+
+if (DEFINED ENV{MPAS_TOOL_DIR})
+  message(STATUS "*** Using MPAS tools from $ENV{MPAS_TOOL_DIR} ***")
+  add_custom_target(namelist_gen)
+  add_custom_command(
+    TARGET namelist_gen PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/namelist_gen ${CMAKE_CURRENT_BINARY_DIR}/namelist_gen)
+  add_custom_target(streams_gen)
+  add_custom_command(
+    TARGET streams_gen PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/streams_gen ${CMAKE_CURRENT_BINARY_DIR}/streams_gen)
+  add_custom_target(parse)
+  add_custom_command(
+    TARGET parse PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $ENV{MPAS_TOOL_DIR}/input_gen/parse ${CMAKE_CURRENT_BINARY_DIR}/parse)
+else()
+  message(STATUS "*** Building MPAS tools from source ***")
+  # Make build tools, need to be compiled with serial compiler.
+  set(CMAKE_C_COMPILER ${SCC})
+
+  add_executable(streams_gen input_gen/streams_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
+  add_executable(namelist_gen input_gen/namelist_gen.c input_gen/test_functions.c ../external/ezxml/ezxml.c)
+  add_executable(parse registry/parse.c registry/dictionary.c registry/gen_inc.c registry/fortprintf.c registry/utility.c ../external/ezxml/ezxml.c)
+
+  foreach(EXEITEM streams_gen namelist_gen parse)
+    target_compile_definitions(${EXEITEM} PRIVATE ${CPPDEFS})
+    target_compile_options(${EXEITEM} PRIVATE "-Uvector")
+    target_include_directories(${EXEITEM} PRIVATE ${INCLUDES})
+  endforeach()
+endif()

--- a/src/tools/input_gen/CMakeLists.txt
+++ b/src/tools/input_gen/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_executable(mpas_namelist_gen namelist_gen.c test_functions.c)
+target_link_libraries(mpas_namelist_gen PUBLIC ${PROJECT_NAME}::external::ezxml)
+
+add_executable(mpas_streams_gen streams_gen.c test_functions.c)
+target_link_libraries(mpas_streams_gen PUBLIC ${PROJECT_NAME}::external::ezxml)

--- a/src/tools/registry/CMakeLists.txt
+++ b/src/tools/registry/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+#Parsing library core-independent code
+add_library(parselib dictionary.c fortprintf.c utility.c)
+target_link_libraries(parselib PUBLIC ${PROJECT_NAME}::external::ezxml)
+target_link_libraries(parselib PUBLIC ${PROJECT_NAME}::external::esmf)
+
+# Generate parser for each core
+#
+# Note: One parser is required per-core because the gen_inc.c depends on
+# a pre-processor define MPAS_NAMELIST_SUFFIX which is core specific
+foreach(_core IN LISTS MPAS_CORES)
+    add_executable(mpas_parse_${_core} parse.c gen_inc.c)
+    target_link_libraries(mpas_parse_${_core} PUBLIC parselib)
+    target_compile_definitions(mpas_parse_${_core} PRIVATE MPAS_NAMELIST_SUFFIX=${_core}
+                                                           MPAS_GIT_VERSION=${MPAS_GIT_VERSION}
+                                                           MPAS_EXE_NAME=${_core}_model)
+endforeach()


### PR DESCRIPTION
Overview
------------------------
* This PR introduces an optional CMake build for the atmosphere and init_atmosphere core of the MPAS-Model, designed to improve support for MPAS-JEDI which employs ecbuild/CMake. 

* The intention is to enhance compatibility and facilitate integration with MPAS-JEDI, while retaining the default build method using GNU make. 

* The CMake build addition is based on contributions from the NSF NCAR Mesoscale and Microscale Meteorology (MMM) Laboratory and the Joint Center for Satellite Data Assimilation (JCSDA). 

Notes
----------
* The CMake build introduced in this PR does not support SMIOL, and requires PIO2.
* We plan to add SMIOL support for the CMake build in the future. 
* Outside of the PIO2 requirement, the only additional dependency for the CMake build is CMake itself. 

Building with CMake
------------------------------
* Make sure CMake, netcdf-c, netcdf-fortran, parallel-netcdf, and parallelio are installed and discoverable. 
    * If using a module package environment, load the modules for the above libraries. 
 * Create a build directory and enter it. ```mkdir <build_dir>; cd <build_dir>```
 * Configure the build with CMake by running ```cmake <mpas_src_dir> <cmake_flags>```, where ```mpas_src_dir``` is the MPAS source directory and ```cmake_flags``` is a string of flags used to set various build options. A list of useful CMake flags is provided below.
   *  **CMAKE_BUILD_TYPE**: Specifies the build type. Possible values are ```Release```, ```Debug```, and ```RelWithDebInfo```. Defaults to ```Release```.
   * **MPAS_DOUBLE_PRECISION**: Controls if MPAS is built with single or double precision. Possible values are ```ON``` and ```OFF```. Defaults to ```ON```.
   * **MPAS_CORES**: Controls which MPAS Cores are built. Possible values are ```atmosphere```, ```init_atmosphere atmosphere```, and ```init_atmosphere```. 
* Next run ```make -j<number_of_jobs>``` where ```number_of_jobs``` is the number of jobs GNU Make will execute in parallel.
