### PR TITLE
Add framework for new tendency, revised PV diagnostics packages

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -410,6 +410,13 @@
                 <package name="limited_area" description="Limited-area simulations, which have lateral boundaries"/>
                 <package name="jedi_da" description="Data Assimilation in JEDI framework"/>
                 <package name="no_invariant_stream" description="No separate invariant I/O stream is active"/>
+
+                <package name="tendencies" description="Diagnostics tendency budget terms for winds, thetam and qv"/>
+                <package name="pv_diagnostics" description="Basic PV diagnostics calculations activated by config_pv_diag"/>
+                <package name="pv_tendencies" description="PV tendency calculations activated by config_pv_tend"/>
+                <package name="pv_scalar" description="PV scalar advection activated by config_pv_scalar"/>
+                <package name="pv_microphysics" description="PV microphysics process tendency calculations activated by config_pv_microphys"/>
+                <package name="pv_isobaric" description="Isobaric PV variable interpolation activated by config_pv_isobaric"/>
         </packages>
 
 
@@ -1628,8 +1635,16 @@
 
                 </var_array>
 #endif
-        </var_struct>
+                <!-- MW: adding a PV scalar ARRAY for optional PV scalar diagnostic variable because the scalar advection subroutine expects a scalar array input !-->
+                <var_array name="pv_scalars" type="real" dimensions="nVertLevels nCells Time" streams="restart">
+                        <var name="pv_scalar" array_group="passive" units="PVU"
+                                description="Ertel's potential vorticity to be advected by the model (1 PVU = 10^{-6} m^{2} s^{-1} K kg^{-1})"
+                                packages="pv_scalar"
+                                streams="restart"/>
+                </var_array>
 
+        </var_struct>
+        
         <var_struct name="diag" time_levs="1">
 
                 <!-- coefficients for the vertical tridiagonal solve -->
@@ -1714,9 +1729,6 @@
 
                 <var name="pv_cell" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
                      description="absolute vertical vorticity averaged to the cell center from the vertices"/>
-
-                <var name="dtheta_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="Potential temperature heating rate from microphysics"/>
 
                 <!-- reconstructed horizontal velocity vectors at cell centers -->
                 <var name="uReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
@@ -1929,6 +1941,14 @@
                              packages="mp_thompson_aers_in"/>
                 </var_array>
 #endif
+                <!-- MW: Tendency variable array for optional pv_scalar diagnostic variable.                                           -->
+                <!--     pv_scalars_tend only contains one variable but we need the array because the scalar transport code expects it -->
+                <var_array name="pv_scalars_tend" type="real" dimensions="nVertLevels nCells Time">
+                        <var name="tend_pv_scalar" array_group="passive" units="PVU kg m^{-3} s^{-1}"
+                             description="Tendency of Ertel's potential vorticity from scalar advection multiplied by dry air density divided by d(zeta)/dz"
+                             packages="pv_scalar" />
+                </var_array>
+
         </var_struct>
 
         <!-- ===================================================================================== -->

--- a/src/core_atmosphere/diagnostics/Makefile
+++ b/src/core_atmosphere/diagnostics/Makefile
@@ -25,12 +25,13 @@ mpas_soundings.o:
 ################### Generally no need to modify below here ###################
 
 
-OBJS = mpas_atm_diagnostics_manager.o mpas_atm_diagnostics_utils.o
+OBJS = mpas_atm_diagnostics_manager.o mpas_atm_diagnostics_utils.o mpas_atm_diagnostics_packages.o
 
 all: $(DIAGNOSTIC_MODULES) $(OBJS)
 
 mpas_atm_diagnostics_manager.o: mpas_atm_diagnostics_utils.o $(DIAGNOSTIC_MODULES)
 
+mpas_atm_diagnostics_packages.o: mpas_atm_diagnostics_utils.o
 
 clean:
 	$(RM) *.o *.mod *.f90

--- a/src/core_atmosphere/diagnostics/Registry_diagnostics.xml
+++ b/src/core_atmosphere/diagnostics/Registry_diagnostics.xml
@@ -19,6 +19,54 @@
 <!-- soundings -->
 #include "Registry_soundings.xml"
 
+<!-- tendencies -->
+#include "Registry_tendencies.xml"
+
+
+<!-- ........................................................................ -->
+<!-- Declare namelist config options for tendency and PV diagnostics packages -->
+<!-- ........................................................................ -->
+<nml_record name="diagnostics" in_defaults="false">
+
+    <!-- NAMELIST VARIABLES ADDED FOR INITIALIZATION OF INITIAL TENDENCY DIAGNOSTICS: -->    
+    <nml_option name="config_tend" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for outputting tendency budget terms for thetam, water-vapor mixing ratio, and reconstructed winds"
+         possible_values=".true. for accumulating tendency terms; .false. otherwise"/>
+
+
+    <!-- NAMELIST VARIABLES ADDED FOR INITIALIZATION OF PV DIAGNOSTICS: -->
+    <nml_option name="config_pv_diag" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for calculation of potential vorticity and variables interpolated to dynamic tropopause"
+         possible_values=".true. for PV diagnostics calculation; .false. otherwise"/>
+
+    <!-- The following are only active when config_pv_diag = True -->
+    <!-- config_pv_tend requires config_tend = True -->
+    <nml_option name="config_pv_tend" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for calculation of potential vorticity tendency diagnostics"
+         possible_values=".true. for PV tendency diagnostics calculation; .false. otherwise"/>
+
+    <nml_option name="config_pv_isobaric" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for interpolation of PV diagnostics onto isobaric levels"
+         possible_values=".true. for PV diagnostics interpolation; .false. otherwise"/>
+
+   <!-- MC_TODO: should only be activated if Thompson MP scheme is used -->
+    <nml_option name="config_pv_microphys" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for calculation of specific process tendencies from Thompson microphysics"
+         possible_values=".true. for PV tendencies from specific mp processes; .false. otherwise"/>
+
+    <!-- MC_TODO: need to deal with restarts; pv_scalars variable defined in Registry.xml -->
+    <nml_option name="config_pv_scalar" type="logical" default_value="false" in_defaults="false"
+         units="-"
+         description="Logical for treating the initial PV field as a passive scalar and transporting it throughout the simulation"
+         possible_values=".true. for calculating scalar PV transport; .false. otherwise"/>
+
+</nml_record>
+
 <!-- ******************************* -->
 <!-- End includes from diagnostics -->
 <!-- ******************************* -->

