### PR TITLE
Update SMIOL code to support specified format for file creation

### DIFF
--- a/src/external/SMIOL/smiol.h
+++ b/src/external/SMIOL/smiol.h
@@ -21,7 +21,7 @@ int SMIOL_inquire(void);
  * File methods
  */
 int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
-                    int mode, struct SMIOL_file **file, size_t bufsize);
+                    int mode, struct SMIOL_file **file, size_t bufsize, int fformat);
 int SMIOL_close_file(struct SMIOL_file **file);
 
 /*

--- a/src/external/SMIOL/smiol_codes.inc
+++ b/src/external/SMIOL/smiol_codes.inc
@@ -6,6 +6,7 @@
 #define SMIOL_LIBRARY_ERROR      (-5)
 #define SMIOL_WRONG_ARG_TYPE     (-6)
 #define SMIOL_INSUFFICIENT_ARG   (-7)
+#define SMIOL_INVALID_FORMAT     (-8)
 
 #define SMIOL_FILE_CREATE         (1)
 #define SMIOL_FILE_READ           (2)
@@ -19,3 +20,6 @@
 #define SMIOL_INT32            (2002)
 #define SMIOL_CHAR             (2003)
 #define SMIOL_UNKNOWN_VAR_TYPE (2004)
+
+#define SMIOL_FORMAT_CDF2      (3000)
+#define SMIOL_FORMAT_CDF5      (3001)


### PR DESCRIPTION
This PR updates the SMIOL code in `src/external/SMIOL` from the MPAS-Dev/SMIOL repository to include modifications that allow the file format to be specified in calls to `SMIOLf_open_file`. By default, new output files are still created in CDF-5 format as before, but it is now possible to specify either `SMIOL_FORMAT_CDF5` for `SMIOL_FORMAT_CDF2` for the optional `fformat` argument to `SMIOLf_open_file`.

The changes introduced here come from commit [5df48736](https://github.com/MPAS-Dev/SMIOL/commit/5df48736) in the MPAS-Dev/SMIOL repository; but since the SMIOL code in this repository has diverged from that in the MPAS-Dev/SMIOL repository, the `smiol.c` file isn't identical between the two repositories.