### PR TITLE
correct the computation of 2-meter diagnostics with Noah-MP #1240

### DIFF
--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -48,6 +48,7 @@ OBJS = \
 	mpas_atmphys_packages.o            \
 	mpas_atmphys_rrtmg_lwinit.o        \
 	mpas_atmphys_rrtmg_swinit.o        \
+	mpas_atmphys_sfc_diagnostics.o     \
 	mpas_atmphys_todynamics.o          \
 	mpas_atmphys_update_surface.o      \
 	mpas_atmphys_update.o              \
@@ -103,6 +104,7 @@ mpas_atmphys_driver.o: \
 	mpas_atmphys_driver_oml.o \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_interface.o \
+	mpas_atmphys_sfc_diagnostics.o \
 	mpas_atmphys_update.o \
 	mpas_atmphys_vars.o
 
@@ -219,6 +221,10 @@ mpas_atmphys_rrtmg_lwinit.o: \
 mpas_atmphys_rrtmg_swinit.o: \
 	mpas_atmphys_constants.o \
 	mpas_atmphys_utilities.o
+
+mpas_atmphys_sfc_diagnostics.o: \
+	mpas_atmphys_constants.o \
+	mpas_atmphys_vars.o
 
 mpas_atmphys_todynamics.o: \
 	mpas_atmphys_constants.o \

--- a/src/core_atmosphere/physics/Registry_noahmp.xml
+++ b/src/core_atmosphere/physics/Registry_noahmp.xml
@@ -360,11 +360,17 @@
       <var name="t2mbxy" type="real" dimensions="nCells Time" units="K"
                 description="2-meter temperature over bare ground" missing_value="-9999.0"/>
 
+      <var name="t2mxy" type="real" dimensions="nCells Time" units="K"
+                description="grid-mean 2-meter temperature" missing_value="-9999.0"/>
+
       <var name="q2mvxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                 description="2-meter water vapor mixing ratio over canopy" missing_value="-9999.0"/>
 
       <var name="q2mbxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
                 description="2-meter water vapor mixing ratio over bare ground" missing_value="-9999.0"/>
+
+      <var name="q2mxy" type="real" dimensions="nCells Time" units="kg kg^{-1}"
+                description="grid-mean 2-meter water vapor mixing ratio" missing_value="-9999.0"/>
 
       <var name="tradxy" type="real" dimensions="nCells Time" units="K"
                 description="surface radiative temperature" missing_value="-9999.0"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -296,14 +296,14 @@
           enddo
        endif
 
