### PR TITLE
Fix portability issue in parse_macros function used by the MPAS registry

### DIFF
--- a/src/tools/registry/utility.c
+++ b/src/tools/registry/utility.c
@@ -309,21 +309,26 @@ int parse_macros(void(*callback)(const char *macro, const char *val, va_list ap)
 
 	for (i = 0; i < count; i++) {
 		char *tmp;
-		char *macrotmp;
-		char *macro;
-		char *val;
+		char *saveptr;
+		const char *macro;
+		const char *val;
+		const char *empty = "";
 
 		tmp = strdup(macros[i]);
-		macrotmp = strtok_r(tmp, "=", &val);
 
-		if (macrotmp == NULL || val == NULL) {
+		macro = strtok_r(tmp, "=", &saveptr);
+		val = strtok_r(NULL, "=", &saveptr);
+
+		if (macro == NULL) {
 			return 1;
 		}
 
-		if (strstr(macrotmp, "-D") == macrotmp) {
-			macro = &macrotmp[2];
-		} else {
-			macro = macrotmp;
+		if (val == NULL) {
+			val = empty;
+		}
+
+		if (strstr(macro, "-D") == macro) {
+			macro = &macro[2];
 		}
 
 		if (callback != NULL) {


### PR DESCRIPTION
This PR fixes a portability issue in the `parse_macros` function used by the MPAS registry.

The `parse_macros` function that is used by the MPAS registry `parse` tool previously made use of the state/saveptr/lasts argument to `strtok_r` when parsing command-line macro definitions. This was not portable and resulted in incorrectly generated output on some systems.

This PR reworks the `parse_macros` function so that it no longer uses the state/saveptr/lasts argument to `strtok_r` and instead relies only on the return value of `strtok_r` to provide portability across systems with different `strtok_r` implementations.