### PR TITLE
correct the computation of 2-meter diagnostics with Noah-MP

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -36,6 +36,11 @@ module mpas_atm_boundaries
 
     public :: nBdyZone, nSpecZone, nRelaxZone
 
+    interface mpas_atm_get_bdy_state
+        module procedure mpas_atm_get_bdy_state_2d
+        module procedure mpas_atm_get_bdy_state_3d
+    end interface mpas_atm_get_bdy_state
+
     private
 
     type (MPAS_Time_Type) :: LBC_intv_end
@@ -311,7 +316,7 @@ module mpas_atm_boundaries
 
     !***********************************************************************
     !
-    !  routine mpas_atm_get_bdy_state
+    !  routine mpas_atm_get_bdy_state_2d
     !
     !> \brief   Returns LBC state at a specified delta-t in the future
     !> \author  Michael Duda
@@ -342,7 +347,7 @@ module mpas_atm_boundaries
     !>   scalars(1,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND)
     !
     !-----------------------------------------------------------------------
-    function mpas_atm_get_bdy_state(clock, block, vertDim, horizDim, field, delta_t) result(return_state)
+    function mpas_atm_get_bdy_state_2d(clock, block, vertDim, horizDim, field, delta_t) result(return_state)
 
         use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
         use mpas_derived_types, only : MPAS_POOL_SILENT
@@ -414,7 +419,86 @@ module mpas_atm_boundaries
             return_state(:,:) = state_scalars(idx,:,:) - dt * tend_scalars(idx,:,:)
         end if
 