-       call allocate_seaice
+       call allocate_seaice(block%configs)
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_seaice(block%configs,diag_physics,sfc_input, &
                              cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        enddo
 !$OMP END PARALLEL DO
-       call deallocate_seaice
+       call deallocate_seaice(block%configs)
     endif
 
     !call to pbl schemes:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -23,6 +23,7 @@
  use mpas_atmphys_driver_oml
  use mpas_atmphys_constants
  use mpas_atmphys_interface
+ use mpas_atmphys_sfc_diagnostics,only: atmphys_sfc_diagnostics
  use mpas_atmphys_update
  use mpas_atmphys_vars, only: l_camlw,l_conv,l_radtlw,l_radtsw
  use mpas_timer
@@ -304,6 +305,13 @@
        enddo
 !$OMP END PARALLEL DO
        call deallocate_seaice(block%configs)
+
+!$OMP PARALLEL DO
+       do thread=1,nThreads
+          call atmphys_sfc_diagnostics(block%configs,mesh,diag,diag_physics,sfc_input,output_noahmp, &
+                           cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
+       enddo
+!$OMP END PARALLEL DO
     endif
 
     !call to pbl schemes:

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
@@ -84,11 +84,11 @@
 
 
 !--- local OUT pointers (with no Noah LSM equivalent as defined in WRF):
- real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,q2mvxy,q2mbxy,tradxy,neexy,gppxy,nppxy,fvegxy,runsfxy,  &
-                                         runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,psnxy,savxy,sagxy,  &
-                                         rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy,chbxy,shgxy,shcxy,    &
-                                         shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy,trxy,evcxy,chleafxy,  &
-                                         chucxy,chv2xy,chb2xy,rs,qtdrain
+ real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,t2mxy,q2mvxy,q2mbxy,q2mxy,tradxy,neexy,gppxy,nppxy,  &
+                                         fvegxy,runsfxy,runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,  &
+                                         psnxy,savxy,sagxy,rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy, &
+                                         chbxy,shgxy,shcxy,shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy, &
+                                         trxy,evcxy,chleafxy,chucxy,chv2xy,chb2xy,rs,qtdrain
 
 
 !--- local OUT additional variables:
@@ -377,8 +377,10 @@
 !    see lines 242-290 in module NoahmpIOVarType.F90):
  call mpas_pool_get_array(output_noahmp,'t2mvxy'  ,t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'t2mbxy'  ,t2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy'   ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'q2mvxy'  ,q2mvxy  )
  call mpas_pool_get_array(output_noahmp,'q2mbxy'  ,q2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'q2mxy'   ,q2mxy   )
  call mpas_pool_get_array(output_noahmp,'tradxy'  ,tradxy  )
  call mpas_pool_get_array(output_noahmp,'neexy'   ,neexy   )
  call mpas_pool_get_array(output_noahmp,'gppxy'   ,gppxy   )
@@ -423,10 +425,12 @@
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain  )
 
  do i = its,ite
-    mpas_noahmp%t2mvxy(i)   = t2mvxy(i)
-    mpas_noahmp%t2mbxy(i)   = t2mbxy(i)
-    mpas_noahmp%q2mvxy(i)   = q2mvxy(i)
-    mpas_noahmp%q2mbxy(i)   = q2mbxy(i)
+!   mpas_noahmp%t2mvxy(i)   = t2mvxy(i)
+!   mpas_noahmp%t2mbxy(i)   = t2mbxy(i)
+!   mpas_noahmp%t2mxy(i)    = t2mxy(i)
+!   mpas_noahmp%q2mvxy(i)   = q2mvxy(i)
+!   mpas_noahmp%q2mbxy(i)   = q2mbxy(i)
+!   mpas_noahmp%q2mxy(i)    = q2mxy(i)
     mpas_noahmp%tradxy(i)   = tradxy(i)
     mpas_noahmp%neexy(i)    = neexy(i)
     mpas_noahmp%gppxy(i)    = gppxy(i)
@@ -685,11 +689,11 @@
 
 
 !--- local OUT pointers (with no Noah LSM equivalent as defined in WRF):
- real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,q2mvxy,q2mbxy,tradxy,neexy,gppxy,nppxy,fvegxy,runsfxy,  &
-                                         runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,psnxy,savxy,sagxy,  &
-                                         rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy,chbxy,shgxy,shcxy,    &
-                                         shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy,trxy,evcxy,chleafxy,  &
-                                         chucxy,chv2xy,chb2xy,rs,qtdrain
+ real(kind=RKIND),dimension(:),pointer:: t2mvxy,t2mbxy,t2mxy,q2mvxy,q2mbxy,q2mxy,tradxy,neexy,gppxy,nppxy,  &
+                                         fvegxy,runsfxy,runsbxy,ecanxy,edirxy,etranxy,fsaxy,firaxy,aparxy,  &
+                                         psnxy,savxy,sagxy,rssunxy,rsshaxy,bgapxy,wgapxy,tgvxy,tgbxy,chvxy, &
+                                         chbxy,shgxy,shcxy,shbxy,evgxy,evbxy,ghvxy,ghbxy,irgxy,ircxy,irbxy, &
+                                         trxy,evcxy,chleafxy,chucxy,chv2xy,chb2xy,rs,qtdrain
 
 
 !--- local OUT additional variables:
@@ -702,7 +706,7 @@
  real(kind=RKIND),dimension(:,:),pointer:: acc_etranixy
 
 !-----------------------------------------------------------------------------------------------------------------
-!call mpas_log_write('--- enter subroutine lsm_noahmp_toMPAS:')
+ call mpas_log_write('--- enter subroutine lsm_noahmp_toMPAS:')
 
 
 !--- initialization of local dimensions:
@@ -865,8 +869,10 @@
 !    lines 242-290 in module NoahmpIOVarType.F90:
  call mpas_pool_get_array(output_noahmp,'t2mvxy'  ,t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'t2mbxy'  ,t2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy'   ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'q2mvxy'  ,q2mvxy  )
  call mpas_pool_get_array(output_noahmp,'q2mbxy'  ,q2mbxy  )
+ call mpas_pool_get_array(output_noahmp,'q2mxy'   ,q2mxy   )
  call mpas_pool_get_array(output_noahmp,'tradxy'  ,tradxy  )
  call mpas_pool_get_array(output_noahmp,'neexy'   ,neexy   )
  call mpas_pool_get_array(output_noahmp,'gppxy'   ,gppxy   )
@@ -913,8 +919,10 @@
  do i = its,ite
     t2mvxy(i)   = mpas_noahmp%t2mvxy(i)
     t2mbxy(i)   = mpas_noahmp%t2mbxy(i)
+    t2mxy(i)    = mpas_noahmp%t2mxy(i)
     q2mvxy(i)   = mpas_noahmp%q2mvxy(i)
     q2mbxy(i)   = mpas_noahmp%q2mbxy(i)
+    q2mxy(i)    = mpas_noahmp%q2mxy(i)
     tradxy(i)   = mpas_noahmp%tradxy(i)
     neexy(i)    = mpas_noahmp%neexy(i)
     gppxy(i)    = mpas_noahmp%gppxy(i)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
@@ -80,9 +80,6 @@
  if(.not.allocated(xice_p)      ) allocate(xice_p(ims:ime,jms:jme)      )
  if(.not.allocated(z0_p)        ) allocate(z0_p(ims:ime,jms:jme)        )
  if(.not.allocated(znt_p)       ) allocate(znt_p(ims:ime,jms:jme)       )
- if(.not.allocated(q2_p)        ) allocate(q2_p(ims:ime,jms:jme)        )
- if(.not.allocated(t2m_p)       ) allocate(t2m_p(ims:ime,jms:jme)       )
- if(.not.allocated(th2m_p)      ) allocate(th2m_p(ims:ime,jms:jme)      )
 
  if(.not.allocated(tsk_sea)     ) allocate(tsk_sea(ims:ime,jms:jme)     )
  if(.not.allocated(tsk_ice)     ) allocate(tsk_ice(ims:ime,jms:jme)     )
@@ -148,9 +145,6 @@
  if(allocated(xice_p)      ) deallocate(xice_p      )
  if(allocated(z0_p)        ) deallocate(z0_p        )
  if(allocated(znt_p)       ) deallocate(znt_p       )
- if(allocated(q2_p)        ) deallocate(q2_p        )
- if(allocated(t2m_p)       ) deallocate(t2m_p       )
- if(allocated(th2m_p)      ) deallocate(th2m_p      )
 
  if(allocated(chs_sea)     ) deallocate(chs_sea     )
  if(allocated(chs2_sea)    ) deallocate(chs2_sea    )
@@ -354,7 +348,6 @@
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,chs,chs2,cpm,cqs2,qgh,qsfc,grdflx,hfx, qfx,lh,noahres, &
                                          potevp,sfc_albedo,sfc_emiss,sfcrunoff,snopcx,z0,znt
  real(kind=RKIND),dimension(:),pointer:: snow,snowc,snowh,skintemp,xice
- real(kind=RKIND),dimension(:),pointer:: t2m,th2m,q2
  real(kind=RKIND),dimension(:,:),pointer:: tslb
 
 !local variables and arrays:
@@ -382,9 +375,6 @@
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
- call mpas_pool_get_array(diag_physics,'t2m'       ,t2m       )
- call mpas_pool_get_array(diag_physics,'th2m'      ,th2m      )
- call mpas_pool_get_array(diag_physics,'q2'        ,q2        )
 
  call mpas_pool_get_array(sfc_input,'snow'    ,snow    )
  call mpas_pool_get_array(sfc_input,'snowc'   ,snowc   )
@@ -393,7 +383,7 @@
  call mpas_pool_get_array(sfc_input,'tslb'    ,tslb    )
  call mpas_pool_get_array(sfc_input,'xice'    ,xice    )
 
-!--- weigh local variables needed in the calculation of t2m, th2m, and q2 over seaice points:
+!--- reconstruct local variables as functions of the seaice fraction:
  do j = jts,jte
     do i = its,ite
        if(xice_p(i,j).ge.xice_threshold .and. xice_p(i,j).le.1._RKIND) then
@@ -413,16 +403,6 @@
        endif
     enddo
  enddo
-
- call sfcdiags( &
-             hfx   = hfx_p  , qfx     = qfx_p   , tsk  = tsk_p , qsfc = qsfc_p , chs = chs_p , &
-             chs2  = chs2_p , cqs2    = cqs2_p  , t2   = t2m_p , th2  = th2m_p , q2  = q2_p  , &
-             psfc  = psfc_p , t3d     = t_p     , qv3d = qv_p  , cp   = cp     , R_d = R_d   , &
-             rovcp = rcp    , ua_phys = ua_phys                                              , &
-             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,           &
-             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
-             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
-                    )
 
 !--- update all variables:
  do j = jts,jte
@@ -454,11 +434,6 @@
        lh(i)   = lh_p(i,j)
        sfc_albedo(i) = sfc_albedo_p(i,j)
        sfc_emiss(i)  = sfc_emiss_p(i,j)
-
-       !--- 2-meter diagnostics:
-       q2(i)   = q2_p(i,j)
-       t2m(i)  = t2m_p(i,j)
-       th2m(i) = th2m_p(i,j)
     enddo
  enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_seaice.F
@@ -36,8 +36,18 @@
 
 
 !=================================================================================================================
- subroutine allocate_seaice
+ subroutine allocate_seaice(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+
+!local pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
 
  if(.not.allocated(acsnom_p)    ) allocate(acsnom_p(ims:ime,jms:jme)    )
  if(.not.allocated(acsnow_p)    ) allocate(acsnow_p(ims:ime,jms:jme)    )
@@ -55,8 +65,6 @@
  if(.not.allocated(hfx_p)       ) allocate(hfx_p(ims:ime,jms:jme)       )
  if(.not.allocated(qfx_p)       ) allocate(qfx_p(ims:ime,jms:jme)       )
  if(.not.allocated(lh_p)        ) allocate(lh_p(ims:ime,jms:jme)        )
- if(.not.allocated(noahres_p)   ) allocate(noahres_p(ims:ime,jms:jme)   )
- if(.not.allocated(potevp_p)    ) allocate(potevp_p(ims:ime,jms:jme)    )
  if(.not.allocated(rainbl_p)    ) allocate(rainbl_p(ims:ime,jms:jme)    )
  if(.not.allocated(sfc_albedo_p)) allocate(sfc_albedo_p(ims:ime,jms:jme))
  if(.not.allocated(sfc_emiss_p) ) allocate(sfc_emiss_p(ims:ime,jms:jme) )
@@ -65,7 +73,6 @@
  if(.not.allocated(snow_p)      ) allocate(snow_p(ims:ime,jms:jme)      )
  if(.not.allocated(snowc_p)     ) allocate(snowc_p(ims:ime,jms:jme)     )
  if(.not.allocated(snowh_p)     ) allocate(snowh_p(ims:ime,jms:jme)     )
- if(.not.allocated(snopcx_p)    ) allocate(snopcx_p(ims:ime,jms:jme)    )
  if(.not.allocated(snowsi_p)    ) allocate(snowsi_p(ims:ime,jms:jme)    )
  if(.not.allocated(swdown_p)    ) allocate(swdown_p(ims:ime,jms:jme)    )
  if(.not.allocated(sr_p)        ) allocate(sr_p(ims:ime,jms:jme)        )
@@ -85,11 +92,30 @@
 
  if(.not.allocated(tslb_p)) allocate(tslb_p(ims:ime,1:num_soils,jms:jme))
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       if(.not.allocated(noahres_p)) allocate(noahres_p(ims:ime,jms:jme))
+       if(.not.allocated(potevp_p) ) allocate(potevp_p(ims:ime,jms:jme) )
+       if(.not.allocated(snopcx_p) ) allocate(snopcx_p(ims:ime,jms:jme) )
+
+    case default
+ end select sf_select
+
  end subroutine allocate_seaice
 
 !=================================================================================================================
- subroutine deallocate_seaice
+ subroutine deallocate_seaice(configs)
 !=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+
+!local pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
 
  if(allocated(acsnom_p)    ) deallocate(acsnom_p    )
  if(allocated(acsnow_p)    ) deallocate(acsnow_p    )
@@ -107,8 +133,6 @@
  if(allocated(hfx_p)       ) deallocate(hfx_p       )
  if(allocated(qfx_p)       ) deallocate(qfx_p       )
  if(allocated(lh_p)        ) deallocate(lh_p        )
- if(allocated(noahres_p)   ) deallocate(noahres_p   )
- if(allocated(potevp_p)    ) deallocate(potevp_p    )
  if(allocated(rainbl_p)    ) deallocate(rainbl_p    )
  if(allocated(sfc_albedo_p)) deallocate(sfc_albedo_p)
  if(allocated(sfc_emiss_p) ) deallocate(sfc_emiss_p )
@@ -117,7 +141,6 @@
  if(allocated(snow_p)      ) deallocate(snow_p      )
  if(allocated(snowc_p)     ) deallocate(snowc_p     )
  if(allocated(snowh_p)     ) deallocate(snowh_p     )
- if(allocated(snopcx_p)    ) deallocate(snopcx_p    )
  if(allocated(snowsi_p)    ) deallocate(snowsi_p    )
  if(allocated(swdown_p)    ) deallocate(swdown_p    )
  if(allocated(sr_p)        ) deallocate(sr_p        )
@@ -146,6 +169,15 @@
 
  if(allocated(tslb_p)) deallocate(tslb_p)
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       if(allocated(noahres_p)) deallocate(noahres_p)
+       if(allocated(potevp_p) ) deallocate(potevp_p )
+       if(allocated(snopcx_p) ) deallocate(snopcx_p )
+
+    case default
+ end select sf_select
+
  end subroutine deallocate_seaice
 
 !=================================================================================================================
@@ -160,6 +192,7 @@
 
 !local pointers:
  character(len=StrKIND),pointer:: convection_scheme, &
+                                  lsm_scheme,        &
                                   microp_scheme
 
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,br,chs,chs2,cpm,cqs2,qgh,qsfc,glw,gsw,grdflx,hfx, &
@@ -175,6 +208,7 @@
 !call mpas_log_write('--- enter subroutine seaice_from_MPAS:')
 
  call mpas_pool_get_config(configs,'config_convection_scheme',convection_scheme)
+ call mpas_pool_get_config(configs,'config_lsm_scheme'       ,lsm_scheme       )
  call mpas_pool_get_config(configs,'config_microp_scheme'    ,microp_scheme    )
 
  call mpas_pool_get_array(diag_physics,'acsnom'    ,acsnom    )
@@ -192,12 +226,9 @@
  call mpas_pool_get_array(diag_physics,'hfx'       ,hfx       )
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'lh'        ,lh        )
- call mpas_pool_get_array(diag_physics,'noahres'   ,noahres   )
- call mpas_pool_get_array(diag_physics,'potevp'    ,potevp    )
  call mpas_pool_get_array(diag_physics,'sfc_albedo',sfc_albedo)
  call mpas_pool_get_array(diag_physics,'sfc_emiss' ,sfc_emiss )
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
- call mpas_pool_get_array(diag_physics,'snopcx'    ,snopcx    )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
 
@@ -236,9 +267,6 @@
        albsi_p(i,j)     = seaice_albedo_default
        snowsi_p(i,j)    = seaice_snowdepth_min
        icedepth_p(i,j)  = seaice_thickness_default
-       !--- inout optional variables:
-       potevp_p(i,j)    = potevp(i)
-       snopcx_p(i,j)    = snopcx(i)
 
        !--- output variables:
        hfx_p(i,j)       = hfx(i)
@@ -248,8 +276,6 @@
        grdflx_p(i,j)    = grdflx(i)
        qsfc_p(i,j)      = qsfc(i)
        chs2_p(i,j)      = chs2(i)
-       !--- output optional variables:
-       noahres_p(i,j)   = noahres(i)
 
        !modify the surface albedo and surface emissivity, and surface temperatures over sea-ice points:
        if(xice(i).ge.xice_threshold .and. xice(i).le.1._RKIND) then
@@ -290,6 +316,24 @@
     endif
  enddo
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call mpas_pool_get_array(diag_physics,'noahres',noahres)
+       call mpas_pool_get_array(diag_physics,'potevp' ,potevp )
+       call mpas_pool_get_array(diag_physics,'snopcx' ,snopcx )
+
+       do j = jts,jte
+          do i = its,ite
+             !--- inout and out optional variables:
+             noahres_p(i,j) = noahres(i)
+             potevp_p(i,j)  = potevp(i)
+             snopcx_p(i,j)  = snopcx(i)
+          enddo
+       enddo
+
+    case default
+ end select sf_select
+
 !call mpas_log_write('--- end subroutine seaice_from_MPAS:')
 
  end subroutine seaice_from_MPAS
@@ -305,7 +349,7 @@
  integer,intent(in):: its,ite
 
 !local pointers:
- character(len=StrKIND),pointer:: config_microp_scheme
+ character(len=StrKIND),pointer:: lsm_scheme
 
  real(kind=RKIND),dimension(:),pointer:: acsnom,acsnow,chs,chs2,cpm,cqs2,qgh,qsfc,grdflx,hfx, qfx,lh,noahres, &
                                          potevp,sfc_albedo,sfc_emiss,sfcrunoff,snopcx,z0,znt
@@ -319,6 +363,8 @@
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write('--- enter subroutine seaice_to_MPAS:')
 
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
  call mpas_pool_get_array(diag_physics,'acsnom'    ,acsnom    )
  call mpas_pool_get_array(diag_physics,'acsnow'    ,acsnow    )
  call mpas_pool_get_array(diag_physics,'chs'       ,chs       )
@@ -331,12 +377,9 @@
  call mpas_pool_get_array(diag_physics,'hfx'       ,hfx       )
  call mpas_pool_get_array(diag_physics,'qfx'       ,qfx       )
  call mpas_pool_get_array(diag_physics,'lh'        ,lh        )
- call mpas_pool_get_array(diag_physics,'noahres'   ,noahres   )
- call mpas_pool_get_array(diag_physics,'potevp'    ,potevp    )
  call mpas_pool_get_array(diag_physics,'sfc_albedo',sfc_albedo)
  call mpas_pool_get_array(diag_physics,'sfc_emiss' ,sfc_emiss )
  call mpas_pool_get_array(diag_physics,'sfcrunoff' ,sfcrunoff )
- call mpas_pool_get_array(diag_physics,'snopcx'    ,snopcx    )
  call mpas_pool_get_array(diag_physics,'z0'        ,z0        )
  call mpas_pool_get_array(diag_physics,'znt'       ,znt       )
  call mpas_pool_get_array(diag_physics,'t2m'       ,t2m       )
@@ -396,15 +439,10 @@
        acsnom(i)    = acsnom_p(i,j)
        acsnow(i)    = acsnow_p(i,j)
        sfcrunoff(i) = sfcrunoff_p(i,j)
-       !--- inout optional variables:
-       potevp(i)    = potevp_p(i,j)
-       snopcx(i)    = snopcx_p(i,j)
 
        !--- output variables:
        znt(i)       = znt_p(i,j)
        grdflx(i)    = grdflx_p(i,j)
-       !--- output optional variables:
-       noahres(i)   = noahres_p(i,j)
 
        chs(i)  = chs_p(i,j)
        chs2(i) = chs2_p(i,j)
@@ -424,6 +462,24 @@
     enddo
  enddo
 
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call mpas_pool_get_array(diag_physics,'noahres',noahres)
+       call mpas_pool_get_array(diag_physics,'potevp' ,potevp )
+       call mpas_pool_get_array(diag_physics,'snopcx' ,snopcx )
+
+       do j = jts,jte
+          do i = its,ite
+             !--- inout and out optional variables:
+             noahres(i) = noahres_p(i,j)
+             potevp(i)  = potevp_p(i,j)
+             snopcx(i)  = snopcx_p(i,j)
+          enddo
+       enddo
+
+    case default
+ end select sf_select
+
 !call mpas_log_write('--- end subroutine seaice_to_MPAS:')
 
  end subroutine seaice_to_MPAS
@@ -441,44 +497,82 @@
  type(mpas_pool_type),intent(inout):: sfc_input
 
 !local pointers:
- integer:: i,j
+ character(len=StrKIND),pointer:: lsm_scheme
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' ')
 !call mpas_log_write('--- enter subroutine driver_seaice: xice_threshold = $r',realArgs=(/xice_threshold/))
 
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
 !copy MPAS arrays to local arrays:
  call seaice_from_MPAS(configs,diag_physics,sfc_input,its,ite)
 
- call seaice_noah( &
-             dz8w      = dz_p        , p8w3d   = pres2_hyd_p  , t3d      = t_p      , &
-             qv3d      = qv_p        , xice    = xice_p       , snoalb2d = snoalb_p , &
-             glw       = glw_p       , swdown  = swdown_p     , rainbl   = rainbl_p , &
-             sr        = sr_p        , qgh     = qgh_p        , tsk      = tsk_p    , &
-             hfx       = hfx_p       , qfx     = qfx_p        , lh       = lh_p     , &
-             grdflx    = grdflx_p    , potevp  = potevp_p     , qsfc     = qsfc_p   , &
-             emiss     = sfc_emiss_p , albedo  = sfc_albedo_p , rib      = br_p     , &
-             cqs2      = cqs2_p      , chs     = chs_p        , chs2     = chs2_p   , &
-             z02d      = z0_p        , znt     = znt_p        , tslb     = tslb_p   , &
-             snow      = snow_p      , snowc   = snowc_p      , snowh2d  = snowh_p  , &
-             snopcx    = snopcx_p    , acsnow  = acsnow_p     , acsnom   = acsnom_p , &
-             sfcrunoff = sfcrunoff_p , albsi   = albsi_p      , snowsi   = snowsi_p , &
-             icedepth  = icedepth_p  , noahres = noahres_p    , dt       = dt_pbl   , &
-             frpcpn    = frpcpn      ,                                                &
-             seaice_albedo_opt        = seaice_albedo_opt        ,                    &
-             seaice_albedo_default    = seaice_albedo_default    ,                    &
-             seaice_thickness_opt     = seaice_thickness_opt     ,                    &
-             seaice_thickness_default = seaice_thickness_default ,                    &
-             seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                    &
-             seaice_snowdepth_max     = seaice_snowdepth_max     ,                    &
-             seaice_snowdepth_min     = seaice_snowdepth_min     ,                    &
-             xice_threshold           = xice_threshold           ,                    &
-             num_soil_layers          = num_soils                ,                    &
-             sf_urban_physics         = sf_urban_physics         ,                    &
-             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,  &
-             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,  &
-             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &
-                 )
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       call seaice_noah( &
+                dz8w   = dz_p         , p8w3d     = pres2_hyd_p , t3d      = t_p         , &
+                qv3d   = qv_p         , xice      = xice_p      , snoalb2d = snoalb_p    , &
+                glw    = glw_p        , swdown    = swdown_p    , rainbl   = rainbl_p    , &
+                sr     = sr_p         , qgh       = qgh_p       , tsk      = tsk_p       , &
+                hfx    = hfx_p        , qfx       =  qfx_p      , lh       = lh_p        , &
+                grdflx = grdflx_p     , qsfc      = qsfc_p      , emiss    = sfc_emiss_p , &
+                albedo = sfc_albedo_p , rib       = br_p        , cqs2     = cqs2_p      , &
+                chs    = chs_p        , chs2      = chs2_p      , z02d     = z0_p        , &
+                znt    = znt_p        , tslb      = tslb_p      , snow     = snow_p      , &
+                snowc  = snowc_p      , snowh2d   = snowh_p     , acsnow   = acsnow_p    , &
+                acsnom = acsnom_p     , sfcrunoff = sfcrunoff_p , albsi    = albsi_p     , &
+                snowsi = snowsi_p     , icedepth  = icedepth_p  , dt       = dt_pbl      , &
+                frpcpn = frpcpn       , noahres = noahres_p     , potevp  = potevp_p     , &
+                snopcx    = snopcx_p                                                     , &
+                seaice_albedo_opt        = seaice_albedo_opt        ,                      &
+                seaice_albedo_default    = seaice_albedo_default    ,                      &
+                seaice_thickness_opt     = seaice_thickness_opt     ,                      &
+                seaice_thickness_default = seaice_thickness_default ,                      &
+                seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                      &
+                seaice_snowdepth_max     = seaice_snowdepth_max     ,                      &
+                seaice_snowdepth_min     = seaice_snowdepth_min     ,                      &
+                xice_threshold           = xice_threshold           ,                      &
+                num_soil_layers          = num_soils                ,                      &
+                sf_urban_physics         = sf_urban_physics         ,                      &
+                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,    &
+                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,    &
+                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte      &
+                       )
+
+
+    case("sf_noahmp")
+       call seaice_noah( &
+                dz8w   = dz_p         , p8w3d     = pres2_hyd_p , t3d      = t_p         , &
+                qv3d   = qv_p         , xice      = xice_p      , snoalb2d = snoalb_p    , &
+                glw    = glw_p        , swdown    = swdown_p    , rainbl   = rainbl_p    , &
+                sr     = sr_p         , qgh       = qgh_p       , tsk      = tsk_p       , &
+                hfx    = hfx_p        , qfx       =  qfx_p      , lh       = lh_p        , &
+                grdflx = grdflx_p     , qsfc      = qsfc_p      , emiss    = sfc_emiss_p , &
+                albedo = sfc_albedo_p , rib       = br_p        , cqs2     = cqs2_p      , &
+                chs    = chs_p        , chs2      = chs2_p      , z02d     = z0_p        , &
+                znt    = znt_p        , tslb      = tslb_p      , snow     = snow_p      , &
+                snowc  = snowc_p      , snowh2d   = snowh_p     , acsnow   = acsnow_p    , &
+                acsnom = acsnom_p     , sfcrunoff = sfcrunoff_p , albsi    = albsi_p     , &
+                snowsi = snowsi_p     , icedepth  = icedepth_p  , dt       = dt_pbl      , &
+                frpcpn = frpcpn       ,                                                    &
+                seaice_albedo_opt        = seaice_albedo_opt        ,                      &
+                seaice_albedo_default    = seaice_albedo_default    ,                      &
+                seaice_thickness_opt     = seaice_thickness_opt     ,                      &
+                seaice_thickness_default = seaice_thickness_default ,                      &
+                seaice_snowdepth_opt     = seaice_snowdepth_opt     ,                      &
+                seaice_snowdepth_max     = seaice_snowdepth_max     ,                      &
+                seaice_snowdepth_min     = seaice_snowdepth_min     ,                      &
+                xice_threshold           = xice_threshold           ,                      &
+                num_soil_layers          = num_soils                ,                      &
+                sf_urban_physics         = sf_urban_physics         ,                      &
+                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,    &
+                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,    &
+                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte      &
+                       )
+
+    case default
+ end select sf_select
 
 !copy local arrays to MPAS grid:
  call seaice_to_MPAS(configs,diag_physics,sfc_input,its,ite)

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -245,7 +245,7 @@
                                          grainxy,lfmassxy,qrainxy,qsnowxy,rtmassxy,sneqvoxy,stblcpxy,stmassxy, &
                                          tahxy,tgxy,tvxy,xsaixy,waxy,woodxy,wslakexy,wtxy,zwtxy
  real(kind=RKIND),dimension(:),pointer:: irwatsi,ireloss,irrsplh,irwatmi,irmivol,irwatfi,irfivol
- real(kind=RKIND),dimension(:),pointer:: qtdrain,t2mbxy,t2mvxy
+ real(kind=RKIND),dimension(:),pointer:: qtdrain,t2mbxy,t2mvxy,t2mxy
  
  real(kind=RKIND),dimension(:,:),pointer:: dzs,sh2o,smois,tslb
  real(kind=RKIND),dimension(:,:),pointer:: snicexy,snliqxy,tsnoxy,zsnsoxy
@@ -388,6 +388,7 @@
 
  call mpas_pool_get_array(output_noahmp,'t2mbxy',t2mbxy  )
  call mpas_pool_get_array(output_noahmp,'t2mvxy',t2mvxy  )
+ call mpas_pool_get_array(output_noahmp,'t2mxy' ,t2mxy   )
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain)
 
 
@@ -476,6 +477,7 @@
     qtdrain(i)  = mpas_noahmp%qtdrain(i)
     t2mbxy(i)   = mpas_noahmp%t2mbxy(i)
     t2mvxy(i)   = mpas_noahmp%t2mvxy(i)
