### PR TITLE
Remove duplicate allocation of indexToEdgeID in mpas_io_setup_edge_block_fields

### DIFF
--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -815,7 +815,6 @@ module mpas_bootstrapping
      ! Global edge indices
      allocate(indexToEdgeID)
      allocate(indexToEdgeID % array(nReadEdges))
-     allocate(indexToEdgeID % array(nReadEdges))
      do i=1,nReadEdges
         readIndices(i) = i + readEdgeStart - 1
      end do


### PR DESCRIPTION
This PR removes a duplicate allocation of `indexToEdgeID % array` in the `mpas_io_setup_edge_block_fields` routine that was the source of a memory leak.
