### PR TITLE
Add 'sf_noahmp_in' package to Noah-MP static fields in atmosphere core registry

### DIFF
--- a/src/core_atmosphere/physics/Registry_noahmp.xml
+++ b/src/core_atmosphere/physics/Registry_noahmp.xml
@@ -25,19 +25,24 @@
  <var_struct name="mesh" time_levs="1">
 
       <var name="soilcomp" type="real" dimensions="nSoilComps nCells" units="unitless"
-                description="soil composition needed as input in the NOAH-MP land surface model"/>
+                description="soil composition needed as input in the NOAH-MP land surface model"
+                packages="sf_noahmp_in"/>
 
       <var name="soilcl1" type="real" dimensions="nCells" units="unitless"
-                description="soil texture class level 1 needed as input for the NOAH-MP land surface model"/>
+                description="soil texture class level 1 needed as input for the NOAH-MP land surface model"
+                packages="sf_noahmp_in"/>
 
       <var name="soilcl2" type="real" dimensions="nCells" units="unitless"
-                description="soil texture class level 2 needed as input for the NOAH-MP land surface model"/>
+                description="soil texture class level 2 needed as input for the NOAH-MP land surface model"
+                packages="sf_noahmp_in"/>
 
       <var name="soilcl3" type="real" dimensions="nCells" units="unitless"
-                description="soil texture class level 3 needed as input for the NOAH-MP land surface model"/>
+                description="soil texture class level 3 needed as input for the NOAH-MP land surface model"
+                packages="sf_noahmp_in"/>
 
       <var name="soilcl4" type="real" dimensions="nCells" units="unitless"
-                description="soil texture class level 4 needed as input for the NOAH-MP land surface model"/>
+                description="soil texture class level 4 needed as input for the NOAH-MP land surface model"
+                packages="sf_noahmp_in"/>
 
  </var_struct>
 


### PR DESCRIPTION
This PR adds the `sf_noahmp_in` package to Noah-MP static fields in the atmosphere core's Registry file.

Prior to this PR, the Noah-MP static fields `soilcomp`, `soilcl1`, `soilcl2`, `soilcl3`, and `soilcl4` did not have any packages attached to them, and as a result, even model simulations that didn't use the Noah-MP scheme would attempt to read these fields from input files. If attempting to run a simulation with the default 'mesoscale_reference' physics suite and an old (<= v8.1.0) input file, the model run would fail when trying to inquire about the `nSoilComps` dimension:
```
  ERROR: At least one fields to be read from the 'input' stream is dimensioned
  ERROR: by 'nSoilComps', but the 'nSoilComps' dimension is not defined
  ERROR: in the file <input stream filename>.
  CRITICAL ERROR: Please check the input file(s) to be read by the 'input' input stream.
```
Since these static fields are only needed by the Noah-MP scheme, this PR attaches the existing `sf_noahmp_in` package to these five fields so that they will only be active, and therefore, only read, if `config_lsm_scheme = 'sf_noahmp'` in the `&physics` namelist group.