### PR TITLE
Correct initialization of soil liquid water content for Noah-MP

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -10,6 +10,7 @@
  use mpas_log
  use mpas_pool_routines
 
+ use mpas_atmphys_constants,only: grav => gravity, t0 => svpt0
  use mpas_atmphys_utilities,only: physics_error_fatal
  use mpas_atmphys_vars,only     : mpas_noahmp
 
@@ -253,7 +254,11 @@
 !local variables and pointers:
  logical,pointer:: do_restart
  logical,parameter:: fndsnowh = .true.
+
  integer:: i,its,ite,ns,nsoil,nsnow,nzsnow
+
+ real(kind=RKIND),parameter:: hlice = 3.335E5
+ real(kind=RKIND):: bexp,fk,smcmax,psisat
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' ')
@@ -390,6 +395,42 @@
  call mpas_pool_get_array(output_noahmp,'t2mvxy',t2mvxy  )
  call mpas_pool_get_array(output_noahmp,'qtdrain',qtdrain)
 
+!--- initialization of the soil liquid water content:
+ do i = its,ite
+    if(ivgtyp(i) == mpas_noahmp%isice_table .and. xice(i) .le. 0._RKIND) then
+       !initialization over landice grid cells (frozen at init time):
+       do ns = 1,nsoil
+          smois(ns,i) = 1._RKIND
+          sh2o(ns,i)  = 0._RKIND
+          tslb(ns,i)  = min(tslb(ns,i),263.15) ! set landice temperature at -10C.
+       enddo
+    else
+       !initialization over all non-landice grid cells:
+       bexp   = mpas_noahmp%bexp_table(isltyp(i))
+       smcmax = mpas_noahmp%smcmax_table(isltyp(i))
+       psisat = mpas_noahmp%psisat_table(isltyp(i))
+
+       do ns = 1,nsoil
+          if(smois(ns,i) > smcmax) smois(ns,i) = smcmax
+       enddo
+       if(bexp.gt.0. .and. smcmax.gt.0. .and. psisat.gt.0.) then
+          do ns = 1,nsoil
+             if(tslb(ns,i) .lt. 273.149) then ! initial soil ice.
+                fk = ( ((hlice/(grav*(-psisat)))*((tslb(ns,i)-t0)/tslb(ns,i)))**(-1/bexp) )*smcmax
+                fk = max(fk,0.02)
+                sh2o(ns,i) = min(fk,smois(ns,i))
+             else
+                sh2o(ns,i) = smois(ns,i)
+             endif
+          enddo
+       else
+          do ns = 1,nsoil
+             sh2o(ns,i) = smois(ns,i)
+          enddo
+       endif
+    endif
+ enddo
+
 
  do i = its,ite
     mpas_noahmp%tmn(i)   = tmn(i)
@@ -419,9 +460,9 @@
     if(snow(i) .gt. 0._RKIND) snowc(i) = 1.
 
     do ns = 1,nsoil
-       mpas_noahmp%sh2o(i,ns)  = sh2o(ns,i)
-       mpas_noahmp%smois(i,ns) = smois(ns,i)
-       mpas_noahmp%tslb(i,ns)  = tslb(ns,i)
+       sh2o(ns,i)  = mpas_noahmp%sh2o(i,ns)
+       smois(ns,i) = mpas_noahmp%smois(i,ns)
+       tslb(ns,i)  = mpas_noahmp%tslb(i,ns)
    enddo
  enddo
 


### PR DESCRIPTION
This PR corrects the computation of the soil temperature (TSLB) in the Noah-MP land surface scheme. In this PR, we added the initialization of the soil liquid water (SH2O) in subroutine noahmp_init in module mpas_atmphys_lsm_noahmpinit.F prior to calling subroutine NoahmpInitMain.

Prior to adding the initialization of SH2O, running Noah-MP led TSLB to be set to ConstFreezePoint (273.16 K) in SoilSnowWaterPhaseChangeMod.F90 although the input TSLB was greater than ConstFreezePoint on the very first time step. This error occurred because TSLB is calculated as a function of the soil liquid (MassWatLiqTmp) and ice (MassWatIceTmp) water mass, and MassWatLiqTmp is always equal to 0 when not properly initializing SH2O.