### PR TITLE
Add module search paths to support compilation of Noah-MP code with nvfortran

### DIFF
--- a/src/core_atmosphere/build_options.mk
+++ b/src/core_atmosphere/build_options.mk
@@ -2,6 +2,9 @@ PWD=$(shell pwd)
 EXE_NAME=atmosphere_model
 NAMELIST_SUFFIX=atmosphere
 override CPPFLAGS += -DCORE_ATMOSPHERE
+FCINCLUDES += -I$(PWD)/src/core_atmosphere/physics/physics_noahmp/drivers/mpas \
+              -I$(PWD)/src/core_atmosphere/physics/physics_noahmp/utility \
+              -I$(PWD)/src/core_atmosphere/physics/physics_noahmp/src
 
 report_builds:
 	@echo "CORE=atmosphere"

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/Makefile
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/Makefile
@@ -66,5 +66,5 @@ clean:
 	$(RM) *.i
 
 .F90.o:
-	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I. -I../../utility -I../../src -I../../../../../framework
+	$(FC) $(CPPFLAGS) $(COREDEF) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES) -I. -I../../utility -I../../src -I../../../../../framework -I../../../../../external/esmf_time_f90
 


### PR DESCRIPTION
This PR adds module search paths to support compilation of MPAS-A with Noah-MP using the nvfortran compiler.

The nvfortran compiler requires paths of modules that are used indirectly to be present in the module search path provided with the `-I...` option. To support compilation of Noah-MP code in MPAS-Atmosphere with the nvfortran compiler, this commit (1) adds Noah-MP source directories to `FCINCLUDES`, and (2) adds the path to the `esmf_time_f90` code when compiling Noah-MP code.