### PR TITLE
Fix data types for invariant fields transferred during init with OpenACC

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -217,9 +217,9 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invDcEdge
       integer, dimension(:,:), pointer :: edgesOnEdge
       integer, dimension(:,:), pointer :: edgesOnVertex
-      integer, dimension(:,:), pointer :: edgesOnVertex_sign
+      real (kind=RKIND), dimension(:,:), pointer :: edgesOnVertex_sign
       integer, dimension(:), pointer :: nEdgesOnEdge
-      integer, dimension(:,:), pointer :: weightsOnEdge
+      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
       integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: verticesOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge
@@ -409,9 +409,9 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: invDcEdge
       integer, dimension(:,:), pointer :: edgesOnEdge
       integer, dimension(:,:), pointer :: edgesOnVertex
-      integer, dimension(:,:), pointer :: edgesOnVertex_sign
+      real (kind=RKIND), dimension(:,:), pointer :: edgesOnVertex_sign
       integer, dimension(:), pointer :: nEdgesOnEdge
-      integer, dimension(:,:), pointer :: weightsOnEdge
+      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge
       integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: verticesOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge


### PR DESCRIPTION
This PR fixes some OpenACC data transfers that occur in `mpas_atm_dynamics_init` and `mpas_atm_dynamics_finalize`. Since the data types for 2 of the variables (`edgesOnVertex_sign` and `weightsOnEdge`) were wrong, the `mpas_pool_get_array` routine would return the NULL pointer for those fields, and the OpenACC `copyin` and `delete` statements would fail to transfer the intended data.

This PR prevents some issues that could occur when the OpenACC data management approach changes to reduce transfers to/from the device during a model timestep.