### PR TITLE
Use more mpi_f08 features in mpi_f08_test for better detection of valid mpi_f08 module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1267,9 +1267,10 @@ mpi_f08_test:
 	$(info Checking for mpi_f08 support...)
 	$(eval MPAS_MPI_F08 := $(shell $\
 		printf "program main\n$\
-		        &   use mpi_f08, only : MPI_Init, MPI_Comm\n$\
+		        &   use mpi_f08, only : MPI_Init, MPI_Comm, MPI_INTEGER, MPI_Datatype\n$\
 		        &   integer :: ierr\n$\
 		        &   type (MPI_Comm) :: comm\n$\
+		        &   type (MPI_Datatype), parameter :: MPI_INTEGERKIND = MPI_INTEGER\n$\
 		        &   call MPI_Init(ierr)\n$\
 		        end program main\n" | sed 's/&/ /' > mpi_f08.f90; $\
 		$\


### PR DESCRIPTION
Use more mpi_f08 features in mpi_f08_test for odd cases where certain MPI implementations not compiled with mpi_f08 enabled still pass the current check.

Using OpenMPI 4.0.0 and gfortran 11.4.1 compiling without mpi_f08 features the MPI wrapper will still link and supply mpi_f08 (-lmpi_usempif08) despite not being valid or usable. This causes the `use mpi_f08` and some features to compile fine, but other mpi_f08 features to not exist and fail compilation.
