### PR TITLE
Fix MPAS-A dycore-only build in version 8.2.0

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1155,10 +1155,6 @@
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
-			<var name="cldfrac"/>
-			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_snow" packages="mp_thompson_in;mp_wsm6_in"/>
 			<var name="u"/>
 			<var name="w"/>
 			<var name="rho"/>
@@ -1171,6 +1167,11 @@
 			<var name="uReconstructZonal"/>
 			<var name="uReconstructMeridional"/>
 			<var name="surface_pressure"/>
+#ifdef DO_PHYSICS
+			<var name="cldfrac"/>
+			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in"/>
+			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in"/>
+			<var name="re_snow" packages="mp_thompson_in;mp_wsm6_in"/>
 			<var name="refl10cm_max"/>
 			<var name="rainc"/>
 			<var name="rainnc"/>
@@ -1209,6 +1210,7 @@
 			<var name="smois"/>
 			<var name="tslb"/>
 			<var name="h_oml_initial"/>
+#endif
                 </stream>
 	</streams>
 
@@ -3588,6 +3590,8 @@
 <!-- **************************************************************************************** -->
 
 #include "diagnostics/Registry_diagnostics.xml"
-#include "physics/Registry_noahmp.xml"
 
+#ifdef DO_PHYSICS
+#include "physics/Registry_noahmp.xml"
+#endif
 </registry>


### PR DESCRIPTION
When building MPAS-A as a dycore, all physics-related components are disabled. An example scenario of this is for use with CAM/CAM-SIMA.

However, the MPAS-A registry file in version 8.2.0 contains the following regressions, which cause the dycore-only build to break:

* The MPAS-A registry file introduced a new stream, `da_state`, which unconditionally includes variables that exist only when physics are enabled.
* The MPAS-A registry file unconditionally includes a new registry file from Noah-MP, which is applicable only when physics are enabled.

This PR fixes MPAS-A dycore-only build by guarding the above regions with the `DO_PHYSICS` macro.

For stand-alone MPAS-A, this PR is an NFC (No Functional Change).