### PR TITLE
Fix intermittent parallel build failures in MPAS-A physics

### DIFF
--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,7 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = git@github.com:NCAR/MMM-physics.git
-tag = 20240525-MPASv8.2
+tag = 20240626-MPASv8.2
 
 required = True
 

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -70,7 +70,7 @@ core_physics_noahmp:
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)
 
-core_physics: core_physics_wrf
+core_physics: core_physics_wrf core_physics_noahmp
 	($(MAKE) phys_interface COREDEF="$(COREDEF)")
 	ar -ru libphys.a $(OBJS)
 

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -68,11 +68,15 @@ core_physics_noahmp:
 	(cd physics_noahmp/drivers/mpas; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
-	ar -ru libphys.a $(OBJS_init)
 
 core_physics: core_physics_wrf core_physics_noahmp
 	($(MAKE) phys_interface COREDEF="$(COREDEF)")
-	ar -ru libphys.a $(OBJS)
+	ar -ru libphys.a $(OBJS_init) $(OBJS)
+	($(MAKE) -C ./physics_mmm -f Makefile.mpas physics_mmm_lib)
+	($(MAKE) -C ./physics_wrf physics_wrf_lib)
+	($(MAKE) -C ./physics_noahmp/drivers/mpas driver_lib)
+	($(MAKE) -C ./physics_noahmp/src src_lib)
+	($(MAKE) -C ./physics_noahmp/utility utility_lib)
 
 phys_interface: $(OBJS)
 

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/Makefile
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/Makefile
@@ -1,5 +1,7 @@
 .SUFFIXES: .o .F90
 
+.PHONY: driver driver_lib
+
 all: dummy driver
 
 dummy:
@@ -26,6 +28,8 @@ OBJS =  NoahmpSnowInitMod.o \
 	PedoTransferSR2006Mod.o
 
 driver: $(OBJS)
+
+driver_lib:
 	ar -ru ./../../../libphys.a $(OBJS)
 
 # DEPENDENCIES:

--- a/src/core_atmosphere/physics/physics_noahmp/src/Makefile
+++ b/src/core_atmosphere/physics/physics_noahmp/src/Makefile
@@ -1,5 +1,7 @@
 .SUFFIXES: .F90 .o
 
+.PHONY: src src_lib
+
 all: dummy src
 
 dummy:
@@ -132,6 +134,8 @@ OBJS =  ConstantDefineMod.o \
 	WaterMainGlacierMod.o
 
 src: $(OBJS)
+
+src_lib:
 	ar -ru ./../../libphys.a $(OBJS)
 
 # DEPENDENCIES:

--- a/src/core_atmosphere/physics/physics_noahmp/utility/Makefile
+++ b/src/core_atmosphere/physics/physics_noahmp/utility/Makefile
@@ -1,5 +1,7 @@
 .SUFFIXES: .F90 .o
 
+.PHONY: utility utility_lib
+
 all: dummy utility
 
 dummy:
@@ -9,6 +11,8 @@ OBJS =  Machine.o \
 	CheckNanMod.o
 
 utility: $(OBJS)
+
+utility_lib:
 	ar -ru ./../../libphys.a $(OBJS)
 
 # DEPENDENCIES:

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -1,5 +1,7 @@
 .SUFFIXES: .F .o
 
+.PHONY: physics_wrf physics_wrf_lib
+
 all: dummy physics_wrf
 
 dummy:
@@ -50,6 +52,8 @@ OBJS = \
 
 
 physics_wrf: $(OBJS)
+
+physics_wrf_lib:
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:


### PR DESCRIPTION
This PR fixes intermittent parallel build failures in MPAS-A physics.

Firstly, this PR adds a missing dependency in `src/core_atmosphere/physics/Makefile`. The `core_physics` target should depend not only on `core_physics_wrf` but also on `core_physics_noahmp`. Note that `core_physics_wrf` already has a dependency on `core_physics_mmm`, and so it isn't necessary to also list `core_physics_mmm` as a dependency for `core_physics`.

Secondly, this PR splits the compilation of source files in MPAS-A physics. Now, Makefiles have been modified so that source files in `physics_wrf`, `physics_noahmp`, and `physics_mmm` can be compiled in parallel first, and as a subsequent step, object files from these directories are added to `libphys.a` in a serial fashion to avoid race conditions during library updates.
