### PR TITLE
Addition of the new static information: BNU soil types and 15" MODIS landuse

### DIFF
--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -136,7 +136,6 @@
                      units="-"
                      description="The number of months in a year"
                      possible_values="Positive integer values"/>
-
         </nml_record>
 
         <nml_record name="data_sources" in_defaults="true">
@@ -165,6 +164,11 @@
                      units="-"
                      description="The land use classification to use (case 7 only)"
                      possible_values="`USGS' or `MODIFIED_IGBP_MODIS_NOAH'"/>
+
+                <nml_option name="config_soilcat_data"          type="character"     default_value="STATSGO"
+                     units="-"
+		     description="The soil category classification to use"
+                     possible_values="`STATSGO' or `BNU'"/>
 
                 <nml_option name="config_topo_data"             type="character"     default_value="GMTED2010"
                      units="-"

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -195,9 +195,14 @@
                      description="The supersampling factor to be used for MODIS maximum snow albedo and monthly albedo datasets (case 7 only)"
                      possible_values="Positive integer values"/>
 
+	        <nml_option name="config_lu_supersample_factor" type="integer"       default_value="1"
+                     units="-"
+                     description="The supersampling factor to be used for 30s or 15s MODIS land use (case 7 only)"
+                     possible_values="Positive integer values"/>
+
                 <nml_option name="config_30s_supersample_factor"    type="integer"       default_value="1"
                      units="-"
-                     description="The supersampling factor to be used for 30s terrain, MODIS land use, soil category, and MODIS FPAR monthly vegetation fraction (case 7 only)"
+                     description="The supersampling factor to be used for 30s terrain, soil category, and MODIS FPAR monthly vegetation fraction (case 7 only)"
                      possible_values="Positive integer values"/>
 
                 <nml_option name="config_use_spechumd"          type="logical"       default_value="false"

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -126,6 +126,7 @@
  character(len=StrKIND), pointer :: config_vegfrac_data
  character(len=StrKIND), pointer :: config_albedo_data
  character(len=StrKIND), pointer :: config_maxsnowalbedo_data
+ character(len=StrKIND), pointer :: config_soilcat_data
  character(len=StrKIND+1) :: geog_data_path      ! same as config_geog_data_path, but guaranteed to have a trailing slash
  character(len=StrKIND+1) :: geog_sub_path       ! subdirectory names in config_geog_data_path, with trailing slash
 
@@ -213,6 +214,7 @@
 
  call mpas_pool_get_config(configs, 'config_geog_data_path', config_geog_data_path)
  call mpas_pool_get_config(configs, 'config_landuse_data', config_landuse_data)
+ call mpas_pool_get_config(configs, 'config_soilcat_data', config_soilcat_data)
  call mpas_pool_get_config(configs, 'config_topo_data', config_topo_data)
  call mpas_pool_get_config(configs, 'config_vegfrac_data', config_vegfrac_data)
  call mpas_pool_get_config(configs, 'config_albedo_data', config_albedo_data)
@@ -410,8 +412,22 @@
 
 !
 ! Interpolate SOILCAT_TOP
