### PR TITLE
Remove redundant query of nCellsSolve dimension in physics_run_init

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -447,7 +447,6 @@
  call mpas_pool_get_dimension(mesh,'nAerLevels' ,nAerLevels )
  call mpas_pool_get_dimension(mesh,'nOznLevels' ,nOznLevels )
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
- call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nSoilLevels',nSoilLevels)
  call mpas_pool_get_dimension(mesh,'nVertLevels',nVertLevels)
 


### PR DESCRIPTION
This PR removes a redundant query of the `nCellsSolve` dimension in the `physics_run_init` routine.

The `physics_run_init` routine in the `mpas_atmphys_manager` module contained a redundant query of the `nCellsSolve` dimension from the `mesh` pool, which has been removed by this PR with no impact on simulations.

