### PR TITLE
added DO_PHYSICS preprocessing option in Registry.xml

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1155,10 +1155,6 @@
 			<var_array name="scalars"/>
 			<var name="initial_time"/>
 			<var name="xtime"/>
-			<var name="cldfrac"/>
-			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in"/>
-			<var name="re_snow" packages="mp_thompson_in;mp_wsm6_in"/>
 			<var name="u"/>
 			<var name="w"/>
 			<var name="rho"/>
@@ -1171,6 +1167,11 @@
 			<var name="uReconstructZonal"/>
 			<var name="uReconstructMeridional"/>
 			<var name="surface_pressure"/>
+#ifdef DO_PHYSICS
+			<var name="cldfrac"/>
+			<var name="re_cloud" packages="mp_thompson_in;mp_wsm6_in"/>
+			<var name="re_ice" packages="mp_thompson_in;mp_wsm6_in"/>
+			<var name="re_snow" packages="mp_thompson_in;mp_wsm6_in"/>
 			<var name="refl10cm_max"/>
 			<var name="rainc"/>
 			<var name="rainnc"/>
@@ -1209,6 +1210,7 @@
 			<var name="smois"/>
 			<var name="tslb"/>
 			<var name="h_oml_initial"/>
+#endif
                 </stream>
 	</streams>
 
@@ -3588,6 +3590,9 @@
 <!-- **************************************************************************************** -->
 
 #include "diagnostics/Registry_diagnostics.xml"
+
+#ifdef DO_PHYSICS
 #include "physics/Registry_noahmp.xml"
+#endif
 
 </registry>


### PR DESCRIPTION
added the pre-processing option DO_PHYSICS in Registry.xml to compile MPAS-Model without physics in 1) the da_state stream; and 2) to not include the Noah-MP Registry when PHYSICS = " " in ./src/core_atmosphere/Makefile.
 