+ select case(trim(config_soilcat_data))
+    case('STATSGO')
+       call mpas_log_write('Using STATSGO 30-arc-second soil type dataset')
+       geog_sub_path = 'soiltype_top_30s/'
+    case('BNU')
+       call mpas_log_write('Using BNU 30-arc-second soil type dataset')
+       geog_sub_path = 'bnu_soiltype_top/'
+    case default
+       call mpas_log_write('*****************************************************************',messageType=MPAS_LOG_ERR)
+       call mpas_log_write('Invalid soil type dataset'''//trim(config_soilcat_data) &
+                                     //''' selected for config_soilcat_data',                  messageType=MPAS_LOG_ERR)
+       call mpas_log_write('   Possible options are: ''STATSGO'',''BNU''',                     messageType=MPAS_LOG_ERR)
+       call mpas_log_write('*****************************************************************',messageType=MPAS_LOG_ERR)
+       call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
+ end select            
 !
- geog_sub_path = 'soiltype_top_30s/'
 
  call mpas_log_write('--- start interpolate SOILCAT_TOP')
  call interp_soilcat(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), iswater_soil, &

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -144,6 +144,7 @@
  type(c_ptr) :: rarray_ptr
 
  integer, pointer :: supersample_fac
+ integer, pointer :: supersample_fac_lu
  integer, pointer :: supersample_fac_30s
 
  real(kind=RKIND):: lat,lon,x,y
@@ -220,6 +221,7 @@
  call mpas_pool_get_config(configs, 'config_albedo_data', config_albedo_data)
  call mpas_pool_get_config(configs, 'config_maxsnowalbedo_data', config_maxsnowalbedo_data)
  call mpas_pool_get_config(configs, 'config_supersample_factor', supersample_fac)
+ call mpas_pool_get_config(configs, 'config_lu_supersample_factor', supersample_fac_lu)
  call mpas_pool_get_config(configs, 'config_30s_supersample_factor', supersample_fac_30s)
 
  write(geog_data_path, '(a)') config_geog_data_path
@@ -412,7 +414,7 @@
 
  call mpas_log_write('--- start interpolate LU_INDEX')
  call interp_landuse(mesh, tree, trim(geog_data_path)//trim(geog_sub_path), isice_lu, iswater_lu, &
-                     supersample_fac=supersample_fac_30s)
+                     supersample_fac=supersample_fac_lu)
  call mpas_log_write('--- end interpolate LU_INDEX')
 
 !

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -350,13 +350,14 @@
  surface_input_select0: select case(trim(config_landuse_data))
     case('USGS')
        write(mminlu,'(a)') 'USGS'
-    case('MODIFIED_IGBP_MODIS_NOAH')
+    case('MODIFIED_IGBP_MODIS_NOAH', 'MODIFIED_IGBP_MODIS_NOAH_15s')
        write(mminlu,'(a)') 'MODIFIED_IGBP_MODIS_NOAH'
     case default
          call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('Invalid land use dataset '''//trim(config_landuse_data) &
                                        //''' selected for config_landuse_data',                   messageType=MPAS_LOG_ERR)
          call mpas_log_write('   Possible options are: ''USGS'', ''MODIFIED_IGBP_MODIS_NOAH''',   messageType=MPAS_LOG_ERR)
+         call mpas_log_write('   '' MODIFIED_IGBP_MODIS_NOAH_15s''',                              messageType=MPAS_LOG_ERR)
          call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
          call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select surface_input_select0
@@ -396,11 +397,15 @@
     case('MODIFIED_IGBP_MODIS_NOAH')
        call mpas_log_write('Using 20-class MODIS 30-arc-second land cover dataset')
        geog_sub_path = 'modis_landuse_20class_30s/'
+    case('MODIFIED_IGBP_MODIS_NOAH_15s')
+       call mpas_log_write('Using 20-class MODIS 15-arc-second land cover dataset')
+       geog_sub_path = 'modis_landuse_20class_15s/'
     case default
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Invalid land use dataset '''//trim(config_landuse_data) &
                                      //''' selected for config_landuse_data',                   messageType=MPAS_LOG_ERR)
        call mpas_log_write('   Possible options are: ''USGS'', ''MODIFIED_IGBP_MODIS_NOAH''',   messageType=MPAS_LOG_ERR)
+       call mpas_log_write('   '' MODIFIED_IGBP_MODIS_NOAH_15s''',                              messageType=MPAS_LOG_ERR)
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Please correct the namelist.', messageType=MPAS_LOG_CRIT)
  end select surface_input_select1


### PR DESCRIPTION
The BNU soil dataset has the same soil categories as in STATSGO with differences in spatial variations.
The MODIFIED_IGBP_MODIS_NOAH_15s has the same categories as in MODIFIED_IGBP_MODIS_NOAH.
The additional static information is introduced via the namelist.init_atmosphere
    config_landuse_data = 'MODIFIED_IGBP_MODIS_NOAH_15s'
    config_soilcat_data = 'BNU'