### PR TITLE
add model version to output file global attributes

### DIFF
--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -512,6 +512,7 @@ module mpas_subdriver
      
       call MPAS_stream_mgr_add_att(domain % streamManager, 'model_name', domain % core % modelName)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'core_name', domain % core % coreName)
+      call MPAS_stream_mgr_add_att(domain % streamManager, 'version', domain % core % modelVersion)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'source', domain % core % source)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'Conventions', domain % core % Conventions)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'git_version', domain % core % git_version)


### PR DESCRIPTION
Add a new 'version' global attribute to all netCDF stream output files.

The value of the attribute is taken from the `domain%core%modelVersion` variable, which ultimately comes from the version attribute in a core's `Registry.xml` file.

Code has been compiled with intel-mpi and a simple test has been completed to demonstrate the impact on the output files. The `version` line below will be added to the NetCDF outputs:

```
// global attributes:
                :model_name = "mpas" ;
                :core_name = "atmosphere" ;
                :version = "8.2.2" ;
                :source = "MPAS" ;
```