+    t2mxy(i)    = mpas_noahmp%t2mxy(i)
  enddo
 
  do i = its, ite

--- a/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_sfc_diagnostics.F
@@ -1,0 +1,128 @@
+! Copyright (c) 2024 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!=================================================================================================================
+ module mpas_atmphys_sfc_diagnostics
+ use mpas_kind_types,only: RKIND,StrKIND
+ use mpas_derived_types,only: mpas_pool_type
+ use mpas_log,only: mpas_log_write
+ use mpas_pool_routines,only: mpas_pool_get_config,mpas_pool_get_dimension,mpas_pool_get_array
+
+ use mpas_atmphys_constants,only: cp,P0,R_d,rcp
+ use mpas_atmphys_vars,only: xice_threshold
+
+
+ implicit none
+ private
+ public:: atmphys_sfc_diagnostics
+
+
+ contains
+
+
+!=================================================================================================================
+ subroutine atmphys_sfc_diagnostics(configs,mesh,diag,diag_physics,sfc_input,output_noahmp,its,ite)
+!=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: mesh
+ type(mpas_pool_type),intent(in):: diag
+ type(mpas_pool_type),intent(in):: output_noahmp
+ type(mpas_pool_type),intent(in):: sfc_input
+ integer,intent(in):: its,ite
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: diag_physics
+
+!local variables and pointers:
+ character(len=StrKIND),pointer:: lsm_scheme
+
+ integer,pointer:: nCellsSolve
+ integer:: i
+
+ real(kind=RKIND),dimension(:),pointer:: psfc
+ real(kind=RKIND),dimension(:),pointer:: tsk,xice,xland
+ real(kind=RKIND),dimension(:),pointer:: hfx,qfx,qsfc,chs2,cqs2
+ real(kind=RKIND),dimension(:),pointer:: q2mxy,t2mxy
+ real(kind=RKIND),dimension(:),pointer:: q2,t2m,th2m
+
+ real(kind=RKIND):: rho
+
+!-----------------------------------------------------------------------------------------------------------------
+!call mpas_log_write(' ')
+!call mpas_log_write('--- enter subroutine atmphys_sfc_diagnostics:')
+
+ call mpas_pool_get_config(configs,'config_lsm_scheme',lsm_scheme)
+
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+
+ call mpas_pool_get_array(diag,'surface_pressure',psfc)
+
+ call mpas_pool_get_array(diag_physics,'chs2',chs2)
+ call mpas_pool_get_array(diag_physics,'cqs2',cqs2)
+ call mpas_pool_get_array(diag_physics,'hfx' ,hfx )
+ call mpas_pool_get_array(diag_physics,'qfx' ,qfx )
+ call mpas_pool_get_array(diag_physics,'qsfc',qsfc)
+ call mpas_pool_get_array(diag_physics,'q2'  ,q2  )
+ call mpas_pool_get_array(diag_physics,'t2m' ,t2m )
+ call mpas_pool_get_array(diag_physics,'th2m',th2m)
+
+ call mpas_pool_get_array(sfc_input,'skintemp',tsk  )
+ call mpas_pool_get_array(sfc_input,'xice'    ,xice )
+ call mpas_pool_get_array(sfc_input,'xland'   ,xland)
+
+ sf_select: select case(trim(lsm_scheme))
+    case("sf_noah")
+       do i = 1,nCellsSolve
+          rho = psfc(i)/(R_d*tsk(i))
+          if(cqs2(i) .lt. 1.e-5) then
+             q2(i) = qsfc(i)
+          else
+             q2(i) = qsfc(i) - qfx(i)/(rho*cqs2(i))
+          endif
+          if(chs2(i) .lt. 1.e-5) then
+             t2m(i) = tsk(i)
+          else
+             t2m(i) = tsk(i) - hfx(i)/(rho*cp*chs2(i))
+          endif
+          th2m(i) = t2m(i)*(P0/psfc(i))**rcp
+       enddo
+
+    case("sf_noahmp")
+       call mpas_pool_get_array(output_noahmp,'q2mxy',q2mxy)
+       call mpas_pool_get_array(output_noahmp,'t2mxy',t2mxy)
+       do i = 1,nCellsSolve
+          rho = psfc(i)/(R_d*tsk(i))
+          if((xland(i)-1.5 .gt. 0._RKIND) .or. (xland(i)-1.5.le.0._RKIND .and. xice(i).ge.xice_threshold)) then
+             if(cqs2(i) .lt. 1.e-5) then
+                q2(i) = qsfc(i)
+             else
+                q2(i) = qsfc(i) - qfx(i)/(rho*cqs2(i))
+             endif
+             if(chs2(i) .lt. 1.e-5) then
+                t2m(i) = tsk(i)
+             else
+                t2m(i) = tsk(i) - hfx(i)/(rho*cp*chs2(i))
+             endif
+          else
+             q2(i)  = q2mxy(i)
+             t2m(i) = t2mxy(i)
+          endif
+          th2m(i) = t2m(i)*(P0/psfc(i))**rcp
+       enddo
+
+    case default
+ end select sf_select
+
+!call mpas_log_write('--- end subroutine atmphys_sfc_diagnostics:')
+
+ end subroutine atmphys_sfc_diagnostics
+
+!=================================================================================================================
+ end module mpas_atmphys_sfc_diagnostics
+!=================================================================================================================
+

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/EnergyVarOutTransferMod.F90
@@ -119,6 +119,7 @@ contains
     NoahmpIO%ZNT     (I) = noahmp%energy%state%RoughLenMomSfcToAtm
     NoahmpIO%T2MVXY  (I) = noahmp%energy%state%TemperatureAir2mVeg
     NoahmpIO%T2MBXY  (I) = noahmp%energy%state%TemperatureAir2mBare
