### PR TITLE
Add support for 1-d real fields in the mpas_halo module

### DIFF
--- a/src/core_test/mpas_halo_testing.F
+++ b/src/core_test/mpas_halo_testing.F
@@ -1,4 +1,4 @@
-! Copyright (c) 2023, The University Corporation for Atmospheric Research (UCAR).
+! Copyright (c) 2023-2024, The University Corporation for Atmospheric Research (UCAR).
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -30,7 +30,7 @@ module mpas_halo_testing
    !-----------------------------------------------------------------------
    subroutine mpas_halo_tests(domain, ierr)
 
-      use mpas_derived_types, only : domain_type, mpas_pool_type, field2DReal, field3DReal
+      use mpas_derived_types, only : domain_type, mpas_pool_type, field1DReal, field2DReal, field3DReal
       use mpas_kind_types, only : StrKIND, RKIND
       use mpas_log, only : mpas_log_write
       use mpas_dmpar, only : mpas_dmpar_max_int
@@ -50,8 +50,10 @@ module mpas_halo_testing
       character(len=StrKIND) :: test_mesg
       type (mpas_pool_type), pointer :: haloExchTest_pool
       type (mpas_pool_type), pointer :: mesh_pool
+      type (field1DReal), pointer :: scratch_1d
       type (field2DReal), pointer :: scratch_2d
       type (field3DReal), pointer :: scratch_3d
+      real (kind=RKIND), dimension(:), pointer :: array_1d
       real (kind=RKIND), dimension(:,:), pointer :: array_2d
       real (kind=RKIND), dimension(:,:,:), pointer :: array_3d
       integer, dimension(:), pointer :: indexToCellID
@@ -98,6 +100,9 @@ module mpas_halo_testing
       call mpas_halo_exch_group_create(domain, 'persistent_group', ierr_local)
       ierr = ior(ierr, ierr_local)
 
