### PR TITLE
Skip static interpolation step if input grid isn't a unit sphere

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -7140,4 +7140,63 @@ call mpas_log_write('Done with soil consistency check')
    end function read_text_array
 
 
+   !-----------------------------------------------------------------------
+   !  routine on_unit_sphere
+   !
+   !> \brief True if sphere surface area is close to unit sphere surface area (4*pii)
+   !> \author G. Dylan Dickerson
+   !> \date   03 Jan 2025
+   !> \details
+   !>
+   !>  This routine will use the global sum of cell areas to
+   !>  approximate the surface area of the sphere. If this surface area
+   !>  is within a factor of 4*pii, the mesh is likely still a unit
+   !>  sphere and this returns true.  Otherwise, returns false since
+   !>  the mesh is likely not a unit sphere.
+   !>
+   !---------------------------------------------------------------------------
+   function on_unit_sphere(dminfo, mesh) result(unit_sphere)
+
+      use mpas_pool_routines, only : mpas_pool_get_array, mpas_pool_get_dimension 
+      use mpas_dmpar, only : mpas_dmpar_sum_real
+      use mpas_constants, only : pii
+
+      implicit none
+
+      ! Input vars
+      type (dm_info), intent(in) :: dminfo
+      type (mpas_pool_type), intent(inout) :: mesh
+
+      ! Output vars
+      logical unit_sphere
+
+      ! Local vars
+      real (kind=RKIND) :: surfArea, g_surfArea
+      real (kind=RKIND) :: tol
+      integer :: iCell
+
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      integer, pointer :: nCellsSolve
+
+      unit_sphere = .false.
+
+      surfArea = 0.0_RKIND
+      g_surfArea = 0.0_RKIND
+      tol = 2.0_RKIND
+
+      call mpas_pool_get_array(mesh, 'areaCell', areaCell)
+      call mpas_pool_get_dimension(mesh, 'nCellsSolve', nCellsSolve)
+
+      ! sum over all owned cells, don't double-count halo cells
+      do iCell = 1, nCellsSolve
+         surfArea = surfArea + areaCell(iCell)
+      end do
+      call mpas_dmpar_sum_real(dminfo, surfArea, g_surfArea)
+
+      if ( (g_surfArea / 4*pii) < tol  ) then
+         unit_sphere = .true.
+      end if
+
+   end function on_unit_sphere
+
 end module init_atm_cases

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -51,7 +51,6 @@ module init_atm_cases
       type (domain_type), intent(inout) :: domain
       type (MPAS_streamManager_type), intent(inout) :: stream_manager
 
-
       integer :: ierr
       type (block_type), pointer :: block_ptr
 
@@ -211,7 +210,15 @@ module init_atm_cases
             end if
 
             if (config_static_interp) then
-               call init_atm_static(mesh, block_ptr % dimensions, block_ptr % configs)
+               if ( on_unit_sphere(domain % dminfo, mesh) ) then
+                  call init_atm_static(mesh, block_ptr % dimensions, block_ptr % configs)
+               else
+                  call mpas_log_write('*************************************************************', messageType=MPAS_LOG_ERR)
+                  call mpas_log_write('Input grid does not describe a unit sphere, static processing', messageType=MPAS_LOG_ERR)
+                  call mpas_log_write('has likely already been applied. Repeating this step can     ', messageType=MPAS_LOG_ERR)
+                  call mpas_log_write('cause issues running the model and unrealistic results.      ', messageType=MPAS_LOG_ERR)
+                  call mpas_log_write('*************************************************************', messageType=MPAS_LOG_CRIT)
+               end if
             end if
 
             if (config_native_gwd_static) then


### PR DESCRIPTION
This PR adds a function to the init_atmosphere core to quickly check if a grid is likely a unit sphere and uses the function to throw an error if the static interpolation step is about to be repeated.

Most cases for the init_atmosphere model assume the input grid is a unit sphere and involve calculations to scale up to a new radius. Unlike the other cases, the case to generate real-data initial conditions is typically run a few times in sequence with different options. It's possible users could cause unintuitive issues by doubly scaling the input grid unless they take great care when editing namelist.init_atmosphere.

This PR protects against such errors. Now, running the init_atmosphere model to generate real-data initial conditions and attempting the static interpolation step with a non-unit sphere input grid will cause the model to abort with an error message.