### PR TITLE
Initial testing framework

### DIFF
--- a/.ci/env/derecho.sh
+++ b/.ci/env/derecho.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+echo "Setting up derecho environment"
+workingDirectory=$PWD
+. /etc/profile.d/z00_modules.sh
+echo "Loading modules : $*"
+cmd="module purge"
+echo $cmd && eval "${cmd}"
+
+# We should be handed in the modules to load
+while [ $# -gt 0 ]; do 
+  cmd="module load $1"
+  echo $cmd && eval "${cmd}"
+  shift
+done
+
+#  Go back for asinine reasons of HPC config changing your directory on you
+if [ "$workingDirectory" != "$PWD" ]; then
+  echo "derecho module loading changed working directory"
+  echo "  Moving back to $workingDirectory"
+  cd $workingDirectory
+fi

--- a/.ci/env/derecho.sh
+++ b/.ci/env/derecho.sh
@@ -14,7 +14,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-#  Go back for asinine reasons of HPC config changing your directory on you
+#  Go back to working directory if for unknown reason HPC config changing your directory on you
 if [ "$workingDirectory" != "$PWD" ]; then
   echo "derecho module loading changed working directory"
   echo "  Moving back to $workingDirectory"

--- a/.ci/env/helpers.sh
+++ b/.ci/env/helpers.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Useful string manipulation functions, leaving in for posterity
+# https://stackoverflow.com/a/8811800
+# contains(string, substring)
+#
+# Returns 0 if the specified string contains the specified substring,
+# otherwise returns 1.
+contains()
+{
+  string="$1"
+  substring="$2"
+  
+  if [ "${string#*"$substring"}" != "$string" ]; then
+    echo 0    # $substring is in $string
+  else
+    echo 1    # $substring is not in $string
+  fi
+}
+
+setenvStr()
+{
+  # Changing IFS produces the most consistent results
+  tmpIFS=$IFS
+  IFS=","
+  string="$1"
+  for s in $string; do
+    if [ ! -z $s ]; then 
+      eval "echo export \"$s\""
+      eval "export \"$s\""
+    fi
+  done
+  IFS=$tmpIFS
+}
+
+banner()
+{
+  lengthBanner=$1
+  shift
+  # https://www.shellscript.sh/examples/banner/
+  printf "#%${lengthBanner}s#\n" | tr " " "="
+  printf "# %-$(( ${lengthBanner} - 2 ))s #\n" "`date`"
+  printf "# %-$(( ${lengthBanner} - 2 ))s #\n" " "
+  printf "# %-$(( ${lengthBanner} - 2 ))s #\n" "$*"
+  printf "#%${lengthBanner}s#\n" | tr " " "="
+}

--- a/.ci/env/hostenv.sh
+++ b/.ci/env/hostenv.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Allow selection of hostname, and if none is provided use the current machine
+# While this may seem unintuitive at first, it provides the flexibility of using
+# "named" configurations without being explicitly tied to fqdn
+hostname=$AS_HOST
+if [ -z "$hostname" ]; then
+  hostname=$( python3 -c "import socket; print( socket.getfqdn() )" )
+fi
+
+if [ $( contains ${hostname} hsn.de.hpc ) -eq 0 ]; then
+  # Derecho HPC SuSE PBS
+  . .ci/env/derecho.sh
+else
+  echo "No known environment for '${hostname}', using current"
+fi

--- a/.ci/mpas_compilation.json
+++ b/.ci/mpas_compilation.json
@@ -1,0 +1,42 @@
+{
+  "submit_options" :
+  {
+    "timelimit" : "00:15:00",
+    "working_directory" : "..",
+    "arguments" :
+    {
+      "base_env_numprocs"      : [ "-e", "NUM_PROCS=4" ],
+
+      ".*make.*::args_build_core"     : [ "-c", "atmosphere" ],
+      ".*debug.*::args_build_debug"     : [ "-d" ],
+      ".*make.*::args_build_options"     : [ "-b", "-j $NUM_PROCS" ],
+      ".*make.*gnu.*::args_target"     : [ "-t", "gnu" ]
+    },
+    "hsn.de.hpc"  :
+    {
+      "submission" : "PBS",
+      "queue"      : "main",
+      "hpc_arguments"  : 
+      {
+        "node_select" : { "-l " : { "select"       : 1, "ncpus" : 16 } },
+        "priority"    : { "-l " : { "job_priority" : "economy"       } }
+      },
+      "arguments"  : 
+      {
+        "base_env_numprocs"      : [ "-e", "NUM_PROCS=16" ],
+        "very_last_modules"       : [  "cray-mpich", "parallel-netcdf" ],
+        ".*gnu.*::test_modules"   : [ "gcc/12.2.0" ]
+      }
+    }
+  },
+  "make-gnu" :
+  {
+    "steps" :
+    {
+      "optimized" :
+      {
+        "command"      : ".ci/tests/build.sh"
+      }
+    }
+  }
+}

--- a/.ci/tests/build.sh
+++ b/.ci/tests/build.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+help()
+{
+  echo "./build.sh as_host workingdir [options] [-- <hostenv.sh options>]"
+  echo "  as_host                   First argument must be the host configuration to use for environment loading"
+  echo "  workingdir                Second argument must be the working dir to immediate cd to"
+  echo "  -b                        Additional make arguments passed in"
+  echo "  -c                        Core to build"
+  echo "  -t                        Target configuration (gnu, intel, etc)"
+  echo "  -d                        Debug build"
+  echo "  -e                        environment variables in comma-delimited list, e.g. var=1,foo,bar=0"
+  echo "  -- <hostenv.sh options>   Directly pass options to hostenv.sh, equivalent to hostenv.sh <options>"
+  echo "  -h                  Print this message"
+  echo ""
+  echo "If you wish to use an env var in your arg such as '-b core=\$CORE -e CORE=atmosphere', you must"
+  echo "you will need to do '-b \\\$CORE -e CORE=atmosphere' to delay shell expansion"
+}
+
+echo "Input arguments:"
+echo "$*"
+
+AS_HOST=$1
+shift
+if [ $AS_HOST = "-h" ]; then
+  help
+  exit 0
+fi
+
+workingDirectory=$1
+shift
+
+cd $workingDirectory
+
+# Get some helper functions, AS_HOST must be set by this point to work
+. .ci/env/helpers.sh
+
+while getopts b:c:t:de:h opt; do
+  case $opt in
+    b)
+      buildCommand="$OPTARG"
+    ;;
+    c)
+      core="$OPTARG"
+    ;;
+    t)
+      target="$OPTARG"
+    ;;
+    d)
+      debug="DEBUG=true"
+    ;;
+    e)
+      envVars="$envVars,$OPTARG"
+    ;;
+    h)  help; exit 0 ;;
+    *)  help; exit 1 ;;
+    :)  help; exit 1 ;;
+    \?) help; exit 1 ;;
+  esac
+done
+
+shift "$((OPTIND - 1))"
+
+# Everything else goes to our env setup, POSIX does not specify how to pass in
+# arguments to sourced script, but all args are already shifted. This is left for
+# posterity to "show" what is happening and the assumption of the remaining args
+. .ci/env/hostenv.sh $*
+
+# Now evaluate env vars in case it pulls from hostenv.sh
+if [ ! -z "$envVars" ]; then
+  setenvStr "$envVars"
+fi
+
+# Re-evaluate input values for delayed expansion
+eval "core=\"$core\""
+eval "target=\"$target\""
+eval "buildCommand=\"$buildCommand\""
+
+make clean CORE=$core
+
+echo "Compiling with options $target core=$core $debug $buildCommand"
+echo "make $target CORE=$core $debug $buildCommand"
+make $target CORE=$core $debug $buildCommand
+result=$?
+
+if [ $result -ne 0 ]; then
+  echo "Failed to compile"
+  exit 1
+fi
+
+echo "TEST $(basename $0) PASS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,21 @@ run-name : ${{ github.event_name == 'push' && 'CI' || github.event.label.name }}
 on:
   push:
     branches: [ master, develop ]
