### PR TITLE
Change URL for MMM-physics external to use https rather than git

### DIFF
--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -1,7 +1,7 @@
 [MMM-physics]
 local_path = ./physics_mmm
 protocol = git
-repo_url = git@github.com:NCAR/MMM-physics.git
+repo_url = https://github.com/NCAR/MMM-physics.git
 tag = 20240525-MPASv8.2
 
 required = True


### PR DESCRIPTION
This PR changes the URL for the `MMM-physics` external to use `https` rather than `git` so that the checkout
of the `MMM-physics` repository will work even for those who don't have SSH keys set up on GitHub.