### PR TITLE
Add "-check all" to LDFLAGS_DEBUG for 'intel' build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ intel:   # BUILDTARGET Intel oneAPI Fortran, C, and C++ compiler suite
 	"FFLAGS_DEBUG = -g -convert big_endian -free -check all -fpe0 -traceback" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
-	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
+	"LDFLAGS_DEBUG = -g -check all -fpe0 -traceback" \
 	"FFLAGS_OMP = -qopenmp" \
 	"CFLAGS_OMP = -qopenmp" \
 	"PICFLAG = -fpic" \


### PR DESCRIPTION
This PR adds `-check all` to `LDFLAGS_DEBUG` for the `intel` build target to resolve linking errors.

When building MPAS with the Intel oneAPI compilers and `DEBUG=true`, the linking step fails with undefined
references to various `__msan` symbols. According to the Intel compiler documentation, if `-check all` is used
to compile source files, that option must also be used during linking. From the Intel 2024.1 manual:
```
     Caution
     Files compiled with option check all should also be
     linked with this same option, or the link step may fail.
```