### PR TITLE
Enable GPU execution of MPAS-Atmosphere initialization of coupled diagnostic fields via OpenACC

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5878,42 +5878,58 @@ module atm_time_integration
       rcv = rgas / (cp-rgas)
       p0 = 1.e5  ! this should come from somewhere else...
 
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop vector
          do k=1,nVertLevels
             theta_m(k,iCell) = theta(k,iCell) * (1._RKIND + rvord * scalars(index_qv,k,iCell))
             rho_zz(k,iCell) = rho(k,iCell) / zz(k,iCell)
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
+      !$acc parallel default(present)
+      !$acc loop gang
       do iEdge=edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
+         !$acc loop vector
          do k=1,nVertLevels
             ru(k,iEdge) = 0.5 * u(k,iEdge) * (rho_zz(k,cell1) + rho_zz(k,cell2))
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
       ! Compute rw (i.e. rho_zz * omega) from rho_zz, w, and ru.
       ! We are reversing the procedure we use in subroutine atm_recover_large_step_variables.
       ! first, the piece that depends on w.
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
          rw(1,iCell) = 0.0
          rw(nVertLevels+1,iCell) = 0.0
+         !$acc loop vector
          do k=2,nVertLevels
             rw(k,iCell) = w(k,iCell)     &
                           * (fzp(k) * rho_zz(k-1,iCell) + fzm(k) * rho_zz(k,iCell)) &
                           * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
          end do
       end do
+      !$acc end parallel
   
       ! next, the piece that depends on ru
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
+            !$acc loop vector
             do k = 2,nVertLevels
                flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
                rw(k,iCell) = rw(k,iCell)   &
@@ -5922,33 +5938,48 @@ module atm_time_integration
             end do
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rho_p(k,iCell) = rho_zz(k,iCell) - rho_base(k,iCell)
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rtheta_base(k,iCell) = theta_base(k,iCell) * rho_base(k,iCell)
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rtheta_p(k,iCell) = theta_m(k,iCell) * rho_p(k,iCell)  &
                                              + rho_base(k,iCell)   * (theta_m(k,iCell) - theta_base(k,iCell))
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             exner(k,iCell) = (zz(k,iCell) * (rgas/p0) * (rtheta_p(k,iCell) + rtheta_base(k,iCell)))**rcv
             exner_base(k,iCell) = (zz(k,iCell) * (rgas/p0) * (rtheta_base(k,iCell)))**rcv  ! WCS addition 20180403
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             pressure_p(k,iCell) = zz(k,iCell) * rgas &
@@ -5958,6 +5989,7 @@ module atm_time_integration
             pressure_base(k,iCell) = zz(k,iCell) * rgas * exner_base(k,iCell) * rtheta_base(k,iCell)      ! WCS addition 20180403
          end do
       end do
+      !$acc end parallel
 
       MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
       ! delete invariant fields

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5788,7 +5788,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       integer :: i, k, iCell, iEdge, cell1, cell2
-      integer, pointer :: nCells, nEdges, nVertLevels
+      integer, pointer :: nVertLevels
       integer, pointer :: index_qv
       real (kind=RKIND) :: p0, rcv, flux
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -5817,8 +5817,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3, zb_cell, zb3_cell
 
 
-      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(state, 'index_qv', index_qv)
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5788,8 +5788,10 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       integer :: i, k, iCell, iEdge, cell1, cell2
-      integer, pointer :: nVertLevels
-      integer, pointer :: index_qv
+      integer, pointer :: nVertLevels_ptr
+      integer, pointer :: index_qv_ptr
+      integer          :: nVertLevels
+      integer          :: index_qv
       real (kind=RKIND) :: p0, rcv, flux
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell
@@ -5817,8 +5819,12 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3, zb_cell, zb3_cell
 
 
-      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels_ptr)
+      call mpas_pool_get_dimension(state, 'index_qv', index_qv_ptr)
+
+      ! Dereference integer pointers for OpenACC
+      nVertLevels = nVertLevels_ptr
+      index_qv = index_qv_ptr
 
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
@@ -5892,10 +5898,10 @@ module atm_time_integration
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             do k = 2,nVertLevels
-            flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
-            rw(k,iCell) = rw(k,iCell)   &
-                          - edgesOnCell_sign(i,iCell) * (zb_cell(k,i,iCell) + sign(1.0_RKIND,flux) * zb3_cell(k,i,iCell))*flux   &
-                          * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
+               flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
+               rw(k,iCell) = rw(k,iCell)   &
+                             - edgesOnCell_sign(i,iCell) * (zb_cell(k,i,iCell) + sign(1.0_RKIND,flux) * zb3_cell(k,i,iCell))*flux   &
+                             * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
             end do
          end do
       end do

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5857,6 +5857,23 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'zb_cell', zb_cell)
       call mpas_pool_get_array(mesh, 'zb3_cell', zb3_cell)
 
+      MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
+      ! copyin invariant fields
+      !$acc enter data copyin(cellsOnEdge,nEdgesOnCell,edgesOnCell, &
+      !$acc                   edgesOnCell_sign,zz,fzm,fzp,zb,zb3, &
+      !$acc                   zb_cell,zb3_cell)
+
+      ! copyin the data that is only on the right-hand side
+      !$acc enter data copyin(scalars(index_qv,:,:),u,w,rho,theta, &
+      !$acc                           rho_base,theta_base)
+
+      ! copyin the data that will be modified in this routine
+      !$acc enter data create(theta_m,rho_zz,ru,rw,rho_p,rtheta_base, &
+      !$acc                   rtheta_p,exner,exner_base,pressure_p, &
+      !$acc                   pressure_base)
+      MPAS_ACC_TIMER_STOP('atm_init_coupled_diagnostics [ACC_data_xfer]')
+
+
 
       rcv = rgas / (cp-rgas)
       p0 = 1.e5  ! this should come from somewhere else...
@@ -5941,6 +5958,22 @@ module atm_time_integration
             pressure_base(k,iCell) = zz(k,iCell) * rgas * exner_base(k,iCell) * rtheta_base(k,iCell)      ! WCS addition 20180403
          end do
       end do
+
+      MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
+      ! delete invariant fields
+      !$acc exit data delete(cellsOnEdge,nEdgesOnCell,edgesOnCell, &
+      !$acc                  edgesOnCell_sign,zz,fzm,fzp,zb,zb3, &
+      !$acc                  zb_cell,zb3_cell)
+
+      ! delete the data that is only on the right-hand side
+      !$acc exit data delete(scalars(index_qv,:,:),u,w,rho,theta, &
+      !$acc                           rho_base,theta_base)
+
+      ! copyout the data that will be modified in this routine
+      !$acc exit data copyout(theta_m,rho_zz,ru,rw,rho_p,rtheta_base, &
+      !$acc                   rtheta_p,exner,exner_base,pressure_p, &
+      !$acc                   pressure_base)
+      MPAS_ACC_TIMER_STOP('atm_init_coupled_diagnostics [ACC_data_xfer]')
 
    end subroutine atm_init_coupled_diagnostics
 


### PR DESCRIPTION
This PR enables GPU calculation of certain diagnostic fields during the initialization phase by adding OpenACC directives to the `atm_init_coupled_diagnostics` routine.

Timing information for the OpenACC data transfers in this routine is captured in the log file by a new timer: `atm_init_coupled_diagnostics [ACC_data_xfer]`.

Since this routine is called during the initialization phase, before `mpas_atm_dynamics_init`, no modifications were made to the `mpas_atm_dynamics_{init,finalize}` routines to copy in or delete the invariant fields used in this routine.