### PR TITLE
Minor bug fix for physics

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -200,6 +200,9 @@ mpas_atmphys_lsm_noahmpinit.o: \
 	mpas_atmphys_utilities.o \
 	mpas_atmphys_vars.o
 
+mpas_atmphys_lsm_noahmpfinalize.o: \
+	mpas_atmphys_vars.o
+
 mpas_atmphys_manager.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_o3climatology.o \

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -300,7 +300,6 @@
        if(allocated(pin_p)        ) deallocate(pin_p        )
        if(allocated(o3clim_p)     ) deallocate(o3clim_p     )
 
-       if(allocated(taod5503d_p)  ) deallocate(taod5503d_p  )
        if(allocated(tauaer_p)     ) deallocate(tauaer_p     )
        if(allocated(ssaaer_p)     ) deallocate(ssaaer_p     )
        if(allocated(asyaer_p)     ) deallocate(asyaer_p     )

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -52,7 +52,7 @@
  logical:: lexist
 
 !-----------------------------------------------------------------------------------------------------------------
-!call mpas_log_write('--- enter subroutine init_atm_gocart:')
+!call mpas_log_write('--- enter subroutine init_atm_thompson_aerosols:')
 
 !inquire if the GOCART input file exists:
  lexist = .false.
@@ -75,7 +75,7 @@
     call mpas_log_write('nwfa and nifa are set to zero and not interpolated from climatological data.')
  endif
 
-!call mpas_log_write('--- end subroutine init_atm_gocart.')
+!call mpas_log_write('--- end subroutine init_atm_thompson_aerosols.')
  call mpas_log_write(' ')
 
  end subroutine init_atm_thompson_aerosols


### PR DESCRIPTION
This PR includes three minor bug fix:

1) In ./src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F, corrected a print statement in subroutine init_atm_thompson_aerosols.

2) In ./src/core_atmosphere/physics/Makefile, added dependency for mpas_atmphys_lsm_noahmpfinalize.F.

3) In ./src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F, removed extra deallocate in subroutine deallocate_radiation_sw.