+# See https://stackoverflow.com/a/78444521 and 
+# https://github.com/orgs/community/discussions/26874#discussioncomment-3253755
+# as well as official (but buried) documentation :
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull-request-events-for-forked-repositories-2
   pull_request:
     types:    [ labeled ]
 
-
+# https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow
+# Also https://stackoverflow.com/a/74959635
+# TL;DR - For public repositories the safest approach will be to use the default read permissions, but at the cost
+# of not being able to modify the labels. That will need to be a separate [trusted] workflow that runs from the base repo
+# permissions :
+#   contents : read
+#   pull-requests : write
+  
 # Write our tests out this way for easier legibility
 # testsSet    :
 #   - key : value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: Regression Suite
+run-name : ${{ github.event_name == 'push' && 'CI' || github.event.label.name }} (${{ github.event_name }})
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    types:    [ labeled ]
+
+
+# Write our tests out this way for easier legibility
+# testsSet    :
+#   - key : value
+#     key : value
+#     tests :
+#       - value
+#       - value
+#   - < next test >
+# https://stackoverflow.com/a/68940067
+jobs:
+  buildtests:
+    if : ${{ github.event.label.name == 'compile-tests' || github.event.label.name == 'all-tests' || github.event_name == 'push' }}
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+      
+        testSet  :
+          - host : derecho
+            hpc-workflows_path : .ci/hpc-workflows
+            archive : /glade/work/aislas/github/runners/mpas/derecho/logs/
+            account : NMMM0012
+            name : "Make Compilation Tests"
+            id   : make-tests
+            fileroot : mpas_compilation
+            args : -j='{"node_select":{"-l ":{"select":1}}}'
+            pool  : 8
+            tpool : 1
+            mkdirs : true
+            tests :
+              - make-gnu
+              # add new compilation tests here
+
+    uses : ./.github/workflows/test_workflow.yml
+    with :
+      # This should be the only hard-coded value, we don't use ${{ github.event.label.name }}
+      # to avoid 'all-tests' to be used in this workflow
+      label    : compile-tests
+
+      # Everything below this should remain the same and comes from the testSet matrix
+      hpc-workflows_path : ${{ matrix.testSet.hpc-workflows_path }}
+      archive  : ${{ matrix.testSet.archive }}
+      name     : ${{ matrix.testSet.name }}
+      id       : ${{ matrix.testSet.id }}
+      host     : ${{ matrix.testSet.host }}
+      fileroot : ${{ matrix.testSet.fileroot }}
+      account  : ${{ matrix.testSet.account }}
+      tests    : ${{ toJson( matrix.testSet.tests ) }}
+      mkdirs   : ${{ matrix.testSet.mkdirs }}
+      args     : ${{ matrix.testSet.args }}
+      pool     : ${{ matrix.testSet.pool }}
+      tpool    : ${{ matrix.testSet.tpool }}
+    permissions:
+      contents: read
+      pull-requests: write
+    name : Test ${{ matrix.testSet.name }} on ${{ matrix.testSet.host }}
+
+  # In the event that 'all-tests' is used, this final job will be the one to remove
+  # the label from the PR
+  removeAllLabel :
+    if : ${{ !cancelled() && github.event.label.name == 'all-tests' }}
+    name : Remove 'all-tests' label
+    runs-on: ubuntu-latest
+    needs : [ buildtests ] # Put tests here to make this wait for the tests to complete
+    steps: 
+      - name : Remove '${{ github.event.label.name }}' label
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          curl \
+            -X DELETE \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H 'Authorization: token ${{ github.token }}' \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${{ github.event.label.name }}

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -1,0 +1,149 @@
+
+
+on :
+  workflow_call :
+    inputs :
+      label : 
+        required : true
+        type     : string
+      hpc-workflows_path :
+        required : true
+        type     : string
+      archive :
+        required : true
+        type     : string
+      
+      name     :
+        required : true
+        type     : string
+      id       :
+        required : true
+        type     : string
+      host     :
+        required : true
+        type     : string
+      fileroot :
+        required : true
+        type     : string
+      account  :
+        required : true
+        type     : string
+      tests    :
+        required : true
+        type     : string
+      mkdirs   :
+        required : true
+        type     : boolean
+      args     :
+        required : false
+        type     : string
+        default  : ""
+      pool     :
+        required : false
+        type     : number
+        default  : 1
+      tpool      :
+        required : false
+        type     : number
+        default  : 1
+      
+
+
+jobs:
+  test_workflow :
+
+    # Is 5 days a reasonable wait time for testing?
+    timeout-minutes: 7200
+    name: Test ${{ inputs.name }} on ${{ inputs.host }}
+    runs-on: ${{ inputs.host }}
+    env :
+      LOG_SUFFIX : ${{ github.event_name == 'push' && 'master' || github.event.number }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path      : main
+        submodules: true
+    
+    # Immediately copy out to # of tests to do
+    - name: Create testing directories
+      if  : ${{ inputs.mkdirs }}
+      id  : cpTestDirs
+      run : |
+        for testDir in ${{ join( fromJson( inputs.tests ), ' ' ) }}; do
+          echo "Creating duplicate directory for $testDir"
+          # Remove if it exists to get a fresh start
+          rm -rf $testDir
+          cp -Rp main/ $testDir
+        done
+
+    - name: Test ${{ inputs.name }}
+      id  : runTest
+      run: |
+        if [ "${{ inputs.mkdirs }}" = "true" ]; then
+          ALT_DIRS="-alt ../${{ join( fromJson( inputs.tests ), '/.ci ../' ) }}/.ci"
+        fi
+        ./main/${{ inputs.hpc-workflows_path }}/.ci/runner.py                   \
+          ./main/.ci/${{ inputs.fileroot }}.json             \
+          -t   ${{ join( fromJson( inputs.tests ), ' ' ) }}  \
+          -a "${{ inputs.account }}"                         \
+          -p ${{ inputs.pool}} -tp ${{ inputs.tpool }}       \
+          ${{ inputs.args }} $ALT_DIRS
+
+
+    - name: Report failed tests and steps
+      if : ${{ failure() }}
+      run : |
+        # move log files to safe location
+        ./main/${{ inputs.hpc-workflows_path }}/.ci/relocator.py ./main/.ci/${{ inputs.fileroot }}.log ${{ inputs.archive }}/$LOG_SUFFIX/${{ inputs.id }}
+
+        # report on them - alt dirs need extra help
+        if [ "${{ inputs.mkdirs }}" = "true" ]; then
+          masterlogLoc=main/.ci
+        fi
+        ./main/${{ inputs.hpc-workflows_path }}/.ci/reporter.py ${{ inputs.archive }}/$LOG_SUFFIX/${{ inputs.id }}/$masterlogLoc/${{ inputs.fileroot }}.log \
+                                             -e ./${{ inputs.hpc-workflows_path }}/.ci/runner.py                             \
+                                             -o GITHUB -m # only mark fail steps with gh syntax
+        
+        # report on them
+        echo "# Summary for ${{ join( fromJson( inputs.tests ), ' ' ) }}" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        ./main/${{ inputs.hpc-workflows_path }}/.ci/reporter.py ${{ inputs.archive }}/$LOG_SUFFIX/${{ inputs.id }}/$masterlogLoc/${{ inputs.fileroot }}.log \
+                                             -e ./${{ inputs.hpc-workflows_path }}/.ci/runner.py                                               \
+                                             -s >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+    - name: Clean up testing directories
+      if : ${{ success() }}
+      id  : rmTestDirs
+      run : |
+        for testDir in ${{ join( fromJson( inputs.tests ), ' ' ) }}; do
+          echo "Removing duplicate directory for $testDir"
+          rm -rf $testDir
+        done
+    
+    - name: Upload test logs
+      if  : ${{ failure() }}
+      uses : actions/upload-artifact@v4
+      with:
+        # as per usual with ci/cd stuff I am shocked but not surprised when the advertised
+        # *documented* functionality doesn't work as expected. Wow, bravo
+        # can't use ${{ env. }} as somehow this combination of matrix->reusable workflow->call step is too complex
+        # and expands to nothing
+        name: ${{ github.event_name == 'push' && 'master' || github.event.number }}-${{ inputs.id }}_logfiles
+        path: ${{ inputs.archive }}/${{ github.event_name == 'push' && 'master' || github.event.number }}/${{ inputs.id }}/
+
+
+    - name : Remove '${{ inputs.label }}' label
+      if : ${{ !cancelled() && github.event.label.name == inputs.label }}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        curl \
+          -X DELETE \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H 'Authorization: token ${{ github.token }}' \
+          https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${{ inputs.label }}
+    
+
+
+  

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -69,12 +69,15 @@ jobs:
       if  : ${{ inputs.mkdirs }}
       id  : cpTestDirs
       run : |
-        for testDir in ${{ join( fromJson( inputs.tests ), ' ' ) }}; do
-          echo "Creating duplicate directory for $testDir"
-          # Remove if it exists to get a fresh start
-          rm -rf $testDir
-          cp -Rp main/ $testDir
-        done
+        # Limit parallel ops to 4 at a time to not thrash login nodes
+
+        # Remove if it exists to get a fresh start
+        echo "Cleaning old test directories..."
+        tests="${{ join( fromJson( inputs.tests ), ' ' ) }}"
+        time printf "%s\n" $tests | xargs -i -P 4 rm -rf {}
+
+        echo "Creating duplicate directory for $tests"
+        time printf "%s\n" $tests | xargs -i -P 4 cp -Rp main/ {}
 
     - name: Test ${{ inputs.name }}
       id  : runTest
@@ -87,6 +90,7 @@ jobs:
           -t   ${{ join( fromJson( inputs.tests ), ' ' ) }}  \
           -a "${{ inputs.account }}"                         \
           -p ${{ inputs.pool}} -tp ${{ inputs.tpool }}       \
+          -jn ${{ github.event_name == 'push' && github.ref_name || format( 'pr{0}', github.event.number ) }}-${{ inputs.id }} \
           ${{ inputs.args }} $ALT_DIRS
 
 
@@ -129,20 +133,21 @@ jobs:
         # *documented* functionality doesn't work as expected. Wow, bravo
         # can't use ${{ env. }} as somehow this combination of matrix->reusable workflow->call step is too complex
         # and expands to nothing
-        name: ${{ github.event_name == 'push' && 'master' || github.event.number }}-${{ inputs.id }}_logfiles
-        path: ${{ inputs.archive }}/${{ github.event_name == 'push' && 'master' || github.event.number }}/${{ inputs.id }}/
+        name: ${{ github.event_name == 'push' && github.ref_name || github.event.number }}-${{ inputs.id }}_logfiles
+        path: ${{ inputs.archive }}/${{ github.event_name == 'push' && github.ref_name || github.event.number }}/${{ inputs.id }}/
 
-
-    - name : Remove '${{ inputs.label }}' label
-      if : ${{ !cancelled() && github.event.label.name == inputs.label }}
-      env:
-        PR_NUMBER: ${{ github.event.number }}
-      run: |
-        curl \
-          -X DELETE \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H 'Authorization: token ${{ github.token }}' \
-          https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${{ inputs.label }}
+    # As noted in ci.yml, this will need to be moved to a separate workflow with pull_request_target
+    # and strictly controlled usage of the GH token
+    # - name : Remove '${{ inputs.label }}' label
+    #   if : ${{ !cancelled() && github.event.label.name == inputs.label }}
+    #   env:
+    #     PR_NUMBER: ${{ github.event.number }}
+    #   run: |
+    #     curl \
+    #       -X DELETE \
+    #       -H "Accept: application/vnd.github.v3+json" \
+    #       -H 'Authorization: token ${{ github.token }}' \
+    #       https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${{ inputs.label }}
     
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hpc-workflows"]
+	path = .ci/hpc-workflows
+	url = https://github.com/islas/hpc-workflows


### PR DESCRIPTION
This PR introduces testing capabilities through a series of compartmentalized commits :
1. Setting up helper scripts to handle environment loading
2. Compilation test script able to exercise the make build
3. A git submodule to the [hpc-workflows](https://github.com/islas/hpc-workflows)  testing framework
4. A test definition config using hpc-workflows
5. CI/CD capabilities with security safeguards in place

The CI/CD capabilities rely on specific github action runner configurations with the assumption of running on Derecho, but is designed with the intention of minimal reliance on machine and CI/CD-specific tooling. Thus, one could port these features to other machines or CI/CD solutions and achieve similar results.