--- a/src/core_atmosphere/diagnostics/Registry_pv.xml
+++ b/src/core_atmosphere/diagnostics/Registry_pv.xml
@@ -1,68 +1,428 @@
-<!-- ***************************************** -->
-<!-- PV diagnostics from Nicholas Szapiro (OU) -->
+<!-- ******************************************* -->
+<!-- ........PV diagnostics package............. -->
+<!-- Nick Szapiro, Manda Chasteen, and May Wong  -->
 <!-- Note that 1 PVU = 10^6 K kg^{−1} m^2 s^{−1} -->
-<!-- ***************************************** -->
-
+<!-- ******************************************* -->
 <var_struct name="diag" time_levs="1">
 
+        <!-- 3D PV fields -->
         <var name="ertel_pv" type="real" dimensions="nVertLevels nCells Time" units="PVU"
-             description="Ertel's potential vorticity"/>
+             description="Ertel's potential vorticity (1 PVU = 10^{-6} m^{2} s^{-1} K kg^{-1})"
+             packages="pv_diagnostics"/>
 
-        <var name="u_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
-             description="Zonal wind on dynamic tropopause"/>
+        <var name="ertel_pv_prev" type="real" dimensions="nVertLevels nCells Time" units="PVU"
+             description="Ertel's PV at beginning of previous time step"
+             packages="pv_tendencies"/>
 
-        <var name="v_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
-             description="Meridional wind on dynamic tropopause"/>
 
-        <var name="theta_pv" type="real" dimensions="nCells Time" units="K"
-             description="Potential temperature on dynamic tropopause"/>
-
-        <var name="vort_pv" type="real" dimensions="nCells Time" units="s^{-1}"
-             description="Relative vertical vorticity on dynamic tropopause"/>
-
-        <var name="iLev_DT" type="integer" dimensions="nCells Time" units="-"
-             description="Lowest vertical level at or above dynamic tropopause (.lt.1 if 2 PVU below column; .gt.nLevels if 2PVU above column)"/>
-
-#ifdef DO_PHYSICS
+       <!-- Instantaneous PV tendencies -->
+       <!-- Diabatic -->
         <var name="depv_dt_lw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from longwave radiation"/>
+             description="Diabatic PV tendency from longwave radiation parameterization scheme"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_sw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from shortwave radiation"/>
+             description="Diabatic PV tendency from shortwave radiation parameterization scheme"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_bl" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from PBL"/>
+             description="Diabatic PV tendency from PBL parameterization scheme"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_cu" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from convection"/>
+             description="Diabatic PV tendency from cumulus parameterization scheme"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from microphysics"/>
-
-        <var name="dtheta_dt_mix" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-             description="Potential temperature heating rate from explicit numerical mixing"/>
+             description="Diabatic PV tendency from microphysics parameterization scheme"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_mix" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency from explicit numerical mixing"/>
-
+             description="Diabatic PV tendency from explicit horizontal mixing"
+             packages="pv_tendencies"/>
+    
         <var name="depv_dt_diab" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Sum of calculated EPV tendencies from diabatic processes"/>
+             description="Sum of calculated PV tendencies from diabatic processes"
+             packages="pv_tendencies"/>
 
+        <!-- Frictional -->
+        <var name="depv_dt_fric_bl" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Frictional PV tendency from PBL and GWD parameterization schemes"
+             packages="pv_tendencies"/>
+
+        <var name="depv_dt_fric_cu" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Frictional PV tendency from cumulus parameterization scheme"
+             packages="pv_tendencies"/>
+
+        <var name="depv_dt_fric_mix" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Frictional PV tendency from explicit horizontal mixing"
+             packages="pv_tendencies"/>
+    
         <var name="depv_dt_fric" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
-             description="Sum of calculated EPV tendencies from frictional processes"/>
+             description="Sum of calculated PV tendencies from frictional processes"
+             packages="pv_tendencies"/>
+    
+        <!-- Dynamics -->
+        <var name="depv_dt_dyn" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="PV tendency from dynamics"
+             packages="pv_tendencies"/>
+    
+        <!-- Specific microphysics process PV tendencies: currently only works for Thompson MP scheme -->
+        <var name="depv_dt_mp_evap_cw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from microphysics - net condensation/evaporation of cloud water"
+             packages="pv_microphysics"/>
 
-        <var name="tend_u_phys" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
-             description="Normal wind tendencies from physics parameterizations"/>
+        <var name="depv_dt_mp_evap_rw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from microphysics - evaporation of rain water"
+             packages="pv_microphysics"/>
 
