### PR TITLE
Add core_physics dependencies for mpas_atmphys_lsm_noahmpfinalize module

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -194,6 +194,9 @@ mpas_atmphys_lsm_noahmpinit.o: \
 	mpas_atmphys_utilities.o \
 	mpas_atmphys_vars.o
 
+mpas_atmphys_lsm_noahmpfinalize.o : \
+	mpas_atmphys_vars.o
+
 mpas_atmphys_manager.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_o3climatology.o \


### PR DESCRIPTION
Module `mpas_atmphys_lsm_noahmpfinalize` added in #1161 does not have the appropriate dependencies in the respective makefile.

This adds the necessary dependencies to the `mpas_atmphys_lsm_noahmpfinalize.o` 

