### PR TITLE
Implementation of the aerosol-aware option in the Thompson MP

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3073,11 +3073,24 @@
 
 
                 <!-- ================================================================================================== -->
-                <!-- ... PARAMERIZATION OF CLOUDINESS:                                                                  -->
+                <!-- ... PARAMETERIZATION OF CLOUDINESS:                                                                -->
                 <!-- ================================================================================================== -->
 
                 <var name="cldfrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="horizontal cloud fraction"/>
+
+
+                <!-- ================================================================================================== -->
+                <!-- ... PARAMERIZATION OF AEROSOL OPTICAL PROPERTIES:                                                  -->
+                <!-- ================================================================================================== -->
+
+                <var name="taod5502d" type="real" dimensions="nCells Time" units="unitless"
+                     description="total aerosol optical depth at 550 nm from the Thompson cloud microphysics"
+                     packages="mp_thompson_aers_in"/>
+
+                <var name="taod5503d" type="real" dimensions="nVertLevels nCells Time" units="unitless"
+                     description="aerosol optical depth at 550 nm from the Thompson cloud microphysics"
+                     packages="mp_thompson_aers_in"/>
 
 
                 <!-- ================================================================================================== -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -397,6 +397,7 @@
         <packages>
                 <package name="mp_kessler_in" description="parameterization of kessler microphysics."/>
                 <package name="mp_thompson_in" description="parameterization of Thompson cloud microphysics."/>
+                <package name="mp_thompson_aers_in" description="parameterization of scale-aware Thompson cloud microphysics."/>
                 <package name="mp_wsm6_in" description="parameterization of WSM6 cloud microphysics."/>
                 <package name="cu_grell_freitas_in" description="parameterization of Grell-Freitas convection."/>
                 <package name="cu_kain_fritsch_in" description="parameterization of Kain-Fritsch convection."/>
@@ -608,13 +609,15 @@
 			<var name="surface_pressure"/>
 
 #ifdef DO_PHYSICS
-			<var name="rainprod" packages="mp_thompson_in"/>
-			<var name="evapprod" packages="mp_thompson_in"/>
-			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_snow" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="nt_c" packages="mp_thompson_in"/>
-			<var name="mu_c" packages="mp_thompson_in"/>
+			<var name="rainprod"/>
+			<var name="evapprod"/>
+			<var name="re_cloud"/>
+			<var name="re_ice"/>
+			<var name="re_snow"/>
+			<var name="nwfa2d"/>
+			<var name="nifa2d"/>
+			<var name="nt_c"/>
+			<var name="mu_c"/>
                         <var name="tend_sfc_pressure"/>
 			<var name="rt_diabatic_tend"/>
 			<var name="nsteps_accum"/>
@@ -627,7 +630,9 @@
 			<var name="i_rainnc"/>
 			<var name="rainncv"/>
 			<var name="rainnc"/>
+			<var name="snowncv"/>
 			<var name="snownc"/>
+			<var name="graupelncv"/>
 			<var name="graupelnc"/>
 			<var name="sr"/>
 			<var name="i_rainc"/>
@@ -775,6 +780,18 @@
 			<var name="xmb_shallow"/>
 			<var name="qc_cu"/>
 			<var name="qi_cu"/>
+			<var name="rthmpten"/>
+			<var name="rqvmpten"/>
+			<var name="rqcmpten"/>
+			<var name="rqrmpten"/>
+			<var name="rqimpten"/>
+			<var name="rqsmpten"/>
+			<var name="rqgmpten"/>
+			<var name="rncmpten"/>
+			<var name="rnimpten"/>
+			<var name="rnrmpten"/>
+			<var name="rnifampten"/>
+			<var name="rnwfampten"/>
 			<var name="rthcuten"/>
 			<var name="rqvcuten"/>
 			<var name="rqccuten"/>
@@ -1521,31 +1538,43 @@
 
                         <var name="qc" array_group="moist" units="kg kg^{-1}"
                              description="Cloud water mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"
-                             packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qi" array_group="moist" units="kg kg^{-1}"
                              description="Ice mixing ratio"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qs" array_group="moist" units="kg kg^{-1}"
                              description="Snow mixing ratio"
-                             packages="bl_mynn_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="qg" array_group="moist" units="kg kg^{-1}"
                              description="Graupel mixing ratio"
-                             packages="mp_thompson_in;mp_wsm6_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="ni" array_group="number" units="nb kg^{-1}"
                              description="Cloud ice number concentration"
-                             packages="bl_mynn_in;mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"/>
 
                         <var name="nr" array_group="number" units="nb kg^{-1}"
                              description="Rain number concentration"
-                             packages="mp_thompson_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in"/>
+
+                        <var name="nc" array_group="number" units="nb kg^{-1}"
+                             description="Cloud water number concentration"
+                             packages="mp_thompson_aers_in"/>
+
+                        <var name="nifa" array_group="number" units="nb kg^{-1}"
+                             description="Ice-friendly aerosol number concentration"
+                             packages="mp_thompson_aers_in"/>
+
+                        <var name="nwfa" array_group="number" units="nb kg^{-1}"
+                             description="Water-friendly aerosol number concentration"
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 #endif
 
@@ -1851,31 +1880,43 @@
 
                         <var name="tend_qc" name_in_code="qc" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of cloud water mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qr" name_in_code="qr" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of rain water mass per unit volume divided by d(zeta)/dz"
-                             packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qi" name_in_code="qi" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of ice mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qs" name_in_code="qs" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of snow mass per unit volume divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_in;mp_wsm6_in"/>
+                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_qg" name_in_code="qg" array_group="moist" units="kg m^{-3} s^{-1}"
                              description="Tendency of graupel mass per unit volume divided by d(zeta)/dz"
-                             packages="mp_thompson_in;mp_wsm6_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                         <var name="tend_ni" name_in_code="ni" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of cloud ice number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_in"/>
+                             packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"/>
 
                         <var name="tend_nr" name_in_code="nr" array_group="number" units="nb m^{-3} s^{-1}" 
                              description="Tendency of rain number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_in"/>
+                             packages="mp_thompson_in;mp_thompson_aers_in"/>
+
+                        <var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}"
+                             description="Tendency of cloud water number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_aers_in"/>
+
+                        <var name="tend_nifa" name_in_code="nifa" array_group="number" units="nb m^{-3} s^{-1}"
+                             description="Tendency of ice-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_aers_in"/>
+
+                        <var name="tend_nwfa" name_in_code="nwfa" array_group="number" units="nb m^{-3} s^{-1}"
+                             description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 #endif
         </var_struct>
@@ -1911,29 +1952,49 @@
                      description="Lateral boundary tendency of rho_zz-coupled theta_m"/>
 
                 <var_array name="lbc_scalars" type="real" dimensions="nVertLevels nCells Time">
-                        <var name="lbc_qv" name_in_code="qv" array_group="moist" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qv" name_in_code="qv" array_group="moist"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of water vapor mixing ratio"/>
 
-                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qc" name_in_code="qc" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of cloud water mixing ratio"/>
 
-                        <var name="lbc_qr" name_in_code="qr" array_group="moist"  packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qr" name_in_code="qr" array_group="moist"  packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of rain water mixing ratio"/>
 
-                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qi" name_in_code="qi" array_group="moist"  packages="bl_mynn_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of ice mixing ratio"/>
 
-                        <var name="lbc_qs" name_in_code="qs" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qs" name_in_code="qs" array_group="moist"  packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of snow mixing ratio"/>
 
-                        <var name="lbc_qg" name_in_code="qg" array_group="moist"  packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1} s^{-1}"
+                        <var name="lbc_qg" name_in_code="qg" array_group="moist"  packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                             units="kg kg^{-1} s^{-1}"
                              description="Lateral boundary tendency of graupel mixing ratio"/>
 
-                        <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in" units="m^{-3} s^{-1}"
+                        <var name="lbc_nr" name_in_code="nr" array_group="number" packages="mp_thompson_in;mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of rain number concentration"/>
 
-                        <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in" units="m^{-3} s^{-1}"
+                        <var name="lbc_ni" name_in_code="ni" array_group="number" packages="bl_mynn_in;mp_thompson_in;mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
                              description="Lateral boundary tendency of ice number concentration"/>
+
+                        <var name="lbc_nc" name_in_code="nc" array_group="number" packages="mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of cloud water number concentration"/>
+
+                        <var name="lbc_nifa" name_in_code="nifa" array_group="number" packages="mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of ice-friendly aerosol number concentration"/>
+
+                        <var name="lbc_nwfa" name_in_code="nwfa" array_group="number" packages="mp_thompson_aers_in"
+                             units="m^{-3} s^{-1}"
+                             description="Lateral boundary tendency of water-friendly aerosol number concentration"/>
                 </var_array>
         </var_struct>
 
@@ -2289,71 +2350,79 @@
 
                 <var name="refl10cm_max" type="real" dimensions="nCells Time" units="dBZ"
                      description="10 cm maximum radar reflectivity"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="refl10cm_1km" type="real" dimensions="nCells Time" units="dBZ"
                      description="diagnosed 10 cm radar reflectivity at 1 km AGL"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="refl10cm_1km_max" type="real" dimensions="nCells Time" units="dBZ"
                      description="maximum diagnosed 10 cm radar reflectivity at 1 km AGL since last output time"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="i_rainnc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated grid-scale precipitation greater than config_bucket_rainnc"
-                     packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="rainncv" type="real" dimensions="nCells Time" units="mm"
                      description="time-step total grid-scale precipitation"
-                     packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="snowncv" type="real" dimensions="nCells Time" units="mm"
                      description="time-step grid-scale precipitation of snow"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="graupelncv" type="real" dimensions="nCells Time" units="mm"
                      description="time-step grid-scale precipitation of graupel"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="rainnc" type="real" dimensions="nCells Time" units="mm"
                      description="accumulated total grid-scale precipitation"
-                     packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="snownc" type="real" dimensions="nCells Time" units="mm"
                      description="accumulated grid-scale precipitation of snow"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="graupelnc" type="real" dimensions="nCells Time" units="mm"
                      description="accumulated grid-scale precipitation of graupel"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="rainprod" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
                      description="rain production rate"
-                     packages="mp_thompson_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="evapprod" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
                      description="rain evaporation rate"
-                     packages="mp_thompson_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="re_cloud" type="real" dimensions="nVertLevels nCells Time" units="m"
                      description="effective radius of cloud water droplets"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="re_ice"  type="real" dimensions="nVertLevels nCells Time"  units="m"
                      description="effective radius of cloud ice crystals"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="re_snow" type="real" dimensions="nVertLevels nCells Time"  units="m"
                      description="effective radius of snow crystals"
-                     packages="mp_thompson_in;mp_wsm6_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
 
                 <var name="nt_c" type="real" dimensions="nCells" units="nb kg^{-1}"
                      description="one-moment constant cloud water droplet concentration"
-                     packages="mp_thompson_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in"/>
 
                 <var name="mu_c" type="real" dimensions="nCells" units="unitless"
                      description="gamma shape parameter"
-                     packages="mp_thompson_in"/>
+                     packages="mp_thompson_in;mp_thompson_aers_in"/>
+
+                <var name="nwfa2d" type="real" dimensions="nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="surface emission of water-friendly aerosols"
+                     packages="mp_thompson_aers_in"/>
+
+                <var name="nifa2d" type="real" dimensions="nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="surface emission of ice-friendly aerosols"
+                     packages="mp_thompson_aers_in"/>
 
                 <var name="sr" type="real" dimensions="nCells Time" units="unitless"
                      description="time-step ratio of frozen versus total grid-scale precipitation"/>
@@ -3143,6 +3212,58 @@
  
 #ifdef DO_PHYSICS
                 <!-- ================================================================================================== -->
+                <!-- TENDENCIES FROM PARAMETERIZATION OF CLOUD MICROPHYSICS:                                            -->
+                <!-- ================================================================================================== -->
+
+                <var name="rthmpten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="tendency of potential temperature due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqvmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of water vapor mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqcmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of cloud water mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqrmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of rain mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqimpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of cloud ice mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqsmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of snow mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rqgmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+                     description="tendency of graupel mixing ratio due to cloud microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"/>
+
+                <var name="rnimpten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of cloud ice number concentration due to microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in"/>
+
+                <var name="rnrmpten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of rain number concentration due to microphysics"
+                     packages="mp_thompson_in;mp_thompson_aers_in"/>
+
+                <var name="rncmpten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of cloud water number concentration due to microphysics"
+                     packages="mp_thompson_aers_in"/>
+
+                <var name="rnifampten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of "ice-friendly" aerosol number concentration due to microphysics"
+                     packages="mp_thompson_aers_in"/>
+
+                <var name="rnwfampten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of "water-friendly" aerosol number concentration due to microphysics"
+                     packages="mp_thompson_aers_in"/>
+
+                <!-- ================================================================================================== -->
                 <!-- TENDENCIES FROM PARAMETERIZATION OF CONVECTION:                                                    -->
                 <!-- ================================================================================================== -->
 
@@ -3395,22 +3516,28 @@
                      description="Potential temperature increment"/>
 
                 <var_array name="scalars_amb" name_in_code="scalars" type="real" dimensions="nVertLevels nCells Time">
-                     <var name="qv_amb"  name_in_code="qv" array_group="moist" units="kg kg^{-1}"
+                     <var name="qv_amb"  name_in_code="qv" array_group="moist"
+                          units="kg kg^{-1}"
                           description="Water vapor mixing ratio increment"/>
 
-                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qc_amb"  name_in_code="qc" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                          units="kg kg^{-1}"
                           description="Cloud water mixing ratio increment"/>
 
-                     <var name="qr_amb"  name_in_code="qr" array_group="moist" packages="mp_kessler_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qr_amb"  name_in_code="qr" array_group="moist" packages="mp_kessler_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                          units="kg kg^{-1}"
                           description="Rain water mixing ratio increment"/>
 
-                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qi_amb"  name_in_code="qi" array_group="moist" packages="bl_mynn_in;bl_ysu_in;cu_ntiedtke_in;mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                          units="kg kg^{-1}"
                           description="Ice mixing ratio increment"/>
 
-                     <var name="qs_amb"  name_in_code="qs" array_group="moist" packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qs_amb"  name_in_code="qs" array_group="moist" packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                          " units="kg kg^{-1}"
                           description="Snow mixing ratio increment"/>
 
-                     <var name="qg_amb"  name_in_code="qg" array_group="moist" packages="mp_thompson_in;mp_wsm6_in" units="kg kg^{-1}"
+                     <var name="qg_amb"  name_in_code="qg" array_group="moist" packages="mp_thompson_in;mp_thompson_aers_in;mp_wsm6_in"
+                          units="kg kg^{-1}"
                           description="Graupel mixing ratio increment"/>
                 </var_array>
          </var_struct>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1573,11 +1573,11 @@
 
                         <var name="nifa" array_group="number" units="nb kg^{-1}"
                              description="Ice-friendly aerosol number concentration"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="nwfa" array_group="number" units="nb kg^{-1}"
                              description="Water-friendly aerosol number concentration"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 #endif
 
@@ -1915,11 +1915,11 @@
 
                         <var name="tend_nifa" name_in_code="nifa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of ice-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="tend_nwfa" name_in_code="nwfa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 #endif
         </var_struct>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -809,7 +809,10 @@
 			<var name="rqcblten"/>
 			<var name="rqiblten"/>
 			<var name="rqsblten"/>
+			<var name="rncblten"/>
 			<var name="rniblten"/>
+			<var name="rnifablten"/>
+			<var name="rnwfablten"/>
 			<var name="rthratensw"/>
 			<var name="rthratenlw"/>
 			<var name="sfc_albbck"/>
@@ -1566,15 +1569,15 @@
 
                         <var name="nc" array_group="number" units="nb kg^{-1}"
                              description="Cloud water number concentration"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
 
                         <var name="nifa" array_group="number" units="nb kg^{-1}"
                              description="Ice-friendly aerosol number concentration"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
 
                         <var name="nwfa" array_group="number" units="nb kg^{-1}"
                              description="Water-friendly aerosol number concentration"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
                 </var_array>
 #endif
 
@@ -1908,15 +1911,15 @@
 
                         <var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of cloud water number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
 
                         <var name="tend_nifa" name_in_code="nifa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of ice-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
 
                         <var name="tend_nwfa" name_in_code="nwfa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of water-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="mp_thompson_aers_in"/>
+                             packages="bl_mynn_in;mp_thompson_aers_in"/>
                 </var_array>
 #endif
         </var_struct>
@@ -3342,8 +3345,20 @@
                      description="tendency of snow mixing ratio due to pbl processes"
                      packages="bl_mynn_in"/>
 
+                <var name="rncblten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of cloud liquid water number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
                 <var name="rniblten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
                      description="tendency of cloud ice number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
+                <var name="rnifablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of ice-friendly aerosol number concentration due to pbl processes"
+                     packages="bl_mynn_in"/>
+
+                <var name="rnwfablten" type="real" dimensions="nVertLevels nCells Time" units="nb kg^{-1} s^{-1}"
+                     description="tendency of water-friendly aerosol number concentration due to pbl processes"
                      packages="bl_mynn_in"/>
 
 	        <!-- MGD should we add packages to the field below? -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -397,7 +397,7 @@
         <packages>
                 <package name="mp_kessler_in" description="parameterization of kessler microphysics."/>
                 <package name="mp_thompson_in" description="parameterization of Thompson cloud microphysics."/>
-                <package name="mp_thompson_aers_in" description="parameterization of scale-aware Thompson cloud microphysics."/>
+                <package name="mp_thompson_aers_in" description="parameterization of aerosol-aware Thompson cloud microphysics."/>
                 <package name="mp_wsm6_in" description="parameterization of WSM6 cloud microphysics."/>
                 <package name="cu_grell_freitas_in" description="parameterization of Grell-Freitas convection."/>
                 <package name="cu_kain_fritsch_in" description="parameterization of Kain-Fritsch convection."/>

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -367,7 +367,7 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni
+      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nc, index_nifa, index_nwfa
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -471,6 +471,11 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+         if(config_microp_scheme == 'mp_thompson_aerosols') then
+            call mpas_pool_get_dimension(state, 'index_nc', index_nc)
+            call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+            call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
+         endif
       endif
 
       !
@@ -927,7 +932,17 @@ module atm_time_integration
                   if (index_ni > 0) then
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
-                  
+                  if(config_microp_scheme == 'mp_thompson_aerosols') then
+                     if (index_nc > 0) then
+                        scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                     end if
+                     if (index_nifa > 0) then
+                        scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                     end if
+                     if (index_nwfa > 0) then
+                        scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                     end if
+                  end if
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1094,7 +1109,17 @@ module atm_time_integration
                if (index_ni > 0) then
                   scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                end if
-               
+               if (config_microp_scheme == 'mp_thompson_aerosols') then
+                  if(index_nc > 0) then
+                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                  end if
+                  if(index_nifa > 0) then
+                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                  end if
+                  if(index_nwfa > 0) then
+                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
+                  end if
+               end if
 !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1254,7 +1279,17 @@ module atm_time_integration
          if (index_ni > 0) then
             scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
          end if
-      
+         if (config_microp_scheme == 'mp_thompson_aerosols') then
+            if (index_nc > 0) then
+               scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
+            end if
+            if (index_nifa > 0) then
+               scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
+            end if
+            if (index_nwfa > 0) then
+               scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
+            end if
+         end if
 !$OMP PARALLEL DO
          do thread=1,nThreads
             call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1182,7 +1182,7 @@ module atm_time_integration
         call mpas_timer_start('microphysics')
 !$OMP PARALLEL DO
         do thread=1,nThreads
-           call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend, itimestep, &
+           call driver_microphysics ( block % configs, mesh, state, 2, diag, diag_physics, tend_physics, tend, itimestep, &
                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
         end do
 !$OMP END PARALLEL DO

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -471,11 +471,9 @@ module atm_time_integration
          call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
          call mpas_pool_get_dimension(state, 'index_nr', index_nr)
          call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-         if(config_microp_scheme == 'mp_thompson_aerosols') then
-            call mpas_pool_get_dimension(state, 'index_nc', index_nc)
-            call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
-            call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
-         endif
+         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
+         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
+         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
       endif
 
       !
@@ -932,16 +930,14 @@ module atm_time_integration
                   if (index_ni > 0) then
                      scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                   end if
-                  if(config_microp_scheme == 'mp_thompson_aerosols') then
-                     if (index_nc > 0) then
-                        scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                     end if
-                     if (index_nifa > 0) then
-                        scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                     end if
-                     if (index_nwfa > 0) then
-                        scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                     end if
+                  if (index_nc > 0) then
+                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+                  end if
+                  if (index_nifa > 0) then
+                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+                  end if
+                  if (index_nwfa > 0) then
+                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                   end if
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
@@ -1109,16 +1105,14 @@ module atm_time_integration
                if (index_ni > 0) then
                   scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
                end if
-               if (config_microp_scheme == 'mp_thompson_aerosols') then
-                  if(index_nc > 0) then
-                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                  end if
-                  if(index_nifa > 0) then
-                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                  end if
-                  if(index_nwfa > 0) then
-                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                  end if
+               if (index_nc > 0) then
+                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
+               end if
+               if (index_nifa > 0) then
+                  scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
+               end if
+               if (index_nwfa > 0) then
+                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
                end if
 !$OMP PARALLEL DO
                do thread=1,nThreads
@@ -1279,16 +1273,14 @@ module atm_time_integration
          if (index_ni > 0) then
             scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
          end if
-         if (config_microp_scheme == 'mp_thompson_aerosols') then
-            if (index_nc > 0) then
-               scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-            end if
-            if (index_nifa > 0) then
-               scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-            end if
-            if (index_nwfa > 0) then
-               scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-            end if
+         if (index_nc > 0) then
+            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
+         end if
+         if (index_nifa > 0) then
+            scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
+         end if
+         if (index_nwfa > 0) then
+            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
          end if
 !$OMP PARALLEL DO
          do thread=1,nThreads

--- a/src/core_atmosphere/physics/checkout_data_files.sh
+++ b/src/core_atmosphere/physics/checkout_data_files.sh
@@ -23,7 +23,7 @@
 ################################################################################
 
 
-mpas_vers="8.0"
+mpas_vers="8.2"
 
 github_org="MPAS-Dev"   # GitHub organization where the MPAS-Data repository is found.
                         # For physics development, it can be helpful for a developer

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -174,7 +174,7 @@
            config_microp_scheme .eq. 'mp_thompson_aerosols' .or. &
            config_microp_scheme .eq. 'mp_wsm6')) then
 
-    write(mpas_err_message,'(A,A10)') 'illegal value for config_microp_scheme:', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for config_microp_scheme:', &
           trim(config_microp_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -187,7 +187,7 @@
            config_convection_scheme .eq. 'cu_tiedtke'       .or. &
            config_convection_scheme .eq. 'cu_ntiedtke')) then
 
-    write(mpas_err_message,'(A,A10)') 'illegal value for config_convection_scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for config_convection_scheme: ', &
           trim(config_convection_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -198,7 +198,7 @@
            config_pbl_scheme .eq. 'bl_mynn' .or. &
            config_pbl_scheme .eq. 'bl_ysu')) then
 
-    write(mpas_err_message,'(A,A10)') 'illegal value for pbl_scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for pbl_scheme: ', &
           trim(config_pbl_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -208,7 +208,7 @@
  if(.not. (config_gwdo_scheme .eq. 'off' .or. &
            config_gwdo_scheme .eq. 'bl_ysu_gwdo')) then
 
-    write(mpas_err_message,'(A,A10)') 'illegal value for gwdo_scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for gwdo_scheme: ', &
           trim(config_gwdo_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -219,7 +219,7 @@
            config_radt_lw_scheme .eq. 'cam_lw' .or. &
            config_radt_lw_scheme .eq. 'rrtmg_lw')) then
  
-    write(mpas_err_message,'(A,A10)') 'illegal value for longwave radiation scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for longwave radiation scheme: ', &
           trim(config_radt_lw_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -230,7 +230,7 @@
            config_radt_sw_scheme .eq. 'cam_sw' .or. &
            config_radt_sw_scheme .eq. 'rrtmg_sw')) then
  
-    write(mpas_err_message,'(A,A10)') 'illegal value for shortwave radiation _scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for shortwave radiation _scheme: ', &
           trim(config_radt_sw_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -242,7 +242,7 @@
            config_radt_cld_scheme .eq. 'cld_fraction'  .or. &
            config_radt_cld_scheme .eq. 'cld_fraction_thompson')) then
 
-    write(mpas_err_message,'(A,A10)') 'illegal value for calculation of cloud fraction: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for calculation of cloud fraction: ', &
           trim(config_radt_cld_scheme)
     call physics_error_fatal(mpas_err_message)
 
@@ -251,10 +251,10 @@
     (config_radt_sw_scheme.ne.'off' .and. config_radt_cld_scheme.eq.'off')) then
 
     call mpas_log_write('')
-    write(mpas_err_message,'(A,A10)') &
+    write(mpas_err_message,'(A,A20)') &
        '    config_radt_cld_scheme is not set for radiation calculation'
     call physics_message(mpas_err_message)
-    write(mpas_err_message,'(A,A10)') &
+    write(mpas_err_message,'(A,A20)') &
        '    switch calculation of cloud fraction to config_radt_cld_scheme = cld_incidence'
     call physics_message(mpas_err_message)
     config_radt_cld_scheme = "cld_incidence"
@@ -267,7 +267,7 @@
            config_sfclayer_scheme .eq. 'sf_monin_obukhov' .or. &
            config_sfclayer_scheme .eq. 'sf_monin_obukhov_rev')) then
  
-    write(mpas_err_message,'(A,A10)') 'illegal value for surface layer scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for surface layer scheme: ', &
           trim(config_sfclayer_scheme)
     call physics_error_fatal(mpas_err_message)
  else
@@ -276,7 +276,7 @@
     elseif(config_pbl_scheme == 'bl_ysu') then
        if(config_sfclayer_scheme /= 'sf_monin_obukhov' .and. &
           config_sfclayer_scheme /= 'sf_monin_obukhov_rev') then
-          write(mpas_err_message,'(A,A10)') 'wrong choice for surface layer scheme with YSU PBL: ', &
+          write(mpas_err_message,'(A,A20)') 'wrong choice for surface layer scheme with YSU PBL: ', &
                 trim(config_sfclayer_scheme)
           call physics_error_fatal(mpas_err_message)
        endif
@@ -293,7 +293,7 @@
  elseif(.not. (config_lsm_scheme .eq. 'off ' .or. &
                config_lsm_scheme .eq. 'sf_noah')) then
  
-    write(mpas_err_message,'(A,A10)') 'illegal value for land surface scheme: ', &
+    write(mpas_err_message,'(A,A20)') 'illegal value for land surface scheme: ', &
           trim(config_lsm_scheme)
     call physics_error_fatal(mpas_err_message)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -72,6 +72,8 @@
 ! * modified logic in subroutine physics_tables_init so that the Thompson microphysics tables are read in each
 !   MPI task.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-12-30.
+! * added the option mp_thompson_aerosols.
+!   Laura D. Fowler (laura@ucar.edu) / 2018-01-31.
 ! * added the option sf_monin_obukhov_rev to run the revised surface layer scheme with the YSU PBL scheme.
 !   Laura D. Fowler (laura@ucar.edu) / 2023-05-15.
 ! * replaced the option "noah" with "sf_noah" to run the NOAH land surface scheme.
@@ -166,9 +168,10 @@
  end if
 
 !cloud microphysics scheme:
- if(.not. (config_microp_scheme .eq. 'off'         .or. &
-           config_microp_scheme .eq. 'mp_kessler'  .or. &
-           config_microp_scheme .eq. 'mp_thompson' .or. &
+ if(.not. (config_microp_scheme .eq. 'off'                  .or. &
+           config_microp_scheme .eq. 'mp_kessler'           .or. &
+           config_microp_scheme .eq. 'mp_thompson'          .or. &
+           config_microp_scheme .eq. 'mp_thompson_aerosols' .or. &
            config_microp_scheme .eq. 'mp_wsm6')) then
 
     write(mpas_err_message,'(A,A10)') 'illegal value for config_microp_scheme:', &
@@ -398,7 +401,8 @@
  if(dminfo % my_proc_id == IO_NODE) then
 
     call mpas_pool_get_config(configs,'config_microp_scheme',config_microp_scheme)
-    if(config_microp_scheme /= "mp_thompson") return
+    if(config_microp_scheme /= "mp_thompson" .or. &
+       config_microp_scheme /= "mp_thompson_aerosols") return
 
     l_qr_acr_qg = .false.
     l_qr_acr_qs = .false.

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -280,8 +280,8 @@
  integer:: errflg
 
 !-----------------------------------------------------------------------------------------------------------------
- call mpas_log_write(' ')
- call mpas_log_write('--- enter subroutine init_microphysics:')
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine init_microphysics:')
 
 !initialization of CCPP-compliant flags:
  errmsg = ' '
@@ -309,7 +309,7 @@
     case default
  end select microp_select
 
- call mpas_log_write('--- end subroutine init_microphysics:')
+!call mpas_log_write('--- end subroutine init_microphysics:')
 
  end subroutine init_microphysics
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -28,7 +28,7 @@
  public:: allocate_microphysics,   &
           deallocate_microphysics, &
           driver_microphysics,     &
-          microphysics_init
+          init_microphysics
 
 
 !MPAS driver for parameterization of cloud microphysics processes.
@@ -109,30 +109,29 @@
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
 
 !sounding variables:
- if(.not.allocated(rho_p)    ) allocate(rho_p(ims:ime,kms:kme,jms:jme) )
- if(.not.allocated(th_p)     ) allocate(th_p(ims:ime,kms:kme,jms:jme)  )
- if(.not.allocated(pi_p)     ) allocate(pi_p(ims:ime,kms:kme,jms:jme)  )
- if(.not.allocated(pres_p)   ) allocate(pres_p(ims:ime,kms:kme,jms:jme))
- if(.not.allocated(z_p)      ) allocate(z_p(ims:ime,kms:kme,jms:jme)   )
- if(.not.allocated(dz_p)     ) allocate(dz_p(ims:ime,kms:kme,jms:jme)  )
- if(.not.allocated(w_p)      ) allocate(w_p(ims:ime,kms:kme,jms:jme)   )
+ if(.not.allocated(rho_p) ) allocate(rho_p(ims:ime,kms:kme,jms:jme) )
+ if(.not.allocated(th_p)  ) allocate(th_p(ims:ime,kms:kme,jms:jme)  )
+ if(.not.allocated(pi_p)  ) allocate(pi_p(ims:ime,kms:kme,jms:jme)  )
+ if(.not.allocated(pres_p)) allocate(pres_p(ims:ime,kms:kme,jms:jme))
+ if(.not.allocated(z_p)   ) allocate(z_p(ims:ime,kms:kme,jms:jme)   )
+ if(.not.allocated(dz_p)  ) allocate(dz_p(ims:ime,kms:kme,jms:jme)  )
+ if(.not.allocated(w_p)   ) allocate(w_p(ims:ime,kms:kme,jms:jme)   )
 
 !mass mixing ratios:
- if(.not.allocated(qv_p)     ) allocate(qv_p(ims:ime,kms:kme,jms:jme))
- if(.not.allocated(qc_p)     ) allocate(qc_p(ims:ime,kms:kme,jms:jme))
- if(.not.allocated(qr_p)     ) allocate(qr_p(ims:ime,kms:kme,jms:jme))
+ if(.not.allocated(qv_p)) allocate(qv_p(ims:ime,kms:kme,jms:jme))
+ if(.not.allocated(qc_p)) allocate(qc_p(ims:ime,kms:kme,jms:jme))
+ if(.not.allocated(qr_p)) allocate(qr_p(ims:ime,kms:kme,jms:jme))
 
  !surface precipitation:
  if(.not.allocated(rainnc_p) ) allocate(rainnc_p(ims:ime,jms:jme) )
  if(.not.allocated(rainncv_p)) allocate(rainncv_p(ims:ime,jms:jme))
 
- microp_select: select case(microp_scheme)
-
-    case ("mp_thompson","mp_wsm6")
+ microp_select: select case(trim(microp_scheme))
+    case ("mp_thompson","mp_thompson_aerosols","mp_wsm6")
        !mass mixing ratios:
-       if(.not.allocated(qi_p)        ) allocate(qi_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qs_p)        ) allocate(qs_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(qg_p)        ) allocate(qg_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qi_p)) allocate(qi_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qs_p)) allocate(qs_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(qg_p)) allocate(qg_p(ims:ime,kms:kme,jms:jme))
 
        !surface precipitation:
        if(.not.allocated(sr_p)        ) allocate(sr_p(ims:ime,jms:jme)        )
@@ -142,28 +141,36 @@
        if(.not.allocated(graupelncv_p)) allocate(graupelncv_p(ims:ime,jms:jme))
 
        !cloud water,cloud ice,and snow effective radii:
-       if(.not.allocated(recloud_p) ) allocate(recloud_p(ims:ime,kms:kme,jms:jme))
-       if(.not.allocated(reice_p)   ) allocate(reice_p(ims:ime,kms:kme,jms:jme)  )
-       if(.not.allocated(resnow_p)  ) allocate(resnow_p(ims:ime,kms:kme,jms:jme) )
+       if(.not.allocated(recloud_p)) allocate(recloud_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(reice_p)  ) allocate(reice_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(resnow_p) ) allocate(resnow_p(ims:ime,kms:kme,jms:jme) )
 
-    microp2_select: select case(microp_scheme)
+       !precipitation flux:
+       if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
 
-       case("mp_thompson")
-          !number concentrations:
+    microp2_select: select case(trim(microp_scheme))
+       case("mp_thompson","mp_thompson_aerosols")
           if(.not.allocated(ntc_p)) allocate(ntc_p(ims:ime,jms:jme))
           if(.not.allocated(muc_p)) allocate(muc_p(ims:ime,jms:jme))
           if(.not.allocated(ni_p) ) allocate(ni_p(ims:ime,kms:kme,jms:jme))
           if(.not.allocated(nr_p) ) allocate(nr_p(ims:ime,kms:kme,jms:jme))
 
-          if(.not.allocated(rainprod_p)) allocate(rainprod_p(ims:ime,kms:kme,jms:jme))
-          if(.not.allocated(evapprod_p)) allocate(evapprod_p(ims:ime,kms:kme,jms:jme))
+          microp3_select: select case(trim(microp_scheme))
+             case("mp_thompson_aerosols")
+                if(.not.allocated(nifa2d_p)) allocate(nifa2d_p(ims:ime,jms:jme))
+                if(.not.allocated(nwfa2d_p)) allocate(nwfa2d_p(ims:ime,jms:jme))
+                if(.not.allocated(nc_p)    ) allocate(nc_p(ims:ime,kms:kme,jms:jme)  )
+                if(.not.allocated(nifa_p)  ) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
+                if(.not.allocated(nwfa_p)  ) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
+
+             case default
+          end select microp3_select
 
        case default
-
     end select microp2_select
 
     case default
-
  end select microp_select
 
  end subroutine allocate_microphysics
@@ -183,67 +190,74 @@
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
 
 !sounding variables:
- if(allocated(rho_p)     ) deallocate(rho_p     )
- if(allocated(th_p)      ) deallocate(th_p      )
- if(allocated(pi_p)      ) deallocate(pi_p      )
- if(allocated(pres_p)    ) deallocate(pres_p    )
- if(allocated(z_p)       ) deallocate(z_p       )
- if(allocated(dz_p)      ) deallocate(dz_p      )
- if(allocated(w_p)       ) deallocate(w_p       )
+ if(allocated(rho_p) ) deallocate(rho_p )
+ if(allocated(th_p)  ) deallocate(th_p  )
+ if(allocated(pi_p)  ) deallocate(pi_p  )
+ if(allocated(pres_p)) deallocate(pres_p)
+ if(allocated(z_p)   ) deallocate(z_p   )
+ if(allocated(dz_p)  ) deallocate(dz_p  )
+ if(allocated(w_p)   ) deallocate(w_p   )
 
 !mass mixing ratios:
- if(allocated(qv_p)      ) deallocate(qv_p      )
- if(allocated(qc_p)      ) deallocate(qc_p      )
- if(allocated(qr_p)      ) deallocate(qr_p      )
+ if(allocated(qv_p)) deallocate(qv_p)
+ if(allocated(qc_p)) deallocate(qc_p)
+ if(allocated(qr_p)) deallocate(qr_p)
 
  !surface precipitation:
- if(allocated(rainnc_p)  ) deallocate(rainnc_p  )
- if(allocated(rainncv_p) ) deallocate(rainncv_p )
+ if(allocated(rainnc_p) ) deallocate(rainnc_p )
+ if(allocated(rainncv_p)) deallocate(rainncv_p)
 
- microp_select: select case(microp_scheme)
-
-    case ("mp_thompson","mp_wsm6")
+ microp_select: select case(trim(microp_scheme))
+    case ("mp_thompson","mp_thompson_aerosols","mp_wsm6")
        !mass mixing ratios:
-       if(allocated(qi_p)         ) deallocate(qi_p         )
-       if(allocated(qs_p)         ) deallocate(qs_p         )
-       if(allocated(qg_p)         ) deallocate(qg_p         )
+       if(allocated(qi_p)) deallocate(qi_p)
+       if(allocated(qs_p)) deallocate(qs_p)
+       if(allocated(qg_p)) deallocate(qg_p)
 
        !surface precipitation:
-       if(allocated(sr_p)         ) deallocate(sr_p         )
-       if(allocated(snownc_p)     ) deallocate(snownc_p     )
-       if(allocated(snowncv_p)    ) deallocate(snowncv_p    )
-       if(allocated(graupelnc_p)  ) deallocate(graupelnc_p  )
-       if(allocated(graupelncv_p) ) deallocate(graupelncv_p )
+       if(allocated(sr_p)        ) deallocate(sr_p        )
+       if(allocated(snownc_p)    ) deallocate(snownc_p    )
+       if(allocated(snowncv_p)   ) deallocate(snowncv_p   )
+       if(allocated(graupelnc_p) ) deallocate(graupelnc_p )
+       if(allocated(graupelncv_p)) deallocate(graupelncv_p)
 
        !cloud water,cloud ice,and snow effective radii:
-       if(allocated(recloud_p) ) deallocate(recloud_p )
-       if(allocated(reice_p)   ) deallocate(reice_p   )
-       if(allocated(resnow_p)  ) deallocate(resnow_p  )
+       if(allocated(recloud_p)) deallocate(recloud_p)
+       if(allocated(reice_p)  ) deallocate(reice_p  )
+       if(allocated(resnow_p) ) deallocate(resnow_p )
 
-    microp2_select: select case(microp_scheme)
+       !precipitation flux:
+       if(allocated(rainprod_p)) deallocate(rainprod_p)
+       if(allocated(evapprod_p)) deallocate(evapprod_p)
 
-       case("mp_thompson")
-          !number concentrations:
+    microp2_select: select case(trim(microp_scheme))
+       case("mp_thompson","mp_thompson_aerosols")
           if(allocated(ntc_p)) deallocate(ntc_p)
           if(allocated(muc_p)) deallocate(muc_p)
           if(allocated(ni_p) ) deallocate(ni_p )
           if(allocated(nr_p) ) deallocate(nr_p )
 
-          if(allocated(rainprod_p)) deallocate(rainprod_p)
-          if(allocated(evapprod_p)) deallocate(evapprod_p)
+          microp3_select: select case(trim(microp_scheme))
+             case("mp_thompson_aerosols")
+                if(allocated(nifa2d_p)) deallocate(nifa2d_p)
+                if(allocated(nwfa2d_p)) deallocate(nwfa2d_p)
+                if(allocated(nc_p)    ) deallocate(nc_p    )
+                if(allocated(nifa_p)  ) deallocate(nifa_p  )
+                if(allocated(nwfa_p)  ) deallocate(nwfa_p  )
+
+             case default
+          end select microp3_select
 
        case default
-
     end select microp2_select
 
     case default
-
  end select microp_select
 
  end subroutine deallocate_microphysics
 
 !=================================================================================================================
- subroutine microphysics_init(dminfo,configs,mesh,sfc_input,diag_physics)
+ subroutine init_microphysics(dminfo,configs,mesh,state,time_lev,sfc_input,diag_physics)
 !=================================================================================================================
 
 !input arguments:
@@ -251,11 +265,14 @@
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
  type(mpas_pool_type),intent(in):: sfc_input
+ integer,intent(in):: time_lev
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
+ type(mpas_pool_type),intent(inout):: state
 
 !local pointer:
+ logical,pointer:: do_restart
  character(len=StrKIND),pointer:: microp_scheme
 
 !CCPP-compliant flags:
@@ -263,31 +280,41 @@
  integer:: errflg
 
 !-----------------------------------------------------------------------------------------------------------------
+ call mpas_log_write(' ')
+ call mpas_log_write('--- enter subroutine init_microphysics:')
 
 !initialization of CCPP-compliant flags:
  errmsg = ' '
  errflg = 0
 
  call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_do_restart'   ,do_restart   )
 
-  microp_select: select case(microp_scheme)
+ microp_select: select case(trim(microp_scheme))
+    case("mp_thompson","mp_thompson_aerosols")
+       call thompson_init(l_mp_tables)
+       call init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag_physics)
 
-     case("mp_thompson")
-        call thompson_init(l_mp_tables)
-        call init_thompson_clouddroplets_forMPAS(mesh,sfc_input,diag_physics)
+       microp2_select: select case(trim(microp_scheme))
+          case("mp_thompson_aerosols")
+             call init_thompson_aerosols_forMPAS(do_restart,dminfo,mesh,state,time_lev,diag_physics)
 
-     case("mp_wsm6")
-        call mp_wsm6_init(den0=rho_a,denr=rho_r,dens=rho_s,cl=cliq,cpv=cpv, &
-                          hail_opt=hail_opt,errmsg=errmsg,errflg=errflg)
+          case default
+       end select microp2_select
 
-     case default
+    case("mp_wsm6")
+       call mp_wsm6_init(den0=rho_a,denr=rho_r,dens=rho_s,cl=cliq,cpv=cpv, &
+                         hail_opt=hail_opt,errmsg=errmsg,errflg=errflg)
 
-  end select microp_select
+    case default
+ end select microp_select
 
- end subroutine microphysics_init
+ call mpas_log_write('--- end subroutine init_microphysics:')
+
+ end subroutine init_microphysics
 
 !=================================================================================================================
- subroutine driver_microphysics(configs,mesh,state,time_lev,diag,diag_physics,tend,itimestep,its,ite)
+ subroutine driver_microphysics(configs,mesh,state,time_lev,diag,diag_physics,tend_physics,tend,itimestep,its,ite)
 !=================================================================================================================
 
  use mpas_constants, only : rvord
@@ -304,6 +331,7 @@
  type(mpas_pool_type),intent(inout):: state
  type(mpas_pool_type),intent(inout):: diag
  type(mpas_pool_type),intent(inout):: diag_physics
+ type(mpas_pool_type),intent(inout):: tend_physics
  type(mpas_pool_type),intent(inout):: tend
 
 !local pointers:
@@ -336,13 +364,12 @@
  call precip_from_MPAS(configs,diag_physics,its,ite)
 
 !... initialization of soundings for non-hydrostatic dynamical cores.
- call microphysics_from_MPAS(configs,mesh,state,time_lev,diag,diag_physics,its,ite)
+ call microphysics_from_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend_physics,its,ite)
 
 !... call to different cloud microphysics schemes:
- microp_select: select case(microp_scheme)
-
+ microp_select: select case(trim(microp_scheme))
     case ("mp_kessler")
-       call mpas_timer_start('Kessler')
+       call mpas_timer_start('mp_kessler')
        call kessler( &
                   t        = th_p      , qv    = qv_p  , qc     = qc_p     ,                &
                   qr       = qr_p      , rho   = rho_p , pii    = pi_p     ,                &
@@ -355,11 +382,11 @@
                   ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme   , &
                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte     &
                    )
-       call mpas_timer_stop('Kessler')
+       call mpas_timer_stop('mp_kessler')
 
     case ("mp_thompson")
+       call mpas_timer_start('mp_thompson')
        istep = 1
-       call mpas_timer_start('Thompson')
        do while (istep .le. n_microp)
        call mp_gt_driver( &
                   th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
@@ -372,14 +399,40 @@
                   sr        = sr_p        , rainprod   = rainprod_p   , evapprod   = evapprod_p   , &
                   re_cloud  = recloud_p   , re_ice     = reice_p      , re_snow    = resnow_p     , &
                   has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
-                  ntc       = ntc_p       , muc        = muc_p        ,                             &
+                  ntc       = ntc_p       , muc        = muc_p                                    , &
                   ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
                   ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
                   its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
                            )
        istep = istep + 1
        enddo
-       call mpas_timer_stop('Thompson')
+       call mpas_timer_stop('mp_thompson')
+
+    case ("mp_thompson_aerosols")
+       call mpas_timer_start('mp_thompson_aerosols')
+       istep = 1
+       do while (istep .le. n_microp)
+       call mp_gt_driver( &
+                  th        = th_p        , qv         = qv_p         , qc         = qc_p         , &
+                  qr        = qr_p        , qi         = qi_p         , qs         = qs_p         , &
+                  qg        = qg_p        , ni         = ni_p         , nr         = nr_p         , &
+                  pii       = pi_p        , p          = pres_p       , dz         = dz_p         , &
+                  w         = w_p         , dt_in      = dt_microp    , itimestep  = itimestep    , &
+                  rainnc    = rainnc_p    , rainncv    = rainncv_p    , snownc     = snownc_p     , &
+                  snowncv   = snowncv_p   , graupelnc  = graupelnc_p  , graupelncv = graupelncv_p , &
+                  sr        = sr_p        , rainprod   = rainprod_p   , evapprod   = evapprod_p   , &
+                  re_cloud  = recloud_p   , re_ice     = reice_p      , re_snow    = resnow_p     , &
+                  has_reqc  = has_reqc    , has_reqi   = has_reqi     , has_reqs   = has_reqs     , &
+                  nc        = nc_p        , nifa       = nifa_p       , nwfa       = nwfa_p       , &
+                  nifa2d    = nifa2d_p    , nwfa2d     = nwfa2d_p     , ntc        = ntc_p        , &
+                  muc       = muc_p       ,                                                         &
+                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde           , &
+                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme           , &
+                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
+                           )
+          istep = istep + 1
+          enddo
+          call mpas_timer_stop('mp_thompson_aerosols')
 
     case ("mp_wsm6")
        call mpas_timer_start('mp_wsm6')
@@ -408,16 +461,15 @@
        call mpas_timer_stop('mp_wsm6')
 
     case default
-
  end select microp_select
 
 !... calculate the 10cm radar reflectivity and relative humidity, if needed:
  if (l_diags) then
-
     !ensure that we only call compute_radar_reflectivity() if we are using an MPS that supports
     !the computation of simulated radar reflectivity:
     if(trim(microp_scheme) == "mp_wsm6"     .or. &
-       trim(microp_scheme) == "mp_thompson") then
+       trim(microp_scheme) == "mp_thompson" .or. &
+       trim(microp_scheme) == "mp_thompson_aerosols") then
        call compute_radar_reflectivity(configs,diag_physics,its,ite)
     else
        call mpas_log_write('*** NOTICE: NOT computing simulated radar reflectivity')
@@ -427,7 +479,6 @@
     !calculate the relative humidity over water if the temperature is strictly greater than 0.C,
     !over ice otherwise.
     call compute_relhum(diag,its,ite)
-
  end if
 
 !... copy updated precipitation from the wrf-physics grid back to the geodesic-dynamics grid:
@@ -435,7 +486,7 @@
 
 !... copy updated cloud microphysics variables from the wrf-physics grid back to the geodesic-
 !    dynamics grid:
- call microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend,itimestep,its,ite)
+ call microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend_physics,tend,its,ite)
 
 !... deallocation of all microphysics arrays:
 !$OMP BARRIER
@@ -489,9 +540,8 @@
  enddo
 
 !variables specific to different cloud microphysics schemes:
- microp_select: select case(microp_scheme)
-
-    case ("mp_thompson","mp_wsm6")
+ microp_select: select case(trim(microp_scheme))
+    case ("mp_thompson","mp_thompson_aerosols","mp_wsm6")
        do j = jts, jte
        do i = its, ite
           snowncv_p(i,j)    = 0._RKIND
@@ -509,7 +559,6 @@
        enddo
 
     case default
-
  end select microp_select
 
  end subroutine precip_from_MPAS
@@ -583,9 +632,8 @@
  enddo
 
 !variables specific to different cloud microphysics schemes:
- microp_select_init: select case(microp_scheme)
-
-    case ("mp_thompson","mp_wsm6")
+ microp_select: select case(trim(microp_scheme))
+    case ("mp_thompson","mp_thompson_aerosols","mp_wsm6")
        do j = jts,jte
        do i = its,ite
           !time-step precipitation:
@@ -600,8 +648,7 @@
        enddo
 
     case default
-
- end select microp_select_init
+ end select microp_select
 
  end subroutine precip_to_MPAS
 
@@ -633,8 +680,7 @@
  call mpas_pool_get_array(diag_physics,'refl10cm_1km',refl10cm_1km)
  call mpas_pool_get_array(diag_physics,'refl10cm_1km_max',refl10cm_1km_max)
 
- microp_select: select case(microp_scheme)
-
+ microp_select: select case(trim(microp_scheme))
     case ("mp_kessler")
        call physics_error_fatal('--- calculation of radar reflectivity is not available' // &
                                  'with kessler cloud microphysics')
@@ -686,7 +732,7 @@
        if(allocated(dBz1d)) deallocate(dBZ1d)
        if(allocated(zp)   ) deallocate(zp   )
 
-    case ("mp_thompson")
+    case ("mp_thompson","mp_thompson_aerosols")
        if(.not.allocated(p1d)  ) allocate(p1d(kts:kte)  )
        if(.not.allocated(t1d)  ) allocate(t1d(kts:kte)  )
        if(.not.allocated(qv1d) ) allocate(qv1d(kts:kte) )
@@ -740,7 +786,6 @@
        if(allocated(zp)   ) deallocate(zp   )
 
     case default
-
  end select microp_select
 
  end subroutine compute_radar_reflectivity

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -713,10 +713,10 @@
  pbl_select: select case (trim(pbl_scheme))
 
     case("bl_mynn")
-       call mpas_log_write('--- enter subroutine bl_mynn_init:')
+!      call mpas_log_write('--- enter subroutine bl_mynn_init:')
        call bl_mynn_init(cp,cpv,cice,cliq,ep_1,ep_2,gravity,karman,P0,R_d,R_v,svp1,svp2,svp3,svpt0, &
                          xlf,xls,xlv,errmsg,errflg)
-       call mpas_log_write('--- end subroutine bl_mynn_mpas_init:')
+!      call mpas_log_write('--- end subroutine bl_mynn_init:')
 
     case default
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -127,60 +127,61 @@
 
     case("bl_ysu")
        !from surface-layer model:
-       if(.not.allocated(br_p)          ) allocate(br_p(ims:ime,jms:jme)                )
-       if(.not.allocated(ctopo_p)       ) allocate(ctopo_p(ims:ime,jms:jme)             )
-       if(.not.allocated(ctopo2_p)      ) allocate(ctopo2_p(ims:ime,jms:jme)            )
-       if(.not.allocated(delta_p)       ) allocate(delta_p(ims:ime,jms:jme)             )
-       if(.not.allocated(psih_p)        ) allocate(psih_p(ims:ime,jms:jme)              )
-       if(.not.allocated(psim_p)        ) allocate(psim_p(ims:ime,jms:jme)              )
-       if(.not.allocated(u10_p)         ) allocate(u10_p(ims:ime,jms:jme)               )
-       if(.not.allocated(v10_p)         ) allocate(v10_p(ims:ime,jms:jme)               )
-       if(.not.allocated(exch_p)        ) allocate(exch_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(wstar_p)       ) allocate(wstar_p(ims:ime,jms:jme)             )
+       if(.not.allocated(br_p)    ) allocate(br_p(ims:ime,jms:jme)          )
+       if(.not.allocated(ctopo_p) ) allocate(ctopo_p(ims:ime,jms:jme)       )
+       if(.not.allocated(ctopo2_p)) allocate(ctopo2_p(ims:ime,jms:jme)      )
+       if(.not.allocated(delta_p) ) allocate(delta_p(ims:ime,jms:jme)       )
+       if(.not.allocated(psih_p)  ) allocate(psih_p(ims:ime,jms:jme)        )
+       if(.not.allocated(psim_p)  ) allocate(psim_p(ims:ime,jms:jme)        )
+       if(.not.allocated(u10_p)   ) allocate(u10_p(ims:ime,jms:jme)         )
+       if(.not.allocated(v10_p)   ) allocate(v10_p(ims:ime,jms:jme)         )
+       if(.not.allocated(exch_p)  ) allocate(exch_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(wstar_p) ) allocate(wstar_p(ims:ime,jms:jme)       )
 
     case("bl_mynn")
-       if(.not.allocated(kbl_plume_p)   ) allocate(kbl_plume_p(ims:ime,jms:jme)         )
-
-       if(.not.allocated(dx_p)          ) allocate(dx_p(ims:ime,jms:jme)                )
-       if(.not.allocated(ch_p)          ) allocate(ch_p(ims:ime,jms:jme)                )
-       if(.not.allocated(qsfc_p)        ) allocate(qsfc_p(ims:ime,jms:jme)              )
-       if(.not.allocated(rmol_p)        ) allocate(rmol_p(ims:ime,jms:jme)              )
-       if(.not.allocated(tsk_p)         ) allocate(tsk_p(ims:ime,jms:jme)               )
-       if(.not.allocated(maxwidthbl_p)  ) allocate(maxwidthbl_p(ims:ime,jms:jme)        )
-       if(.not.allocated(maxmfbl_p)     ) allocate(maxmfbl_p(ims:ime,jms:jme)           )
-       if(.not.allocated(zbl_plume_p)   ) allocate(zbl_plume_p(ims:ime,jms:jme)         )
-
-       if(.not.allocated(cov_p)         ) allocate(cov_p(ims:ime,kms:kme,jms:jme)       )
-       if(.not.allocated(qke_p)         ) allocate(qke_p(ims:ime,kms:kme,jms:jme)       )
-       if(.not.allocated(qsq_p)         ) allocate(qsq_p(ims:ime,kms:kme,jms:jme)       )
-       if(.not.allocated(tsq_p)         ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)       )
-       if(.not.allocated(qkeadv_p)      ) allocate(qkeadv_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(elpbl_p)       ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(tkepbl_p)      ) allocate(tkepbl_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(sh3d_p)        ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(sm3d_p)        ) allocate(sm3d_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(dqke_p)        ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(qbuoy_p)       ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(qdiss_p)       ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(qshear_p)      ) allocate(qshear_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(qwt_p)         ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)       )
-       if(.not.allocated(qcbl_p)        ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(qibl_p)        ) allocate(qibl_p(ims:ime,kms:kme,jms:jme)      )
-       if(.not.allocated(cldfrabl_p)    ) allocate(cldfrabl_p(ims:ime,kms:kme,jms:jme)  )
-       if(.not.allocated(edmfa_p)       ) allocate(edmfa_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(edmfw_p)       ) allocate(edmfw_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(edmfqt_p)      ) allocate(edmfqt_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(edmfthl_p)     ) allocate(edmfthl_p(ims:ime,kms:kme,jms:jme)   )
-       if(.not.allocated(edmfent_p)     ) allocate(edmfent_p(ims:ime,kms:kme,jms:jme)   )
-       if(.not.allocated(edmfqc_p)      ) allocate(edmfqc_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(subthl_p)      ) allocate(subthl_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(subqv_p)       ) allocate(subqv_p(ims:ime,kms:kme,jms:jme)     )
-       if(.not.allocated(detthl_p)      ) allocate(detthl_p(ims:ime,kms:kme,jms:jme)    )
-       if(.not.allocated(detqv_p)       ) allocate(detqv_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(kbl_plume_p) ) allocate(kbl_plume_p(ims:ime,jms:jme)         )
+       if(.not.allocated(dx_p)        ) allocate(dx_p(ims:ime,jms:jme)                )
+       if(.not.allocated(ch_p)        ) allocate(ch_p(ims:ime,jms:jme)                )
+       if(.not.allocated(qsfc_p)      ) allocate(qsfc_p(ims:ime,jms:jme)              )
+       if(.not.allocated(rmol_p)      ) allocate(rmol_p(ims:ime,jms:jme)              )
+       if(.not.allocated(tsk_p)       ) allocate(tsk_p(ims:ime,jms:jme)               )
+       if(.not.allocated(maxwidthbl_p)) allocate(maxwidthbl_p(ims:ime,jms:jme)        )
+       if(.not.allocated(maxmfbl_p)   ) allocate(maxmfbl_p(ims:ime,jms:jme)           )
+       if(.not.allocated(zbl_plume_p) ) allocate(zbl_plume_p(ims:ime,jms:jme)         )
+       if(.not.allocated(cov_p)       ) allocate(cov_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qke_p)       ) allocate(qke_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qsq_p)       ) allocate(qsq_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(tsq_p)       ) allocate(tsq_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qkeadv_p)    ) allocate(qkeadv_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(elpbl_p)     ) allocate(elpbl_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(tkepbl_p)    ) allocate(tkepbl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(sh3d_p)      ) allocate(sh3d_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(sm3d_p)      ) allocate(sm3d_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(dqke_p)      ) allocate(dqke_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(qbuoy_p)     ) allocate(qbuoy_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(qdiss_p)     ) allocate(qdiss_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(qshear_p)    ) allocate(qshear_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(qwt_p)       ) allocate(qwt_p(ims:ime,kms:kme,jms:jme)       )
+       if(.not.allocated(qcbl_p)      ) allocate(qcbl_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(qibl_p)      ) allocate(qibl_p(ims:ime,kms:kme,jms:jme)      )
+       if(.not.allocated(cldfrabl_p)  ) allocate(cldfrabl_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(edmfa_p)     ) allocate(edmfa_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(edmfw_p)     ) allocate(edmfw_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(edmfqt_p)    ) allocate(edmfqt_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(edmfthl_p)   ) allocate(edmfthl_p(ims:ime,kms:kme,jms:jme)   )
+       if(.not.allocated(edmfent_p)   ) allocate(edmfent_p(ims:ime,kms:kme,jms:jme)   )
+       if(.not.allocated(edmfqc_p)    ) allocate(edmfqc_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(subthl_p)    ) allocate(subthl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(subqv_p)     ) allocate(subqv_p(ims:ime,kms:kme,jms:jme)     )
+       if(.not.allocated(detthl_p)    ) allocate(detthl_p(ims:ime,kms:kme,jms:jme)    )
+       if(.not.allocated(detqv_p)     ) allocate(detqv_p(ims:ime,kms:kme,jms:jme)     )
 
        !additional tendencies:
-       if(.not.allocated(rqsblten_p)    ) allocate(rqsblten_p(ims:ime,kms:kme,jms:jme)  )
-       if(.not.allocated(rniblten_p)    ) allocate(rniblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rqsblten_p)  ) allocate(rqsblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rncblten_p)  ) allocate(rncblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rniblten_p)  ) allocate(rniblten_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(rnifablten_p)) allocate(rnifablten_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(rnwfablten_p)) allocate(rnwfablten_p(ims:ime,kms:kme,jms:jme))
 
        !allocation of additional arrays:
        if(.not.allocated(pattern_spp_pbl)) allocate(pattern_spp_pbl(ims:ime,kms:kme,jms:jme))
@@ -235,60 +236,62 @@
 
     case("bl_ysu")
        !from surface-layer model:
-       if(allocated(br_p)          ) deallocate(br_p          )
-       if(allocated(ctopo_p)       ) deallocate(ctopo_p       )
-       if(allocated(ctopo2_p)      ) deallocate(ctopo2_p      )
-       if(allocated(delta_p)       ) deallocate(delta_p       )
-       if(allocated(psih_p)        ) deallocate(psih_p        )
-       if(allocated(psim_p)        ) deallocate(psim_p        )
-       if(allocated(u10_p)         ) deallocate(u10_p         )
-       if(allocated(v10_p)         ) deallocate(v10_p         )
-       if(allocated(exch_p)        ) deallocate(exch_p        )
-       if(allocated(wstar_p)       ) deallocate(wstar_p       )
+       if(allocated(br_p)    ) deallocate(br_p    )
+       if(allocated(ctopo_p) ) deallocate(ctopo_p )
+       if(allocated(ctopo2_p)) deallocate(ctopo2_p)
+       if(allocated(delta_p) ) deallocate(delta_p )
+       if(allocated(psih_p)  ) deallocate(psih_p  )
+       if(allocated(psim_p)  ) deallocate(psim_p  )
+       if(allocated(u10_p)   ) deallocate(u10_p   )
+       if(allocated(v10_p)   ) deallocate(v10_p   )
+       if(allocated(exch_p)  ) deallocate(exch_p  )
+       if(allocated(wstar_p) ) deallocate(wstar_p )
 
     case("bl_mynn")
-       if(allocated(kbl_plume_p)   ) deallocate(kbl_plume_p   )
+       if(allocated(kbl_plume_p) ) deallocate(kbl_plume_p )
+       if(allocated(dx_p)        ) deallocate(dx_p        )
+       if(allocated(ch_p)        ) deallocate(ch_p        )
+       if(allocated(qsfc_p)      ) deallocate(qsfc_p      )
+       if(allocated(rmol_p)      ) deallocate(rmol_p      )
+       if(allocated(tsk_p)       ) deallocate(tsk_p       )
+       if(allocated(maxwidthbl_p)) deallocate(maxwidthbl_p)
+       if(allocated(maxmfbl_p)   ) deallocate(maxmfbl_p   )
+       if(allocated(zbl_plume_p) ) deallocate(zbl_plume_p )
 
-       if(allocated(dx_p)          ) deallocate(dx_p          )
-       if(allocated(ch_p)          ) deallocate(ch_p          )
-       if(allocated(qsfc_p)        ) deallocate(qsfc_p        )
-       if(allocated(rmol_p)        ) deallocate(rmol_p        )
-       if(allocated(tsk_p)         ) deallocate(tsk_p         )
-       if(allocated(maxwidthbl_p)  ) deallocate(maxwidthbl_p  )
-       if(allocated(maxmfbl_p)     ) deallocate(maxmfbl_p     )
-       if(allocated(zbl_plume_p)   ) deallocate(zbl_plume_p   )
-
-       if(allocated(cov_p)         ) deallocate(cov_p         )
-       if(allocated(qke_p)         ) deallocate(qke_p         )
-       if(allocated(qsq_p)         ) deallocate(qsq_p         )
-       if(allocated(tsq_p)         ) deallocate(tsq_p         )
-       if(allocated(qkeadv_p)      ) deallocate(qkeadv_p      )
-       if(allocated(elpbl_p)       ) deallocate(elpbl_p       )
-       if(allocated(tkepbl_p)      ) deallocate(tkepbl_p      )
-       if(allocated(sh3d_p)        ) deallocate(sh3d_p        )
-       if(allocated(sm3d_p)        ) deallocate(sm3d_p        )
-       if(allocated(dqke_p)        ) deallocate(dqke_p        )
-       if(allocated(qbuoy_p)       ) deallocate(qbuoy_p       )
-       if(allocated(qdiss_p)       ) deallocate(qdiss_p       )
-       if(allocated(qshear_p)      ) deallocate(qshear_p      )
-       if(allocated(qwt_p)         ) deallocate(qwt_p         )
-       if(allocated(qcbl_p)        ) deallocate(qcbl_p        )
-       if(allocated(qibl_p)        ) deallocate(qibl_p        )
-       if(allocated(cldfrabl_p)    ) deallocate(cldfrabl_p    )
-       if(allocated(edmfa_p)       ) deallocate(edmfa_p       )
-       if(allocated(edmfw_p)       ) deallocate(edmfw_p       )
-       if(allocated(edmfqt_p)      ) deallocate(edmfqt_p      )
-       if(allocated(edmfthl_p)     ) deallocate(edmfthl_p     )
-       if(allocated(edmfent_p)     ) deallocate(edmfent_p     )
-       if(allocated(edmfqc_p)      ) deallocate(edmfqc_p      )
-       if(allocated(subthl_p)      ) deallocate(subthl_p      )
-       if(allocated(subqv_p)       ) deallocate(subqv_p       )
-       if(allocated(detthl_p)      ) deallocate(detthl_p      )
-       if(allocated(detqv_p)       ) deallocate(detqv_p       )
+       if(allocated(cov_p)       ) deallocate(cov_p       )
+       if(allocated(qke_p)       ) deallocate(qke_p       )
+       if(allocated(qsq_p)       ) deallocate(qsq_p       )
+       if(allocated(tsq_p)       ) deallocate(tsq_p       )
+       if(allocated(qkeadv_p)    ) deallocate(qkeadv_p    )
+       if(allocated(elpbl_p)     ) deallocate(elpbl_p     )
+       if(allocated(tkepbl_p)    ) deallocate(tkepbl_p    )
+       if(allocated(sh3d_p)      ) deallocate(sh3d_p      )
+       if(allocated(sm3d_p)      ) deallocate(sm3d_p      )
+       if(allocated(dqke_p)      ) deallocate(dqke_p      )
+       if(allocated(qbuoy_p)     ) deallocate(qbuoy_p     )
+       if(allocated(qdiss_p)     ) deallocate(qdiss_p     )
+       if(allocated(qshear_p)    ) deallocate(qshear_p    )
+       if(allocated(qwt_p)       ) deallocate(qwt_p       )
+       if(allocated(qcbl_p)      ) deallocate(qcbl_p      )
+       if(allocated(qibl_p)      ) deallocate(qibl_p      )
+       if(allocated(cldfrabl_p)  ) deallocate(cldfrabl_p  )
+       if(allocated(edmfa_p)     ) deallocate(edmfa_p     )
+       if(allocated(edmfw_p)     ) deallocate(edmfw_p     )
+       if(allocated(edmfqt_p)    ) deallocate(edmfqt_p    )
+       if(allocated(edmfthl_p)   ) deallocate(edmfthl_p   )
+       if(allocated(edmfent_p)   ) deallocate(edmfent_p   )
+       if(allocated(edmfqc_p)    ) deallocate(edmfqc_p    )
+       if(allocated(subthl_p)    ) deallocate(subthl_p    )
+       if(allocated(subqv_p)     ) deallocate(subqv_p     )
+       if(allocated(detthl_p)    ) deallocate(detthl_p    )
+       if(allocated(detqv_p)     ) deallocate(detqv_p     )
 
        !additional tendencies:
-       if(allocated(rqsblten_p)    ) deallocate(rqsblten_p    )
-       if(allocated(rniblten_p)    ) deallocate(rniblten_p    )
+       if(allocated(rqsblten_p)  ) deallocate(rqsblten_p  )
+       if(allocated(rncblten_p)  ) deallocate(rncblten_p  )
+       if(allocated(rniblten_p)  ) deallocate(rniblten_p  )
+       if(allocated(rnifablten_p)) deallocate(rnifablten_p)
+       if(allocated(rnwfablten_p)) deallocate(rnwfablten_p)
 
        !deallocation of additional arrays:
        if(allocated(pattern_spp_pbl)) deallocate(pattern_spp_pbl)
@@ -485,8 +488,11 @@
           qshear_p(i,k,j)   = 0._RKIND
           qwt_p(i,k,j)      = 0._RKIND
 
-          rqsblten_p(i,k,j) = 0._RKIND
-          rniblten_p(i,k,j) = 0._RKIND
+          rqsblten_p(i,k,j)   = 0._RKIND
+          rncblten_p(i,k,j)   = 0._RKIND
+          rniblten_p(i,k,j)   = 0._RKIND
+          rnifablten_p(i,k,j) = 0._RKIND
+          rnwfablten_p(i,k,j) = 0._RKIND
 
           pattern_spp_pbl(i,k,j) = 0._RKIND
        enddo
@@ -546,7 +552,7 @@
  real(kind=RKIND),dimension(:),pointer  :: hpbl
  real(kind=RKIND),dimension(:,:),pointer:: kzh,kzm,kzq
  real(kind=RKIND),dimension(:,:),pointer:: rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,rqsblten
- real(kind=RKIND),dimension(:,:),pointer:: rniblten
+ real(kind=RKIND),dimension(:,:),pointer:: rncblten,rniblten,rnifablten,rnwfablten
 
 !local pointers for YSU scheme:
  real(kind=RKIND),dimension(:,:),pointer:: exch_h
@@ -649,7 +655,6 @@
        call mpas_pool_get_array(diag_physics,'det_qv'    ,det_qv    )
 
        call mpas_pool_get_array(tend_physics,'rqsblten'  ,rqsblten  )
-       call mpas_pool_get_array(tend_physics,'rniblten'  ,rniblten  )
 
        do j = jts,jte
        do k = kts,kte
@@ -683,10 +688,34 @@
           qwt(k,i)        = qwt_p(i,k,j)
 
           rqsblten(k,i)   = rqsblten_p(i,k,j)
-          rniblten(k,i)   = rniblten_p(i,k,j)
        enddo
        enddo
        enddo
+
+       if(f_ni) then
+          call mpas_pool_get_array(tend_physics,'rniblten',rniblten)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   rniblten(k,i) = rniblten_p(i,k,j)
+                enddo
+             enddo
+          enddo
+       endif
+       if(f_nc .and. f_nifa .and. f_nwfa) then
+          call mpas_pool_get_array(tend_physics,'rncblten'  ,rncblten  )
+          call mpas_pool_get_array(tend_physics,'rnifablten',rnifablten)
+          call mpas_pool_get_array(tend_physics,'rnwfablten',rnwfablten)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   rncblten(k,i)   = rncblten_p(i,k,j)
+                   rnifablten(k,i) = rnifablten_p(i,k,j)
+                   rnwfablten(k,i) = rnwfablten_p(i,k,j)
+                enddo
+             enddo
+          enddo
+       endif
 
     case default
 
@@ -873,58 +902,60 @@
 
        call mpas_timer_start('bl_mynn')
        call mynn_bl_driver( &
-                  f_qc       = f_qc         , f_qi     = f_qi       , f_qs        = f_qs             , &
-                  f_qoz      = f_qoz        , f_nc     = f_nc       , f_ni        = f_ni             , &
-                  f_nifa     = f_nifa       , f_nwfa   = f_nwfa     , f_nbca      = f_nbca           , &
-                  icloud_bl  = icloud_bl    , delt     = dt_pbl     , dx          = dx_p             , &
-                  xland      = xland_p      , ps       = psfc_p     , ts          = tsk_p            , &
-                  qsfc       = qsfc_p       , ust      = ust_p      , ch          = ch_p             , &
-                  hfx        = hfx_p        , qfx      = qfx_p      , rmol        = rmol_p           , &
-                  wspd       = wspd_p       , znt      = znt_p      , uoce        = uoce_p           , &
-                  voce       = voce_p       , dz       = dz_p       , u           = u_p              , &
-                  v          = v_p          , w        = w_p        , th          = th_p             , &
-                  tt         = t_p          , p        = pres_hyd_p , exner       = pi_p             , &
-                  rho        = rho_p        , qv       = qv_p       , qc          = qc_p             , &
-                  qi         = qi_p         , qs       = qs_p       , ni          = ni_p             , &
-                  rthraten   = rthraten_p   , pblh     = hpbl_p     , kpbl        = kpbl_p           , &
-                  cldfra_bl  = cldfrabl_p   , qc_bl    = qcbl_p     , qi_bl       = qibl_p           , &
-                  maxwidth   = maxwidthbl_p , maxmf    = maxmfbl_p  , ktop_plume  = kbl_plume_p      , &
-                  ztop_plume = zbl_plume_p  , dqke     = dqke_p     , qke_adv     = qkeadv_p         , &
-                  tsq        = tsq_p        , qsq      = qsq_p      , cov         = cov_p            , &
-                  el_pbl     = elpbl_p      , rublten  = rublten_p  , rvblten     = rvblten_p        , &
-                  rthblten   = rthblten_p   , rqvblten = rqvblten_p , rqcblten    = rqcblten_p       , &
-                  rqiblten   = rqiblten_p   , rqsblten = rqsblten_p , rniblten    = rniblten_p       , &
-                  edmf_a     = edmfa_p      , edmf_w   = edmfw_p    , edmf_qt     = edmfqt_p         , &
-                  edmf_thl   = edmfthl_p    , edmf_ent = edmfent_p  , edmf_qc     = edmfqc_p         , &
-                  sub_thl    = subthl_p     , sub_sqv  = subqv_p    , det_thl     = detthl_p         , &
-                  det_sqv    = detqv_p      , exch_h   = kzh_p      , exch_m      = kzm_p            , &
-                  qke        = qke_p        , qwt      = qwt_p      , qshear      = qshear_p         , &
-                  qbuoy      = qbuoy_p      , qdiss    = qdiss_p    , sh3d        = sh3d_p           , &
-                  sm3d       = sm3d_p       , spp_pbl  = spp_pbl    , pattern_spp = pattern_spp_pbl  , &
-                  do_restart         = config_do_restart   ,                                           &
-                  do_DAcycling       = config_do_DAcycling ,                                           &
-                  initflag           = initflag            ,                                           &
-                  bl_mynn_tkeadvect  = bl_mynn_tkeadvect   ,                                           &
-                  bl_mynn_tkebudget  = bl_mynn_tkebudget   ,                                           &
-                  bl_mynn_cloudpdf   = bl_mynn_cloudpdf    ,                                           &
-                  bl_mynn_mixlength  = bl_mynn_mixlength   ,                                           &
-                  bl_mynn_closure    = bl_mynn_closure     ,                                           &
-                  bl_mynn_stfunc     = bl_mynn_stfunc      ,                                           &
-                  bl_mynn_topdown    = bl_mynn_topdown     ,                                           &
-                  bl_mynn_scaleaware = bl_mynn_scaleaware  ,                                           &
-                  bl_mynn_dheat_opt  = bl_mynn_dheat_opt   ,                                           &
-                  bl_mynn_edmf       = bl_mynn_edmf        ,                                           &
-                  bl_mynn_edmf_dd    = bl_mynn_edmf_dd     ,                                           &
-                  bl_mynn_edmf_mom   = bl_mynn_edmf_mom    ,                                           &
-                  bl_mynn_edmf_tke   = bl_mynn_edmf_tke    ,                                           &
-                  bl_mynn_output     = bl_mynn_edmf_output ,                                           &
-                  bl_mynn_mixscalars = bl_mynn_mixscalars  ,                                           &
-                  bl_mynn_cloudmix   = bl_mynn_cloudmix    ,                                           &
-                  bl_mynn_mixqt      = bl_mynn_mixqt       ,                                           &
-                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,              &
-                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,              &
-                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,              &
-                  errmsg = errmsg , errflg = errflg                                                    &
+                  f_qc       = f_qc         , f_qi       = f_qi         , f_qs        = f_qs            , &
+                  f_qoz      = f_qoz        , f_nc       = f_nc         , f_ni        = f_ni            , &
+                  f_nifa     = f_nifa       , f_nwfa     = f_nwfa       , f_nbca      = f_nbca          , &
+                  icloud_bl  = icloud_bl    , delt       = dt_pbl       , dx          = dx_p            , &
+                  xland      = xland_p      , ps         = psfc_p       , ts          = tsk_p           , &
+                  qsfc       = qsfc_p       , ust        = ust_p        , ch          = ch_p            , &
+                  hfx        = hfx_p        , qfx        = qfx_p        , rmol        = rmol_p          , &
+                  wspd       = wspd_p       , znt        = znt_p        , uoce        = uoce_p          , &
+                  voce       = voce_p       , dz         = dz_p         , u           = u_p             , &
+                  v          = v_p          , w          = w_p          , th          = th_p            , &
+                  tt         = t_p          , p          = pres_hyd_p   , exner       = pi_p            , &
+                  rho        = rho_p        , qv         = qv_p         , qc          = qc_p            , &
+                  qi         = qi_p         , qs         = qs_p         , nc          = nc_p            , &
+                  ni         = ni_p         , nifa       = nifa_p       , nwfa        = nwfa_p          , &
+                  rthraten   = rthraten_p   , pblh       = hpbl_p       , kpbl        = kpbl_p          , &
+                  cldfra_bl  = cldfrabl_p   , qc_bl      = qcbl_p       , qi_bl       = qibl_p          , &
+                  maxwidth   = maxwidthbl_p , maxmf      = maxmfbl_p    , ktop_plume  = kbl_plume_p     , &
+                  ztop_plume = zbl_plume_p  , dqke       = dqke_p       , qke_adv     = qkeadv_p        , &
+                  tsq        = tsq_p        , qsq        = qsq_p        , cov         = cov_p           , &
+                  el_pbl     = elpbl_p      , rublten    = rublten_p    , rvblten     = rvblten_p       , &
+                  rthblten   = rthblten_p   , rqvblten   = rqvblten_p   , rqcblten    = rqcblten_p      , &
+                  rqiblten   = rqiblten_p   , rqsblten   = rqsblten_p   , rncblten    = rncblten_p      , &
+                  rniblten   = rniblten_p   , rnifablten = rnifablten_p , rnwfablten  = rnwfablten_p    , &
+                  edmf_a     = edmfa_p      , edmf_w     = edmfw_p      , edmf_qt     = edmfqt_p        , &
+                  edmf_thl   = edmfthl_p    , edmf_ent   = edmfent_p    , edmf_qc     = edmfqc_p        , &
+                  sub_thl    = subthl_p     , sub_sqv    = subqv_p      , det_thl     = detthl_p        , &
+                  det_sqv    = detqv_p      , exch_h     = kzh_p        , exch_m      = kzm_p           , &
+                  qke        = qke_p        , qwt        = qwt_p        , qshear      = qshear_p        , &
+                  qbuoy      = qbuoy_p      , qdiss      = qdiss_p      , sh3d        = sh3d_p          , &
+                  sm3d       = sm3d_p       , spp_pbl    = spp_pbl      , pattern_spp = pattern_spp_pbl , &
+                  do_restart         = config_do_restart   ,                                              &
+                  do_DAcycling       = config_do_DAcycling ,                                              &
+                  initflag           = initflag            ,                                              &
+                  bl_mynn_tkeadvect  = bl_mynn_tkeadvect   ,                                              &
+                  bl_mynn_tkebudget  = bl_mynn_tkebudget   ,                                              &
+                  bl_mynn_cloudpdf   = bl_mynn_cloudpdf    ,                                              &
+                  bl_mynn_mixlength  = bl_mynn_mixlength   ,                                              &
+                  bl_mynn_closure    = bl_mynn_closure     ,                                              &
+                  bl_mynn_stfunc     = bl_mynn_stfunc      ,                                              &
+                  bl_mynn_topdown    = bl_mynn_topdown     ,                                              &
+                  bl_mynn_scaleaware = bl_mynn_scaleaware  ,                                              &
+                  bl_mynn_dheat_opt  = bl_mynn_dheat_opt   ,                                              &
+                  bl_mynn_edmf       = bl_mynn_edmf        ,                                              &
+                  bl_mynn_edmf_dd    = bl_mynn_edmf_dd     ,                                              &
+                  bl_mynn_edmf_mom   = bl_mynn_edmf_mom    ,                                              &
+                  bl_mynn_edmf_tke   = bl_mynn_edmf_tke    ,                                              &
+                  bl_mynn_output     = bl_mynn_edmf_output ,                                              &
+                  bl_mynn_mixscalars = bl_mynn_mixscalars  ,                                              &
+                  bl_mynn_cloudmix   = bl_mynn_cloudmix    ,                                              &
+                  bl_mynn_mixqt      = bl_mynn_mixqt       ,                                              &
+                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,                 &
+                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,                 &
+                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte ,                 &
+                  errmsg = errmsg , errflg = errflg                                                       &
                           )
        call mpas_timer_stop('bl_mynn')
 !      call mpas_log_write('--- exit subroutine mynn_bl_driver:')

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -418,7 +418,7 @@
 
     case("rrtmg_lw")
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
              if(config_microp_re) then
                 call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
                 call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
@@ -690,7 +690,7 @@
     case("rrtmg_lw")
 
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
              call mpas_pool_get_array(diag_physics,'rre_cloud',rre_cloud)
              call mpas_pool_get_array(diag_physics,'rre_ice'  ,rre_ice  )
              call mpas_pool_get_array(diag_physics,'rre_snow' ,rre_snow )

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -9,7 +9,7 @@
  module mpas_atmphys_driver_radiation_lw
  use mpas_kind_types
  use mpas_pool_routines
- use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+ use mpas_timer,only: mpas_timer_start,mpas_timer_stop
 
  use mpas_atmphys_driver_radiation_sw, only: radconst
  use mpas_atmphys_constants
@@ -138,7 +138,6 @@
  if(.not.allocated(rthratenlw_p) ) allocate(rthratenlw_p(ims:ime,kms:kme,jms:jme) )
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
-
     case("rrtmg_lw")
 
        if(.not.allocated(recloud_p)    ) allocate(recloud_p(ims:ime,kms:kme,jms:jme)       )
@@ -202,7 +201,6 @@
        endif
 
     case default
-
  end select radiation_lw_select
 
  end subroutine allocate_radiation_lw
@@ -243,7 +241,6 @@
  if(allocated(rthratenlw_p) ) deallocate(rthratenlw_p )
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
-
     case("rrtmg_lw")
        if(allocated(recloud_p)    ) deallocate(recloud_p    )
        if(allocated(reice_p)      ) deallocate(reice_p      )
@@ -292,7 +289,6 @@
        if(allocated(aerosolcp_p)  ) deallocate(aerosolcp_p  )
 
     case default
-
  end select radiation_lw_select
 
  end subroutine deallocate_radiation_lw
@@ -320,9 +316,9 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_microp_re
  character(len=StrKIND),pointer:: radt_lw_scheme
  character(len=StrKIND),pointer:: microp_scheme
- logical,pointer:: config_microp_re
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: skintemp,snow,xice,xland
@@ -339,10 +335,10 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
+ call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re    )
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme      )
  call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme       )
- call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re    )
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -415,7 +411,6 @@
  enddo
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
-
     case("rrtmg_lw")
        microp_select: select case(microp_scheme)
           case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
@@ -610,7 +605,6 @@
        enddo
 
     case default
-
  end select radiation_lw_select
 
  end subroutine radiation_lw_from_MPAS
@@ -629,9 +623,9 @@
  integer,intent(in):: its,ite
 
 !local pointers:
+ logical,pointer:: config_microp_re
  character(len=StrKIND),pointer:: radt_lw_scheme
  character(len=StrKIND),pointer:: microp_scheme
- logical,pointer:: config_microp_re
 
  real(kind=RKIND),dimension(:),pointer :: glw,lwcf,lwdnb,lwdnbc,lwdnt,lwdntc,lwupb,lwupbc, &
                                           lwupt,lwuptc,olrtoa
@@ -645,9 +639,9 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme  )
- call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme   )
  call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re)
+ call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme   )
+ call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme  )
 
  call mpas_pool_get_array(diag_physics,'glw'   ,glw   )
  call mpas_pool_get_array(diag_physics,'lwcf'  ,lwcf  )
@@ -795,7 +789,6 @@
  call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme)
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
-
     case ("rrtmg_lw")
        call rrtmg_initlw_forMPAS(dminfo)
 
@@ -803,7 +796,6 @@
        call camradinit(dminfo,mesh,atm_input,diag,diag_physics,state,time_lev)
     
     case default
-
  end select radiation_lw_select
 
  end subroutine init_radiation_lw
@@ -847,12 +839,11 @@
 
 !call to longwave radiation scheme:
  radiation_lw_select: select case (trim(radt_lw_scheme))
-
     case ("rrtmg_lw")
        o3input = 0
        if(config_o3climatology) o3input = 2
 
-       call mpas_timer_start('RRTMG_lw')
+       call mpas_timer_start('rrtmg_lwrad')
        call rrtmg_lwrad( &
             p3d        = pres_hyd_p    , p8w       = pres2_hyd_p , pi3d     = pi_p     , &
             t3d        = t_p           , t8w       = t2_p        , dz8w     = dz_p     , &
@@ -874,7 +865,7 @@
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &
                        )
-       call mpas_timer_stop('RRTMG_lw')
+       call mpas_timer_stop('rrtmg_lwrad')
 
     case ("cam_lw")
        xtime_m = xtime_s/60.
@@ -941,7 +932,6 @@
        call mpas_timer_stop('CAMRAD_lw')
 
     case default
-
  end select radiation_lw_select
 
 !copy local arrays to MPAS grid:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -433,7 +433,7 @@
     case("rrtmg_sw")
 
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
              if(config_microp_re) then
                 call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
                 call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -9,7 +9,7 @@
  module mpas_atmphys_driver_radiation_sw
  use mpas_kind_types
  use mpas_pool_routines
- use mpas_timer, only : mpas_timer_start, mpas_timer_stop
+ use mpas_timer,only: mpas_timer_start,mpas_timer_stop
 
  use mpas_atmphys_constants
  use mpas_atmphys_manager, only: gmt,curr_julday,julday,year
@@ -18,6 +18,8 @@
  use mpas_atmphys_vars
  
 !wrf physics:
+ use module_mp_thompson_aerosols
+ use module_ra_rrtmg_sw_aerosols
  use module_ra_cam
  use module_ra_rrtmg_sw
 
@@ -87,6 +89,14 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2023-04-21.
 ! * removed the variables f_qv and f_qg in the call to subroutine camrad.
 !   Laura D. Fowler (laura@ucar.edu) / 2024-02-13.
+! * in subroutine radiation_sw_from_MPAS, added the calculation of the optical properties of "water-friendly" and
+!   "ice-friendly" aerosols from the Thompson cloud microphysics scheme for use in the RRTMG short-wave radiation
+!   code.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
+! * in subroutine driver_radiation_sw, modified the argument list in the call to subroutine rrtmg_sw to include
+!   the optical properties of "water-friendly" and "ice-friendly" aerosols from the Thompson cloud microphysics
+!   scheme.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
 
 
  contains
@@ -101,10 +111,12 @@
  real(kind=RKIND),intent(in):: xtime_s
 
 !local pointers:
- character(len=StrKIND),pointer:: radt_sw_scheme
+ character(len=StrKIND),pointer:: mp_scheme,     &
+                                  radt_sw_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 
+ call mpas_pool_get_config(configs,'config_microp_scheme' ,mp_scheme     )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme)
 
  if(.not.allocated(f_ice)        ) allocate(f_ice(ims:ime,kms:kme,jms:jme)        )
@@ -134,7 +146,6 @@
  if(.not.allocated(rthratensw_p) ) allocate(rthratensw_p(ims:ime,kms:kme,jms:jme) )
 
  radiation_sw_select: select case (trim(radt_sw_scheme))
-
     case("rrtmg_sw")
        if(.not.allocated(recloud_p)    ) allocate(recloud_p(ims:ime,kms:kme,jms:jme)       )
        if(.not.allocated(reice_p)      ) allocate(reice_p(ims:ime,kms:kme,jms:jme)         )
@@ -160,6 +171,20 @@
 
        if(.not.allocated(pin_p)        ) allocate(pin_p(num_oznlevels)                     )
        if(.not.allocated(o3clim_p)     ) allocate(o3clim_p(ims:ime,1:num_oznlevels,jms:jme))
+
+       if(.not.allocated(tauaer_p)     ) allocate(tauaer_p(ims:ime,kms:kme,jms:jme,nbndsw) )
+       if(.not.allocated(ssaaer_p)     ) allocate(ssaaer_p(ims:ime,kms:kme,jms:jme,nbndsw) )
+       if(.not.allocated(asyaer_p)     ) allocate(asyaer_p(ims:ime,kms:kme,jms:jme,nbndsw) )
+
+       aerosol_select: select case(mp_scheme)
+          case("mp_thompson_aerosols")
+             if(.not.allocated(ht_p)       ) allocate(ht_p(ims:ime,jms:jme)       )
+             if(.not.allocated(taer_type_p)) allocate(taer_type_p(ims:ime,jms:jme))
+             if(.not.allocated(taod5502d_p)) allocate(taod5502d_p(ims:ime,jms:jme))
+             if(.not.allocated(taod5503d_p)) allocate(taod5503d_p(ims:ime,kms:kme,jms:jme))
+
+          case default
+       end select aerosol_select
 
     case("cam_sw")
        if(.not.allocated(glw_p)        ) allocate(glw_p(ims:ime,jms:jme)                )
@@ -217,10 +242,12 @@
  type(mpas_pool_type),intent(in):: configs
 
 !local pointers:
- character(len=StrKIND),pointer:: radt_sw_scheme
+ character(len=StrKIND),pointer:: mp_scheme,     &
+                                  radt_sw_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 
+ call mpas_pool_get_config(configs,'config_microp_scheme' ,mp_scheme     )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme)
 
  if(allocated(f_ice)        ) deallocate(f_ice        )
@@ -247,7 +274,6 @@
  if(allocated(rthratensw_p) ) deallocate(rthratensw_p )
 
  radiation_sw_select: select case (trim(radt_sw_scheme))
-
     case("rrtmg_sw")
        if(allocated(recloud_p)    ) deallocate(recloud_p    )
        if(allocated(reice_p)      ) deallocate(reice_p      )
@@ -273,6 +299,21 @@
 
        if(allocated(pin_p)        ) deallocate(pin_p        )
        if(allocated(o3clim_p)     ) deallocate(o3clim_p     )
+
+       if(allocated(taod5503d_p)  ) deallocate(taod5503d_p  )
+       if(allocated(tauaer_p)     ) deallocate(tauaer_p     )
+       if(allocated(ssaaer_p)     ) deallocate(ssaaer_p     )
+       if(allocated(asyaer_p)     ) deallocate(asyaer_p     )
+
+       aerosol_select: select case(mp_scheme)
+          case("mp_thompson","mp_thompson_aerosols")
+             if(allocated(ht_p)       ) deallocate(ht_p       )
+             if(allocated(taer_type_p)) deallocate(taer_type_p)
+             if(allocated(taod5502d_p)) deallocate(taod5502d_p)
+             if(allocated(taod5503d_p)) deallocate(taod5503d_p)
+
+          case default
+       end select aerosol_select
 
     case("cam_sw")
        if(allocated(pin_p)        ) deallocate(pin_p        )
@@ -334,24 +375,27 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_microp_re
  character(len=StrKIND),pointer:: radt_sw_scheme
  character(len=StrKIND),pointer:: microp_scheme
- logical,pointer:: config_microp_re
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: skintemp,snow,xice,xland
  real(kind=RKIND),dimension(:),pointer    :: m_ps,pin
  real(kind=RKIND),dimension(:),pointer    :: sfc_albedo,sfc_emiss
+ real(kind=RKIND),dimension(:),pointer    :: taod5502d
+ real(kind=RKIND),dimension(:,:),pointer  :: zgrid
  real(kind=RKIND),dimension(:,:),pointer  :: cldfrac,m_hybi,o3clim
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
+ real(kind=RKIND),dimension(:,:),pointer  :: taod5503d
  real(kind=RKIND),dimension(:,:,:),pointer:: aerosols,ozmixm
 
 !-----------------------------------------------------------------------------------------------------------------
 
+ call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re    )
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme      )
  call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme       )
- call mpas_pool_get_config(configs,'config_microp_re'     ,config_microp_re    )
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -428,10 +472,22 @@
  enddo
  enddo
 
+ aer_opt = 0
+ do n = 1,nbndsw
+ do j = jts,jte
+ do k = kts,kte
+ do i = its,ite
+    tauaer_p(i,k,j,n) = 0._RKIND
+    ssaaer_p(i,k,j,n) = 1._RKIND
+    asyaer_p(i,k,j,n) = 0._RKIND
+ enddo
+ enddo
+ enddo
+ enddo
+
  radiation_sw_select: select case (trim(radt_sw_scheme))
 
     case("rrtmg_sw")
-
        microp_select: select case(microp_scheme)
           case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
              if(config_microp_re) then
@@ -466,6 +522,63 @@
 
           case default          
        end select microp_select
+
+       aerosol_select: select case(microp_scheme)
+          case("mp_thompson_aerosols")
+             call mpas_pool_get_array(mesh,'zgrid',zgrid)
+             call mpas_pool_get_array(diag_physics,'taod5502d',taod5502d)
+             call mpas_pool_get_array(diag_physics,'taod5503d',taod5503d)
+
+             aer_opt = 3
+             do j = jts,jte
+             do i = its,ite
+                ht_p(i,j) = zgrid(1,i)
+                if(xland_p(i,j)==1._RKIND) then
+                   taer_type_p(i,j) = 1
+                elseif(xland_p(i,j)==2._RKIND) then
+                   taer_type_p(i,j) = 3
+                endif
+             enddo
+             enddo
+
+             !--- calculation of the 550 nm optical depth of the water- and ice-friendly aerosols:
+             call gt_aod( &
+                     p_phy = pres_hyd_p , dz8w = dz_p   , t_phy     = t_p         , qvapor = qv_p , &
+                     nwfa  = nwfa_p     , nifa = nifa_p , taod5503d = taod5503d_p ,                 &
+                     ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
+                     its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &
+                        )
+
+             do j = jts,jte
+             do i = its,ite
+                taod5502d_p(i,j) = 0._RKIND
+                do k = kts,kte
+                   taod5502d_p(i,j) = taod5502d_p(i,j) + taod5503d_p(i,k,j)
+                   taod5503d(k,i) = taod5503d_p(i,k,j)
+                enddo
+                taod5502d(i) = taod5502d_p(i,j)
+             enddo
+             enddo
+
+             !--- calculation of the spectral optical depth, single-scattering albedo, and asymmetry factor
+             !as a function of the 550 nm optical depth of the water- and ice-friendly aerosols:
+             call calc_aerosol_rrtmg_sw( &
+                               ht       = ht_p         , dz8w     = dz_p        , &
+                               p        = pres_hyd_p   , t3d      = t_p         , &
+                               qv3d     = qv_p         , tauaer   = tauaer_p    , &
+                               ssaaer   = ssaaer_p     , asyaer   = asyaer_p    , &
+                               aod5502d = taod5502d_p  , aod5503d = taod5503d_p , &
+                               aer_type = taer_type_p  ,                                               &
+                               aer_aod550_opt = taer_aod550_opt , aer_angexp_opt = taer_angexp_opt   , &
+                               aer_ssa_opt    = taer_ssa_opt    , aer_asy_opt    = taer_asy_opt      , &
+                               aer_aod550_val = aer_aod550_val  , aer_angexp_val = aer_angexp_val    , &
+                               aer_ssa_val    = aer_ssa_val     , aer_asy_val    = aer_asy_val       , &
+                               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme , &
+                               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte   &
+                                        )
+
+          case default
+       end select aerosol_select
 
        do j = jts,jte
        do k = kts,kte+2
@@ -588,7 +701,6 @@
        enddo
 
     case default
-
  end select radiation_sw_select
 
  end subroutine radiation_sw_from_MPAS
@@ -690,7 +802,6 @@
 
 !call to shortwave radiation scheme:
  radiation_sw_select: select case (trim(radt_sw_scheme))
-
     case ("rrtmg_sw")
        call rrtmg_initsw_forMPAS(dminfo)
 
@@ -698,7 +809,6 @@
        call camradinit(dminfo,mesh,atm_input,diag,diag_physics,state,time_lev)
 
     case default
-
  end select radiation_sw_select
 
  end subroutine init_radiation_sw
@@ -766,12 +876,11 @@
     
 !call to shortwave radiation scheme:
  radiation_sw_select: select case (trim(radt_sw_scheme))
-
     case ("rrtmg_sw")
        o3input = 0
        if(config_o3climatology) o3input = 2
 
-       call mpas_timer_start('RRTMG_sw')
+       call mpas_timer_start('rrtmg_swrad')
        call rrtmg_swrad( &
               p3d        = pres_hyd_p   , p8w        = pres2_hyd_p   , pi3d     = pi_p     , &
               t3d        = t_p          , t8w        = t2_p          , dz8w     = dz_p     , &
@@ -788,18 +897,20 @@
               o3clim     = o3clim_p     , gsw        = gsw_p         , swcf     = swcf_p   , &
               rthratensw = rthratensw_p , has_reqc   = has_reqc      , has_reqi = has_reqi , &
               has_reqs   = has_reqs     , re_cloud   = recloud_p     , re_ice   = reice_p  , &
-              re_snow    = resnow_p     , swupt      = swupt_p       , swuptc   = swuptc_p , &
-              swdnt      = swdnt_p      , swdntc     = swdntc_p      , swupb    = swupb_p  , &
-              swupbc     = swupbc_p     , swdnb      = swdnb_p       , swdnbc   = swdnbc_p , &
-              swddir     = swddir_p     , swddni     = swddni_p      , swddif   = swddif_p , &
+              re_snow    = resnow_p     , aer_opt    = aer_opt       , tauaer3d = tauaer_p , &
+              ssaaer3d   = ssaaer_p     , asyaer3d   = asyaer_p      , swupt    = swupt_p  , &
+              swuptc     = swuptc_p     , swdnt      = swdnt_p       , swdntc   = swdntc_p , &
+              swupb      = swupb_p      , swupbc     = swupbc_p      , swdnb    = swdnb_p  , &
+              swdnbc     = swdnbc_p     , swddir     = swddir_p      , swddni   = swddni_p , &
+              swddif     = swddif_p     ,                                                    &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &
                        )
-       call mpas_timer_stop('RRTMG_sw')
+       call mpas_timer_stop('rrtmg_swrad')
 
     case ("cam_sw")
-       call mpas_timer_start('CAMRAD_sw')
+       call mpas_timer_start('camrad_sw')
        call camrad( dolw = .false. , dosw = .true. ,                                         &
                 p_phy         = pres_hyd_p    , p8w           = pres2_hyd_p   ,              &
                 pi_phy        = pi_p          , t_phy         = t_p           ,              &
@@ -847,10 +958,9 @@
                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,      &
                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte        &
                   )
-       call mpas_timer_stop('CAMRAD_sw')
+       call mpas_timer_stop('camrad_sw')
 
     case default
-
  end select radiation_sw_select
 
 !copy local arrays to MPAS grid:

--- a/src/core_atmosphere/physics/mpas_atmphys_finalize.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_finalize.F
@@ -43,8 +43,10 @@
 
  call mpas_pool_get_config(configs,'config_microp_scheme',config_microp_scheme)
 
- if(trim(config_microp_scheme) == 'mp_thompson') &
+ if(trim(config_microp_scheme) == 'mp_thompson'         .or. &
+    trim(config_microp_scheme) == 'mp_thompson_aerosols') then
     call mp_thompson_deallocate
+ endif
 
  end subroutine atmphys_finalize
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -419,7 +419,7 @@
 
 !local pointers:
  integer,pointer:: index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni
+ integer,pointer:: index_nc,index_ni,index_nifa,index_nwfa
 
 !-----------------------------------------------------------------------------------------------------------------
 
@@ -443,15 +443,20 @@
  if(index_qg .gt. -1) f_qg = .true.
 
 !initializes the logical assigned to number concentrations:
- f_nc   = .false. !nc is not defined in Registry.xml - therefore f_nc is initialized to false.
+ f_nc   = .false.
  f_ni   = .false.
- f_nifa = .false. !nifa is not defined in Registry.xml - therefore f_nc is initialized to false.
- f_nwfa = .false. !nwfa is not defined in Registry.xml - therefore f_nc is initialized to false.
+ f_nifa = .false.
+ f_nwfa = .false.
  f_nbca = .false. !nbca is not defined in Registry.xml - therefore f_nc is initialized to false.
+ call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+ call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
+ call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+ call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
 
- call mpas_pool_get_dimension(state,'index_ni',index_ni)
-
- if(index_ni .gt. -1) f_ni = .true.
+ if(index_nc   .gt. -1) f_nc   = .true.
+ if(index_ni   .gt. -1) f_ni   = .true.
+ if(index_nifa .gt. -1) f_nifa = .true.
+ if(index_nwfa .gt. -1) f_nwfa = .true.
 
  end subroutine init_physics_flags
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -11,13 +11,13 @@
  use mpas_pool_routines
  use mpas_timekeeping
 
- use mpas_atmphys_driver_convection, only: init_convection
+ use mpas_atmphys_driver_convection,only: init_convection
  use mpas_atmphys_driver_lsm,only: init_lsm
- use mpas_atmphys_driver_microphysics
+ use mpas_atmphys_driver_microphysics,only: init_microphysics
  use mpas_atmphys_driver_pbl,only: init_pbl
- use mpas_atmphys_driver_radiation_lw, only: init_radiation_lw
- use mpas_atmphys_driver_radiation_sw, only: init_radiation_sw
- use mpas_atmphys_driver_sfclayer
+ use mpas_atmphys_driver_radiation_lw,only: init_radiation_lw
+ use mpas_atmphys_driver_radiation_sw,only: init_radiation_sw
+ use mpas_atmphys_driver_sfclayer,only: init_sfclayer
  use mpas_atmphys_vars,only: f_qc,f_qr,f_qi,f_qs,f_qg,f_qoz,f_nc,f_ni,f_nifa,f_nwfa,f_nbca
 
  use mpas_atmphys_landuse
@@ -95,8 +95,9 @@
  type(mpas_pool_type),intent(inout):: sfc_input
 
 !local pointers:
- logical,pointer:: config_do_restart,       &
-                   config_o3climatology
+ logical,pointer:: config_do_restart,    &
+                   config_o3climatology, &
+                   config_oml1d
 
  character(len=StrKIND),pointer::            &
                    config_convection_scheme, &
@@ -108,39 +109,35 @@
                    config_radt_sw_scheme
 
  integer,pointer:: nCellsSolve,nLags
- integer,dimension(:),pointer  :: i_rainc,i_rainnc
- integer,dimension(:),pointer  :: i_acswdnb,i_acswdnbc,i_acswdnt,i_acswdntc, &
-                                  i_acswupb,i_acswupbc,i_acswupt,i_acswuptc, &
-                                  i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
-                                  i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
+ integer,dimension(:),pointer:: i_rainc,i_rainnc
+ integer,dimension(:),pointer:: i_acswdnb,i_acswdnbc,i_acswdnt,i_acswdntc, &
+                                i_acswupb,i_acswupbc,i_acswupt,i_acswuptc, &
+                                i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
+                                i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
 
- real(kind=RKIND),dimension(:),pointer  :: acswdnb,acswdnbc,acswdnt,acswdntc,  &
-                                           acswupb,acswupbc,acswupt,acswuptc,  &
-                                           aclwdnb,aclwdnbc,aclwdnt,aclwdntc,  &
-                                           aclwupb,aclwupbc,aclwupt,aclwuptc
- real(kind=RKIND),dimension(:),pointer  :: nsteps_accum,ndays_accum,tday_accum, &
-                                           tyear_accum,tyear_mean
- real(kind=RKIND),dimension(:),pointer  :: sst,sstsk,tmn,xice,xicem
+ real(kind=RKIND),dimension(:),pointer:: acswdnb,acswdnbc,acswdnt,acswdntc, &
+                                         acswupb,acswupbc,acswupt,acswuptc, &
+                                         aclwdnb,aclwdnbc,aclwdnt,aclwdntc, &
+                                         aclwupb,aclwupbc,aclwupt,aclwuptc
+ real(kind=RKIND),dimension(:),pointer:: nsteps_accum,ndays_accum,tday_accum, &
+                                         tyear_accum,tyear_mean
+ real(kind=RKIND),dimension(:),pointer:: sst,sstsk,tmn,xice,xicem
  real(kind=RKIND),dimension(:,:),pointer:: tlag
 
- real(kind=RKIND),dimension(:),pointer  :: t_oml, t_oml_initial, t_oml_200m_initial
- real(kind=RKIND),dimension(:),pointer  :: h_oml, h_oml_initial, hu_oml, hv_oml
- real(kind=RKIND), pointer :: config_oml_hml0
- integer,pointer:: nCells
- logical,pointer:: config_oml1d
- 
- 
+ real(kind=RKIND),pointer:: config_oml_hml0
+ real(kind=RKIND),dimension(:),pointer:: t_oml,t_oml_initial,t_oml_200m_initial
+ real(kind=RKIND),dimension(:),pointer:: h_oml,h_oml_initial,hu_oml,hv_oml
 
 !local variables and arrays:
  type(MPAS_Time_Type):: currTime
 
  logical:: init_done
  integer:: ierr,julday 
- integer:: iCell,iLag,iEdge,nEdges_m
+ integer:: iCell,iLag
 
 !-----------------------------------------------------------------------------------------------------------------
-! call mpas_log_write('')
-! call mpas_log_write('--- enter subroutine physics_init:')
+!call mpas_log_write('')
+!call mpas_log_write('--- enter subroutine physics_init:')
 
  call mpas_pool_get_config(configs,'config_do_restart'       ,config_do_restart       )
  call mpas_pool_get_config(configs,'config_o3climatology'    ,config_o3climatology    )
@@ -211,7 +208,6 @@
  call mpas_pool_get_array(diag_physics,'hv_oml'            ,hv_oml)
  call mpas_pool_get_config(configs,'config_oml1d'          ,config_oml1d  )
  call mpas_pool_get_config(configs,'config_oml_hml0'       ,config_oml_hml0  )
- call mpas_pool_get_dimension(mesh,'nCells',nCells)
 
  currTime = mpas_get_clock_time(clock,MPAS_NOW,ierr)
  call mpas_get_time(curr_time=currTime,DoY=julday,ierr=ierr)
@@ -284,7 +280,7 @@
 
 !initialization of xicem:
  if(.not.config_do_restart) then
-!    call mpas_log_write('--- initialization of xicem:')
+!   call mpas_log_write('--- initialization of xicem:')
     do iCell = 1, nCellsSolve
        xicem(iCell) = xice(iCell)
     enddo
@@ -294,47 +290,47 @@
 !sea-surface temperature is applied. This avoids having the array sstsk equal to
 !zero over land:
  if(.not. config_do_restart) then
-!    call mpas_log_write('--- initialization of sstsk:')
+!   call mpas_log_write('--- initialization of sstsk:')
     do iCell = 1, nCellsSolve
        sstsk(iCell) = sst(iCell)
     enddo
  endif
 
-! initialized the 1D ocean mixed-layer model  (code from wrf module_sf_oml)
- if (config_oml1d) then
-   if (.not. config_do_restart) then
-      call mpas_log_write('--- initialization of 1D ocean mixed layer model ')
-      do iCell = 1, nCellsSolve
-        t_oml(iCell) = sst(iCell)
-        t_oml_initial(iCell) = sst(iCell)
-      end do
-      if (config_oml_hml0 .gt. 0) then
-        do iCell = 1, nCellsSolve
-          h_oml(iCell) = config_oml_hml0
-          h_oml_initial(iCell) = config_oml_hml0
-          hu_oml(iCell) = 0.
-          hv_oml(iCell) = 0.
-          t_oml_200m_initial(iCell) = sst(iCell) - 5.
-        end do
-      else if (config_oml_hml0 .eq. 0) then
-! initializing with climatological mixed layer depth only
-        do iCell = 1, nCellsSolve
-          h_oml(iCell) = h_oml_initial(iCell)
-          hu_oml(iCell) = 0.
-          hv_oml(iCell) = 0.
-          t_oml_200m_initial(iCell) = sst(iCell) - 5.
-        end do
-      else
-        do iCell = 1, nCellsSolve
-          h_oml(iCell) = h_oml_initial(iCell)
-          ! WRF COMMENT:
-          ! fill in near coast area with SST: 200 K was set as missing value in ocean pre-processing code
-          if( (t_oml_200m_initial(iCell) > 200.) .and. (t_oml_200m_initial(iCell) <= 200.) )  &
-               t_oml_200m_initial(iCell) = sst(iCell)
-        end do
-      end if
-   end if
- end if
+!initialized the 1D ocean mixed-layer model (code from wrf module_sf_oml):
+ if(config_oml1d) then
+    if(.not. config_do_restart) then
+       call mpas_log_write('--- initialization of 1D ocean mixed layer model ')
+       do iCell = 1, nCellsSolve
+          t_oml(iCell) = sst(iCell)
+          t_oml_initial(iCell) = sst(iCell)
+       enddo
+       if(config_oml_hml0 .gt. 0) then
+          do iCell = 1, nCellsSolve
+             h_oml(iCell) = config_oml_hml0
+             h_oml_initial(iCell) = config_oml_hml0
+             hu_oml(iCell) = 0.
+             hv_oml(iCell) = 0.
+             t_oml_200m_initial(iCell) = sst(iCell) - 5.
+          enddo
+       elseif(config_oml_hml0 .eq. 0) then
+! initializing with climatological mixed layer depth only:
+          do iCell = 1, nCellsSolve
+             h_oml(iCell) = h_oml_initial(iCell)
+             hu_oml(iCell) = 0.
+             hv_oml(iCell) = 0.
+             t_oml_200m_initial(iCell) = sst(iCell) - 5.
+          enddo
+       else
+          do iCell = 1, nCellsSolve
+             h_oml(iCell) = h_oml_initial(iCell)
+             ! WRF COMMENT:
+             ! fill in near coast area with SST: 200 K was set as missing value in ocean pre-processing code
+             if( (t_oml_200m_initial(iCell) > 200.) .and. (t_oml_200m_initial(iCell) <= 200.) )  &
+                  t_oml_200m_initial(iCell) = sst(iCell)
+          enddo
+       endif
+    endif
+ endif
 
 !initialization of temperatures needed for updating the deep soil temperature:
  if(.not. config_do_restart) then
@@ -363,7 +359,7 @@
 
 !initialization of cloud microphysics processes:
  if(config_microp_scheme .ne. 'off') &
-    call microphysics_init(dminfo,configs,mesh,sfc_input,diag_physics)
+    call init_microphysics(dminfo,configs,mesh,state,time_lev,sfc_input,diag_physics)
 
 !initialization of PBL processes:
  if(config_pbl_scheme .ne. 'off') call init_pbl(configs)

--- a/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
@@ -5,20 +5,23 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
+#define DM_BCAST_MACRO(A) call mpas_dmpar_bcast_reals(dminfo,size(A),A)
 
 !=================================================================================================================
  module mpas_atmphys_init_microphysics
  use mpas_dmpar
  use mpas_kind_types
+ use mpas_log
  use mpas_pool_routines
 
  use mpas_atmphys_utilities
-!use module_mp_thompson, only: is_aerosol_aware,naCCN0,naCCN1,naIN0,naIN1,ntb_arc,ntb_arw,ntb_art,ntb_arr, &
-!                              ntb_ark,tnccn_act
+ use module_mp_thompson, only: is_aerosol_aware,naCCN0,naCCN1,naIN0,naIN1,ntb_arc,ntb_arw,ntb_art,ntb_arr, &
+                               ntb_ark,tnccn_act
 
  implicit none
  private
- public:: init_thompson_clouddroplets_forMPAS
+ public:: init_thompson_clouddroplets_forMPAS, &
+          init_thompson_aerosols_forMPAS
 
 !MPAS main initialization of the Thompson parameterization of cloud microphysics with nucleation of cloud
 !droplets based on distributions of CCNs and INs (aerosol-aware parameterization).
@@ -29,6 +32,15 @@
 ! ----------------------------------------
 ! * added "use mpas_dmpar" at the top of the module.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-04-04.
+! * modified the initialization of nifa and nwfa.If nifa and nwfa are already available in the initial conditions
+!   using the climatological GOCART data,do not recalculate nifa and nwfa using an exponential profile of CCN and
+!   IN as a function of height.
+!   Laura D. Fowler (laura@ucar.edu) / 2016-05-27.
+! * modified the subroutine init_thompson_aerosols_forMPAS for exact restartibility when using the microphysics
+!   option "mp_thompson_aerosols".
+!   Laura D. Fowler (laura@ucar.edu) / 2018-02-23.
+! * changed the definition of DM_BCAST_MACRO to compile table_ccnAct with the default DOUBLE PRECISION.
+!   Laura D. Fowler (laura@ucar.edu) / 2018-03-07.
 
 
  contains
@@ -80,8 +92,227 @@
  end subroutine init_thompson_clouddroplets_forMPAS 
 
 !=================================================================================================================
- end module mpas_atmphys_init_microphysics
+ subroutine init_thompson_aerosols_forMPAS(do_restart,dminfo,mesh,state,time_lev,diag_physics)
 !=================================================================================================================
 
- 
- 
+!input variables:
+ type(dm_info),intent(in):: dminfo
+ type(mpas_pool_type),intent(in):: mesh
+ logical,intent(in):: do_restart
+ integer,intent(in):: time_lev
+
+!inout variables:
+ type(mpas_pool_type),intent(inout):: diag_physics
+ type(mpas_pool_type),intent(inout):: state
+
+!local variables and pointers:
+ integer,pointer:: nCellsSolve,nVertLevels
+ integer,pointer:: index_nifa,index_nwfa
+
+ real(kind=RKIND),dimension(:),pointer    :: areaCell
+ real(kind=RKIND),dimension(:),pointer    :: nifa2d,nwfa2d
+ real(kind=RKIND),dimension(:,:),pointer  :: zgrid,zz
+ real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,nifa,nwfa
+ real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+
+ character(len=StrKIND):: mess
+
+ integer:: iCell, k
+
+ real(kind=RKIND):: max_test
+ real(kind=RKIND):: airmass
+ real(kind=RKIND):: h_01
+ real(kind=RKIND):: niIN3,niCCN3
+ real(kind=RKIND):: nifa_max,nifa_min,global_nifa_max,global_nifa_min
+ real(kind=RKIND):: nwfa_max,nwfa_min,global_nwfa_max,global_nwfa_min
+ real(kind=RKIND),dimension(:,:),allocatable:: hgt
+
+!-----------------------------------------------------------------------------------------------------------------
+ call mpas_log_write('--- enter subroutine init_thompson_aerosols_forMPAS:')
+
+ is_aerosol_aware = .true.
+
+!... read a static file containing CCN activation of aerosols. The data were created from a parcel model by
+!... Feingold & Heymsfield with further changes by Eidhammer and Kriedenweis.
+ call table_ccnAct(dminfo)
+ call mpas_log_write('--- end read table_ccnAct:')
+
+!... if do_restart is true, then we do not need to check the initialization of nwfa, nifa, and nwfa2d. If false,
+!    then, we proceed with the initialization:
+ if(do_restart) return
+
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+ call mpas_pool_get_dimension(mesh,'nVertLevels',nVertLevels)
+
+ call mpas_pool_get_array(mesh,'areaCell',areaCell)
+ call mpas_pool_get_array(mesh,'zgrid'   ,zgrid   )
+ call mpas_pool_get_array(mesh,'zz'      ,zz      )
+
+ call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
+ call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
+
+ call mpas_pool_get_dimension(state,'index_nifa'  ,index_nifa  )
+ call mpas_pool_get_dimension(state,'index_nwfa'  ,index_nwfa  )
+
+ call mpas_pool_get_array(state,'scalars',scalars,time_lev)
+ nifa   => scalars(index_nifa,:,:)
+ nwfa   => scalars(index_nwfa,:,:)
+
+ call mpas_pool_get_array(state,'rho_zz',rho_zz,time_lev)
+
+ if(.not.allocated(hgt)) allocate(hgt(1:nVertLevels,1:nCellsSolve))
+ do iCell = 1, nCellsSolve
+    do k = 1, nVertLevels
+       hgt(k,iCell) = 0.5_RKIND * (zgrid(k,iCell)+zgrid(k+1,iCell))
+    enddo
+ enddo
+
+!... initialize the distribution of hygroscopic ("water friendly") aerosols if not already initialized using
+!    GOCART data:
+ global_nwfa_min = 0._RKIND
+ global_nwfa_max = 0._RKIND
+ nwfa_min = minval(nwfa(:,1:nCellsSolve))
+ nwfa_max = maxval(nwfa(:,1:nCellsSolve))
+ call mpas_dmpar_min_real(dminfo,nwfa_min,global_nwfa_min)
+ call mpas_dmpar_max_real(dminfo,nwfa_max,global_nwfa_max)
+ call mpas_log_write('--- global_nwfa_min = $r',realArgs=(/global_nwfa_min/))
+ call mpas_log_write('--- global_nwfa_max = $r',realArgs=(/global_nwfa_max/))
+
+ if(global_nwfa_min == 0._RKIND .and. global_nwfa_max == 0._RKIND) then
+    call mpas_log_write('--- initialize nwfa using an exponential distribution of CCN as a function of height.')
+    do iCell = 1, nCellsSolve
+       if(hgt(1,iCell).le.1000.0) then
+          h_01 = 0.8
+       elseif(hgt(1,iCell).ge.2500.0) then
+          h_01 = 0.01
+       else
+          h_01 = 0.8*cos(hgt(1,iCell)*0.001 - 1.0)
+       endif
+       niCCN3 = -1.0*ALOG(naCCN1/naCCN0)/h_01
+       nwfa(1,iCell) = naCCN1+naCCN0*exp(-((hgt(2,iCell)-hgt(1,iCell))/1000.)*niCCN3)
+       do k = 2, nVertLevels
+          nwfa(k,iCell) = naCCN1+naCCN0*exp(-((hgt(k,iCell)-hgt(1,iCell))/1000.)*niCCN3)
+       enddo
+    enddo
+ else
+    call mpas_log_write('--- initialize nwfa using the climatological GOCART data.')
+ endif
+
+!... initialize the distribution of nonhygroscopic ("ice friendly") aerosols if not already initialized using
+!    GOCART data:
+ global_nifa_min = 0._RKIND
+ global_nifa_max = 0._RKIND
+ nifa_min = minval(nifa(:,1:nCellsSolve))
+ nifa_max = maxval(nifa(:,1:nCellsSolve))
+ call mpas_dmpar_min_real(dminfo,nifa_min,global_nifa_min)
+ call mpas_dmpar_max_real(dminfo,nifa_max,global_nifa_max)
+ call mpas_log_write('--- global_nifa_min = $r',realArgs=(/global_nifa_min/))
+ call mpas_log_write('--- global_nifa_max = $r',realArgs=(/global_nifa_max/))
+
+ if(global_nifa_min == 0._RKIND .and. global_nifa_max == 0._RKIND) then
+    call mpas_log_write('--- initialize nifa using an exponential distribution of IN as a function of height.')
+    do iCell = 1, nCellsSolve
+       if(hgt(1,iCell).le.1000.0) then
+          h_01 = 0.8
+       elseif(hgt(1,iCell).ge.2500.0) then
+          h_01 = 0.01
+       else
+          h_01 = 0.8*cos(hgt(1,iCell)*0.001 - 1.0)
+       endif
+       niIN3 = -1.0*ALOG(naIN1/naIN0)/h_01
+       nifa(1,iCell) = naIN1+naIN0*exp(-((hgt(2,iCell)-hgt(1,iCell))/1000.)*niIN3)
+       do k = 2, nVertLevels
+          nifa(k,iCell) = naIN1+naIN0*exp(-((hgt(k,iCell)-hgt(1,iCell))/1000.)*niIN3)
+       enddo
+    enddo
+ else
+    call mpas_log_write('--- initialize nifa using the climatological GOCART data.')
+ endif
+
+!... scale the lowest level aerosol data into an emissions rate.  This is very far from ideal, but
+!... need higher emissions where larger amount of (climo) existing and lesser emissions where there
+!... exists fewer to begin as a first-order simplistic approach.  Later, proper connection to emission
+!... inventory would be better, but, for now, scale like this:
+!... where: Nwfa=50 per cc, emit 0.875E4 aerosols per second per grid box unit
+!... that was tested as ~(20kmx20kmx50m = 2.E10 m**-3).
+
+ k = 1
+ do iCell = 1, nCellsSolve
+!   airmass = rho_zz(k,iCell)*zz(k,iCell)
+!   airmass = airmass*(zgrid(k+1,iCell)-zgrid(k,iCell))*areaCell(iCell) ! (in kg)
+!   nwfa2d(iCell) = nwfa(k,iCell)*0.000196*(airmass*2.E-10)
+    nwfa2d(iCell) = 0._RKIND
+    nifa2d(iCell) = 0._RKIND
+!   call mpas_log_write('$i $r $r $r $r',intArgs=(/iCell/),realArgs=(/airmass,nwfa2d(iCell), &
+!                       nwfa2d(iCell)*450.,nifa2d(iCell)/))
+ enddo
+
+!... deallocate local arrays:
+ if(allocated(hgt)) deallocate(hgt)
+
+ call mpas_log_write('--- end subroutine init_thompson_aerosols_forMPAS.')
+
+ end subroutine init_thompson_aerosols_forMPAS
+
+!=================================================================================================================
+ subroutine table_ccnAct(dminfo)
+!=================================================================================================================
+
+!input variables:
+ type(dm_info),intent(in):: dminfo
+
+!local variables:
+ logical:: opened
+ integer:: ccn_unit,i,istat
+ character(len=StrKIND):: errmess
+!-----------------------------------------------------------------------------------------------------------------
+
+ if(.not.allocated(tnccn_act)) allocate(tnccn_act(ntb_arc,ntb_arw,ntb_art,ntb_arr,ntb_ark))
+
+!get a unit to open binary file:
+ istat = -999
+ if(dminfo % my_proc_id == IO_NODE) then
+    do i = 10,99
+       inquire(i,opened = opened,iostat=istat)
+       if(.not. opened ) then
+          ccn_unit = i
+          exit
+       endif
+    enddo
+    if(istat /= 0) &
+       call physics_error_fatal('mpas_atmphys_init_microphysics table_ccnAct: Can not '// &
+                                'find unused fortran unit to read in lookup table.' )
+ endif
+
+!distribute unit to other processors:
+ call mpas_dmpar_bcast_int(dminfo,ccn_unit)
+
+!open binary file:
+ istat = -999
+ if(dminfo % my_proc_id == IO_NODE) then
+    open(ccn_unit,file='CCN_ACTIVATE_DATA',form='UNFORMATTED',status='OLD',iostat=istat)
+    if(istat /= 0) then
+       write(errmess,'(A,I4)') 'mpas_atmphys_init_microphysics table_ccnAct:: '// &
+                               'error opening CCN_ACTIVATE_DATA on unit', ccn_unit
+       call physics_error_fatal(errmess)
+    endif
+ endif
+
+!read and broadcast data to all nodes:
+ istat = -999
+ if(dminfo % my_proc_id == IO_NODE) then
+    read(ccn_unit,iostat=istat) tnccn_act
+    if(istat /= 0) then
+       write(errmess,'(A,I4)') 'mpas_atmphys_init_microphysics table_ccnAct:: '// &
+                               'error reading tnccn_act on unit', ccn_unit
+       call physics_error_fatal(errmess)
+    endif
+ endif
+
+ DM_BCAST_MACRO(tnccn_act)
+
+ end subroutine table_ccnAct
+
+!=================================================================================================================
+ end module mpas_atmphys_init_microphysics
+!=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
@@ -234,17 +234,15 @@
 !... exists fewer to begin as a first-order simplistic approach.  Later, proper connection to emission
 !... inventory would be better, but, for now, scale like this:
 !... where: Nwfa=50 per cc, emit 0.875E4 aerosols per second per grid box unit
-!... that was tested as ~(20kmx20kmx50m = 2.E10 m**-3).
+!... that was tested as ~(20kmx20kmx50m = 2.E10 m**3).
 
  k = 1
  do iCell = 1, nCellsSolve
-!   airmass = rho_zz(k,iCell)*zz(k,iCell)
-!   airmass = airmass*(zgrid(k+1,iCell)-zgrid(k,iCell))*areaCell(iCell) ! (in kg)
-!   nwfa2d(iCell) = nwfa(k,iCell)*0.000196*(airmass*2.E-10)
-    nwfa2d(iCell) = 0._RKIND
+    airmass = rho_zz(k,iCell)*zz(k,iCell)
+    airmass = airmass*(zgrid(k+1,iCell)-zgrid(k,iCell))*areaCell(iCell) ! (in kg)
+    nwfa2d(iCell) = nwfa(k,iCell)*0.000196*airmass*0.5e-10
     nifa2d(iCell) = 0._RKIND
-!   call mpas_log_write('$i $r $r $r $r',intArgs=(/iCell/),realArgs=(/airmass,nwfa2d(iCell), &
-!                       nwfa2d(iCell)*450.,nifa2d(iCell)/))
+!   call mpas_log_write('$i $r $r $r',intArgs=(/iCell/),realArgs=(/airmass,nwfa2d(iCell),nifa2d(iCell)/))
  enddo
 
 !... deallocate local arrays:

--- a/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
@@ -128,7 +128,7 @@
  real(kind=RKIND),dimension(:,:),allocatable:: hgt
 
 !-----------------------------------------------------------------------------------------------------------------
- call mpas_log_write('--- enter subroutine init_thompson_aerosols_forMPAS:')
+!call mpas_log_write('--- enter subroutine init_thompson_aerosols_forMPAS:')
 
  is_aerosol_aware = .true.
 
@@ -248,7 +248,7 @@
 !... deallocate local arrays:
  if(allocated(hgt)) deallocate(hgt)
 
- call mpas_log_write('--- end subroutine init_thompson_aerosols_forMPAS.')
+!call mpas_log_write('--- end subroutine init_thompson_aerosols_forMPAS.')
 
  end subroutine init_thompson_aerosols_forMPAS
 

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -114,7 +114,7 @@
  if(.not.allocated(qs_p)   ) allocate(qs_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qg_p)   ) allocate(qg_p(ims:ime,kms:kme,jms:jme)   )
 
- pbl_select: select case (trim(pbl_scheme))
+ pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
        if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
 
@@ -178,7 +178,7 @@
  if(allocated(qs_p)    ) deallocate(qs_p    )
  if(allocated(qg_p)    ) deallocate(qg_p    )
 
- pbl_select: select case (trim(pbl_scheme))
+ pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
        if(allocated(ni_p)) deallocate(ni_p)
 
@@ -318,7 +318,7 @@
  enddo
  enddo
 
- pbl_select: select case (trim(pbl_scheme))
+ pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
        call mpas_pool_get_dimension(state,'index_ni',index_ni)
        ni => scalars(index_ni,:,:)
@@ -470,7 +470,7 @@
  end subroutine MPAS_to_physics
 
 !=================================================================================================================
- subroutine microphysics_from_MPAS(configs,mesh,state,time_lev,diag,diag_physics,its,ite)
+ subroutine microphysics_from_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend_physics,its,ite)
 !=================================================================================================================
 
 !input variables:
@@ -483,18 +483,23 @@
  integer,intent(in):: its,ite
  integer:: time_lev
 
+!inout variables:
+ type(mpas_pool_type),intent(inout):: tend_physics
+
 !local pointers:
- character(len=StrKIND),pointer:: microp_scheme
+ character(len=StrKIND),pointer:: mp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nr
- real(kind=RKIND),dimension(:),pointer    :: nt_c,mu_c
+ integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
+ real(kind=RKIND),dimension(:),pointer    :: nifa2d,nwfa2d,nt_c,mu_c
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid,w
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr
+ real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
+ real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
+ real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
 
 !local variables:
@@ -502,7 +507,7 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme',mp_scheme)
 
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
  call mpas_pool_get_array(mesh,'zz'   ,zz   )
@@ -511,31 +516,17 @@
  call mpas_pool_get_array(diag,'pressure_base',pressure_b)
  call mpas_pool_get_array(diag,'pressure_p'   ,pressure_p)
 
- call mpas_pool_get_array(diag_physics,'nt_c'    ,nt_c    )
- call mpas_pool_get_array(diag_physics,'mu_c'    ,mu_c    )
- call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
- call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
- call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
- call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
- call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
-
  call mpas_pool_get_array(state,'rho_zz' ,rho_zz ,time_lev)
  call mpas_pool_get_array(state,'theta_m',theta_m,time_lev)
  call mpas_pool_get_array(state,'w'      ,w      ,time_lev)
 
- call mpas_pool_get_dimension(state,'index_qv'  ,index_qv  )
- call mpas_pool_get_dimension(state,'index_qc'  ,index_qc  )
- call mpas_pool_get_dimension(state,'index_qr'  ,index_qr  )
- call mpas_pool_get_dimension(state,'index_qi'  ,index_qi  )
- call mpas_pool_get_dimension(state,'index_qs'  ,index_qs  )
- call mpas_pool_get_dimension(state,'index_qg'  ,index_qg  )
- call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
- call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
-
+ call mpas_pool_get_dimension(state,'index_qv',index_qv)
+ call mpas_pool_get_dimension(state,'index_qc',index_qc)
+ call mpas_pool_get_dimension(state,'index_qr',index_qr)
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
- qv   => scalars(index_qv,:,:)
- qc   => scalars(index_qc,:,:)
- qr   => scalars(index_qr,:,:)
+ qv => scalars(index_qv,:,:)
+ qc => scalars(index_qc,:,:)
+ qr => scalars(index_qr,:,:)
 
 !initialize variables needed in the cloud microphysics schemes:
  do j = jts, jte
@@ -558,13 +549,21 @@
  enddo
  enddo
 
-!additional initialization as function of cloud microphysics scheme:
- microp_select_init: select case(microp_scheme)
+!initialize cloud water species and aerosols as function of cloud microphysics scheme:
+ mp_select: select case(trim(mp_scheme))
+    case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
+       call mpas_pool_get_dimension(state,'index_qi',index_qi)
+       call mpas_pool_get_dimension(state,'index_qs',index_qs)
+       call mpas_pool_get_dimension(state,'index_qg',index_qg)
+       qi => scalars(index_qi,:,:)
+       qs => scalars(index_qs,:,:)
+       qg => scalars(index_qg,:,:)
 
-    case ("mp_thompson","mp_wsm6")
-       qi   => scalars(index_qi,:,:)
-       qs   => scalars(index_qs,:,:)
-       qg   => scalars(index_qg,:,:)
+       call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
+       call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
+       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
+       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
+       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
 
        do j = jts, jte
        do k = kts, kte
@@ -572,77 +571,168 @@
           qi_p(i,k,j) = qi(k,i)
           qs_p(i,k,j) = qs(k,i)
           qg_p(i,k,j) = qg(k,i)
-          recloud_p(i,k,j) = re_cloud(k,i)
-          reice_p(i,k,j)   = re_ice(k,i)
-          resnow_p(i,k,j)  = re_snow(k,i)
+
+          rainprod_p(i,k,j) = rainprod(k,i)
+          evapprod_p(i,k,j) = evapprod(k,k)
+          recloud_p(i,k,j)  = re_cloud(k,i)
+          reice_p(i,k,j)    = re_ice(k,i)
+          resnow_p(i,k,j)   = re_snow(k,i)
        enddo
        enddo
        enddo
 
-    microp2_select: select case(microp_scheme)
+       mp2_select: select case(trim(mp_scheme))
+          case("mp_thompson","mp_thompson_aerosols")
+             call mpas_pool_get_dimension(state,'index_ni',index_ni)
+             call mpas_pool_get_dimension(state,'index_nr',index_nr)
+             ni   => scalars(index_ni,:,:)
+             nr   => scalars(index_nr,:,:)
 
-       case("mp_thompson")
-          ni   => scalars(index_ni,:,:)
-          nr   => scalars(index_nr,:,:)
+             call mpas_pool_get_array(diag_physics,'nt_c',nt_c)
+             call mpas_pool_get_array(diag_physics,'mu_c',mu_c)
+             do j = jts,jte
+             do i = its,ite
+                muc_p(i,j) = mu_c(i)
+                ntc_p(i,j) = nt_c(i)
+             enddo
+             do k = kts, kte
+             do i = its, ite
+                ni_p(i,k,j) = ni(k,i)
+                nr_p(i,k,j) = nr(k,i)
+             enddo
+             enddo
+             enddo
 
-          do j = jts,jte
-          do i = its,ite
-             muc_p(i,j) = mu_c(i)
-             ntc_p(i,j) = nt_c(i)
-          enddo
-          enddo
-          do j = jts, jte
-          do k = kts, kte
-          do i = its, ite
-             ni_p(i,k,j) = ni(k,i)
-             nr_p(i,k,j) = nr(k,i)
-             rainprod_p(i,k,j) = rainprod(k,i)
-             evapprod_p(i,k,j) = evapprod(k,i)
-          enddo
-          enddo
-          enddo
+          mp3_select: select case(trim(mp_scheme))
+             case("mp_thompson_aerosols")
+                call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+                call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+                call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+                nc   => scalars(index_nc,:,:)
+                nifa => scalars(index_nifa,:,:)
+                nwfa => scalars(index_nwfa,:,:)
 
-       case default
+                call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
+                call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
+                do j = jts,jte
+                do i = its,ite
+                   nifa2d_p(i,j) = nifa2d(i)
+                   nwfa2d_p(i,j) = nwfa2d(i)
+                enddo
+                do k = kts, kte
+                do i = its, ite
+                   nc_p(i,k,j) = nc(k,i)
+                   nifa_p(i,k,j) = nifa(k,i)
+                   nwfa_p(i,k,j) = nwfa(k,i)
+                enddo
+                enddo
+                enddo
 
-    end select microp2_select
+             case default
+          end select mp3_select
+
+          case default
+       end select mp2_select
 
     case default
+ end select mp_select
 
- end select microp_select_init
+!begin calculation of cloud microphysics tendencies:
+ mp_tend_select: select case(trim(mp_scheme))
+    case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
+       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
+       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
+       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
+       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
+       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
+       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
+       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
+
+       do k = kts,kte
+       do i = its,ite
+          rthmpten(k,i) = theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))
+          rqvmpten(k,i) = qv(k,i)
+          rqcmpten(k,i) = qc(k,i)
+          rqrmpten(k,i) = qr(k,i)
+          rqimpten(k,i) = qi(k,i)
+          rqsmpten(k,i) = qs(k,i)
+          rqgmpten(k,i) = qg(k,i)
+       enddo
+       enddo
+
+       mp2_tend_select: select case(trim(mp_scheme))
+          case("mp_thompson","mp_thompson_aerosols")
+             call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
+             call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
+
+             do k = kts,kte
+             do i = its,ite
+                rnimpten(k,i) = ni(k,i)
+                rnrmpten(k,i) = nr(k,i)
+             enddo
+             enddo
+
+             mp3_tend_select: select case(trim(mp_scheme))
+                case("mp_thompson_aerosols")
+                   call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
+                   call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
+                   call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
+
+                   do k = kts,kte
+                   do i = its,ite
+                      rncmpten(k,i) = nc(k,i)
+                      rnifampten(k,i) = nifa(k,i)
+                      rnwfampten(k,i) = nwfa(k,i)
+                   enddo
+                   enddo
+
+                case default
+             end select mp3_tend_select
+
+          case default
+       end select mp2_tend_select
+
+    case default
+ end select mp_tend_select
 
  end subroutine microphysics_from_MPAS
 
 !=================================================================================================================
- subroutine microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend,itimestep,its,ite)
+ subroutine microphysics_to_MPAS(configs,mesh,state,time_lev,diag,diag_physics,tend_physics,tend,its,ite)
 !=================================================================================================================
 
 !input variables:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
 
- integer,intent(in):: itimestep,time_lev
+ integer,intent(in):: time_lev
  integer,intent(in):: its,ite
 
-!output variables:
+!inout variables:
  type(mpas_pool_type),intent(inout):: state
  type(mpas_pool_type),intent(inout):: diag
  type(mpas_pool_type),intent(inout):: tend
  type(mpas_pool_type),intent(inout):: diag_physics
+ type(mpas_pool_type),intent(inout):: tend_physics
+
 
 !local pointers:
- character(len=StrKIND),pointer:: microp_scheme
+ character(len=StrKIND),pointer:: mp_scheme
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni,index_nr
+ integer,pointer:: index_nc,index_ni,index_nr,index_nifa,index_nwfa
  real(kind=RKIND),dimension(:),pointer    :: surface_pressure,tend_sfc_pressure
+ real(kind=RKIND),dimension(:),pointer    :: nifa2d,nwfa2d
  real(kind=RKIND),dimension(:,:),pointer  :: zgrid
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,exner_b,pressure_b,rtheta_p,rtheta_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p
  real(kind=RKIND),dimension(:,:),pointer  :: rt_diabatic_tend
  real(kind=RKIND),dimension(:,:),pointer  :: dtheta_dt_mp
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni,nr
+ real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nr,nifa,nwfa
  real(kind=RKIND),dimension(:,:),pointer  :: rainprod,evapprod
  real(kind=RKIND),dimension(:,:),pointer  :: re_cloud,re_ice,re_snow
+ real(kind=RKIND),dimension(:,:),pointer  :: rthmpten,rqvmpten,rqcmpten,rqrmpten,rqimpten,rqsmpten,rqgmpten
+ real(kind=RKIND),dimension(:,:),pointer  :: rncmpten,rnimpten,rnrmpten,rnifampten,rnwfampten
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
 
 !local variables:
@@ -652,7 +742,7 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme',mp_scheme)
 
  call mpas_pool_get_array(mesh,'zz'   ,zz   )
  call mpas_pool_get_array(mesh,'zgrid',zgrid)
@@ -666,12 +756,6 @@
  call mpas_pool_get_array(diag,'surface_pressure',surface_pressure)
  call mpas_pool_get_array(diag,'dtheta_dt_mp'    ,dtheta_dt_mp    )
 
- call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
- call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
- call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
- call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
- call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
-
  call mpas_pool_get_array(tend,'tend_sfc_pressure',tend_sfc_pressure)
 
  call mpas_pool_get_array(state,'rho_zz' ,rho_zz ,time_lev)
@@ -680,12 +764,6 @@
  call mpas_pool_get_dimension(state,'index_qv'  ,index_qv  )
  call mpas_pool_get_dimension(state,'index_qc'  ,index_qc  )
  call mpas_pool_get_dimension(state,'index_qr'  ,index_qr  )
- call mpas_pool_get_dimension(state,'index_qi'  ,index_qi  )
- call mpas_pool_get_dimension(state,'index_qs'  ,index_qs  )
- call mpas_pool_get_dimension(state,'index_qg'  ,index_qg  )
- call mpas_pool_get_dimension(state,'index_ni'  ,index_ni  )
- call mpas_pool_get_dimension(state,'index_nr'  ,index_nr  )
-
  call mpas_pool_get_array(state,'scalars',scalars,time_lev)
  qv   => scalars(index_qv,:,:)
  qc   => scalars(index_qc,:,:)
@@ -727,7 +805,7 @@
  enddo
  enddo
 
-!updates the surface pressure and calculates the surface pressure tendency:
+!update surface pressure and calculates the surface pressure tendency:
  do j = jts,jte
  do i = its,ite
     tem1 = zgrid(2,i)-zgrid(1,i)
@@ -745,20 +823,31 @@
  enddo
  enddo
 
-!variables specific to different cloud microphysics schemes:
- microp_select_init: select case(microp_scheme)
+!update cloud water species and aerosols as functions of cloud microphysics schemes:
+ mp_select: select case(trim(mp_scheme))
+    case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
+       call mpas_pool_get_dimension(state,'index_qi',index_qi)
+       call mpas_pool_get_dimension(state,'index_qs',index_qs)
+       call mpas_pool_get_dimension(state,'index_qg',index_qg)
+       qi => scalars(index_qi,:,:)
+       qs => scalars(index_qs,:,:)
+       qg => scalars(index_qg,:,:)
 
-    case ("mp_thompson","mp_wsm6")
-       qi   => scalars(index_qi,:,:)
-       qs   => scalars(index_qs,:,:)
-       qg   => scalars(index_qg,:,:)
+       call mpas_pool_get_array(diag_physics,'rainprod',rainprod)
+       call mpas_pool_get_array(diag_physics,'evapprod',evapprod)
+       call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
+       call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
+       call mpas_pool_get_array(diag_physics,'re_snow' ,re_snow )
 
-       do j = jts, jte
-       do k = kts, kte
-       do i = its, ite
+       do j = jts,jte
+       do k = kts,kte
+       do i = its,ite
           qi(k,i) = qi_p(i,k,j)
           qs(k,i) = qs_p(i,k,j)
           qg(k,i) = qg_p(i,k,j)
+
+          rainprod(k,i) = rainprod_p(i,k,j)
+          evapprod(k,i) = evapprod_p(i,k,j)
           re_cloud(k,i) = recloud_p(i,k,j)
           re_ice(k,i)   = reice_p(i,k,j)
           re_snow(k,i)  = resnow_p(i,k,j)
@@ -766,30 +855,113 @@
        enddo
        enddo
 
-    microp2_select: select case(microp_scheme)
+       mp2_select: select case(trim(mp_scheme))
+          case("mp_thompson","mp_thompson_aerosols")
+             call mpas_pool_get_dimension(state,'index_ni',index_ni)
+             call mpas_pool_get_dimension(state,'index_nr',index_nr)
+             ni   => scalars(index_ni,:,:)
+             nr   => scalars(index_nr,:,:)
 
-       case("mp_thompson")
-          ni   => scalars(index_ni,:,:)
-          nr   => scalars(index_nr,:,:)
+             do j = jts,jte
+             do k = kts,kte
+             do i = its,ite
+                ni(k,i) = ni_p(i,k,j)
+                nr(k,i) = nr_p(i,k,j)
+             enddo
+             enddo
+             enddo
 
-          do j = jts, jte
-          do k = kts, kte
-          do i = its, ite
-             ni(k,i) = ni_p(i,k,j)
-             nr(k,i) = nr_p(i,k,j)
-             rainprod(k,i) = rainprod_p(i,k,j)
-             evapprod(k,i) = evapprod_p(i,k,j)
-          enddo
-          enddo
-          enddo
+             mp3_select: select case(trim(mp_scheme))
+                case("mp_thompson_aerosols")
+                   call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+                   call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+                   call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+                   nc   => scalars(index_nc,:,:)
+                   nifa => scalars(index_nifa,:,:)
+                   nwfa => scalars(index_nwfa,:,:)
 
-       case default
+                   call mpas_pool_get_array(diag_physics,'nifa2d',nifa2d)
+                   call mpas_pool_get_array(diag_physics,'nwfa2d',nwfa2d)
+                   do j = jts,jte
+                   do i = its,ite
+                      nifa2d(i) = nifa2d_p(i,j)
+                      nwfa2d(i) = nwfa2d_p(i,j)
+                   enddo
+                   do k = kts, kte
+                   do i = its, ite
+                      nc(k,i)   = nc_p(i,k,j)
+                      nifa(k,i) = nifa_p(i,k,j)
+                      nwfa(k,i) = nwfa_p(i,k,j)
+                   enddo
+                   enddo
+                   enddo
 
-    end select microp2_select
+                case default
+             end select mp3_select
+
+          case default
+       end select mp2_select
 
     case default
+ end select mp_select
 
- end select microp_select_init
+!end calculation of cloud microphysics tendencies:
+ mp_tend_select: select case(trim(mp_scheme))
+    case("mp_thompson","mp_thompson_aerosols","mp_wsm6")
+       call mpas_pool_get_array(tend_physics,'rthmpten',rthmpten)
+       call mpas_pool_get_array(tend_physics,'rqvmpten',rqvmpten)
+       call mpas_pool_get_array(tend_physics,'rqcmpten',rqcmpten)
+       call mpas_pool_get_array(tend_physics,'rqrmpten',rqrmpten)
+       call mpas_pool_get_array(tend_physics,'rqimpten',rqimpten)
+       call mpas_pool_get_array(tend_physics,'rqsmpten',rqsmpten)
+       call mpas_pool_get_array(tend_physics,'rqgmpten',rqgmpten)
+
+       do k = kts,kte
+       do i = its,ite
+          rthmpten(k,i) = (theta_m(k,i)/(1._RKIND+R_v/R_d*max(0._RKIND,qv(k,i)))-rthmpten(k,i))/dt_dyn
+          rqvmpten(k,i) = (qv(k,i)-rqvmpten(k,i))/dt_dyn
+          rqcmpten(k,i) = (qc(k,i)-rqcmpten(k,i))/dt_dyn
+          rqrmpten(k,i) = (qr(k,i)-rqrmpten(k,i))/dt_dyn
+          rqimpten(k,i) = (qi(k,i)-rqimpten(k,i))/dt_dyn
+          rqsmpten(k,i) = (qs(k,i)-rqsmpten(k,i))/dt_dyn
+          rqgmpten(k,i) = (qg(k,i)-rqgmpten(k,i))/dt_dyn
+       enddo
+       enddo
+
+       mp2_tend_select: select case(trim(mp_scheme))
+          case("mp_thompson","mp_thompson_aerosols")
+             call mpas_pool_get_array(tend_physics,'rnimpten',rnimpten)
+             call mpas_pool_get_array(tend_physics,'rnrmpten',rnrmpten)
+
+             do k = kts,kte
+             do i = its,ite
+                rnimpten(k,i) = (ni(k,i)-rnimpten(k,i))/dt_dyn
+                rnrmpten(k,i) = (nr(k,i)-rnrmpten(k,i))/dt_dyn
+             enddo
+             enddo
+
+             mp3_tend_select: select case(trim(mp_scheme))
+                case("mp_thompson_aerosols")
+                   call mpas_pool_get_array(tend_physics,'rncmpten',rncmpten)
+                   call mpas_pool_get_array(tend_physics,'rnifampten',rnifampten)
+                   call mpas_pool_get_array(tend_physics,'rnwfampten',rnwfampten)
+
+                   do k = kts,kte
+                   do i = its,ite
+                      rncmpten(k,i)   = (nc(k,i)-rncmpten(k,i))/dt_dyn
+                      rnifampten(k,i) = (nifa(k,i)-rnifampten(k,i))/dt_dyn
+                      rnwfampten(k,i) = (nwfa(k,i)-rnwfampten(k,i))/dt_dyn
+                   enddo
+                   enddo
+
+                case default
+             end select mp3_tend_select
+
+          case default
+       end select mp2_tend_select
+
+    case default
+ end select mp_tend_select
 
  end subroutine microphysics_to_MPAS
 

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -77,11 +77,12 @@
  type(mpas_pool_type),intent(in):: configs
 
 !local pointers:
- character(len=StrKIND),pointer:: pbl_scheme
+ character(len=StrKIND),pointer:: microp_scheme,pbl_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_pbl_scheme'   ,pbl_scheme   )
 
  if(.not.allocated(psfc_p) ) allocate(psfc_p(ims:ime,jms:jme)         )
  if(.not.allocated(ptop_p) ) allocate(ptop_p(ims:ime,jms:jme)         )
@@ -114,15 +115,20 @@
  if(.not.allocated(qs_p)   ) allocate(qs_p(ims:ime,kms:kme,jms:jme)   )
  if(.not.allocated(qg_p)   ) allocate(qg_p(ims:ime,kms:kme,jms:jme)   )
 
- pbl_select: select case(trim(pbl_scheme))
-    case("bl_mynn")
-       if(.not.allocated(nc_p)  ) allocate(nc_p(ims:ime,kms:kme,jms:jme)  )
-       if(.not.allocated(ni_p)  ) allocate(ni_p(ims:ime,kms:kme,jms:jme)  )
+ microp_select: select case(trim(microp_scheme))
+    case("mp_thompson_aerosols")
        if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
 
     case default
+ end select microp_select
 
+ pbl_select: select case(trim(pbl_scheme))
+    case("bl_mynn")
+       if(.not.allocated(nc_p)) allocate(nc_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+
+    case default
  end select pbl_select
 
 !... arrays used for calculating the hydrostatic pressure and exner function:
@@ -144,11 +150,12 @@
  type(mpas_pool_type),intent(in):: configs
 
 !local pointers:
- character(len=StrKIND),pointer:: pbl_scheme
+ character(len=StrKIND),pointer:: microp_scheme,pbl_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_pbl_scheme'   ,pbl_scheme   )
 
  if(allocated(psfc_p)  ) deallocate(psfc_p  )
  if(allocated(ptop_p)  ) deallocate(ptop_p  )
@@ -181,15 +188,20 @@
  if(allocated(qs_p)    ) deallocate(qs_p    )
  if(allocated(qg_p)    ) deallocate(qg_p    )
 
- pbl_select: select case(trim(pbl_scheme))
-    case("bl_mynn")
-       if(allocated(nc_p)  ) deallocate(nc_p  )
-       if(allocated(ni_p)  ) deallocate(ni_p  )
+ microp_select: select case(trim(microp_scheme))
+    case("mp_thompson_aerosols")
        if(allocated(nifa_p)) deallocate(nifa_p)
        if(allocated(nwfa_p)) deallocate(nwfa_p)
 
     case default
+ end select microp_select
 
+ pbl_select: select case(trim(pbl_scheme))
+    case("bl_mynn")
+       if(allocated(nc_p)) deallocate(nc_p)
+       if(allocated(ni_p)) deallocate(ni_p)
+
+    case default
  end select pbl_select
 
  if(allocated(psfc_hyd_p)  ) deallocate(psfc_hyd_p  )
@@ -219,7 +231,7 @@
  type(mpas_pool_type),intent(inout):: diag_physics
 
 !local pointers:
- character(len=StrKIND),pointer:: pbl_scheme
+ character(len=StrKIND),pointer:: microp_scheme,pbl_scheme
 
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_nc,index_ni,index_nifa,index_nwfa
@@ -252,7 +264,8 @@
 !call mpas_log_write('kts=$i kte=$i',intArgs=(/kts,kte/))
 
 !initialization:
- call mpas_pool_get_config(configs,'config_pbl_scheme',pbl_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme',microp_scheme)
+ call mpas_pool_get_config(configs,'config_pbl_scheme'   ,pbl_scheme   )
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -324,6 +337,26 @@
  enddo
  enddo
 
+ microp_select: select case(trim(microp_scheme))
+    case("mp_thompson_aerosols")
+       nullify(nifa)
+       nullify(nwfa)
+       call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+       call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+       nifa => scalars(index_nifa,:,:)
+       nwfa => scalars(index_nwfa,:,:)
+       do j = jts,jte
+          do k = kts,kte
+             do i = its,ite
+                nifa_p(i,k,j) = max(0.,nifa(k,i))
+                nwfa_p(i,k,j) = max(0.,nwfa(k,i))
+             enddo
+          enddo
+       enddo
+
+    case default
+ end select microp_select
+
  pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
        do j = jts,jte
@@ -331,8 +364,6 @@
              do i = its,ite
                 nc_p(i,k,j)   = 0._RKIND
                 ni_p(i,k,j)   = 0._RKIND
-                nifa_p(i,k,j) = 0._RKIND
-                nwfa_p(i,k,j) = 0._RKIND
              enddo
           enddo
        enddo
@@ -350,22 +381,14 @@
           enddo
        endif
        !initializes nc_p, nifa_p, and nwfa_p when running the option "mp_thompson_aerosols":
-       if(f_nc .and. f_nifa .and. f_nwfa) then
+       if(f_nc) then
           nullify(nc)
-          nullify(nifa)
-          nullify(nwfa)
-          call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
-          call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
-          call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+          call mpas_pool_get_dimension(state,'index_nc',index_nc)
           nc   => scalars(index_nc,:,:)
-          nifa => scalars(index_nifa,:,:)
-          nwfa => scalars(index_nwfa,:,:)
           do j = jts,jte
              do k = kts,kte
                 do i = its,ite
                    nc_p(i,k,j)   = max(0.,nc(k,i)  )
-                   nifa_p(i,k,j) = max(0.,nifa(k,i))
-                   nwfa_p(i,k,j) = max(0.,nwfa(k,i))
                 enddo
              enddo
           enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -116,7 +116,10 @@
 
  pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
-       if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nc_p)  ) allocate(nc_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(ni_p)  ) allocate(ni_p(ims:ime,kms:kme,jms:jme)  )
+       if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
 
     case default
 
@@ -180,7 +183,10 @@
 
  pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
-       if(allocated(ni_p)) deallocate(ni_p)
+       if(allocated(nc_p)  ) deallocate(nc_p  )
+       if(allocated(ni_p)  ) deallocate(ni_p  )
+       if(allocated(nifa_p)) deallocate(nifa_p)
+       if(allocated(nwfa_p)) deallocate(nwfa_p)
 
     case default
 
@@ -216,7 +222,7 @@
  character(len=StrKIND),pointer:: pbl_scheme
 
  integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni
+ integer,pointer:: index_nc,index_ni,index_nifa,index_nwfa
 
  real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
  real(kind=RKIND),dimension(:),pointer    :: fzm,fzp,rdzw
@@ -225,7 +231,7 @@
  real(kind=RKIND),dimension(:,:),pointer  :: zz,exner,pressure_b,rtheta_p,rtheta_b
  real(kind=RKIND),dimension(:,:),pointer  :: rho_zz,theta_m,pressure_p,u,v,w
  real(kind=RKIND),dimension(:,:),pointer  :: qv,qc,qr,qi,qs,qg
- real(kind=RKIND),dimension(:,:),pointer  :: ni
+ real(kind=RKIND),dimension(:,:),pointer  :: nc,ni,nifa,nwfa
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
 
 !local variables:
@@ -320,19 +326,52 @@
 
  pbl_select: select case(trim(pbl_scheme))
     case("bl_mynn")
-       call mpas_pool_get_dimension(state,'index_ni',index_ni)
-       ni => scalars(index_ni,:,:)
-
        do j = jts,jte
-       do k = kts,kte
-       do i = its,ite
-          ni_p(i,k,j) = max(0.,ni(k,i))
+          do k = kts,kte
+             do i = its,ite
+                nc_p(i,k,j)   = 0._RKIND
+                ni_p(i,k,j)   = 0._RKIND
+                nifa_p(i,k,j) = 0._RKIND
+                nwfa_p(i,k,j) = 0._RKIND
+             enddo
+          enddo
        enddo
-       enddo
-       enddo
+       !initializes ni_p when running the options "mp_thompson" or "mp_thompson_aerosols":
+       if(f_ni) then
+          nullify(ni)
+          call mpas_pool_get_dimension(state,'index_ni',index_ni)
+          ni => scalars(index_ni,:,:)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   ni_p(i,k,j) = max(0.,ni(k,i))
+                enddo
+             enddo
+          enddo
+       endif
+       !initializes nc_p, nifa_p, and nwfa_p when running the option "mp_thompson_aerosols":
+       if(f_nc .and. f_nifa .and. f_nwfa) then
+          nullify(nc)
+          nullify(nifa)
+          nullify(nwfa)
+          call mpas_pool_get_dimension(state,'index_nc'  ,index_nc  )
+          call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+          call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+          nc   => scalars(index_nc,:,:)
+          nifa => scalars(index_nifa,:,:)
+          nwfa => scalars(index_nwfa,:,:)
+          do j = jts,jte
+             do k = kts,kte
+                do i = its,ite
+                   nc_p(i,k,j)   = max(0.,nc(k,i)  )
+                   nifa_p(i,k,j) = max(0.,nifa(k,i))
+                   nwfa_p(i,k,j) = max(0.,nwfa(k,i))
+                enddo
+             enddo
+          enddo
+       endif
 
     case default
-
  end select pbl_select
 
 !calculation of the surface pressure using hydrostatic assumption down to the surface::

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -183,12 +183,12 @@
 !call mpas_log_write('--- enter subroutine physics_timetracker: itimestep = $i', intArgs=(/itimestep/))
 
  call mpas_pool_get_config(domain%blocklist%configs,'config_convection_scheme',config_convection_scheme)
- call mpas_pool_get_config(domain%blocklist%configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme  )
- call mpas_pool_get_config(domain%blocklist%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme  )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
 
- call mpas_pool_get_config(domain%blocklist%configs,'config_conv_interval'   ,config_conv_interval   )
- call mpas_pool_get_config(domain%blocklist%configs,'config_radtlw_interval' ,config_radtlw_interval )
- call mpas_pool_get_config(domain%blocklist%configs,'config_radtsw_interval' ,config_radtsw_interval )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_conv_interval'  ,config_conv_interval  )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radtlw_interval',config_radtlw_interval)
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radtsw_interval',config_radtsw_interval)
 
  call mpas_pool_get_config(domain%blocklist%configs,'config_frac_seaice'        ,config_frac_seaice        )
  call mpas_pool_get_config(domain%blocklist%configs,'config_o3climatology'      ,config_o3climatology      )
@@ -209,13 +209,13 @@
  julday = DoY
  curr_julday = real(julday-1) + utc_h / 24.0
  LeapYear = isLeapYear(year)
-! call mpas_log_write('     YEAR        =$i', intArgs=(/year/))
-! call mpas_log_write('     JULDAY      =$i', intArgs=(/julday/))
-! call mpas_log_write('     GMT         =$r', realArgs=(/gmt/))
-! call mpas_log_write('     UTC_H       =$r', realArgs=(/utc_h/))
-! call mpas_log_write('     CURR_JULDAY =$r', realArgs=(/curr_julday/))
-! call mpas_log_write('     LEAP_YEAR   =$l', logicArgs=(/LeapYear/))
-! call mpas_log_write('     TIME STAMP  ='//trim(timeStamp))
+!call mpas_log_write('     YEAR        = $i', intArgs=(/year/))
+!call mpas_log_write('     JULDAY      = $i', intArgs=(/julday/))
+!call mpas_log_write('     GMT         = $r', realArgs=(/gmt/))
+!call mpas_log_write('     UTC_H       = $r', realArgs=(/utc_h/))
+!call mpas_log_write('     CURR_JULDAY = $r', realArgs=(/curr_julday/))
+!call mpas_log_write('     LEAP_YEAR   = $l', logicArgs=(/LeapYear/))
+!call mpas_log_write('     TIME STAMP  = '//trim(timeStamp))
 
  block => domain % blocklist
  do while(associated(block))
@@ -266,7 +266,7 @@
     elseif(config_radtlw_interval == "none") then
        l_radtlw = .true.
     endif
-    call mpas_log_write('--- time to run the LW radiation scheme L_RADLW =$l',logicArgs=(/l_radtlw/))
+    call mpas_log_write('--- time to run the LW radiation scheme L_RADLW = $l',logicArgs=(/l_radtlw/))
  endif
 
  if(trim(config_radt_sw_scheme) /= "off") then
@@ -280,7 +280,7 @@
     elseif(config_radtsw_interval == "none") then
        l_radtsw = .true.
     endif
-    call mpas_log_write('--- time to run the SW radiation scheme L_RADSW =$l',logicArgs=(/l_radtsw/))
+    call mpas_log_write('--- time to run the SW radiation scheme L_RADSW = $l',logicArgs=(/l_radtsw/))
  endif
 
 !check to see if it is time to run the parameterization of convection:
@@ -295,7 +295,7 @@
     elseif(config_conv_interval == "none") then
        l_conv = .true.
     endif
-    call mpas_log_write('--- time to run the convection scheme L_CONV    =$l',logicArgs=(/l_conv/))
+    call mpas_log_write('--- time to run the convection scheme L_CONV    = $l',logicArgs=(/l_conv/))
  endif
 
 !check to see if it is time to update ozone to the current julian day in the RRTMG radiation codes:
@@ -334,7 +334,7 @@
        call mpas_reset_clock_alarm(clock,camlwAlarmID,camlwTimeStep,ierr=ierr)
        l_camlw = .true.
     endif
-    call mpas_log_write('--- time to write local CAM arrays to MPAS arrays L_CAMLW          =$l',logicArgs=(/l_camlw/))
+    call mpas_log_write('--- time to write local CAM arrays to MPAS arrays L_CAMLW          = $l',logicArgs=(/l_camlw/))
  endif
 
 !check to see if it is time to apply limit to the accumulated rain due to cloud microphysics
@@ -345,7 +345,7 @@
        call mpas_reset_clock_alarm(clock,acrainAlarmID,acrainTimeStep,ierr=ierr)
        l_acrain = .true.
     endif
-    call mpas_log_write('--- time to apply limit to accumulated rainc and rainnc L_ACRAIN   =$l',logicArgs=(/l_acrain/))
+    call mpas_log_write('--- time to apply limit to accumulated rainc and rainnc L_ACRAIN   = $l',logicArgs=(/l_acrain/))
  endif
 
 !check to see if it is time to apply limit to the accumulated radiation diagnostics due to
@@ -356,7 +356,7 @@
        call mpas_reset_clock_alarm(clock,acradtAlarmID,acradtTimeStep,ierr=ierr)
        l_acradt = .true.
     endif
-    call mpas_log_write('--- time to apply limit to accumulated radiation diags. L_ACRADT   =$l',logicArgs=(/l_acradt/))
+    call mpas_log_write('--- time to apply limit to accumulated radiation diags. L_ACRADT   = $l',logicArgs=(/l_acradt/))
  endif
 
 !check to see if it is time to calculate additional physics diagnostics:
@@ -368,7 +368,7 @@
  if (mpas_is_alarm_ringing(clock,diagAlarmID,interval=dtInterval,ierr=ierr)) then
     l_diags = .true.
  end if
- call mpas_log_write('--- time to calculate additional physics_diagnostics               =$l',logicArgs=(/l_diags/))
+ call mpas_log_write('--- time to calculate additional physics_diagnostics               = $l',logicArgs=(/l_diags/))
 
  end subroutine physics_timetracker
 
@@ -384,18 +384,18 @@
  type (MPAS_streamManager_type), intent(inout) :: stream_manager
 
 !local pointers:
- character(len=StrKIND),pointer:: config_convection_scheme,      &
-                                  config_lsm_scheme,             &
-                                  config_microp_scheme,          &
-                                  config_radt_lw_scheme,         &
+ character(len=StrKIND),pointer:: config_convection_scheme, &
+                                  config_lsm_scheme,        &
+                                  config_microp_scheme,     &
+                                  config_radt_lw_scheme,    &
                                   config_radt_sw_scheme
 
- character(len=StrKIND),pointer:: config_conv_interval,          &
-                                  config_pbl_interval,           &
-                                  config_radtlw_interval,        &
-                                  config_radtsw_interval,        &
-                                  config_bucket_update,          &
-                                  config_camrad_abs_update,      &
+ character(len=StrKIND),pointer:: config_conv_interval,     &
+                                  config_pbl_interval,      &
+                                  config_radtlw_interval,   &
+                                  config_radtsw_interval,   &
+                                  config_bucket_update,     &
+                                  config_camrad_abs_update, &
                                   config_greeness_update
 
  logical,pointer:: config_sst_update
@@ -642,10 +642,11 @@
     end if
  endif
 
- call mpas_log_write('     DT_RADTLW   =$r', realArgs=(/dt_radtlw/))
- call mpas_log_write('     DT_RADTSW   =$r', realArgs=(/dt_radtsw/))
- call mpas_log_write('     DT_CU       =$r', realArgs=(/dt_cu/))
- call mpas_log_write('     DT_PBL      =$r', realArgs=(/dt_pbl/))
+ call mpas_log_write(' ')
+ call mpas_log_write('DT_RADTLW = $r',realArgs=(/dt_radtlw/))
+ call mpas_log_write('DT_RADTSW = $r',realArgs=(/dt_radtsw/))
+ call mpas_log_write('DT_CU     = $r',realArgs=(/dt_cu/))
+ call mpas_log_write('DT_PBL    = $r',realArgs=(/dt_pbl/))
 
 !initialization of physics dimensions to mimic a rectangular grid:
  ims=1   ; ime = nCellsSolve
@@ -660,15 +661,16 @@
  jts=jms ; jte = jme
  kts=kms ; kte = kme-1
 
- call mpas_log_write('     IMS =$i   IME =$i', intArgs=(/ims,ime/))
- call mpas_log_write('     JMS =$i   JME =$i', intArgs=(/jms,jme/))
- call mpas_log_write('     KMS =$i   KME =$i', intArgs=(/kms,kme/))
- call mpas_log_write('     IDS =$i   IDE =$i', intArgs=(/ids,ide/))
- call mpas_log_write('     JDS =$i   JDE =$i', intArgs=(/jds,jde/))
- call mpas_log_write('     KDS =$i   KDE =$i', intArgs=(/kds,kde/))
- call mpas_log_write('     ITS =$i   ITE =$i', intArgs=(/its,ite/))
- call mpas_log_write('     JTS =$i   JTE =$i', intArgs=(/jts,jte/))
- call mpas_log_write('     KTS =$i   KTE =$i', intArgs=(/kts,kte/))
+ call mpas_log_write(' ')
+ call mpas_log_write('IMS = $i   IME = $i',intArgs=(/ims,ime/))
+ call mpas_log_write('JMS = $i   JME = $i',intArgs=(/jms,jme/))
+ call mpas_log_write('KMS = $i   KME = $i',intArgs=(/kms,kme/))
+ call mpas_log_write('IDS = $i   IDE = $i',intArgs=(/ids,ide/))
+ call mpas_log_write('JDS = $i   JDE = $i',intArgs=(/jds,jde/))
+ call mpas_log_write('KDS = $i   KDE = $i',intArgs=(/kds,kde/))
+ call mpas_log_write('ITS = $i   ITE = $i',intArgs=(/its,ite/))
+ call mpas_log_write('JTS = $i   JTE = $i',intArgs=(/jts,jte/))
+ call mpas_log_write('KTS = $i   KTE = $i',intArgs=(/kts,kte/))
 
 !initialization local physics variables:
  num_months = nMonths
@@ -682,12 +684,14 @@
 !... cloud microphysics:
  dt_microp = dt_dyn
  n_microp  = 1
- if(trim(config_microp_scheme)=='mp_thompson') then
+ if(trim(config_microp_scheme)=='mp_thompson' .or. &
+    trim(config_microp_scheme)=='mp_thompson_aerosols') then
     dt_microp = 90._RKIND
     n_microp  = max(nint(dt_dyn/dt_microp),1)
     dt_microp = dt_dyn / n_microp
     if(dt_dyn <= dt_microp) dt_microp = dt_dyn
  endif
+ call mpas_log_write(' ')
  call mpas_log_write('--- specifics on cloud microphysics option microp_scheme = '//trim(config_microp_scheme))
  call mpas_log_write('--- dt_microp = $r', realArgs=(/dt_microp/))
  call mpas_log_write('--- n_microp  = $i', intArgs=(/n_microp/))
@@ -743,7 +747,8 @@
  has_reqi = 0
  has_reqs = 0
  if(config_microp_re) then
-    if(trim(config_microp_scheme)=='mp_thompson' .or. &
+    if(trim(config_microp_scheme)=='mp_thompson'          .or. &
+       trim(config_microp_scheme)=='mp_thompson_aerosols' .or. &
        trim(config_microp_scheme)=='mp_wsm6') then
        if(trim(config_radt_lw_scheme)=='rrtmg_lw' .and. trim(config_radt_sw_scheme)=='rrtmg_sw') then
           has_reqc = 1
@@ -755,6 +760,7 @@
  call mpas_log_write('--- has_reqc  = $i', intArgs=(/has_reqc/))
  call mpas_log_write('--- has_reqi  = $i', intArgs=(/has_reqi/))
  call mpas_log_write('--- has_reqs  = $i', intArgs=(/has_reqs/))
+ call mpas_log_write(' ')
 
  end subroutine physics_run_init
 

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -80,7 +80,8 @@
 
  if(config_microp_scheme == 'mp_kessler') then
     mp_kessler_in = .true.
- elseif(config_microp_scheme == 'mp_thompson') then
+ elseif(config_microp_scheme == 'mp_thompson' .or. &
+        config_microp_scheme == 'mp_thompson_aerosols') then
     mp_thompson_in = .true.
  elseif(config_microp_scheme == 'mp_wsm6') then
     mp_wsm6_in = .true.

--- a/src/core_atmosphere/physics/mpas_atmphys_packages.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_packages.F
@@ -36,7 +36,7 @@
  character(len=StrKIND),pointer:: config_microp_scheme
  character(len=StrKIND),pointer:: config_convection_scheme
  character(len=StrKIND),pointer:: config_pbl_scheme
- logical,pointer:: mp_kessler_in,mp_thompson_in,mp_wsm6_in
+ logical,pointer:: mp_kessler_in,mp_thompson_in,mp_thompson_aers_in,mp_wsm6_in
  logical,pointer:: cu_grell_freitas_in,cu_kain_fritsch_in,cu_ntiedtke_in
  logical,pointer:: bl_mynn_in,bl_ysu_in
 
@@ -61,11 +61,15 @@
  nullify(mp_thompson_in)
  call mpas_pool_get_package(packages,'mp_thompson_inActive',mp_thompson_in)
 
+ nullify(mp_thompson_aers_in)
+ call mpas_pool_get_package(packages,'mp_thompson_aers_inActive',mp_thompson_aers_in)
+
  nullify(mp_wsm6_in)
  call mpas_pool_get_package(packages,'mp_wsm6_inActive',mp_wsm6_in)
 
- if(.not.associated(mp_kessler_in)  .or. &
-    .not.associated(mp_thompson_in) .or. &
+ if(.not.associated(mp_kessler_in      )  .or. &
+    .not.associated(mp_thompson_in     ) .or. &
+    .not.associated(mp_thompson_aers_in) .or. &
     .not.associated(mp_wsm6_in)) then
     call mpas_log_write('====================================================================================',messageType=MPAS_LOG_ERR)
     call mpas_log_write('* Error while setting up packages for cloud microphysics options in atmosphere core.',messageType=MPAS_LOG_ERR)
@@ -74,21 +78,24 @@
     return
  endif
 
- mp_kessler_in           = .false.
- mp_thompson_in          = .false.
- mp_wsm6_in              = .false.
+ mp_kessler_in       = .false.
+ mp_thompson_in      = .false.
+ mp_thompson_aers_in = .false.
+ mp_wsm6_in          = .false.
 
  if(config_microp_scheme == 'mp_kessler') then
     mp_kessler_in = .true.
- elseif(config_microp_scheme == 'mp_thompson' .or. &
-        config_microp_scheme == 'mp_thompson_aerosols') then
+ elseif(config_microp_scheme == 'mp_thompson') then
     mp_thompson_in = .true.
+ elseif(config_microp_scheme == 'mp_thompson_aerosols') then
+    mp_thompson_aers_in = .true.
  elseif(config_microp_scheme == 'mp_wsm6') then
     mp_wsm6_in = .true.
  endif
 
  call mpas_log_write('    mp_kessler_in           = $l', logicArgs=(/mp_kessler_in/))
  call mpas_log_write('    mp_thompson_in          = $l', logicArgs=(/mp_thompson_in/))
+ call mpas_log_write('    mp_thompson_aers_in     = $l', logicArgs=(/mp_thompson_aers_in/))
  call mpas_log_write('    mp_wsm6_in              = $l', logicArgs=(/mp_wsm6_in/))
 
 !--- initialization of all packages for parameterizations of convection:

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -10,6 +10,7 @@
  use mpas_kind_types
  use mpas_pool_routines
  use mpas_dmpar
+ use mpas_atm_dimensions
 
  use mpas_atmphys_constants, only: R_d,R_v,degrad
 
@@ -21,37 +22,26 @@
 !Interface between the physics parameterizations and the non-hydrostatic dynamical core.
 !Laura D. Fowler (send comments to laura@ucar.edu).
 !2013-05-01.
-!
-!
+
+
 ! subroutines in mpas_atmphys_todynamics:
 ! ---------------------------------------
-! physics_get_tend: add and mass-weigh tendencies before being added to dynamics tendencies.
-! tend_toEdges   : interpolate wind-tendencies from centers to edges of grid-cells.
+! physics_get_tend     : intermediate subroutine between the dynamical core and calculation of the total
+!                        physics tendencies.
+! physics_get_tend_work: add and mass-weigh physics tendencies before being added to dynamics tendencies.
+! tend_toEdges         : interpolate wind-tendencies from centers to edges of grid-cells.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
-! * added calculation of the advective tendency of the potential temperature due to horizontal
-!   and vertical advection, and horizontal mixing (diffusion).
-!   Laura D. Fowler (birch.mmm.ucar.edu) / 2013-11-19.
-! * throughout the sourcecode, replaced all "var_struct" defined arrays by local pointers.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-04-22.
-! * modified sourcecode to use pools.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-05-15.
-! * renamed config_conv_deep_scheme to config_convection_scheme.
-!   Laura D. Fowler (laura@ucar.edu) / 2014-09-18.
-! * renamed "tiedtke" with "cu_tiedtke".
-!   Laura D. Fowler (laura@ucar.edu) / 2016-03-22.
-! * modified the sourcecode to accomodate the packages "cu_kain_fritsch_in" and "cu_ntiedtke_in".
-!   Laura D. Fowler (laura@ucar.edu) / 2016-03-24.
-! * added the option bl_mynn for the calculation of the tendency for the cloud ice number concentration.
-!   Laura D. Fowler (laura@ucar.edu) / 2016-04-11.
-! * in subroutine physics_get_tend_work, added the option cu_ntiedtke in the calculation of rucuten_Edge.
-!   Laura D. Fowler (laura@ucar.edu) / 2016-10-28.
+! * cleaned-up subroutines physics_get_tend and physics_get_tend_work.
+!   Laura D. Fowler (laura@ucar.edu) / 2018-01-23.
+! * removed the option bl_mynn_wrf390.
+!   Laura D. Fowler (laura@ucar.edu) / 2018-01-24.
 
- !
- ! Abstract interface for routine used to communicate halos of fields
- ! in a named group
- !
+!
+! Abstract interface for routine used to communicate halos of fields
+! in a named group
+!
  abstract interface
     subroutine halo_exchange_routine(domain, halo_group, ierr)
 
@@ -69,34 +59,34 @@
 
  
 !=================================================================================================================
- subroutine physics_get_tend( block, mesh, state, diag, tend, tend_physics, configs, rk_step, dynamics_substep, &
-                              tend_ru_physics, tend_rtheta_physics, tend_rho_physics, exchange_halo_group )
+ subroutine physics_get_tend(block,mesh,state,diag,tend,tend_physics,configs,rk_step,dynamics_substep, &
+                             tend_ru_physics,tend_rtheta_physics,tend_rho_physics,exchange_halo_group)
 !=================================================================================================================
-   
- use mpas_atm_dimensions
 
 !input variables:
  type(block_type),intent(in),target:: block
  type(mpas_pool_type),intent(in):: mesh
  type(mpas_pool_type),intent(in):: state
  type(mpas_pool_type),intent(in):: configs
- integer, intent(in):: rk_step
- integer, intent(in):: dynamics_substep
- procedure (halo_exchange_routine) :: exchange_halo_group
+ integer,intent(in):: rk_step
+ integer,intent(in):: dynamics_substep
+ procedure(halo_exchange_routine):: exchange_halo_group
 
 !inout variables:
  type(mpas_pool_type),intent(inout):: diag
  type(mpas_pool_type),intent(inout):: tend
  type(mpas_pool_type),intent(inout):: tend_physics
 
- real(kind=RKIND),dimension(:,:) :: tend_ru_physics, tend_rtheta_physics, tend_rho_physics
+ real(kind=RKIND),intent(inout),dimension(:,:):: tend_ru_physics,tend_rtheta_physics,tend_rho_physics
 
 !local variables:
- character(len=StrKIND), pointer :: config_pbl_scheme, config_convection_scheme, &
-                                    config_radt_lw_scheme, config_radt_sw_scheme
+ character(len=StrKIND),pointer:: pbl_scheme,        &
+                                  convection_scheme, &
+                                  radt_lw_scheme,    &
+                                  radt_sw_scheme
 
  integer:: i,iCell,k,n
- integer,pointer:: index_qv, index_qc, index_qr, index_qi, index_qs, index_qg
+ integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
  integer,pointer:: index_ni
  integer,pointer:: nCells,nCellsSolve,nEdges,nEdgesSolve
 
@@ -104,6 +94,7 @@
  real(kind=RKIND),dimension(:,:),pointer:: mass_edge     ! diag rho_edge
  real(kind=RKIND),dimension(:,:),pointer:: theta_m       ! time level 1
  real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+
  real(kind=RKIND),dimension(:,:),pointer:: rthblten,rqvblten,rqcblten, &
                                            rqiblten,rqsblten,rublten,rvblten
  real(kind=RKIND),dimension(:,:),pointer:: rniblten
@@ -113,335 +104,312 @@
  real(kind=RKIND),dimension(:,:),pointer:: rthratenlw,rthratensw                                    
  
  real(kind=RKIND),dimension(:,:),pointer:: tend_u_phys !nick
- real(kind=RKIND),dimension(:,:),pointer  :: tend_theta,tend_theta_euler,tend_u
  real(kind=RKIND),dimension(:,:,:),pointer:: tend_scalars
- real(kind=RKIND):: coeff
 
- real(kind=RKIND):: tem
  real(kind=RKIND),dimension(:,:),pointer:: rublten_Edge,rucuten_Edge
 
- real(kind=RKIND),dimension(:,:),allocatable:: theta,tend_th
-
+ real(kind=RKIND),dimension(:,:),allocatable:: tend_th
 
 !=================================================================================================================
- call mpas_pool_get_dimension(mesh, 'nCells', nCells)
- call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
- call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
- call mpas_pool_get_dimension(mesh, 'nEdgesSolve', nEdgesSolve)
 
- call mpas_pool_get_config(configs, 'config_pbl_scheme', config_pbl_scheme)
- call mpas_pool_get_config(configs, 'config_convection_scheme', config_convection_scheme)
- call mpas_pool_get_config(configs, 'config_radt_lw_scheme', config_radt_lw_scheme)
- call mpas_pool_get_config(configs, 'config_radt_sw_scheme', config_radt_sw_scheme)
+ call mpas_pool_get_dimension(mesh,'nCells',nCells)
+ call mpas_pool_get_dimension(mesh,'nEdges',nEdges)
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+ call mpas_pool_get_dimension(mesh,'nEdgesSolve',nEdgesSolve)
 
- call mpas_pool_get_array(state, 'theta_m', theta_m, 1)
- call mpas_pool_get_array(state, 'scalars', scalars, 1)
- call mpas_pool_get_array(state, 'rho_zz', mass, 2)
- call mpas_pool_get_array(diag , 'rho_edge', mass_edge)
+ call mpas_pool_get_config(configs,'config_pbl_scheme'       ,pbl_scheme       )
+ call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
+ call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,radt_lw_scheme   )
+ call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,radt_sw_scheme   )
 
- call mpas_pool_get_array(diag , 'tend_u_phys', tend_u_phys) !nick
+ call mpas_pool_get_array(state,'theta_m' ,theta_m,1)
+ call mpas_pool_get_array(state,'scalars' ,scalars,1)
+ call mpas_pool_get_array(state,'rho_zz'  ,mass,2   )
+ call mpas_pool_get_array(diag ,'rho_edge',mass_edge)
+ call mpas_pool_get_array(diag ,'tend_u_phys',tend_u_phys)
 
- call mpas_pool_get_dimension(state, 'index_qv', index_qv)
- call mpas_pool_get_dimension(state, 'index_qc', index_qc)
- call mpas_pool_get_dimension(state, 'index_qr', index_qr)
- call mpas_pool_get_dimension(state, 'index_qi', index_qi)
- call mpas_pool_get_dimension(state, 'index_qs', index_qs)
- call mpas_pool_get_dimension(state, 'index_qg', index_qg)
- call mpas_pool_get_dimension(state, 'index_ni', index_ni)
+ call mpas_pool_get_dimension(state,'index_qv',index_qv)
+ call mpas_pool_get_dimension(state,'index_qc',index_qc)
+ call mpas_pool_get_dimension(state,'index_qr',index_qr)
+ call mpas_pool_get_dimension(state,'index_qi',index_qi)
+ call mpas_pool_get_dimension(state,'index_qs',index_qs)
+ call mpas_pool_get_dimension(state,'index_qg',index_qg)
+ call mpas_pool_get_dimension(state,'index_ni',index_ni)
 
- call mpas_pool_get_array(tend_physics, 'rublten', rublten)
- call mpas_pool_get_array(tend_physics, 'rvblten', rvblten)
- call mpas_pool_get_array(tend_physics, 'rublten_Edge', rublten_Edge)
- call mpas_pool_get_array(tend_physics, 'rthblten', rthblten)
- call mpas_pool_get_array(tend_physics, 'rqvblten', rqvblten)
- call mpas_pool_get_array(tend_physics, 'rqcblten', rqcblten)
- call mpas_pool_get_array(tend_physics, 'rqiblten', rqiblten)
- call mpas_pool_get_array(tend_physics, 'rqsblten', rqsblten)
- call mpas_pool_get_array(tend_physics, 'rniblten', rniblten)
+ call mpas_pool_get_array(tend_physics,'rublten',rublten)
+ call mpas_pool_get_array(tend_physics,'rvblten',rvblten)
+ call mpas_pool_get_array(tend_physics,'rthblten',rthblten)
+ call mpas_pool_get_array(tend_physics,'rqvblten',rqvblten)
+ call mpas_pool_get_array(tend_physics,'rqcblten',rqcblten)
+ call mpas_pool_get_array(tend_physics,'rqiblten',rqiblten)
+ call mpas_pool_get_array(tend_physics,'rqsblten',rqsblten)
+ call mpas_pool_get_array(tend_physics,'rniblten',rniblten)
+ call mpas_pool_get_array(tend_physics,'rublten_Edge',rublten_Edge)
 
- call mpas_pool_get_array(tend_physics, 'rucuten', rucuten)
- call mpas_pool_get_array(tend_physics, 'rvcuten', rvcuten)
- call mpas_pool_get_array(tend_physics, 'rucuten_Edge', rucuten_Edge)
- call mpas_pool_get_array(tend_physics, 'rthcuten', rthcuten)
- call mpas_pool_get_array(tend_physics, 'rqvcuten', rqvcuten)
- call mpas_pool_get_array(tend_physics, 'rqccuten', rqccuten)
- call mpas_pool_get_array(tend_physics, 'rqrcuten', rqrcuten)
- call mpas_pool_get_array(tend_physics, 'rqicuten', rqicuten)
- call mpas_pool_get_array(tend_physics, 'rqscuten', rqscuten)
+ call mpas_pool_get_array(tend_physics,'rucuten',rucuten)
+ call mpas_pool_get_array(tend_physics,'rvcuten',rvcuten)
+ call mpas_pool_get_array(tend_physics,'rthcuten',rthcuten)
+ call mpas_pool_get_array(tend_physics,'rqvcuten',rqvcuten)
+ call mpas_pool_get_array(tend_physics,'rqccuten',rqccuten)
+ call mpas_pool_get_array(tend_physics,'rqrcuten',rqrcuten)
+ call mpas_pool_get_array(tend_physics,'rqicuten',rqicuten)
+ call mpas_pool_get_array(tend_physics,'rqscuten',rqscuten)
+ call mpas_pool_get_array(tend_physics,'rucuten_Edge',rucuten_Edge)
 
- call mpas_pool_get_array(tend_physics, 'rthratenlw', rthratenlw)
- call mpas_pool_get_array(tend_physics, 'rthratensw', rthratensw)
+ call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
+ call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
 
- call mpas_pool_get_array(tend,'u'           , tend_u         )
- call mpas_pool_get_array(tend,'theta_m'     , tend_theta     )
- call mpas_pool_get_array(tend,'theta_euler' ,tend_theta_euler)
- call mpas_pool_get_array(tend,'scalars_tend',tend_scalars    )
+ call mpas_pool_get_array(tend,'scalars_tend',tend_scalars)
+
 
 !initialize the tendency for the potential temperature and all scalars due to PBL, convection,
 !and longwave and shortwave radiation:
-! allocate(theta(nVertLevels,nCellsSolve)  )
  allocate(tend_th(nVertLevels,nCellsSolve))
  tend_th = 0._RKIND
 
- tend_scalars(:,:,:) = 0._RKIND
-
- tend_ru_physics(:,:) = 0._RKIND
+ tend_scalars(:,:,:)      = 0._RKIND
+ tend_ru_physics(:,:)     = 0._RKIND
  tend_rtheta_physics(:,:) = 0._RKIND
- tend_rho_physics(:,:) = 0._RKIND       ! NB: rho tendency is not currently supplied by physics, but this
-                                        !     field may be later filled with IAU or other tendencies
+ tend_rho_physics(:,:)    = 0._RKIND
 
- !
- ! In case some variables are not allocated due to their associated packages,
- ! we need to make their pointers associated here to avoid triggering run-time
- ! checks when calling physics_get_tend_work
- !
- if (.not. associated(rublten))  allocate(rublten(0,0) )
- if (.not. associated(rvblten))  allocate(rvblten(0,0) )
- if (.not. associated(rthblten)) allocate(rthblten(0,0))
- if (.not. associated(rqvblten)) allocate(rqvblten(0,0))
- if (.not. associated(rqcblten)) allocate(rqcblten(0,0))
- if (.not. associated(rqiblten)) allocate(rqiblten(0,0))
- if (.not. associated(rqsblten)) allocate(rqsblten(0,0))
- if (.not. associated(rniblten)) allocate(rniblten(0,0))
- if (.not. associated(rucuten))  allocate(rucuten(0,0) )
- if (.not. associated(rvcuten))  allocate(rvcuten(0,0) )
- if (.not. associated(rthcuten)) allocate(rthcuten(0,0))
- if (.not. associated(rqvcuten)) allocate(rqvcuten(0,0))
- if (.not. associated(rqccuten)) allocate(rqccuten(0,0))
- if (.not. associated(rqicuten)) allocate(rqicuten(0,0))
- if (.not. associated(rqrcuten)) allocate(rqrcuten(0,0))
- if (.not. associated(rqscuten)) allocate(rqscuten(0,0))
 
- call physics_get_tend_work(block, mesh, nCells, nEdges, nCellsSolve, nEdgesSolve, &
-                           rk_step, dynamics_substep, &
-                           config_pbl_scheme, config_convection_scheme, config_radt_lw_scheme, config_radt_sw_scheme, &
-                           index_qv, index_qc, index_qr, index_qi, index_qs, index_ni, &
-                           rublten, rvblten, mass_edge, rublten_Edge, &
-                           tend_ru_physics, &
-                           rucuten, rvcuten, rucuten_Edge, &
-                           tend_th, tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, rqsblten, rniblten, &
-                           rthcuten, rqvcuten, rqccuten, rqrcuten, rqicuten, rqscuten, &
-                           rthratenlw, rthratensw, &
-                           tend_u_phys, &
-                           theta_m, scalars, &
-                           tend_rtheta_physics, &
-                           tend_theta_euler, &
-                           exchange_halo_group &
-                           )
+!in case some variables are not allocated due to their associated packages. We need to make their pointers
+!associated here to avoid triggering run-time. checks when calling physics_get_tend_work:
+ if(.not. associated(rucuten) ) allocate(rucuten(0,0) )
+ if(.not. associated(rvcuten) ) allocate(rvcuten(0,0) )
+ if(.not. associated(rthcuten)) allocate(rthcuten(0,0))
+ if(.not. associated(rqvcuten)) allocate(rqvcuten(0,0))
+ if(.not. associated(rqccuten)) allocate(rqccuten(0,0))
+ if(.not. associated(rqicuten)) allocate(rqicuten(0,0))
+ if(.not. associated(rqrcuten)) allocate(rqrcuten(0,0))
+ if(.not. associated(rqscuten)) allocate(rqscuten(0,0))
 
- !
- ! Clean up any pointers that were allocated with zero size before the call to
- ! physics_get_tend_work
- !
- if (size(rublten)  == 0) deallocate(rublten )
- if (size(rvblten)  == 0) deallocate(rvblten )
- if (size(rthblten) == 0) deallocate(rthblten)
- if (size(rqvblten) == 0) deallocate(rqvblten)
- if (size(rqcblten) == 0) deallocate(rqcblten)
- if (size(rqiblten) == 0) deallocate(rqiblten)
- if (size(rqsblten) == 0) deallocate(rqsblten)
- if (size(rniblten) == 0) deallocate(rniblten)
- if (size(rucuten)  == 0) deallocate(rucuten )
- if (size(rvcuten)  == 0) deallocate(rvcuten )
- if (size(rthcuten) == 0) deallocate(rthcuten)
- if (size(rqvcuten) == 0) deallocate(rqvcuten)
- if (size(rqccuten) == 0) deallocate(rqccuten)
- if (size(rqicuten) == 0) deallocate(rqicuten)
- if (size(rqrcuten) == 0) deallocate(rqrcuten)
- if (size(rqscuten) == 0) deallocate(rqscuten)
+ if(.not. associated(rublten) ) allocate(rublten(0,0) )
+ if(.not. associated(rvblten) ) allocate(rvblten(0,0) )
+ if(.not. associated(rthblten)) allocate(rthblten(0,0))
+ if(.not. associated(rqvblten)) allocate(rqvblten(0,0))
+ if(.not. associated(rqcblten)) allocate(rqcblten(0,0))
+ if(.not. associated(rqiblten)) allocate(rqiblten(0,0))
+ if(.not. associated(rqsblten)) allocate(rqsblten(0,0))
+ if(.not. associated(rniblten)) allocate(rniblten(0,0))
 
-! deallocate(theta)
+ call physics_get_tend_work( &
+              block,mesh,nCells,nEdges,nCellsSolve,nEdgesSolve,rk_step,dynamics_substep, &
+              pbl_scheme,convection_scheme,radt_lw_scheme,radt_sw_scheme,                &
+              index_qv,index_qc,index_qr,index_qi,index_qs,                              &
+              index_ni,                                                                  &
+              mass,mass_edge,theta_m,scalars,                                            &
+              rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,                       &
+              rqsblten,                                                                  &
+              rniblten,                                                                  &
+              rucuten,rvcuten,rthcuten,rqvcuten,rqccuten,rqrcuten,rqicuten,rqscuten,     &
+              rthratenlw,rthratensw,rublten_Edge,rucuten_Edge,                           &
+              tend_th,tend_rtheta_physics,tend_scalars,tend_ru_physics,tend_u_phys,      &
+              exchange_halo_group)
+
+!clean up any pointers that were allocated with zero size before the call to physics_get_tend_work:
+ if(size(rucuten) == 0 ) deallocate(rucuten )
+ if(size(rvcuten) == 0 ) deallocate(rvcuten )
+ if(size(rthcuten) == 0) deallocate(rthcuten)
+ if(size(rqvcuten) == 0) deallocate(rqvcuten)
+ if(size(rqccuten) == 0) deallocate(rqccuten)
+ if(size(rqicuten) == 0) deallocate(rqicuten)
+ if(size(rqrcuten) == 0) deallocate(rqrcuten)
+ if(size(rqscuten) == 0) deallocate(rqscuten)
+
+ if(size(rublten) == 0 ) deallocate(rublten )
+ if(size(rvblten) == 0 ) deallocate(rvblten )
+ if(size(rthblten) == 0) deallocate(rthblten)
+ if(size(rqvblten) == 0) deallocate(rqvblten)
+ if(size(rqcblten) == 0) deallocate(rqcblten)
+ if(size(rqiblten) == 0) deallocate(rqiblten)
+ if(size(rqsblten) == 0) deallocate(rqsblten)
+ if(size(rniblten) == 0) deallocate(rniblten)
+
  deallocate(tend_th)
-
-! if(rk_step .eq. 3) then
-!    call mpas_log_write('')
-!    call mpas_log_write('--- enter subroutine physics_get_tend:')
-!    call mpas_log_write('max rthblten   = $r',realArgs=(/maxval(rthblten(:,1:nCellsSolve))/))
-!    call mpas_log_write('min rthblten   = $r',realArgs=(/minval(rthblten(:,1:nCellsSolve))/))
-!    call mpas_log_write('max rthcuten   = $r',realArgs=(/maxval(rthcuten(:,1:nCellsSolve))/))
-!    call mpas_log_write('min rthcuten   = $r',realArgs=(/minval(rthcuten(:,1:nCellsSolve))/))
-!    call mpas_log_write('max rthratenlw = $r',realArgs=(/maxval(rthratenlw(:,1:nCellsSolve))/))
-!    call mpas_log_write('min rthratenlw = $r',realArgs=(/minval(rthratenlw(:,1:nCellsSolve))/))
-!    call mpas_log_write('max rthratensw = $r',realArgs=(/maxval(rthratensw(:,1:nCellsSolve))/))
-!    call mpas_log_write('min rthratensw = $r',realArgs=(/minval(rthratensw(:,1:nCellsSolve))/))
-!    call mpas_log_write('--- end subroutine physics_get_tend')
-!    call mpas_log_write('')
-! endif
 
  end subroutine physics_get_tend
 
- !==================================================================================================
- subroutine physics_get_tend_work(block, mesh, nCells, nEdges, nCellsSolve, nEdgesSolve, &
-                                 rk_step, dynamics_substep, &
-                                 config_pbl_scheme, config_convection_scheme, config_radt_lw_scheme, config_radt_sw_scheme, &
-                                 index_qv, index_qc, index_qr, index_qi, index_qs, index_ni, &
-                                 rublten, rvblten, mass_edge, rublten_Edge, tend_u, &
-                                 rucuten, rvcuten, rucuten_Edge, &
-                                 tend_th, tend_scalars, mass, rthblten, rqvblten, rqcblten, rqiblten, rqsblten, rniblten, &
-                                 rthcuten, rqvcuten, rqccuten, rqrcuten, rqicuten, rqscuten, &
-                                 rthratenlw, rthratensw, &
-                                 tend_u_phys, &
-                                 theta_m, scalars, tend_theta, tend_theta_euler, &
-                                 exchange_halo_group &
-                                )
-!==================================================================================================
+!=================================================================================================================
+ subroutine physics_get_tend_work( &
+                    block,mesh,nCells,nEdges,nCellsSolve,nEdgesSolve,rk_step,dynamics_substep, &
+                    pbl_scheme,convection_scheme,radt_lw_scheme,radt_sw_scheme,                &
+                    index_qv,index_qc,index_qr,index_qi,index_qs,                              &
+                    index_ni,                                                                  &
+                    mass,mass_edge,theta_m,scalars,                                            &
+                    rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,rqsblten,              &
+                    rniblten,                                                                  &
+                    rucuten,rvcuten,rthcuten,rqvcuten,rqccuten,rqrcuten,rqicuten,rqscuten,     &
+                    rthratenlw,rthratensw,rublten_Edge,rucuten_Edge,                           &
+                    tend_th,tend_theta,tend_scalars,tend_u,tend_u_phys,                        &
+                    exchange_halo_group)
+!=================================================================================================================
 
-    use mpas_atm_dimensions
- 
-    implicit none
+!input arguments:
+ procedure(halo_exchange_routine):: exchange_halo_group
 
-    type(block_type), intent(in) :: block
-    type(mpas_pool_type), intent(in) :: mesh
-    integer, intent(in) :: nCells, nEdges, nCellsSolve, nEdgesSolve
-    integer, intent(in) :: rk_step, dynamics_substep
-    character(len=StrKIND), intent(in) :: config_pbl_scheme
-    character(len=StrKIND), intent(in) :: config_convection_scheme
-    character(len=StrKIND), intent(in) :: config_radt_lw_scheme
-    character(len=StrKIND), intent(in) :: config_radt_sw_scheme
-    integer, intent(in) :: index_qv, index_qc, index_qr, index_qi, index_qs, index_ni
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rublten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rvblten
-    real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(in) :: mass_edge
-    real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(inout) :: rublten_Edge
-    real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(inout) :: tend_u
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rucuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rvcuten
-    real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(inout) :: rucuten_Edge
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout) :: tend_th
-    real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1), intent(inout) :: tend_scalars
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: mass
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rthblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqvblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqcblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqiblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqsblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rniblten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rthcuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqvcuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqccuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqrcuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqicuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rqscuten
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rthratenlw
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: rthratensw
-    real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(inout) :: tend_u_phys
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: theta_m
-    real (kind=RKIND), dimension(num_scalars,nVertLevels,nCells+1), intent(in) :: scalars
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout) :: tend_theta
-    real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(in) :: tend_theta_euler
-    procedure (halo_exchange_routine) :: exchange_halo_group
+ type(block_type),intent(in)    :: block
+ type(mpas_pool_type),intent(in):: mesh
 
-    integer :: i, k
-    real (kind=RKIND) :: coeff
+ character(len=StrKIND),intent(in):: pbl_scheme
+ character(len=StrKIND),intent(in):: convection_scheme
+ character(len=StrKIND),intent(in):: radt_lw_scheme
+ character(len=StrKIND),intent(in):: radt_sw_scheme
 
-    !add coupled tendencies due to PBL processes:
-    if (config_pbl_scheme .ne. 'off') then
-       if (rk_step == 1 .and. dynamics_substep == 1) then
-          call exchange_halo_group(block % domain, 'physics:blten')
-          call tend_toEdges(block,mesh,rublten,rvblten,rublten_Edge)
+ integer,intent(in):: nCells,nEdges,nCellsSolve,nEdgesSolve
+ integer,intent(in):: rk_step,dynamics_substep
+ integer,intent(in):: index_qv,index_qc,index_qr,index_qi,index_qs
+ integer,intent(in):: index_ni
 
-          !MGD for PV budget? should a similar line be in the cumulus section below?
-          tend_u_phys(1:nVertLevels,1:nEdges) = rublten_Edge(1:nVertLevels,1:nEdges)
-       end if
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: mass
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nEdges+1):: mass_edge
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: theta_m
+ real(kind=RKIND),intent(in),dimension(num_scalars,nVertLevels,nCells+1):: scalars
 
-       do i = 1, nEdgesSolve
-       do k  = 1, nVertLevels
-          tend_u(k,i)=tend_u(k,i)+rublten_Edge(k,i)*mass_edge(k,i)
-       enddo
-       enddo
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rublten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rvblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rthblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqvblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqcblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqiblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqsblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rniblten
 
-       do i = 1, nCellsSolve
-       do k = 1, nVertLevels
-          tend_th(k,i) = tend_th(k,i) + rthblten(k,i)*mass(k,i)
-          tend_scalars(index_qv,k,i) = tend_scalars(index_qv,k,i) + rqvblten(k,i)*mass(k,i)
-          tend_scalars(index_qc,k,i) = tend_scalars(index_qc,k,i) + rqcblten(k,i)*mass(k,i)
-          tend_scalars(index_qi,k,i) = tend_scalars(index_qi,k,i) + rqiblten(k,i)*mass(k,i)
-       enddo
-       enddo
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rucuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rvcuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rthcuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqvcuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqccuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqrcuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqicuten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqscuten
 
-       pbl_select: select case (trim(config_pbl_scheme))
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rthratenlw
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rthratensw
 
-          case("bl_mynn")
+!inout arguments:
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nEdges+1):: rublten_Edge
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nEdges+1):: rucuten_Edge
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nEdges+1):: tend_u
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nEdges+1):: tend_u_phys
 
-             do i = 1, nCellsSolve
-             do k = 1, nVertLevels
-                tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqsblten(k,i)*mass(k,i)
-                tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
-             enddo
-             enddo
-   
-          case default         
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nCells+1):: tend_th
+ real(kind=RKIND),intent(inout),dimension(nVertLevels,nCells+1):: tend_theta
 
-        end select pbl_select
-    endif
+ real(kind=RKIND),intent(inout),dimension(num_scalars,nVertLevels,nCells+1):: tend_scalars
 
-    !add coupled tendencies due to convection:
-    if (config_convection_scheme .ne. 'off') then
+!local variables:
+ integer:: i,k
+ real(kind=RKIND):: coeff
 
-       do i = 1, nCellsSolve
-       do k = 1, nVertLevels
-          tend_th(k,i) = tend_th(k,i) + rthcuten(k,i)*mass(k,i)
-          tend_scalars(index_qv,k,i) = tend_scalars(index_qv,k,i) + rqvcuten(k,i)*mass(k,i)
-          tend_scalars(index_qc,k,i) = tend_scalars(index_qc,k,i) + rqccuten(k,i)*mass(k,i)
-          tend_scalars(index_qi,k,i) = tend_scalars(index_qi,k,i) + rqicuten(k,i)*mass(k,i)
-       enddo
-       enddo
+!-----------------------------------------------------------------------------------------------------------------
 
-        convection_select: select case(config_convection_scheme)
+!add coupled tendencies due to PBL processes:
+ if(pbl_scheme .ne. 'off') then
+    if(rk_step == 1 .and. dynamics_substep == 1) then
+       call exchange_halo_group(block%domain,'physics:blten')
+       call tend_toEdges(block,mesh,rublten,rvblten,rublten_Edge)
 
-           case('cu_kain_fritsch')
-              do i = 1, nCellsSolve
-              do k = 1, nVertLevels
-                 tend_scalars(index_qr,k,i) = tend_scalars(index_qr,k,i) + rqrcuten(k,i)*mass(k,i)
-                 tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqscuten(k,i)*mass(k,i)
-              enddo
-              enddo
-    
-           case('cu_tiedtke','cu_ntiedtke')
-              if (rk_step == 1 .and. dynamics_substep == 1) then
-                 call exchange_halo_group(block % domain, 'physics:cuten')
-                 call tend_toEdges(block,mesh,rucuten,rvcuten,rucuten_Edge)
-                 
-                 tend_u_phys(1:nVertLevels,1:nEdges) = tend_u_phys(1:nVertLevels,1:nEdges) &
-                                                     + rucuten_Edge(1:nVertLevels,1:nEdges)
-              end if
-              do i = 1, nEdgesSolve
-              do k  = 1, nVertLevels
-                 tend_u(k,i)=tend_u(k,i)+rucuten_Edge(k,i)*mass_edge(k,i)
-              enddo
-              enddo
+       tend_u_phys(1:nVertLevels,1:nEdges) = rublten_Edge(1:nVertLevels,1:nEdges)
+    end if
 
-            case default
-        end select convection_select
-    endif
+    do i = 1, nEdgesSolve
+    do k = 1, nVertLevels
+       tend_u(k,i)=tend_u(k,i)+rublten_Edge(k,i)*mass_edge(k,i)
+    enddo
+    enddo
 
-    !add coupled tendencies due to longwave radiation:
-    if (config_radt_lw_scheme .ne. 'off') then
-       do i = 1, nCellsSolve
-       do k = 1, nVertLevels
-          tend_th(k,i) = tend_th(k,i) + rthratenlw(k,i)*mass(k,i)
-       enddo
-       enddo
-    endif
-    
-    !add coupled tendencies due to shortwave radiation:
-    if (config_radt_sw_scheme .ne. 'off') then
-       do i = 1, nCellsSolve
-       do k = 1, nVertLevels
-          tend_th(k,i) = tend_th(k,i) + rthratensw(k,i)*mass(k,i)
-       enddo
-       enddo
-    endif
-
-    !if non-hydrostatic core, convert the tendency for the potential temperature to a
-    !tendency for the modified potential temperature:
     do i = 1, nCellsSolve
     do k = 1, nVertLevels
-       coeff = (1. + R_v/R_d * scalars(index_qv,k,i))
-       tend_th(k,i) = coeff * tend_th(k,i) + R_v/R_d * theta_m(k,i) * tend_scalars(index_qv,k,i) / coeff
-       tend_theta(k,i) = tend_theta(k,i) + tend_th(k,i)
+       tend_th(k,i) = tend_th(k,i) + rthblten(k,i)*mass(k,i)
+       tend_scalars(index_qv,k,i) = tend_scalars(index_qv,k,i) + rqvblten(k,i)*mass(k,i)
+       tend_scalars(index_qc,k,i) = tend_scalars(index_qc,k,i) + rqcblten(k,i)*mass(k,i)
+       tend_scalars(index_qi,k,i) = tend_scalars(index_qi,k,i) + rqiblten(k,i)*mass(k,i)
     enddo
     enddo
+
+    pbl_select: select case(trim(pbl_scheme))
+       case('bl_mynn')
+          do i = 1, nCellsSolve
+          do k = 1, nVertLevels
+             tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqsblten(k,i)*mass(k,i)
+             tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
+          enddo
+          enddo
+
+       case default
+    end select pbl_select
+ endif
+
+
+!add coupled tendencies due to convection:
+ if(convection_scheme .ne. 'off') then
+    do i = 1, nCellsSolve
+    do k = 1, nVertLevels
+       tend_th(k,i) = tend_th(k,i) + rthcuten(k,i)*mass(k,i)
+       tend_scalars(index_qv,k,i) = tend_scalars(index_qv,k,i) + rqvcuten(k,i)*mass(k,i)
+       tend_scalars(index_qc,k,i) = tend_scalars(index_qc,k,i) + rqccuten(k,i)*mass(k,i)
+       tend_scalars(index_qi,k,i) = tend_scalars(index_qi,k,i) + rqicuten(k,i)*mass(k,i)
+    enddo
+    enddo
+
+    cu_select: select case(trim(convection_scheme))
+       case('cu_kain_fritsch')
+          do i = 1, nCellsSolve
+          do k = 1, nVertLevels
+             tend_scalars(index_qr,k,i) = tend_scalars(index_qr,k,i) + rqrcuten(k,i)*mass(k,i)
+             tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqscuten(k,i)*mass(k,i)
+          enddo
+          enddo
+
+       case('cu_tiedtke','cu_ntiedtke')
+          if(rk_step == 1 .and. dynamics_substep == 1) then
+             call exchange_halo_group(block%domain,'physics:cuten')
+             call tend_toEdges(block,mesh,rucuten,rvcuten,rucuten_Edge)
+
+             tend_u_phys(1:nVertLevels,1:nEdges) = tend_u_phys(1:nVertLevels,1:nEdges) &
+                                                 + rucuten_Edge(1:nVertLevels,1:nEdges)
+          endif
+          do i = 1, nEdgesSolve
+          do k = 1, nVertLevels
+             tend_u(k,i)=tend_u(k,i)+rucuten_Edge(k,i)*mass_edge(k,i)
+          enddo
+          enddo
+
+       case default
+    end select cu_select
+ endif
+
+
+!add coupled tendencies due to longwave radiation:
+ if(radt_lw_scheme .ne. 'off') then
+    do i = 1, nCellsSolve
+    do k = 1, nVertLevels
+       tend_th(k,i) = tend_th(k,i) + rthratenlw(k,i)*mass(k,i)
+    enddo
+    enddo
+ endif
+
+
+!add coupled tendencies due to shortwave radiation:
+ if(radt_sw_scheme .ne. 'off') then
+    do i = 1, nCellsSolve
+    do k = 1, nVertLevels
+       tend_th(k,i) = tend_th(k,i) + rthratensw(k,i)*mass(k,i)
+    enddo
+    enddo
+ endif
+
+
+!convert the tendency for the potential temperature to tendency for the modified potential temperature:
+ do i = 1, nCellsSolve
+ do k = 1, nVertLevels
+    coeff = (1. + R_v/R_d * scalars(index_qv,k,i))
+    tend_th(k,i) = coeff * tend_th(k,i) + R_v/R_d * theta_m(k,i) * tend_scalars(index_qv,k,i) / coeff
+    tend_theta(k,i) = tend_theta(k,i) + tend_th(k,i)
+ enddo
+ enddo
+
 
  end subroutine physics_get_tend_work
 
@@ -465,20 +433,19 @@
  integer,pointer:: nCells,nCellsSolve,nEdges
  integer,dimension(:,:),pointer:: cellsOnEdge
 
- real(kind=RKIND), dimension(:,:), pointer :: east, north, edgeNormalVectors
-
+ real(kind=RKIND),dimension(:,:),pointer:: east,north,edgeNormalVectors
  
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_dimension(mesh, 'nCells', nCells)
- call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
- call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
+ call mpas_pool_get_dimension(mesh,'nCells',nCells)
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+ call mpas_pool_get_dimension(mesh,'nEdges',nEdges)
 
- call mpas_pool_get_array(mesh, 'east', east)
- call mpas_pool_get_array(mesh, 'north', north)
- call mpas_pool_get_array(mesh, 'edgeNormalVectors', edgeNormalVectors)
+ call mpas_pool_get_array(mesh,'east',east)
+ call mpas_pool_get_array(mesh,'north',north)
+ call mpas_pool_get_array(mesh,'edgeNormalVectors',edgeNormalVectors)
 
- call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
+ call mpas_pool_get_array(mesh,'cellsOnEdge',cellsOnEdge)
 
  do iEdge = 1, nEdges
     cell1 = cellsOnEdge(1,iEdge)
@@ -487,14 +454,14 @@
     U_tend(:,iEdge) =  Ux_tend(:,cell1) * 0.5 * (edgeNormalVectors(1,iEdge) * east(1,cell1)   &
                                               +  edgeNormalVectors(2,iEdge) * east(2,cell1)   &
                                               +  edgeNormalVectors(3,iEdge) * east(3,cell1))  &
-                     + Uy_tend(:,cell1) * 0.5 * (edgeNormalVectors(1,iEdge) * north(1,cell1)   &
-                                              +  edgeNormalVectors(2,iEdge) * north(2,cell1)   &
-                                              +  edgeNormalVectors(3,iEdge) * north(3,cell1))  &
+                     + Uy_tend(:,cell1) * 0.5 * (edgeNormalVectors(1,iEdge) * north(1,cell1)  &
+                                              +  edgeNormalVectors(2,iEdge) * north(2,cell1)  &
+                                              +  edgeNormalVectors(3,iEdge) * north(3,cell1)) &
                      + Ux_tend(:,cell2) * 0.5 * (edgeNormalVectors(1,iEdge) * east(1,cell2)   &
                                               +  edgeNormalVectors(2,iEdge) * east(2,cell2)   &
                                               +  edgeNormalVectors(3,iEdge) * east(3,cell2))  &
-                     + Uy_tend(:,cell2) * 0.5 * (edgeNormalVectors(1,iEdge) * north(1,cell2)   &
-                                              +  edgeNormalVectors(2,iEdge) * north(2,cell2)   &
+                     + Uy_tend(:,cell2) * 0.5 * (edgeNormalVectors(1,iEdge) * north(1,cell2)  &
+                                              +  edgeNormalVectors(2,iEdge) * north(2,cell2)  &
                                               +  edgeNormalVectors(3,iEdge) * north(3,cell2))
  end do
  

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -37,6 +37,9 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2018-01-23.
 ! * removed the option bl_mynn_wrf390.
 !   Laura D. Fowler (laura@ucar.edu) / 2018-01-24.
+! * added tendencies of cloud liquid water number concentration, and water-friendly and ice-friendly aerosol
+!   number concentrations due to PBL processes.
+!   Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
 
 !
 ! Abstract interface for routine used to communicate halos of fields
@@ -82,12 +85,13 @@
 !local variables:
  character(len=StrKIND),pointer:: pbl_scheme,        &
                                   convection_scheme, &
+                                  microp_scheme,     &
                                   radt_lw_scheme,    &
                                   radt_sw_scheme
 
  integer:: i,iCell,k,n
- integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs,index_qg
- integer,pointer:: index_ni
+ integer,pointer:: index_qv,index_qc,index_qr,index_qi,index_qs
+ integer,pointer:: index_nc,index_ni,index_nifa,index_nwfa
  integer,pointer:: nCells,nCellsSolve,nEdges,nEdgesSolve
 
  real(kind=RKIND),dimension(:,:),pointer:: mass          ! time level 2 rho_zz
@@ -97,7 +101,7 @@
 
  real(kind=RKIND),dimension(:,:),pointer:: rthblten,rqvblten,rqcblten, &
                                            rqiblten,rqsblten,rublten,rvblten
- real(kind=RKIND),dimension(:,:),pointer:: rniblten
+ real(kind=RKIND),dimension(:,:),pointer:: rncblten,rniblten,rnifablten,rnwfablten
  real(kind=RKIND),dimension(:,:),pointer:: rthcuten,rqvcuten,rqccuten, &
                                            rqrcuten,rqicuten,rqscuten, &
                                            rucuten,rvcuten
@@ -117,8 +121,9 @@
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nEdgesSolve',nEdgesSolve)
 
- call mpas_pool_get_config(configs,'config_pbl_scheme'       ,pbl_scheme       )
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
+ call mpas_pool_get_config(configs,'config_microp_scheme'    ,microp_scheme    )
+ call mpas_pool_get_config(configs,'config_pbl_scheme'       ,pbl_scheme       )
  call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,radt_lw_scheme   )
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,radt_sw_scheme   )
 
@@ -133,8 +138,10 @@
  call mpas_pool_get_dimension(state,'index_qr',index_qr)
  call mpas_pool_get_dimension(state,'index_qi',index_qi)
  call mpas_pool_get_dimension(state,'index_qs',index_qs)
- call mpas_pool_get_dimension(state,'index_qg',index_qg)
+ call mpas_pool_get_dimension(state,'index_nc',index_nc)
  call mpas_pool_get_dimension(state,'index_ni',index_ni)
+ call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+ call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
 
  call mpas_pool_get_array(tend_physics,'rublten',rublten)
  call mpas_pool_get_array(tend_physics,'rvblten',rvblten)
@@ -143,7 +150,10 @@
  call mpas_pool_get_array(tend_physics,'rqcblten',rqcblten)
  call mpas_pool_get_array(tend_physics,'rqiblten',rqiblten)
  call mpas_pool_get_array(tend_physics,'rqsblten',rqsblten)
+ call mpas_pool_get_array(tend_physics,'rncblten',rncblten)
  call mpas_pool_get_array(tend_physics,'rniblten',rniblten)
+ call mpas_pool_get_array(tend_physics,'rnifablten',rnifablten)
+ call mpas_pool_get_array(tend_physics,'rnwfablten',rnwfablten)
  call mpas_pool_get_array(tend_physics,'rublten_Edge',rublten_Edge)
 
  call mpas_pool_get_array(tend_physics,'rucuten',rucuten)
@@ -191,17 +201,19 @@
  if(.not. associated(rqcblten)) allocate(rqcblten(0,0))
  if(.not. associated(rqiblten)) allocate(rqiblten(0,0))
  if(.not. associated(rqsblten)) allocate(rqsblten(0,0))
+ if(.not. associated(rncblten)) allocate(rncblten(0,0))
  if(.not. associated(rniblten)) allocate(rniblten(0,0))
+ if(.not. associated(rnifablten)) allocate(rnifablten(0,0))
+ if(.not. associated(rnwfablten)) allocate(rnwfablten(0,0))
 
  call physics_get_tend_work( &
               block,mesh,nCells,nEdges,nCellsSolve,nEdgesSolve,rk_step,dynamics_substep, &
-              pbl_scheme,convection_scheme,radt_lw_scheme,radt_sw_scheme,                &
+              pbl_scheme,convection_scheme,microp_scheme,radt_lw_scheme,radt_sw_scheme,  &
               index_qv,index_qc,index_qr,index_qi,index_qs,                              &
-              index_ni,                                                                  &
+              index_nc,index_ni,index_nifa,index_nwfa,                                   &
               mass,mass_edge,theta_m,scalars,                                            &
-              rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,                       &
-              rqsblten,                                                                  &
-              rniblten,                                                                  &
+              rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,rqsblten,              &
+              rncblten,rniblten,rnifablten,rnwfablten,                                   &
               rucuten,rvcuten,rthcuten,rqvcuten,rqccuten,rqrcuten,rqicuten,rqscuten,     &
               rthratenlw,rthratensw,rublten_Edge,rucuten_Edge,                           &
               tend_th,tend_rtheta_physics,tend_scalars,tend_ru_physics,tend_u_phys,      &
@@ -224,7 +236,10 @@
  if(size(rqcblten) == 0) deallocate(rqcblten)
  if(size(rqiblten) == 0) deallocate(rqiblten)
  if(size(rqsblten) == 0) deallocate(rqsblten)
+ if(size(rncblten) == 0) deallocate(rncblten)
  if(size(rniblten) == 0) deallocate(rniblten)
+ if(size(rnifablten) == 0) deallocate(rnifablten)
+ if(size(rnwfablten) == 0) deallocate(rnwfablten)
 
  deallocate(tend_th)
 
@@ -233,12 +248,12 @@
 !=================================================================================================================
  subroutine physics_get_tend_work( &
                     block,mesh,nCells,nEdges,nCellsSolve,nEdgesSolve,rk_step,dynamics_substep, &
-                    pbl_scheme,convection_scheme,radt_lw_scheme,radt_sw_scheme,                &
+                    pbl_scheme,convection_scheme,microp_scheme,radt_lw_scheme,radt_sw_scheme,  &
                     index_qv,index_qc,index_qr,index_qi,index_qs,                              &
-                    index_ni,                                                                  &
+                    index_nc,index_ni,index_nifa,index_nwfa,                                   &
                     mass,mass_edge,theta_m,scalars,                                            &
                     rublten,rvblten,rthblten,rqvblten,rqcblten,rqiblten,rqsblten,              &
-                    rniblten,                                                                  &
+                    rncblten,rniblten,rnifablten,rnwfablten,                                   &
                     rucuten,rvcuten,rthcuten,rqvcuten,rqccuten,rqrcuten,rqicuten,rqscuten,     &
                     rthratenlw,rthratensw,rublten_Edge,rucuten_Edge,                           &
                     tend_th,tend_theta,tend_scalars,tend_u,tend_u_phys,                        &
@@ -251,15 +266,16 @@
  type(block_type),intent(in)    :: block
  type(mpas_pool_type),intent(in):: mesh
 
- character(len=StrKIND),intent(in):: pbl_scheme
  character(len=StrKIND),intent(in):: convection_scheme
+ character(len=StrKIND),intent(in):: microp_scheme
+ character(len=StrKIND),intent(in):: pbl_scheme
  character(len=StrKIND),intent(in):: radt_lw_scheme
  character(len=StrKIND),intent(in):: radt_sw_scheme
 
  integer,intent(in):: nCells,nEdges,nCellsSolve,nEdgesSolve
  integer,intent(in):: rk_step,dynamics_substep
  integer,intent(in):: index_qv,index_qc,index_qr,index_qi,index_qs
- integer,intent(in):: index_ni
+ integer,intent(in):: index_nc,index_ni,index_nifa,index_nwfa
 
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: mass
  real(kind=RKIND),intent(in),dimension(nVertLevels,nEdges+1):: mass_edge
@@ -273,7 +289,10 @@
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqcblten
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqiblten
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rqsblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rncblten
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rniblten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rnifablten
+ real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rnwfablten
 
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rucuten
  real(kind=RKIND),intent(in),dimension(nVertLevels,nCells+1):: rvcuten
@@ -333,7 +352,10 @@
           do i = 1, nCellsSolve
           do k = 1, nVertLevels
              tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqsblten(k,i)*mass(k,i)
+             tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
              tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
+             tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
+             tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
           enddo
           enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -451,7 +451,10 @@
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rqsblten_p,       &!tendency of snow mixing ratio due to PBL processes.
-    rniblten_p         !tendency of cloud ice number concentration due to PBL processes.
+    rncblten_p,       &!tendency of cloud liquid water number concentration due to PBL processes.
+    rniblten_p,       &!tendency of cloud ice number concentration due to PBL processes.
+    rnifablten_p,     &!tendency of ice-friendly aerosol number concentration due to PBL processes.
+    rnwfablten_p       !tendency of water-friendly aerosol number concentration due to PBL processes.
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     pattern_spp_pbl    !stochastic forcing for the MYMM PBL and surface layer schemes.

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -599,6 +599,35 @@
     icedepth_p         !seaice thickness                                                                       [m]
 
 !=================================================================================================================
+!... variables and arrays related to the calculation of the optical properties of aerosols: to date, the only kind
+!    of aerosols included in MPAS are the "water-friendly" and "ice-friendly" aerosols used in the Thompson cloud
+!    cloud microphysics scheme.
+!=================================================================================================================
+
+ integer,parameter:: taer_aod550_opt = 2!input option for nwfa, nifa optical depth at 500 nm.
+ integer,parameter:: taer_angexp_opt = 3!input option for nwfa, nifa aerosol Angstrom exponent.
+ integer,parameter:: taer_ssa_opt    = 3!input option for nwfa, nifa aerosol single-scattering albedo.
+ integer,parameter:: taer_asy_opt    = 3!input option for nwfa, nifa aerosol asymmetry factor.
+
+ integer:: aer_opt                      !=[0,3]  : 0 for no aerosols, 3 for "water-" and "ice-friendly" aerosols.
+ integer,dimension(:,:),allocatable:: &
+                     taer_type_p        !=[1,2,3]: 1 for rural, 2 is urban and 3 is maritime in WRF. In MPAS,
+                                        !aer_type is initialized as a function of landmask (=1 over land; =2 over
+                                        !oceans.
+
+ real(kind=RKIND),parameter:: aer_aod550_val = 0.12
+ real(kind=RKIND),parameter:: aer_angexp_val = 1.3
+ real(kind=RKIND),parameter:: aer_ssa_val    = 0.85
+ real(kind=RKIND),parameter:: aer_asy_val    = 0.9
+
+ real(kind=RKIND),dimension(:,:),allocatable  ::   taod5502d_p!total aerosol optical depth at 550 nm           [-]
+ real(kind=RKIND),dimension(:,:,:),allocatable::   taod5503d_p!aerosol optical depth at 550 nm                 [-]
+
+ real(kind=RKIND),dimension(:,:,:,:),allocatable:: tauaer_p   !aerosol optical depth in RRTMG SW               [-]
+ real(kind=RKIND),dimension(:,:,:,:),allocatable:: ssaaer_p   !aerosol single scatterin albedo in RRTMG SW     [-]
+ real(kind=RKIND),dimension(:,:,:,:),allocatable:: asyaer_p   !aerosol asymmetry factor in RRTMG SW            [-]
+
+!=================================================================================================================
 !... variables and arrays related to parameterization of short-wave radiation:
 !=================================================================================================================
 

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -204,6 +204,7 @@
     qg_p               !graupel mixing ratio                                                [kg/kg]
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
+    nc_p,             &!cloud water droplet number concentration                             [#/kg]
     ni_p,             &!cloud ice crystal number concentration                               [#/kg]
     nr_p               !rain drop number concentration                                       [#/kg]
 
@@ -247,7 +248,7 @@
     f_qc,             &!parameter set to true to include the cloud water mixing ratio.
     f_qr,             &!parameter set to true to include the rain mixing ratio.
     f_qi,             &!parameter set to true to include the cloud ice mixing ratio.
-    f_qs,             &!parameter set to true to include the snow minxg ratio.
+    f_qs,             &!parameter set to true to include the snow mixing ratio.
     f_qg,             &!parameter set to true to include the graupel mixing ratio.
     f_qoz              !parameter set to true to include the ozone mixing ratio.
 
@@ -271,15 +272,11 @@
     graupelncv_p,     &!
     sr_p
 
-!... added for the thompson and wsm6 cloud microphysics:
  integer:: & 
     has_reqc,         &!
     has_reqi,         &!
     has_reqs
 
- real(kind=RKIND),dimension(:,:),allocatable:: &
-    ntc_p,            &!
-    muc_p              !
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rainprod_p,       &!
     evapprod_p,       &!
@@ -287,6 +284,17 @@
     reice_p,          &!
     resnow_p,         &!
     refl10cm_p         !
+
+!... for Thompson cloud microphysics parameterization, including aerosol-aware option:
+ real(kind=RKIND),dimension(:,:),allocatable:: &
+    ntc_p,            &!
+    muc_p,            &!
+    nifa2d_p,         &!surface emission of "ice-friendly" aerosols                                     [#/kg-1/s]
+    nwfa2d_p           !surface emission of "water-friendly" aerosols                                   [#/kg-1/s]
+
+ real(kind=RKIND),dimension(:,:,:),allocatable:: &
+    nifa_p,           &!"ice-friendly" number concentration                                                 [#/kg]
+    nwfa_p             !"water-friendly" number concentration                                               [#/kg]
 
 !=================================================================================================================
 !... variables and arrays related to parameterization of convection:

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -20,12 +20,14 @@ OBJS = \
 	module_cu_kfeta.o              \
 	module_mp_kessler.o            \
 	module_mp_thompson.o           \
+	module_mp_thompson_aerosols.o  \
 	module_mp_thompson_cldfra3.o   \
 	module_mp_wsm6.o               \
 	module_ra_cam.o                \
 	module_ra_cam_support.o        \
 	module_ra_rrtmg_lw.o           \
 	module_ra_rrtmg_sw.o           \
+	module_ra_rrtmg_sw_aerosols.o  \
 	module_ra_rrtmg_vinterp.o      \
 	module_sf_bem.o                \
 	module_sf_bep.o                \

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson.F
@@ -1,4 +1,7 @@
 !=================================================================================================================
+!reference: WRF-v4.1.4
+!Laura D. Fowler (laura@ucar.edu) / 2020-01-10.
+
 !module_mp_thompson was originally copied from./phys/module_mp_thompson.F from WRF version 3.8. Modifications made
 !to the original sourcecode are mostly confined to subroutine thompson_init.
 !Laura D. Fowler (laura@ucar.edu) / 2016-06-04.
@@ -11,7 +14,18 @@
 !     Laura D. Fowler (laura@ucar.edu) / 2016-10-29.
 !   * in subroutine mp_gt_driver, moved the initialization of variables Nt_c and mu_c
 !     before initialization of local mixing ratios and number concentrations.
-!     Laura D. Fowler (lara@ucar.edu) / 2916-12-30.
+!     Laura D. Fowler (laura@ucar.edu) / 2016-12-30.
+!   * in subroutine freezeH2O, modified the calculation of the variable prob, following
+!     Greg Thompson for the release of WRF version 3.9.0.
+!     Laura D. Fowler (laura@ucar.edu) / 2017-03-27.
+!   * in subroutine mp_gt_driver, added the variables vqr, vqi, vqs, and vqg to output the
+!     mean mass-weighted fall velocities of rain, cloud ice, snow, and graupel to compute
+!     diagnostics of lightning flash rates.
+!     Laura D. Fowler (laura@ucar.edu) / 2017-04-19.
+!   * in subroutine mp_gt_driver, changed the declarations of arrays vqg1d, vqid1,vqr1d, and vqs1d,
+!     from (kts:kte) to (kts:kte+1) to match the dimensions of arrays vtgk, vtik, vtsk, and vtrk, in
+!     subroutine mp_thompson.
+!     Laura D. Fowler (laura@ucar.edu) / 2017-08-31.
 
 
 !+---+-----------------------------------------------------------------+
@@ -52,7 +66,7 @@
 !.. Remaining values should probably be left alone.
 !..
 !..Author: Greg Thompson, NCAR-RAL, gthompsn@ucar.edu, 303-497-2805
-!..Last modified: 01 Aug 2016   Aerosol additions to v3.5.1 code 9/2013
+!..Last modified: 24 Jan 2018   Aerosol additions to v3.5.1 code 9/2013
 !..                 Cloud fraction additions 11/2014 part of pre-v3.7
 !+---+-----------------------------------------------------------------+
 !wrft:model_layer:physics
@@ -60,6 +74,7 @@
 !
       MODULE module_mp_thompson
 
+      use mpas_log
       use mpas_kind_types
       use mpas_atmphys_functions, only: gammp,wgamma,rslf,rsif
       use mpas_atmphys_utilities
@@ -90,6 +105,8 @@
 !.. scheme.  In 2-moment cloud water, Nt_c represents a maximum of
 !.. droplet concentration and nu_c is also variable depending on local
 !.. droplet number concentration.
+!.. MPAS: Nt_c is initialized to 100.E6 over oceans and 300.E6 over land as
+!   a function of landmask in subroutine init_thompson_clouddroplets_forMPAS.
 !     REAL, PARAMETER, PRIVATE:: Nt_c = 100.E6
       REAL, PARAMETER, PRIVATE:: Nt_c_max = 1999.E6
       REAL, PRIVATE:: Nt_c
@@ -97,10 +114,12 @@
 !..Declaration of constants for assumed CCN/IN aerosols when none in
 !.. the input data.  Look inside the init routine for modifications
 !.. due to surface land-sea points or vegetation characteristics.
-      REAL, PARAMETER, PRIVATE:: naIN0 = 1.5E6
-      REAL, PARAMETER, PRIVATE:: naIN1 = 0.5E6
-      REAL, PARAMETER, PRIVATE:: naCCN0 = 300.0E6
-      REAL, PARAMETER, PRIVATE:: naCCN1 = 50.0E6
+!.. MPAS: naIN0, naIN1, naCCN0, and naCCN1 are used in init_thompson_aerosols_forMPAS
+!.. for initialization of nwfa. and nifa.
+      REAL, PARAMETER, PUBLIC:: naIN0 = 1.5E6
+      REAL, PARAMETER, PUBLIC:: naIN1 = 0.5E6
+      REAL, PARAMETER, PUBLIC:: naCCN0 = 300.0E6
+      REAL, PARAMETER, PUBLIC:: naCCN1 = 50.0E6
 
 !..Generalized gamma distributions for rain, graupel and cloud ice.
 !.. N(D) = N_0 * D**mu * exp(-lamda*D);  mu=0 is exponential.
@@ -235,12 +254,12 @@
       INTEGER, PARAMETER, PRIVATE:: ntb_i1 = 55
       INTEGER, PARAMETER, PRIVATE:: ntb_t = 9
       INTEGER, PRIVATE:: nic1, nic2, nii2, nii3, nir2, nir3, nis2, nig2, nig3
-      INTEGER, PARAMETER, PRIVATE:: ntb_arc = 7
-      INTEGER, PARAMETER, PRIVATE:: ntb_arw = 9
-      INTEGER, PARAMETER, PRIVATE:: ntb_art = 7
-      INTEGER, PARAMETER, PRIVATE:: ntb_arr = 5
-      INTEGER, PARAMETER, PRIVATE:: ntb_ark = 4
-      INTEGER, PARAMETER, PRIVATE:: ntb_IN = 55
+      INTEGER, PARAMETER, PUBLIC:: ntb_arc = 7
+      INTEGER, PARAMETER, PUBLIC:: ntb_arw = 9
+      INTEGER, PARAMETER, PUBLIC:: ntb_art = 7
+      INTEGER, PARAMETER, PUBLIC:: ntb_arr = 5
+      INTEGER, PARAMETER, PUBLIC:: ntb_ark = 4
+      INTEGER, PARAMETER, PUBLIC:: ntb_IN = 55
       INTEGER, PRIVATE:: niIN2
 
       DOUBLE PRECISION, DIMENSION(nbins+1):: xDx
@@ -979,17 +998,18 @@
 !+---+-----------------------------------------------------------------+
 !..This is a wrapper routine designed to transfer values from 3D to 1D.
 !+---+-----------------------------------------------------------------+
-      SUBROUTINE mp_gt_driver(qv, qc, qr, qi, qs, qg, ni, nr, nc,       &
-                              nwfa, nifa, nwfa2d,                       &
-                              th, pii, p, w, dz, dt_in, itimestep,      &
-                              RAINNC, RAINNCV, &
-                              SNOWNC, SNOWNCV, &
-                              GRAUPELNC, GRAUPELNCV, SR, &
+      SUBROUTINE mp_gt_driver(qv, qc, qr, qi, qs, qg, ni, nr, nc,     &
+                              nwfa, nifa, nwfa2d, nifa2d,             &
+                              th, pii, p, w, dz, dt_in, itimestep,    &
+                              RAINNC, RAINNCV,                        &
+                              SNOWNC, SNOWNCV,                        &
+                              GRAUPELNC, GRAUPELNCV, SR,              &
+                              rainprod, evapprod,                     &
                               refl_10cm, diagflag, do_radar_ref,      &
                               re_cloud, re_ice, re_snow,              &
                               has_reqc, has_reqi, has_reqs,           &
 #if defined(mpas)
-                              ntc,muc,rainprod,evapprod, &
+                              ntc,muc,                                &
 #endif
                               ids,ide, jds,jde, kds,kde, &             ! domain dims
                               ims,ime, jms,jme, kms,kme, &             ! memory dims
@@ -1005,7 +1025,7 @@
                           qv, qc, qr, qi, qs, qg, ni, nr, th
       REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT):: &
                           nc, nwfa, nifa
-      REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(IN):: nwfa2d
+      REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(IN):: nwfa2d, nifa2d
       REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: &
                           re_cloud, re_ice, re_snow
       INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
@@ -1015,11 +1035,11 @@
                           RAINNC, RAINNCV, SR
       REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(INOUT)::      &
                           SNOWNC, SNOWNCV, GRAUPELNC, GRAUPELNCV
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT):: &
+                          rainprod,evapprod
 #if defined(mpas)
       REAL, DIMENSION(ims:ime, jms:jme), INTENT(IN):: &
                           ntc,muc
-      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: &
-                          rainprod,evapprod
       REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT), OPTIONAL:: &
                           refl_10cm
 #else
@@ -1035,10 +1055,7 @@
                           nr1d, nc1d, nwfa1d, nifa1d,                   &
                           t1d, p1d, w1d, dz1d, rho, dBZ
       REAL, DIMENSION(kts:kte):: re_qc1d, re_qi1d, re_qs1d
-#if defined(mpas)
-      REAL, DIMENSION(kts:kte):: &
-                          rainprod1d, evapprod1d
-#endif
+      REAL, DIMENSION(kts:kte):: rainprod1d, evapprod1d
       REAL, DIMENSION(its:ite, jts:jte):: pcp_ra, pcp_sn, pcp_gr, pcp_ic
       REAL:: dt, pptrain, pptsnow, pptgraul, pptice
       REAL:: qc_max, qr_max, qs_max, qi_max, qg_max, ni_max, nr_max
@@ -1050,7 +1067,7 @@
       INTEGER:: i_start, j_start, i_end, j_end
       LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
       INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
-      CHARACTER*256:: mp_debug
+!     CHARACTER*256:: mp_debug
 
 !+---+
 
@@ -1098,9 +1115,9 @@
       kmax_qg = 0
       kmax_ni = 0
       kmax_nr = 0
-      do i = 1, 256
-         mp_debug(i:i) = char(0)
-      enddo
+!     do i = 1, 256
+!        mp_debug(i:i) = char(0)
+!     enddo
 
 !     if (.NOT. is_aerosol_aware .AND. PRESENT(nc) .AND. PRESENT(nwfa)  &
 !               .AND. PRESENT(nifa) .AND. PRESENT(nwfa2d)) then
@@ -1128,6 +1145,11 @@
          Nt_c = ntc(i,j)
          mu_c = muc(i,j)
 #endif
+         do k = kts,kte
+            rainprod1d(k) = 0.
+            evapprod1d(k) = 0.
+         enddo
+
          do k = kts, kte
             t1d(k) = th(i,k,j)*pii(i,k,j)
             p1d(k) = p(i,k,j)
@@ -1141,6 +1163,7 @@
             qg1d(k) = qg(i,k,j)
             ni1d(k) = ni(i,k,j)
             nr1d(k) = nr(i,k,j)
+            rho(k) = 0.622*p1d(k)/(R*t1d(k)*(qv1d(k)+0.622))
          enddo
          if (is_aerosol_aware) then
             do k = kts, kte
@@ -1151,7 +1174,6 @@
             nwfa1 = nwfa2d(i,j)
          else
             do k = kts, kte
-               rho(k) = 0.622*p1d(k)/(R*t1d(k)*(qv1d(k)+0.622))
                nc1d(k) = Nt_c/rho(k)
                nwfa1d(k) = 11.1E6/rho(k)
                nifa1d(k) = naIN1*0.01/rho(k)
@@ -1161,10 +1183,8 @@
 
          call mp_thompson(qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d,     &
                       nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dz1d,  &
-                      pptrain, pptsnow, pptgraul, pptice, &
-#if defined(mpas)
-                      rainprod1d, evapprod1d, &
-#endif
+                      pptrain, pptsnow, pptgraul, pptice,               &
+                      rainprod1d, evapprod1d,                           &
                       kts, kte, dt, i, j)
 
          pcp_ra(i,j) = pptrain
@@ -1191,6 +1211,7 @@
          if (is_aerosol_aware) then
 !-GT        nwfa1d(kts) = nwfa1
             nwfa1d(kts) = nwfa1d(kts) + nwfa2d(i,j)*dt_in
+            nifa1d(kts) = nifa1d(kts) + nifa2d(i,j)*dt_in
 
             do k = kts, kte
                nc(i,k,j) = nc1d(k)
@@ -1219,8 +1240,10 @@
              kmax_qc = k
              qc_max = qc1d(k)
             elseif (qc1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qc ', qc1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qc $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qc1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative qc ', qc1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (qr1d(k) .gt. qr_max) then
@@ -1229,8 +1252,10 @@
              kmax_qr = k
              qr_max = qr1d(k)
             elseif (qr1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qr ', qr1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qr $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qr1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative qr ', qr1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (nr1d(k) .gt. nr_max) then
@@ -1239,8 +1264,10 @@
              kmax_nr = k
              nr_max = nr1d(k)
             elseif (nr1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative nr ', nr1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative nr $r at i,j,k = $i $i $i ', &
+                       realArgs=(/nr1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative nr ', nr1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (qs1d(k) .gt. qs_max) then
@@ -1249,8 +1276,10 @@
              kmax_qs = k
              qs_max = qs1d(k)
             elseif (qs1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qs ', qs1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qs $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qs1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative qs ', qs1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (qi1d(k) .gt. qi_max) then
@@ -1259,8 +1288,10 @@
              kmax_qi = k
              qi_max = qi1d(k)
             elseif (qi1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qi ', qi1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qi $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qi1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative qi ', qi1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (qg1d(k) .gt. qg_max) then
@@ -1269,8 +1300,10 @@
              kmax_qg = k
              qg_max = qg1d(k)
             elseif (qg1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qg ', qg1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qg $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qg1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative qg ', qg1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (ni1d(k) .gt. ni_max) then
@@ -1279,21 +1312,31 @@
              kmax_ni = k
              ni_max = ni1d(k)
             elseif (ni1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative ni ', ni1d(k),        &
-                        ' at i,j,k=', i,j,k
+             call mpas_log_write('--- WARNING, negative qni $r at i,j,k = $i $i $i ', &
+                       realArgs=(/ni1d(k)/),intArgs=(/i,j,k/))
+!            write(mp_debug,*) 'WARNING, negative ni ', ni1d(k),        &
+!                       ' at i,j,k=', i,j,k
 !            CALL wrf_debug(150, mp_debug)
             endif
             if (qv1d(k) .lt. 0.0) then
-             write(mp_debug,*) 'WARNING, negative qv ', qv1d(k),        &
-                        ' at i,j,k=', i,j,k
-!            CALL wrf_debug(150, mp_debug)
+             call mpas_log_write('--- WARNING, negative qv $r at i,j,k = $i $i $i ', &
+                       realArgs=(/qv1d(k)/),intArgs=(/i,j,k/))
              if (k.lt.kte-2 .and. k.gt.kts+1) then
-                write(mp_debug,*) '   below and above are: ', qv(i,k-1,j), qv(i,k+1,j)
-!               CALL wrf_debug(150, mp_debug)
+                call mpas_log_write('-- below and above are: $r $r',realArgs=(/qv(i,k-1,j), qv(i,k+1,j)/))
                 qv(i,k,j) = MAX(1.E-7, 0.5*(qv(i,k-1,j) + qv(i,k+1,j)))
              else
                 qv(i,k,j) = 1.E-7
              endif
+!            write(mp_debug,*) 'WARNING, negative qv ', qv1d(k),        &
+!                       ' at i,j,k=', i,j,k
+!            CALL wrf_debug(150, mp_debug)
+!            if (k.lt.kte-2 .and. k.gt.kts+1) then
+!               write(mp_debug,*) '   below and above are: ', qv(i,k-1,j), qv(i,k+1,j)
+!               CALL wrf_debug(150, mp_debug)
+!               qv(i,k,j) = MAX(1.E-7, 0.5*(qv(i,k-1,j) + qv(i,k+1,j)))
+!            else
+!               qv(i,k,j) = 1.E-7
+!            endif
             endif
          enddo
 
@@ -1326,20 +1369,20 @@
       enddo j_loop
 
 ! DEBUG - GT
-      write(mp_debug,'(a,7(a,e13.6,1x,a,i3,a,i3,a,i3,a,1x))') 'MP-GT:', &
-         'qc: ', qc_max, '(', imax_qc, ',', jmax_qc, ',', kmax_qc, ')', &
-         'qr: ', qr_max, '(', imax_qr, ',', jmax_qr, ',', kmax_qr, ')', &
-         'qi: ', qi_max, '(', imax_qi, ',', jmax_qi, ',', kmax_qi, ')', &
-         'qs: ', qs_max, '(', imax_qs, ',', jmax_qs, ',', kmax_qs, ')', &
-         'qg: ', qg_max, '(', imax_qg, ',', jmax_qg, ',', kmax_qg, ')', &
-         'ni: ', ni_max, '(', imax_ni, ',', jmax_ni, ',', kmax_ni, ')', &
-         'nr: ', nr_max, '(', imax_nr, ',', jmax_nr, ',', kmax_nr, ')'
+!     write(mp_debug,'(a,7(a,e13.6,1x,a,i3,a,i3,a,i3,a,1x))') 'MP-GT:', &
+!        'qc: ', qc_max, '(', imax_qc, ',', jmax_qc, ',', kmax_qc, ')', &
+!        'qr: ', qr_max, '(', imax_qr, ',', jmax_qr, ',', kmax_qr, ')', &
+!        'qi: ', qi_max, '(', imax_qi, ',', jmax_qi, ',', kmax_qi, ')', &
+!        'qs: ', qs_max, '(', imax_qs, ',', jmax_qs, ',', kmax_qs, ')', &
+!        'qg: ', qg_max, '(', imax_qg, ',', jmax_qg, ',', kmax_qg, ')', &
+!        'ni: ', ni_max, '(', imax_ni, ',', jmax_ni, ',', kmax_ni, ')', &
+!        'nr: ', nr_max, '(', imax_nr, ',', jmax_nr, ',', kmax_nr, ')'
 !     CALL wrf_debug(150, mp_debug)
 ! END DEBUG - GT
 
-      do i = 1, 256
-         mp_debug(i:i) = char(0)
-      enddo
+!     do i = 1, 256
+!        mp_debug(i:i) = char(0)
+!     enddo
 
       END SUBROUTINE mp_gt_driver
 
@@ -1354,12 +1397,10 @@
 !.. Thompson et al. (2004, 2008).
 !+---+-----------------------------------------------------------------+
 !
-      subroutine mp_thompson (qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d, &
+      subroutine mp_thompson (qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d,   &
                           nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dzq, &
-                          pptrain, pptsnow, pptgraul, pptice, &
-#if defined(mpas)
-                          rainprod, evapprod, &
-#endif
+                          pptrain, pptsnow, pptgraul, pptice,             &
+                          rainprod, evapprod,                             &
                           kts, kte, dt, ii, jj)
 
       implicit none
@@ -1372,10 +1413,8 @@
       REAL, DIMENSION(kts:kte), INTENT(IN):: p1d, w1d, dzq
       REAL, INTENT(INOUT):: pptrain, pptsnow, pptgraul, pptice
       REAL, INTENT(IN):: dt
-#if defined(mpas)
       REAL, DIMENSION(kts:kte), INTENT(INOUT):: &
                           rainprod, evapprod
-#endif
 
 !..Local variables
       REAL, DIMENSION(kts:kte):: tten, qvten, qcten, qiten, &
@@ -1449,7 +1488,7 @@
       REAL:: r_frac, g_frac
       REAL:: Ef_rw, Ef_sw, Ef_gw, Ef_rr
       REAL:: Ef_ra, Ef_sa, Ef_ga
-      REAL:: dtsave, odts, odt, odzq, hgt_agl
+      REAL:: dtsave, odts, odt, odzq, hgt_agl, SR
       REAL:: xslw1, ygra1, zans1, eva_factor
       INTEGER:: i, k, k2, n, nn, nstep, k_0, kbot, IT, iexfrq
       INTEGER, DIMENSION(5):: ksed1
@@ -1463,8 +1502,13 @@
       CHARACTER*256:: mp_debug
       INTEGER:: nu_c
 
+!     modifications proposed by Ted Mansell for MPAS.
+!     Laura D. Fowler (laura@ucar.edu) / 2017-03-27.
+!     real, parameter:: mvd_r_breakup = 1.e-3
+!...  end modifications.
+      LOGICAL, DIMENSION(kts:kte):: L_nifa,L_nwfa
+      REAL:: tem
 !+---+
-
 
       debug_flag = .false.
 !     if (ii.eq.901 .and. jj.eq.379) debug_flag = .true.
@@ -1576,12 +1620,19 @@
          pnd_scd(k) = 0.
          pnd_gcd(k) = 0.
       enddo
-#if defined(mpas)
       do k = kts, kte
          rainprod(k) = 0.
          evapprod(k) = 0.
       enddo
-#endif
+!.. initialize the logicals L_nifa and L_nwfa used to detect instances of the cloud
+!.. ice and cloud liquid water mixing ratios being greater than R1 but their number
+!.. concentration being less than 2. and R2:
+      if(is_aerosol_aware) then
+         do k = kts, kte
+            L_nifa(k) = .false.
+            L_nwfa(k) = .false.
+         enddo
+      endif
 
 !..Bug fix (2016Jun15), prevent use of uninitialized value(s) of snow moments.
       do k = kts, kte
@@ -1611,8 +1662,10 @@
          if (qc1d(k) .gt. R1) then
             no_micro = .false.
             rc(k) = qc1d(k)*rho(k)
-            nc(k) = MAX(2., nc1d(k)*rho(k))
+            nc(k) = MAX(2., MIN(nc1d(k)*rho(k), Nt_c_max))
             L_qc(k) = .true.
+!.. set L_nwfa to true when the cloud liquid water number concentration is less than 2.:
+            if(is_aerosol_aware .and. nc(k) .le. 2.) L_nwfa(k) = .true.
             nu_c = MIN(15, NINT(1000.E6/nc(k)) + 2)
             lamc = (nc(k)*am_r*ccg(2,nu_c)*ocg1(nu_c)/rc(k))**obmr
             xDc = (bm_r + nu_c + 1.) / lamc
@@ -1636,17 +1689,20 @@
             no_micro = .false.
             ri(k) = qi1d(k)*rho(k)
             ni(k) = MAX(R2, ni1d(k)*rho(k))
-            if (ni(k).le. R2) then
-               lami = cie(2)/25.E-6
-               ni(k) = MIN(499.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
-            endif
             L_qi(k) = .true.
+!.. set L_nifa to true when the cloud ice number concentration is less than R2:
+            if(is_aerosol_aware .and. ni(k) .le. R2) L_nifa(k) = .true.
+            if (ni(k).le. R2) then
+               lami = cie(2)/5.E-6
+               ni(k) = MIN(9999.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+            endif
+!           L_qi(k) = .true.
             lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
             ilami = 1./lami
             xDi = (bm_i + mu_i + 1.) * ilami
             if (xDi.lt. 5.E-6) then
              lami = cie(2)/5.E-6
-             ni(k) = MIN(499.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+             ni(k) = MIN(9999.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
             elseif (xDi.gt. 300.E-6) then
              lami = cie(2)/300.E-6
              ni(k) = cig(1)*oig2*ri(k)/am_i*lami**bm_i
@@ -1925,7 +1981,7 @@
           tau  = 3.72/(rc(k)*taud)
           prr_wau(k) = zeta/tau
           prr_wau(k) = MIN(DBLE(rc(k)*odts), prr_wau(k))
-          pnr_wau(k) = prr_wau(k) / (am_r*nu_c*D0r*D0r*D0r)              ! RAIN2M
+          pnr_wau(k) = prr_wau(k) / (am_r*nu_c*200.*D0r*D0r*D0r)         ! RAIN2M
           pnc_wau(k) = MIN(DBLE(nc(k)*odts), prr_wau(k)                 &
                      / (am_r*mvd_c(k)*mvd_c(k)*mvd_c(k)))                   ! Qc2M
          endif
@@ -1964,8 +2020,12 @@
 !..Compute all frozen hydrometeor species' process terms.
 !+---+-----------------------------------------------------------------+
       if (.not. iiwarm) then
+      !..vts_boost is the factor applied to snow terminal
+      !..fallspeed due to riming of snow
       do k = kts, kte
-         vts_boost(k) = 1.5
+         vts_boost(k) = 1.0
+         xDs = 0.0
+         if (L_qs(k)) xDs = smoc(k) / smob(k)
 
 !..Temperature lookup table indexes.
          tempc = temp(k) - 273.15
@@ -2117,13 +2177,12 @@
 
 !..Snow collecting cloud water.  In CE, assume Dc<<Ds and vtc=~0.
          if (L_qc(k) .and. mvd_c(k).gt. D0c) then
-          xDs = 0.0
-          if (L_qs(k)) xDs = smoc(k) / smob(k)
           if (xDs .gt. D0s) then
            idx = 1 + INT(nbs*DLOG(xDs/Ds(1))/DLOG(Ds(nbs)/Ds(1)))
            idx = MIN(idx, nbs)
            Ef_sw = t_Efsw(idx, INT(mvd_c(k)*1.E6))
            prs_scw(k) = rhof(k)*t1_qs_qc*Ef_sw*rc(k)*smoe(k)
+           prs_scw(k) = MIN(DBLE(rc(k)*odts), prs_scw(k))
            pnc_scw(k) = rhof(k)*t1_qs_qc*Ef_sw*nc(k)*smoe(k)                ! Qc2M
            pnc_scw(k) = MIN(DBLE(nc(k)*odts), pnc_scw(k))
           endif
@@ -2152,7 +2211,6 @@
 
 !..Snow and graupel collecting aerosols, wet scavenging.
          if (rs(k) .gt. r_s(1)) then
-          xDs = smoc(k) / smob(k)
           Ef_sa = Eff_aero(xDs,0.04E-6,visco(k),rho(k),temp(k),'s')
           pna_sca(k) = rhof(k)*t1_qs_qc*Ef_sa*nwfa(k)*smoe(k)
           pna_sca(k) = MIN(DBLE(nwfa(k)*odts), pna_sca(k))
@@ -2199,6 +2257,7 @@
                          + tnr_racs2(idx_s,idx_t,idx_r1,idx_r)          &
                          + tnr_sacr1(idx_s,idx_t,idx_r1,idx_r)          &
                          + tnr_sacr2(idx_s,idx_t,idx_r1,idx_r)
+            pnr_rcs(k) = MIN(DBLE(nr(k)*odts), pnr_rcs(k))
            else
             prs_rcs(k) = -tcs_racs1(idx_s,idx_t,idx_r1,idx_r)           &
                          - tms_sacr1(idx_s,idx_t,idx_r1,idx_r)          &
@@ -2206,10 +2265,7 @@
                          + tcr_sacr2(idx_s,idx_t,idx_r1,idx_r)
             prs_rcs(k) = MAX(DBLE(-rs(k)*odts), prs_rcs(k))
             prr_rcs(k) = -prs_rcs(k)
-            pnr_rcs(k) = tnr_racs2(idx_s,idx_t,idx_r1,idx_r)            &   ! RAIN2M
-                         + tnr_sacr2(idx_s,idx_t,idx_r1,idx_r)
            endif
-           pnr_rcs(k) = MIN(DBLE(nr(k)*odts), pnr_rcs(k))
           endif
 
 !..Rain collecting graupel.  Cannot assume Wisner (1972) approximation
@@ -2229,7 +2285,15 @@
             prr_rcg(k) = MIN(DBLE(rg(k)*odts), prr_rcg(k))
             prg_rcg(k) = -prr_rcg(k)
 !..Put in explicit drop break-up due to collisions.
-            pnr_rcg(k) = -5.*tnr_gacr(idx_g1,idx_g,idx_r1,idx_r)         ! RAIN2M
+!...  modifications to drop break-up due to collision of rain collecting graupel, ad-hoc
+!     change proposed by Ted Mansell for MPAS: basically reduces rain breakup in graupel
+!     collisions when the mean volume diameter of rain is less than 1mm.
+!     Laura D. Fowler (laura@ucar.edu) / 2017-03-27.
+!           if ( mvd_r(k) > mvd_r_breakup ) then
+              pnr_rcg(k) = -5.0*tnr_gacr(idx_g1,idx_g,idx_r1,idx_r)       ! RAIN2M
+!           else
+!             pnr_rcg(k) = -3.0*tnr_gacr(idx_g1,idx_g,idx_r1,idx_r)       ! RAIN2M
+!           endif
            endif
           endif
          endif
@@ -2287,8 +2351,7 @@
            pnr_rfz(k) = MIN(DBLE(nr(k)*odts), pnr_rfz(k))
           elseif (rr(k).gt. R1 .and. temp(k).lt.HGFR) then
            pri_rfz(k) = rr(k)*odts
-           pnr_rfz(k) = nr(k)*odts                                         ! RAIN2M
-           pni_rfz(k) = pnr_rfz(k)
+           pni_rfz(k) = nr(k)*odts                                         ! RAIN2M
           endif
 
           if (rc(k).gt. r_c(1)) then
@@ -2319,7 +2382,7 @@
 
 !..Freezing of aqueous aerosols based on Koop et al (2001, Nature)
           xni = smo0(k)+ni(k) + (pni_rfz(k)+pni_wfz(k)+pni_inu(k))*dtsave
-          if (is_aerosol_aware .AND. homogIce .AND. (xni.le.500.E3)     &
+          if (is_aerosol_aware .AND. homogIce .AND. (xni.le.999.E3)     &
      &                .AND.(temp(k).lt.238).AND.(ssati(k).ge.0.4) ) then
             xnc = iceKoop(temp(k),qv(k),qvs(k),nwfa(k), dtsave)
             pni_iha(k) = xnc*odts
@@ -2442,7 +2505,7 @@
                          prs_sde(k).gt.eps) then
            r_frac = MIN(30.0D0, prs_scw(k)/prs_sde(k))
            g_frac = MIN(0.95, 0.15 + (r_frac-2.)*.028)
-           vts_boost(k) = MIN(1.5, 1.1 + (r_frac-2.)*.016)
+           vts_boost(k) = MIN(1.5, 1.1 + (r_frac-2.)*.014)
            prg_scw(k) = g_frac*prs_scw(k)
            prs_scw(k) = (1. - g_frac)*prs_scw(k)
           endif
@@ -2454,12 +2517,13 @@
           if (L_qs(k)) then
            prr_sml(k) = (tempc*tcond(k)-lvap0*diffu(k)*delQvs(k))       &
                       * (t1_qs_me*smo1(k) + t2_qs_me*rhof2(k)*vsc2(k)*smof(k))
-           prr_sml(k) = prr_sml(k) + 4218.*olfus*tempc &
-                                   * (prr_rcs(k)+prs_scw(k))
+           if (prr_sml(k) .gt. 0.) then
+              prr_sml(k) = prr_sml(k) + 4218.*olfus*tempc               &
+                                      * (prr_rcs(k)+prs_scw(k))
+           endif
            prr_sml(k) = MIN(DBLE(rs(k)*odts), MAX(0.D0, prr_sml(k)))
            pnr_sml(k) = smo0(k)/rs(k)*prr_sml(k) * 10.0**(-0.25*tempc)      ! RAIN2M
            pnr_sml(k) = MIN(DBLE(smo0(k)*odts), pnr_sml(k))
-!          if (tempc.gt.3.5 .or. rs(k).lt.0.005E-3) pnr_sml(k)=0.0
 
            if (ssati(k).lt. 0.) then
             prs_sde(k) = C_cube*t1_subl*diffu(k)*ssati(k)*rvs &
@@ -2478,7 +2542,6 @@
            prr_gml(k) = MIN(DBLE(rg(k)*odts), MAX(0.D0, prr_gml(k)))
            pnr_gml(k) = N0_g(k)*cgg(2)*ilamg(k)**cge(2) / rg(k)         &   ! RAIN2M
                       * prr_gml(k) * 10.0**(-0.5*tempc)
-!          if (tempc.gt.7.5 .or. rg(k).lt.0.005E-3) pnr_gml(k)=0.0
 
            if (ssati(k).lt. 0.) then
             prg_gde(k) = C_cube*t1_subl*diffu(k)*ssati(k)*rvs &
@@ -2514,7 +2577,7 @@
 !.. supersat again.
          sump = pri_inu(k) + pri_ide(k) + prs_ide(k) &
               + prs_sde(k) + prg_gde(k) + pri_iha(k)
-         rate_max = (qv(k)-qvsi(k))*odts*0.999
+         rate_max = (qv(k)-qvsi(k))*rho(k)*odts*0.999
          if ( (sump.gt. eps .and. sump.gt. rate_max) .or. &
               (sump.lt. -eps .and. sump.lt. rate_max) ) then
           ratio = rate_max/sump
@@ -2687,7 +2750,7 @@
            xDi = (bm_i + mu_i + 1.) * ilami
            if (xDi.lt. 5.E-6) then
             lami = cie(2)/5.E-6
-            xni = MIN(499.D3, cig(1)*oig2*xri/am_i*lami**bm_i)
+            xni = MIN(9999.D3, cig(1)*oig2*xri/am_i*lami**bm_i)
             niten(k) = (xni-ni1d(k)*rho(k))*odts*orho
            elseif (xDi.gt. 300.E-6) then
             lami = cie(2)/300.E-6
@@ -2698,8 +2761,8 @@
           niten(k) = -ni1d(k)*odts
          endif
          xni=MAX(0.,(ni1d(k) + niten(k)*dtsave)*rho(k))
-         if (xni.gt.499.E3) &
-                niten(k) = (499.E3-ni1d(k)*rho(k))*odts*orho
+         if (xni.gt.9999.E3) &
+                niten(k) = (9999.E3-ni1d(k)*rho(k))*odts*orho
 
 !..Rain tendency
          qrten(k) = qrten(k) + (prr_wau(k) + prr_rcw(k) &
@@ -2711,7 +2774,7 @@
 !..Rain number tendency
          nrten(k) = nrten(k) + (pnr_wau(k) + pnr_sml(k) + pnr_gml(k)    &
                       - (pnr_rfz(k) + pnr_rcr(k) + pnr_rcg(k)           &
-                      + pnr_rcs(k) + pnr_rci(k)) )                      &
+                      + pnr_rcs(k) + pnr_rci(k) + pni_rfz(k)) )         &
                       * orho
 
 !..Rain mass/number balance; keep median volume diameter between
@@ -2799,10 +2862,12 @@
          lvt2(k)=lvap(k)*lvap(k)*ocp(k)*oRv*otemp*otemp
 
          nwfa(k) = MAX(11.1E6, (nwfa1d(k) + nwfaten(k)*DT)*rho(k))
+      enddo
 
+      do k = kts, kte
          if ((qc1d(k) + qcten(k)*DT) .gt. R1) then
             rc(k) = (qc1d(k) + qcten(k)*DT)*rho(k)
-            nc(k) = MAX(2., (nc1d(k) + ncten(k)*DT)*rho(k))
+            nc(k) = MAX(2., MIN((nc1d(k)+ncten(k)*DT)*rho(k), Nt_c_max))
             if (.NOT. is_aerosol_aware) nc(k) = Nt_c
             L_qc(k) = .true.
          else
@@ -2864,6 +2929,12 @@
 !.. intercepts/slopes of graupel and rain.
 !+---+-----------------------------------------------------------------+
       if (.not. iiwarm) then
+      do k = kts, kte
+         smo2(k) = 0.
+         smob(k) = 0.
+         smoc(k) = 0.
+         smod(k) = 0.
+      enddo
       do k = kts, kte
          if (.not. L_qs(k)) CYCLE
          tc0 = MIN(-0.1, temp(k)-273.15)
@@ -3031,9 +3102,10 @@
            !           -tpc_wev(idx_d, idx_c, idx_n)*orho*odt)
             prw_vcd(k) = MAX(DBLE(-rc(k)*0.99*orho*odt), prw_vcd(k))
             pnc_wcd(k) = MAX(DBLE(-nc(k)*0.99*orho*odt),                &
-                             DBLE(-tnc_wev(idx_d, idx_c, idx_n)*orho*odt))
+                       -tnc_wev(idx_d, idx_c, idx_n)*orho*odt)
 
            endif
+           if(is_aerosol_aware .and. L_nwfa(k)) L_nwfa(k) = .false.
           else
            prw_vcd(k) = -rc(k)*orho*odt
            pnc_wcd(k) = -nc(k)*orho*odt
@@ -3047,7 +3119,8 @@
           nwfaten(k) = nwfaten(k) - pnc_wcd(k)
           tten(k) = tten(k) + lvap(k)*ocp(k)*prw_vcd(k)*(1-IFDRY)
           rc(k) = MAX(R1, (qc1d(k) + DT*qcten(k))*rho(k))
-          nc(k) = MAX(2., (nc1d(k) + DT*ncten(k))*rho(k))
+          if (rc(k).eq.R1) L_qc(k) = .false.
+          nc(k) = MAX(2., MIN((nc1d(k)+ncten(k)*DT)*rho(k), Nt_c_max))
           if (.NOT. is_aerosol_aware) nc(k) = Nt_c
           qv(k) = MAX(1.E-10, qv1d(k) + DT*qvten(k))
           temp(k) = t1d(k) + DT*tten(k)
@@ -3108,7 +3181,7 @@
           prv_rev(k) = MIN(DBLE(rate_max), prv_rev(k)*orho)
 
 !..TEST: G. Thompson  10 May 2013
-!..Reduce the rain evaporation in same places as melting graupel occurs. 
+!..Reduce the rain evaporation in same places as melting graupel occurs.
 !..Rationale: falling and simultaneous melting graupel in subsaturated
 !..regions will not melt as fast because particle temperature stays
 !..at 0C.  Also not much shedding of the water from the graupel so
@@ -3136,7 +3209,6 @@
           rho(k) = 0.622*pres(k)/(R*temp(k)*(qv(k)+0.622))
          endif
       enddo
-#if defined(mpas)
       do k = kts, kte
          evapprod(k) = prv_rev(k) - (min(zeroD0,prs_sde(k)) + &
                                      min(zeroD0,prg_gde(k)))
@@ -3145,7 +3217,6 @@
                                     prg_gcw(k) + prs_sci(k) + &
                                     pri_rci(k)
       enddo
-#endif
 
 !+---+-----------------------------------------------------------------+
 !..Find max terminal fallspeed (distribution mass-weighted mean
@@ -3168,6 +3239,8 @@
          vtck(k) = 0.
          vtnck(k) = 0.
       enddo
+
+      if (ANY(L_qr .eqv. .true.)) then
       do k = kte, kts, -1
          vtr = 0.
          rhof(k) = SQRT(RHO_NOT/rho(k))
@@ -3198,9 +3271,11 @@
       enddo
       if (ksed1(1) .eq. kte) ksed1(1) = kte-1
       if (nstep .gt. 0) onstep(1) = 1./REAL(nstep)
+      endif
 
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qc .eqv. .true.)) then
       hgt_agl = 0.
       do k = kts, kte-1
          if (rc(k) .gt. R2) ksed1(5) = k
@@ -3221,11 +3296,13 @@
           vtnck(k) = vtc
          endif
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 
       if (.not. iiwarm) then
 
+       if (ANY(L_qi .eqv. .true.)) then
        nstep = 0
        do k = kte, kts, -1
           vti = 0.
@@ -3253,9 +3330,11 @@
        enddo
        if (ksed1(2) .eq. kte) ksed1(2) = kte-1
        if (nstep .gt. 0) onstep(2) = 1./REAL(nstep)
+       endif
 
 !+---+-----------------------------------------------------------------+
 
+       if (ANY(L_qs .eqv. .true.)) then
        nstep = 0
        do k = kte, kts, -1
           vts = 0.
@@ -3273,8 +3352,8 @@
            t4_vts = Kap1*Mrat**mu_s*csg(7)*ils2**cse(7)
            vts = rhof(k)*av_s * (t1_vts+t2_vts)/(t3_vts+t4_vts)
            if (temp(k).gt. (T_0+0.1)) then
-            vtsk(k) = MAX(vts*vts_boost(k),                             &
-     &                vts*((vtrk(k)-vts*vts_boost(k))/(temp(k)-T_0)))
+            SR = rs(k)/(rs(k)+rr(k))
+            vtsk(k) = vts*SR + (1.-SR)*vtrk(k)
            else
             vtsk(k) = vts*vts_boost(k)
            endif
@@ -3290,9 +3369,11 @@
        enddo
        if (ksed1(3) .eq. kte) ksed1(3) = kte-1
        if (nstep .gt. 0) onstep(3) = 1./REAL(nstep)
+       endif
 
 !+---+-----------------------------------------------------------------+
 
+       if (ANY(L_qg .eqv. .true.)) then
        nstep = 0
        do k = kte, kts, -1
           vtg = 0.
@@ -3316,18 +3397,16 @@
        enddo
        if (ksed1(4) .eq. kte) ksed1(4) = kte-1
        if (nstep .gt. 0) onstep(4) = 1./REAL(nstep)
+       endif
       endif
 
 !+---+-----------------------------------------------------------------+
 !..Sedimentation of mixing ratio is the integral of v(D)*m(D)*N(D)*dD,
 !.. whereas neglect m(D) term for number concentration.  Therefore,
 !.. cloud ice has proper differential sedimentation.
-!.. New in v3.0+ is computing separate for rain, ice, snow, and
-!.. graupel species thus making code faster with credit to J. Schmidt.
-!.. Bug fix, 2013Nov01 to tendencies using rho(k+1) correction thanks to
-!.. Eric Skyllingstad.
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qr .eqv. .true.)) then
       nstep = NINT(1./onstep(1))
       do n = 1, nstep
          do k = kte, kts, -1
@@ -3354,12 +3433,14 @@
                                            *odzq*DT*onstep(1))
          enddo
 
-         if (rr(kts).gt.R1*10.) &
+         if (rr(kts).gt.R1*1000.) &
          pptrain = pptrain + sed_r(kts)*DT*onstep(1)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qc .eqv. .true.)) then
       do k = kte, kts, -1
          sed_c(k) = vtck(k)*rc(k)
          sed_n(k) = vtnck(k)*nc(k)
@@ -3372,9 +3453,11 @@
          rc(k) = MAX(R1, rc(k) + (sed_c(k+1)-sed_c(k)) *odzq*DT)
          nc(k) = MAX(10., nc(k) + (sed_n(k+1)-sed_n(k)) *odzq*DT)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qi .eqv. .true.)) then
       nstep = NINT(1./onstep(2))
       do n = 1, nstep
          do k = kte, kts, -1
@@ -3401,12 +3484,14 @@
                                            *odzq*DT*onstep(2))
          enddo
 
-         if (ri(kts).gt.R1*10.) &
+         if (ri(kts).gt.R1*1000.) &
          pptice = pptice + sed_i(kts)*DT*onstep(2)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qs .eqv. .true.)) then
       nstep = NINT(1./onstep(3))
       do n = 1, nstep
          do k = kte, kts, -1
@@ -3426,12 +3511,14 @@
                                            *odzq*DT*onstep(3))
          enddo
 
-         if (rs(kts).gt.R1*10.) &
+         if (rs(kts).gt.R1*1000.) &
          pptsnow = pptsnow + sed_s(kts)*DT*onstep(3)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qg .eqv. .true.)) then
       nstep = NINT(1./onstep(4))
       do n = 1, nstep
          do k = kte, kts, -1
@@ -3451,9 +3538,10 @@
                                            *odzq*DT*onstep(4))
          enddo
 
-         if (rg(kts).gt.R1*10.) &
+         if (rg(kts).gt.R1*1000.) &
          pptgraul = pptgraul + sed_g(kts)*DT*onstep(4)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 !.. Instantly melt any cloud ice into cloud water if above 0C and
@@ -3490,10 +3578,10 @@
          t1d(k)  = t1d(k) + tten(k)*DT
          qv1d(k) = MAX(1.E-10, qv1d(k) + qvten(k)*DT)
          qc1d(k) = qc1d(k) + qcten(k)*DT
-         nc1d(k) = MAX(2./rho(k), nc1d(k) + ncten(k)*DT)
-         nwfa1d(k) = MAX(11.1E6/rho(k), MIN(9999.E6/rho(k),             &
+         nc1d(k) = MAX(2./rho(k), MIN(nc1d(k) + ncten(k)*DT, Nt_c_max))
+         nwfa1d(k) = MAX(11.1E6, MIN(9999.E6,                           &
                        (nwfa1d(k)+nwfaten(k)*DT)))
-         nifa1d(k) = MAX(naIN1*0.01, MIN(9999.E6/rho(k),                &
+         nifa1d(k) = MAX(naIN1*0.01, MIN(9999.E6,                       &
                        (nifa1d(k)+nifaten(k)*DT)))
 
          if (qc1d(k) .le. R1) then
@@ -3527,7 +3615,7 @@
             lami = cie(2)/300.E-6
            endif
            ni1d(k) = MIN(cig(1)*oig2*qi1d(k)/am_i*lami**bm_i,           &
-                         499.D3/rho(k))
+                         9999.D3/rho(k))
          endif
          qr1d(k) = qr1d(k) + qrten(k)*DT
          nr1d(k) = MAX(R2/rho(k), nr1d(k) + nrten(k)*DT)
@@ -3640,7 +3728,8 @@
             tcg_racg(i,j,k,m) = t1
             tmr_racg(i,j,k,m) = DMIN1(z1, r_r(m)*1.0d0)
             tcr_gacr(i,j,k,m) = t2
-            tmg_gacr(i,j,k,m) = z2
+            tmg_gacr(i,j,k,m) = DMIN1(z2, r_g(j)*1.0d0)
+            !DAVE tmg_gacr(i,j,k,m) = DMIN1(z2, DBLE(r_g(j)))
             tnr_racg(i,j,k,m) = y1
             tnr_gacr(i,j,k,m) = y2
          enddo
@@ -3829,8 +3918,10 @@
 
 !..Local variables
       INTEGER:: i, j, k, m, n, n2
-      DOUBLE PRECISION, DIMENSION(nbr):: N_r, massr
-      DOUBLE PRECISION, DIMENSION(nbc):: N_c, massc
+      INTEGER:: km, km_s, km_e
+      DOUBLE PRECISION:: N_r, N_c
+      DOUBLE PRECISION, DIMENSION(nbr):: massr
+      DOUBLE PRECISION, DIMENSION(nbc):: massc
       DOUBLE PRECISION:: sum1, sum2, sumn1, sumn2, &
                          prob, vol, Texp, orho_w, &
                          lam_exp, lamr, N0_r, lamc, N0_c, y
@@ -3848,10 +3939,14 @@
          massc(n) = am_r*Dc(n)**bm_r
         enddo
 
+        km_s = 0
+        km_e = ntb_IN*45 - 1
+
 !..Freeze water (smallest drops become cloud ice, otherwise graupel).
-        do m = 1, ntb_IN
-        T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
-        do k = 1, 45
+        do km = km_s, km_e
+         m = km / 45 + 1
+         k = mod( km , 45 ) + 1
+         T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
 !         print*, ' Freezing water for temp = ', -k
          Texp = DEXP( REAL(k,KIND=R8SIZE) - T_adjust*1.0D0 ) - 1.0D0
          do j = 1, ntb_r1
@@ -3864,15 +3959,15 @@
                sumn1 = 0.0d0
                sumn2 = 0.0d0
                do n2 = nbr, 1, -1
-                  N_r(n2) = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
+                  N_r = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
                   vol = massr(n2)*orho_w
-                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
+                  prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
                   if (massr(n2) .lt. xm0g) then
-                     sumn1 = sumn1 + prob*N_r(n2)
-                     sum1 = sum1 + prob*N_r(n2)*massr(n2)
+                     sumn1 = sumn1 + prob*N_r
+                     sum1 = sum1 + prob*N_r*massr(n2)
                   else
-                     sumn2 = sumn2 + prob*N_r(n2)
-                     sum2 = sum2 + prob*N_r(n2)*massr(n2)
+                     sumn2 = sumn2 + prob*N_r
+                     sum2 = sum2 + prob*N_r*massr(n2)
                   endif
                   if ((sum1+sum2).ge.r_r(i)) EXIT
                enddo
@@ -3892,10 +3987,10 @@
                sumn2 = 0.0d0
                do n = nbc, 1, -1
                   vol = massc(n)*orho_w
-                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
-                  N_c(n) = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
-                  sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c(n))
-                  sum1 = sum1 + prob*N_c(n)*massc(n)
+                  prob = MAX(0.0D0, 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp))
+                  N_c = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
+                  sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c)
+                  sum1 = sum1 + prob*N_c*massc(n)
                   if (sum1 .ge. r_c(i)) EXIT
                enddo
                tpi_qcfz(i,j,k,m) = sum1
@@ -3903,9 +3998,9 @@
             enddo
          enddo
         enddo
-        enddo
 
       end subroutine freezeH2O
+
 !+---+-----------------------------------------------------------------+
 !ctrlL
 !+---+-----------------------------------------------------------------+
@@ -4282,7 +4377,7 @@
 
       end subroutine table_ccnAct
 #endif
-!^L
+!
 !+---+-----------------------------------------------------------------+
 !..Retrieve fraction of CCN that gets activated given the model temp,
 !.. vertical velocity, and available CCN concentration.  The lookup
@@ -4622,7 +4717,7 @@
 !        mux = hx*p_alpha*n_in*rho
 !        xni = mux*((6700.*nifa)-200.)/((6700.*5.E5)-200.)
 !     elseif (satw.ge.0.985 .and. tempc.gt.HGFR-273.15) then
-         nifa_cc = nifa*RHO_NOT0*1.E-6/rho
+         nifa_cc = MAX(0.5, nifa*RHO_NOT0*1.E-6/rho)
 !        xni  = 3.*nifa_cc**(1.25)*exp((0.46*(-tempc))-11.6)              !  [DeMott, 2015]
          xni = (5.94e-5*(-tempc)**3.33)                                 & !  [DeMott, 2010]
                     * (nifa_cc**((-0.0264*(tempc))+0.0033))
@@ -4739,7 +4834,7 @@
       do k = kts, kte
          rho(k) = 0.622*p1d(k)/(R*t1d(k)*(qv1d(k)+0.622))
          rc(k) = MAX(R1, qc1d(k)*rho(k))
-         nc(k) = MAX(R2, nc1d(k)*rho(k))
+         nc(k) = MAX(2., MIN(nc1d(k)*rho(k), Nt_c_max))
          if (.NOT. is_aerosol_aware) nc(k) = Nt_c
          if (rc(k).gt.R1 .and. nc(k).gt.R2) has_qc = .true.
          ri(k) = MAX(R1, qi1d(k)*rho(k))
@@ -4751,6 +4846,7 @@
 
       if (has_qc) then
       do k = kts, kte
+         re_qc1d(k) = 2.49E-6
          if (rc(k).le.R1 .or. nc(k).le.R2) CYCLE
          if (nc(k).lt.100) then
             inu_c = 15
@@ -4766,14 +4862,16 @@
 
       if (has_qi) then
       do k = kts, kte
+         re_qi1d(k) = 2.49E-6
          if (ri(k).le.R1 .or. ni(k).le.R2) CYCLE
          lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
-         re_qi1d(k) = MAX(5.01E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
+         re_qi1d(k) = MAX(2.51E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
       enddo
       endif
 
       if (has_qs) then
       do k = kts, kte
+         re_qs1d(k) = 4.99E-6
          if (rs(k).le.R1) CYCLE
          tc0 = MIN(-0.1, t1d(k)-273.15)
          smob = rs(k)*oams
@@ -4808,7 +4906,7 @@
      &        + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
      &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
          smoc = a_ * smo2**b_
-         re_qs1d(k) = MAX(10.E-6, MIN(0.5*(smoc/smob), 999.E-6))
+         re_qs1d(k) = MAX(5.01E-6, MIN(0.5*(smoc/smob), 999.E-6))
       enddo
       endif
 
@@ -4909,6 +5007,14 @@
 !..Calculate y-intercept, slope, and useful moments for snow.
 !+---+-----------------------------------------------------------------+
       do k = kts, kte
+         smo2(k) = 0.
+         smob(k) = 0.
+         smoc(k) = 0.
+         smoz(k) = 0.
+      enddo
+      if (ANY(L_qs .eqv. .true.)) then
+      do k = kts, kte
+         if (.not. L_qs(k)) CYCLE
          tc0 = MIN(-0.1, temp(k)-273.15)
          smob(k) = rs(k)*oams
 
@@ -4957,11 +5063,13 @@
      &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(3)*cse(3)*cse(3)
          smoz(k) = a_ * smo2(k)**b_
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 !..Calculate y-intercept, slope values for graupel.
 !+---+-----------------------------------------------------------------+
 
+      if (ANY(L_qg .eqv. .true.)) then
       N0_min = gonv_max
       k_0 = kts
       do k = kte, kts, -1
@@ -4984,6 +5092,7 @@
          ilamg(k) = 1./lamg
          N0_g(k) = N0_exp/(cgg(2)*lam_exp) * lamg**cge(2)
       enddo
+      endif
 
 !+---+-----------------------------------------------------------------+
 !..Locate K-level of start of melting (k_0 is level above).

--- a/src/core_atmosphere/physics/physics_wrf/module_mp_thompson_aerosols.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_mp_thompson_aerosols.F
@@ -1,0 +1,214 @@
+!=================================================================================================================
+!module_mp_thompson_aerosols includes subroutine gt_aod. gt_aod is called from subroutine radiation_sw_from_MPAS
+!in mpas_atmphys_driver_radiation_sw.F. gt_aod calculates the 550 nm aerosol optical depth of "water-friendly"
+!and "ice-friendly" aerosols from the Thompson cloud microphysics scheme. gt_aod was copied from WRF-4.0.2 (see
+!module_radiation_driver.F).
+!Laura D. Fowler (laura@ucar.edu) / 2019-01-13.
+
+ module module_mp_thompson_aerosols
+ use mpas_atmphys_functions,only: rslf
+ use mpas_atmphys_utilities, only: physics_error_fatal,physics_message
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
+
+ implicit none
+ private
+ public:: gt_aod
+
+
+ contains
+
+
+!=================================================================================================================
+      SUBROUTINE gt_aod(p_phy,DZ8W,t_phy,qvapor, nwfa,nifa, taod5503d,  &
+     &             ims,ime, jms,jme, kms,kme, its,ite, jts,jte, kts,kte)
+
+!     USE module_mp_thompson, only: RSLF
+
+!     IMPLICIT NONE
+
+      INTEGER,  INTENT(IN):: ims,ime, jms,jme, kms,kme,                 &
+     &                       its,ite, jts,jte, kts,kte
+
+      REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN) ::           &
+     &                                            t_phy,p_phy, DZ8W,    &
+     &                                            qvapor, nifa, nwfa
+      REAL,DIMENSION(ims:ime,kms:kme,jms:jme),INTENT(INOUT):: taod5503d
+
+      !..Local variables. 
+
+      REAL, DIMENSION(its:ite,kts:kte,jts:jte):: AOD_wfa, AOD_ifa
+      REAL:: RH, a_RH,b_RH, rh_d,rh_f, rhoa,qvsat, unit_bext1,unit_bext3
+      REAL:: ntemp
+      INTEGER :: i, k, j, RH_idx, RH_idx1, RH_idx2, t_idx
+      INTEGER, PARAMETER:: rind=8
+      REAL, DIMENSION(rind), PARAMETER:: rh_arr =                       &
+     &                      (/10., 60., 70., 80., 85., 90., 95., 99.8/)
+      REAL, DIMENSION(rind,4,2) :: lookup_tabl                           ! RH, temp, water-friendly, ice-friendly
+
+      lookup_tabl(1,1,1) =  5.73936E-15
+      lookup_tabl(1,1,2) =  2.63577E-12
+      lookup_tabl(1,2,1) =  5.73936E-15
+      lookup_tabl(1,2,2) =  2.63577E-12
+      lookup_tabl(1,3,1) =  5.73936E-15
+      lookup_tabl(1,3,2) =  2.63577E-12
+      lookup_tabl(1,4,1) =  5.73936E-15
+      lookup_tabl(1,4,2) =  2.63577E-12
+
+      lookup_tabl(2,1,1) = 6.93515E-15
+      lookup_tabl(2,1,2) = 2.72095E-12
+      lookup_tabl(2,2,1) = 6.93168E-15
+      lookup_tabl(2,2,2) = 2.72092E-12
+      lookup_tabl(2,3,1) = 6.92570E-15
+      lookup_tabl(2,3,2) = 2.72091E-12
+      lookup_tabl(2,4,1) = 6.91833E-15
+      lookup_tabl(2,4,2) = 2.72087E-12
+
+      lookup_tabl(3,1,1) = 7.24707E-15
+      lookup_tabl(3,1,2) = 2.77219E-12
+      lookup_tabl(3,2,1) = 7.23809E-15
+      lookup_tabl(3,2,2) = 2.77222E-12
+      lookup_tabl(3,3,1) = 7.23108E-15
+      lookup_tabl(3,3,2) = 2.77201E-12
+      lookup_tabl(3,4,1) = 7.21800E-15
+      lookup_tabl(3,4,2) = 2.77111E-12
+
+      lookup_tabl(4,1,1) = 8.95130E-15
+      lookup_tabl(4,1,2) = 2.87263E-12
+      lookup_tabl(4,2,1) = 9.01582E-15
+      lookup_tabl(4,2,2) = 2.87252E-12
+      lookup_tabl(4,3,1) = 9.13216E-15
+      lookup_tabl(4,3,2) = 2.87241E-12
+      lookup_tabl(4,4,1) = 9.16219E-15
+      lookup_tabl(4,4,2) = 2.87211E-12
+
+      lookup_tabl(5,1,1) = 1.06695E-14
+      lookup_tabl(5,1,2) = 2.96752E-12
+      lookup_tabl(5,2,1) = 1.06370E-14
+      lookup_tabl(5,2,2) = 2.96726E-12
+      lookup_tabl(5,3,1) = 1.05999E-14
+      lookup_tabl(5,3,2) = 2.96702E-12
+      lookup_tabl(5,4,1) = 1.05443E-14
+      lookup_tabl(5,4,2) = 2.96603E-12
+
+      lookup_tabl(6,1,1) = 1.37908E-14
+      lookup_tabl(6,1,2) = 3.15081E-12
+      lookup_tabl(6,2,1) = 1.37172E-14
+      lookup_tabl(6,2,2) = 3.15020E-12
+      lookup_tabl(6,3,1) = 1.36362E-14
+      lookup_tabl(6,3,2) = 3.14927E-12
+      lookup_tabl(6,4,1) = 1.35287E-14
+      lookup_tabl(6,4,2) = 3.14817E-12
+
+      lookup_tabl(7,1,1) = 2.26019E-14
+      lookup_tabl(7,1,2) = 3.66798E-12
+      lookup_tabl(7,2,1) = 2.24435E-14
+      lookup_tabl(7,2,2) = 3.66540E-12
+      lookup_tabl(7,3,1) = 2.23254E-14
+      lookup_tabl(7,3,2) = 3.66173E-12
+      lookup_tabl(7,4,1) = 2.20496E-14
+      lookup_tabl(7,4,2) = 3.65796E-12
+
+      lookup_tabl(8,1,1) = 4.41983E-13
+      lookup_tabl(8,1,2) = 7.50091E-11
+      lookup_tabl(8,2,1) = 3.93335E-13
+      lookup_tabl(8,2,2) = 6.79097E-11
+      lookup_tabl(8,3,1) = 3.45569E-13
+      lookup_tabl(8,3,2) = 6.07845E-11
+      lookup_tabl(8,4,1) = 2.96971E-13
+      lookup_tabl(8,4,2) = 5.36085E-11
+
+      DO j=jts,jte
+         DO k=kts,kte
+            DO i=its,ite
+               AOD_wfa(i,k,j) = 0.
+               AOD_ifa(i,k,j) = 0.
+            END DO
+         END DO
+      END DO
+
+      DO j=jts,jte
+         DO k=kts,kte
+            DO i=its,ite
+               rhoa = p_phy(i,k,j)/(287.*t_phy(i,k,j))
+               t_idx = MAX(1, MIN(nint(10.999-0.0333*t_phy(i,k,j)),4))
+               qvsat = rslf(p_phy(i,k,j),t_phy(i,k,j))
+               RH = MIN(98., MAX(10.1, qvapor(i,k,j)/qvsat*100.))
+
+               !..Get the index for the RH array element
+
+               if (RH .lt. 60) then
+                  RH_idx1 = 1
+                  RH_idx2 = 2
+               elseif (RH .ge. 60 .AND. RH.lt.80) then
+                  a_RH = 0.1
+                  b_RH = -4
+                  RH_idx = nint(a_RH*RH+b_RH)
+                  rh_d = rh-rh_arr(rh_idx)
+                  if (rh_d .lt. 0) then
+                     RH_idx1 = RH_idx-1
+                     RH_idx2 = RH_idx
+                  else
+                     RH_idx1 = RH_idx
+                     RH_idx2 = RH_idx+1
+                     if (RH_idx2.gt.rind) then
+                        RH_idx2 = rind
+                        RH_idx1 = rind-1
+                     endif
+                  endif
+               else
+                  a_RH = 0.2
+                  b_RH = -12.
+                  RH_idx = MIN(rind, nint(a_RH*RH+b_RH))
+                  rh_d = rh-rh_arr(rh_idx)
+                  if (rh_d .lt. 0) then
+                     RH_idx1 = RH_idx-1
+                     RH_idx2 = RH_idx
+                  else
+                     RH_idx1 = RH_idx
+                     RH_idx2 = RH_idx+1
+                     if (RH_idx2.gt.rind) then
+                        RH_idx2 = rind
+                        RH_idx1 = rind-1
+                     endif
+                  endif
+               endif
+
+               !..RH fraction to be used
+
+               rh_f = MAX(0., MIN(1.0, (rh/(100-rh)-rh_arr(rh_idx1)     &
+     &                                  /(100-rh_arr(rh_idx1)))         &
+     &                        /(rh_arr(rh_idx2)/(100-rh_arr(rh_idx2))   &
+     &                        -rh_arr(rh_idx1)/(100-rh_arr(rh_idx1))) ))
+
+
+               unit_bext1 = lookup_tabl(RH_idx1,t_idx,1)                &
+     &                    + (lookup_tabl(RH_idx2,t_idx,1)               &
+     &                    - lookup_tabl(RH_idx1,t_idx,1))*rh_f
+               unit_bext3 = lookup_tabl(RH_idx1,t_idx,2)                &
+     &                    + (lookup_tabl(RH_idx2,t_idx,2)               &
+     &                    - lookup_tabl(RH_idx1,t_idx,2))*rh_f
+
+               ntemp = MAX(1., MIN(99999.E6, nwfa(i,k,j)))
+               AOD_wfa(i,k,j) = unit_bext1*ntemp*dz8w(i,k,j)*rhoa
+
+               ntemp = MAX(0.01, MIN(9999.E6, nifa(i,k,j)))
+               AOD_ifa(i,k,j) = unit_bext3*ntemp*dz8w(i,k,j)*rhoa
+
+            END DO
+         END DO
+      END DO
+
+      DO j=jts,jte
+         DO k=kts,kte
+            DO i=its,ite
+               taod5503d(i,k,j) = aod_wfa(i,k,j) + aod_ifa(i,k,j)
+            END DO
+         END DO
+      END DO
+
+      END SUBROUTINE gt_aod
+
+!=================================================================================================================
+ end module module_mp_thompson_aerosols
+!=================================================================================================================

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -9840,6 +9840,13 @@ use module_ra_rrtmg_vinterp,only: vinterp_ozn
 !>     microphysics scheme as inputs to the subroutine rrtmg_swrad. revised the initialization of arrays rel,
 !>     rei, and res, accordingly.
 !>     Laura D. Fowler (laura@ucar.edu) / 2016-07-07.
+!>   * added the optional arguments, tauaer3d, ssaaer3d, and asyaer3d to include the optical depth, single
+!>     scattering albedo, and asymmetry factor of aerosols. to date, the only kind of aerosols included in MPAS
+!>     are the "water-friendly" and "ice-friendly" aerosols used in the Thompson cloud microphysics scheme.
+!>     Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
+!>   * added the option aer_opt in the argument list. revised the initialization of arrays tauaer,ssaaer, and
+!>     asmaer to include the optical properties of aerosols.
+!>     Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
 !MPAS specfic end.
 
 #else
@@ -9873,6 +9880,7 @@ CONTAINS
                        noznlevels,pin,o3clim,gsw,swcf,rthratensw,      &
                        has_reqc,has_reqi,has_reqs,re_cloud,            &
                        re_ice,re_snow,                                 &
+                       aer_opt,tauaer3d,ssaaer3d,asyaer3d,             &
                        swupt,swuptc,swdnt,swdntc,                      &
                        swupb,swupbc,swdnb,swdnbc,                      &
                        swupflx, swupflxc, swdnflx, swdnflxc,           &
@@ -9908,6 +9916,12 @@ CONTAINS
  integer,intent(in):: noznlevels
  real,intent(in),dimension(1:noznlevels),optional:: pin
  real,intent(in),dimension(ims:ime,1:noznlevels,jms:jme),optional:: o3clim
+
+!--- additional input arguments of the aerosol optical depth, single scattering albedo, and asymmetry factor. to
+!    date, the only kind of aerosols included in MPAS are the "water-friendly" and "ice-friendly" aerosols used
+!    in the Thompson cloud microphysics scheme:
+ integer,intent(in),optional:: aer_opt
+ real,intent(in),dimension(ims:ime,kms:kme,jms:jme,1:nbndsw),optional:: tauaer3d,ssaaer3d,asyaer3d
 
 !--- inout arguments:
  real,intent(inout),dimension(ims:ime,jms:jme):: coszr,gsw,swcf
@@ -9967,7 +9981,6 @@ CONTAINS
 !--- additional local variables related to the implementation of aerosols in rrtmg_swrad in WRF 3.8.
 !    In WRF 3.8, these variables are in the argument list of subroutine rrtmg_swrad, but are made
 !    local here:
- integer:: aer_opt 
  real,dimension(1,kts:kte+1,naerec):: ecaer
 
 !--- set trace gas volume mixing ratios, 2005 values, IPCC (2007):
@@ -10131,7 +10144,6 @@ CONTAINS
           enddo
 
           !--- initialization of aerosol optical properties:
-          aer_opt = 0
           do n = 1, ncol
              do k = 1, nlay
                 do na = 1, naerec
@@ -10367,13 +10379,27 @@ CONTAINS
                       fsfcmcl)
 
           !--- initialization of aerosol optical properties:
-          do nb = 1, nbndsw
-             do k = kts, kte+1
+          if(present(tauaer3d) .and. present(ssaaer3d) .and. present(asyaer3d)) then
+             do nb = 1, nbndsw
+                do k = kts, kte
+                   tauaer(ncol,k,nb) = tauaer3d(i,k,j,nb)
+                   ssaaer(ncol,k,nb) = ssaaer3d(i,k,j,nb)
+                   asmaer(ncol,k,nb) = asyaer3d(i,k,j,nb)
+                enddo
+                k = kte+1
                 tauaer(ncol,k,nb) = 0.
                 ssaaer(ncol,k,nb) = 1.
                 asmaer(ncol,k,nb) = 0.
              enddo
-          enddo
+          else
+             do nb = 1, nbndsw
+                do k = kts, kte+1
+                   tauaer(ncol,k,nb) = 0.
+                   ssaaer(ncol,k,nb) = 1.
+                   asmaer(ncol,k,nb) = 0.
+                enddo
+             enddo
+          endif
 
           do na = 1, naerec
              do k = kts, kte+1

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw_aerosols.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw_aerosols.F
@@ -84,12 +84,13 @@ subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                   
     data (upper_wvl(i),i=1,N_BANDS) /3.846,3.077,2.500,2.150,1.942,1.626,1.299,1.2420,0.7782,0.6250,0.4415,0.3448,0.2632,12.195/
 
     ! I/O variables
+    integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                           its,ite,jts,jte,kts,kte
+
     real, dimension(ims:ime, kms:kme, jms:jme), intent(in) :: p,     & ! pressure (Pa)
                                                               t3d,   & ! temperature (K)
                                                               dz8w,  & ! dz between full levels (m)
                                                               qv3d     ! water vapor mixing ratio (kg/kg)
-    integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
-                           its,ite,jts,jte,kts,kte
 !-- MPAS modifications: aer_type is a function of the land-sea mask, and set to 1 over land (or rural classification in WRF),
 !   and set to 0 over oceans (or maritime classification in WRF):
 !   integer, intent(in) :: aer_type
@@ -140,9 +141,9 @@ subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                   
           if (minval(aod5502d) .lt. 0) then
              FATAL_ERROR('AOD@550 must be positive. Negative value(s) found in auxinput')
           end if
-          call mpas_log_write('--- aer_aod550_opt = $i: AOD@550 nm read from auxinput min = $r  max = $r', &
-                              intArgs=(/aer_aod550_opt/),realArgs=(/minval(aod5502d(its:ite,jts:jte)), &
-                              maxval(aod5502d(its:ite,jts:jte))/))
+!         call mpas_log_write('--- aer_aod550_opt = $i: AOD@550 nm read from auxinput min = $r  max = $r', &
+!                             intArgs=(/aer_aod550_opt/),realArgs=(/minval(aod5502d(its:ite,jts:jte)), &
+!                             maxval(aod5502d(its:ite,jts:jte))/))
        case default
           write(wrf_err_message,*) 'Expected aer_aod550_opt=[1,2]. Got',aer_aod550_opt
           FATAL_ERROR(trim(wrf_err_message))
@@ -209,8 +210,8 @@ subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                   
 
        case(3)
           ! spectral disaggregation based on a prescribed aerosol type and relative humidity
-          call mpas_log_write('--- aer_angexp_opt = $i: angstrom exponent calculated from RH and aer_type $i', &
-                              intArgs=(/aer_angexp_opt,aer_type/))
+!         call mpas_log_write('--- aer_angexp_opt = $i: angstrom exponent calculated from RH and aer_type $i', &
+!                             intArgs=(/aer_angexp_opt,aer_type/))
           call calc_spectral_aod_rrtmg_sw(ims,ime,jms,jme,kms,kme,      &
                                           its,ite,jts,jte,kts,kte,      &
                                           rh,aer_type,aod5502d,         &
@@ -339,8 +340,8 @@ subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                   
 
        case(3)
           ! spectral disaggregation based on a prescribed aerosol type and relative humidity
-          call mpas_log_write('--- aer_ssa_opt    = $i: single-scattering albedo calculated from RH and aer_type $i', &
-                              intArgs=(/aer_ssa_opt,aer_type/))
+!         call mpas_log_write('--- aer_ssa_opt    = $i: single-scattering albedo calculated from RH and aer_type $i', &
+!                             intArgs=(/aer_ssa_opt,aer_type/))
           call calc_spectral_ssa_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
                                           its,ite,jts,jte,kts,kte,  &
                                           rh,aer_type,ssaaer        )
@@ -417,8 +418,8 @@ subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                   
 
        case(3)
           ! spectral disaggregation based on a prescribed aerosol type and relative humidity
-          call mpas_log_write('--- aer_asy_opt    = $i: asymmetry parameter calculated from RH and aer_type $i', &
-                              intArgs=(/aer_asy_opt,aer_type/))
+!         call mpas_log_write('--- aer_asy_opt    = $i: asymmetry parameter calculated from RH and aer_type $i', &
+!                             intArgs=(/aer_asy_opt,aer_type/))
           call calc_spectral_asy_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
                                           its,ite,jts,jte,kts,kte,  &
                                           rh,aer_type,asyaer        )

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw_aerosols.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw_aerosols.F
@@ -1,0 +1,924 @@
+!=================================================================================================================
+!module_ra_rrtmg_sw_aerosols includes subroutine calc_aerosol_rrtmg_sw. subroutine calc_aerosol_rrtmg_sw is called
+!from subroutine radiation_sw_from_MPAS in mpas_atmphys_driver_radiation_sw.F. calc_aerosol_rrtmg_sw calculates
+!the optical properties (aerosol optical depth,asymmetry factor,and single-scattering albedo) of "water-friendly"
+!and "ice-friendly" aerosols from the Thompson cloud microphysics scheme. calc_aerosol_rrtmg_sw was copied from
+!from WRF-4.0.2 (see module_radiation_driver.F).
+!Laura D. Fowler (laura@ucar.edu) / 2024-05-16.
+
+ module module_ra_rrtmg_sw_aerosols
+ use mpas_log
+ use mpas_atmphys_functions,only: rslf
+ use mpas_atmphys_utilities, only: physics_error_fatal,physics_message
+#define FATAL_ERROR(M) call physics_error_fatal(M)
+#define WRITE_MESSAGE(M) call physics_message(M)
+
+ implicit none
+ private
+ public:: calc_aerosol_rrtmg_sw
+
+
+ contains
+
+
+!=================================================================================================================
+!--------------------------------------------------------------
+!       INDICES CONVENTION
+!--------------------------------------------------------------       
+!       kms:kme define the range for full-level indices
+!       kts:kte define the range for half-level indices
+!       
+!       kms=1 is the first full level at surface
+!       kts=1 is the first half level at surface
+!       
+!       kme is the last full level at toa
+!       kte is the last half level at toa
+!       
+!       There is one more full level than half levels.
+!       Therefore, kme=kte+1. I checked it in one of my
+!       simulations:
+!       
+!         namelist.input:
+!              s_vert=1  e_vert=28        
+!         code:
+!              kms= 1    kts= 1
+!              kms=28    kte=27
+!       
+!       In the vertical dimension there is no tiling for
+!       parallelization as in the horizontal dimensions.
+!       For i-dim and j-dim, the t-indices define the
+!       range of indices over which each tile runs.
+!--------------------------------------------------------------
+!
+!  namelist options:
+!    aer_aod550_opt = [1,2] : 
+!        1 = input constant value for AOD at 550 nm from namelist. 
+!            In this case, the value is read from aer_aod550_val; 
+!        2 = input value from auxiliary input 15. It is a time-varying 2D grid in netcdf wrf-compatible 
+!            format. The default operation is aer_aod550_opt=1 and aer_aod550_val=0.12
+!    aer_angexp_opt = [1,2,3] : 
+!        1 = input constant value for Angstrom exponent from namelist. In this case, the value is read 
+!            from aer_angexp_val; 
+!        2 = input value from auxiliary input 15, as in aer_aod550_opt; 
+!        3 = Angstrom exponent value estimated from the aerosol type defined in aer_type, and modulated 
+!            with the RH in WRF. Default operation is aer_angexp_opt = 1, and aer_angexp_val=1.3.
+!    aer_ssa_opt and aer_asy_opt are similar to aer_angexp_opt.
+!
+!    aer_type = [1,2,3] : 1 for rural, 2 is urban and 3 is maritime.
+!--------------------------------------------------------------
+
+subroutine calc_aerosol_rrtmg_sw(ht,dz8w,p,t3d,qv3d,aer_type,                               &
+                                 aer_aod550_opt, aer_angexp_opt, aer_ssa_opt, aer_asy_opt,  &
+                                 aer_aod550_val, aer_angexp_val, aer_ssa_val, aer_asy_val,  &
+                                 aod5502d, angexp2d, aerssa2d, aerasy2d,                    &
+                                 ims,ime,jms,jme,kms,kme,its,ite,jts,jte,kts,kte,           &
+                                 tauaer, ssaaer, asyaer, aod5503d                           )
+
+    ! constants
+    integer, parameter :: N_BANDS=14
+    ! local index variables
+    integer :: i,j,k,nb
+
+    real :: lower_wvl(N_BANDS),upper_wvl(N_BANDS)
+    data (lower_wvl(i),i=1,N_BANDS) /3.077,2.500,2.150,1.942,1.626,1.299,1.242,0.7782,0.6250,0.4415,0.3448,0.2632,0.2000,3.846/
+    data (upper_wvl(i),i=1,N_BANDS) /3.846,3.077,2.500,2.150,1.942,1.626,1.299,1.2420,0.7782,0.6250,0.4415,0.3448,0.2632,12.195/
+
+    ! I/O variables
+    real, dimension(ims:ime, kms:kme, jms:jme), intent(in) :: p,     & ! pressure (Pa)
+                                                              t3d,   & ! temperature (K)
+                                                              dz8w,  & ! dz between full levels (m)
+                                                              qv3d     ! water vapor mixing ratio (kg/kg)
+    integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                           its,ite,jts,jte,kts,kte
+!-- MPAS modifications: aer_type is a function of the land-sea mask, and set to 1 over land (or rural classification in WRF),
+!   and set to 0 over oceans (or maritime classification in WRF):
+!   integer, intent(in) :: aer_type
+    integer, dimension(ims:ime,jms:jme), intent(in):: aer_type
+    character(len=256):: wrf_err_message
+!-- end MPAS modifications..
+    integer, intent(in) :: aer_aod550_opt, aer_angexp_opt, aer_ssa_opt, aer_asy_opt
+    real, intent(in)    :: aer_aod550_val, aer_angexp_val, aer_ssa_val, aer_asy_val
+
+    real, dimension(ims:ime, jms:jme), intent(in)    :: ht
+    real, dimension(ims:ime, jms:jme), optional, intent(inout) :: aod5502d, angexp2d, aerssa2d, aerasy2d
+    real, dimension(ims:ime, kms:kme, jms:jme, 1:N_BANDS), intent(inout) :: tauaer, ssaaer, asyaer
+
+    real, dimension(ims:ime, kms:kme, jms:jme), optional, intent(in) :: aod5503d   ! trude
+
+    ! local variables
+    real :: angexp_val,aod_rate,x,xy,xx
+    real, dimension(ims:ime, jms:jme, 1:N_BANDS) :: aod550spc
+    real, dimension(ims:ime, kms:kme, jms:jme, 1:N_BANDS) :: aod550spc3d    !  trude
+    real, dimension(ims:ime, kms:kme, jms:jme)   :: rh  ! relative humidity
+
+    call calc_relative_humidity(p,t3d,qv3d,                 &
+                                ims,ime,jms,jme,kms,kme,    &
+                                its,ite,jts,jte,kts,kte,    &
+                                rh                          )
+
+    aer_aod550_opt_select: select case(aer_aod550_opt)
+       !case(0)
+       ! reserved for climatology
+       case(1)
+          if (aer_aod550_val .lt. 0) then
+             write(wrf_err_message,'("aer_aod550_val must be positive. Negative value ",F7.4," found")') aer_aod550_val
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          write( wrf_err_message, '("aer_aod550_opt=",I1,": AOD@550 nm fixed to value ",F6.3)') aer_aod550_opt,aer_aod550_val
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                aod5502d(i,j)=aer_aod550_val
+             end do
+          end do
+
+       case(2) 
+          if (.not.(present(aod5502d))) then
+             write(wrf_err_message,*) 'Expected gridded total AOD@550 nm, but it is not in the radiation driver'
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          if (minval(aod5502d) .lt. 0) then
+             FATAL_ERROR('AOD@550 must be positive. Negative value(s) found in auxinput')
+          end if
+          call mpas_log_write('--- aer_aod550_opt = $i: AOD@550 nm read from auxinput min = $r  max = $r', &
+                              intArgs=(/aer_aod550_opt/),realArgs=(/minval(aod5502d(its:ite,jts:jte)), &
+                              maxval(aod5502d(its:ite,jts:jte))/))
+       case default
+          write(wrf_err_message,*) 'Expected aer_aod550_opt=[1,2]. Got',aer_aod550_opt
+          FATAL_ERROR(trim(wrf_err_message))
+    end select aer_aod550_opt_select
+
+
+    ! here, the 3d aod550 is calculated according to the aer_angexp_opt case
+    aer_angexp_opt_select: select case(aer_angexp_opt)
+       !case(0)
+       ! reserved for climatology
+       case(1)
+          if (aer_angexp_val .lt. -0.3) then
+             write(wrf_err_message,'("WARNING: aer_angexp_val limited to -0.3. Illegal value ",F7.4," found")') aer_angexp_val
+             WRITE_MESSAGE(trim(wrf_err_message))
+          end if
+          if (aer_angexp_val .gt. 2.5) then
+             write(wrf_err_message,'("WARNING: aer_angexp_val limited to 2.5. Illegal value ",F7.4," found")') aer_angexp_val
+             WRITE_MESSAGE(trim(wrf_err_message))
+          end if
+          write( wrf_err_message , '("aer_angexp_opt=",I1,": Aerosol Angstrom exponent fixed to value ",F6.3)') &
+                                      aer_angexp_opt,aer_angexp_val
+          WRITE_MESSAGE(trim(wrf_err_message))
+          angexp_val=min(2.5,max(-0.3,aer_angexp_val))
+          do nb=1,N_BANDS
+             if ((angexp_val .lt. 0.999) .or. (angexp_val .gt. 1.001)) then
+                aod_rate=((0.55**angexp_val)*(upper_wvl(nb)**(1.-angexp_val)- &
+                          lower_wvl(nb)**(1.-angexp_val)))/((1.-angexp_val)*(upper_wvl(nb)-lower_wvl(nb)))
+             else
+                aod_rate=(0.55/(upper_wvl(nb)-lower_wvl(nb)))*log(upper_wvl(nb)/lower_wvl(nb))
+             end if
+             do j=jts,jte
+                do i=its,ite
+                   aod550spc(i,j,nb)=aod5502d(i,j)*aod_rate
+                end do
+             end do
+          end do
+          do j=jts,jte
+             do i=its,ite
+                angexp2d(i,j)=angexp_val
+             end do
+          end do
+       case(2)
+          if (.not.(present(angexp2d))) then
+             write(wrf_err_message,*) 'Expected gridded aerosol Angstrom exponent, but it is not in the radiation driver'
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          write( wrf_err_message, '("aer_angexp_opt=",I1,": Angstrom exponent read from auxinput (min=",F6.3," max=",F6.3,")")') &
+                                  aer_angexp_opt,minval(angexp2d),maxval(angexp2d)
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                angexp_val=min(2.5,max(-0.3,angexp2d(i,j)))
+                do nb=1,N_BANDS
+                   if ((angexp_val .lt. 0.999) .or. (angexp_val .gt. 1.001)) then
+                      aod_rate=((0.55**angexp_val)*(upper_wvl(nb)**(1.-angexp_val)- &
+                                lower_wvl(nb)**(1.-angexp_val)))/((1.-angexp_val)*(upper_wvl(nb)-lower_wvl(nb)))
+                   else
+                      aod_rate=(0.55/(upper_wvl(nb)-lower_wvl(nb)))*log(upper_wvl(nb)/lower_wvl(nb))
+                   end if
+                   aod550spc(i,j,nb)=aod5502d(i,j)*aod_rate
+                end do
+             end do
+          end do
+
+       case(3)
+          ! spectral disaggregation based on a prescribed aerosol type and relative humidity
+          call mpas_log_write('--- aer_angexp_opt = $i: angstrom exponent calculated from RH and aer_type $i', &
+                              intArgs=(/aer_angexp_opt,aer_type/))
+          call calc_spectral_aod_rrtmg_sw(ims,ime,jms,jme,kms,kme,      &
+                                          its,ite,jts,jte,kts,kte,      &
+                                          rh,aer_type,aod5502d,         &
+                                          aod550spc,                    &
+                                          aod5503d, aod550spc3d)         ! trude
+
+!-- MPAS modifications: we do not need the variable angexp2d outside of subroutine calc_aerosol_rrtmg_sw. Since it is
+!   declared as an optional variable, we simply test if it is present or not (Laura D. Fowler/2019-01-13):
+          if(present(angexp2d)) then
+          do j=jts,jte
+            do i=its,ite
+              angexp2d(i,j) = 0.0
+            enddo
+          enddo
+
+          if (present(aod5503d)) then
+            do j=jts,jte
+             do k=kts,kte
+              do i=its,ite
+                xy=0
+                xx=0
+                do nb=8,N_BANDS-3  ! bands between 0.4 and  1.0 um
+                   ! the slope of a linear regression with intercept=0 is m=E(xy)/E(x^2), where y=m*x
+                   x=log(0.5*(lower_wvl(nb)+upper_wvl(nb))/0.55)
+                   xy=xy+x*log(aod550spc3d(i,k,j,nb)/aod5503d(i,k,j))
+                   xx=xx+x*x
+                end do
+                angexp2d(i,j) = angexp2d(i,j) - (xy/(N_BANDS-3-8+1))/(xx/(N_BANDS-3-8+1))
+              enddo
+             enddo
+            enddo
+          else
+
+          ! added July, 16th, 2013: angexp2d is in the wrfout when aer_angexp_opt=3. It is the average
+          ! value in the spectral bands between 0.4 and 1. um
+          do j=jts,jte
+             do i=its,ite
+                xy=0
+                xx=0
+                do nb=8,N_BANDS-3  ! bands between 0.4 and  1.0 um
+                   ! the slope of a linear regression with intercept=0 is m=E(xy)/E(x^2), where y=m*x
+                   x=log(0.5*(lower_wvl(nb)+upper_wvl(nb))/0.55)
+                   xy=xy+x*log(aod550spc(i,j,nb)/aod5502d(i,j))
+                   xx=xx+x*x
+                end do
+                angexp2d(i,j)=-(xy/(N_BANDS-3-8+1))/(xx/(N_BANDS-3-8+1))
+             end do
+          end do
+          endif
+       endif ! end MPAS modifications.
+
+       case default
+          write(wrf_err_message,*) 'Expected aer_angexp_opt=[1,2,3]. Got',aer_angexp_opt
+          FATAL_ERROR(trim(wrf_err_message))
+    end select aer_angexp_opt_select
+
+!..If 3D AOD (at 550nm) was provided explicitly, then no need to assume a
+!.. vertical distribution, just use what was provided.  (Trude)
+
+      if (present(aod5503d)) then
+         do nb=1,N_BANDS
+          do j=jts,jte
+           do k=kts,kte
+            do i=its,ite
+               tauaer(i,k,j,nb) = aod550spc3d(i,k,j,nb)
+            enddo
+           enddo
+          enddo
+         enddo
+      else
+         ! exponental -vertical- profile
+         call aod_profiler(ht,dz8w,aod550spc,n_bands,ims,ime,jms,jme,kms,kme, &
+                      its,ite,jts,jte,kts,kte,tauaer                     )
+      endif
+
+    aer_ssa_opt_select: select case(aer_ssa_opt)
+       !case(0)
+       ! reserved for climatology
+       case(1)
+          if ((aer_ssa_val .lt. 0) .or. (aer_ssa_val .gt. 1)) then
+             write(wrf_err_message,'("aer_ssa_val must be within [0,1]. Illegal value ",F7.4," found")') aer_ssa_val
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          write( wrf_err_message, &
+                '("aer_ssa_opt=",I1,": single-scattering albedo fixed to value ",F6.3)') aer_ssa_opt,aer_ssa_val
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                do k=kts,kte
+                   do nb=1,N_BANDS
+                      ! no spectral disaggregation
+                      ssaaer(i,k,j,nb)=aer_ssa_val
+                   end do
+                end do
+             end do
+          end do
+          do j=jts,jte
+             do i=its,ite
+                aerssa2d(i,j)=aer_ssa_val
+             end do
+          end do
+
+       case(2)
+          if (.not.(present(aerssa2d))) then
+             write(wrf_err_message,*) 'Expected gridded aerosol single-scattering albedo, but it is not in the radiation driver'
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          if ((minval(aerssa2d) .lt. 0) .or. (maxval(aerssa2d) .gt. 1)) then
+             write(wrf_err_message,*) 'Aerosol single-scattering albedo must be within [0,1]. ' // &
+                                      'Out of bounds value(s) found in auxinput'
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          write( wrf_err_message, '("aer_ssa_opt=",I1,": single-scattering albedo from auxinput (min=",F6.3," max=",F6.3,")")') &
+                                  aer_ssa_opt,minval(aerssa2d),maxval(aerssa2d)
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                do k=kts,kte
+                   do nb=1,N_BANDS
+                      ! no spectral disaggregation
+                      ssaaer(i,k,j,nb)=aerssa2d(i,j)
+                   end do
+                end do
+             end do
+          end do
+
+       case(3)
+          ! spectral disaggregation based on a prescribed aerosol type and relative humidity
+          call mpas_log_write('--- aer_ssa_opt    = $i: single-scattering albedo calculated from RH and aer_type $i', &
+                              intArgs=(/aer_ssa_opt,aer_type/))
+          call calc_spectral_ssa_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
+                                          its,ite,jts,jte,kts,kte,  &
+                                          rh,aer_type,ssaaer        )
+!-- MPAS modifications: we do not need the variable aerssa2d outside of subroutine calc_aerosol_rrtmg_sw. Since it is
+!   declared as an optional variable, we simply test if it is present or not (Laura D. Fowler/2018=04-09):
+          if(present(aerssa2d)) then
+          ! added July, 16th, 2013: aerssa2d is in the wrfout when aer_ssa_opt=3. It is the average
+          ! value in the spectral bands between 0.4 and 1. um
+          do j=jts,jte
+             do i=its,ite
+                aerssa2d(i,j)=0
+             end do
+          end do
+          do j=jts,jte
+             do i=its,ite
+                do nb=8,N_BANDS-3  ! bands between 0.4 and 1.0 um
+                   aerssa2d(i,j)=aerssa2d(i,j)+ssaaer(i,kts,j,nb)
+                end do
+                aerssa2d(i,j)=aerssa2d(i,j)/(N_BANDS-3-8+1)
+             end do
+          end do
+          endif ! end MPAS modifications.
+
+       case default
+          write(wrf_err_message,*) 'Expected aer_ssa_opt=[1,2,3]. Got',aer_ssa_opt
+          FATAL_ERROR(trim(wrf_err_message))
+    end select aer_ssa_opt_select
+
+    aer_asy_opt_select: select case(aer_asy_opt)
+       !case(0)
+       ! reserved for climatology
+       case(1)
+          if ((aer_asy_val .lt. 0) .or. (aer_asy_val .gt. 1)) then
+             write(wrf_err_message,'("aer_asy_val must be withing [-1,1]. Illegal value ",F7.4," found")') aer_asy_val
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          write( wrf_err_message , '("aer_asy_opt=",I1,": asymmetry parameter fixed to value ",F6.3)') aer_asy_opt,aer_asy_val
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                do k=kts,kte
+                   do nb=1,N_BANDS
+                      asyaer(i,k,j,nb)=aer_asy_val
+                   end do
+                end do
+             end do
+          end do
+          do j=jts,jte
+             do i=its,ite
+                aerasy2d(i,j)=aer_asy_val
+             end do
+          end do
+
+       case(2)
+          if (.not.(present(aerasy2d))) then
+             write(wrf_err_message,*) 'Expected gridded aerosol asymmetry parameter, but it is not in the radiation driver'
+             FATAL_ERROR(trim(wrf_err_message))
+          end if
+          if ((minval(aerasy2d) .lt. -1) .or. (maxval(aerasy2d) .gt. 1)) then
+             FATAL_ERROR('Aerosol asymmetry parameter must be within [-1,1]. Out of bounds value(s) found in auxinput')
+          end if
+          write( wrf_err_message, '("aer_asy_opt=",I1,": asymmetry parameter read from auxinput (min=",F6.3," max=",F6.3,")")') &
+                                  aer_asy_opt,minval(aerasy2d),maxval(aerasy2d)
+          WRITE_MESSAGE(trim(wrf_err_message))
+          do j=jts,jte
+             do i=its,ite
+                do k=kts,kte
+                   do nb=1,N_BANDS
+                      asyaer(i,k,j,nb)=aerasy2d(i,j)
+                   end do
+                end do
+             end do
+          end do
+
+       case(3)
+          ! spectral disaggregation based on a prescribed aerosol type and relative humidity
+          call mpas_log_write('--- aer_asy_opt    = $i: asymmetry parameter calculated from RH and aer_type $i', &
+                              intArgs=(/aer_asy_opt,aer_type/))
+          call calc_spectral_asy_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
+                                          its,ite,jts,jte,kts,kte,  &
+                                          rh,aer_type,asyaer        )
+!-- MPAS modifications: we do not need the variable aerasy2d outside of subroutine calc_aerosol_rrtmg_sw. Since it is
+!   declared as an optional variable, we simply test if it is present or not (Laura D. Fowler/2018=04-09):
+          if(present(aerasy2d)) then
+          ! added July, 16th, 2013: aerasy2d is in the wrfout when aer_asy_opt=3. It is the average
+          ! value in the spectral bands between 0.4 and 1. um
+          do j=jts,jte
+             do i=its,ite
+                aerasy2d(i,j)=0
+             end do
+          end do
+          do j=jts,jte
+             do i=its,ite
+                do nb=8,N_BANDS-3  ! bands between 0.4 and 1.0 um
+                   aerasy2d(i,j)=aerasy2d(i,j)+asyaer(i,kts,j,nb)
+                end do
+                aerasy2d(i,j)=aerasy2d(i,j)/(N_BANDS-3-8+1)
+             end do
+          end do
+          endif ! end MPAS modifications.
+
+       case default
+          write(wrf_err_message,*) 'Expected aer_asy_opt=[1,2,3]. Got',aer_asy_opt
+          FATAL_ERROR(trim(wrf_err_message))
+    end select aer_asy_opt_select
+
+end subroutine calc_aerosol_rrtmg_sw
+
+subroutine calc_spectral_aod_rrtmg_sw(ims,ime,jms,jme,kms,kme,          &
+                                      its,ite,jts,jte,kts,kte,          &
+                                      rh,aer_type,aod550,               &
+                                      tauaer,                           &
+                                      aod550_3d, tauaer3d)               ! trude
+
+   implicit none
+   
+   ! constants
+   integer, parameter :: N_AER_TYPES=3
+   integer, parameter :: N_RH=8
+   integer, parameter :: N_BANDS=14
+   integer, parameter :: N_INT_POINTS=4
+
+   ! I/O variables
+   integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                          its,ite,jts,jte,kts,kte
+!- MPAS modifications: aer_type is a function of the land-sea mask, and set to 1 over land (or rural classification in WRF),
+!  and set to 0 over oceans (or maritime classification in WRF):
+!  integer, intent(in) :: aer_type
+   integer:: aer_t
+   integer, dimension(ims:ime,jms:jme), intent(in):: aer_type
+!- end MPAS modifications (Laura D. Fowler/2018=04-09).
+
+   real, dimension(ims:ime, kms:kme, jms:jme),   intent(in) :: rh        ! relative humidity
+   real, dimension(ims:ime, jms:jme),            intent(in) :: aod550    ! Total AOD at 550 nm at surface
+   real, dimension(ims:ime, jms:jme, 1:N_BANDS), intent(inout) :: tauaer ! Total spectral aerosol optical depth at surface
+
+   ! ++ Trude
+   real, dimension(ims:ime, kms:kme, jms:jme), optional, intent(in) :: aod550_3d ! 3D  AOD at 550 nm 
+   real, dimension(ims:ime, kms:kme, jms:jme, 1:N_BANDS), optional, intent(inout) :: tauaer3d ! 
+   ! -- Trude
+
+   ! local variables
+   integer :: i,j,k,ib,imax,imin,ii,jj,kk
+   real    :: rhs(N_RH),lj
+   real    :: raod_lut(N_AER_TYPES,N_BANDS,N_RH)
+
+   ! relative humidity steps
+   data (rhs(i),i=1,8) /0.,50.,70.,80.,90.,95.,98.,99./
+
+   ! aer_type = 1 : rural (SF79)
+   data (raod_lut(1,ib,1),ib=1,N_BANDS) /0.0735,0.0997,0.1281,0.1529,0.1882,0.2512,0.3010,0.4550,0.7159,1.0357, &
+                                         1.3582,1.6760,2.2523,0.0582/
+   data (raod_lut(1,ib,2),ib=1,N_BANDS) /0.0741,0.1004,0.1289,0.1537,0.1891,0.2522,0.3021,0.4560,0.7166,1.0351, &
+                                         1.3547,1.6687,2.2371,0.0587/
+   data (raod_lut(1,ib,3),ib=1,N_BANDS) /0.0752,0.1017,0.1304,0.1554,0.1909,0.2542,0.3042,0.4580,0.7179,1.0342, &
+                                         1.3485,1.6559,2.2102,0.0596/
+   data (raod_lut(1,ib,4),ib=1,N_BANDS) /0.0766,0.1034,0.1323,0.1575,0.1932,0.2567,0.3068,0.4605,0.7196,1.0332, &
+                                         1.3411,1.6407,2.1785,0.0608/
+   data (raod_lut(1,ib,5),ib=1,N_BANDS) /0.0807,0.1083,0.1379,0.1635,0.1998,0.2639,0.3143,0.4677,0.7244,1.0305, &
+                                         1.3227,1.6031,2.1006,0.0644/
+   data (raod_lut(1,ib,6),ib=1,N_BANDS) /0.0884,0.1174,0.1482,0.1746,0.2118,0.2769,0.3277,0.4805,0.7328,1.0272, &
+                                         1.2977,1.5525,1.9976,0.0712/
+   data (raod_lut(1,ib,7),ib=1,N_BANDS) /0.1072,0.1391,0.1724,0.2006,0.2396,0.3066,0.3581,0.5087,0.7510,1.0231, &
+                                         1.2622,1.4818,1.8565,0.0878/
+   data (raod_lut(1,ib,8),ib=1,N_BANDS) /0.1286,0.1635,0.1991,0.2288,0.2693,0.3377,0.3895,0.5372,0.7686,1.0213, &
+                                         1.2407,1.4394,1.7739,0.1072/
+
+   ! aer_type = 2 : urban (SF79)
+   data (raod_lut(2,ib,1),ib=1,N_BANDS) /0.1244,0.1587,0.1939,0.2233,0.2635,0.3317,0.3835,0.5318,0.7653,1.0344, &
+                                         1.3155,1.5885,2.0706,0.1033/
+   data (raod_lut(2,ib,2),ib=1,N_BANDS) /0.1159,0.1491,0.1834,0.2122,0.2518,0.3195,0.3712,0.5207,0.7585,1.0331, &
+                                         1.3130,1.5833,2.0601,0.0956/
+   data (raod_lut(2,ib,3),ib=1,N_BANDS) /0.1093,0.1416,0.1752,0.2035,0.2427,0.3099,0.3615,0.5118,0.7529,1.0316, &
+                                         1.3083,1.5739,2.0408,0.0898/
+   data (raod_lut(2,ib,4),ib=1,N_BANDS) /0.1062,0.1381,0.1712,0.1993,0.2382,0.3052,0.3567,0.5074,0.7501,1.0302, &
+                                         1.3025,1.5620,2.0168,0.0870/
+   data (raod_lut(2,ib,5),ib=1,N_BANDS) /0.1045,0.1361,0.1690,0.1970,0.2357,0.3025,0.3540,0.5049,0.7486,1.0271, &
+                                         1.2864,1.5297,1.9518,0.0854/
+   data (raod_lut(2,ib,6),ib=1,N_BANDS) /0.1065,0.1384,0.1716,0.1997,0.2386,0.3056,0.3571,0.5078,0.7504,1.0227, &
+                                         1.2603,1.4780,1.8492,0.0872/
+   data (raod_lut(2,ib,7),ib=1,N_BANDS) /0.1147,0.1478,0.1820,0.2107,0.2503,0.3179,0.3696,0.5192,0.7575,1.0146, &
+                                         1.2116,1.3830,1.6658,0.0946/
+   data (raod_lut(2,ib,8),ib=1,N_BANDS) /0.1247,0.1590,0.1943,0.2237,0.2639,0.3322,0.3840,0.5322,0.7656,1.0082, &
+                                         1.1719,1.3075,1.5252,0.1036/
+
+   ! aer_type = 3 : maritime (SF79)
+   data (raod_lut(3,ib,1),ib=1,N_BANDS) /0.3053,0.3507,0.3932,0.4261,0.4681,0.5334,0.5797,0.6962,0.8583,1.0187, &
+                                         1.1705,1.3049,1.5205,0.2748/
+   data (raod_lut(3,ib,2),ib=1,N_BANDS) /0.3566,0.4023,0.4443,0.4765,0.5170,0.5792,0.6227,0.7298,0.8756,1.0162, &
+                                         1.1472,1.2614,1.4415,0.3256/
+   data (raod_lut(3,ib,3),ib=1,N_BANDS) /0.4359,0.4803,0.5203,0.5505,0.5879,0.6441,0.6828,0.7756,0.8985,1.0135, &
+                                         1.1198,1.2109,1.3518,0.4051/
+   data (raod_lut(3,ib,4),ib=1,N_BANDS) /0.5128,0.5544,0.5913,0.6187,0.6523,0.7020,0.7358,0.8149,0.9174,1.0115, &
+                                         1.0995,1.1740,1.2875,0.4835/
+   data (raod_lut(3,ib,5),ib=1,N_BANDS) /0.6479,0.6816,0.7108,0.7320,0.7575,0.7946,0.8193,0.8752,0.9455,1.0092, &
+                                         1.0728,1.1263,1.2061,0.6236/
+   data (raod_lut(3,ib,6),ib=1,N_BANDS) /0.7582,0.7831,0.8043,0.8196,0.8377,0.8636,0.8806,0.9184,0.9649,1.0080, &
+                                         1.0564,1.0973,1.1576,0.7399/
+   data (raod_lut(3,ib,7),ib=1,N_BANDS) /0.8482,0.8647,0.8785,0.8884,0.9000,0.9164,0.9272,0.9506,0.9789,1.0072, &
+                                         1.0454,1.0780,1.1256,0.8360/
+   data (raod_lut(3,ib,8),ib=1,N_BANDS) /0.8836,0.8965,0.9073,0.9149,0.9239,0.9365,0.9448,0.9626,0.9841,1.0069, &
+                                         1.0415,1.0712,1.1145,0.8741/
+
+!   ++ Trude    ;  if 3D AOD, disaggreaget at all levels.
+   if (present(aod550_3d)) then
+      do j=jts,jte
+         do i=its,ite
+            !-- initialization of aerosol type:
+            aer_t = aer_type(i,j)
+            !   common part of the Lagrange's interpolator
+            !   only depends on the relative humidity value
+            do kk = kts,kte
+               ii=1
+               do while ( (ii.le.N_RH) .and. (rh(i,kk,j).gt.rhs(ii)) )
+                  ii=ii+1
+               end do
+               imin=max(1,ii-N_INT_POINTS/2-1)
+               imax=min(N_RH,ii+N_INT_POINTS/2)
+
+               do ib=1,N_BANDS
+                  tauaer3d(i,kk,j,ib)=0.
+                  do jj=imin,imax
+                     lj=1.
+                     do k=imin,imax
+                        if (k.ne.jj) lj=lj*(rh(i,kk,j)-rhs(k))/(rhs(jj)-rhs(k))
+                     end do
+                     tauaer3d(i,kk,j,ib)=tauaer3d(i,kk,j,ib)+lj*raod_lut(aer_t,ib,jj)*aod550_3d(i,kk,j)
+                  end do
+               end do
+            end do
+         end do
+      end do
+    else
+! -- Trude
+
+   do j=jts,jte
+      do i=its,ite
+         !-- initialization of aerosol type:
+         aer_t = aer_type(i,j)
+         ! common part of the Lagrange's interpolator
+         !   only depends on the relative humidity value
+         ii=1
+         do while ( (ii.le.N_RH) .and. (rh(i,kts,j).gt.rhs(ii)) )
+            ii=ii+1
+         end do
+         imin=max(1,ii-N_INT_POINTS/2-1)
+         imax=min(N_RH,ii+N_INT_POINTS/2)
+
+         do ib=1,N_BANDS
+            tauaer(i,j,ib)=0.
+            do jj=imin,imax
+               lj=1.
+               do k=imin,imax
+                  if (k.ne.jj) lj=lj*(rh(i,kts,j)-rhs(k))/(rhs(jj)-rhs(k))
+               end do
+               tauaer(i,j,ib)=tauaer(i,j,ib)+lj*raod_lut(aer_t,ib,jj)*aod550(i,j)
+            end do
+         end do
+      end do
+   end do
+   endif
+
+end subroutine calc_spectral_aod_rrtmg_sw
+
+subroutine calc_spectral_ssa_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
+                                      its,ite,jts,jte,kts,kte,  &
+                                      rh,aer_type,              &
+                                      ssaaer                    )
+   implicit none
+   
+   ! constants
+   integer, parameter :: N_AER_TYPES=3
+   integer, parameter :: N_RH=8
+   integer, parameter :: N_BANDS=14
+   integer, parameter :: N_INT_POINTS=4
+
+   ! I/O variables
+   integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                          its,ite,jts,jte,kts,kte
+!- MPAS modifications: aer_type is a function of the land-sea mask, and set to 1 over land (or rural classification in WRF),
+!  and set to 0 over oceans (or maritime classification in WRF):
+!  integer, intent(in) :: aer_type
+   integer:: aer_t
+   integer, dimension(ims:ime,jms:jme), intent(in):: aer_type
+!- end MPAS modifications (Laura D. Fowler/2018=04-09).
+   real, dimension(ims:ime, kms:kme, jms:jme),            intent(in)    :: rh     ! surface relative humidity
+   real, dimension(ims:ime, kms:kme, jms:jme, 1:N_BANDS), intent(inout) :: ssaaer ! aerosol single-scattering albedo at surface
+
+   ! local variables
+   integer :: i,j,k,kk,ib,imax,imin,ii,jj
+   real    :: rhs(N_RH),lj
+   real    :: ssa_lut(N_AER_TYPES,N_BANDS,N_RH)
+
+   ! relative humidity steps
+   data (rhs(i),i=1,8) /0.,50.,70.,80.,90.,95.,98.,99./
+
+   ! aer_type = 1 : rural (SF79)
+   data (ssa_lut(1,ib,1),ib=1,N_BANDS) /0.8730,0.6695,0.8530,0.8601,0.8365,0.7949,0.8113,0.8810,0.9305,0.9436, &
+                                        0.9532,0.9395,0.8007,0.8634/
+   data (ssa_lut(1,ib,2),ib=1,N_BANDS) /0.8428,0.6395,0.8571,0.8645,0.8408,0.8007,0.8167,0.8845,0.9326,0.9454, &
+                                        0.9545,0.9416,0.8070,0.8589/
+   data (ssa_lut(1,ib,3),ib=1,N_BANDS) /0.8000,0.6025,0.8668,0.8740,0.8503,0.8140,0.8309,0.8943,0.9370,0.9489, &
+                                        0.9577,0.9451,0.8146,0.8548/
+   data (ssa_lut(1,ib,4),ib=1,N_BANDS) /0.7298,0.5666,0.9030,0.9049,0.8863,0.8591,0.8701,0.9178,0.9524,0.9612, &
+                                        0.9677,0.9576,0.8476,0.8578/
+   data (ssa_lut(1,ib,5),ib=1,N_BANDS) /0.7010,0.5606,0.9312,0.9288,0.9183,0.9031,0.9112,0.9439,0.9677,0.9733, &
+                                        0.9772,0.9699,0.8829,0.8590/
+   data (ssa_lut(1,ib,6),ib=1,N_BANDS) /0.6933,0.5620,0.9465,0.9393,0.9346,0.9290,0.9332,0.9549,0.9738,0.9782, &
+                                        0.9813,0.9750,0.8980,0.8594/
+   data (ssa_lut(1,ib,7),ib=1,N_BANDS) /0.6842,0.5843,0.9597,0.9488,0.9462,0.9470,0.9518,0.9679,0.9808,0.9839, &
+                                        0.9864,0.9794,0.9113,0.8648/
+   data (ssa_lut(1,ib,8),ib=1,N_BANDS) /0.6786,0.5897,0.9658,0.9522,0.9530,0.9610,0.9651,0.9757,0.9852,0.9871, &
+                                        0.9883,0.9835,0.9236,0.8618/
+
+   ! aer_type = 2: urban (SF79)
+   data (ssa_lut(2,ib,1),ib=1,N_BANDS) /0.4063,0.3663,0.4093,0.4205,0.4487,0.4912,0.5184,0.5743,0.6233,0.6392, &
+                                        0.6442,0.6408,0.6105,0.4094/
+   data (ssa_lut(2,ib,2),ib=1,N_BANDS) /0.4113,0.3654,0.4215,0.4330,0.4604,0.5022,0.5293,0.5848,0.6336,0.6493, &
+                                        0.6542,0.6507,0.6205,0.4196/
+   data (ssa_lut(2,ib,3),ib=1,N_BANDS) /0.4500,0.3781,0.4924,0.5050,0.5265,0.5713,0.6048,0.6274,0.6912,0.7714, &
+                                        0.7308,0.7027,0.6772,0.4820/
+   data (ssa_lut(2,ib,4),ib=1,N_BANDS) /0.5075,0.4139,0.5994,0.6127,0.6350,0.6669,0.6888,0.7333,0.7704,0.7809, &
+                                        0.7821,0.7762,0.7454,0.5709/
+   data (ssa_lut(2,ib,5),ib=1,N_BANDS) /0.5596,0.4570,0.7009,0.7118,0.7317,0.7583,0.7757,0.8093,0.8361,0.8422, &
+                                        0.8406,0.8337,0.8036,0.6525/
+   data (ssa_lut(2,ib,6),ib=1,N_BANDS) /0.6008,0.4971,0.7845,0.7906,0.8075,0.8290,0.8418,0.8649,0.8824,0.8849, &
+                                        0.8815,0.8739,0.8455,0.7179/
+   data (ssa_lut(2,ib,7),ib=1,N_BANDS) /0.6401,0.5407,0.8681,0.8664,0.8796,0.8968,0.9043,0.9159,0.9244,0.9234, &
+                                        0.9182,0.9105,0.8849,0.7796/
+   data (ssa_lut(2,ib,8),ib=1,N_BANDS) /0.6567,0.5618,0.9073,0.9077,0.9182,0.9279,0.9325,0.9398,0.9440,0.9413, &
+                                        0.9355,0.9278,0.9039,0.8040/
+
+   ! aer_type = 3 : maritime (SF79)
+   data (ssa_lut(3,ib,1),ib=1,N_BANDS) /0.9697,0.9183,0.9749,0.9820,0.9780,0.9712,0.9708,0.9778,0.9831,0.9827, &
+                                        0.9826,0.9723,0.8763,0.9716/
+   data (ssa_lut(3,ib,2),ib=1,N_BANDS) /0.9070,0.8491,0.9730,0.9816,0.9804,0.9742,0.9738,0.9802,0.9847,0.9841, &
+                                        0.9838,0.9744,0.8836,0.9546/
+   data (ssa_lut(3,ib,3),ib=1,N_BANDS) /0.8378,0.7761,0.9797,0.9827,0.9829,0.9814,0.9812,0.9852,0.9882,0.9875, &
+                                        0.9871,0.9791,0.9006,0.9348/
+   data (ssa_lut(3,ib,4),ib=1,N_BANDS) /0.7866,0.7249,0.9890,0.9822,0.9856,0.9917,0.9924,0.9932,0.9943,0.9938, &
+                                        0.9933,0.9887,0.9393,0.9204/
+   data (ssa_lut(3,ib,5),ib=1,N_BANDS) /0.7761,0.7164,0.9959,0.9822,0.9834,0.9941,0.9955,0.9952,0.9960,0.9956, &
+                                        0.9951,0.9922,0.9538,0.9152/
+   data (ssa_lut(3,ib,6),ib=1,N_BANDS) /0.7671,0.7114,0.9902,0.9786,0.9838,0.9954,0.9970,0.9965,0.9971,0.9968, &
+                                        0.9964,0.9943,0.9644,0.9158/
+   data (ssa_lut(3,ib,7),ib=1,N_BANDS) /0.7551,0.7060,0.9890,0.9743,0.9807,0.9966,0.9989,0.9978,0.9982,0.9980, &
+                                        0.9978,0.9964,0.9757,0.9122/
+   data (ssa_lut(3,ib,8),ib=1,N_BANDS) /0.7439,0.7000,0.9870,0.9695,0.9769,0.9970,1.0000,0.9984,0.9988,0.9986, &
+                                        0.9984,0.9975,0.9825,0.9076/
+
+   do j=jts,jte
+      do i=its,ite
+         !-- initialization of aerosol type:
+         aer_t = aer_type(i,j)
+         do k=kts,kte
+            ! common part of the Lagrange's interpolator
+            !   only depends on the relative humidity value
+            ii=1
+            do while ( (ii.le.N_RH) .and. (rh(i,k,j).gt.rhs(ii)) )
+               ii=ii+1
+            end do
+            imin=max(1,ii-N_INT_POINTS/2-1)
+            imax=min(N_RH,ii+N_INT_POINTS/2)
+
+            do ib=1,N_BANDS
+               ssaaer(i,k,j,ib)=0.
+               do jj=imin,imax
+                  lj=1.
+                  do kk=imin,imax
+                     if (kk.ne.jj) lj=lj*(rh(i,k,j)-rhs(kk))/(rhs(jj)-rhs(kk))
+                  end do
+                  ssaaer(i,k,j,ib)=ssaaer(i,k,j,ib)+lj*ssa_lut(aer_t,ib,jj)
+               end do
+            end do
+         end do
+      end do
+   end do
+end subroutine calc_spectral_ssa_rrtmg_sw
+
+subroutine calc_spectral_asy_rrtmg_sw(ims,ime,jms,jme,kms,kme,  &
+                                      its,ite,jts,jte,kts,kte,  &
+                                      rh,aer_type,              &
+                                      asyaer                    )
+   implicit none
+   
+   ! constants
+   integer, parameter :: N_AER_TYPES=3
+   integer, parameter :: N_RH=8
+   integer, parameter :: N_BANDS=14
+   integer, parameter :: N_INT_POINTS=4
+
+   ! I/O variables
+   integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                          its,ite,jts,jte,kts,kte
+!- MPAS modifications: aer_type is a function of the land-sea mask, and set to 1 over land (or rural classification in WRF),
+!  and set to 0 over oceans (or maritime classification in WRF):
+!  integer, intent(in) :: aer_type
+   integer:: aer_t
+   integer, dimension(ims:ime,jms:jme), intent(in):: aer_type
+!- end MPAS modifications (Laura D. Fowler/2018=04-09).
+   real, dimension(ims:ime, kms:kme, jms:jme),            intent(in)    :: rh ! surface relative humidity
+   real, dimension(ims:ime, kms:kme, jms:jme, 1:N_BANDS), intent(inout) :: asyaer ! aerosol asymmetry parameter at surface
+
+   ! local variables
+   integer :: i,j,k,kk,ib,imax,imin,ii,jj
+   real    :: rhs(N_RH),lj
+   real    :: asy_lut(N_AER_TYPES,N_BANDS,N_RH)
+
+   ! relative humidity steps
+   data (rhs(i),i=1,8) /0.,50.,70.,80.,90.,95.,98.,99./
+
+   ! aer_type = 1 : rural (SF79)
+   data (asy_lut(1,ib,1),ib=1,N_BANDS) /0.7444,0.7711,0.7306,0.7103,0.6693,0.6267,0.6169,0.6207,0.6341,0.6497, &
+                                        0.6630,0.6748,0.7208,0.7419/
+   data (asy_lut(1,ib,2),ib=1,N_BANDS) /0.7444,0.7747,0.7314,0.7110,0.6711,0.6301,0.6210,0.6251,0.6392,0.6551, &
+                                        0.6680,0.6799,0.7244,0.7436/
+   data (asy_lut(1,ib,3),ib=1,N_BANDS) /0.7438,0.7845,0.7341,0.7137,0.6760,0.6381,0.6298,0.6350,0.6497,0.6657, &
+                                        0.6790,0.6896,0.7300,0.7477/
+   data (asy_lut(1,ib,4),ib=1,N_BANDS) /0.7336,0.7934,0.7425,0.7217,0.6925,0.6665,0.6616,0.6693,0.6857,0.7016, &
+                                        0.7139,0.7218,0.7495,0.7574/
+   data (asy_lut(1,ib,5),ib=1,N_BANDS) /0.7111,0.7865,0.7384,0.7198,0.6995,0.6864,0.6864,0.6987,0.7176,0.7326, &
+                                        0.7427,0.7489,0.7644,0.7547/
+   data (asy_lut(1,ib,6),ib=1,N_BANDS) /0.7009,0.7828,0.7366,0.7196,0.7034,0.6958,0.6979,0.7118,0.7310,0.7452, &
+                                        0.7542,0.7593,0.7692,0.7522/
+   data (asy_lut(1,ib,7),ib=1,N_BANDS) /0.7226,0.8127,0.7621,0.7434,0.7271,0.7231,0.7248,0.7351,0.7506,0.7622, &
+                                        0.7688,0.7719,0.7756,0.7706/
+   data (asy_lut(1,ib,8),ib=1,N_BANDS) /0.7296,0.8219,0.7651,0.7513,0.7404,0.7369,0.7386,0.7485,0.7626,0.7724, &
+                                        0.7771,0.7789,0.7790,0.7760/
+
+   ! aer_type = 2: urban (SF79)
+   data (asy_lut(2,ib,1),ib=1,N_BANDS) /0.7399,0.7372,0.7110,0.6916,0.6582,0.6230,0.6147,0.6214,0.6412,0.6655, &
+                                        0.6910,0.7124,0.7538,0.7395/
+   data (asy_lut(2,ib,2),ib=1,N_BANDS) /0.7400,0.7419,0.7146,0.6952,0.6626,0.6287,0.6209,0.6280,0.6481,0.6723, &
+                                        0.6974,0.7180,0.7575,0.7432/
+   data (asy_lut(2,ib,3),ib=1,N_BANDS) /0.7363,0.7614,0.7303,0.7100,0.6815,0.6550,0.6498,0.6590,0.6802,0.7032, &
+                                        0.7255,0.7430,0.7735,0.7580/
+   data (asy_lut(2,ib,4),ib=1,N_BANDS) /0.7180,0.7701,0.7358,0.7163,0.6952,0.6807,0.6801,0.6935,0.7160,0.7370, &
+                                        0.7553,0.7681,0.7862,0.7623/
+   data (asy_lut(2,ib,5),ib=1,N_BANDS) /0.7013,0.7733,0.7374,0.7203,0.7057,0.7006,0.7035,0.7192,0.7415,0.7596, &
+                                        0.7739,0.7827,0.7906,0.7596/
+   data (asy_lut(2,ib,6),ib=1,N_BANDS) /0.6922,0.7773,0.7404,0.7264,0.7170,0.7179,0.7228,0.7389,0.7595,0.7746, &
+                                        0.7851,0.7909,0.7918,0.7562/
+   data (asy_lut(2,ib,7),ib=1,N_BANDS) /0.6928,0.7875,0.7491,0.7393,0.7345,0.7397,0.7455,0.7602,0.7773,0.7883, &
+                                        0.7944,0.7970,0.7912,0.7555/
+   data (asy_lut(2,ib,8),ib=1,N_BANDS) /0.7021,0.7989,0.7590,0.7512,0.7613,0.7746,0.7718,0.7727,0.7867,0.7953, &
+                                        0.7988,0.7994,0.7906,0.7600/
+
+   ! aer_type = 3 : maritime (SF79)
+   data (asy_lut(3,ib,1),ib=1,N_BANDS) /0.6620,0.7011,0.7111,0.7068,0.6990,0.6918,0.6883,0.6827,0.6768,0.6773, &
+                                        0.6863,0.6940,0.7245,0.6719/
+   data (asy_lut(3,ib,2),ib=1,N_BANDS) /0.6880,0.7394,0.7297,0.7240,0.7162,0.7083,0.7038,0.6957,0.6908,0.6917, &
+                                        0.6952,0.7035,0.7356,0.6977/
+   data (asy_lut(3,ib,3),ib=1,N_BANDS) /0.7266,0.7970,0.7666,0.7593,0.7505,0.7427,0.7391,0.7293,0.7214,0.7210, &
+                                        0.7212,0.7265,0.7519,0.7340/
+   data (asy_lut(3,ib,4),ib=1,N_BANDS) /0.7683,0.8608,0.8120,0.8030,0.7826,0.7679,0.7713,0.7760,0.7723,0.7716, &
+                                        0.7726,0.7767,0.7884,0.7768/
+   data (asy_lut(3,ib,5),ib=1,N_BANDS) /0.7776,0.8727,0.8182,0.8083,0.7985,0.7939,0.7953,0.7913,0.7846,0.7870, &
+                                        0.7899,0.7918,0.7969,0.7870/
+   data (asy_lut(3,ib,6),ib=1,N_BANDS) /0.7878,0.8839,0.8231,0.8130,0.8050,0.7977,0.7945,0.7932,0.7955,0.7992, &
+                                        0.8025,0.8035,0.8055,0.7956/
+   data (asy_lut(3,ib,7),ib=1,N_BANDS) /0.8005,0.8957,0.8273,0.8179,0.8105,0.8035,0.8010,0.8030,0.8081,0.8108, &
+                                        0.8143,0.8174,0.8174,0.8042/
+   data (asy_lut(3,ib,8),ib=1,N_BANDS) /0.8104,0.9034,0.8294,0.8212,0.8144,0.8087,0.8077,0.8118,0.8175,0.8202, &
+                                        0.8239,0.8265,0.8246,0.8095/
+
+   do j=jts,jte
+      do i=its,ite
+         !-- initialization of aerosol type:
+         aer_t = aer_type(i,j)
+         do k=kts,kte
+            ! common part of the Lagrange's interpolator
+            !   only depends on the relative humidity value
+            ii=1
+            do while ( (ii.le.N_RH) .and. (rh(i,k,j).gt.rhs(ii)) )
+               ii=ii+1
+            end do
+            imin=max(1,ii-N_INT_POINTS/2-1)
+            imax=min(N_RH,ii+N_INT_POINTS/2)
+
+            do ib=1,N_BANDS
+               asyaer(i,k,j,ib)=0.
+               do jj=imin,imax
+                  lj=1.
+                  do kk=imin,imax
+                     if (kk.ne.jj) lj=lj*(rh(i,k,j)-rhs(kk))/(rhs(jj)-rhs(kk))
+                  end do
+                  asyaer(i,k,j,ib)=asyaer(i,k,j,ib)+lj*asy_lut(aer_t,ib,jj)
+               end do
+            end do
+         end do
+      end do
+   end do
+end subroutine calc_spectral_asy_rrtmg_sw
+
+subroutine aod_profiler(ht,dz8w,taod550,n_bands,   &
+                        ims,ime,jms,jme,kms,kme,   &
+                        its,ite,jts,jte,kts,kte,   &
+                        aod550                     &
+                                                   )
+   implicit none
+   
+   ! constants
+   real, parameter :: scale_height=2500. ! meters
+
+   ! I/O variables
+   integer, intent(in) :: n_bands
+   integer, intent(in) :: ims,ime,jms,jme,kms,kme, &
+                          its,ite,jts,jte,kts,kte
+   real, dimension( ims:ime, jms:jme),            intent(in) :: ht
+   real, dimension( ims:ime, kms:kme, jms:jme ),  intent(in) :: dz8w
+   real, dimension( ims:ime, jms:jme, 1:n_bands), intent(in) :: taod550
+   real, dimension( ims:ime, kms:kme, jms:jme, 1:n_bands ), intent(inout) :: aod550
+
+   ! local variables
+   real, dimension(its:ite,kts:kte) :: z2d,aod5502d
+   real, dimension(its:ite)         :: htoa
+   real :: aod_scale
+   real :: aod_acum
+   integer :: i,j,k,nb
+
+   ! input variables from driver are defined such as kms is sfc and
+   ! kme is toa. Equivalently, kts is sfc and kte is toa
+   do j=jts,jte
+      ! heigth profile
+      !   kts=surface, kte=toa
+      do i=its,ite
+         z2d(i,kts)=ht(i,j)+0.5*dz8w(i,kts,j)
+         do k=kts+1,kte
+            z2d(i,k)=z2d(i,k-1)+0.5*(dz8w(i,k-1,j)+dz8w(i,k,j))
+         end do
+         htoa(i)=z2d(i,kte)+0.5*dz8w(i,kte,j)
+      end do
+
+      do nb=1,n_bands
+         ! AOD exponential profile
+         do i=its,ite
+            aod_scale=taod550(i,j,nb)/(scale_height*(exp(-ht(i,j)/scale_height)-exp(-htoa(i)/scale_height)))
+            do k=kts,kte
+               aod550(i,k,j,nb)=aod_scale*dz8w(i,k,j)*exp(-z2d(i,k)/scale_height)
+            end do
+         end do 
+      end do ! nb-loop
+   end do ! j-loop
+end subroutine aod_profiler
+
+subroutine calc_relative_humidity(p,t3d,qv3d,                 &
+                                  ims,ime,jms,jme,kms,kme,    &
+                                  its,ite,jts,jte,kts,kte,    &
+                                  rh                          )
+   implicit none
+   
+   ! I/O variables
+   integer, intent(in) :: ims,ime,jms,jme,kms,kme,its,ite,jts,jte,kts,kte
+   ! Naming convention: 8~at => p8w reads as "p-at-w" (w=full levels)
+   real, dimension(ims:ime, kms:kme, jms:jme), intent(in)    :: p,    & ! pressure (Pa)
+                                                                t3d,  & ! temperature (K)
+                                                                qv3d    ! water vapor mixing ratio (kg/kg)
+   real, dimension(ims:ime, kms:kme, jms:jme), intent(inout) :: rh      ! relative humidity at surface
+
+   ! local variables
+   real    :: tc,rv,es,e
+   integer :: i,j,k
+
+   do j=jts,jte
+      do i=its,ite
+         do k=kts,kte                               ! only calculations at surface level
+            tc=t3d(i,k,j)-273.15                    ! temperature (C)
+            rv=max(0.,qv3d(i,k,j))                  ! water vapor mixing ration (kg kg-1)
+            es=6.112*exp((17.6*tc)/(tc+243.5))      ! saturation vapor pressure, hPa, Bolton (1980)
+            e =0.01*rv*p(i,k,j)/(rv+0.62197)        ! vapor pressure, hPa, (ECMWF handouts, page 6, Atmosph. Thermdyn.)
+                                                    ! rv=eps * e/(p-e) -> e=p * rv/(rv+eps), eps=0.62197
+            rh(i,k,j)=min(99.,max(0.,100.*e/es))    ! relative humidity (%)
+         end do
+      end do
+   end do
+
+end subroutine calc_relative_humidity
+
+!=================================================================================================================
+ end module module_ra_rrtmg_sw_aerosols
+!=================================================================================================================

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -14,6 +14,7 @@ OBJS =  \
 	mpas_init_atm_gwd.o \
 	mpas_init_atm_surface.o \
 	mpas_init_atm_vinterp.o \
+	mpas_init_atm_thompson_aerosols.o \
 	read_geogrid.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_date_time.o \
@@ -57,12 +58,21 @@ mpas_init_atm_cases.o: \
 	mpas_init_atm_static.o \
 	mpas_init_atm_gwd.o \
 	mpas_init_atm_surface.o \
+	mpas_init_atm_thompson_aerosols.o \
 	mpas_init_atm_vinterp.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_functions.o \
 	mpas_atmphys_initialize_real.o
 
 mpas_init_atm_hinterp.o: mpas_init_atm_queue.o mpas_init_atm_bitarray.o
+
+mpas_init_atm_thompson_aerosols.o: \
+	mpas_init_atm_read_met.o \
+	mpas_init_atm_hinterp.o \
+	mpas_init_atm_llxy.o \
+	mpas_init_atm_vinterp.o \
+	mpas_atmphys_date_time.o \
+	mpas_atmphys_utilities.o
 
 mpas_advection.o: 
 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -454,6 +454,9 @@
                         <var name="zb" packages="met_stage_in"/>
                         <var name="zb3" packages="met_stage_in"/>
                         <var name="dss" packages="met_stage_in"/>
+                        <var name="nifa_gocart_clim" packages="met_stage_in"/>
+                        <var name="nwfa_gocart_clim" packages="met_stage_in"/>
+                        <var name="pwif_gocart_clim" packages="met_stage_in"/>
 		</stream>
 
 		<stream name="output" 
@@ -591,9 +594,9 @@
                         <var name="q2" packages="met_stage_out"/>
                         <var name="rh2" packages="met_stage_out"/>
                         <var name="t2m" packages="met_stage_out"/>
-                        <var name="nifa_gocart_clim" packages="met_stage_out"/>
-                        <var name="nwfa_gocart_clim" packages="met_stage_out"/>
-                        <var name="pwif_gocart_clim" packages="met_stage_out"/>
+                        <var name="nifa_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
+                        <var name="nwfa_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
+                        <var name="pwif_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
 		</stream>
 
 		<stream name="surface" 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -38,6 +38,8 @@
                      description="The number of first-guess soil layers"/>
                 <dim name="nVertLevelsP1" definition="nVertLevels+1"
                      description="The number of atmospheric levels, always one more than the number of layers"/>
+                <dim name="nGocartLevels" definition="namelist:config_gocartlevels"
+                     description="The number of prescribed pressure levels in the climatological GOCART data set"/>
                 <dim name="nMonths" definition="namelist:config_months"
                      description="The number of months in a year"/>
         </dims>
@@ -121,6 +123,11 @@
                 <nml_option name="config_nfgsoillevels"         type="integer"       default_value="4"
                      units="-"
                      description="The number of vertical soil levels in the first-guess dataset (case 7 only)"
+                     possible_values="Positive integer values"/>
+
+                <nml_option name="config_gocartlevels"          type="integer"       default_value="30"
+                     units="-"
+                     description="The number of vertical gocart levels in the climatological gocart data set"
                      possible_values="Positive integer values"/>
 
                 <nml_option name="config_months"                type="integer"       default_value="12"      in_defaults="false"
@@ -583,6 +590,9 @@
                         <var name="q2" packages="met_stage_out"/>
                         <var name="rh2" packages="met_stage_out"/>
                         <var name="t2m" packages="met_stage_out"/>
+                        <var name="nifa_gocart_clim" packages="met_stage_out"/>
+                        <var name="nwfa_gocart_clim" packages="met_stage_out"/>
+                        <var name="pwif_gocart_clim" packages="met_stage_out"/>
 		</stream>
 
 		<stream name="surface" 
@@ -841,6 +851,19 @@
                      description="effective orographic length for north-westerly flow"
                      packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
 
+                <!-- GOCART aerosol fields -->
+                <var name="nifa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
+                     description="climatological Gocart ice-friendly number concentration"
+                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+
+                <var name="nwfa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
+                     description="climatological Gocart water-friendly number concentration"
+                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+
+                <var name="pwif_gocart_clim" type="real"  dimensions="nMonths nGocartLevels nCells" units="Pa"
+                     description="climatological Gocart pressure levels"
+                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+
                 <!-- description of the vertical grid structure -->
                 <var name="hx" type="real" dimensions="nVertLevelsP1 nCells" units="m"
                      description="terrain influence in vertical coordinate, $h_s(x,y,\zeta)$ in Klemp (MWR 2011)"
@@ -976,6 +999,12 @@
 
                         <var name="qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio"/>
+
+                        <var name="nifa" array_group="number" units="nb kg^{-1}"
+                             description="Gocart ice-friendly aerosol number concentration"/>
+
+                        <var name="nwfa" array_group="number" units="nb kg^{-1}"
+                             description="Gocart water-friendly aerosol number concentration"/>
                 </var_array>
 
                 <!-- Climatology for ocean mixed-layer depth -->
@@ -1010,6 +1039,12 @@
 
                         <var name="lbc_qr" array_group="moist" units="kg kg^{-1}"
                              description="Rain water mixing ratio on lateral boundary cells"/>
+
+                        <var name="lbc_nifa" array_group="number" units="nb kg^{-1}"
+                             description="Gocart ice-friendly aerosol number concentration on lateral boundary cells"/>
+
+                        <var name="lbc_nwfa" array_group="number" units="nb kg^{-1}"
+                             description="Gocart water-friendly aerosol number concentration on lateral boundary cells"/>
                 </var_array>
 
         </var_struct>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -454,9 +454,6 @@
                         <var name="zb" packages="met_stage_in"/>
                         <var name="zb3" packages="met_stage_in"/>
                         <var name="dss" packages="met_stage_in"/>
-                        <var name="nifa_gocart_clim" packages="met_stage_in"/>
-                        <var name="nwfa_gocart_clim" packages="met_stage_in"/>
-                        <var name="pwif_gocart_clim" packages="met_stage_in"/>
 		</stream>
 
 		<stream name="output" 
@@ -594,9 +591,6 @@
                         <var name="q2" packages="met_stage_out"/>
                         <var name="rh2" packages="met_stage_out"/>
                         <var name="t2m" packages="met_stage_out"/>
-                        <var name="nifa_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
-                        <var name="nwfa_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
-                        <var name="pwif_gocart_clim" packages="met_stage_out;mp_thompson_aers_in"/>
 		</stream>
 
 		<stream name="surface" 

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -351,6 +351,7 @@
                 <package name="met_stage_in" description="Active only if meteorological fields are being interpolated"/>
                 <package name="met_stage_out" description="Active only if meteorological fields are being interpolated"/>
                 <package name="first_guess_field" description="3-d atmospheric or land-surface fields on first-guess levels"/>
+                <package name="mp_thompson_aers_in" description="initialization of GOCART-based Thompson water- and ice-friendly aerosols"/>
         </packages>
 
 
@@ -557,7 +558,7 @@
                         <var name="v_init" packages="met_stage_out"/>
                         <var name="t_init" packages="met_stage_out"/>
                         <var name="qv_init" packages="met_stage_out"/>
-                        <var_array name="scalars" packages="met_stage_out"/>
+                        <var_array name="scalars" packages="met_stage_out";mp_thompson_aers_in"/>
                         <var name="u" packages="met_stage_out"/>
                         <var name="w" packages="met_stage_out"/>
                         <var name="dz" packages="met_stage_out"/>
@@ -854,15 +855,15 @@
                 <!-- GOCART aerosol fields -->
                 <var name="nifa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
                      description="climatological Gocart ice-friendly number concentration"
-                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+                     packages="mp_thompson_aers_in"/>
 
                 <var name="nwfa_gocart_clim" type="real" dimensions="nMonths nGocartLevels nCells" units="nb kg^{-1}"
                      description="climatological Gocart water-friendly number concentration"
-                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+                     packages="mp_thompson_aers_in"/>
 
                 <var name="pwif_gocart_clim" type="real"  dimensions="nMonths nGocartLevels nCells" units="Pa"
                      description="climatological Gocart pressure levels"
-                     packages="gwd_stage_out;vertical_stage_out;met_stage_out"/>
+                     packages="mp_thompson_aers_in"/>
 
                 <!-- description of the vertical grid structure -->
                 <var name="hx" type="real" dimensions="nVertLevelsP1 nCells" units="m"
@@ -1001,10 +1002,12 @@
                              description="Rain water mixing ratio"/>
 
                         <var name="nifa" array_group="number" units="nb kg^{-1}"
-                             description="Gocart ice-friendly aerosol number concentration"/>
+                             description="Gocart ice-friendly aerosol number concentration"
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="nwfa" array_group="number" units="nb kg^{-1}"
-                             description="Gocart water-friendly aerosol number concentration"/>
+                             description="Gocart water-friendly aerosol number concentration"
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 
                 <!-- Climatology for ocean mixed-layer depth -->
@@ -1041,10 +1044,12 @@
                              description="Rain water mixing ratio on lateral boundary cells"/>
 
                         <var name="lbc_nifa" array_group="number" units="nb kg^{-1}"
-                             description="Gocart ice-friendly aerosol number concentration on lateral boundary cells"/>
+                             description="Gocart ice-friendly aerosol number concentration on lateral boundary cells"
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="lbc_nwfa" array_group="number" units="nb kg^{-1}"
-                             description="Gocart water-friendly aerosol number concentration on lateral boundary cells"/>
+                             description="Gocart water-friendly aerosol number concentration on lateral boundary cells"
+                             packages="mp_thompson_aers_in"/>
                 </var_array>
 
         </var_struct>

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -19,7 +19,7 @@ module init_atm_cases
    use mpas_timer
    use mpas_init_atm_static
    use mpas_init_atm_surface
-   use mpas_init_atm_thompson_aerosols
+   use mpas_init_atm_thompson_aerosols, only: init_atm_thompson_aerosols, init_atm_thompson_aerosols_lbc
    use mpas_atmphys_constants, only: svpt0,svp1,svp2,svp3
    use mpas_atmphys_functions
    use mpas_atmphys_initialize_real
@@ -329,6 +329,7 @@ module init_atm_cases
 
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
+               call init_atm_thompson_aerosols_lbc(timeString, mesh, diag, state, lbc_state)
 
                block_ptr => block_ptr % next
             end do

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -79,7 +79,7 @@ module init_atm_cases
       type (MPAS_Time_type)  :: curr_time, stop_time, start_time
       type (MPAS_TimeInterval_type)  :: clock_interval, lbc_stream_interval, surface_stream_interval
       type (MPAS_TimeInterval_type)  :: time_since_start
-      character(len=StrKIND) :: timeString
+      character(len=StrKIND) :: timeStart,timeString
 
       integer, pointer :: nCells
       integer, pointer :: nEdges
@@ -329,7 +329,9 @@ module init_atm_cases
 
                call init_atm_case_lbc(timeString, block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
-               call init_atm_thompson_aerosols_lbc(timeString, mesh, diag, state, lbc_state)
+
+               call mpas_get_time(start_time, dateTimeString=timeStart)
+               call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, state, lbc_state)
 
                block_ptr => block_ptr % next
             end do

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -19,6 +19,7 @@ module init_atm_cases
    use mpas_timer
    use mpas_init_atm_static
    use mpas_init_atm_surface
+   use mpas_init_atm_thompson_aerosols
    use mpas_atmphys_constants, only: svpt0,svp1,svp2,svp3
    use mpas_atmphys_functions
    use mpas_atmphys_initialize_real
@@ -244,6 +245,7 @@ module init_atm_cases
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
             
             if (config_met_interp) then
+               call init_atm_thompson_aerosols(block_ptr, mesh, block_ptr % configs, diag, state)
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
             end if
 

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -112,11 +112,13 @@ module init_atm_core_interface
       type (mpas_pool_type), intent(inout) :: packages
       type (mpas_io_context_type), intent(inout) :: iocontext
       integer :: ierr
+      logical :: lexist
 
       logical, pointer :: initial_conds, sfc_update, lbcs
       logical, pointer :: gwd_stage_in, gwd_stage_out, vertical_stage_in, vertical_stage_out, met_stage_in, met_stage_out
       logical, pointer :: config_native_gwd_static, config_static_interp, config_vertical_grid, config_met_interp
       logical, pointer :: first_guess_field
+      logical, pointer :: mp_thompson_aers_in
       integer, pointer :: config_init_case
 
 
@@ -155,6 +157,9 @@ module init_atm_core_interface
       nullify(met_stage_out)
       call mpas_pool_get_package(packages, 'met_stage_outActive', met_stage_out)
 
+      nullify(mp_thompson_aers_in)
+      call mpas_pool_get_package(packages, 'mp_thompson_aers_inActive', mp_thompson_aers_in)
+
       if (.not. associated(initial_conds) .or. &
           .not. associated(sfc_update) .or. &
           .not. associated(gwd_stage_in) .or. &
@@ -162,7 +167,8 @@ module init_atm_core_interface
           .not. associated(vertical_stage_in) .or. &
           .not. associated(vertical_stage_out) .or. &
           .not. associated(met_stage_in) .or. &
-          .not. associated(met_stage_out)) then
+          .not. associated(met_stage_out) .or. &
+          .not. associated(mp_thompson_aers_in)) then
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('* Error while setting up packages for init_atmosphere core.',                      messageType=MPAS_LOG_ERR)
          call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
@@ -180,8 +186,12 @@ module init_atm_core_interface
 
       if (config_init_case == 9) then
          lbcs = .true.
+         mp_thompson_aers_in = .false.
+         inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
+         if(lexist) mp_thompson_aers_in = .true.
       else
          lbcs = .false.
+         mp_thompson_aers_in = .false.
       end if
 
       if (config_init_case == 7) then
@@ -203,6 +213,10 @@ module init_atm_core_interface
                         (.not. config_static_interp) .and. &
                         (.not. config_vertical_grid)
          met_stage_out = config_met_interp
+
+         mp_thompson_aers_in = .false.
+         inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
+         if(lexist) mp_thompson_aers_in = .true.
 
       else if (config_init_case == 8) then
          gwd_stage_in = .false.

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -216,7 +216,7 @@ module init_atm_core_interface
 
          mp_thompson_aers_in = .false.
          inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
-         if(lexist) mp_thompson_aers_in = .true.
+         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
 
       else if (config_init_case == 8) then
          gwd_stage_in = .false.
@@ -237,6 +237,10 @@ module init_atm_core_interface
          vertical_stage_out = .false.
          met_stage_in = .true.
          met_stage_out = .true.
+
+         mp_thompson_aers_in = .false.
+         inquire(file="QNWFA_QNIFA_SIGMA_MONTHLY.dat",exist=lexist)
+         if((lexist .and. met_stage_out) .or. (lexist .and. met_stage_in)) mp_thompson_aers_in = .true.
 
          initial_conds = .false.   ! Also, turn off the initial_conds package to avoid writing the IC "output" stream
 

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -56,7 +56,7 @@
 !call mpas_log_write('--- enter subroutine init_atm_gocart:')
 
 !inquire if the GOCART input file exists:
- filename_gocart = "QNWFA_QNIFA_Monthly_Sigma.dat"
+ filename_gocart = "QNWFA_QNIFA_SIGMA_MONTHLY.dat"
 
  inquire(file=filename_gocart,exist=lexist)
  if(lexist) then
@@ -71,7 +71,7 @@
     initial_date = trim(config_start_time)
     call init_vinterp_gocart(initial_date,mesh,diag,state)
  else
-    call mpas_log_write('QNWFA_QNIFA_Monthly_Sigma.dat was not found in local directory:')
+    call mpas_log_write('QNWFA_QNIFA_SIGMA_MONTHLY.dat was not found in local directory:')
     call mpas_log_write('nwfa and nifa are set to zero and not interpolated from climatological data.')
  endif
 
@@ -240,7 +240,7 @@
 
  dminfo => block%domain%dminfo
 
- filename_gocart = "QNWFA_QNIFA_Monthly_Sigma.dat"
+ filename_gocart = "QNWFA_QNIFA_SIGMA_MONTHLY.dat"
 
  call mpas_pool_get_dimension(mesh,'nCells',nCells)
 

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -254,7 +254,7 @@
 
 !open intermediate file:
  istatus = 0
- call read_gocart_init(trim(filename_gocart),istatus)
+ call read_met_init(trim(filename_gocart),.true.,'not needed',istatus)
  if(istatus /= 0) then
     call mpas_log_write('********************************************************************************')
     call mpas_log_write('Error opening gocart file '//trim(filename_gocart))
@@ -295,7 +295,7 @@
 
 !read gocart data:
  istatus = 0
- call read_gocart_init(trim(filename_gocart),istatus)
+ call read_met_init(trim(filename_gocart),.true.,'not needed',istatus)
  if(istatus /= 0) then
     call mpas_log_write('********************************************************************************')
     call mpas_log_write('Error opening gocart file '// trim(filename_gocart))
@@ -853,36 +853,6 @@
 !call mpas_log_write('--- end subroutine init_lbc_gocart:')
 
  end subroutine init_atm_thompson_aerosols_lbc
-
-!=================================================================================================================
- subroutine read_gocart_init(fg_source,istatus)
-!=================================================================================================================
-
-!input arguments:
- character(len=*),intent(in):: fg_source
-
-!output arguments:
- integer,intent(out):: istatus
-
-!local variables:
- logical:: is_used
- integer:: io_status
-
-!-----------------------------------------------------------------------------------------------------------------
-
- istatus = 0
-
- do input_unit = 10, 100
-    inquire(unit=input_unit,opened=is_used)
-    if (.not. is_used) exit
- end do
- if(input_unit > 100) &
-    call mpas_log_write('Error: In read_gocart_init(), couldn''t find an available Fortran unit.')
- open(unit=input_unit, file=trim(fg_source), status='old', form='unformatted', iostat=io_status)
-
- if (io_status > 0) istatus = 1
-
- end subroutine read_gocart_init
 
 !=================================================================================================================
  end module mpas_init_atm_thompson_aerosols

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -154,7 +154,7 @@
  enddo
  do iCell = 1, nCells
     sorted_arr(1,1:nGocartLevels) = 0._RKIND
-    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(2,1:nGocartLevels) = 0._RKIND
     do k = 1, nGocartLevels
        kk = nGocartLevels + 1 -k
        sorted_arr(1,kk) = pwif_int(k,iCell)
@@ -177,7 +177,7 @@
  enddo
  do iCell = 1, nCells
     sorted_arr(1,1:nGocartLevels) = 0._RKIND
-    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(2,1:nGocartLevels) = 0._RKIND
     do k = 1, nGocartLevels
        kk = nGocartLevels + 1 -k
        sorted_arr(1,kk) = pwif_int(k,iCell)

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -53,7 +53,7 @@
  logical:: lexist
 
 !-----------------------------------------------------------------------------------------------------------------
- call mpas_log_write('--- enter subroutine init_atm_gocart:')
+!call mpas_log_write('--- enter subroutine init_atm_gocart:')
 
 !inquire if the GOCART input file exists:
  filename_gocart = "QNWFA_QNIFA_Monthly_Sigma.dat"
@@ -75,7 +75,7 @@
     call mpas_log_write('nwfa and nifa are set to zero and not interpolated from climatological data.')
  endif
 
- call mpas_log_write('--- end subroutine init_atm_gocart.')
+!call mpas_log_write('--- end subroutine init_atm_gocart.')
  call mpas_log_write(' ')
 
  end subroutine init_atm_thompson_aerosols
@@ -108,7 +108,7 @@
  real(kind=RKIND),dimension(:,:),allocatable:: dummy1
 
 !-----------------------------------------------------------------------------------------------------------------
- call mpas_log_write('--- enter subroutine init_vinterp_gocart:')
+!call mpas_log_write('--- enter subroutine init_vinterp_gocart:')
 
  call mpas_pool_get_dimension(mesh,'nCells'       ,nCells       )
  call mpas_pool_get_dimension(mesh,'nGocartLevels',nGocartLevels)
@@ -199,7 +199,7 @@
  if(allocated(pwif_int)  ) deallocate(pwif_int  )
  if(allocated(sorted_arr)) deallocate(sorted_arr)
  
- call mpas_log_write('--- enter subroutine init_vinterp_gocart:')
+!call mpas_log_write('--- end subroutine init_vinterp_gocart:')
 
  end subroutine init_vinterp_gocart
 
@@ -236,7 +236,7 @@
  real(kind=RKIND),dimension(:,:),allocatable:: maskslab,rslab
 
 !-----------------------------------------------------------------------------------------------------------------
- call mpas_log_write('--- enter subroutine init_hinterp_gocart:')
+!call mpas_log_write('--- enter subroutine init_hinterp_gocart:')
 
  dminfo => block%domain%dminfo
 
@@ -714,7 +714,7 @@
 
  call read_met_close()
 
- call mpas_log_write('--- end subroutine init_hinterp_gocart:')
+!call mpas_log_write('--- end subroutine init_hinterp_gocart:')
 
  end subroutine init_hinterp_gocart
  

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -1,0 +1,753 @@
+! Copyright (c) 2024 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_init_atm_thompson_aerosols
+ use mpas_derived_types
+ use mpas_kind_types
+ use mpas_log
+ use mpas_dmpar
+ use mpas_pool_routines
+
+ use init_atm_read_met
+ use init_atm_hinterp
+ use init_atm_llxy
+ use init_atm_vinterp
+ use mpas_atmphys_date_time
+ use mpas_atmphys_utilities
+
+ implicit none
+ private
+ public:: init_atm_thompson_aerosols
+
+
+!mpas_init_atm_thompson_aerosols contains the subroutines needed for the interpolation of climatological
+!monthly-averaged hygroscopic ("water friendly") and nonhygroscopic ("ice friendly") aerosols used in the
+!Thompson parameterization of cloud microphysics with Gocart CCN and IN nucleation.
+!Laura D. Fowler (laura@ucar.edu) / 2024-04-10.
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine init_atm_thompson_aerosols(block,mesh,configs,diag,state)
+!=================================================================================================================
+
+!input arguments:
+ type (mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: diag
+
+!inout arguments:
+ type(block_type),intent(inout),target:: block 
+ type(mpas_pool_type),intent(inout)   :: mesh
+ type(mpas_pool_type),intent(inout)   :: state
+!local variables and pointers:
+ character (len=StrKIND),pointer:: config_start_time
+ character(len=StrKIND):: filename_gocart
+ character(len=StrKIND):: initial_date,mess
+
+ logical:: lexist
+
+!-----------------------------------------------------------------------------------------------------------------
+ call mpas_log_write('--- enter subroutine init_atm_gocart:')
+
+!inquire if the GOCART input file exists:
+ filename_gocart = "QNWFA_QNIFA_Monthly_Sigma.dat"
+
+ inquire(file=filename_gocart,exist=lexist)
+ if(lexist) then
+
+    call mpas_pool_get_config(configs,'config_start_time',config_start_time)
+
+    !--- horizontal interpolation of the climatological monthly-averaged GOCART data to the MPAS mesh:  
+    call init_hinterp_gocart(block,mesh)
+
+    !--- interpolation of the monthly-averaged GOCART data to the initial date, and vertical interpolation to
+    !    the MPAS levels:
+    initial_date = trim(config_start_time)
+    call init_vinterp_gocart(initial_date,mesh,diag,state)
+ else
+    call mpas_log_write('QNWFA_QNIFA_Monthly_Sigma.dat was not found in local directory:')
+    call mpas_log_write('nwfa and nifa are set to zero and not interpolated from climatological data.')
+ endif
+
+ call mpas_log_write('--- end subroutine init_atm_gocart.')
+ call mpas_log_write(' ')
+
+ end subroutine init_atm_thompson_aerosols
+
+!=================================================================================================================
+ subroutine init_vinterp_gocart(initial_date,mesh,diag,state)
+!=================================================================================================================
+
+!input arguments:
+ character(len=StrKIND),intent(in):: initial_date
+ type(mpas_pool_type),intent(in):: diag
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: mesh
+ type(mpas_pool_type),intent(inout):: state
+
+!local variables and pointers:
+ integer,pointer:: nCells,nGocartLevels,nVertLevels,nMonths
+ integer,pointer:: index_nifa,index_nwfa
+ integer:: iCell,k,kk,n
+
+ real(kind=RKIND),dimension(:,:),pointer  :: nifa,nwfa,pressure
+ real(kind=RKIND),dimension(:,:,:),pointer:: nifa_clim,nwfa_clim,pwif_clim
+ real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+
+ real(kind=RKIND):: target_p
+ real(kind=RKIND),dimension(:,:),allocatable:: nifa_int,nwfa_int,pwif_int,sorted_arr
+
+ real(kind=RKIND),dimension(:),allocatable::   dummy2
+ real(kind=RKIND),dimension(:,:),allocatable:: dummy1
+
+!-----------------------------------------------------------------------------------------------------------------
+ call mpas_log_write('--- enter subroutine init_vinterp_gocart:')
+
+ call mpas_pool_get_dimension(mesh,'nCells'       ,nCells       )
+ call mpas_pool_get_dimension(mesh,'nGocartLevels',nGocartLevels)
+ call mpas_pool_get_dimension(mesh,'nVertLevels'  ,nVertLevels  )
+ call mpas_pool_get_dimension(mesh,'nMonths'      ,nMonths      )
+
+ call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+ call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+    
+ call mpas_pool_get_array(diag,'pressure_base',pressure)
+
+ call mpas_pool_get_array(mesh,'nifa_gocart_clim',nifa_clim)
+ call mpas_pool_get_array(mesh,'nwfa_gocart_clim',nwfa_clim)
+ call mpas_pool_get_array(mesh,'pwif_gocart_clim',pwif_clim)
+
+ call mpas_pool_get_array(state,'scalars',scalars)
+ nifa => scalars(index_nifa,:,:)
+ nwfa => scalars(index_nwfa,:,:)
+
+ if(.not.allocated(nifa_int)  ) allocate(nifa_int(nGocartLevels,nCells))
+ if(.not.allocated(nwfa_int)  ) allocate(nwfa_int(nGocartLevels,nCells))
+ if(.not.allocated(pwif_int)  ) allocate(pwif_int(nGocartLevels,nCells))
+ if(.not.allocated(sorted_arr)) allocate(sorted_arr(2,nGocartLevels))
+
+!--- interpolation of the monthly-averaged GOCART data to the initial date, and vertical interpolation to the
+!    MPAS levels:
+ if(.not.allocated(dummy2)) allocate(dummy2(nCells))
+ if(.not.allocated(dummy1)) allocate(dummy1(nMonths,nCells))
+
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = pwif_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,initial_date,dummy1,dummy2)
+    pwif_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+
+!--- nifa:
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = nifa_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,initial_date,dummy1,dummy2)
+    nifa_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+ do iCell = 1, nCells
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    do k = 1, nGocartLevels
+       kk = nGocartLevels + 1 -k
+       sorted_arr(1,kk) = pwif_int(k,iCell)
+       sorted_arr(2,kk) = nifa_int(k,iCell)
+    enddo
+    do k = nVertLevels, 1, -1
+       target_p = pressure(k,iCell)
+       nifa(k,iCell) = vertical_interp(target_p,nGocartLevels-1, &
+                                sorted_arr(:,1:nGocartLevels-1),order=1,extrap=0)
+       if(target_p >= pwif_int(1,iCell) .and. k < nVertLevels) nifa(k,iCell) = nifa(k+1,iCell)
+    enddo
+ enddo
+
+!--- nwfa:
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = nwfa_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,initial_date,dummy1,dummy2)
+    nwfa_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+ do iCell = 1, nCells
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    do k = 1, nGocartLevels
+       kk = nGocartLevels + 1 -k
+       sorted_arr(1,kk) = pwif_int(k,iCell)
+       sorted_arr(2,kk) = nwfa_int(k,iCell)
+    enddo
+    do k = nVertLevels, 1, -1
+       target_p = pressure(k,iCell)
+       nwfa(k,iCell) = vertical_interp(target_p,nGocartLevels-1, &
+                                sorted_arr(:,1:nGocartLevels-1),order=1,extrap=0)
+       if(target_p >= pwif_int(1,iCell) .and. k < nVertLevels) nwfa(k,iCell) = nwfa(k+1,iCell)
+    enddo
+ enddo
+
+!--- deallocation of local arrays:
+ if(allocated(dummy1)    ) deallocate(dummy1    )
+ if(allocated(dummy2)    ) deallocate(dummy2    )
+ if(allocated(nifa_int)  ) deallocate(nifa_int  )
+ if(allocated(nwfa_int)  ) deallocate(nwfa_int  )
+ if(allocated(pwif_int)  ) deallocate(pwif_int  )
+ if(allocated(sorted_arr)) deallocate(sorted_arr)
+ 
+ call mpas_log_write('--- enter subroutine init_vinterp_gocart:')
+
+ end subroutine init_vinterp_gocart
+
+!=================================================================================================================
+ subroutine init_hinterp_gocart(block,mesh)
+!=================================================================================================================
+
+!inout arguments:
+ type(block_type),intent(inout),target:: block 
+ type (mpas_pool_type),intent(inout)  :: mesh
+
+!local variables:
+ type(dm_info),pointer:: dminfo
+ type(met_data) :: field !real*4 meteorological data.
+ type(proj_info):: proj
+
+ character(len=StrKIND):: filename_gocart
+ logical:: have_landmask
+
+ integer,pointer:: nCells
+ integer:: i,j
+ integer:: iCell,istatus,k,masked,nmonths,nInterpPoints
+ integer,dimension(5):: interp_list
+ integer,dimension(:),pointer:: landmask
+ integer,dimension(:),pointer:: mask_array
+
+ real(kind=RKIND):: fillval,maskval,msgval
+ real(kind=RKIND):: lat,lon,x,y
+ real(kind=RKIND),dimension(:),pointer    :: latCell,lonCell
+ real(kind=RKIND),dimension(:),pointer    :: latPoints,lonPoints
+ real(kind=RKIND),dimension(:,:,:),pointer:: nifa_clim,nwfa_clim,pwif_clim
+ real(kind=RKIND),dimension(:,:,:),pointer:: destField3d
+
+ real(kind=RKIND),dimension(:,:),allocatable:: maskslab,rslab
+
+!-----------------------------------------------------------------------------------------------------------------
+ call mpas_log_write('--- enter subroutine init_hinterp_gocart:')
+
+ dminfo => block%domain%dminfo
+
+ filename_gocart = "QNWFA_QNIFA_Monthly_Sigma.dat"
+
+ call mpas_pool_get_dimension(mesh,'nCells',nCells)
+
+ call mpas_pool_get_array(mesh,'landmask',landmask)
+ call mpas_pool_get_array(mesh,'latCell' ,latCell )
+ call mpas_pool_get_array(mesh,'lonCell' ,lonCell )
+
+ call mpas_pool_get_array(mesh,'nifa_gocart_clim',nifa_clim)
+ call mpas_pool_get_array(mesh,'nwfa_gocart_clim',nwfa_clim)
+ call mpas_pool_get_array(mesh,'pwif_gocart_clim',pwif_clim)
+
+!open intermediate file:
+ istatus = 0
+ call read_gocart_init(trim(filename_gocart),istatus)
+ if(istatus /= 0) then
+    call mpas_log_write('********************************************************************************')
+    call mpas_log_write('Error opening gocart file '//trim(filename_gocart))
+    call mpas_log_write('********************************************************************************')
+    call mpas_dmpar_abort(dminfo)
+ else
+    call mpas_log_write('Processing file '//trim(filename_gocart))
+ end if
+
+!scan through all fields in the file, looking for the LANDSEA field:
+ have_landmask = .false.
+ call read_next_met_field(field,istatus)
+ do while (istatus == 0)
+    if(index(field % field, 'LANDSEA') /= 0) then
+       have_landmask = .true.
+       if(.not.allocated(maskslab)) allocate(maskslab(-2:field%nx+3,field%ny))
+
+       maskslab(1:field%nx,1:field%ny) = field%slab(1:field%nx,1:field%ny)
+       maskslab(0 ,1:field%ny) = field%slab(field%nx  ,1:field%ny)
+       maskslab(-1,1:field%ny) = field%slab(field%nx-1,1:field%ny)
+       maskslab(-2,1:field%ny) = field%slab(field%nx-2,1:field%ny)
+       maskslab(field%nx+1,1:field%ny) = field%slab(1,1:field%ny)
+       maskslab(field%nx+2,1:field%ny) = field%slab(2,1:field%ny)
+       maskslab(field%nx+3,1:field%ny) = field%slab(3,1:field%ny)
+!      call mpas_log_write('minval, maxval of LANDSEA = $r $r',realArgs=(/minval(maskslab),maxval(maskslab)/))
+    end if
+    deallocate(field%slab)
+    call read_next_met_field(field,istatus)
+ end do
+ call read_met_close()
+
+ if(.not. have_landmask) then
+    call mpas_log_write('********************************************************************************')
+    call mpas_log_write('Landsea mask not available from the surface file')
+    call mpas_log_write('********************************************************************************')
+ end if
+
+
+!read gocart data:
+ istatus = 0
+ call read_gocart_init(trim(filename_gocart),istatus)
+ if(istatus /= 0) then
+    call mpas_log_write('********************************************************************************')
+    call mpas_log_write('Error opening gocart file '// trim(filename_gocart))
+    call mpas_log_write('********************************************************************************')
+    call mpas_dmpar_abort(dminfo)
+ endif
+ call read_next_met_field(field, istatus)
+
+!horizontally interpolate GOCART data:
+ do while(istatus == 0)
+
+    interp_list(1) = FOUR_POINT
+    interp_list(2) = W_AVERAGE4
+    interp_list(3) = W_AVERAGE16
+    interp_list(4) = SEARCH
+    interp_list(5) = 0
+
+    maskval = -1.0
+    masked  = -1
+    fillval = 0.0
+    msgval  = 0.0
+
+    mask_array => landmask
+
+    if(index(field % field, 'QNIFA_JAN') /= 0 .or. &
+       index(field % field, 'QNIFA_FEB') /= 0 .or. &
+       index(field % field, 'QNIFA_MAR') /= 0 .or. &
+       index(field % field, 'QNIFA_APR') /= 0 .or. &
+       index(field % field, 'QNIFA_MAY') /= 0 .or. &
+       index(field % field, 'QNIFA_JUN') /= 0 .or. &
+       index(field % field, 'QNIFA_JUL') /= 0 .or. &
+       index(field % field, 'QNIFA_AUG') /= 0 .or. &
+       index(field % field, 'QNIFA_SEP') /= 0 .or. &
+       index(field % field, 'QNIFA_OCT') /= 0 .or. &
+       index(field % field, 'QNIFA_NOV') /= 0 .or. &
+       index(field % field, 'QNIFA_DEC') /= 0 .or. &
+       index(field % field, 'QNWFA_JAN') /= 0 .or. &
+       index(field % field, 'QNWFA_FEB') /= 0 .or. &
+       index(field % field, 'QNWFA_MAR') /= 0 .or. &
+       index(field % field, 'QNWFA_APR') /= 0 .or. &
+       index(field % field, 'QNWFA_MAY') /= 0 .or. &
+       index(field % field, 'QNWFA_JUN') /= 0 .or. &
+       index(field % field, 'QNWFA_JUL') /= 0 .or. &
+       index(field % field, 'QNWFA_AUG') /= 0 .or. &
+       index(field % field, 'QNWFA_SEP') /= 0 .or. &
+       index(field % field, 'QNWFA_OCT') /= 0 .or. &
+       index(field % field, 'QNWFA_NOV') /= 0 .or. &
+       index(field % field, 'QNWFA_DEC') /= 0 .or. &
+       index(field % field, 'P_WIF_JAN') /= 0 .or. &
+       index(field % field, 'P_WIF_FEB') /= 0 .or. &
+       index(field % field, 'P_WIF_MAR') /= 0 .or. &
+       index(field % field, 'P_WIF_APR') /= 0 .or. &
+       index(field % field, 'P_WIF_MAY') /= 0 .or. &
+       index(field % field, 'P_WIF_JUN') /= 0 .or. &
+       index(field % field, 'P_WIF_JUL') /= 0 .or. &
+       index(field % field, 'P_WIF_AUG') /= 0 .or. &
+       index(field % field, 'P_WIF_SEP') /= 0 .or. &
+       index(field % field, 'P_WIF_OCT') /= 0 .or. &
+       index(field % field, 'P_WIF_NOV') /= 0 .or. &
+       index(field % field, 'P_WIF_DEC') /= 0) then
+
+       !
+       !set up projection:
+       !
+       call map_init(proj)
+   
+       if(field%iproj == PROJ_LATLON) then
+          call map_set(PROJ_LATLON,proj, &
+                       latinc = real(field%deltalat,RKIND), &
+                       loninc = real(field%deltalon,RKIND), &
+                       knowni = 1.0_RKIND, &
+                       knownj = 1.0_RKIND, &
+                       lat1   = real(field%startlat,RKIND), &
+                       lon1   = real(field%startlon,RKIND))
+       elseif(field%iproj == PROJ_GAUSS) then
+          call map_set(PROJ_GAUSS,proj, &
+                       nlat = nint(field%deltalat), &
+                       loninc = 360.0_RKIND / real(field%nx,RKIND), &
+                       lat1 = real(field%startlat,RKIND), &
+                       lon1 = real(field%startlon,RKIND))
+       endif
+       
+       !
+       !horizontally interpolate field at level k:
+       !
+       if(index(field%field,'QNIFA_JAN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_JAN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 1
+       elseif(index(field%field,'QNIFA_FEB') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_FEB at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 2
+       elseif(index(field%field,'QNIFA_MAR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_MAR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 3
+       elseif(index(field%field,'QNIFA_APR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_APR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 4
+       elseif(index(field%field,'QNIFA_MAY') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_MAY at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 5
+       elseif(index(field%field,'QNIFA_JUN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_JUN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 6
+       elseif(index(field%field,'QNIFA_JUL') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_JUL at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 7
+       elseif(index(field%field,'QNIFA_AUG') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_AUG at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 8
+       elseif(index(field%field,'QNIFA_SEP') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_SEP at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 9
+       elseif(index(field%field,'QNIFA_OCT') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_OCT at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 10
+       elseif(index(field%field,'QNIFA_NOV') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_NOV at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 11
+       elseif(index(field%field,'QNIFA_DEC') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNIFA_DEC at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nifa_gocart_clim',destField3d)
+          nmonths = 12
+       elseif(index(field%field,'QNWFA_JAN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_JAN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 1
+       elseif(index(field%field,'QNWFA_FEB') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_FEB at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 2
+       elseif(index(field%field,'QNWFA_MAR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_MAR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 3
+       elseif(index(field%field,'QNWFA_APR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_APR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 4
+       elseif(index(field%field,'QNWFA_MAY') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_MAY at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 5
+       elseif(index(field%field,'QNWFA_JUN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_JUN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 6
+       elseif(index(field%field,'QNWFA_JUL') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_JUL at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 7
+       elseif(index(field%field,'QNWFA_AUG') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_AUG at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 8
+       elseif(index(field%field,'QNWFA_SEP') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_SEP at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 9
+       elseif(index(field%field,'QNWFA_OCT') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_OCT at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 10
+       elseif(index(field%field,'QNWFA_NOV') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_NOV at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 11
+       elseif(index(field%field,'QNWFA_DEC') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating QNWFA_DEC at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'nwfa_gocart_clim',destField3d)
+          nmonths = 12
+      elseif(index(field%field,'P_WIF_JAN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_JAN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 1
+       elseif(index(field%field,'P_WIF_FEB') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_FEB at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 2
+       elseif(index(field%field,'P_WIF_MAR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_MAR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 3
+       elseif(index(field%field,'P_WIF_APR') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_APR at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 4
+       elseif(index(field%field,'P_WIF_MAY') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_MAY at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 5
+       elseif(index(field%field,'P_WIF_JUN') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_JUN at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 6
+       elseif(index(field%field,'P_WIF_JUL') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_JUL at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 7
+       elseif(index(field%field,'P_WIF_AUG') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_AUG at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 8
+       elseif(index(field%field,'P_WIF_SEP') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_SEP at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 9
+       elseif(index(field%field,'P_WIF_OCT') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_OCT at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 10
+       elseif(index(field%field,'P_WIF_NOV') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_NOV at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 11
+       elseif(index(field%field,'P_WIF_DEC') /= 0) then
+          k = field%xlvl
+          call mpas_log_write('Interpolating P_WIF_DEC at $i',intArgs=(/k/))
+          nInterpPoints = nCells
+          latPoints => latCell
+          lonPoints => lonCell
+          call mpas_pool_get_array(mesh,'pwif_gocart_clim',destField3d)
+          nmonths = 12
+       endif
+
+       allocate(rslab(-2:field%nx+3,field%ny))
+       rslab(1:field%nx,1:field%ny) = field%slab(1:field%nx,1:field%ny)
+       rslab(0,1:field%ny)  = field%slab(field%nx  ,1:field%ny)
+       rslab(-1,1:field%ny) = field%slab(field%nx-1,1:field%ny)
+       rslab(-2,1:field%ny) = field%slab(field%nx-2,1:field%ny)
+       rslab(field%nx+1,1:field%ny) = field%slab(1,1:field%ny)
+       rslab(field%nx+2,1:field%ny) = field%slab(2,1:field%ny)
+       rslab(field%nx+3,1:field%ny) = field%slab(3,1:field%ny)
+
+       do iCell = 1, nInterpPoints
+          if(mask_array(iCell) /= masked) then
+             lat = latPoints(iCell)*DEG_PER_RAD
+             lon = lonPoints(iCell)*DEG_PER_RAD
+             call latlon_to_ij(proj,lat,lon,x,y)
+             if(x < 0.5) then
+                lon = lon + 360.0
+                call latlon_to_ij(proj,lat,lon,x,y)
+             elseif(x > real(field%nx,kind=RKIND)+ 0.5) then
+                lon = lon - 360.0
+                call latlon_to_ij(proj,lat,lon,x,y)
+             endif
+
+             if(maskval /= -1.0) then
+                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, \
+                                                  interp_list,1,maskval=maskval,mask_array=maskslab)
+             else
+                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, \
+                                                  interp_list,1)
+             endif
+          else
+             destField3d(nmonths,k,iCell) = fillval
+          endif
+       enddo
+       deallocate(rslab)
+
+    endif
+    deallocate(field%slab)
+    call read_next_met_field(field,istatus)
+
+ enddo
+
+ call read_met_close()
+
+ call mpas_log_write('--- end subroutine init_hinterp_gocart:')
+
+ end subroutine init_hinterp_gocart
+ 
+!=================================================================================================================
+ subroutine read_gocart_init(fg_source,istatus)
+!=================================================================================================================
+
+!input arguments:
+ character(len=*),intent(in):: fg_source
+
+!output arguments:
+ integer,intent(out):: istatus
+
+!local variables:
+ logical:: is_used
+ integer:: io_status
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ istatus = 0
+
+ do input_unit = 10, 100
+    inquire(unit=input_unit,opened=is_used)
+    if (.not. is_used) exit
+ end do
+ if(input_unit > 100) &
+    call mpas_log_write('Error: In read_gocart_init(), couldn''t find an available Fortran unit.')
+ open(unit=input_unit, file=trim(fg_source), status='old', form='unformatted', iostat=io_status)
+
+ if (io_status > 0) istatus = 1
+
+ end subroutine read_gocart_init
+
+!=================================================================================================================
+ end module mpas_init_atm_thompson_aerosols
+!=================================================================================================================

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -21,8 +21,7 @@
 
  implicit none
  private
- public:: init_atm_thompson_aerosols
-
+ public:: init_atm_thompson_aerosols,init_atm_thompson_aerosols_lbc
 
 !mpas_init_atm_thompson_aerosols contains the subroutines needed for the interpolation of climatological
 !monthly-averaged hygroscopic ("water friendly") and nonhygroscopic ("ice friendly") aerosols used in the
@@ -56,6 +55,7 @@
 !call mpas_log_write('--- enter subroutine init_atm_gocart:')
 
 !inquire if the GOCART input file exists:
+ lexist = .false.
  filename_gocart = "QNWFA_QNIFA_SIGMA_MONTHLY.dat"
 
  inquire(file=filename_gocart,exist=lexist)
@@ -718,6 +718,142 @@
 
  end subroutine init_hinterp_gocart
  
+!=================================================================================================================
+ subroutine init_atm_thompson_aerosols_lbc(timestamp,mesh,diag,state,lbc_state)
+!=================================================================================================================
+
+!input arguments:
+ character(len=StrKIND),intent(in):: timestamp
+ type(mpas_pool_type),intent(in):: diag
+ type(mpas_pool_type),intent(in):: state
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: mesh
+ type(mpas_pool_type),intent(inout):: lbc_state
+
+!local variables and pointers:
+ logical:: lexist
+ character(len=StrKIND):: filename_gocart
+
+ integer,pointer:: nCells,nGocartLevels,nVertLevels,nMonths
+ integer,pointer:: index_nifa,index_nwfa
+ integer:: iCell,k,kk,n
+
+ real(kind=RKIND),dimension(:,:),pointer  :: nifa,nwfa,pressure
+ real(kind=RKIND),dimension(:,:,:),pointer:: nifa_clim,nwfa_clim,pwif_clim
+ real(kind=RKIND),dimension(:,:,:),pointer:: scalars
+
+ real(kind=RKIND):: target_p
+ real(kind=RKIND),dimension(:,:),allocatable:: nifa_int,nwfa_int,pwif_int,sorted_arr
+
+ real(kind=RKIND),dimension(:),allocatable::   dummy2
+ real(kind=RKIND),dimension(:,:),allocatable:: dummy1
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write('--- enter subroutine init_lbc_gocart at time: ' //trim(timestamp))
+
+!inquire if the GOCART input file exists:
+ lexist = .false.
+ filename_gocart = "QNWFA_QNIFA_SIGMA_MONTHLY.dat"
+ inquire(file=filename_gocart,exist=lexist)
+ if(.not. lexist) return
+
+ call mpas_pool_get_dimension(mesh,'nCells'       ,nCells       )
+ call mpas_pool_get_dimension(mesh,'nGocartLevels',nGocartLevels)
+ call mpas_pool_get_dimension(mesh,'nVertLevels'  ,nVertLevels  )
+ call mpas_pool_get_dimension(mesh,'nMonths'      ,nMonths      )
+
+ call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+ call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+
+ call mpas_pool_get_array(diag,'pressure_base',pressure)
+
+ call mpas_pool_get_array(mesh,'nifa_gocart_clim',nifa_clim)
+ call mpas_pool_get_array(mesh,'nwfa_gocart_clim',nwfa_clim)
+ call mpas_pool_get_array(mesh,'pwif_gocart_clim',pwif_clim)
+
+ call mpas_pool_get_array(lbc_state,'lbc_scalars',scalars)
+ nifa => scalars(index_nifa,:,:)
+ nwfa => scalars(index_nwfa,:,:)
+
+ if(.not.allocated(nifa_int)  ) allocate(nifa_int(nGocartLevels,nCells))
+ if(.not.allocated(nwfa_int)  ) allocate(nwfa_int(nGocartLevels,nCells))
+ if(.not.allocated(pwif_int)  ) allocate(pwif_int(nGocartLevels,nCells))
+ if(.not.allocated(sorted_arr)) allocate(sorted_arr(2,nGocartLevels))
+
+ nifa(:,:) = 0._RKIND
+ nwfa(:,:) = 0._RKIND
+
+!--- interpolation of the monthly-averaged GOCART data to the initial date, and vertical interpolation to the
+!    MPAS levels:
+ if(.not.allocated(dummy2)) allocate(dummy2(nCells))
+ if(.not.allocated(dummy1)) allocate(dummy1(nMonths,nCells))
+
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = pwif_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,timestamp,dummy1,dummy2)
+    pwif_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+
+!--- nifa:
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = nifa_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,timestamp,dummy1,dummy2)
+    nifa_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+ do iCell = 1, nCells
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(2,1:nGocartLevels) = 0._RKIND
+    do k = 1, nGocartLevels
+       kk = nGocartLevels + 1 -k
+       sorted_arr(1,kk) = pwif_int(k,iCell)
+       sorted_arr(2,kk) = nifa_int(k,iCell)
+    enddo
+    do k = nVertLevels, 1, -1
+       target_p = pressure(k,iCell)
+       nifa(k,iCell) = vertical_interp(target_p,nGocartLevels-1, &
+                                sorted_arr(:,1:nGocartLevels-1),order=1,extrap=0)
+       if(target_p >= pwif_int(1,iCell) .and. k < nVertLevels) nifa(k,iCell) = nifa(k+1,iCell)
+    enddo
+ enddo
+
+!--- nwfa:
+ do k = 1, nGocartLevels
+    dummy2(1:nCells) = 0._RKIND
+    dummy1(1:nMonths,1:nCells) = nwfa_clim(1:nMonths,k,1:nCells)
+    call monthly_interp_to_date(nCells,timestamp,dummy1,dummy2)
+    nwfa_int(k,1:nCells) = dummy2(1:nCells)
+ enddo
+ do iCell = 1, nCells
+    sorted_arr(1,1:nGocartLevels) = 0._RKIND
+    sorted_arr(2,1:nGocartLevels) = 0._RKIND
+    do k = 1, nGocartLevels
+       kk = nGocartLevels + 1 -k
+       sorted_arr(1,kk) = pwif_int(k,iCell)
+       sorted_arr(2,kk) = nwfa_int(k,iCell)
+    enddo
+    do k = nVertLevels, 1, -1
+       target_p = pressure(k,iCell)
+       nwfa(k,iCell) = vertical_interp(target_p,nGocartLevels-1, &
+                                sorted_arr(:,1:nGocartLevels-1),order=1,extrap=0)
+       if(target_p >= pwif_int(1,iCell) .and. k < nVertLevels) nwfa(k,iCell) = nwfa(k+1,iCell)
+    enddo
+ enddo
+
+!--- deallocation of local arrays:
+ if(allocated(dummy1)    ) deallocate(dummy1    )
+ if(allocated(dummy2)    ) deallocate(dummy2    )
+ if(allocated(nifa_int)  ) deallocate(nifa_int  )
+ if(allocated(nwfa_int)  ) deallocate(nwfa_int  )
+ if(allocated(pwif_int)  ) deallocate(pwif_int  )
+ if(allocated(sorted_arr)) deallocate(sorted_arr)
+
+!call mpas_log_write('--- end subroutine init_lbc_gocart:')
+
+ end subroutine init_atm_thompson_aerosols_lbc
+
 !=================================================================================================================
  subroutine read_gocart_init(fg_source,istatus)
 !=================================================================================================================

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -719,15 +719,16 @@
  end subroutine init_hinterp_gocart
  
 !=================================================================================================================
- subroutine init_atm_thompson_aerosols_lbc(timestamp,mesh,diag,state,lbc_state)
+ subroutine init_atm_thompson_aerosols_lbc(timestamp,timestart,block,mesh,diag,state,lbc_state)
 !=================================================================================================================
 
 !input arguments:
- character(len=StrKIND),intent(in):: timestamp
+ character(len=StrKIND),intent(in):: timestart,timestamp
  type(mpas_pool_type),intent(in):: diag
  type(mpas_pool_type),intent(in):: state
 
 !inout arguments:
+ type(block_type),intent(inout),target:: block
  type(mpas_pool_type),intent(inout):: mesh
  type(mpas_pool_type),intent(inout):: lbc_state
 
@@ -757,6 +758,13 @@
  filename_gocart = "QNWFA_QNIFA_SIGMA_MONTHLY.dat"
  inquire(file=filename_gocart,exist=lexist)
  if(.not. lexist) return
+
+
+!horizontally interpolate GOCART input when computing when the initial conditions at start time:
+ if(timestamp == timestart) then
+    call init_hinterp_gocart(block,mesh)
+ endif
+
 
  call mpas_pool_get_dimension(mesh,'nCells'       ,nCells       )
  call mpas_pool_get_dimension(mesh,'nGocartLevels',nGocartLevels)

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -694,10 +694,10 @@
              endif
 
              if(maskval /= -1.0) then
-                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, \
+                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, &
                                                   interp_list,1,maskval=maskval,mask_array=maskslab)
              else
-                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, \
+                destField3d(nmonths,k,iCell) = interp_sequence(x,y,1,rslab,-2,field%nx+3,1,field%ny,1,1,msgval, &
                                                   interp_list,1)
              endif
           else


### PR DESCRIPTION
This PR updates the Thompson cloud microphysics parameterization to include the aerosol-aware option based on the WRF model release 4.1.4.

* In ./src/core_init_atmosphere, we added the initialization of the "water-friendly" and "ice-friendly" aerosols as a function of a monthly-mean based climatology from the GOddard Chemistry Aerosol and Transport Model (GOCART). The variables nwfa and nifa are included in the scalars array.

* In ./src/core_atmosphere/physics, the aerosol-aware option is triggered when config_microp_scheme is set to "mp_thompson_aerosols", and used to activate CCN and IN to form cloud liquid water droplets and ice crystals. In addition to nwfa and nifa, the number concentration of cloud liquid water droplets (nc) is an additional prognostic variable, also in the scalars array.

* In ./src/core_atmosphere/physics, the MYNN PBL scheme is used for mixing of aerosols in the PBL and free-troposphere. The radiative effect of aerosols is included in the RRTMG shortwave radiation code.