### PR TITLE
Fix issue in destroying halo groups when there are multiple domain instances

### DIFF
--- a/src/core_atmosphere/mpas_atm_halos.F
+++ b/src/core_atmosphere/mpas_atm_halos.F
@@ -26,7 +26,6 @@ module mpas_atm_halos
       end subroutine halo_exchange_routine
    end interface
 
-   character(len=StrKIND), pointer, private :: config_halo_exch_method
    procedure (halo_exchange_routine), pointer :: exchange_halo_group
 
 
@@ -56,8 +55,13 @@ module mpas_atm_halos
       use mpas_halo, only  : mpas_halo_init, mpas_halo_exch_group_create, mpas_halo_exch_group_add_field, &
                              mpas_halo_exch_group_complete, mpas_halo_exch_group_full_halo_exch
 
+      ! Arguments
       type (domain_type), intent(inout) :: domain
       integer, intent(inout) :: ierr
+
+      ! Local variables
+      character(len=StrKIND), pointer :: config_halo_exch_method
+
 
       !
       ! Determine from the namelist option config_halo_exch_method which halo exchange method to employ
@@ -350,9 +354,15 @@ module mpas_atm_halos
       use mpas_dmpar, only : mpas_dmpar_exch_group_destroy
       use mpas_halo, only  : mpas_halo_exch_group_destroy, mpas_halo_finalize
 
+      ! Arguments
       type (domain_type), intent(inout) :: domain
       integer, intent(inout) :: ierr
 
+      ! Local variables
+      character(len=StrKIND), pointer :: config_halo_exch_method
+
+
+      call mpas_pool_get_config(domain % blocklist % configs, 'config_halo_exch_method', config_halo_exch_method)
 
       if (trim(config_halo_exch_method) == 'mpas_dmpar') then
          !


### PR DESCRIPTION
This PR fixes a potential issue in destroying halo exchange groups when there are multiple domain instances.

When there exist multiple domain instances, and `atm_destroy_halo_groups` and `mpas_deallocate_domain` are called in a particular order for the domains, the `config_halo_exch_method` module variable in the `mpas_atm_halos` module may be invalid, leading to an error when destroying halo groups. This results in as the error message
```
  ERROR: Failed to destroy halo exchange groups.
```
in the MPAS-Atmosphere log file.

Consider a situation in which we have two domain instances, `domain_0` and `domain_1`. If the `atm_build_halo_groups` routine and the `atm_destroy_halo_groups` plus `mpas_deallocate_domain` routines are called in "last-in, first-out" order, i.e.,
```
  call atm_build_halo_groups(domain_0, ierr)

  call atm_build_halo_groups(domain_1, ierr)

  ...

  call atm_destroy_halo_groups(domain_1, ierr)
  call mpas_deallocate_domain(domain_1)

  call atm_destroy_halo_groups(domain_0, ierr)
  call mpas_deallocate_domain(domain_0)
```
the module variable `config_halo_exch_method` would be first set to point to memory owned by `domain_0` and then re-set to point to memory owned by `domain_1` in the calls to `atm_build_halo_groups`. Upon calling `atm_destroy_halo_groups` for `domain_1` followed by a call to `mpas_deallocate_domain`, the `config_halo_exch_method` pointer would become invalid, leading to an error when calling `mpas_destroy_halo_groups` for `domain_0`.

Since the domain instance is passed as an argument to `atm_destroy_halo_groups` routine, rather than using a module variable set when halo exchange groups were built, we can simply retrieve `config_halo_exch_method` from the domain argument, thereby avoiding the original problem.