### PR TITLE
Fix double-precision builds of MPAS-A v8.2.0

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init_microphysics.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the LICENSE file
 ! distributed with this code, or at http://mpas-dev.github.com/license.html
 !
-#define DM_BCAST_MACRO(A) call mpas_dmpar_bcast_reals(dminfo,size(A),A)
+#define DM_BCAST_MACRO(A) call mpas_dmpar_bcast_real4s(dminfo,size(A),A)
 
 !=================================================================================================================
  module mpas_atmphys_init_microphysics

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -98,6 +98,7 @@ include 'mpif.h'
    public :: mpas_dmpar_bcast_ints
    public :: mpas_dmpar_bcast_real
    public :: mpas_dmpar_bcast_reals
+   public :: mpas_dmpar_bcast_real4s
    public :: mpas_dmpar_bcast_double
    public :: mpas_dmpar_bcast_doubles
    public :: mpas_dmpar_bcast_logical
@@ -550,6 +551,46 @@ include 'mpif.h'
 #endif
 
    end subroutine mpas_dmpar_bcast_reals!}}}
+
+!-----------------------------------------------------------------------
+!  routine mpas_dmpar_bcast_real4s
+!
+!> \brief MPAS dmpar broadcast R4KIND routine.
+!> \author Michael Duda, William Lipscomb
+!> \date 8 July 2024
+!> \details
+!>  This routine broadcasts an array of R4KIND reals to all processors in
+!>  the communicator. An optional argument specifies the source node; else
+!>  broadcast from IO_NODE.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_dmpar_bcast_real4s(dminfo, n, rarray, proc)!{{{
+
+      implicit none
+
+      type (dm_info), intent(in) :: dminfo !< Input: Domain information
+      integer, intent(in) :: n !< Input: Length of array
+      real (kind=R4KIND), dimension(n), intent(inout) :: rarray !< Input/Output: Array of reals to be broadcast
+      integer, intent(in), optional :: proc  !< optional argument indicating which processor to broadcast from
+
+#ifdef _MPI
+      integer :: mpi_ierr, source
+      integer :: threadNum
+
+      threadNum = mpas_threading_get_thread_num()
+
+      if ( threadNum == 0 ) then
+         if (present(proc)) then
+            source = proc
+         else
+            source = IO_NODE
+         endif
+
+         call MPI_Bcast(rarray, n, MPI_REAL, source, dminfo % comm, mpi_ierr)
+      end if
+#endif
+
+   end subroutine mpas_dmpar_bcast_real4s!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_bcast_double


### PR DESCRIPTION
This PR corrects double-precision build failures of `mpas_atmphys_init_microphysics.F` in MPAS-A v8.2.0.

The `mpas_atmphys_init_microphysics` module contains a routine, `table_ccnAct`, that
broadcasts an `R4KIND` real array, `tnccn_act`, from the Thompson microphysics
scheme. This broadcast was previously performed by a call to
`mpas_dmpar_bcast_reals` through the macro `DM_BCAST_MACRO`. However,
because the `mpas_dmpar_bcast_reals` routine broadcasts arrays of kind `RKIND`, when
MPAS-A is compiled with double-precision reals, the `mpas_dmpar_bcast_reals`
routine can no longer be used with the `tnccn_act` array.
    
With this PR, the `DM_BCAST_MACRO` in `mpas_atmphys_init_microphysics.F` has 
been defined to `mpas_dmpar_bcast_real4s`, which broadcasts arrays of `R4KIND`
reals. This works for both single- and double-precision builds of MPAS-A, since
the kind type of the `tnccn_act` array is independent of the MPAS-A build
precision.