+        <var name="depv_dt_mp_depo_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from microphysics - net deposition/sublimation of all ice hydrometeors"
+             packages="pv_microphysics"/>
+
+        <var name="depv_dt_mp_melt_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from microphysics - melting of all ice hydrometeors"
+             packages="pv_microphysics"/>
+
+        <var name="depv_dt_mp_frez_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from microphysics - freezing of all ice hydrometeors"
+             packages="pv_microphysics"/>
+
+        <var name="depv_dt_mp_allproc" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Diabatic PV tendency from summed microphysical processes"
+             packages="pv_microphysics"/>
+
+    
+       <!-- Accumulated PV tendencies -->
+       <!-- Diabatic -->
+        <var name="acc_depv_dt_lw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from longwave radiation scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+
+        <var name="acc_depv_dt_sw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from shortwave radiation scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_bl" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from PBL scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_cu" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from cumulus scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mix" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from explicit horizontal mixing"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_diab" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated sum of calculated PV tendencies from diabatic processes"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <!-- Frictional -->
+        <var name="acc_depv_dt_fric_bl" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated frictional PV tendency from PBL and GWD schemes"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_fric_cu" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated frictional PV tendency from cumulus scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_fric_mix" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated frictional PV tendency from explicit horizontal mixing"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_fric" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated sum of calculated PV tendencies from frictional processes"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <!-- Dynamics -->
+        <var name="acc_depv_dt_dyn" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated PV tendency from dynamics"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+       <!-- Specific microphysics process PV tendencies: currently only works for Thompson MP scheme -->
+        <var name="acc_depv_dt_mp_evap_cw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics - net condensation/evaporation of cloud water"
+             packages="pv_microphysics"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp_evap_rw" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics - evaporation of rain water"
+             packages="pv_microphysics"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp_depo_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics - net deposition/sublimation of all ice hydrometeors"
+             packages="pv_microphysics"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp_melt_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics - melting of all ice hydrometeors"
+             packages="pv_microphysics"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp_frez_ice" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from microphysics - freezing of all ice hydrometeors"
+             packages="pv_microphysics"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_mp_allproc" type="real" dimensions="nVertLevels nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency from summed microphysical processes"
+             packages="pv_microphysics"
+             streams="restart"/>
+
+    
+        <!-- Accumulated latent heating tendencies --> 
+        <var name="acc_dtheta_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Accumulated potential temperature tendency due to microphysics scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_dtheta_dt_cu" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Accumulated potential temperature tendency due to cumulus scheme"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+
+        <!-- Static variables on dynamic tropopause -->
+        <var name="iLev_DT" type="integer" dimensions="nCells Time" units="-"
+             description="Lowest vertical model level at or above dynamic tropopause (< 1 if 2 PVU below column; > nVertLevels if 2 PVU above column)"
+             packages="pv_diagnostics"/>
+
+        <var name="iLev_DT_prev" type="integer" dimensions="nCells Time" units="-"
+             description="Lowest vertical level at or above dynamic tropopause at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="u_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+             description="Zonal wind on dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+        <var name="v_pv" type="real" dimensions="nCells Time" units="m s^{-1}"
+             description="Meridional wind on dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+        <var name="theta_pv" type="real" dimensions="nCells Time" units="K"
+             description="Potential temperature on dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+        <var name="vort_pv" type="real" dimensions="nCells Time" units="s^{-1}"
+             description="Relative vertical vorticity on dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+        <var name="pres_pv" type="real" dimensions="nCells Time" units="Pa"
+             description="Pressure of dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+        <var name="height_pv" type="real" dimensions="nCells Time" units="m MSL"
+             description="Geopotential height of dynamic tropopause diagnosed at current time step (i.e., iLev_DT)"
+             packages="pv_diagnostics"/>
+
+    
+        <!-- Instantaneous PV tendencies on dynamic tropopause -->
         <var name="depv_dt_diab_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
-             description="Diabatic EPV tendency on dynamic tropopause"/>
+             description="Diabatic PV tendency on dynamic tropopause diagnosed at beginning of previous time step (i.e., iLev_DT_prev)"
+             packages="pv_tendencies"/>
 
         <var name="depv_dt_fric_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
-             description="Frictional EPV tendency on dynamic tropopause"/>
-#endif
+             description="Frictional PV tendency on dynamic tropopause diagnosed at beginning of previous time step (i.e., iLev_DT_prev)"
+             packages="pv_tendencies"/>
 
