### PR TITLE
Make Noah-MP-only static fields optional in the init_atmosphere core

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -196,7 +196,7 @@
                      description="The supersampling factor to be used for 30s terrain, MODIS land use, soil category, and MODIS FPAR monthly vegetation fraction (case 7 only)"
                      possible_values="Positive integer values"/>
 
-                <nml_option name="config_noahmp_static" type="logical" default_value="true"
+                <nml_option name="config_noahmp_static" type="logical" default_value="true" in_defaults="false"
                      units="-"
                      description="Whether to process, read, and write static fields only required by Noah-MP"
                      possible_values="true or false"/>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -196,6 +196,11 @@
                      description="The supersampling factor to be used for 30s terrain, MODIS land use, soil category, and MODIS FPAR monthly vegetation fraction (case 7 only)"
                      possible_values="Positive integer values"/>
 
+                <nml_option name="config_noahmp_static" type="logical" default_value="true"
+                     units="-"
+                     description="Whether to process, read, and write static fields only required by Noah-MP"
+                     possible_values="true or false"/>
+
                 <nml_option name="config_use_spechumd"          type="logical"       default_value="false"
                      units="-"
                      description="Whether to use specific-humidity as the first-guess moisture variable. If this option is False, relative humidity will be used."
@@ -354,6 +359,7 @@
                 <package name="met_stage_out" description="Active only if meteorological fields are being interpolated"/>
                 <package name="first_guess_field" description="3-d atmospheric or land-surface fields on first-guess levels"/>
                 <package name="mp_thompson_aers_in" description="initialization of GOCART-based Thompson water- and ice-friendly aerosols"/>
+                <package name="noahmp" description="Whether to process, read, and write static fields only required by Noah-MP"/>
         </packages>
 
 
@@ -822,19 +828,24 @@
 
                 <!-- SOIL COMPOSITION fields needed for the NOAH-MP land surface scheme -->
                 <var name="soilcomp" type="real" dimensions="nSoilComps nCells" units="percent"
-                     description="soil composition needed as input in the NOAH-MP land surface model"/>
+                     description="soil composition needed as input in the NOAH-MP land surface model"
+                     packages="noahmp"/>
 
                 <var name="soilcl1" type="real" dimensions="nCells" units="unitless"
-                     description="soil texture class level 1 needed as input for the NOAH-MP land surface model"/>
+                     description="soil texture class level 1 needed as input for the NOAH-MP land surface model"
+                     packages="noahmp"/>
 
                 <var name="soilcl2" type="real" dimensions="nCells" units="unitless"
-                     description="soil texture class level 2 needed as input for the NOAH-MP land surface model"/>
+                     description="soil texture class level 2 needed as input for the NOAH-MP land surface model"
+                     packages="noahmp"/>
 
                 <var name="soilcl3" type="real" dimensions="nCells" units="unitless"
-                     description="soil texture class level 3 needed as input for the NOAH-MP land surface model"/>
+                     description="soil texture class level 3 needed as input for the NOAH-MP land surface model"
+                     packages="noahmp"/>
 
                 <var name="soilcl4" type="real" dimensions="nCells" units="unitless"
-                     description="soil texture class level 4 needed as input for the NOAH-MP land surface model"/>
+                     description="soil texture class level 4 needed as input for the NOAH-MP land surface model"
+                     packages="noahmp"/>
 
                 <!-- GWDO fields -->
                 <var name="var2d" type="real" dimensions="nCells" units="m"

--- a/src/core_init_atmosphere/mpas_init_atm_core_interface.F
+++ b/src/core_init_atmosphere/mpas_init_atm_core_interface.F
@@ -120,6 +120,7 @@ module init_atm_core_interface
       logical, pointer :: first_guess_field
       logical, pointer :: mp_thompson_aers_in
       integer, pointer :: config_init_case
+      logical, pointer :: noahmp, config_noahmp_static
 
 
       ierr = 0
@@ -271,6 +272,32 @@ module init_atm_core_interface
       first_guess_field = .false.
       if ((config_init_case == 7 .and. config_met_interp) .or. config_init_case == 9) then
          first_guess_field = .true.
+      end if
+
+      !
+      ! Noah-MP
+      !
+      nullify(config_noahmp_static)
+      call mpas_pool_get_config(configs, 'config_noahmp_static', config_noahmp_static)
+
+      nullify(noahmp)
+      call mpas_pool_get_package(packages, 'noahmpActive', noahmp)
+
+      if (associated(config_noahmp_static) .and. associated(noahmp)) then
+         noahmp = config_noahmp_static
+      else
+         call mpas_log_write('********************************************************************************', &
+                             messageType=MPAS_LOG_ERR)
+         call mpas_log_write('* Error while setting up packages for init_atmosphere core:',                      &
+                             messageType=MPAS_LOG_ERR)
+         call mpas_log_write('*    Either the ''noahmp'' package or the ''config_noahmp_static'' namelist',      &
+                             messageType=MPAS_LOG_ERR)
+         call mpas_log_write('*    option is not defined.', &
+                             messageType=MPAS_LOG_ERR)
+         call mpas_log_write('********************************************************************************', &
+                             messageType=MPAS_LOG_ERR)
+         ierr = 1
+         return
       end if
 
    end function init_atm_setup_packages

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -126,6 +126,7 @@
  character(len=StrKIND), pointer :: config_vegfrac_data
  character(len=StrKIND), pointer :: config_albedo_data
  character(len=StrKIND), pointer :: config_maxsnowalbedo_data
+ logical, pointer :: config_noahmp_static
  character(len=StrKIND+1) :: geog_data_path      ! same as config_geog_data_path, but guaranteed to have a trailing slash
  character(len=StrKIND+1) :: geog_sub_path       ! subdirectory names in config_geog_data_path, with trailing slash
 
