### PR TITLE
Make CO2 a function of year instead of a single constant

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -870,6 +870,7 @@
             rre_snow   = rresnow_p     , lwupt     = lwupt_p     , lwuptc   = lwuptc_p , &
             lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p    , lwupb    = lwupb_p  , &
             lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p     , lwdnbc   = lwdnbc_p , &
+            yr         = year          ,                                                 &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -17,6 +17,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_lwinit
  use mpas_atmphys_vars
+ use mpas_atmphys_functions, only: co2_estimate
 
 !wrf physics:
  use module_ra_cam            
@@ -835,6 +836,7 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_lw: ')
@@ -851,6 +853,7 @@
     case ("rrtmg_lw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2 = co2_estimate(year,curr_julday)
 
        call mpas_timer_start('RRTMG_lw')
        call rrtmg_lwrad( &
@@ -870,7 +873,7 @@
             rre_snow   = rresnow_p     , lwupt     = lwupt_p     , lwuptc   = lwuptc_p , &
             lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p    , lwupb    = lwupb_p  , &
             lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p     , lwdnbc   = lwdnbc_p , &
-            yr         = year          ,                                                 &
+            co2        = co2           ,                                                 &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,      &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -16,6 +16,7 @@
  use mpas_atmphys_camrad_init
  use mpas_atmphys_rrtmg_swinit
  use mpas_atmphys_vars
+ use mpas_atmphys_functions, only: co2_estimate
  
 !wrf physics:
  use module_ra_cam
@@ -733,6 +734,7 @@
 !local variables:
  integer:: o3input
  real(kind=RKIND):: radt,xtime_m
+ real(kind=RKIND):: co2
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' --- enter subroutine driver_radiation_sw: $i',intArgs=(/itimestep/))
@@ -770,6 +772,7 @@
     case ("rrtmg_sw")
        o3input = 0
        if(config_o3climatology) o3input = 2
+       co2 = co2_estimate(year,curr_julday)
 
        call mpas_timer_start('RRTMG_sw')
        call rrtmg_swrad( &
@@ -792,7 +795,7 @@
               swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
               swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
-              yr         = year         ,                                                    &
+              co2        = co2          ,                                                    &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -792,6 +792,7 @@
               swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
               swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
               swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
+              yr         = year         ,                                                    &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_functions.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_functions.F
@@ -14,7 +14,7 @@
 
  implicit none
  private
- public:: gammln,gammp,wgamma,rslf,rsif
+ public:: gammln,gammp,wgamma,rslf,rsif,co2_estimate
 
 
  contains
@@ -215,6 +215,29 @@
 !     ESI = EXP(9.550426 - 5723.265/T + 3.53068*ALOG(T) - 0.00728332*T)
 
       END FUNCTION RSIF
+
+!+---+-----------------------------------------------------------------+
+! This function calculates CO2 from an equation in WRF by J. Dudhia
+!
+      real(kind=rkind) function co2_estimate(year,curr_julday)
+
+      implicit none
+      integer, intent(in) :: year
+      real, intent(in) :: curr_julday
+      real(kind=rkind) :: rdays,ryear
+      integer :: ny1, ny2, ny3
+
+      rdays = 365.
+      ny1 = mod(year,4)
+      ny2 = mod(year,100)
+      ny3 = mod(year,400)
+      if(ny1.eq.0.and.ny2.ne.0.or.ny3.eq.0) rdays = 366.
+      ryear = float(year)+curr_julday/rdays
+
+! Annual function for co2 from WRF v4.2
+      co2_estimate = (280. + 90.*exp(0.02*(ryear-2000.)))*1.e-6
+
+      end function co2_estimate
 
 !=================================================================================================================
  end module mpas_atmphys_functions

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -11482,6 +11482,7 @@ CONTAINS
                        lwupt,lwuptc,lwdnt,lwdntc,                 &
                        lwupb,lwupbc,lwdnb,lwdnbc,                 &
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
+                       yr,                                        &
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte                  &
@@ -11497,6 +11498,7 @@ CONTAINS
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
  integer,intent(in),optional:: o3input
+ integer,intent(in):: yr
 
  real,intent(in),dimension(ims:ime,jms:jme):: emiss,tsk,snow,xice,xland
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: t3d,p3d,pi3d
@@ -11565,7 +11567,7 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+!data co2 / 379.e-6 / 
 !methane (1774 ppbv)
  real :: ch4
  data ch4 / 1774.e-9 / 
@@ -11639,6 +11641,9 @@ CONTAINS
              249.89,246.67,243.48,240.25,236.66,233.86/	
 
 !-----------------------------------------------------------------------------------------------------------------
+
+! Annual function for co2 in WRF v4.2
+ co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -11482,7 +11482,7 @@ CONTAINS
                        lwupt,lwuptc,lwdnt,lwdntc,                 &
                        lwupb,lwupbc,lwdnb,lwdnbc,                 &
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
-                       yr,                                        &
+                       co2,                                       &
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte                  &
@@ -11498,7 +11498,6 @@ CONTAINS
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
  integer,intent(in),optional:: o3input
- integer,intent(in):: yr
 
  real,intent(in),dimension(ims:ime,jms:jme):: emiss,tsk,snow,xice,xland
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: t3d,p3d,pi3d
@@ -11641,9 +11640,6 @@ CONTAINS
              249.89,246.67,243.48,240.25,236.66,233.86/	
 
 !-----------------------------------------------------------------------------------------------------------------
-
-! Annual function for co2 in WRF v4.2
- co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9877,6 +9877,7 @@ CONTAINS
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
                        swddir,swddni,swddif,                           &
+                       yr,                                             &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -9891,7 +9892,7 @@ CONTAINS
                       ims,ime, jms,jme, kms,kme, &
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
- integer,intent(in):: julday
+ integer,intent(in):: julday,yr
  integer,intent(in),optional:: o3input
 
  real,intent(in):: radt,degrad,xtime,declin,solcon,gmt
@@ -9973,7 +9974,7 @@ CONTAINS
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
 !carbon dioxide (379 ppmv)
  real :: co2
- data co2 / 379.e-6 / 
+!data co2 / 379.e-6 / 
 !methane (1774 ppbv)
  real :: ch4
  data ch4 / 1774.e-9 / 
@@ -10004,6 +10005,9 @@ CONTAINS
   data amdo2 / 0.905190 /
 
 !-----------------------------------------------------------------------------------------------------------------
+
+! Annual function for co2 in WRF v4.2
+      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9877,7 +9877,7 @@ CONTAINS
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
                        swddir,swddni,swddif,                           &
-                       yr,                                             &
+                       co2,                                            &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -9892,7 +9892,7 @@ CONTAINS
                       ims,ime, jms,jme, kms,kme, &
                       its,ite, jts,jte, kts,kte
  integer,intent(in):: icloud,has_reqc,has_reqi,has_reqs
- integer,intent(in):: julday,yr
+ integer,intent(in):: julday
  integer,intent(in),optional:: o3input
 
  real,intent(in):: radt,degrad,xtime,declin,solcon,gmt
@@ -10005,9 +10005,6 @@ CONTAINS
   data amdo2 / 0.905190 /
 
 !-----------------------------------------------------------------------------------------------------------------
-
-! Annual function for co2 in WRF v4.2
-      co2 = (280. + 90.*exp(0.02*(yr-2000)))*1.e-6
 
 !--- all fields are ordered vertically from bottom to top (pressures are in mb):
  ncol = 1


### PR DESCRIPTION
This PR makes CO2 a function of the year following what's done in WRF since v4.2, instead of using a single constant of 379, which is valid for 2005. The value for the year is approximately the same as what's observed. For example, for 2020, the observed and computed value is about 414. 