+        <var name="depv_dt_dyn_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
+             description="PV tendency from dynamics on dynamic tropopause diagnosed at beginning of previous time step (i.e., iLev_DT_prev)"
+             packages="pv_tendencies"/>
+
+    
+        <!-- Accumulated PV tendencies on dynamic tropopause -->
+        <var name="acc_depv_dt_diab_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
+             description="Accumulated diabatic PV tendency on dynamic tropopause"
+             packages="pv_tendencies"
+             streams="restart"/>
+    
+        <var name="acc_depv_dt_fric_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
+             description="Accumulated frictional PV tendency on dynamic tropopause"
+             packages="pv_tendencies"
+             streams="restart"/>
+
+        <var name="acc_depv_dt_dyn_pv" type="real" dimensions="nCells Time" units="PVU s^{-1}"
+             description="Accumulated advective PV tendency on dynamic tropopause"
+             packages="pv_tendencies"
+             streams="restart"/>
+
+    
+        <!-- Intermediate static variables --> 
+        <var name="zgrid_cell" type="real" dimensions="nVertLevels nCells Time" units="m"
+             description="Geometric height of cell centers on mass levels"
+             packages="pv_diagnostics"/>
+
+        <var name="wCell" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+             description="Vertical velocity interpolated to cell centers"
+             packages="pv_diagnostics"/>
+    
+        <var name="dtheta_dz" type="real" dimensions="nVertLevels nCells Time" units="K m^{-1}"
+             description="Vertical gradient of potential temperature"
+             packages="pv_diagnostics"/>
+
+        <var name="uReconstructZonal_prev" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+             description="Reconstructed zonal wind at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="uReconstructMeridional_prev" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+             description="Reconstructed meridional wind at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="wCell_prev" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+             description="Vertical velocity interpolated to cell centers at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="theta_prev" type="real" dimensions="nVertLevels nCells Time" units="K"
+             description="Potential temperature at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="rho_prev" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3}"
+             description="Density at cell center at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+        <var name="qv_prev" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1}"
+             description="Water vapor mixing ratio at beginning of the time step"
+             packages="pv_tendencies"/>
+
+        <var name="pv_vertex_prev" type="real" dimensions="nVertLevels nVertices Time" units="s^{-1}"
+             description="Absolute vertical voricity at cell vertices at beginning of previous time step"
+             packages="pv_tendencies"/>
+
+
+       <!-- Intermediate tendency variables --> 
+       <!-- Diabatic and moisture --> 
+       <var name="dtheta_dt_mix" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature heating rate from explicit horizontal mixing"
+             packages="pv_tendencies"/>
+
+       <var name="dtheta_dt_dyn" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from dynamics"
+             packages="pv_tendencies"/>
+
+       <var name="thmblten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Theta_m tendency from PBL scheme calculated over RK timestep integration"
+             packages="pv_tendencies"/>
+
+        <var name="qvblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+             description="Mixing ratio tendency from PBL scheme calculated over RK timestep integration"
+             packages="pv_tendencies"/>        
+
+        <var name="dtheta_dt_pbl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from PBL scheme -- derived from theta_m and qv tendencies"
+             packages="pv_tendencies"/>
+
+        <var name="thmcuten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Theta_m tendency from cumulus scheme calculated over RK timestep integration"
+             packages="pv_tendencies"/>
+
+        <var name="qvcuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+             description="Mixing ratio tendency from cumulus scheme calculated over RK timestep integration"
+             packages="pv_tendencies"/>
+
+        <var name="dtheta_dt_cu" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from cumulus scheme -- derived from theta_m and qv tendencies"
+             packages="pv_tendencies"/>
+
+        <var name="thmlwten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Theta_m tendency from longwave radiation calculated over RK timestep integration"
+             packages="pv_tendencies"/>
+
+       <var name="dtheta_dt_lw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from longwave radiation scheme -- derived from theta_m tendency"
+             packages="pv_tendencies"/>
+
+        <var name="thmswten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Theta_m tendency from shortwave radiation calculated over RK timestep integration"
+             packages="pv_tendencies"/>
+
+        <var name="dtheta_dt_sw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from shortwave radiation scheme -- derived from theta_m tendency"
+             packages="pv_tendencies"/>
+
+        <var name="thmmpten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Theta_m tendency from microphysics scheme"
+             packages="pv_tendencies"/>    
+
+        <var name="qvmpten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+             description="Mixing ratio tendency from microphysics scheme"
+             packages="pv_tendencies"/>
+
+        <var name="dtheta_dt_mp" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+             description="Potential temperature tendency from microphysics scheme -- derived from theta_m and qv tendencies"
+             packages="pv_tendencies"/>
+
+
+        <!-- Momentum --> 
+        <!-- Some related tendency variables are included in Registry.xml file (e.g., u_tend_diff) -->
+        <var name="tend_u_pbl" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+             description="Normal wind tendencies from PBL and GWD parameterization schemes"
+             packages="pv_tendencies"/>
+
+        <var name="tend_u_cu" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+             description="Normal wind tendencies from cumulus parameterization scheme"
+             packages="pv_tendencies"/>
+    
+        <var name="uTend_curl_diff" type="real" dimensions="nVertLevels nVertices Time" units="s^{-2}"
+             description="Curl of the normal wind tendencies from diffusion at the cell vertices"
+             packages="pv_tendencies"/>
+
+        <var name="uTend_curl_pbl" type="real" dimensions="nVertLevels nVertices Time" units="s^{-2}"
+             description="Curl of the normal wind tendencies from PBL+GWD at the cell vertices"
+             packages="pv_tendencies"/>
+
+        <var name="uTend_curl_cu" type="real" dimensions="nVertLevels nVertices Time" units="s^{-2}"
+             description="Curl of the normal wind tendencies from cumulus at the cell vertices"
+             packages="pv_tendencies"/>
+
+        <var name="uTend_curl_dyn" type="real" dimensions="nVertLevels nVertices Time" units="s^{-2}"
+             description="Curl of the normal wind tendencies from dynamics at the cell vertices"
+             packages="pv_tendencies"/>
+
+        <var name="tend_wCell_diff" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+             description="Uncoupled vertical velocity tendency from mixing interpolated to mass levels"
+             packages="pv_tendencies"/>
+
+        <var name="tenddyn_wCell" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+             description="Uncoupled vertical velocity tendency from dynamics interpolated to mass levels"
+             packages="pv_tendencies"/>
+
+    
+        <!-- Dynamic tropopause identification routine --> 
         <var name="inTropo" type="integer" dimensions="nVertLevels nCells Time" units="0/1"
