### PR TITLE
Add ONLY clause to USE statements for the 'mpi_f08' module

### DIFF
--- a/src/framework/mpas_abort.F
+++ b/src/framework/mpas_abort.F
@@ -33,7 +33,7 @@ module mpas_abort
 #ifdef _MPI
 #ifndef NOMPIMOD
 #ifdef MPAS_USE_MPI_F08
-      use mpi_f08
+      use mpi_f08, only : MPI_COMM_WORLD, MPI_Comm_rank, MPI_Comm_size, MPI_Abort
 #else
       use mpi
 #endif

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -32,7 +32,16 @@ module mpas_dmpar
 #ifdef _MPI
 #ifndef NOMPIMOD
 #ifdef MPAS_USE_MPI_F08
-   use mpi_f08
+   use mpi_f08, only : MPI_Comm, MPI_Datatype
+   use mpi_f08, only : MPI_INTEGER, MPI_2INTEGER, MPI_REAL, MPI_2REAL, MPI_DOUBLE_PRECISION, &
+                       MPI_2DOUBLE_PRECISION, MPI_CHARACTER, MPI_INTEGER8
+   use mpi_f08, only : MPI_COMM_SELF, MPI_COMM_WORLD, MPI_INFO_NULL, MPI_THREAD_SINGLE, &
+                       MPI_THREAD_SERIALIZED, MPI_THREAD_FUNNELED, MPI_THREAD_MULTIPLE, MPI_STATUS_IGNORE
+   use mpi_f08, only : MPI_Query_thread, MPI_Comm_dup
+   use mpi_f08, only : MPI_Init_thread , MPI_Init, MPI_Comm_rank, MPI_Comm_size, MPI_Finalize, &
+                       MPI_Comm_free, MPI_Abort, MPI_Bcast, MPI_Allreduce, MPI_Scatterv, MPI_Recv, &
+                       MPI_Send, MPI_Request, MPI_Irecv, MPI_Isend, MPI_Wait, MPI_Wtime, MPI_Test
+   use mpi_f08, only : MPI_SUM, MPI_MIN, MPI_MAX, MPI_MINLOC, MPI_MAXLOC
 #else
    use mpi
 #endif

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -486,7 +486,10 @@ module mpas_halo
     subroutine mpas_halo_exch_group_full_halo_exch(domain, groupName, iErr)
 
 #ifdef MPAS_USE_MPI_F08
-        use mpi_f08
+        use mpi_f08, only : MPI_Datatype, MPI_Comm
+        use mpi_f08, only : MPI_REAL, MPI_DOUBLE_PRECISION, MPI_REQUEST_NULL, &
+                            MPI_STATUS_IGNORE, MPI_STATUSES_IGNORE
+        use mpi_f08, only : MPI_Irecv, MPI_Isend, MPI_Waitany, MPI_Waitall
 #else
         use mpi
 #endif

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -809,7 +809,7 @@ module mpas_log
 #ifdef _MPI
 #ifndef NOMPIMOD
 #ifdef MPAS_USE_MPI_F08
-      use mpi_f08
+      use mpi_f08, only : MPI_COMM_WORLD, MPI_Abort
 #else
       use mpi
 #endif


### PR DESCRIPTION
This PR adds `ONLY` clauses to all `USE` statements for the `mpi_f08` module in MPAS.

Besides being a generally good practice, the use of only those entities from the 'mpi_f08' module that are actually needed eliminates link-time issues with debug builds using the Intel oneAPI compilers (with the Cray MPICH library).