### PR TITLE
Implement new Makefile logic for sharing framework builds across cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,8 @@ restart_timestamp
 *.TBL
 *DATA*
 
-# Ignore MPAS core build files.
-.mpas_core_*
+# Files for detecting whether builds of cores or shared framework can be reused
+.build_opts*
 
 # Ignore all runtime config files
 namelist.*

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,12 +6,6 @@ include Makefile.in.$(ESM)
 
 else
 
-ifeq "$(AUTOCLEAN)" "true"
-AUTOCLEAN_DEPS=clean_shared
-else
-AUTOCLEAN_DEPS=
-endif
-
 all: mpas
 
 mpas: $(AUTOCLEAN_DEPS) externals frame ops dycore drver
@@ -45,18 +39,24 @@ dycore: $(AUTOCLEAN_DEPS) build_tools externals frame ops
 clean: clean_shared clean_core
 
 clean_core:
+ifeq "$(AUTOCLEAN)" "true"
+	$(info )
+	$(info *********************************************************************************************)
+	$(info The $(CORE) core will be cleaned and re-compiled.)
+	$(info *********************************************************************************************)
+	$(info )
+endif
 	if [ -d core_$(CORE) ] ; then \
 	   ( cd core_$(CORE); $(MAKE) clean ) \
 	fi;
 
 clean_shared:
 ifeq "$(AUTOCLEAN)" "true"
-	@echo ""
-	@echo "*********************************************************************************************"
-	@echo "The MPAS infrastructure is currently built for a core different from $(CORE)."
-	@echo "The infrastructure will be cleaned and re-built for the $(CORE) core."
-	@echo "*********************************************************************************************"
-	@echo ""
+	$(info )
+	$(info *********************************************************************************************)
+	$(info The infrastructure will be cleaned and re-compiled.)
+	$(info *********************************************************************************************)
+	$(info )
 endif
 	$(RM) libframework.a libops.a libdycore.a lib$(CORE).a *.o
 	( cd tools; $(MAKE) clean )


### PR DESCRIPTION
This PR updates the top-level `Makefile` (and also the `Makefile` in `src/`) to enable reuse of existing builds of either the shared infrastructure or a core when all build options in the current build are compatible with those used to previously compile the infrastructure or core.

Previously, after compiling one core but before compiling another, an intermediate clean step was required (or the `AUTOCLEAN=true` option could be specified, which automatically executed the clean step). However, the infrastructure code in `src/framework`, `src/operators`, and `src/external` is core-independent and can be reused by multiple MPAS cores, provided build options are the same.

Now when compiling, build options are saved to the files `.build_opts.$(CORE)` and `.build_opts.framework`.  If either of these files already exist, the build options saved in them are compared with the current build options to determine whether the core or the shared infrastructure needs to be recompiled.

The `AUTOCLEAN=true` option now cleans the core, shared infrastructure, or both as needed.

Also in this PR, old logic in the top-level `Makefile` for determining whether cleaning was necessary has been removed and the `.gitignore` file has been updated to ignore the new `.build_opts.*` files.