-             description="1 if within troposphere based on EPV flood fill"/>
+             description="1 if within troposphere based on PV flood fill"
+             packages="pv_diagnostics"/>
+
+        <var name="candInTropo" type="integer" dimensions="nVertLevels nCells Time" units="0/1"
+             description="1 if candidate of troposphere"
+             packages="pv_diagnostics"/>
+
+        <var name="candInStrato" type="integer" dimensions="nVertLevels nCells Time" units="0/1"
+             description="1 if candidate of stratosphere"
+             packages="pv_diagnostics"/>
+
+
+        <!-- MC: needs to be deleted after further code modifications have been done -->
+        <var name="tend_u_phys" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+             description="Normal wind tendencies from physics parameterizations"/>   
 
 </var_struct>
 

--- a/src/core_atmosphere/diagnostics/Registry_tendencies.xml
+++ b/src/core_atmosphere/diagnostics/Registry_tendencies.xml
@@ -1,0 +1,484 @@
+<var_struct name="diag" time_levs="1">
+
+	<!-- MW: added this for PV  -->
+	<var name="rw_tend_dyn_large" type="real" dimensions="nVertLevelsP1 nCells Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled vertical momentum tendency due to large-time-step dynamics tendency"
+             packages="tendencies"/>
+
+	<var name="rw_tend_dyn_small" type="real" dimensions="nVertLevelsP1 nCells Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled vertical momentum tendency due to small-time-step dynamics tendency"
+             packages="tendencies"/>
+
+	<var name="rw_tend_diff" type="real" dimensions="nVertLevelsP1 nCells Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled vertical momentum tendency from (horiz) diffusion"
+             packages="tendencies"/>
+
+	<var name="w_tend_dcpl" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
+	     description="Vertical velocity tendency component from decoupling from mass"
+             packages="tendencies"/>
+
+	<var name="dthetam_dt_dyn" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Moist potential temperature dynamic tendency (large+small+dcpl)"
+             packages="tendencies"/>
+
+	<var name="dthetam_dt_mix" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Moist potential temperature explicit diffusion tendency (diff)"
+             packages="tendencies"/>
+
+	<var name="dqv_dt_dyn" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Water vapor advective tendency"
+             packages="tendencies"/>
+
+	<var name="du_dt_dyn" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Horizontal winds dynamics tendency"
+             packages="tendencies"/>
+
+	<var name="du_dt_dyn_zonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Zonal winds dynamics tendency (reconstructed in PV code)"
+             packages="tendencies"/>
+
+	<var name="du_dt_dyn_meridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Meridional winds dynamics tendency (reconstructed in PV code)"
+             packages="tendencies"/>
+
+	<var name="dw_dt_dyn" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-2}"
+	     description="Vertical winds dynamics tendency"
+             packages="tendencies"/>
+
+
+	<!-- MW: Initial Tendency Method: variables for accumulated tendencies-->
+	<!-- Note:    not meant to be output -->
+
+	<!-- momentum -->
+	<var name="ru_tend_dyn_large" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled horizontal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="ru_tend_dyn_small" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled horizontal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="ru_tend_diff" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<!-- added for PV diagnostics -->
+	<var name="pv_vertex_dyn" type="real" dimensions="nVertLevels nVertices Time" units="s^{-1} kg^{-1} m^3"
+	     description="absolute vorticity/rho_zz at a vertex after dynamics"
+             packages="tendencies"/>
+
+	<var name="u_tend_diff" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Uncoupled horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="u_tend_diff_reconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Uncoupled horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="u_tend_diff_reconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Uncoupled horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="w_tend_diff" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-2}"
+	     description="Uncoupled vertical momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="u_dyn" type= "real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="uReconstructX_dyn" type= "real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="uReconstructY_dyn" type= "real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="uReconstructZ_dyn" type= "real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="uReconstructZonal_dyn" type= "real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="uReconstructMeridional_dyn" type= "real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+	     description="Uncoupled horizontal velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="w_dyn" type= "real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
+	     description="Uncoupled vertical velocity field after dynamics"
+             packages="tendencies"/>
+
+	<var name="theta_dyn" type= "real" dimensions="nVertLevels nCells Time" units="K"
+	     description="Uncoupled potential temperature field after dynamics"
+             packages="tendencies"/>
+
+	<var name="rho_dyn" type= "real" dimensions="nVertLevels nCells Time" units="kg m^{-3}"
+	     description="Dry density field after dynamics"
+             packages="tendencies"/>
+
+	<var name="ru_tend_physics" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled horizontal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="ru_tend_smdiv" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-1}"
+	     description="Coupled horizontal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="rublten_tend" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-2}"
+	     description="Coupled horizontal momentum tendency due to PBL (includes GWDO)"
+             packages="tendencies"/>
+
+	<var name="rugwdo_tend" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-2}"
+	     description="Coupled horizontal momentum tendency due to GWDO scheme"
+             packages="tendencies"/>
+
+	<var name="rucuten_tend" type="real" dimensions="nVertLevels nEdges Time" units="kg m^{-2} s^{-2}"
+	     description="Coupled horizontal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="u_tend_dcpl" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
+	     description="Horizontal momentum tendency due to dcoupling from mass"
+             packages="tendencies"/>
+
+	<!-- theta -->
+	<var name="rth_tend_dyn_large" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K"
+	     description="Coupled potential temperature large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="rth_tend_dyn_small" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K"
+	     description="Coupled potential temperature acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="rth_tend_diff" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K"
+	     description="Coupled potential temperature tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="rth_tend_physics" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K"
+	     description="Coupled potential temperature tendency from physics"
+             packages="tendencies"/>
+
+	<var name="rthblten_tend" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K s^{-1}"
+	     description="Coupled potential temperature tendency due to PBL"
+             packages="tendencies"/>
+
+	<var name="rthcuten_tend" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K s^{-1}"
+	     description="Coupled potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="rthratensw_tend" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K s^{-1}"
+	     description="Coupled potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="rthratenlw_tend" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} K s^{-1}"
+	     description="Coupled potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="th_tend_dcpl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Potential temperature tendency due to dcoupling from mass"
+             packages="tendencies"/>
+
+	<!-- qv -->
+	<var name="rqv_tend_diff" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-3} kg kg^{-1}"
+	     description="Coupled water vapor tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="qvblten_tend" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Coupled water vapor tendency due to PBL"
+             packages="tendencies"/>
+
+	<var name="qvcuten_tend" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Coupled water vapor tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="qv_mp_tend" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Water vapor tendency due to microphysics"
+             packages="tendencies"/>
+
+	<!-- Note:    for output --> 
+	<var name="acc_u_tend_dyn_large" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated hrizontal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to PBL scheme (includes GWDO) "
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- theta -->
+	<var name="acc_th_tend_dyn_large" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated moist potential temperature large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_th_tend_dyn_small" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated moist potential temperature acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_th_tend_diff" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_th_tend_physics" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_thblten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to PBL"
+             packages="tendencies"/>
+
+	<var name="acc_thcuten" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_thratensw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_thratenlw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_th_tend_diabatic" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to latent heat"
+             packages="tendencies"/>
+
+	<var name="acc_th_tend_dcpl" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+	     description="Accumulated potential temperature tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- qv -->
+	<var name="acc_qv_tend_dyn_large" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Accumulated water vapor large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_qv_tend_diff" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Accumulated water vapor tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_qvblten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Accumulated water vapor tendency due to PBL"
+             packages="tendencies"/>
+
+	<var name="acc_qvcuten" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Accumulated water vapor tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_qv_mp_tend" type="real" dimensions="nVertLevels nCells Time" units="kg kg^{-1} s^{-1}"
+	     description="Accumulated water vapor tendency due to latent heat"
+             packages="tendencies"/>
+
+	<!-- zonal --> 
+	<var name="acc_u_tend_dyn_large_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" uzonalnits="m s^{-2}"
+	     description="Accumulated zonal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency due to PBL scheme (includes GWDO) "
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl_ReconstructZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated zonal momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- meridional -->
+	<var name="acc_u_tend_dyn_large_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" uzonalnits="m s^{-2}"
+	     description="Accumulated meridional momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency due to PBL scheme (includes GWDO)"
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl_ReconstructMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated meridional momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- X -->
+	<var name="acc_u_tend_dyn_large_ReconstructX" type="real" dimensions="nVertLevels nCells Time" uzonalnits="m s^{-2}"
+	     description="Accumulated horizontal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated hrizontal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to PBL scheme (includes GWDO)"
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl_ReconstructX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- Y --> 
+	<var name="acc_u_tend_dyn_large_ReconstructY" type="real" dimensions="nVertLevels nCells Time" uzonalnits="m s^{-2}"
+	     description="Accumulated horizontal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated hrizontal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to PBL scheme (includes GWDO)"
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl_ReconstructY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+	<!-- Z --> 
+	<var name="acc_u_tend_dyn_large_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" uzonalnits="m s^{-2}"
+	     description="Accumulated horizontal momentum large-time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dyn_small_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated hrizontal momentum acoustic time-step dynamic tendency"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_diff_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from diffusion"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_physics_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency from physics"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_smdiv_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to divergence damping"
+             packages="tendencies"/>
+
+	<var name="acc_ublten_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to PBL scheme (includes GWDO)"
+             packages="tendencies"/>
+
+	<var name="acc_ugwdoten_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to GWDO scheme "
+             packages="tendencies"/>
+
+	<var name="acc_ucuten_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to cumulus scheme"
+             packages="tendencies"/>
+
+	<var name="acc_u_tend_dcpl_ReconstructZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-2}"
+	     description="Accumulated horizontal momentum tendency due to decoupling from mass"
+             packages="tendencies"/>
+
+</var_struct>

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_packages.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_packages.F
@@ -1,0 +1,250 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_atm_diagnostics_packages
+
+ 
+ use mpas_kind_types
+ use mpas_derived_types, only : mpas_pool_type, mpas_io_context_type, MPAS_LOG_ERR, MPAS_LOG_WARN
+ use mpas_pool_routines, only : mpas_pool_get_config, mpas_pool_get_package
+ use mpas_log, only : mpas_log_write
+
+ implicit none
+ private
+ public :: diagnostics_setup_packages
+
+
+! Module mpas_diagnostics_packages contains the definitions for the tendency and PV diagnostics packages
+! Script is modeled after mpas_atmphys_packages.F
+!
+! Manda Chasteen, 21 May 2024
+
+ contains
+
+
+!=================================================================================================================
+ function diagnostics_setup_packages(configs, packages, iocontext) result(ierr)
+!=================================================================================================================
+
+ ! inout arguments:
+ type (mpas_pool_type), intent(inout) :: configs
+ type (mpas_pool_type), intent(inout) :: packages
+ type (mpas_io_context_type), intent(inout) :: iocontext
+
+ ! microphysics config:
+ character(len=StrKIND), pointer :: config_microp_scheme
+
+ ! LBC config:
+ logical, pointer :: config_apply_lbcs
+ 
+ ! Tendencies diagnostics config:
+ logical, pointer :: config_tend
+
+ ! MC note: May's code in mpas_atm_core_interface is written in terms of tendenciesActive, but 
+ ! physics code is written in terms of package names in Registry... why?
+ 
+ ! Tendencies package:
+ logical, pointer :: tendenciesActive
+
+ ! PV diagnostics configs:
+ logical, pointer :: config_pv_diag, config_pv_tend, config_pv_scalar, &
+                     config_pv_microphys, config_pv_isobaric
+
+ ! PV diagnostics packages:
+ logical, pointer :: pv_diagnosticsActive, pv_tendenciesActive, pv_scalarActive, &
+                     pv_microphysicsActive, pv_isobaricActive
+
+ integer :: ierr                    
+
+!-----------------------------------------------------------------------------------------------------------------
+
+! call mpas_log_write('')
+! call mpas_log_write('--- enter subroutine diagnostics_setup_packages:')
+
+ ierr = 0
+
+!-----------------------------------------------------------------------------------------------------------------
+!--- initialization of package for model tendency diagnostics:
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_log_write('----- Setting up tendency diagnostics variables -----')
+ call mpas_log_write('')
+ 
+ nullify(config_tend)
+ call mpas_pool_get_config(configs, 'config_tend', config_tend)
+
+ nullify(tendenciesActive)
+ call mpas_pool_get_package(packages, 'tendenciesActive', tendenciesActive)
+
+ if (associated(config_tend) .and. associated(tendenciesActive)) then
+    tendenciesActive = config_tend
+    call mpas_log_write('    tendenciesActive           = $l', logicArgs=(/tendenciesActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''tendencies''. '// &
+        'Either ''tendencies'' is not a package, or ''config_tend'' is not a namelist option.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+
+
+!-----------------------------------------------------------------------------------------------------------------
+!--- initialization of packages for PV diagnostics:
+!    This contains compatability checks for various config_pv options. 
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_log_write('----- Performing compatability checks for PV diagnostics configs -----')
+ call mpas_log_write('')
+ 
+ call mpas_pool_get_config(configs, 'config_apply_lbcs', config_apply_lbcs)
+ call mpas_pool_get_config(configs, 'config_microp_scheme', config_microp_scheme)
+ 
+ nullify(config_pv_diag)  
+ call mpas_pool_get_config(configs, 'config_pv_diag', config_pv_diag) 
+
+ nullify(config_pv_tend) 
+ call mpas_pool_get_config(configs, 'config_pv_tend', config_pv_tend)
+
+ nullify(config_pv_scalar)
+ call mpas_pool_get_config(configs, 'config_pv_scalar', config_pv_scalar)  
+
+ nullify(config_pv_microphys)
+ call mpas_pool_get_config(configs, 'config_pv_microphys', config_pv_microphys)  
+
+ nullify(config_pv_isobaric)
+ call mpas_pool_get_config(configs, 'config_pv_isobaric', config_pv_isobaric)  
+
+  
+ ! Before setting packages, need to check compatability of config flags and then disable them as appropriate.
+
+ ! if limited area simulation, disable all PV flags if activated
+ if (config_apply_lbcs .and. (config_pv_diag .or. config_pv_tend .or. config_pv_scalar &
+    .or. config_pv_microphys .or. config_pv_isobaric)) then
+    call mpas_log_write('PV diagnostics are not supported for limited-area simulations. Disabling.', MPAS_LOG_WARN)
+    config_pv_diag = .false.
+    config_pv_tend = .false.
+    config_pv_scalar = .false.
+    config_pv_microphys = .false.
+    config_pv_isobaric = .false.
+ end if 
+
+ ! if dependent config_pv flags are activated but parent config_pv_diag flag is not, deactivate them. 
+ if ((.not. config_pv_diag) .and. (config_pv_tend .or. config_pv_scalar .or. config_pv_microphys .or. config_pv_isobaric)) then
+    config_pv_tend = .false.
+    config_pv_scalar = .false.
+    config_pv_microphys = .false.
+    config_pv_isobaric = .false.
+    call mpas_log_write('config_pv_diag is not activated; deactivated all dependent PV configs.', MPAS_LOG_WARN)
+ end if 
+
+ ! if config_pv_tend is activated but config_tend is not, deactivate.
+ if ((.not. config_tend) .and. (config_pv_tend .or. config_pv_microphys .or. config_pv_isobaric)) then
+    config_pv_tend = .false.
+    config_pv_microphys = .false.
+    config_pv_isobaric = .false.
+    call mpas_log_write('config_tend is not activated; deactivated all dependent PV configs.', MPAS_LOG_WARN)
+ end if 
+    
+ ! if config_pv_microphys or config_pv_isobaric is activated but config_pv_tend is not, deactivate.
+ if ((.not. config_pv_tend) .and. (config_pv_microphys .or. config_pv_isobaric)) then
+    config_pv_microphys = .false.
+    config_pv_isobaric = .false.
+    call mpas_log_write('config_pv_tend is not activated; deactivated all dependent PV configs.', MPAS_LOG_WARN)
+ end if
+
+ ! Ensure Thompson scheme is enabled for microphysics PV tendencies
+ if ((config_pv_microphys) .and. (config_microp_scheme /= 'mp_thompson')) then
+    call mpas_log_write('config_pv_microphys is not compatible with   = '''//trim(config_microp_scheme)//''' -- disabling', MPAS_LOG_WARN)
+    config_pv_microphys = .false.
+ end if 
+ 
+
+ call mpas_log_write('----- Setting up PV diagnostics variables -----')
+ call mpas_log_write('')
+
+ nullify(pv_diagnosticsActive)
+ nullify(pv_tendenciesActive)
+ nullify(pv_scalarActive)
+ nullify(pv_microphysicsActive)
+ nullify(pv_isobaricActive)
+ 
+ call mpas_pool_get_package(packages, 'pv_diagnosticsActive', pv_diagnosticsActive)
+ call mpas_pool_get_package(packages, 'pv_tendenciesActive', pv_tendenciesActive)
+ call mpas_pool_get_package(packages, 'pv_scalarActive', pv_scalarActive)
+ call mpas_pool_get_package(packages, 'pv_microphysicsActive', pv_microphysicsActive)
+ call mpas_pool_get_package(packages, 'pv_isobaricActive', pv_isobaricActive)
+
+
+ ! pv_diagnostics:
+ if (associated(config_pv_diag) .and. associated(pv_diagnosticsActive)) then
+    pv_diagnosticsActive = config_pv_diag
+    call mpas_log_write('    pv_diagnosticsActive          = $l', logicArgs=(/pv_diagnosticsActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''pv_diagnostics''. '// &
+        'Either ''pv_diagnostics'' is not a package, ''config_pv_diag'' is not a namelist option, or '//&
+        ' ''config_pv_diag'' has been disabled due to incompatability with other model configuration options.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+ 
+ ! pv_tendencies:
+ if (associated(config_pv_tend) .and. associated(pv_tendenciesActive)) then
+    pv_tendenciesActive = config_pv_tend
+    call mpas_log_write('    pv_tendenciesActive           = $l', logicArgs=(/pv_tendenciesActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''pv_tendencies''. '// &
+        'Either ''pv_tendencies'' is not a package, ''config_pv_tend'' is not a namelist option, or '//&
+        ' ''config_pv_tend'' has been disabled due to incompatability with other model configuration options.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+
+ ! pv_scalar:
+ if (associated(config_pv_scalar) .and. associated(pv_scalarActive)) then
+    pv_scalarActive = config_pv_scalar
+    call mpas_log_write('    pv_scalarActive               = $l', logicArgs=(/pv_scalarActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''pv_scalar''. '// &
+        'Either ''pv_scalar'' is not a package, ''config_pv_scalar'' is not a namelist option, or '//&
+        ' ''config_pv_scalar'' has been disabled due to incompatability with other model configuration options.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+
+ ! pv_microphys:
+ if (associated(config_pv_microphys) .and. associated(pv_microphysicsActive)) then
+    pv_microphysicsActive = config_pv_microphys
+    call mpas_log_write('    pv_microphysicsActive         = $l', logicArgs=(/pv_microphysicsActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''pv_microphysics''. '// &
+        'Either ''pv_microphysics'' is not a package, ''config_pv_microphys'' is not a namelist option, or '//&
+        ' ''config_pv_microphys'' has been disabled due to incompatability with other model configuration options.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+
+ ! pv_isobaric:
+ if (associated(config_pv_isobaric) .and. associated(pv_isobaricActive)) then
+    pv_isobaricActive = config_pv_isobaric
+    call mpas_log_write('    pv_isobaricActive             = $l', logicArgs=(/pv_isobaricActive/))
+ else
+    ierr = ierr + 1
+    call mpas_log_write('Package setup failed for ''pv_isobaric''. '// &
+        'Either ''pv_isobaric'' is not a package, ''config_pv_isobaric'' is not a namelist option, or '//&
+        ' ''config_pv_isobaric'' has been disabled due to incompatability with other model configuration options.', &
+        messageType=MPAS_LOG_ERR)
+ end if
+ 
+
+ end function diagnostics_setup_packages
+
+!=================================================================================================================
+ end module mpas_atm_diagnostics_packages
+!=================================================================================================================
+
+
+

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -110,6 +110,8 @@ module atm_core_interface
       use mpas_atmphys_packages
 #endif
 
+      use mpas_atm_diagnostics_packages     ! MC added
+
       implicit none
 
       type (mpas_pool_type), intent(inout) :: configs
@@ -207,6 +209,17 @@ module atm_core_interface
          call mpas_log_write('Package setup failed for atmphys in core_atmosphere', messageType=MPAS_LOG_ERR)
       end if
 #endif
+
+
+      ! MC ADDED
+      ! Tendency and PV diagnostics
+      !
+      local_ierr = diagnostics_setup_packages(configs, packages, iocontext)
+      if (local_ierr /= 0) then
+         ierr = ierr + 1
+         call mpas_log_write('Package setup failed for diagnostics in core_atmosphere', messageType=MPAS_LOG_ERR)
+      end if
+
 
    end function atm_setup_packages
 


### PR DESCRIPTION
### _This PR includes commits that provide the framework for a new tendencies diagnostics package and a significantly revised PV diagnostics package for MPAS-Atmosphere._ 

This framework includes a new `Registry_tendencies.xml` file and the addition of a number of new variables in `Registry_pv.xml`. These diagnostic variables are now connected to variable packages that are defined in `Registry.xml` and tied to namelist `config_*` options (defined in `Registry_diagnostics.xml`), enabling their activation at runtime.  These new features and changes are described further in each commit. 

This PR corresponds to PR1 described in [issue #1201](https://github.com/MPAS-Dev/MPAS-Model/issues/1201). 
