### PR TITLE
Add 'sf_noahmp' to list of possible_values for config_lsm_scheme

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2107,7 +2107,7 @@
                 <nml_option name="config_lsm_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"
                      description="configuration for land-surface schemes"
-                     possible_values="`suite',`noah',`off'"/>
+                     possible_values="`suite',`sf_noah',`sf_noahmp`, `off'"/>
 
                 <nml_option name="config_pbl_scheme" type="character" default_value="suite" in_defaults="false"
                      units="-"


### PR DESCRIPTION
This PR adds `sf_noahmp` to the list of possible options for the `config_lsm_scheme` namelist variable in the atmosphere core's `Registry.xml` file. Also included in this PR is an update of the name of the `noah` option to `sf_noah` under `possible_values` for `config_lsm_scheme`.