-    end function mpas_atm_get_bdy_state
+    end function mpas_atm_get_bdy_state_2d
+
+
+    !***********************************************************************
+    !
+    !  routine mpas_atm_get_bdy_state_3d
+    !
+    !> \brief   Returns LBC state at a specified delta-t in the future
+    !> \author  Michael Duda
+    !> \date    4 September 2024
+    !> \details
+    !>  This function returns an array providing the state for the requested
+    !>  progostic variable delta_t in the future from the current time known
+    !>  by the simulation clock (which is typically the time at the start of
+    !>  the current timestep).
+    !>
+    !>  The innerDim, vertDim, and horizDim should match the nominal block
+    !>  dimensions of the field to be returned by the call; for example, a
+    !>  call to retrieve the state of the 'scalars' field would set
+    !>  innerDim=num_scalars, vertDim=nVertLevels, and horizDim=nCells. This
+    !>  function internally adds 1 to the horizontal dimension to account for
+    !>  the "garbage" element.
+    !>
+    !>  The field is identified by the 'field' argument, and this argument is
+    !>  prefixed with 'lbc_' before attempting to retrieve the field from
+    !>  the 'lbc' pool.
+    !>
+    !>  Example calls to this function:
+    !>
+    !>   scalar(:,:,:) = mpas_atm_get_bdy_state(clock, domain % blocklist, &
+    !>                       num_scalars, nVertLevels, nCells, 'scalars', 0.0_RKIND)
+    !
+    !-----------------------------------------------------------------------
+    function mpas_atm_get_bdy_state_3d(clock, block, innerDim, vertDim, horizDim, field, delta_t) result(return_state)
+
+        use mpas_pool_routines, only : mpas_pool_get_error_level, mpas_pool_set_error_level
+        use mpas_derived_types, only : MPAS_POOL_SILENT
+
+        implicit none
+
+        type (mpas_clock_type), intent(in) :: clock
+        type (block_type), intent(inout) :: block
+        integer, intent(in) :: innerDim, vertDim, horizDim
+        character(len=*), intent(in) :: field
+        real (kind=RKIND), intent(in) :: delta_t
+
+        real (kind=RKIND), dimension(innerDim,vertDim,horizDim+1) :: return_state
+
+        type (mpas_pool_type), pointer :: lbc
+        real (kind=RKIND), dimension(:,:,:), pointer :: tend
+        real (kind=RKIND), dimension(:,:,:), pointer :: state
+        type (MPAS_Time_Type) :: currTime
+        type (MPAS_TimeInterval_Type) :: lbc_interval
+        integer :: dd_intv, s_intv, sn_intv, sd_intv
+        real (kind=RKIND) :: dt
+        integer :: err_level
+        integer :: ierr
+
+
+        currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
+
+        lbc_interval = LBC_intv_end - currTime
+
+        call mpas_get_timeInterval(interval=lbc_interval, DD=dd_intv, S=s_intv, S_n=sn_intv, S_d=sd_intv, ierr=ierr)
+        dt = 86400.0_RKIND * real(dd_intv, kind=RKIND) + real(s_intv, kind=RKIND) &
+             + (real(sn_intv, kind=RKIND) / real(sd_intv, kind=RKIND))
+
+        dt = dt - delta_t
+
+        call mpas_pool_get_subpool(block % structs, 'lbc', lbc)
+
+        nullify(tend)
+        nullify(state)
+
+        call mpas_pool_get_array(lbc, 'lbc_'//trim(field), tend, 1)
+        call mpas_pool_get_array(lbc, 'lbc_'//trim(field), state, 2)
+
+        return_state(:,:,:) = state(:,:,:) - dt * tend(:,:,:)
+
+    end function mpas_atm_get_bdy_state_3d
 
 
     !***********************************************************************

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5710,7 +5710,9 @@ module atm_time_integration
       ! Compute circulation and relative vorticity at each vertex
       !
       do iVertex=vertexStart,vertexEnd
-         vorticity(1:nVertLevels,iVertex) = 0.0
+         do k=1,nVertLevels
+            vorticity(k,iVertex) = 0.0_RKIND
+         end do
          do i=1,vertexDegree
             iEdge = edgesOnVertex(i,iVertex)
             s = edgesOnVertex_sign(i,iVertex) * dcEdge(iEdge)
@@ -5730,7 +5732,9 @@ module atm_time_integration
       ! Compute the divergence at each cell center
       !
       do iCell=cellStart,cellEnd
-         divergence(1:nVertLevels,iCell) = 0.0
+         do k=1,nVertLevels
+            divergence(k,iCell) = 0.0_RKIND
+         end do
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             s = edgesOnCell_sign(i,iCell) * dvEdge(iEdge)
@@ -5754,7 +5758,9 @@ module atm_time_integration
       ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
       ! compiler will actually allow "float raised to float" operation
       do iCell=cellStart,cellEnd
-         ke(1:nVertLevels,iCell) = 0.0
+         do k=1,nVertLevels
+            ke(k,iCell) = 0.0_RKIND
+         end do
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             do k=1,nVertLevels
@@ -5830,7 +5836,9 @@ module atm_time_integration
 
       if (reconstruct_v) then
         do iEdge = edgeStart,edgeEnd
-          v(1:nVertLevels,iEdge) = 0.0
+          do k = 1,nVertLevels
+            v(k,iEdge) = 0.0_RKIND
+          end do
           do i=1,nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(i,iEdge)
 !DIR$ IVDEP
@@ -5876,23 +5884,25 @@ module atm_time_integration
 
       if (config_apvm_upwinding > 0.0) then
 
-      !
-      ! Compute pv at cell centers
-      !    ( this computes pv_cell for all real cells )
-      !  only needed for APVM upwinding
-      !
-      do iCell=cellStart,cellEnd
-         pv_cell(1:nVertLevels,iCell) = 0.0
-         r = invAreaCell(iCell)
-         do i=1,nEdgesOnCell(iCell)
-            iVertex = verticesOnCell(i,iCell)
-            j = kiteForCell(i,iCell)
-!DIR$ IVDEP
+         !
+         ! Compute pv at cell centers
+         !    ( this computes pv_cell for all real cells )
+         !  only needed for APVM upwinding
+         !
+         do iCell=cellStart,cellEnd
             do k = 1,nVertLevels
-               pv_cell(k,iCell) = pv_cell(k,iCell) + kiteAreasOnVertex(j,iVertex) * pv_vertex(k,iVertex) * r
+               pv_cell(k,iCell) = 0.0_RKIND
+            end do
+            r = invAreaCell(iCell)
+            do i=1,nEdgesOnCell(iCell)
+               iVertex = verticesOnCell(i,iCell)
+               j = kiteForCell(i,iCell)
+!DIR$ IVDEP
+               do k = 1,nVertLevels
+                  pv_cell(k,iCell) = pv_cell(k,iCell) + kiteAreasOnVertex(j,iVertex) * pv_vertex(k,iVertex) * r
+               end do
             end do
          end do
-      end do
 
 
 !$OMP BARRIER

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6166,42 +6166,58 @@ module atm_time_integration
       rcv = rgas / (cp-rgas)
       p0 = 1.e5  ! this should come from somewhere else...
 
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop vector
          do k=1,nVertLevels
             theta_m(k,iCell) = theta(k,iCell) * (1._RKIND + rvord * scalars(index_qv,k,iCell))
             rho_zz(k,iCell) = rho(k,iCell) / zz(k,iCell)
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
+      !$acc parallel default(present)
+      !$acc loop gang
       do iEdge=edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
+         !$acc loop vector
          do k=1,nVertLevels
             ru(k,iEdge) = 0.5 * u(k,iEdge) * (rho_zz(k,cell1) + rho_zz(k,cell2))
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
       ! Compute rw (i.e. rho_zz * omega) from rho_zz, w, and ru.
       ! We are reversing the procedure we use in subroutine atm_recover_large_step_variables.
       ! first, the piece that depends on w.
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
          rw(1,iCell) = 0.0
          rw(nVertLevels+1,iCell) = 0.0
+         !$acc loop vector
          do k=2,nVertLevels
             rw(k,iCell) = w(k,iCell)     &
                           * (fzp(k) * rho_zz(k-1,iCell) + fzm(k) * rho_zz(k,iCell)) &
                           * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
          end do
       end do
+      !$acc end parallel
   
       ! next, the piece that depends on ru
+      !$acc parallel default(present)
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
+            !$acc loop vector
             do k = 2,nVertLevels
                flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
                rw(k,iCell) = rw(k,iCell)   &
@@ -6210,33 +6226,48 @@ module atm_time_integration
             end do
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rho_p(k,iCell) = rho_zz(k,iCell) - rho_base(k,iCell)
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rtheta_base(k,iCell) = theta_base(k,iCell) * rho_base(k,iCell)
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             rtheta_p(k,iCell) = theta_m(k,iCell) * rho_p(k,iCell)  &
                                              + rho_base(k,iCell)   * (theta_m(k,iCell) - theta_base(k,iCell))
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             exner(k,iCell) = (zz(k,iCell) * (rgas/p0) * (rtheta_p(k,iCell) + rtheta_base(k,iCell)))**rcv
             exner_base(k,iCell) = (zz(k,iCell) * (rgas/p0) * (rtheta_base(k,iCell)))**rcv  ! WCS addition 20180403
          end do
       end do
+      !$acc end parallel
 
+      !$acc parallel default(present)
+      !$acc loop collapse(2)
       do iCell=cellStart,cellEnd
          do k=1,nVertLevels
             pressure_p(k,iCell) = zz(k,iCell) * rgas &
@@ -6246,6 +6277,7 @@ module atm_time_integration
             pressure_base(k,iCell) = zz(k,iCell) * rgas * exner_base(k,iCell) * rtheta_base(k,iCell)      ! WCS addition 20180403
          end do
       end do
+      !$acc end parallel
 
       MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
       ! delete invariant fields

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5685,9 +5685,26 @@ module atm_time_integration
       logical :: reconstruct_v
 
 
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc enter data copyin(cellsOnEdge,dcEdge,dvEdge, &
+      !$acc                   edgesOnVertex,edgesOnVertex_sign,invAreaTriangle, &
+      !$acc                   nEdgesOnCell,edgesOnCell, &
+      !$acc                   edgesOnCell_sign,invAreaCell, &
+      !$acc                   invAreaTriangle,edgesOnVertex, &
+      !$acc                   verticesOnCell,kiteForCell,kiteAreasOnVertex, &
+      !$acc                   nEdgesOnEdge,edgesOnEdge,weightsOnEdge, &
+      !$acc                   fVertex, &
+      !$acc                   verticesOnEdge, &
+      !$acc                   invDvEdge,invDcEdge)
+      !$acc enter data copyin(u,h)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+
       !
       ! Compute height on cell edges at velocity locations
       !
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc enter data create(h_edge,ke_edge,vorticity,divergence)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
       !$acc parallel default(present)
       !$acc loop gang
       do iEdge=edgeStart,edgeEnd
@@ -5772,7 +5789,10 @@ module atm_time_integration
       !
       ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
       ! compiler will actually allow "float raised to float" operation
-      !$acc parallel
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc enter data create(ke)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc parallel default(present)
       !$acc loop gang
       do iCell=cellStart,cellEnd
          !$acc loop vector
@@ -5798,6 +5818,9 @@ module atm_time_integration
 
 
       if (hollingsworth) then
+         MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc enter data create(ke_vertex)
+         MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
 
          ! Compute ke at cell vertices - AG's new KE construction, part 1
          ! *** approximation here because we don't have inner triangle areas
@@ -5805,7 +5828,7 @@ module atm_time_integration
 
          ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
          ! compiler will actually allow "float raised to float" operation
-         !$acc parallel
+         !$acc parallel default(present)
          !$acc loop gang
          do iVertex=vertexStart,vertexEnd
             r = 0.25 * invAreaTriangle(iVertex) 
@@ -5830,14 +5853,13 @@ module atm_time_integration
 
          ke_fact = 1.0 - .375
 
-         !$acc parallel
+         !$acc parallel default(present)
          !$acc loop collapse(2)
          do iCell=cellStart,cellEnd
             do k=1,nVertLevels
                ke(k,iCell) = ke_fact * ke(k,iCell)
             end do
          end do
-         !$acc end parallel
 
 
          !$acc loop gang
@@ -5856,6 +5878,9 @@ module atm_time_integration
          end do
          !$acc end parallel
 
+         MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc exit data delete(ke_vertex)
+         MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
       end if
 
       !
@@ -5867,8 +5892,16 @@ module atm_time_integration
         if(rk_step /= 3) reconstruct_v = .false.
       end if
 
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
       if (reconstruct_v) then
-        !$acc parallel
+         !$acc enter data create(v)
+      else
+         !$acc enter data copyin(v)
+      end if
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+
+      if (reconstruct_v) then
+        !$acc parallel default(present)
         !$acc loop gang
         do iEdge = edgeStart,edgeEnd
           !$acc loop vector
@@ -5894,7 +5927,10 @@ module atm_time_integration
       !
       ! Avoid dividing h_vertex by areaTriangle and move areaTriangle into
       ! numerator for the pv_vertex calculation
-      !$acc parallel
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc enter data create(pv_vertex)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc parallel default(present)
       !$acc loop collapse(2)
       do iVertex = vertexStart,vertexEnd
 !DIR$ IVDEP
@@ -5917,7 +5953,10 @@ module atm_time_integration
       ! Compute pv at the edges
       !   ( this computes pv_edge at all edges bounding real cells )
       !
-      !$acc parallel
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc enter data create(pv_edge)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc parallel default(present)
       !$acc loop collapse(2)
       do iEdge = edgeStart,edgeEnd
 !DIR$ IVDEP
@@ -5934,7 +5973,10 @@ module atm_time_integration
          !    ( this computes pv_cell for all real cells )
          !  only needed for APVM upwinding
          !
-         !$acc parallel
+         MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc enter data create(pv_cell)
+         MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc parallel default(present)
          !$acc loop gang
          do iCell=cellStart,cellEnd
             !$acc loop vector
@@ -5972,8 +6014,11 @@ module atm_time_integration
          ! Merged loops for calculating gradPVt, gradPVn and pv_edge
          ! Also precomputed inverses of dvEdge and dcEdge to avoid repeated divisions
          !
+         MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc enter data create(gradPVt,gradPVn)
+         MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
          r = config_apvm_upwinding * dt
-         !$acc parallel
+         !$acc parallel default(present)
          !$acc loop gang
          do iEdge = edgeStart,edgeEnd
             r1 = 1.0_RKIND * invDvEdge(iEdge)
@@ -5988,7 +6033,30 @@ module atm_time_integration
          end do
          !$acc end parallel
 
+         MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+         !$acc exit data delete(pv_cell,gradPVt,gradPVn)
+         MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+
       end if  ! apvm upwinding
+
+
+      MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
+      !$acc exit data delete(cellsOnEdge,dcEdge,dvEdge, &
+      !$acc                  edgesOnVertex,edgesOnVertex_sign,invAreaTriangle, &
+      !$acc                  nEdgesOnCell,edgesOnCell, &
+      !$acc                  edgesOnCell_sign,invAreaCell, &
+      !$acc                  invAreaTriangle,edgesOnVertex, &
+      !$acc                  verticesOnCell,kiteForCell,kiteAreasOnVertex, &
+      !$acc                  nEdgesOnEdge,edgesOnEdge,weightsOnEdge, &
+      !$acc                  verticesOnEdge, &
+      !$acc                  fVertex,invDvEdge,invDcEdge)
+      !$acc exit data delete(u,h)
+      !$acc exit data copyout(h_edge,ke_edge,vorticity,divergence, &
+      !$acc                   ke, &
+      !$acc                   v, &
+      !$acc                   pv_vertex, &
+      !$acc                   pv_edge)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
 
    end subroutine atm_compute_solve_diagnostics_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6076,8 +6076,10 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       integer :: i, k, iCell, iEdge, cell1, cell2
-      integer, pointer :: nVertLevels
-      integer, pointer :: index_qv
+      integer, pointer :: nVertLevels_ptr
+      integer, pointer :: index_qv_ptr
+      integer          :: nVertLevels
+      integer          :: index_qv
       real (kind=RKIND) :: p0, rcv, flux
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell
@@ -6105,8 +6107,12 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3, zb_cell, zb3_cell
 
 
-      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(state, 'index_qv', index_qv)
+      call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels_ptr)
+      call mpas_pool_get_dimension(state, 'index_qv', index_qv_ptr)
+
+      ! Dereference integer pointers for OpenACC
+      nVertLevels = nVertLevels_ptr
+      index_qv = index_qv_ptr
 
       call mpas_pool_get_array(mesh, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
@@ -6180,10 +6186,10 @@ module atm_time_integration
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             do k = 2,nVertLevels
-            flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
-            rw(k,iCell) = rw(k,iCell)   &
-                          - edgesOnCell_sign(i,iCell) * (zb_cell(k,i,iCell) + sign(1.0_RKIND,flux) * zb3_cell(k,i,iCell))*flux   &
-                          * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
+               flux = (fzm(k)*ru(k,iEdge) + fzp(k)*ru(k-1,iEdge))
+               rw(k,iCell) = rw(k,iCell)   &
+                             - edgesOnCell_sign(i,iCell) * (zb_cell(k,i,iCell) + sign(1.0_RKIND,flux) * zb3_cell(k,i,iCell))*flux   &
+                             * (fzp(k) * zz(k-1,iCell) + fzm(k) * zz(k,iCell))
             end do
          end do
       end do

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6076,7 +6076,7 @@ module atm_time_integration
       integer, intent(in) :: cellSolveStart, cellSolveEnd, vertexSolveStart, vertexSolveEnd, edgeSolveStart, edgeSolveEnd
 
       integer :: i, k, iCell, iEdge, cell1, cell2
-      integer, pointer :: nCells, nEdges, nVertLevels
+      integer, pointer :: nVertLevels
       integer, pointer :: index_qv
       real (kind=RKIND) :: p0, rcv, flux
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -6105,8 +6105,6 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb, zb3, zb_cell, zb3_cell
 
 
-      call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-      call mpas_pool_get_dimension(mesh, 'nEdges', nEdges)
       call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(state, 'index_qv', index_qv)
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -627,7 +627,6 @@ module atm_time_integration
       character (len=StrKIND), pointer :: config_convection_scheme
 
       integer, pointer :: num_scalars, index_qv, nCells, nCellsSolve, nEdges, nEdgesSolve, nVertices, nVerticesSolve, nVertLevels
-      integer, pointer :: index_qc, index_qr, index_qi, index_qs, index_qg, index_nr, index_ni, index_nc, index_nifa, index_nwfa
 
       character(len=StrKIND), pointer :: config_IAU_option
 
@@ -723,17 +722,6 @@ module atm_time_integration
 #endif
       if (config_apply_lbcs) then
          call mpas_pool_get_dimension(state, 'num_scalars', num_scalars)
-         call mpas_pool_get_dimension(state, 'index_qv', index_qv)
-         call mpas_pool_get_dimension(state, 'index_qc', index_qc)
-         call mpas_pool_get_dimension(state, 'index_qr', index_qr)
-         call mpas_pool_get_dimension(state, 'index_qi', index_qi)
-         call mpas_pool_get_dimension(state, 'index_qs', index_qs)
-         call mpas_pool_get_dimension(state, 'index_qg', index_qg)  
-         call mpas_pool_get_dimension(state, 'index_nr', index_nr)
-         call mpas_pool_get_dimension(state, 'index_ni', index_ni)
-         call mpas_pool_get_dimension(state, 'index_nc', index_nc)
-         call mpas_pool_get_dimension(state, 'index_nifa', index_nifa)
-         call mpas_pool_get_dimension(state, 'index_nwfa', index_nwfa)
       endif
 
       !
@@ -1164,41 +1152,12 @@ module atm_time_integration
 
                   allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-                  !  get the scalar values driving the regional boundary conditions
                   !
-                  if (index_qv > 0) then
-                     scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
-                  end if
-                  if (index_qc > 0) then
-                     scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
-                  end if
-                  if (index_qr > 0) then
-                     scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
-                  end if
-                  if (index_qi > 0) then
-                     scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
-                  end if
-                  if (index_qs > 0) then
-                     scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
-                  end if
-                  if (index_qg > 0) then
-                     scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
-                  end if
-                  if (index_nr > 0) then
-                     scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
-                  end if
-                  if (index_ni > 0) then
-                     scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-                  end if
-                  if (index_nc > 0) then
-                     scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-                  end if
-                  if (index_nifa > 0) then
-                     scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-                  end if
-                  if (index_nwfa > 0) then
-                     scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
-                  end if
+                  ! get the scalar values driving the regional boundary conditions
+                  !
+                  scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                                                  'scalars', rk_timestep(rk_step))
+
                   !$OMP PARALLEL DO
                   do thread=1,nThreads
                      call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1339,41 +1298,12 @@ module atm_time_integration
    
                allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-               !  get the scalar values driving the regional boundary conditions
                !
-               if (index_qv > 0) then
-                  scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', rk_timestep(rk_step) )
-               end if
-               if (index_qc > 0) then
-                  scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', rk_timestep(rk_step) )
-               end if
-               if (index_qr > 0) then
-                  scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', rk_timestep(rk_step) )
-               end if
-               if (index_qi > 0) then
-                  scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', rk_timestep(rk_step) )
-               end if
-               if (index_qs > 0) then
-                  scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', rk_timestep(rk_step) )
-               end if
-               if (index_qg > 0) then
-                  scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', rk_timestep(rk_step) )
-               end if
-               if (index_nr > 0) then
-                  scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', rk_timestep(rk_step) )
-               end if
-               if (index_ni > 0) then
-                  scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', rk_timestep(rk_step) )
-               end if
-               if (index_nc > 0) then
-                  scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', rk_timestep(rk_step) )
-               end if
-               if (index_nifa > 0) then
-                  scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', rk_timestep(rk_step) )
-               end if
-               if (index_nwfa > 0) then
-                  scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', rk_timestep(rk_step) )
-               end if
+               ! get the scalar values driving the regional boundary conditions
+               !
+               scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, &
+                                                               'scalars', rk_timestep(rk_step))
+
 !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_bdy_adjust_scalars( state, diag, mesh, block % configs, scalars_driving, nVertLevels, dt, rk_timestep(rk_step), &
@@ -1507,41 +1437,11 @@ module atm_time_integration
 
          allocate(scalars_driving(num_scalars,nVertLevels,nCells+1))
 
-         !  get the scalar values driving the regional boundary conditions
          !
-         if (index_qv > 0) then
-            scalars_driving(index_qv,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qv', dt )
-         end if
-         if (index_qc > 0) then
-            scalars_driving(index_qc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qc', dt )
-         end if
-         if (index_qr > 0) then
-            scalars_driving(index_qr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qr', dt )
-         end if
-         if (index_qi > 0) then
-            scalars_driving(index_qi,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qi', dt )
-         end if
-         if (index_qs > 0) then
-            scalars_driving(index_qs,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qs', dt )
-         end if
-         if (index_qg > 0) then
-            scalars_driving(index_qg,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'qg', dt )
-         end if
-         if (index_nr > 0) then
-            scalars_driving(index_nr,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nr', dt )
-         end if
-         if (index_ni > 0) then
-            scalars_driving(index_ni,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'ni', dt )
-         end if
-         if (index_nc > 0) then
-            scalars_driving(index_nc,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nc', dt )
-         end if
-         if (index_nifa > 0) then
-            scalars_driving(index_nifa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nifa', dt )
-         end if
-         if (index_nwfa > 0) then
-            scalars_driving(index_nwfa,1:nVertLevels,1:nCells+1) = mpas_atm_get_bdy_state( clock, block, nVertLevels, nCells, 'nwfa', dt )
-         end if
+         ! get the scalar values driving the regional boundary conditions
+         !
+         scalars_driving(:,:,:) = mpas_atm_get_bdy_state(clock, block, num_scalars, nVertLevels, nCells, 'scalars', dt)
+
 !$OMP PARALLEL DO
          do thread=1,nThreads
             call atm_bdy_set_scalars( state, mesh, scalars_driving, nVertLevels, &

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -212,6 +212,22 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invAreaCell
       integer, dimension(:), pointer :: bdyMaskCell
       integer, dimension(:), pointer :: bdyMaskEdge
+      real (kind=RKIND), dimension(:), pointer :: invDvEdge
+      real (kind=RKIND), dimension(:), pointer :: dcEdge
+      real (kind=RKIND), dimension(:), pointer :: invDcEdge
+      integer, dimension(:,:), pointer :: edgesOnEdge
+      integer, dimension(:,:), pointer :: edgesOnVertex
+      integer, dimension(:,:), pointer :: edgesOnVertex_sign
+      integer, dimension(:), pointer :: nEdgesOnEdge
+      integer, dimension(:,:), pointer :: weightsOnEdge
+      integer, dimension(:,:), pointer :: cellsOnVertex
+      integer, dimension(:,:), pointer :: verticesOnCell
+      integer, dimension(:,:), pointer :: verticesOnEdge
+      real (kind=RKIND), dimension(:), pointer :: invAreaTriangle
+      integer, dimension(:,:), pointer :: kiteForCell
+      real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real (kind=RKIND), dimension(:), pointer :: fEdge
+      real (kind=RKIND), dimension(:), pointer :: fVertex
 #endif
 
 
@@ -271,6 +287,54 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       !$acc enter data copyin(bdyMaskEdge)
+
+      call mpas_pool_get_array(mesh, 'invDvEdge', invDvEdge)
+      !$acc enter data copyin(invDvEdge)
+
+      call mpas_pool_get_array(mesh, 'dcEdge', dcEdge)
+      !$acc enter data copyin(dcEdge)
+
+      call mpas_pool_get_array(mesh, 'invDcEdge', invDcEdge)
+      !$acc enter data copyin(invDcEdge)
+
+      call mpas_pool_get_array(mesh, 'edgesOnEdge', edgesOnEdge)
+      !$acc enter data copyin(edgesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'edgesOnVertex', edgesOnVertex)
+      !$acc enter data copyin(edgesOnVertex)
+
+      call mpas_pool_get_array(mesh, 'edgesOnVertex_sign', edgesOnVertex_sign)
+      !$acc enter data copyin(edgesOnVertex_sign)
+
+      call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
+      !$acc enter data copyin(nEdgesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
+      !$acc enter data copyin(weightsOnEdge)
+
+      call mpas_pool_get_array(mesh, 'cellsOnVertex', cellsOnVertex)
+      !$acc enter data copyin(cellsOnVertex)
+
+      call mpas_pool_get_array(mesh, 'verticesOnCell', verticesOnCell)
+      !$acc enter data copyin(verticesOnCell)
+
+      call mpas_pool_get_array(mesh, 'verticesOnEdge', verticesOnEdge)
+      !$acc enter data copyin(verticesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'invAreaTriangle', invAreaTriangle)
+      !$acc enter data copyin(invAreaTriangle)
+
+      call mpas_pool_get_array(mesh, 'kiteForCell', kiteForCell)
+      !$acc enter data copyin(kiteForCell)
+
+      call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      !$acc enter data copyin(kiteAreasOnVertex)
+
+      call mpas_pool_get_array(mesh, 'fVertex', fVertex)
+      !$acc enter data copyin(fVertex)
+
+      call mpas_pool_get_array(mesh, 'fEdge', fEdge)
+      !$acc enter data copyin(fEdge)
 #endif
 
    end subroutine mpas_atm_dynamics_init
@@ -319,6 +383,22 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invAreaCell
       integer, dimension(:), pointer :: bdyMaskCell
       integer, dimension(:), pointer :: bdyMaskEdge
+      real (kind=RKIND), dimension(:), pointer :: invDvEdge
+      real (kind=RKIND), dimension(:), pointer :: dcEdge
+      real (kind=RKIND), dimension(:), pointer :: invDcEdge
+      integer, dimension(:,:), pointer :: edgesOnEdge
+      integer, dimension(:,:), pointer :: edgesOnVertex
+      integer, dimension(:,:), pointer :: edgesOnVertex_sign
+      integer, dimension(:), pointer :: nEdgesOnEdge
+      integer, dimension(:,:), pointer :: weightsOnEdge
+      integer, dimension(:,:), pointer :: cellsOnVertex
+      integer, dimension(:,:), pointer :: verticesOnCell
+      integer, dimension(:,:), pointer :: verticesOnEdge
+      real (kind=RKIND), dimension(:), pointer :: invAreaTriangle
+      integer, dimension(:,:), pointer :: kiteForCell
+      real (kind=RKIND), dimension(:,:), pointer :: kiteAreasOnVertex
+      real (kind=RKIND), dimension(:), pointer :: fEdge
+      real (kind=RKIND), dimension(:), pointer :: fVertex
 #endif
 
 
@@ -378,6 +458,54 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'bdyMaskEdge', bdyMaskEdge)
       !$acc exit data delete(bdyMaskEdge)
+
+      call mpas_pool_get_array(mesh, 'invDvEdge', invDvEdge)
+      !$acc exit data delete(invDvEdge)
+
+      call mpas_pool_get_array(mesh, 'dcEdge', dcEdge)
+      !$acc exit data delete(dcEdge)
+
+      call mpas_pool_get_array(mesh, 'invDcEdge', invDcEdge)
+      !$acc exit data delete(invDcEdge)
+
+      call mpas_pool_get_array(mesh, 'edgesOnEdge', edgesOnEdge)
+      !$acc exit data delete(edgesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'edgesOnVertex', edgesOnVertex)
+      !$acc exit data delete(edgesOnVertex)
+
+      call mpas_pool_get_array(mesh, 'edgesOnVertex_sign', edgesOnVertex_sign)
+      !$acc exit data delete(edgesOnVertex_sign)
+
+      call mpas_pool_get_array(mesh, 'nEdgesOnEdge', nEdgesOnEdge)
+      !$acc exit data delete(nEdgesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
+      !$acc exit data delete(weightsOnEdge)
+
+      call mpas_pool_get_array(mesh, 'cellsOnVertex', cellsOnVertex)
+      !$acc exit data delete(cellsOnVertex)
+
+      call mpas_pool_get_array(mesh, 'verticesOnCell', verticesOnCell)
+      !$acc exit data delete(verticesOnCell)
+
+      call mpas_pool_get_array(mesh, 'verticesOnEdge', verticesOnEdge)
+      !$acc exit data delete(verticesOnEdge)
+
+      call mpas_pool_get_array(mesh, 'invAreaTriangle', invAreaTriangle)
+      !$acc exit data delete(invAreaTriangle)
+
+      call mpas_pool_get_array(mesh, 'kiteForCell', kiteForCell)
+      !$acc exit data delete(kiteForCell)
+
+      call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
+      !$acc exit data delete(kiteAreasOnVertex)
+
+      call mpas_pool_get_array(mesh, 'fVertex', fVertex)
+      !$acc exit data delete(fVertex)
+
+      call mpas_pool_get_array(mesh, 'fEdge', fEdge)
+      !$acc exit data delete(fEdge)
 #endif
 
    end subroutine mpas_atm_dynamics_finalize

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -5688,10 +5688,13 @@ module atm_time_integration
       !
       ! Compute height on cell edges at velocity locations
       !
+      !$acc parallel default(present)
+      !$acc loop gang
       do iEdge=edgeStart,edgeEnd
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
 !DIR$ IVDEP
+         !$acc loop vector
          do k=1,nVertLevels
             h_edge(k,iEdge) = 0.5 * (h(k,cell1) + h(k,cell2))
          end do
@@ -5700,6 +5703,7 @@ module atm_time_integration
 !  it would be good to move this somewhere else?
 
          efac = dcEdge(iEdge)*dvEdge(iEdge)
+         !$acc loop vector
          do k=1,nVertLevels
             ke_edge(k,iEdge) = efac*u(k,iEdge)**2
          end do
@@ -5709,19 +5713,24 @@ module atm_time_integration
       !
       ! Compute circulation and relative vorticity at each vertex
       !
+      !$acc loop gang
       do iVertex=vertexStart,vertexEnd
+         !$acc loop vector
          do k=1,nVertLevels
             vorticity(k,iVertex) = 0.0_RKIND
          end do
+         !$acc loop seq
          do i=1,vertexDegree
             iEdge = edgesOnVertex(i,iVertex)
             s = edgesOnVertex_sign(i,iVertex) * dcEdge(iEdge)
 !DIR$ IVDEP
+            !$acc loop vector
             do k=1,nVertLevels
                vorticity(k,iVertex) = vorticity(k,iVertex) + s * u(k,iEdge)
             end do
          end do
 !DIR$ IVDEP
+         !$acc loop vector
          do k=1,nVertLevels
             vorticity(k,iVertex) = vorticity(k,iVertex) * invAreaTriangle(iVertex)
          end do
@@ -5731,23 +5740,29 @@ module atm_time_integration
       !
       ! Compute the divergence at each cell center
       !
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop vector
          do k=1,nVertLevels
             divergence(k,iCell) = 0.0_RKIND
          end do
+         !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
             s = edgesOnCell_sign(i,iCell) * dvEdge(iEdge)
 !DIR$ IVDEP
+            !$acc loop vector
             do k=1,nVertLevels
               divergence(k,iCell) = divergence(k,iCell) + s * u(k,iEdge)
             end do
          end do
          r = invAreaCell(iCell)
+         !$acc loop vector
          do k = 1,nVertLevels
             divergence(k,iCell) = divergence(k,iCell) * r
          end do
       end do
+      !$acc end parallel
 
 
 !$OMP BARRIER
@@ -5757,22 +5772,29 @@ module atm_time_integration
       !
       ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
       ! compiler will actually allow "float raised to float" operation
+      !$acc parallel
+      !$acc loop gang
       do iCell=cellStart,cellEnd
+         !$acc loop vector
          do k=1,nVertLevels
             ke(k,iCell) = 0.0_RKIND
          end do
+         !$acc loop seq
          do i=1,nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i,iCell)
+            !$acc loop vector
             do k=1,nVertLevels
 !               ke(k,iCell) = ke(k,iCell) + 0.25 * dcEdge(iEdge) * dvEdge(iEdge) * u(k,iEdge)**2
                ke(k,iCell) = ke(k,iCell) + 0.25 * ke_edge(k,iEdge)
             end do
          end do
 !DIR$ IVDEP
+         !$acc loop vector
          do k=1,nVertLevels
             ke(k,iCell) = ke(k,iCell) * invAreaCell(iCell)
          end do
       end do
+      !$acc end parallel
 
 
       if (hollingsworth) then
@@ -5783,8 +5805,11 @@ module atm_time_integration
 
          ! Replace 2.0 with 2 in exponentiation to avoid outside chance that
          ! compiler will actually allow "float raised to float" operation
+         !$acc parallel
+         !$acc loop gang
          do iVertex=vertexStart,vertexEnd
             r = 0.25 * invAreaTriangle(iVertex) 
+            !$acc loop vector
             do k=1,nVertLevels
 
 !               ke_vertex(k,iVertex) = (  dcEdge(EdgesOnVertex(1,iVertex))*dvEdge(EdgesOnVertex(1,iVertex))*u(k,EdgesOnVertex(1,iVertex))**2  &
@@ -5796,6 +5821,7 @@ module atm_time_integration
 
             end do
          end do
+         !$acc end parallel
 
 !$OMP BARRIER
 
@@ -5804,24 +5830,31 @@ module atm_time_integration
 
          ke_fact = 1.0 - .375
 
+         !$acc parallel
+         !$acc loop collapse(2)
          do iCell=cellStart,cellEnd
             do k=1,nVertLevels
                ke(k,iCell) = ke_fact * ke(k,iCell)
             end do
          end do
+         !$acc end parallel
 
 
+         !$acc loop gang
          do iCell=cellStart,cellEnd
             r = invAreaCell(iCell)
+            !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iVertex = verticesOnCell(i,iCell)
                j = kiteForCell(i,iCell)
 !DIR$ IVDEP
+               !$acc loop vector
                do k = 1,nVertLevels
                   ke(k,iCell) = ke(k,iCell) + (1.-ke_fact)*kiteAreasOnVertex(j,iVertex) * ke_vertex(k,iVertex) * r
                end do
             end do
          end do
+         !$acc end parallel
 
       end if
 
@@ -5835,18 +5868,24 @@ module atm_time_integration
       end if
 
       if (reconstruct_v) then
+        !$acc parallel
+        !$acc loop gang
         do iEdge = edgeStart,edgeEnd
+          !$acc loop vector
           do k = 1,nVertLevels
             v(k,iEdge) = 0.0_RKIND
           end do
+          !$acc loop seq
           do i=1,nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(i,iEdge)
 !DIR$ IVDEP
+            !$acc loop vector
             do k = 1,nVertLevels
               v(k,iEdge) = v(k,iEdge) + weightsOnEdge(i,iEdge) * u(k, eoe)
             end do
           end do
         end do
+        !$acc end parallel
       end if
 
       !
@@ -5855,6 +5894,8 @@ module atm_time_integration
       !
       ! Avoid dividing h_vertex by areaTriangle and move areaTriangle into
       ! numerator for the pv_vertex calculation
+      !$acc parallel
+      !$acc loop collapse(2)
       do iVertex = vertexStart,vertexEnd
 !DIR$ IVDEP
          do k=1,nVertLevels
@@ -5868,6 +5909,7 @@ module atm_time_integration
             pv_vertex(k,iVertex) = (fVertex(iVertex) + vorticity(k,iVertex))
          end do
       end do
+      !$acc end parallel
 
 !$OMP BARRIER
 
@@ -5875,12 +5917,15 @@ module atm_time_integration
       ! Compute pv at the edges
       !   ( this computes pv_edge at all edges bounding real cells )
       !
+      !$acc parallel
+      !$acc loop collapse(2)
       do iEdge = edgeStart,edgeEnd
 !DIR$ IVDEP
          do k=1,nVertLevels
             pv_edge(k,iEdge) =  0.5 * (pv_vertex(k,verticesOnEdge(1,iEdge)) + pv_vertex(k,verticesOnEdge(2,iEdge)))
          end do
       end do
+      !$acc end parallel
 
       if (config_apvm_upwinding > 0.0) then
 
@@ -5889,20 +5934,26 @@ module atm_time_integration
          !    ( this computes pv_cell for all real cells )
          !  only needed for APVM upwinding
          !
+         !$acc parallel
+         !$acc loop gang
          do iCell=cellStart,cellEnd
+            !$acc loop vector
             do k = 1,nVertLevels
                pv_cell(k,iCell) = 0.0_RKIND
             end do
             r = invAreaCell(iCell)
+            !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iVertex = verticesOnCell(i,iCell)
                j = kiteForCell(i,iCell)
 !DIR$ IVDEP
+               !$acc loop vector
                do k = 1,nVertLevels
                   pv_cell(k,iCell) = pv_cell(k,iCell) + kiteAreasOnVertex(j,iVertex) * pv_vertex(k,iVertex) * r
                end do
             end do
          end do
+         !$acc end parallel
 
 
 !$OMP BARRIER
@@ -5922,16 +5973,20 @@ module atm_time_integration
          ! Also precomputed inverses of dvEdge and dcEdge to avoid repeated divisions
          !
          r = config_apvm_upwinding * dt
+         !$acc parallel
+         !$acc loop gang
          do iEdge = edgeStart,edgeEnd
             r1 = 1.0_RKIND * invDvEdge(iEdge)
             r2 = 1.0_RKIND * invDcEdge(iEdge)
 !DIR$ IVDEP
+            !$acc loop vector
             do k = 1,nVertLevels
                gradPVt(k,iEdge) = (pv_vertex(k,verticesOnEdge(2,iEdge)) - pv_vertex(k,verticesOnEdge(1,iEdge))) * r1
                gradPVn(k,iEdge) = (pv_cell(k,cellsOnEdge(2,iEdge)) - pv_cell(k,cellsOnEdge(1,iEdge))) * r2
                pv_edge(k,iEdge) = pv_edge(k,iEdge) - r * (v(k,iEdge) * gradPVt(k,iEdge) + u(k,iEdge) * gradPVn(k,iEdge))
             end do
          end do
+         !$acc end parallel
 
       end if  ! apvm upwinding
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6145,6 +6145,23 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'zb_cell', zb_cell)
       call mpas_pool_get_array(mesh, 'zb3_cell', zb3_cell)
 
+      MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
+      ! copyin invariant fields
+      !$acc enter data copyin(cellsOnEdge,nEdgesOnCell,edgesOnCell, &
+      !$acc                   edgesOnCell_sign,zz,fzm,fzp,zb,zb3, &
+      !$acc                   zb_cell,zb3_cell)
+
+      ! copyin the data that is only on the right-hand side
+      !$acc enter data copyin(scalars(index_qv,:,:),u,w,rho,theta, &
+      !$acc                           rho_base,theta_base)
+
+      ! copyin the data that will be modified in this routine
+      !$acc enter data create(theta_m,rho_zz,ru,rw,rho_p,rtheta_base, &
+      !$acc                   rtheta_p,exner,exner_base,pressure_p, &
+      !$acc                   pressure_base)
+      MPAS_ACC_TIMER_STOP('atm_init_coupled_diagnostics [ACC_data_xfer]')
+
+
 
       rcv = rgas / (cp-rgas)
       p0 = 1.e5  ! this should come from somewhere else...
@@ -6229,6 +6246,22 @@ module atm_time_integration
             pressure_base(k,iCell) = zz(k,iCell) * rgas * exner_base(k,iCell) * rtheta_base(k,iCell)      ! WCS addition 20180403
          end do
       end do
+
+      MPAS_ACC_TIMER_START('atm_init_coupled_diagnostics [ACC_data_xfer]')
+      ! delete invariant fields
+      !$acc exit data delete(cellsOnEdge,nEdgesOnCell,edgesOnCell, &
+      !$acc                  edgesOnCell_sign,zz,fzm,fzp,zb,zb3, &
+      !$acc                  zb_cell,zb3_cell)
+
+      ! delete the data that is only on the right-hand side
+      !$acc exit data delete(scalars(index_qv,:,:),u,w,rho,theta, &
+      !$acc                           rho_base,theta_base)
+
+      ! copyout the data that will be modified in this routine
+      !$acc exit data copyout(theta_m,rho_zz,ru,rw,rho_p,rtheta_base, &
+      !$acc                   rtheta_p,exner,exner_base,pressure_p, &
+      !$acc                   pressure_base)
+      MPAS_ACC_TIMER_STOP('atm_init_coupled_diagnostics [ACC_data_xfer]')
 
    end subroutine atm_init_coupled_diagnostics
 

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -48,6 +48,7 @@ OBJS = \
 	mpas_atmphys_packages.o            \
 	mpas_atmphys_rrtmg_lwinit.o        \
 	mpas_atmphys_rrtmg_swinit.o        \
+	mpas_atmphys_sfc_diagnostics.o     \
 	mpas_atmphys_todynamics.o          \
 	mpas_atmphys_update_surface.o      \
 	mpas_atmphys_update.o              \
@@ -103,6 +104,7 @@ mpas_atmphys_driver.o: \
 	mpas_atmphys_driver_oml.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_interface.o \
+	mpas_atmphys_sfc_diagnostics.o \
 	mpas_atmphys_update.o \
 	mpas_atmphys_vars.o
 
@@ -222,6 +224,10 @@ mpas_atmphys_rrtmg_lwinit.o: \
 mpas_atmphys_rrtmg_swinit.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_utilities.o
+
+mpas_atmphys_sfc_diagnostics.o: \
+	mpas_atmphys_constants.o \
+	mpas_atmphys_vars.o
 
 mpas_atmphys_todynamics.o: \
 	mpas_atmphys_constants.o \

--- a/src/core_atmosphere/physics/Registry_noahmp.xml
+++ b/src/core_atmosphere/physics/Registry_noahmp.xml
@@ -360,11 +360,17 @@
       <var name="t2mbxy" type="real" dimensions="nCells Time" units="K"
                 description="2-meter temperature over bare ground" missing_value="-9999.0"/>
 
+      <var name="t2mxy" type="real" dimensions="nCells Time" units="K"
+                description="grid-mean 2-meter temperature" missing_value="-9999.0"/>
+
       <var name="q2mvxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                 description="2-meter water vapor mixing ratio over canopy" missing_value="-9999.0"/>
 
       <var name="q2mbxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                 description="2-meter water vapor mixing ratio over bare ground" missing_value="-9999.0"/>
+
+      <var name="q2mxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
+                description="grid-mean 2-meter water vapor mixing ratio" missing_value="-9999.0"/>
 
       <var name="tradxy" type="real" dimensions="nCells Time" units="K"
                 description="surface radiative temperature" missing_value="-9999.0"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -296,14 +296,14 @@
           enddo
        endif
 
-       call allocate_seaice
+       call allocate_seaice(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_seaice(block%configs,diag_physics,sfc_input, &
                              cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        enddo
 !$OMP END PARALLEL DO
-       call deallocate_seaice
+       call deallocate_seaice(block%configs)
     endif
 
     !call to pbl schemes:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -23,6 +23,7 @@
  use mpas_atmphys_driver_oml
  use mpas_atmphys_constants
  use mpas_atmphys_interface
+ use mpas_atmphys_sfc_diagnostics,only: atmphys_sfc_diagnostics
  use mpas_atmphys_update
  use mpas_atmphys_vars, only: l_camlw,l_conv,l_radtlw,l_radtsw
  use mpas_timer
@@ -304,6 +305,13 @@
        enddo
 !$OMP END PARALLEL DO
        call deallocate_seaice(block%configs)
+
+!$OMP PARALLEL DO
+       do thread=1,nThreads
+          call atmphys_sfc_diagnostics(block%configs,mesh,diag,diag_physics,sfc_input,output_noahmp, &
+                           cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
+       enddo
+!$OMP END PARALLEL DO
     endif
 
     !call to pbl schemes:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
@@ -84,11 +84,11 @@
 
 
 !--- local OUT pointers (with no Noah LSM equivalent as defined in WRF):
- real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,q2mvxy,q2mbxy,tradxy,neexy,gppxy,nppxy,fvegxy,runsfxy,  &
-                                         runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,psnxy,savxy,sagxy,  &
-                                         rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy,chbxy,shgxy,shcxy,    &
-                                         shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy,trxy,evcxy,chleafxy,  &
-                                         chucxy,chv2xy,chb2xy,rs,qtdrain
+ real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,t2mxy,q2mvxy,q2mbxy,q2mxy,tradxy,neexy,gppxy,nppxy,  &
+                                         fvegxy,runsfxy,runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,  &
+                                         psnxy,savxy,sagxy,rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy, &
+                                         chbxy,shgxy,shcxy,shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy, &
+                                         trxy,evcxy,chleafxy,chucxy,chv2xy,chb2xy,rs,qtdrain
 
 
 !--- local OUT additional variables:
@@ -377,8 +377,10 @@
 !    see lines 242-290 in module NoahmpIOVarType.F90):
  call mpas_pool_get_array(output_noahmp,'t2mvxy'  ,t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'t2mbxy'  ,t2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy'   ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'q2mvxy'  ,q2mvxy  )
  call mpas_pool_get_array(output_noahmp,'q2mbxy'  ,q2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'q2mxy'   ,q2mxy   )
  call mpas_pool_get_array(output_noahmp,'tradxy'  ,tradxy  )
  call mpas_pool_get_array(output_noahmp,'neexy'   ,neexy   )
  call mpas_pool_get_array(output_noahmp,'gppxy'   ,gppxy   )
@@ -423,10 +425,12 @@
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain  )
 
  do i = its,ite
-    mpas_noahmp%t2mvxy(i)   = t2mvxy(i)
-    mpas_noahmp%t2mbxy(i)   = t2mbxy(i)
-    mpas_noahmp%q2mvxy(i)   = q2mvxy(i)
-    mpas_noahmp%q2mbxy(i)   = q2mbxy(i)
+!   mpas_noahmp%t2mvxy(i)   = t2mvxy(i)
+!   mpas_noahmp%t2mbxy(i)   = t2mbxy(i)
+!   mpas_noahmp%t2mxy(i)    = t2mxy(i)
+!   mpas_noahmp%q2mvxy(i)   = q2mvxy(i)
+!   mpas_noahmp%q2mbxy(i)   = q2mbxy(i)
+!   mpas_noahmp%q2mxy(i)    = q2mxy(i)
     mpas_noahmp%tradxy(i)   = tradxy(i)
     mpas_noahmp%neexy(i)    = neexy(i)
     mpas_noahmp%gppxy(i)    = gppxy(i)
@@ -685,11 +689,11 @@
 
 
 !--- local OUT pointers (with no Noah LSM equivalent as defined in WRF):
- real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,q2mvxy,q2mbxy,tradxy,neexy,gppxy,nppxy,fvegxy,runsfxy,  &
-                                         runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,psnxy,savxy,sagxy,  &
-                                         rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy,chbxy,shgxy,shcxy,    &
-                                         shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy,trxy,evcxy,chleafxy,  &
-                                         chucxy,chv2xy,chb2xy,rs,qtdrain
+ real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,t2mxy,q2mvxy,q2mbxy,q2mxy,tradxy,neexy,gppxy,nppxy,  &
+                                         fvegxy,runsfxy,runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,  &
+                                         psnxy,savxy,sagxy,rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy, &
+                                         chbxy,shgxy,shcxy,shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy, &
+                                         trxy,evcxy,chleafxy,chucxy,chv2xy,chb2xy,rs,qtdrain
 
 
 !--- local OUT additional variables:
@@ -702,7 +706,7 @@
  real(kind=RKIND),dimension(:,:),pointer:: acc_etranixy
 
 !-----------------------------------------------------------------------------------------------------------------
-!call mpas_log_write('--- enter subroutine lsm_noahmp_toMPAS:')
+ call mpas_log_write('--- enter subroutine lsm_noahmp_toMPAS:')
 
 
 !--- initialization of local dimensions:
@@ -865,8 +869,10 @@
 !    lines 242-290 in module NoahmpIOVarType.F90:
  call mpas_pool_get_array(output_noahmp,'t2mvxy'  ,t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'t2mbxy'  ,t2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy'   ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'q2mvxy'  ,q2mvxy  )
  call mpas_pool_get_array(output_noahmp,'q2mbxy'  ,q2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'q2mxy'   ,q2mxy   )
  call mpas_pool_get_array(output_noahmp,'tradxy'  ,tradxy  )
  call mpas_pool_get_array(output_noahmp,'neexy'   ,neexy   )
  call mpas_pool_get_array(output_noahmp,'gppxy'   ,gppxy   )
@@ -913,8 +919,10 @@
  do i = its,ite
     t2mvxy(i)   = mpas_noahmp%t2mvxy(i)
     t2mbxy(i)   = mpas_noahmp%t2mbxy(i)
+    t2mxy(i)    = mpas_noahmp%t2mxy(i)
     q2mvxy(i)   = mpas_noahmp%q2mvxy(i)
     q2mbxy(i)   = mpas_noahmp%q2mbxy(i)
+    q2mxy(i)    = mpas_noahmp%q2mxy(i)
     tradxy(i)   = mpas_noahmp%tradxy(i)
     neexy(i)    = mpas_noahmp%neexy(i)
     gppxy(i)    = mpas_noahmp%gppxy(i)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
@@ -80,9 +80,6 @@
  if(.not.allocated(xice_p)      ) allocate(xice_p(ims:ime,jms:jme)      )
  if(.not.allocated(z0_p)        ) allocate(z0_p(ims:ime,jms:jme)        )
  if(.not.allocated(znt_p)       ) allocate(znt_p(ims:ime,jms:jme)       )
- if(.not.allocated(q2_p)        ) allocate(q2_p(ims:ime,jms:jme)        )
- if(.not.allocated(t2m_p)       ) allocate(t2m_p(ims:ime,jms:jme)       )
- if(.not.allocated(th2m_p)      ) allocate(th2m_p(ims:ime,jms:jme)      )
 
  if(.not.allocated(tsk_sea)     ) allocate(tsk_sea(ims:ime,jms:jme)     )
  if(.not.allocated(tsk_ice)     ) allocate(tsk_ice(ims:ime,jms:jme)     )
@@ -148,9 +145,6 @@
  if(allocated(xice_p)      ) deallocate(xice_p      )
  if(allocated(z0_p)        ) deallocate(z0_p        )
  if(allocated(znt_p)       ) deallocate(znt_p       )
- if(allocated(q2_p)        ) deallocate(q2_p        )
- if(allocated(t2m_p)       ) deallocate(t2m_p       )
- if(allocated(th2m_p)      ) deallocate(th2m_p      )
 
  if(allocated(chs_sea)     ) deallocate(chs_sea     )
  if(allocated(chs2_sea)    ) deallocate(chs2_sea    )
@@ -354,7 +348,6 @@
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,chs,chs2,cpm,cqs2,qgh,qsfc,grdflx,hfx, qfx,lh,noahres, &
                                          potevp,sfc_albedo,sfc_emiss,sfcrunoff,snopcx,z0,znt
  real(kind=RKIND),dimension(:),pointer:: snow,snowc,snowh,skintemp,xice
- real(kind=RKIND),dimension(:),pointer:: t2m,th2m,q2
  real(kind=RKIND),dimension(:,:),pointer:: tslb
 
 !local variables and arrays:
@@ -382,9 +375,6 @@
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
- call mpas_pool_get_array(diag_physics,'t2m'       ,t2m       )
- call mpas_pool_get_array(diag_physics,'th2m'      ,th2m      )
- call mpas_pool_get_array(diag_physics,'q2'        ,q2        )
 
  call mpas_pool_get_array(sfc_input,'snow'    ,snow    )
  call mpas_pool_get_array(sfc_input,'snowc'   ,snowc   )
@@ -393,7 +383,7 @@
  call mpas_pool_get_array(sfc_input,'tslb'    ,tslb    )
  call mpas_pool_get_array(sfc_input,'xice'    ,xice    )
 
-!--- weigh local variables needed in the calculation of t2m, th2m, and q2 over seaice points:
+!--- reconstruct local variables as functions of the seaice fraction:
  do j = jts,jte
     do i = its,ite
        if(xice_p(i,j).ge.xice_threshold .and. xice_p(i,j).le.1._RKIND) then
@@ -413,16 +403,6 @@
        endif
     enddo
  enddo
-
- call sfcdiags( &
-             hfx   = hfx_p  , qfx     = qfx_p   , tsk  = tsk_p , qsfc = qsfc_p , chs = chs_p , &
-             chs2  = chs2_p , cqs2    = cqs2_p  , t2   = t2m_p , th2  = th2m_p , q2  = q2_p  , &
-             psfc  = psfc_p , t3d     = t_p     , qv3d = qv_p  , cp   = cp     , R_d = R_d   , &
-             rovcp = rcp    , ua_phys = ua_phys                                              , &
-             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,           &
-             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
-             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
-                    )
 
 !--- update all variables:
  do j = jts,jte
@@ -454,11 +434,6 @@
        lh(i)   = lh_p(i,j)
        sfc_albedo(i) = sfc_albedo_p(i,j)
        sfc_emiss(i)  = sfc_emiss_p(i,j)
-
-       !--- 2-meter diagnostics:
-       q2(i)   = q2_p(i,j)
-       t2m(i)  = t2m_p(i,j)
-       th2m(i) = th2m_p(i,j)
     enddo
  enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
@@ -36,8 +36,18 @@
 
 
 !=================================================================================================================
- subroutine allocate_seaice
+ subroutine allocate_seaice(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+
+!local pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
 
  if(.not.allocated(acsnom_p)    ) allocate(acsnom_p(ims:ime,jms:jme)    )
  if(.not.allocated(acsnow_p)    ) allocate(acsnow_p(ims:ime,jms:jme)    )
@@ -55,8 +65,6 @@
  if(.not.allocated(hfx_p)       ) allocate(hfx_p(ims:ime,jms:jme)       )
  if(.not.allocated(qfx_p)       ) allocate(qfx_p(ims:ime,jms:jme)       )
  if(.not.allocated(lh_p)        ) allocate(lh_p(ims:ime,jms:jme)        )
- if(.not.allocated(noahres_p)   ) allocate(noahres_p(ims:ime,jms:jme)   )
- if(.not.allocated(potevp_p)    ) allocate(potevp_p(ims:ime,jms:jme)    )
  if(.not.allocated(rainbl_p)    ) allocate(rainbl_p(ims:ime,jms:jme)    )
  if(.not.allocated(sfc_albedo_p)) allocate(sfc_albedo_p(ims:ime,jms:jme))
  if(.not.allocated(sfc_emiss_p) ) allocate(sfc_emiss_p(ims:ime,jms:jme) )
@@ -65,7 +73,6 @@
  if(.not.allocated(snow_p)      ) allocate(snow_p(ims:ime,jms:jme)      )
  if(.not.allocated(snowc_p)     ) allocate(snowc_p(ims:ime,jms:jme)     )
  if(.not.allocated(snowh_p)     ) allocate(snowh_p(ims:ime,jms:jme)     )
- if(.not.allocated(snopcx_p)    ) allocate(snopcx_p(ims:ime,jms:jme)    )
  if(.not.allocated(snowsi_p)    ) allocate(snowsi_p(ims:ime,jms:jme)    )
  if(.not.allocated(swdown_p)    ) allocate(swdown_p(ims:ime,jms:jme)    )
  if(.not.allocated(sr_p)        ) allocate(sr_p(ims:ime,jms:jme)        )
@@ -85,11 +92,30 @@
 
  if(.not.allocated(tslb_p)) allocate(tslb_p(ims:ime,1:num_soils,jms:jme))
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       if(.not.allocated(noahres_p)) allocate(noahres_p(ims:ime,jms:jme))
+       if(.not.allocated(potevp_p) ) allocate(potevp_p(ims:ime,jms:jme) )
+       if(.not.allocated(snopcx_p) ) allocate(snopcx_p(ims:ime,jms:jme) )
+
+    case default
+ end select sf_select
+
  end subroutine allocate_seaice
 
 !=================================================================================================================
- subroutine deallocate_seaice
+ subroutine deallocate_seaice(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+
+!local pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
 
  if(allocated(acsnom_p)    ) deallocate(acsnom_p    )
  if(allocated(acsnow_p)    ) deallocate(acsnow_p    )
@@ -107,8 +133,6 @@
  if(allocated(hfx_p)       ) deallocate(hfx_p       )
  if(allocated(qfx_p)       ) deallocate(qfx_p       )
  if(allocated(lh_p)        ) deallocate(lh_p        )
- if(allocated(noahres_p)   ) deallocate(noahres_p   )
- if(allocated(potevp_p)    ) deallocate(potevp_p    )
  if(allocated(rainbl_p)    ) deallocate(rainbl_p    )
  if(allocated(sfc_albedo_p)) deallocate(sfc_albedo_p)
  if(allocated(sfc_emiss_p) ) deallocate(sfc_emiss_p )
@@ -117,7 +141,6 @@
  if(allocated(snow_p)      ) deallocate(snow_p      )
  if(allocated(snowc_p)     ) deallocate(snowc_p     )
  if(allocated(snowh_p)     ) deallocate(snowh_p     )
- if(allocated(snopcx_p)    ) deallocate(snopcx_p    )
  if(allocated(snowsi_p)    ) deallocate(snowsi_p    )
  if(allocated(swdown_p)    ) deallocate(swdown_p    )
  if(allocated(sr_p)        ) deallocate(sr_p        )
@@ -146,6 +169,15 @@
 
  if(allocated(tslb_p)) deallocate(tslb_p)
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       if(allocated(noahres_p)) deallocate(noahres_p)
+       if(allocated(potevp_p) ) deallocate(potevp_p )
+       if(allocated(snopcx_p) ) deallocate(snopcx_p )
+
+    case default
+ end select sf_select
+
  end subroutine deallocate_seaice
 
 !=================================================================================================================
@@ -160,6 +192,7 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: convection_scheme, &
+                                  lsm_scheme,        &
                                   microp_scheme
 
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,br,chs,chs2,cpm,cqs2,qgh,qsfc,glw,gsw,grdflx,hfx, &
@@ -175,6 +208,7 @@
 !call mpas_log_write('--- enter subroutine seaice_from_MPAS:')
 
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
+ call mpas_pool_get_config(configs,'config_lsm_scheme'       ,lsm_scheme       )
  call mpas_pool_get_config(configs,'config_microp_scheme'    ,microp_scheme    )
 
  call mpas_pool_get_array(diag_physics,'acsnom'    ,acsnom    )
@@ -192,12 +226,9 @@
  call mpas_pool_get_array(diag_physics,'hfx'       ,hfx       )
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'lh'        ,lh        )
- call mpas_pool_get_array(diag_physics,'noahres'   ,noahres   )
- call mpas_pool_get_array(diag_physics,'potevp'    ,potevp    )
  call mpas_pool_get_array(diag_physics,'sfc_albedo',sfc_albedo)
  call mpas_pool_get_array(diag_physics,'sfc_emiss' ,sfc_emiss )
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
- call mpas_pool_get_array(diag_physics,'snopcx'    ,snopcx    )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
 
@@ -236,9 +267,6 @@
        albsi_p(i,j)     = seaice_albedo_default
        snowsi_p(i,j)    = seaice_snowdepth_min
        icedepth_p(i,j)  = seaice_thickness_default
-       !--- inout optional variables:
-       potevp_p(i,j)    = potevp(i)
-       snopcx_p(i,j)    = snopcx(i)
 
        !--- output variables:
        hfx_p(i,j)       = hfx(i)
@@ -248,8 +276,6 @@
        grdflx_p(i,j)    = grdflx(i)
        qsfc_p(i,j)      = qsfc(i)
        chs2_p(i,j)      = chs2(i)
-       !--- output optional variables:
-       noahres_p(i,j)   = noahres(i)
 
        !modify the surface albedo and surface emissivity, and surface temperatures over sea-ice points:
        if(xice(i).ge.xice_threshold .and. xice(i).le.1._RKIND) then
@@ -290,6 +316,24 @@
     endif
  enddo
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call mpas_pool_get_array(diag_physics,'noahres',noahres)
+       call mpas_pool_get_array(diag_physics,'potevp' ,potevp )
+       call mpas_pool_get_array(diag_physics,'snopcx' ,snopcx )
+
+       do j = jts,jte
+          do i = its,ite
+             !--- inout and out optional variables:
+             noahres_p(i,j) = noahres(i)
+             potevp_p(i,j)  = potevp(i)
+             snopcx_p(i,j)  = snopcx(i)
+          enddo
+       enddo
+
+    case default
+ end select sf_select
+
 !call mpas_log_write('--- end subroutine seaice_from_MPAS:')
 
  end subroutine seaice_from_MPAS
@@ -305,7 +349,7 @@
  integer,intent(in):: its,ite
 
 !local pointers:
- character(len=StrKIND),pointer:: config_microp_scheme
+ character(len=StrKIND),pointer:: lsm_scheme
 
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,chs,chs2,cpm,cqs2,qgh,qsfc,grdflx,hfx, qfx,lh,noahres, &
                                          potevp,sfc_albedo,sfc_emiss,sfcrunoff,snopcx,z0,znt
@@ -319,6 +363,8 @@
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('--- enter subroutine seaice_to_MPAS:')
 
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
  call mpas_pool_get_array(diag_physics,'acsnom'    ,acsnom    )
  call mpas_pool_get_array(diag_physics,'acsnow'    ,acsnow    )
  call mpas_pool_get_array(diag_physics,'chs'       ,chs       )
@@ -331,12 +377,9 @@
  call mpas_pool_get_array(diag_physics,'hfx'       ,hfx       )
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'lh'        ,lh        )
- call mpas_pool_get_array(diag_physics,'noahres'   ,noahres   )
- call mpas_pool_get_array(diag_physics,'potevp'    ,potevp    )
  call mpas_pool_get_array(diag_physics,'sfc_albedo',sfc_albedo)
  call mpas_pool_get_array(diag_physics,'sfc_emiss' ,sfc_emiss )
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
- call mpas_pool_get_array(diag_physics,'snopcx'    ,snopcx    )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
  call mpas_pool_get_array(diag_physics,'t2m'       ,t2m       )
@@ -396,15 +439,10 @@
        acsnom(i)    = acsnom_p(i,j)
        acsnow(i)    = acsnow_p(i,j)
        sfcrunoff(i) = sfcrunoff_p(i,j)
-       !--- inout optional variables:
-       potevp(i)    = potevp_p(i,j)
-       snopcx(i)    = snopcx_p(i,j)
 
        !--- output variables:
        znt(i)       = znt_p(i,j)
        grdflx(i)    = grdflx_p(i,j)
-       !--- output optional variables:
-       noahres(i)   = noahres_p(i,j)
 
        chs(i)  = chs_p(i,j)
        chs2(i) = chs2_p(i,j)
@@ -424,6 +462,24 @@
     enddo
  enddo
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call mpas_pool_get_array(diag_physics,'noahres',noahres)
+       call mpas_pool_get_array(diag_physics,'potevp' ,potevp )
+       call mpas_pool_get_array(diag_physics,'snopcx' ,snopcx )
+
+       do j = jts,jte
+          do i = its,ite
+             !--- inout and out optional variables:
+             noahres(i) = noahres_p(i,j)
+             potevp(i)  = potevp_p(i,j)
+             snopcx(i)  = snopcx_p(i,j)
+          enddo
+       enddo
+
+    case default
+ end select sf_select
+
 !call mpas_log_write('--- end subroutine seaice_to_MPAS:')
 
  end subroutine seaice_to_MPAS
@@ -441,44 +497,82 @@
  type(mpas_pool_type),intent(inout):: sfc_input
 
 !local pointers:
- integer:: i,j
+ character(len=StrKIND),pointer:: lsm_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' ')
 !call mpas_log_write('--- enter subroutine driver_seaice: xice_threshold = $r',realArgs=(/xice_threshold/))
 
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
 !copy MPAS arrays to local arrays:
  call seaice_from_MPAS(configs,diag_physics,sfc_input,its,ite)
 
- call seaice_noah( &
-             dz8w      = dz_p        , p8w3d   = pres2_hyd_p  , t3d      = t_p      , &
-             qv3d      = qv_p        , xice    = xice_p       , snoalb2d = snoalb_p , &
-             glw       = glw_p       , swdown  = swdown_p     , rainbl   = rainbl_p , &
-             sr        = sr_p        , qgh     = qgh_p        , tsk      = tsk_p    , &
-             hfx       = hfx_p       , qfx     = qfx_p        , lh       = lh_p     , &
-             grdflx    = grdflx_p    , potevp  = potevp_p     , qsfc     = qsfc_p   , &
-             emiss     = sfc_emiss_p , albedo  = sfc_albedo_p , rib      = br_p     , &
-             cqs2      = cqs2_p      , chs     = chs_p        , chs2     = chs2_p   , &
-             z02d      = z0_p        , znt     = znt_p        , tslb     = tslb_p   , &
-             snow      = snow_p      , snowc   = snowc_p      , snowh2d  = snowh_p  , &
-             snopcx    = snopcx_p    , acsnow  = acsnow_p     , acsnom   = acsnom_p , &
-             sfcrunoff = sfcrunoff_p , albsi   = albsi_p      , snowsi   = snowsi_p , &
-             icedepth  = icedepth_p  , noahres = noahres_p    , dt       = dt_pbl   , &
-             frpcpn    = frpcpn      ,                                                &
-             seaice_albedo_opt        = seaice_albedo_opt        ,                    &
-             seaice_albedo_default    = seaice_albedo_default    ,                    &
-             seaice_thickness_opt     = seaice_thickness_opt     ,                    &
-             seaice_thickness_default = seaice_thickness_default ,                    &
-             seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                    &
-             seaice_snowdepth_max     = seaice_snowdepth_max     ,                    &
-             seaice_snowdepth_min     = seaice_snowdepth_min     ,                    &
-             xice_threshold           = xice_threshold           ,                    &
-             num_soil_layers          = num_soils                ,                    &
-             sf_urban_physics         = sf_urban_physics         ,                    &
-             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,  &
-             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,  &
-             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &
-                 )
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call seaice_noah( &
+                dz8w   = dz_p         , p8w3d     = pres2_hyd_p , t3d      = t_p         , &
+                qv3d   = qv_p         , xice      = xice_p      , snoalb2d = snoalb_p    , &
+                glw    = glw_p        , swdown    = swdown_p    , rainbl   = rainbl_p    , &
+                sr     = sr_p         , qgh       = qgh_p       , tsk      = tsk_p       , &
+                hfx    = hfx_p        , qfx       =  qfx_p      , lh       = lh_p        , &
+                grdflx = grdflx_p     , qsfc      = qsfc_p      , emiss    = sfc_emiss_p , &
+                albedo = sfc_albedo_p , rib       = br_p        , cqs2     = cqs2_p      , &
+                chs    = chs_p        , chs2      = chs2_p      , z02d     = z0_p        , &
+                znt    = znt_p        , tslb      = tslb_p      , snow     = snow_p      , &
+                snowc  = snowc_p      , snowh2d   = snowh_p     , acsnow   = acsnow_p    , &
+                acsnom = acsnom_p     , sfcrunoff = sfcrunoff_p , albsi    = albsi_p     , &
+                snowsi = snowsi_p     , icedepth  = icedepth_p  , dt       = dt_pbl      , &
+                frpcpn = frpcpn       , noahres = noahres_p     , potevp  = potevp_p     , &
+                snopcx    = snopcx_p                                                     , &
+                seaice_albedo_opt        = seaice_albedo_opt        ,                      &
+                seaice_albedo_default    = seaice_albedo_default    ,                      &
+                seaice_thickness_opt     = seaice_thickness_opt     ,                      &
+                seaice_thickness_default = seaice_thickness_default ,                      &
+                seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                      &
+                seaice_snowdepth_max     = seaice_snowdepth_max     ,                      &
+                seaice_snowdepth_min     = seaice_snowdepth_min     ,                      &
+                xice_threshold           = xice_threshold           ,                      &
+                num_soil_layers          = num_soils                ,                      &
+                sf_urban_physics         = sf_urban_physics         ,                      &
+                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,    &
+                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,    &
+                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte      &
+                       )
+
+
+    case("sf_noahmp")
+       call seaice_noah( &
+                dz8w   = dz_p         , p8w3d     = pres2_hyd_p , t3d      = t_p         , &
+                qv3d   = qv_p         , xice      = xice_p      , snoalb2d = snoalb_p    , &
+                glw    = glw_p        , swdown    = swdown_p    , rainbl   = rainbl_p    , &
+                sr     = sr_p         , qgh       = qgh_p       , tsk      = tsk_p       , &
+                hfx    = hfx_p        , qfx       =  qfx_p      , lh       = lh_p        , &
+                grdflx = grdflx_p     , qsfc      = qsfc_p      , emiss    = sfc_emiss_p , &
+                albedo = sfc_albedo_p , rib       = br_p        , cqs2     = cqs2_p      , &
+                chs    = chs_p        , chs2      = chs2_p      , z02d     = z0_p        , &
+                znt    = znt_p        , tslb      = tslb_p      , snow     = snow_p      , &
+                snowc  = snowc_p      , snowh2d   = snowh_p     , acsnow   = acsnow_p    , &
+                acsnom = acsnom_p     , sfcrunoff = sfcrunoff_p , albsi    = albsi_p     , &
+                snowsi = snowsi_p     , icedepth  = icedepth_p  , dt       = dt_pbl      , &
+                frpcpn = frpcpn       ,                                                    &
+                seaice_albedo_opt        = seaice_albedo_opt        ,                      &
+                seaice_albedo_default    = seaice_albedo_default    ,                      &
+                seaice_thickness_opt     = seaice_thickness_opt     ,                      &
+                seaice_thickness_default = seaice_thickness_default ,                      &
+                seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                      &
+                seaice_snowdepth_max     = seaice_snowdepth_max     ,                      &
+                seaice_snowdepth_min     = seaice_snowdepth_min     ,                      &
+                xice_threshold           = xice_threshold           ,                      &
+                num_soil_layers          = num_soils                ,                      &
+                sf_urban_physics         = sf_urban_physics         ,                      &
+                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,    &
+                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,    &
+                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte      &
+                       )
+
+    case default
+ end select sf_select
 
 !copy local arrays to MPAS grid:
  call seaice_to_MPAS(configs,diag_physics,sfc_input,its,ite)

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -245,7 +245,7 @@
                                          grainxy,lfmassxy,qrainxy,qsnowxy,rtmassxy,sneqvoxy,stblcpxy,stmassxy, &
                                          tahxy,tgxy,tvxy,xsaixy,waxy,woodxy,wslakexy,wtxy,zwtxy
  real(kind=RKIND),dimension(:),pointer:: irwatsi,ireloss,irrsplh,irwatmi,irmivol,irwatfi,irfivol
- real(kind=RKIND),dimension(:),pointer:: qtdrain,t2mbxy,t2mvxy
+ real(kind=RKIND),dimension(:),pointer:: qtdrain,t2mbxy,t2mvxy,t2mxy
  
  real(kind=RKIND),dimension(:,:),pointer:: dzs,sh2o,smois,tslb
  real(kind=RKIND),dimension(:,:),pointer:: snicexy,snliqxy,tsnoxy,zsnsoxy
@@ -388,6 +388,7 @@
 
  call mpas_pool_get_array(output_noahmp,'t2mbxy',t2mbxy  )
  call mpas_pool_get_array(output_noahmp,'t2mvxy',t2mvxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy' ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain)
 
 
@@ -476,6 +477,7 @@
     qtdrain(i)  = mpas_noahmp%qtdrain(i)
     t2mbxy(i)   = mpas_noahmp%t2mbxy(i)
     t2mvxy(i)   = mpas_noahmp%t2mvxy(i)
+    t2mxy(i)    = mpas_noahmp%t2mxy(i)
  enddo
 
  do i = its, ite

--- a/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
@@ -1,0 +1,128 @@
+! Copyright (c) 2024 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_atmphys_sfc_diagnostics
+ use mpas_kind_types,only: RKIND,StrKIND
+ use mpas_derived_types,only: mpas_pool_type
+ use mpas_log,only: mpas_log_write
+ use mpas_pool_routines,only: mpas_pool_get_config,mpas_pool_get_dimension,mpas_pool_get_array
+
+ use mpas_atmphys_constants,only: cp,P0,R_d,rcp
+ use mpas_atmphys_vars,only: xice_threshold
+
+
+ implicit none
+ private
+ public:: atmphys_sfc_diagnostics
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine atmphys_sfc_diagnostics(configs,mesh,diag,diag_physics,sfc_input,output_noahmp,its,ite)
+!=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: diag
+ type(mpas_pool_type),intent(in):: output_noahmp
+ type(mpas_pool_type),intent(in):: sfc_input
+ integer,intent(in):: its,ite
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: diag_physics
+
+!local variables and pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+ integer,pointer:: nCellsSolve
+ integer:: i
+
+ real(kind=RKIND),dimension(:),pointer:: psfc
+ real(kind=RKIND),dimension(:),pointer:: tsk,xice,xland
+ real(kind=RKIND),dimension(:),pointer:: hfx,qfx,qsfc,chs2,cqs2
+ real(kind=RKIND),dimension(:),pointer:: q2mxy,t2mxy
+ real(kind=RKIND),dimension(:),pointer:: q2,t2m,th2m
+
+ real(kind=RKIND):: rho
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine atmphys_sfc_diagnostics:')
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+
+ call mpas_pool_get_array(diag,'surface_pressure',psfc)
+
+ call mpas_pool_get_array(diag_physics,'chs2',chs2)
+ call mpas_pool_get_array(diag_physics,'cqs2',cqs2)
+ call mpas_pool_get_array(diag_physics,'hfx' ,hfx )
+ call mpas_pool_get_array(diag_physics,'qfx' ,qfx )
+ call mpas_pool_get_array(diag_physics,'qsfc',qsfc)
+ call mpas_pool_get_array(diag_physics,'q2'  ,q2  )
+ call mpas_pool_get_array(diag_physics,'t2m' ,t2m )
+ call mpas_pool_get_array(diag_physics,'th2m',th2m)
+
+ call mpas_pool_get_array(sfc_input,'skintemp',tsk  )
+ call mpas_pool_get_array(sfc_input,'xice'    ,xice )
+ call mpas_pool_get_array(sfc_input,'xland'   ,xland)
+
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       do i = 1,nCellsSolve
+          rho = psfc(i)/(R_d*tsk(i))
+          if(cqs2(i) .lt. 1.e-5) then
+             q2(i) = qsfc(i)
+          else
+             q2(i) = qsfc(i) - qfx(i)/(rho*cqs2(i))
+          endif
+          if(chs2(i) .lt. 1.e-5) then
+             t2m(i) = tsk(i)
+          else
+             t2m(i) = tsk(i) - hfx(i)/(rho*cp*chs2(i))
+          endif
+          th2m(i) = t2m(i)*(P0/psfc(i))**rcp
+       enddo
+
+    case("sf_noahmp")
+       call mpas_pool_get_array(output_noahmp,'q2mxy',q2mxy)
+       call mpas_pool_get_array(output_noahmp,'t2mxy',t2mxy)
+       do i = 1,nCellsSolve
+          rho = psfc(i)/(R_d*tsk(i))
+          if((xland(i)-1.5 .gt. 0._RKIND) .or. (xland(i)-1.5.le.0._RKIND .and. xice(i).ge.xice_threshold)) then
+             if(cqs2(i) .lt. 1.e-5) then
+                q2(i) = qsfc(i)
+             else
+                q2(i) = qsfc(i) - qfx(i)/(rho*cqs2(i))
+             endif
+             if(chs2(i) .lt. 1.e-5) then
+                t2m(i) = tsk(i)
+             else
+                t2m(i) = tsk(i) - hfx(i)/(rho*cp*chs2(i))
+             endif
+          else
+             q2(i)  = q2mxy(i)
+             t2m(i) = t2mxy(i)
+          endif
+          th2m(i) = t2m(i)*(P0/psfc(i))**rcp
+       enddo
+
+    case default
+ end select sf_select
+
+!call mpas_log_write('--- end subroutine atmphys_sfc_diagnostics:')
+
+ end subroutine atmphys_sfc_diagnostics
+
+!=================================================================================================================
+ end module mpas_atmphys_sfc_diagnostics
+!=================================================================================================================
+

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
@@ -119,6 +119,7 @@ contains
     NoahmpIO%ZNT     (I) = noahmp%energy%state%RoughLenMomSfcToAtm
     NoahmpIO%T2MVXY  (I) = noahmp%energy%state%TemperatureAir2mVeg
     NoahmpIO%T2MBXY  (I) = noahmp%energy%state%TemperatureAir2mBare
+    NoahmpIO%T2MXY   (I) = noahmp%energy%state%TemperatureAir2m
     NoahmpIO%TRADXY  (I) = noahmp%energy%state%TemperatureRadSfc
     NoahmpIO%FVEGXY  (I) = noahmp%energy%state%VegFrac
     NoahmpIO%RSSUNXY (I) = noahmp%energy%state%ResistanceStomataSunlit
@@ -135,6 +136,7 @@ contains
     NoahmpIO%CHB2XY  (I) = noahmp%energy%state%ExchCoeffSh2mBare
     NoahmpIO%Q2MVXY  (I) = noahmp%energy%state%SpecHumidity2mVeg /(1.0-noahmp%energy%state%SpecHumidity2mVeg)  ! spec humidity to mixing ratio
     NoahmpIO%Q2MBXY  (I) = noahmp%energy%state%SpecHumidity2mBare/(1.0-noahmp%energy%state%SpecHumidity2mBare)
+    NoahmpIO%Q2MXY   (I) = noahmp%energy%state%SpecHumidity2m/(1.0-noahmp%energy%state%SpecHumidity2m)
     NoahmpIO%IRRSPLH (I) = NoahmpIO%IRRSPLH(I) + &
                              (noahmp%energy%flux%HeatLatentIrriEvap * noahmp%config%domain%MainTimeStep)
     NoahmpIO%TSLB    (I,1:NumSoilLayer)       = noahmp%energy%state%TemperatureSoilSnow(1:NumSoilLayer)

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarFinalizeMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarFinalizeMod.F90
@@ -196,8 +196,10 @@ contains
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)   
     if ( allocated (NoahmpIO%t2mvxy)     ) deallocate ( NoahmpIO%t2mvxy             ) ! 2m temperature of vegetation part
     if ( allocated (NoahmpIO%t2mbxy)     ) deallocate ( NoahmpIO%t2mbxy             ) ! 2m temperature of bare ground part
+    if ( allocated (NoahmpIO%t2mxy)      ) deallocate ( NoahmpIO%t2mxy              ) ! 2m grid-mean temperature
     if ( allocated (NoahmpIO%q2mvxy)     ) deallocate ( NoahmpIO%q2mvxy             ) ! 2m mixing ratio of vegetation part
     if ( allocated (NoahmpIO%q2mbxy)     ) deallocate ( NoahmpIO%q2mbxy             ) ! 2m mixing ratio of bare ground part
+    if ( allocated (NoahmpIO%q2mxy)      ) deallocate ( NoahmpIO%q2mxy              ) ! 2m grid-mean mixing ratio
     if ( allocated (NoahmpIO%tradxy)     ) deallocate ( NoahmpIO%tradxy             ) ! surface radiative temperature (K)
     if ( allocated (NoahmpIO%neexy)      ) deallocate ( NoahmpIO%neexy              ) ! net ecosys exchange (g/m2/s CO2)
     if ( allocated (NoahmpIO%gppxy)      ) deallocate ( NoahmpIO%gppxy              ) ! gross primary assimilation [g/m2/s C]

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarInitMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarInitMod.F90
@@ -200,8 +200,10 @@ contains
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)   
     if ( .not. allocated (NoahmpIO%t2mvxy)     ) allocate ( NoahmpIO%t2mvxy      (its:ite) ) ! 2m temperature of vegetation part
     if ( .not. allocated (NoahmpIO%t2mbxy)     ) allocate ( NoahmpIO%t2mbxy      (its:ite) ) ! 2m temperature of bare ground part
+    if ( .not. allocated (NoahmpIO%t2mxy)      ) allocate ( NoahmpIO%t2mxy       (its:ite) ) ! 2m grid-mean temperature
     if ( .not. allocated (NoahmpIO%q2mvxy)     ) allocate ( NoahmpIO%q2mvxy      (its:ite) ) ! 2m mixing ratio of vegetation part
     if ( .not. allocated (NoahmpIO%q2mbxy)     ) allocate ( NoahmpIO%q2mbxy      (its:ite) ) ! 2m mixing ratio of bare ground part
+    if ( .not. allocated (NoahmpIO%q2mxy)      ) allocate ( NoahmpIO%q2mxy       (its:ite) ) ! 2m grid-mean mixing ratio
     if ( .not. allocated (NoahmpIO%tradxy)     ) allocate ( NoahmpIO%tradxy      (its:ite) ) ! surface radiative temperature (K)
     if ( .not. allocated (NoahmpIO%neexy)      ) allocate ( NoahmpIO%neexy       (its:ite) ) ! net ecosys exchange (g/m2/s CO2)
     if ( .not. allocated (NoahmpIO%gppxy)      ) allocate ( NoahmpIO%gppxy       (its:ite) ) ! gross primary assimilation [g/m2/s C]
@@ -547,8 +549,10 @@ contains
     NoahmpIO%snowc           = undefined_real
     NoahmpIO%t2mvxy          = undefined_real
     NoahmpIO%t2mbxy          = undefined_real
+    NoahmpIO%t2mxy           = undefined_real
     NoahmpIO%q2mvxy          = undefined_real
     NoahmpIO%q2mbxy          = undefined_real
+    NoahmpIO%q2mxy           = undefined_real
     NoahmpIO%tradxy          = undefined_real
     NoahmpIO%neexy           = undefined_real
     NoahmpIO%gppxy           = undefined_real

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarType.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarType.F90
@@ -233,10 +233,12 @@ module NoahmpIOVarType
     real(kind=kind_noahmp), allocatable, dimension(:)      :: loctim               ! local time
  
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mvxy              ! 2m temperature of vegetation part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mbxy              ! 2m temperature of bare ground part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mvxy              ! 2m mixing ratio of vegetation part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mbxy              ! 2m mixing ratio of bare ground part
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mvxy              ! 2m temperature of vegetation part [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mbxy              ! 2m temperature of bare ground part [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mxy               ! 2m grid-mean temperature [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mvxy              ! 2m mixing ratio of vegetation part [kg/kg]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mbxy              ! 2m mixing ratio of bare ground part [kg/kg]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mxy               ! 2m grid-mean mixing ratio [kg/kg]
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  tradxy              ! surface radiative temperature (K)
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  neexy               ! net ecosys exchange (g/m2/s CO2)
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  gppxy               ! gross primary assimilation [g/m2/s C]

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
@@ -127,9 +127,11 @@
        NoahmpIO%tahxy(i)    = NoahmpIO%tsk(i)
        NoahmpIO%t2mvxy(i)   = NoahmpIO%tsk(i)
        NoahmpIO%t2mbxy(i)   = NoahmpIO%tsk(i)
+       NoahmpIO%t2mxy(i)    = NoahmpIO%tsk(i)
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%tahxy(i)  = t0
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mvxy(i) = t0
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mbxy(i) = t0
+       if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mxy(i)  = t0
 
        NoahmpIO%cmxy(i)     = 0.0
        NoahmpIO%chxy(i)     = 0.0

--- a/src/core_test/mpas_halo_testing.F
+++ b/src/core_test/mpas_halo_testing.F
@@ -1,4 +1,4 @@
-! Copyright (c) 2023, The University Corporation for Atmospheric Research (UCAR).
+! Copyright (c) 2023-2024, The University Corporation for Atmospheric Research (UCAR).
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -30,7 +30,7 @@ module mpas_halo_testing
    !-----------------------------------------------------------------------
    subroutine mpas_halo_tests(domain, ierr)
 
-      use mpas_derived_types, only : domain_type, mpas_pool_type, field2DReal, field3DReal
+      use mpas_derived_types, only : domain_type, mpas_pool_type, field1DReal, field2DReal, field3DReal
       use mpas_kind_types, only : StrKIND, RKIND
       use mpas_log, only : mpas_log_write
       use mpas_dmpar, only : mpas_dmpar_max_int
@@ -50,8 +50,10 @@ module mpas_halo_testing
       character(len=StrKIND) :: test_mesg
       type (mpas_pool_type), pointer :: haloExchTest_pool
       type (mpas_pool_type), pointer :: mesh_pool
+      type (field1DReal), pointer :: scratch_1d
       type (field2DReal), pointer :: scratch_2d
       type (field3DReal), pointer :: scratch_3d
+      real (kind=RKIND), dimension(:), pointer :: array_1d
       real (kind=RKIND), dimension(:,:), pointer :: array_2d
       real (kind=RKIND), dimension(:,:,:), pointer :: array_3d
       integer, dimension(:), pointer :: indexToCellID
@@ -98,6 +100,9 @@ module mpas_halo_testing
       call mpas_halo_exch_group_create(domain, 'persistent_group', ierr_local)
       ierr = ior(ierr, ierr_local)
 
+      call mpas_halo_exch_group_add_field(domain, 'persistent_group', 'cellPersistReal1D', iErr=ierr_local)
+      ierr = ior(ierr, ierr_local)
+
       call mpas_halo_exch_group_add_field(domain, 'persistent_group', 'cellPersistReal2D', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
@@ -127,6 +132,9 @@ module mpas_halo_testing
       call mpas_halo_exch_group_add_field(domain, 'scratch_group', 'cellScratchReal2D', iErr=ierr_local)
       ierr = ior(ierr, ierr_local)
 
+      call mpas_halo_exch_group_add_field(domain, 'scratch_group', 'cellScratchReal1D', iErr=ierr_local)
+      ierr = ior(ierr, ierr_local)
+
       call mpas_halo_exch_group_complete(domain, 'scratch_group', ierr_local)
       ierr = ior(ierr, ierr_local)
 
@@ -141,6 +149,10 @@ module mpas_halo_testing
       ! Exchange a group with persistent fields
       !
       write(test_mesg, '(a)') '  Exchanging a halo group with persistent fields: '
+
+      call mpas_pool_get_array(haloExchTest_pool, 'cellPersistReal1D', array_1d)
+      array_1d(:) = -1.0_RKIND
+      array_1d(1:nCellsSolve) = real(indexToCellID(1:nCellsSolve), kind=RKIND)
 
       call mpas_pool_get_array(haloExchTest_pool, 'cellPersistReal2D', array_2d)
       do k = 1, size(array_2d, dim=1)
@@ -160,6 +172,9 @@ module mpas_halo_testing
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND
+
+      diff = diff + sum(abs(array_1d(1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
+
       do k = 1, size(array_2d, dim=1)
          diff = diff + sum(abs(array_2d(k,1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
       end do
@@ -187,11 +202,17 @@ module mpas_halo_testing
       !
       write(test_mesg, '(a)') '  Exchanging a halo group with scratch fields: '
 
+      call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal1D', scratch_1d)
       call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal2D', scratch_2d)
       call mpas_pool_get_field(haloExchTest_pool, 'cellScratchReal3D', scratch_3d)
 
+      call mpas_allocate_scratch_field(scratch_1d)
       call mpas_allocate_scratch_field(scratch_2d)
       call mpas_allocate_scratch_field(scratch_3d)
+
+      call mpas_pool_get_array(haloExchTest_pool, 'cellScratchReal1D', array_1d)
+      array_1d(:) = -1.0_RKIND
+      array_1d(1:nCellsSolve) = real(indexToCellID(1:nCellsSolve), kind=RKIND)
 
       call mpas_pool_get_array(haloExchTest_pool, 'cellScratchReal2D', array_2d)
       do k = 1, size(array_2d, dim=1)
@@ -211,6 +232,9 @@ module mpas_halo_testing
       ierr = ior(ierr, ierr_local)
 
       diff = 0.0_RKIND
+
+      diff = diff + sum(abs(array_1d(1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
+
       do k = 1, size(array_2d, dim=1)
          diff = diff + sum(abs(array_2d(k,1:nCells) - real(indexToCellID(1:nCells), kind=RKIND)))
       end do
@@ -221,6 +245,7 @@ module mpas_halo_testing
       end do
       end do
 
+      call mpas_deallocate_scratch_field(scratch_1d)
       call mpas_deallocate_scratch_field(scratch_2d)
       call mpas_deallocate_scratch_field(scratch_3d)
 

--- a/src/external/SMIOL/smiol.h
+++ b/src/external/SMIOL/smiol.h
@@ -21,7 +21,7 @@ int SMIOL_inquire(void);
  * File methods
  */
 int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
-                    int mode, struct SMIOL_file **file, size_t bufsize);
+                    int mode, struct SMIOL_file **file, size_t bufsize, int fformat);
 int SMIOL_close_file(struct SMIOL_file **file);
 
 /*

--- a/src/external/SMIOL/smiol_codes.inc
+++ b/src/external/SMIOL/smiol_codes.inc
@@ -6,6 +6,7 @@
 #define SMIOL_LIBRARY_ERROR      (-5)
 #define SMIOL_WRONG_ARG_TYPE     (-6)
 #define SMIOL_INSUFFICIENT_ARG   (-7)
+#define SMIOL_INVALID_FORMAT     (-8)
 
 #define SMIOL_FILE_CREATE         (1)
 #define SMIOL_FILE_READ           (2)
@@ -19,3 +20,6 @@
 #define SMIOL_INT32            (2002)
 #define SMIOL_CHAR             (2003)
 #define SMIOL_UNKNOWN_VAR_TYPE (2004)
+
+#define SMIOL_FORMAT_CDF2      (3000)
+#define SMIOL_FORMAT_CDF5      (3001)

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -152,7 +152,7 @@ module mpas_halo
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_iterator_type, MPAS_POOL_CONFIG, &
                                        MPAS_POOL_REAL, MPAS_HALO_REAL, mpas_halo_group, MPAS_LOG_CRIT, &
-                                       field2DReal, field3DReal
+                                       field1DReal, field2DReal, field3DReal
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_remove_subpool, mpas_pool_destroy_pool, &
                                        mpas_pool_begin_iteration, mpas_pool_get_next_member, mpas_pool_get_dimension, &
                                        mpas_pool_remove_field, mpas_pool_get_field
@@ -170,6 +170,7 @@ module mpas_halo
         integer, dimension(:), pointer :: fieldHaloInfo
         integer, dimension(:), pointer :: haloLayers
         type (mpas_halo_group), pointer :: newGroup
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
         integer, pointer :: timeLevel
@@ -229,7 +230,14 @@ module mpas_halo
                 end select
 
                 if (fieldHaloInfo(1) == MPAS_POOL_REAL) then
-                    if (fieldHaloInfo(2) == 2) then
+                    if (fieldHaloInfo(2) == 1) then
+                        call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r1d)
+                        call mpas_halo_compact_halo_info(domain, r1d % sendList, r1d % recvList, r1d % dimSizes, &
+                                                         haloLayers, &
+                                                         newGroup % fields(i) % compactHaloInfo, &
+                                                         newGroup % fields(i) % compactSendLists, &
+                                                         newGroup % fields(i) % compactRecvLists)
+                    else if (fieldHaloInfo(2) == 2) then
                         call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r2d)
                         call mpas_halo_compact_halo_info(domain, r2d % sendList, r2d % recvList, r2d % dimSizes, &
                                                          haloLayers, &
@@ -387,7 +395,7 @@ module mpas_halo
     subroutine mpas_halo_exch_group_add_field(domain, groupName, fieldName, timeLevel, haloLayers, iErr)
 
         use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_field_info_type, MPAS_POOL_REAL, &
-                                       field2DReal, field3DReal, MPAS_LOG_CRIT
+                                       field1DReal, field2DReal, field3DReal, MPAS_LOG_CRIT
         use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_add_config, mpas_pool_get_field_info, &
                                        mpas_pool_add_dimension, mpas_pool_get_field, mpas_pool_add_field
         use mpas_log, only : mpas_log_write
@@ -405,6 +413,7 @@ module mpas_halo
         type (mpas_pool_field_info_type) :: info
         integer, allocatable, dimension(:) :: fieldHaloInfo
         integer :: local_timeLevel
+        type (field1DReal), pointer :: r1d
         type (field2DReal), pointer :: r2d
         type (field3DReal), pointer :: r3d
 
@@ -456,7 +465,10 @@ module mpas_halo
         ! Store a reference to the field itself in the pool
         !
         if (info % fieldType == MPAS_POOL_REAL) then
-            if (info % nDims == 2) then
+            if (info % nDims == 1) then
+                call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r1d, timeLevel=local_timeLevel)
+                call mpas_pool_add_field(group, fieldName//'.field', r1d)
+            else if (info % nDims == 2) then
                 call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r2d, timeLevel=local_timeLevel)
                 call mpas_pool_add_field(group, fieldName//'.field', r2d)
             else if (info % nDims == 3) then
@@ -621,6 +633,27 @@ module mpas_halo
                 select case (group % fields(i) % nDims)
 
                 !
+                ! Packing code for 1-d real-valued fields
+                !
+                case (1)
+                    call mpas_pool_get_array(domain % blocklist % allFields, trim(group % fields(i) % fieldName), &
+                                             group % fields(i) % r1arr, timeLevel=group % fields(i) % timeLevel)
+
+                    !
+                    ! Pack send buffer for all neighbors for current field
+                    !
+                    do iEndp = 1, nSendEndpts
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNSendList
+                                if (j <= nSendLists(iHalo,iEndp)) then
+                                    group % sendBuf(packOffsets(iEndp) + sendListDst(j,iHalo,iEndp)) = &
+                                        group % fields(i) % r1arr(sendListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
+                    end do
+
+                !
                 ! Packing code for 2-d real-valued fields
                 !
                 case (2)
@@ -732,6 +765,22 @@ module mpas_halo
                     select case (group % fields(i) % nDims)
 
                     !
+                    ! Unpacking code for 1-d real-valued fields
+                    !
+                    case (1)
+                        !
+                        ! Unpack recv buffer from all neighbors for current field
+                        !
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNRecvList
+                                if (j <= nRecvLists(iHalo,iEndp)) then
+                                    group % fields(i) % r1arr(recvListDst(j,iHalo,iEndp)) = &
+                                        group % recvBuf(unpackOffsets(iEndp) + recvListSrc(j,iHalo,iEndp))
+                                end if
+                            end do
+                        end do
+
+                    !
                     ! Unpacking code for 2-d real-valued fields
                     !
                     case (2)
@@ -780,7 +829,9 @@ module mpas_halo
         ! to not leave pointers to what might later be incorrect targets
         !
         do i = 1, group % nFields
-            if (group % fields(i) % nDims == 2) then
+            if (group % fields(i) % nDims == 1) then
+                nullify(group % fields(i) % r1arr)
+            else if (group % fields(i) % nDims == 2) then
                 nullify(group % fields(i) % r2arr)
             else if (group % fields(i) % nDims == 3) then
                 nullify(group % fields(i) % r3arr)

--- a/src/framework/mpas_halo_types.inc
+++ b/src/framework/mpas_halo_types.inc
@@ -31,6 +31,7 @@
         integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListDst => null()  ! (maxNRecvList,nHalos,nRecvEndpts)
         integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets => null()    ! (nRecvEndpts)
 
+        real (kind=RKIND), dimension(:), pointer :: r1arr => null()      ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:), pointer :: r2arr => null()    ! Pointer to field array, only used internally
         real (kind=RKIND), dimension(:,:,:), pointer :: r3arr => null()  ! Pointer to field array, only used internally
     end type mpas_halo_field


### PR DESCRIPTION
This PR corrects the calculation of the 2-meter diagnostics (T2M, TH2M, and Q2) when using the Noah-MP land surface scheme. While the computation of 2-meter diagnostics is the same for Noah and Noah-MP over oceans, it is different between the two land surface schemes over land. In Noah-MP, the 2-meter diagnostics are weighted as functions of their respective diagnostics over bare soil and over vegetation. The updated diagnostics for Noah and Noah-MP are now computed in the new file mpas_atmphys_sfc_diagnostics.F.



