### PR TITLE
Refactor mpas_atm_get_bdy_state to simplify MPAS-A treatment of LBC scalars

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -36,6 +36,11 @@ module mpas_atm_boundaries
 
     public :: nBdyZone, nSpecZone, nRelaxZone
 
+    interface mpas_atm_get_bdy_state
+        module procedure mpas_atm_get_bdy_state_2d
+        module procedure mpas_atm_get_bdy_state_3d
+    end interface mpas_atm_get_bdy_state
+
     private
 
     type (MPAS_Time_Type) :: LBC_intv_end
@@ -311,7 +316,7 @@ module mpas_atm_boundaries
 
     !***********************************************************************
     !
-    !  routine mpas_atm_get_bdy_state
+    !  routine mpas_atm_get_bdy_state_2d
     !
     !> \brief   Returns LBC state at a specified delta-t in the future
     !> \author  Michael Duda
@@ -342,7 +347,7 @@ module mpas_atm_boundaries
     !>   scalars(1,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND)
     !
     !-----------------------------------------------------------------------
-    function mpas_atm_get_bdy_state(clock, block, vertDim, horizDim, field, delta_t) result(return_state)
+    function mpas_atm_get_bdy_state_2d(clock, block, vertDim, horizDim, field, delta_t) result(return_state)
 
         use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
         use mpas_derived_types, only : MPAS_POOL_SILENT
@@ -414,7 +419,86 @@ module mpas_atm_boundaries
             return_state(:,:) = state_scalars(idx,:,:) - dt * tend_scalars(idx,:,:)
         end if
 
-    end function mpas_atm_get_bdy_state
+    end function mpas_atm_get_bdy_state_2d
+
+
+    !***********************************************************************
+    !
+    !  routine mpas_atm_get_bdy_state_3d
+    !
+    !> \brief   Returns LBC state at a specified delta-t in the future
+    !> \author  Michael Duda
+    !> \date    4 September 2024
+    !> \details
+    !>  This function returns an array providing the state for the requested
+    !>  progostic variable delta_t in the future from the current time known
+    !>  by the simulation clock (which is typically the time at the start of
+    !>  the current timestep).
+    !>
+    !>  The innerDim, vertDim, and horizDim should match the nominal block
+    !>  dimensions of the field to be returned by the call; for example, a
+    !>  call to retrieve the state of the 'scalars' field would set
+    !>  innerDim=num_scalars, vertDim=nVertLevels, and horizDim=nCells. This
+    !>  function internally adds 1 to the horizontal dimension to account for
+    !>  the "garbage" element.
+    !>
+    !>  The field is identified by the 'field' argument, and this argument is
+    !>  prefixed with 'lbc_' before attempting to retrieve the field from
+    !>  the 'lbc' pool.
+    !>
+    !>  Example calls to this function:
+    !>
+    !>   scalar(:,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, &
+    !>                       num_scalars, nVertLevels, nCells, 'scalars', 0.0_RKIND)
+    !
+    !-----------------------------------------------------------------------
+    function mpas_atm_get_bdy_state_3d(clock, block, innerDim, vertDim, horizDim, field, delta_t) result(return_state)
+
+        use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
+        use mpas_derived_types, only : MPAS_POOL_SILENT
+
+        implicit none
+
+        type (mpas_clock_type), intent(in) :: clock
+        type (block_type), intent(inout) :: block
+        integer, intent(in) :: innerDim, vertDim, horizDim
+        character(len=*), intent(in) :: field
+        real (kind=RKIND), intent(in) :: delta_t
+
+        real (kind=RKIND), dimension(innerDim,vertDim,horizDim+1) :: return_state
+
+        type (mpas_pool_type), pointer :: lbc
+        real (kind=RKIND), dimension(:,:,:), pointer :: tend
+        real (kind=RKIND), dimension(:,:,:), pointer :: state
+        type (MPAS_Time_Type) :: currTime
+        type (MPAS_TimeInterval_Type) :: lbc_interval
+        integer :: dd_intv, s_intv, sn_intv, sd_intv
+        real (kind=RKIND) :: dt
+        integer :: err_level
+        integer :: ierr
+
+
+        currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
+
+        lbc_interval = LBC_intv_end - currTime
+
+        call mpas_get_timeInterval(interval=lbc_interval, DD=dd_intv, S=s_intv, S_n=sn_intv, S_d=sd_intv, ierr=ierr)
+        dt = 86400.0_RKIND * real(dd_intv, kind=RKIND) + real(s_intv, kind=RKIND) &
+             + (real(sn_intv, kind=RKIND) / real(sd_intv, kind=RKIND))
+
+        dt = dt - delta_t
+
+        call mpas_pool_get_subpool(block % structs, 'lbc', lbc)
+
+        nullify(tend)
+        nullify(state)
+
+        call mpas_pool_get_array(lbc, 'lbc_'//trim(field), tend, 1)
+        call mpas_pool_get_array(lbc, 'lbc_'//trim(field), state, 2)
+
+        return_state(:,:,:) = state(:,:,:) - dt * tend(:,:,:)
+
+    end function mpas_atm_get_bdy_state_3d
 
 
     !***********************************************************************

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -499,7 +499,6 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nc, index_nifa, index_nwfa
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -595,17 +594,6 @@ module atm_time_integration
 #endif
       if (config_apply_lbcs) then
          call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-         call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-         call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-         call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-         call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-         call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-         call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
-         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
-         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
       endif
 
       !
@@ -1036,41 +1024,12 @@ module atm_time_integration
 
                   allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-                  !  get the scalar values driving the regional boundary conditions
                   !
-                  if (index_qv > 0) then
-                     scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
-                  end if
-                  if (index_qc > 0) then
-                     scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
-                  end if
-                  if (index_qr > 0) then
-                     scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
-                  end if
-                  if (index_qi > 0) then
-                     scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
-                  end if
-                  if (index_qs > 0) then
-                     scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
-                  end if
-                  if (index_qg > 0) then
-                     scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
-                  end if
-                  if (index_nr > 0) then
-                     scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
-                  end if
-                  if (index_ni > 0) then
-                     scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                  end if
-                  if (index_nc > 0) then
-                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-                  end if
-                  if (index_nifa > 0) then
-                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-                  end if
-                  if (index_nwfa > 0) then
-                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
-                  end if
+                  ! get the scalar values driving the regional boundary conditions
+                  !
+                  scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                                                  'scalars', rk_timestep(rk_step))
+
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1211,41 +1170,12 @@ module atm_time_integration
    
                allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-               !  get the scalar values driving the regional boundary conditions
                !
-               if (index_qv > 0) then
-                  scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
-               end if
-               if (index_qc > 0) then
-                  scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
-               end if
-               if (index_qr > 0) then
-                  scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
-               end if
-               if (index_qi > 0) then
-                  scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
-               end if
-               if (index_qs > 0) then
-                  scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
-               end if
-               if (index_qg > 0) then
-                  scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
-               end if
-               if (index_nr > 0) then
-                  scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
-               end if
-               if (index_ni > 0) then
-                  scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-               end if
-               if (index_nc > 0) then
-                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-               end if
-               if (index_nifa > 0) then
-                  scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-               end if
-               if (index_nwfa > 0) then
-                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
-               end if
+               ! get the scalar values driving the regional boundary conditions
+               !
+               scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                                               'scalars', rk_timestep(rk_step))
+
 !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1379,41 +1309,11 @@ module atm_time_integration
 
          allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-         !  get the scalar values driving the regional boundary conditions
          !