+    NoahmpIO%T2MXY   (I) = noahmp%energy%state%TemperatureAir2m
     NoahmpIO%TRADXY  (I) = noahmp%energy%state%TemperatureRadSfc
     NoahmpIO%FVEGXY  (I) = noahmp%energy%state%VegFrac
     NoahmpIO%RSSUNXY (I) = noahmp%energy%state%ResistanceStomataSunlit
@@ -135,6 +136,7 @@ contains
     NoahmpIO%CHB2XY  (I) = noahmp%energy%state%ExchCoeffSh2mBare
     NoahmpIO%Q2MVXY  (I) = noahmp%energy%state%SpecHumidity2mVeg /(1.0-noahmp%energy%state%SpecHumidity2mVeg)  ! spec humidity to mixing ratio
     NoahmpIO%Q2MBXY  (I) = noahmp%energy%state%SpecHumidity2mBare/(1.0-noahmp%energy%state%SpecHumidity2mBare)
+    NoahmpIO%Q2MXY   (I) = noahmp%energy%state%SpecHumidity2m/(1.0-noahmp%energy%state%SpecHumidity2m)
     NoahmpIO%IRRSPLH (I) = NoahmpIO%IRRSPLH(I) + &
                              (noahmp%energy%flux%HeatLatentIrriEvap * noahmp%config%domain%MainTimeStep)
     NoahmpIO%TSLB    (I,1:NumSoilLayer)       = noahmp%energy%state%TemperatureSoilSnow(1:NumSoilLayer)

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarFinalizeMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarFinalizeMod.F90
@@ -196,8 +196,10 @@ contains
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)   
     if ( allocated (NoahmpIO%t2mvxy)     ) deallocate ( NoahmpIO%t2mvxy             ) ! 2m temperature of vegetation part
     if ( allocated (NoahmpIO%t2mbxy)     ) deallocate ( NoahmpIO%t2mbxy             ) ! 2m temperature of bare ground part
