### PR TITLE
Enhance lib / lib64 library detection for pnetcdf and netcdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,10 +549,10 @@ endif
 
 
 ifneq "$(PNETCDF)" ""
-ifneq ($(wildcard $(PNETCDF)/lib), )
+ifneq ($(wildcard $(PNETCDF)/lib/libpnetcdf.*), )
 	PNETCDFLIBLOC = lib
 endif
-ifneq ($(wildcard $(PNETCDF)/lib64), )
+ifneq ($(wildcard $(PNETCDF)/lib64/libpnetcdf.*), )
 	PNETCDFLIBLOC = lib64
 endif
 	CPPINCLUDES += -I$(PNETCDF)/include

--- a/Makefile
+++ b/Makefile
@@ -525,10 +525,10 @@ ifneq ($(wildcard $(PIO_LIB)/libgptl\.*), )
 endif
 
 ifneq "$(NETCDF)" ""
-ifneq ($(wildcard $(NETCDF)/lib), )
+ifneq ($(wildcard $(NETCDF)/lib/libnetcdf.*), )
 	NETCDFLIBLOC = lib
 endif
-ifneq ($(wildcard $(NETCDF)/lib64), )
+ifneq ($(wildcard $(NETCDF)/lib64/libnetcdf.*), )
 	NETCDFLIBLOC = lib64
 endif
 	CPPINCLUDES += -I$(NETCDF)/include


### PR DESCRIPTION
The original additions of checking lib64/ for pnetcdf/netcdf (#592) made assumptions that when the variable supplied for the respective library location, if a lib64/ folder exists to use that. This leads to problems when existence of the actual library is not checked and if a lib64/ folder does exist but the library is not installed there. As this configuration layout is not unusual, the fix is to keep the precedence of lib64/, but check that the library exists within the directory before assigning values.