### PR TITLE
Make the registry 'parse' tool core-independent

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -30,7 +30,7 @@ core_input_gen:
 
 gen_includes: core_reg
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -30,7 +30,7 @@ core_input_gen:
 
 gen_includes: core_reg
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -41,7 +41,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_init_atmosphere/Makefile
+++ b/src/core_init_atmosphere/Makefile
@@ -41,7 +41,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_landice/Makefile
+++ b/src/core_landice/Makefile
@@ -31,7 +31,7 @@ core_reg:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_landice/Makefile
+++ b/src/core_landice/Makefile
@@ -31,7 +31,7 @@ core_reg:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -31,7 +31,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_ocean/Makefile
+++ b/src/core_ocean/Makefile
@@ -31,7 +31,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_seaice/Makefile
+++ b/src/core_seaice/Makefile
@@ -9,7 +9,7 @@ core_seaice: column_package shared analysis_members model_forward
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 core_input_gen:
 	if [ ! -e default_inputs ]; then  mkdir default_inputs; fi

--- a/src/core_seaice/Makefile
+++ b/src/core_seaice/Makefile
@@ -9,7 +9,7 @@ core_seaice: column_package shared analysis_members model_forward
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 core_input_gen:
 	if [ ! -e default_inputs ]; then  mkdir default_inputs; fi

--- a/src/core_sw/Makefile
+++ b/src/core_sw/Makefile
@@ -21,7 +21,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_sw/Makefile
+++ b/src/core_sw/Makefile
@@ -21,7 +21,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -28,7 +28,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml $(CPPFLAGS) )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/core_test/Makefile
+++ b/src/core_test/Makefile
@@ -28,7 +28,7 @@ core_input_gen:
 gen_includes:
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) Registry.xml > Registry_processed.xml
 	(if [ ! -d inc ]; then mkdir -p inc; fi) # To generate *.inc files
-	(cd inc; $(REG_PARSE) < ../Registry_processed.xml )
+	(cd inc; $(REG_PARSE) ../Registry_processed.xml )
 
 post_build:
 	if [ ! -e $(ROOT_DIR)/default_inputs ]; then mkdir $(ROOT_DIR)/default_inputs; fi

--- a/src/tools/registry/gen_inc.h
+++ b/src/tools/registry/gen_inc.h
@@ -11,7 +11,7 @@
 
 void add_attribute_if_not_ignored(FILE *fd, char *index, char *att_name, char *pointer_name_arr, char *temp_str);
 int find_string_in_array(char *input_string, const char *array[], size_t rows);
-void write_model_variables(ezxml_t registry);
+void write_model_variables(ezxml_t registry, int macro_count, const char **macros);
 int write_field_pointer_arrays(FILE* fd);
 int set_pointer_name(int type, int ndims, char *pointer_name, int time_levs);
 int add_package_to_list(const char * package, const char * package_list);

--- a/src/tools/registry/parse.c
+++ b/src/tools/registry/parse.c
@@ -33,11 +33,12 @@ int main(int argc, char ** argv)/*{{{*/
 	struct package * pkgs;
 	int err;
 
-	if (argc != 2) {
-		fprintf(stderr,"Reading registry file from standard input\n");
-		regfile = stdin;
+	if (argc < 2) {
+		fprintf(stderr,"\nUsage: %s <Registry file>\n\n", argv[0]);
+		return 1;
 	}
-	else if (!(regfile = fopen(argv[1], "r"))) {
+
+	if (!(regfile = fopen(argv[1], "r"))) {
 		fprintf(stderr,"\nError: Could not open file %s for reading.\n\n", argv[1]);
 		return 1;
 	}   

--- a/src/tools/registry/parse.c
+++ b/src/tools/registry/parse.c
@@ -34,7 +34,9 @@ int main(int argc, char ** argv)/*{{{*/
 	int err;
 
 	if (argc < 2) {
-		fprintf(stderr,"\nUsage: %s <Registry file>\n\n", argv[0]);
+		fprintf(stderr,"\nUsage: %s <Registry file> [macro definitions]\n\n", argv[0]);
+		fprintf(stderr,"   where [macro definitions] may be any number of macro\n");
+		fprintf(stderr,"   definitions of the form -D<macro_name>[=<macro_value>]\n\n");
 		return 1;
 	}
 
@@ -59,7 +61,11 @@ int main(int argc, char ** argv)/*{{{*/
 		return 1;
 	}
 
-	write_model_variables(registry);
+	if (argc > 2) {
+		write_model_variables(registry, (argc-2), (const char**)&argv[2]);
+	} else {
+		write_model_variables(registry, 0, NULL);
+	}
 
 	if (parse_reg_xml(registry)) {
 		fprintf(stderr, "Parsing failed.....\n");

--- a/src/tools/registry/utility.h
+++ b/src/tools/registry/utility.h
@@ -15,3 +15,5 @@ char * check_packages(ezxml_t registry, char * packages);
 char * check_dimensions(ezxml_t registry, char * dims);
 char * check_streams(ezxml_t registry, char * streams);
 int check_persistence(const char * persistence);
+int parse_macros(void(*callback)(const char *macro, const char *val, va_list ap),
+                 int count, const char **macros, ...);


### PR DESCRIPTION
This PR introduces changes to allow the registry `parse` tool to be core-independent, with any core-dependent
output that it produces depending only on run-time arguments.

The `parse` tool now requires its first command-line argument to be the name of a `Registry.xml` file, and it requires
subsequent arguments that specify definitions of at least the following macros in the form `-D<macro>=<value>`:

 - `MPAS_EXE_NAME`
 - `MPAS_GIT_VERSION`
 - `MPAS_BUILD_TARGET`
 - `MPAS_NAMELIST_SUFFIX`

Additionally, this PR updates the main `Makefile` for each core so that the processed `Registry.xml` file is passed as the first command-line argument to `parse` and the contents of `$(CPPFLAGS)`, which contains definitions of at least the aforementioned macros, as subsequent command-line arguments.