### PR TITLE
Work around Noah-MP compilation issues with GNU -std=f2008 flag

### DIFF
--- a/src/core_atmosphere/physics/physics_noahmp/src/Makefile
+++ b/src/core_atmosphere/physics/physics_noahmp/src/Makefile
@@ -1,5 +1,11 @@
 .SUFFIXES: .F90 .o
 
+#
+# The Noah-MP code fails to build with the GNU compilers with -std=f2008,
+# so remove that flag here if it is present in FFLAGS
+#
+FFLAGS_NONSTD = $(shell printf "%s" "$(FFLAGS)" | sed -e 's/-std=f2008//g' )
+
 all: dummy src
 
 dummy:
@@ -337,5 +343,5 @@ clean:
 	$(RM) *.i
 
 .F90.o:
-	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I../utility -I../../../../framework
+	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS_NONSTD) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I../utility -I../../../../framework
 


### PR DESCRIPTION
This PR adds a work-around for Noah-MP compilation issues with the GNU `-std=f2008` flag.

At present, the Noah-MP code fails to compile with the GNU compilers using the `-std=f2008` flag, which is included in the `FFLAGS` set for the 'gnu' build target:
```
  RunoffSurfaceDynamicVicMod.F90:205:4:

    151 |                           goto 1003
        |                                   2
  ......
    205 | 1003                if ( DepthYTmp <= 0.0 ) DepthYTmp = 0.0
        |    1
  Error: Legacy Extension: Label at (1) is not in the same block as the GOTO statement at (2)
  RunoffSurfaceDynamicVicMod.F90:205:4:

    175 |                              goto 1003
        |                                      2
  ......
    205 | 1003                if ( DepthYTmp <= 0.0 ) DepthYTmp = 0.0
        |    1
  Error: Legacy Extension: Label at (1) is not in the same block as the GOTO statement at (2)
```
As a work-around for this issue, this PR adds logic to the Noah-MP `Makefile` to remove `-std=f2008` if it is present in `FFLAGS`. The modified `FFLAGS` are only used when compiling Noah-MP, and so Fortran 2008 compliance is still enforced for other code when building with the 'gnu' target.