### PR TITLE
OpenACC port of atm_bdy_reset_speczone_values

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6962,15 +6962,29 @@ module atm_time_integration
       call mpas_pool_get_array(state, 'theta_m', theta_m, 2)
       call mpas_pool_get_array(diag, 'rtheta_p', rtheta_p)
       call mpas_pool_get_array(diag, 'rtheta_base', rtheta_base)
+
+      MPAS_ACC_TIMER_START('atm_bdy_reset_speczone_values [ACC_data_xfer]')
+      !$acc enter data copyin(rt_driving_values, rho_driving_values, rtheta_base, &
+      !$acc                   theta_m, rtheta_p)
+      MPAS_ACC_TIMER_STOP('atm_bdy_reset_speczone_values [ACC_data_xfer]')
       
+      !$acc parallel default(present)
+      !$acc loop gang worker
       do iCell = cellSolveStart, cellSolveEnd
          if( bdyMaskCell(iCell) > nRelaxZone) then
+            !$acc loop vector
             do k=1, nVertLevels
               theta_m(k,iCell) = rt_driving_values(k,iCell)/rho_driving_values(k,iCell)
               rtheta_p(k,iCell) = rt_driving_values(k,iCell) - rtheta_base(k,iCell)
             end do
          end if
       end do
+      !$acc end parallel
+
+      MPAS_ACC_TIMER_START('atm_bdy_reset_speczone_values [ACC_data_xfer]')
+      !$acc exit data copyout(theta_m, rtheta_p) &
+      !$acc            delete(rt_driving_values, rho_driving_values, rtheta_base)
+      MPAS_ACC_TIMER_STOP('atm_bdy_reset_speczone_values [ACC_data_xfer]')
 
    end subroutine atm_bdy_reset_speczone_values
 


### PR DESCRIPTION
This PR enables the GPU execution of the atm_bdy_reset_speczone_values subroutine using OpenACC directives for the data movements and loops.

A new timer, 'atm_bdy_reset_speczone_values [ACC_data_xfer]', has been added for host-device data transfers in this subroutine.