### PR TITLE
Enable GPU exection of atm_bdy_adjust_scalars_work via OpenACC

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -233,6 +233,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb3_cell
       real (kind=RKIND), dimension(:), pointer :: fzm
       real (kind=RKIND), dimension(:), pointer :: fzp
+      real (kind=RKIND), dimension(:), pointer :: meshScalingRegionalCell
 #endif
 
 
@@ -356,6 +357,9 @@ module atm_time_integration
       call mpas_pool_get_array(mesh, 'fzp', fzp)
       !$acc enter data copyin(fzp)
 
+      call mpas_pool_get_array(mesh, 'meshScalingRegionalCell', meshScalingRegionalCell)
+      !$acc enter data copyin(meshScalingRegionalCell)
+
 #endif
 
    end subroutine mpas_atm_dynamics_init
@@ -425,6 +429,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:,:,:), pointer :: zb3_cell
       real (kind=RKIND), dimension(:), pointer :: fzm
       real (kind=RKIND), dimension(:), pointer :: fzp
+      real (kind=RKIND), dimension(:), pointer :: meshScalingRegionalCell
 #endif
 
 
@@ -547,6 +552,10 @@ module atm_time_integration
 
       call mpas_pool_get_array(mesh, 'fzp', fzp)
       !$acc exit data delete(fzp)
+
+      call mpas_pool_get_array(mesh, 'meshScalingRegionalCell', meshScalingRegionalCell)
+      !$acc exit data delete(meshScalingRegionalCell)
+
 #endif
 
    end subroutine mpas_atm_dynamics_finalize

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6789,8 +6789,12 @@ module atm_time_integration
       integer :: iCell, iEdge, iScalar, i, k, cell1, cell2
 
       !---
+      MPAS_ACC_TIMER_START('atm_bdy_adjust_scalars [ACC_data_xfer]')
+      !$acc enter data create(scalars_tmp) &
+      !$acc            copyin(scalars_driving, scalars_new)
+      MPAS_ACC_TIMER_STOP('atm_bdy_adjust_scalars [ACC_data_xfer]')
 
-      !$acc parallel
+      !$acc parallel default(present)
       !$acc loop gang worker
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
 
@@ -6855,7 +6859,7 @@ module atm_time_integration
 
 !$OMP BARRIER
 
-      !$acc parallel
+      !$acc parallel default(present)
       !$acc loop gang worker
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
          if (bdyMaskCell(iCell) > 1) then ! update values
@@ -6869,6 +6873,11 @@ module atm_time_integration
          end if
       end do
       !$acc end parallel
+
+      MPAS_ACC_TIMER_START('atm_bdy_adjust_scalars [ACC_data_xfer]')
+      !$acc exit data delete(scalars_tmp, scalars_driving) &
+      !$acc           copyout(scalars_new)
+      MPAS_ACC_TIMER_STOP('atm_bdy_adjust_scalars [ACC_data_xfer]')
 
    end subroutine atm_bdy_adjust_scalars_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6781,12 +6781,15 @@ module atm_time_integration
 
       !---
 
+      !$acc parallel
+      !$acc loop gang worker
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
 
          if ( (bdyMaskCell(iCell) > 1) .and. (bdyMaskCell(iCell) <= nRelaxZone) ) then ! relaxation zone
 
             laplacian_filter_coef = dt_rk*(real(bdyMaskCell(iCell)) - 1.)/real(nRelaxZone)/(10.*dt*meshScalingRegionalCell(iCell))
             rayleigh_damping_coef = laplacian_filter_coef/5.0
+            !$acc loop vector collapse(2)
             do k=1,nVertLevels
                do iScalar=1,num_scalars
                   scalars_tmp(iScalar,k,iCell) = scalars_new(iScalar,k,iCell)
@@ -6795,6 +6798,7 @@ module atm_time_integration
 
             !  first, we compute the 2nd-order laplacian filter
             !
+            !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i,iCell)
                !  edge_sign = r_areaCell*edgesOnCell_sign(i,iCell) * dvEdge(iEdge) * invDcEdge(iEdge) * laplacian_filter_coef
@@ -6803,6 +6807,7 @@ module atm_time_integration
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
 !DIR$ IVDEP
+               !$acc loop vector collapse(2)
                do k=1,nVertLevels
                   do iScalar = 1, num_scalars
                      filter_flux = edge_sign*(   (scalars_new(iScalar,k,cell2)-scalars_driving(iScalar,k,cell2)) &
@@ -6815,6 +6820,7 @@ module atm_time_integration
             !  second, we compute the Rayleigh damping component
             !
 !DIR$ IVDEP
+            !$acc loop vector collapse(2)
             do k=1,nVertLevels
                do iScalar = 1, num_scalars
                   scalars_tmp(iScalar,k,iCell) =scalars_tmp(iScalar,k,iCell) - rayleigh_damping_coef * (scalars_new(iScalar,k,iCell)-scalars_driving(iScalar,k,iCell))
@@ -6826,6 +6832,7 @@ module atm_time_integration
             !  update the specified-zone values
             !
 !DIR$ IVDEP
+            !$acc loop vector collapse(2)
             do k=1,nVertLevels
                do iScalar = 1, num_scalars
                   scalars_tmp(iScalar,k,iCell) = scalars_driving(iScalar,k,iCell)
@@ -6835,12 +6842,16 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
+      !$acc end parallel
 
 !$OMP BARRIER
 
+      !$acc parallel
+      !$acc loop gang worker
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells
          if (bdyMaskCell(iCell) > 1) then ! update values
 !DIR$ IVDEP
+            !$acc loop vector collapse(2)
             do k=1,nVertLevels
                do iScalar = 1, num_scalars
                   scalars_new(iScalar,k,iCell) = scalars_tmp(iScalar,k,iCell)
@@ -6848,6 +6859,7 @@ module atm_time_integration
             end do
          end if
       end do
+      !$acc end parallel
 
    end subroutine atm_bdy_adjust_scalars_work
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6787,7 +6787,11 @@ module atm_time_integration
 
             laplacian_filter_coef = dt_rk*(real(bdyMaskCell(iCell)) - 1.)/real(nRelaxZone)/(10.*dt*meshScalingRegionalCell(iCell))
             rayleigh_damping_coef = laplacian_filter_coef/5.0
-            scalars_tmp(1:num_scalars,1:nVertLevels,iCell) = scalars_new(1:num_scalars,1:nVertLevels,iCell)
+            do k=1,nVertLevels
+               do iScalar=1,num_scalars
+                  scalars_tmp(iScalar,k,iCell) = scalars_new(iScalar,k,iCell)
+               end do
+            end do
 
             !  first, we compute the 2nd-order laplacian filter
             !
@@ -6818,7 +6822,7 @@ module atm_time_integration
             end do
 
          else  if ( bdyMaskCell(iCell) > nRelaxZone) then ! specified zone
-            
+
             !  update the specified-zone values
             !
 !DIR$ IVDEP
@@ -6831,7 +6835,7 @@ module atm_time_integration
          end if
 
       end do  ! updates now in temp storage
-            
+
 !$OMP BARRIER
 
       do iCell = cellSolveStart, cellSolveEnd ! threaded over cells


### PR DESCRIPTION
This PR makes small code modifications and adds OpenACC directives so the atm_bdy_adjust_scalars_work routine can execute on GPU(s).

Timing information for the OpenACC data transfers in this routine is captured in the log file by a new timer: atm_bdy_adjust_scalars [ACC_data_xfer].

Invariant fields used in this routine are also copied to the device within mpas_atm_dynamics_init and are deleted in mpas_atm_dynamics_finalize.