### PR TITLE
add `brtemp` and `cldmask` under `diag` var_struct of `src/core_atmosphere/Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1839,6 +1839,15 @@
                 <var name="surface_pressure" type="real" dimensions="nCells Time" units="Pa"
                      description="Diagnosed surface pressure"/>
 
+                <!-- observation-related variables interfacing to Non-Variational SAtellite-based Cloud Analysis (SACA)  -->
+                <var name="cldmask" type="real" dimensions="nCells Time" units="unitless"
+                     description="cloud mask (1=cloudy ; 0=clear)"
+                     packages="jedi_da"/>
+
+                <var name="brtemp" type="real" dimensions="nCells Time" units="K"
+                     description="brightness temperature to calculate cloud top height; usually from geostationary IR window channel"
+                     packages="jedi_da"/>
+
         </var_struct>
 
         <var_struct name="tend" time_levs="1">


### PR DESCRIPTION
Add brtemp and cldmask fields to atmosphere Registry.xml file for MPAS-JEDI.

These fields are required by MPAS-JEDI and are associated with the `jedi_da` package,
which is active only if `config_jedi_da = true`.
Without setting `config_jedi_da = true` this PR should have no impact on
memory usage for stand-alone MPAS-A applications.