+    if ( allocated (NoahmpIO%t2mxy)      ) deallocate ( NoahmpIO%t2mxy              ) ! 2m grid-mean temperature
     if ( allocated (NoahmpIO%q2mvxy)     ) deallocate ( NoahmpIO%q2mvxy             ) ! 2m mixing ratio of vegetation part
     if ( allocated (NoahmpIO%q2mbxy)     ) deallocate ( NoahmpIO%q2mbxy             ) ! 2m mixing ratio of bare ground part
+    if ( allocated (NoahmpIO%q2mxy)      ) deallocate ( NoahmpIO%q2mxy              ) ! 2m grid-mean mixing ratio
     if ( allocated (NoahmpIO%tradxy)     ) deallocate ( NoahmpIO%tradxy             ) ! surface radiative temperature (K)
     if ( allocated (NoahmpIO%neexy)      ) deallocate ( NoahmpIO%neexy              ) ! net ecosys exchange (g/m2/s CO2)
     if ( allocated (NoahmpIO%gppxy)      ) deallocate ( NoahmpIO%gppxy              ) ! gross primary assimilation [g/m2/s C]

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarInitMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarInitMod.F90
@@ -200,8 +200,10 @@ contains
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)   
     if ( .not. allocated (NoahmpIO%t2mvxy)     ) allocate ( NoahmpIO%t2mvxy      (its:ite) ) ! 2m temperature of vegetation part
     if ( .not. allocated (NoahmpIO%t2mbxy)     ) allocate ( NoahmpIO%t2mbxy      (its:ite) ) ! 2m temperature of bare ground part