+      call mpas_halo_exch_group_add_field(domain, 'persistent_group', 'cellPersistReal1D', iErr=ierr_local)
+      ierr = ior(ierr, ierr_local)
+
       call mpas_halo_exch_group_add_field(domain, 'persistent_group', 'cellPersistReal2D', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
@@ -127,6 +132,9 @@ module mpas_halo_testing
       call mpas_halo_exch_group_add_field(domain, 'scratch_group', 'cellScratchReal2D', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
+      call mpas_halo_exch_group_add_field(domain, 'scratch_group', 'cellScratchReal1D', iErr=ierr_local)
+      ierr = ior(ierr, ierr_local)
+
       call mpas_halo_exch_group_complete(domain, 'scratch_group', ierr_local)
       ierr = ior(ierr, ierr_local)
 
@@ -141,6 +149,10 @@ module mpas_halo_testing
       ! Exchange a group with persistent fields
       !
       write(test_mesg, '(a)') '  Exchanging a halo group with persistent fields: '
+
+      call mpas_pool_get_array(haloExchTest_pool, 'cellPersistReal1D', array_1d)
+      array_1d(:) = -1.0_RKIND
+      array_1d(1:nCellsSolve) = real(indexToCellID(1:nCellsSolve), kind=RKIND)
 
       call mpas_pool_get_array(haloExchTest_pool, 'cellPersistReal2D', array_2d)
       do k = 1, size(array_2d, dim=1)
@@ -160,6 +172,9 @@ module mpas_halo_testing
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND
+
+      diff = diff + sum(abs(array_1d(1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
+
       do k = 1, size(array_2d, dim=1)
          diff = diff + sum(abs(array_2d(k,1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
       end do
@@ -187,11 +202,17 @@ module mpas_halo_testing
       !
       write(test_mesg, '(a)') '  Exchanging a halo group with scratch fields: '
 
+      call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal1D', scratch_1d)
       call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal2D', scratch_2d)
       call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal3D', scratch_3d)
 
+      call mpas_allocate_scratch_field(scratch_1d)
       call mpas_allocate_scratch_field(scratch_2d)
       call mpas_allocate_scratch_field(scratch_3d)
+
+      call mpas_pool_get_array(haloExchTest_pool, 'cellScratchReal1D', array_1d)
+      array_1d(:) = -1.0_RKIND
+      array_1d(1:nCellsSolve) = real(indexToCellID(1:nCellsSolve), kind=RKIND)
 
       call mpas_pool_get_array(haloExchTest_pool, 'cellScratchReal2D', array_2d)
       do k = 1, size(array_2d, dim=1)
@@ -211,6 +232,9 @@ module mpas_halo_testing
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND
+
+      diff = diff + sum(abs(array_1d(1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
+
       do k = 1, size(array_2d, dim=1)
          diff = diff + sum(abs(array_2d(k,1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
       end do
@@ -221,6 +245,7 @@ module mpas_halo_testing
       end do
       end do
 
+      call mpas_deallocate_scratch_field(scratch_1d)
       call mpas_deallocate_scratch_field(scratch_2d)
       call mpas_deallocate_scratch_field(scratch_3d)
 

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -152,7 +152,7 @@ module mpas_halo
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_iterator_type, MPAS_POOL_CONFIG, &
                                        MPAS_POOL_REAL, MPAS_HALO_REAL, mpas_halo_group, MPAS_LOG_CRIT, &
-                                       field2DReal, field3DReal
+                                       field1DReal, field2DReal, field3DReal
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_remove_subpool, mpas_pool_destroy_pool, &
                                        mpas_pool_begin_iteration, mpas_pool_get_next_member, mpas_pool_get_dimension, &
                                        mpas_pool_remove_field, mpas_pool_get_field
@@ -170,6 +170,7 @@ module mpas_halo
         integer, dimension(:), pointer :: fieldHaloInfo
         integer, dimension(:), pointer :: haloLayers
         type (mpas_halo_group), pointer :: newGroup
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
         integer, pointer :: timeLevel
@@ -229,7 +230,14 @@ module mpas_halo
                 end select
 
                 if (fieldHaloInfo(1) == MPAS_POOL_REAL) then
-                    if (fieldHaloInfo(2) == 2) then
+                    if (fieldHaloInfo(2) == 1) then
+                        call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r1d)
+                        call mpas_halo_compact_halo_info(domain, r1d % sendList, r1d % recvList, r1d % dimSizes, &
+                                                         haloLayers, &
+                                                         newGroup % fields(i) % compactHaloInfo, &
+                                                         newGroup % fields(i) % compactSendLists, &
+                                                         newGroup % fields(i) % compactRecvLists)
+                    else if (fieldHaloInfo(2) == 2) then
                         call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r2d)
                         call mpas_halo_compact_halo_info(domain, r2d % sendList, r2d % recvList, r2d % dimSizes, &
                                                          haloLayers, &
@@ -387,7 +395,7 @@ module mpas_halo
     subroutine mpas_halo_exch_group_add_field(domain, groupName, fieldName, timeLevel, haloLayers, iErr)
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_field_info_type, MPAS_POOL_REAL, &
-                                       field2DReal, field3DReal, MPAS_LOG_CRIT
+                                       field1DReal, field2DReal, field3DReal, MPAS_LOG_CRIT
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_add_config, mpas_pool_get_field_info, &
                                        mpas_pool_add_dimension, mpas_pool_get_field, mpas_pool_add_field
         use mpas_log, only : mpas_log_write
@@ -405,6 +413,7 @@ module mpas_halo
         type (mpas_pool_field_info_type) :: info
         integer, allocatable, dimension(:) :: fieldHaloInfo
         integer :: local_timeLevel
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
 
@@ -456,7 +465,10 @@ module mpas_halo
         ! Store a reference to the field itself in the pool
         !
         if (info % fieldType == MPAS_POOL_REAL) then
-            if (info % nDims == 2) then
+            if (info % nDims == 1) then
+                call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r1d, timeLevel=local_timeLevel)
+                call mpas_pool_add_field(group, fieldName//'.field', r1d)
+            else if (info % nDims == 2) then
                 call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r2d, timeLevel=local_timeLevel)
                 call mpas_pool_add_field(group, fieldName//'.field', r2d)
             else if (info % nDims == 3) then
@@ -597,6 +609,27 @@ module mpas_halo
                 select case (group % fields(i) % nDims)
 
                 !
+                ! Packing code for 1-d real-valued fields
+                !
+                case (1)
+                    call mpas_pool_get_array(domain % blocklist % allFields, trim(group % fields(i) % fieldName), &
+                                             group % fields(i) % r1arr, timeLevel=group % fields(i) % timeLevel)
+
+                    !
+                    ! Pack send buffer for all neighbors for current field
+                    !
+                    do iEndp = 1, nSendEndpts
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNSendList
+                                if (j <= nSendLists(iHalo,iEndp)) then
+                                    group % sendBuf(packOffsets(iEndp) + sendListDst(j,iHalo,iEndp)) = &
+                                        group % fields(i) % r1arr(sendListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
+                    end do
+
+                !
                 ! Packing code for 2-d real-valued fields
                 !
                 case (2)
@@ -708,6 +741,22 @@ module mpas_halo
                     select case (group % fields(i) % nDims)
 
                     !
+                    ! Unpacking code for 1-d real-valued fields
+                    !
+                    case (1)
+                        !
+                        ! Unpack recv buffer from all neighbors for current field
+                        !
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNRecvList
+                                if (j <= nRecvLists(iHalo,iEndp)) then
+                                    group % fields(i) % r1arr(recvListDst(j,iHalo,iEndp)) = &
+                                        group % recvBuf(unpackOffsets(iEndp) + recvListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
+
+                    !
                     ! Unpacking code for 2-d real-valued fields
                     !
                     case (2)
@@ -756,7 +805,9 @@ module mpas_halo
         ! to not leave pointers to what might later be incorrect targets
         !
         do i = 1, group % nFields
-            if (group % fields(i) % nDims == 2) then
+            if (group % fields(i) % nDims == 1) then
+                nullify(group % fields(i) % r1arr)
+            else if (group % fields(i) % nDims == 2) then
                 nullify(group % fields(i) % r2arr)
             else if (group % fields(i) % nDims == 3) then
                 nullify(group % fields(i) % r3arr)

--- a/src/framework/mpas_halo_types.inc
+++ b/src/framework/mpas_halo_types.inc
@@ -31,6 +31,7 @@
         integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListDst => null()  ! (maxNRecvList,nHalos,nRecvEndpts)
         integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets => null()    ! (nRecvEndpts)
 
+        real (kind=RKIND), dimension(:), pointer :: r1arr => null()      ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:), pointer :: r2arr => null()    ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:,:), pointer :: r3arr => null()  ! Pointer to field array, only used internally
     end type mpas_halo_field


### PR DESCRIPTION
This PR adds support for 1-d real fields to the `mpas_halo` module.

Previously, the `mpas_halo` module only supported halo exchanges for 2-d and 3-d
real-valued fields. This PR adds support for 1-d real fields as well. There
are no changes to interfaces, and besides the addition of a 1-d array pointer to
the `mpas_halo_field type`, only the following routines in the `mpas_halo` module
have been modified:

 * `mpas_halo_exch_group_add_field`
 * `mpas_halo_exch_group_complete`
 * `mpas_halo_exch_group_full_halo_exch`

Also included in this PR are extensions of the halo exchange unit tests for the
`mpas_halo` module in the `test` core.