### PR TITLE
corrrect pool name in init_atm_thompson_aerosols_lbc

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -331,7 +331,7 @@ module init_atm_cases
                                       diag, lbc_state, block_ptr % dimensions, block_ptr % configs)
 
                call mpas_get_time(start_time, dateTimeString=timeStart)
-               call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, state, lbc_state)
+               call init_atm_thompson_aerosols_lbc(timeString, timeStart, block_ptr, mesh, diag, lbc_state)
 
                block_ptr => block_ptr % next
             end do

--- a/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
+++ b/src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F
@@ -719,13 +719,12 @@
  end subroutine init_hinterp_gocart
  
 !=================================================================================================================
- subroutine init_atm_thompson_aerosols_lbc(timestamp,timestart,block,mesh,diag,state,lbc_state)
+ subroutine init_atm_thompson_aerosols_lbc(timestamp,timestart,block,mesh,diag,lbc_state)
 !=================================================================================================================
 
 !input arguments:
  character(len=StrKIND),intent(in):: timestart,timestamp
  type(mpas_pool_type),intent(in):: diag
- type(mpas_pool_type),intent(in):: state
 
 !inout arguments:
  type(block_type),intent(inout),target:: block
@@ -771,8 +770,8 @@
  call mpas_pool_get_dimension(mesh,'nVertLevels'  ,nVertLevels  )
  call mpas_pool_get_dimension(mesh,'nMonths'      ,nMonths      )
 
- call mpas_pool_get_dimension(state,'index_nifa',index_nifa)
- call mpas_pool_get_dimension(state,'index_nwfa',index_nwfa)
+ call mpas_pool_get_dimension(lbc_state,'index_lbc_nifa',index_nifa)
+ call mpas_pool_get_dimension(lbc_state,'index_lbc_nwfa',index_nwfa)
 
  call mpas_pool_get_array(diag,'pressure_base',pressure)
 


### PR DESCRIPTION
In ./src/core_init_atmosphere/mpas_init_atm_thompson_aerosols.F, corrected the pool name to get the dimension for index_nifa and index_nwfa in subroutine init_atm_thompson_aerosols_lbc. In its original release, index_nifa and index_nwfa
was obtained from the pool "state' instead of the pool "lbc_state".

This PR replaces the pool name "state" with the pool name "lbc_state", and modified the list of arguments needed in subroutine init_atm_thompson_aerosols_lbc.



