### PR TITLE
Improve check on deallocation of hash table in mpas_geotile_mgr_finalize

### DIFF
--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -345,9 +345,9 @@ module mpas_geotile_manager
                 endif
             enddo
         enddo
-        deallocate(mgr % hash)
+        deallocate(mgr % hash, stat=ierr)
 
-        if (associated(mgr % hash)) then
+        if (associated(mgr % hash) .or. (ierr /= 0)) then
             call mpas_log_write("Problem deallocating the geotile hash table", messageType=MPAS_LOG_ERR)
             ierr = -1
             return


### PR DESCRIPTION
This PR improves the check on the deallocation of the geotile manager hash table in `mpas_geotile_mgr_finalize`,
resolving apparent issues with this deallocation under some conditions.

In some cases (typically with the Intel oneAPI compilers), parallel remapping of static fields in the init_atmosphere core will fail with the message
```
  ERROR: Problem deallocating the geotile hash table
```
for some MPI ranks. There is apparently a problem in deallocating the `hash` member of `mpas_geotile_mgr_type` instances in `mpas_geotile_mgr_finalize`.

This PR improves the checks on the deallocation of `mgr % hash` in the `mpas_geotile_mgr_finalize` routine, making them more stringent. With the modifications to the deallocation checks, the deallocation errors no longer occur, suggesting that they were entirely spurious.