### PR TITLE
Bug fix to for MYNN PBL option with Thompson cloud microphysics

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1576,7 +1576,7 @@
 
                         <var name="nc" array_group="number" units="nb kg^{-1}"
                              description="Cloud water number concentration"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="nifa" array_group="number" units="nb kg^{-1}"
                              description="Ice-friendly aerosol number concentration"
@@ -1918,7 +1918,7 @@
 
                         <var name="tend_nc" name_in_code="nc" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of cloud water number concentration multiplied by dry air density divided by d(zeta)/dz"
-                             packages="bl_mynn_in;mp_thompson_aers_in"/>
+                             packages="mp_thompson_aers_in"/>
 
                         <var name="tend_nifa" name_in_code="nifa" array_group="number" units="nb m^{-3} s^{-1}"
                              description="Tendency of ice-friendly aerosol number concentration multiplied by dry air density divided by d(zeta)/dz"

--- a/src/core_atmosphere/physics/mpas_atmphys_interface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_interface.F
@@ -127,6 +127,8 @@
     case("bl_mynn")
        if(.not.allocated(nc_p)) allocate(nc_p(ims:ime,kms:kme,jms:jme))
        if(.not.allocated(ni_p)) allocate(ni_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nifa_p)) allocate(nifa_p(ims:ime,kms:kme,jms:jme))
+       if(.not.allocated(nwfa_p)) allocate(nwfa_p(ims:ime,kms:kme,jms:jme))
 
     case default
  end select pbl_select
@@ -200,6 +202,8 @@
     case("bl_mynn")
        if(allocated(nc_p)) deallocate(nc_p)
        if(allocated(ni_p)) deallocate(ni_p)
+       if(allocated(nifa_p)) deallocate(nifa_p)
+       if(allocated(nwfa_p)) deallocate(nwfa_p)
 
     case default
  end select pbl_select
@@ -364,6 +368,8 @@
              do i = its,ite
                 nc_p(i,k,j)   = 0._RKIND
                 ni_p(i,k,j)   = 0._RKIND
+                nifa_p(i,k,j) = 0._RKIND
+                nwfa_p(i,k,j) = 0._RKIND
              enddo
           enddo
        enddo
@@ -381,14 +387,22 @@
           enddo
        endif
        !initializes nc_p, nifa_p, and nwfa_p when running the option "mp_thompson_aerosols":
-       if(f_nc) then
+       if(f_nc .and. f_nifa .and. f_nwfa) then
           nullify(nc)
+          nullify(nifa)
+          nullify(nwfa)
           call mpas_pool_get_dimension(state,'index_nc',index_nc)
+          call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
+          call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
           nc   => scalars(index_nc,:,:)
+          nifa => scalars(index_nifa,:,:)
+          nwfa => scalars(index_nwfa,:,:)
           do j = jts,jte
              do k = kts,kte
                 do i = its,ite
-                   nc_p(i,k,j)   = max(0.,nc(k,i)  )
+                   nc_p(i,k,j)   = max(0.,nc(k,i))
+                   nifa_p(i,k,j) = max(0.,nifa(k,i))
+                   nwfa_p(i,k,j) = max(0.,nwfa(k,i))
                 enddo
              enddo
           enddo

--- a/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_todynamics.F
@@ -352,12 +352,19 @@
           do i = 1, nCellsSolve
           do k = 1, nVertLevels
              tend_scalars(index_qs,k,i) = tend_scalars(index_qs,k,i) + rqsblten(k,i)*mass(k,i)
-             tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
              tend_scalars(index_ni,k,i) = tend_scalars(index_ni,k,i) + rniblten(k,i)*mass(k,i)
-             tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
-             tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
           enddo
           enddo
+
+          if(trim(microp_scheme) == 'mp_thompson_aerosols') then
+             do i = 1, nCellsSolve
+             do k = 1, nVertLevels
+                tend_scalars(index_nc,k,i) = tend_scalars(index_nc,k,i) + rncblten(k,i)*mass(k,i)
+                tend_scalars(index_nifa,k,i) = tend_scalars(index_nifa,k,i) + rnifablten(k,i)*mass(k,i)
+                tend_scalars(index_nwfa,k,i) = tend_scalars(index_nwfa,k,i) + rnwfablten(k,i)*mass(k,i)
+             enddo
+             enddo
+          endif
 
        case default
     end select pbl_select


### PR DESCRIPTION
When running ./atmosphere_model with the convection_permitting suite, forecasts crash because we update the arrays tend_scalars(index_nc,...), tend_scalars(index_nifa,...) , and tend_scalars(index_nwfa,...) in mpas_atmphys_todynamics when they have not been allocated. Note that these arrays are only allocated when we run the aerosol-aware option of the
Thompson cloud microphysics scheme (microp_scheme = mp_thompson_aerosols).

This error is fixed by ensuring that we only update these three arrays when we run the aerosol-aware option of the Thompson cloud microphysics scheme.