+    if ( .not. allocated (NoahmpIO%t2mxy)      ) allocate ( NoahmpIO%t2mxy       (its:ite) ) ! 2m grid-mean temperature
     if ( .not. allocated (NoahmpIO%q2mvxy)     ) allocate ( NoahmpIO%q2mvxy      (its:ite) ) ! 2m mixing ratio of vegetation part
     if ( .not. allocated (NoahmpIO%q2mbxy)     ) allocate ( NoahmpIO%q2mbxy      (its:ite) ) ! 2m mixing ratio of bare ground part
+    if ( .not. allocated (NoahmpIO%q2mxy)      ) allocate ( NoahmpIO%q2mxy       (its:ite) ) ! 2m grid-mean mixing ratio
     if ( .not. allocated (NoahmpIO%tradxy)     ) allocate ( NoahmpIO%tradxy      (its:ite) ) ! surface radiative temperature (K)
     if ( .not. allocated (NoahmpIO%neexy)      ) allocate ( NoahmpIO%neexy       (its:ite) ) ! net ecosys exchange (g/m2/s CO2)
     if ( .not. allocated (NoahmpIO%gppxy)      ) allocate ( NoahmpIO%gppxy       (its:ite) ) ! gross primary assimilation [g/m2/s C]
@@ -547,8 +549,10 @@ contains
     NoahmpIO%snowc           = undefined_real
     NoahmpIO%t2mvxy          = undefined_real
     NoahmpIO%t2mbxy          = undefined_real