-         if (index_qv > 0) then
-            scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
-         end if
-         if (index_qc > 0) then
-            scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', dt )
-         end if
-         if (index_qr > 0) then
-            scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', dt )
-         end if
-         if (index_qi > 0) then
-            scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', dt )
-         end if
-         if (index_qs > 0) then
-            scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', dt )
-         end if
-         if (index_qg > 0) then
-            scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
-         end if
-         if (index_nr > 0) then
-            scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
-         end if
-         if (index_ni > 0) then
-            scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-         end if
-         if (index_nc > 0) then
-            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
-         end if
-         if (index_nifa > 0) then
-            scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
-         end if
-         if (index_nwfa > 0) then
-            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
-         end if
+         ! get the scalar values driving the regional boundary conditions
+         !
+         scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, 'scalars', dt)
+
 !$OMP PARALLEL DO
          do thread=1,nThreads
             call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &


### PR DESCRIPTION
This PR refactors the `mpas_atm_get_bdy_state` routine in the 
`mpas_atm_boundaries` module to allow for simplification of the treatment of LBC
scalars.

Previously, it was necessary to retrieve the state of each scalar constituent 
along the lateral boundaries of a regional domain one at a time in the MPAS-A
solver. As a result, any developer who added new scalars needed to make changes 
to the MPAS-A dynamics to handle those new scalars.

Now, `mpas_atm_get_bdy_state` is a generic interface that provides specific 
routines for retrieving both 2-d and 3-d LBC fields. Using the 3-d field
implementation of `mpas_atm_get_bdy_state`, we can now retrieve the state of all
scalars at once, simplifying the dynamics code and removing the need for
modifications to LBC code in the dynamics whenever new scalars are defined in
the Registry.