@@ -219,6 +220,7 @@
  call mpas_pool_get_config(configs, 'config_maxsnowalbedo_data', config_maxsnowalbedo_data)
  call mpas_pool_get_config(configs, 'config_supersample_factor', supersample_fac)
  call mpas_pool_get_config(configs, 'config_30s_supersample_factor', supersample_fac_30s)
+ call mpas_pool_get_config(configs, 'config_noahmp_static', config_noahmp_static)
 
  write(geog_data_path, '(a)') config_geog_data_path
  i = len_trim(geog_data_path)
@@ -1171,55 +1173,59 @@
 
  call mpas_log_write('--- end interpolate ALBEDO12M')
 
-!
-! Interpolate SOILCOMP
-!
- geog_sub_path = 'soilgrids/soilcomp/'
- call mpas_log_write('--- start interpolate SOILCOMP')
- call interp_soilcomp(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
-                     supersample_fac=supersample_fac_30s)
- call mpas_log_write('--- end interpolate SOILCOMP')
+ if (config_noahmp_static) then
 
-!
-! Interpolate SOILCL1
-!
- geog_sub_path = 'soilgrids/texture_layer1/'
+    !
+    ! Interpolate SOILCOMP
+    !
+    geog_sub_path = 'soilgrids/soilcomp/'
 
- call mpas_log_write('--- start interpolate SOILCL1')
- call interp_soil_texture('soilcl1', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
-                          supersample_fac=supersample_fac_30s)
- call mpas_log_write('--- end interpolate SOILCL1')
+    call mpas_log_write('--- start interpolate SOILCOMP')
+    call interp_soilcomp(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
+                         supersample_fac=supersample_fac_30s)
+    call mpas_log_write('--- end interpolate SOILCOMP')
 
-!
-! Interpolate SOILCL2
-!
- geog_sub_path = 'soilgrids/texture_layer2/'
+    !
+    ! Interpolate SOILCL1
+    !
+    geog_sub_path = 'soilgrids/texture_layer1/'
 
- call mpas_log_write('--- start interpolate SOILCL2')
- call interp_soil_texture('soilcl2', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
-                          supersample_fac=supersample_fac_30s)
- call mpas_log_write('--- end interpolate SOILCL2')
+    call mpas_log_write('--- start interpolate SOILCL1')
+    call interp_soil_texture('soilcl1', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
+                             supersample_fac=supersample_fac_30s)
+    call mpas_log_write('--- end interpolate SOILCL1')
 
-!
-! Interpolate SOILCL3
-!
- geog_sub_path = 'soilgrids/texture_layer3/'
+    !
+    ! Interpolate SOILCL2
+    !
+    geog_sub_path = 'soilgrids/texture_layer2/'
 
- call mpas_log_write('--- start interpolate SOILCL3')
- call interp_soil_texture('soilcl3', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
-                          supersample_fac=supersample_fac_30s)
- call mpas_log_write('--- end interpolate SOILCL3')
+    call mpas_log_write('--- start interpolate SOILCL2')
+    call interp_soil_texture('soilcl2', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
+                             supersample_fac=supersample_fac_30s)
+    call mpas_log_write('--- end interpolate SOILCL2')
 
-!
-! Interpolate SOILCL4
-!
- geog_sub_path = 'soilgrids/texture_layer4/'
+    !
+    ! Interpolate SOILCL3
+    !
+    geog_sub_path = 'soilgrids/texture_layer3/'
 
- call mpas_log_write('--- start interpolate SOILCL4')
- call interp_soil_texture('soilcl4', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
-                          supersample_fac=supersample_fac_30s)
- call mpas_log_write('--- end interpolate SOILCL4')
+    call mpas_log_write('--- start interpolate SOILCL3')
+    call interp_soil_texture('soilcl3', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
+                             supersample_fac=supersample_fac_30s)
+    call mpas_log_write('--- end interpolate SOILCL3')
 
+    !
+    ! Interpolate SOILCL4
+    !
+    geog_sub_path = 'soilgrids/texture_layer4/'
+
+    call mpas_log_write('--- start interpolate SOILCL4')
+    call interp_soil_texture('soilcl4', mesh, tree, trim(geog_data_path)//trim(geog_sub_path), &
+                             supersample_fac=supersample_fac_30s)
+    call mpas_log_write('--- end interpolate SOILCL4')
+
+ end if
 
 !
 ! Deallocate and free the KD Tree


### PR DESCRIPTION
This PR introduces changes that make Noah-MP static fields optional in the `init_atmosphere` core.

Previously, the `soilcomp` and `soilcl{1,2,3,4}` fields needed only by the Noah-MP scheme were required in all static files read by the `init_atmosphere` core. In cases where the Noah-MP scheme will not be used when running the `atmosphere` core, it would be desirable to not require these Noah-MP-only fields.

Now, a new namelist option and package in the `init_atmosphere` core permit the generation and the use of static files that do not contain `soilcomp` and `soilcl{1,2,3,4}`.

1) The new `config_noahmp_static` namelist option in the `&data_sources` namelist group determines whether the Noah-MP-only static fields will be allocated, read, computed, and written in the `init_atmosphere` core. This namelist option defaults to `true`, yielding the default behavior of the `init_atmosphere_model` program prior to this commit.

2) The new `noahmp` package, which is active if and only if `config_noahmp_static` is `true`, controls the allocation, reading, and writing of the Noah-MP-only static fields.

3) In the `init_atm_static` routine, which is called when `config_static_interp` is `true`, the `soilcomp` and `soilcl{1,2,3,4}` fields are computed only if `config_noahmp_static` is true.