+    NoahmpIO%t2mxy           = undefined_real
     NoahmpIO%q2mvxy          = undefined_real
     NoahmpIO%q2mbxy          = undefined_real
+    NoahmpIO%q2mxy           = undefined_real
     NoahmpIO%tradxy          = undefined_real
     NoahmpIO%neexy           = undefined_real
     NoahmpIO%gppxy           = undefined_real

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarType.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpIOVarType.F90
@@ -233,10 +233,12 @@ module NoahmpIOVarType
     real(kind=kind_noahmp), allocatable, dimension(:)      :: loctim               ! local time
  
     ! OUT (with no Noah LSM equivalent) (as defined in WRF)
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mvxy              ! 2m temperature of vegetation part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mbxy              ! 2m temperature of bare ground part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mvxy              ! 2m mixing ratio of vegetation part
-    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mbxy              ! 2m mixing ratio of bare ground part
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mvxy              ! 2m temperature of vegetation part [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mbxy              ! 2m temperature of bare ground part [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  t2mxy               ! 2m grid-mean temperature [K]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mvxy              ! 2m mixing ratio of vegetation part [kg/kg]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mbxy              ! 2m mixing ratio of bare ground part [kg/kg]
+    real(kind=kind_noahmp), allocatable, dimension(:)      ::  q2mxy               ! 2m grid-mean mixing ratio [kg/kg]
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  tradxy              ! surface radiative temperature (K)
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  neexy               ! net ecosys exchange (g/m2/s CO2)
     real(kind=kind_noahmp), allocatable, dimension(:)      ::  gppxy               ! gross primary assimilation [g/m2/s C]

--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
@@ -127,9 +127,11 @@
        NoahmpIO%tahxy(i)    = NoahmpIO%tsk(i)
        NoahmpIO%t2mvxy(i)   = NoahmpIO%tsk(i)
        NoahmpIO%t2mbxy(i)   = NoahmpIO%tsk(i)
+       NoahmpIO%t2mxy(i)    = NoahmpIO%tsk(i)
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%tahxy(i)  = t0
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mvxy(i) = t0
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mbxy(i) = t0
+       if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%tsk(i) > t0) ) NoahmpIO%t2mxy(i)  = t0
 
        NoahmpIO%cmxy(i)     = 0.0
        NoahmpIO%chxy(i)     = 0.0


### PR DESCRIPTION
This PR corrects the calculation of the 2-meter diagnostics (T2M, TH2M, and Q2) when using the Noah-MP land surface scheme. While the computation of 2-meter diagnostics is the same for Noah and Noah-MP over oceans, it is different between the two land surface schemes over land. In Noah-MP, the 2-meter diagnostics are weighted as functions of their respective diagnostics over bare soil and over vegetation. The updated diagnostics for Noah and Noah-MP are now computed in the new file mpas_atmphys_sfc_diagnostics.F.
