### PR TITLE
Ignore the entire physics_mmm subdirectory of src/core_atmosphere/physics

### DIFF
--- a/src/core_atmosphere/physics/.gitignore
+++ b/src/core_atmosphere/physics/.gitignore
@@ -1,6 +1,4 @@
 *.f90
 physics_wrf/*.f90
 physics_wrf/files/
-physics_mmm/.gitignore
-physics_mmm/README.md
-physics_mmm/LICENSE
+physics_mmm


### PR DESCRIPTION
This PR updates the MPAS-A physics `.gitignore` file so that the entire `physics_mmm` subdirectory is ignored. The `physics_mmm` directory is populated from the external MMM-physics repository and should be ignored in its entirety.