### PR TITLE
Allow using the SMIOL I/O library when building with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,14 @@ option(MPAS_DOUBLE_PRECISION "Use double precision 64-bit Floating point." TRUE)
 option(MPAS_PROFILE "Enable GPTL profiling" OFF)
 option(MPAS_OPENMP "Enable OpenMP" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(MPAS_USE_SMIOL "Build with smiol I/O library" OFF)
 
 message(STATUS "[OPTION] MPAS_CORES: ${MPAS_CORES}")
 message(STATUS "[OPTION] MPAS_DOUBLE_PRECISION: ${MPAS_DOUBLE_PRECISION}")
 message(STATUS "[OPTION] MPAS_PROFILE: ${MPAS_PROFILE}")
 message(STATUS "[OPTION] MPAS_OPENMP: ${MPAS_OPENMP}")
 message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+message(STATUS "[OPTION] MPAS_USE_SMIOL: ${MPAS_USE_SMIOL}")
 
 # Build product output locations
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -59,7 +61,9 @@ find_package(OpenMP COMPONENTS Fortran)
 find_package(MPI REQUIRED COMPONENTS Fortran)
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
 find_package(PnetCDF REQUIRED COMPONENTS Fortran)
-find_package(PIO REQUIRED COMPONENTS Fortran C)
+if(NOT MPAS_USE_SMIOL)
+    find_package(PIO REQUIRED COMPONENTS Fortran C)
+endif()
 if(MPAS_PROFILE)
     find_package(GPTL REQUIRED)
 endif()
@@ -88,6 +92,9 @@ set(MPAS_SUBDRIVER_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas_subdriver.F)
 
 ## Create targets
 add_subdirectory(src/external/ezxml) # Target: MPAS::external::ezxml
+if(MPAS_USE_SMIOL)
+    add_subdirectory(src/external/SMIOL) # Target: MPAS::external::smiol
+endif()
 if(ESMF_FOUND)
   message(STATUS "Configure MPAS for external ESMF")
   add_definitions(-DMPAS_EXTERNAL_ESMF_LIB -DMPAS_NO_ESMF_INIT)

--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -80,10 +80,16 @@ function(mpas_fortran_target target)
 
     # Global Fortran configuration
     set_target_properties(${target} PROPERTIES Fortran_FORMAT FREE)
-    set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
-        _MPI=1
-        USE_PIO2=1
-    )
+    if(MPAS_USE_SMIOL)
+        set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
+            MPAS_SMIOL_SUPPORT=1
+        )
+    else()
+        set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
+            USE_PIO2=1
+        )
+    endif()
+    list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS _MPI=1)
     # Enable OpenMP support
     if(MPAS_OPENMP)
         target_link_libraries(${target} PUBLIC OpenMP::OpenMP_Fortran)

--- a/src/external/SMIOL/CMakeLists.txt
+++ b/src/external/SMIOL/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+find_package(MPI REQUIRED COMPONENTS C Fortran)
+find_package(NetCDF REQUIRED COMPONENTS Fortran C)
+find_package(PnetCDF REQUIRED COMPONENTS Fortran C)
+
+# Specify the library source files
+set(SMIOL_C_SOURCES smiol.c smiol_utils.c)
+set(SMIOL_F_SOURCES smiolf.F90)
+
+# Create the C library
+add_library(smiol ${SMIOL_C_SOURCES})
+add_library(${PROJECT_NAME}::external::smiol ALIAS smiol)
+target_compile_definitions(smiol PRIVATE SMIOL_PNETCDF SINGLE_PRECISION)
+target_include_directories(smiol PRIVATE ${MPI_INCLUDE_PATH})
+target_link_libraries( smiol PRIVATE MPI::MPI_C PnetCDF::PnetCDF_C )
+
+# Create the Fortran library
+add_library(smiolf ${SMIOL_F_SOURCES})
+enable_language(Fortran)
+mpas_fortran_target(smiolf)
+add_library(${PROJECT_NAME}::external::smiolf ALIAS smiolf)
+target_compile_definitions(smiolf PRIVATE SMIOL_PNETCDF )
+# fortran lib requires the c lib
+target_link_libraries(smiolf PUBLIC smiol)
+target_include_directories(smiol PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+install(TARGETS smiol EXPORT ${PROJECT_NAME}ExportsExternal
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS smiolf EXPORT ${PROJECT_NAME}ExportsExternal
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -39,10 +39,18 @@ set(MPAS_FRAMEWORK_SOURCES
 add_library(framework ${MPAS_FRAMEWORK_SOURCES})
 set_MPAS_DEBUG_flag(framework)
 set(FRAMEWORK_COMPILE_DEFINITIONS
-        USE_PIO2
-        MPAS_PIO_SUPPORT
-        mpas=1
-        MPAS_NATIVE_TIMERS)
+    mpas=1
+    MPAS_NATIVE_TIMERS)
+if (MPAS_USE_SMIOL)
+    list(APPEND FRAMEWORK_COMPILE_DEFINITIONS MPAS_SMIOL_SUPPORT)
+    set(IO_LIBS
+        ${PROJECT_NAME}::external::smiolf)
+else()
+    list(APPEND FRAMEWORK_COMPILE_DEFINITIONS USE_PIO2 MPAS_PIO_SUPPORT)
+    set(IO_LIBS
+        PIO::PIO_Fortran
+        PIO::PIO_C)
+endif()
 target_compile_definitions(framework PRIVATE ${FRAMEWORK_COMPILE_DEFINITIONS})
 
 mpas_fortran_target(framework)
@@ -53,8 +61,7 @@ set_target_properties(framework PROPERTIES OUTPUT_NAME mpas_framework)
 set(FRAMEWORK_LINK_LIBRARIES
         ${PROJECT_NAME}::external::esmf
         ${PROJECT_NAME}::external::ezxml
-        PIO::PIO_Fortran
-        PIO::PIO_C
+        ${IO_LIBS}
         PnetCDF::PnetCDF_Fortran
         NetCDF::NetCDF_Fortran
         NetCDF::NetCDF_C


### PR DESCRIPTION
This PR removes the restriction of only using the PIO I/O library when building with cmake.

The default behavior will build using PIO.
In order to build and use the SMIOL I/O library provide `-DMPAS_USE_SMIOL=1` on the command line when running cmake.

Test run include the mpasjedi ctests, as well as the MPAS-Workflow cylc tests:
3dvar_OIE120km_WarmStart_TEST/
3dvar_OIE120km_ColdStart_TEST/
3dvar_O30kmIE60km_ColdStart_TEST/
3denvar_O30kmIE60km_WarmStart_TEST/
4denvar_OIE120km_WarmStart_TEST/
4dhybrid_OIE120km_WarmStart_TEST/
eda_OIE120km_WarmStart_TEST/
getkf_OIE120km_WarmStart_TEST/
ForecastFromGFSAnalysesMPT_TEST/
3denvar_OIE120km_IAU_WarmStart_TEST/
  - this test fail with:
  ```
ERROR: SMIOLf_open_file failed with error -5
ERROR: NetCDF: Attempt to use feature that was not turned on when netCDF was built.
```
because the test tries to read an HDF5 data file.