### PR TITLE
Enable GPU execution of mpas_atm_get_bdy_state functions via OpenACC

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -363,7 +363,7 @@ module mpas_atm_boundaries
         real (kind=RKIND), dimension(vertDim,horizDim+1) :: return_state
 
         type (mpas_pool_type), pointer :: lbc
-        integer, pointer :: idx
+        integer, pointer :: idx_ptr
         real (kind=RKIND), dimension(:,:), pointer :: tend
         real (kind=RKIND), dimension(:,:), pointer :: state
         real (kind=RKIND), dimension(:,:,:), pointer :: tend_scalars
@@ -374,6 +374,7 @@ module mpas_atm_boundaries
         real (kind=RKIND) :: dt
         integer :: err_level
         integer :: ierr
+        integer :: i,j,idx
 
 
         currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
@@ -410,13 +411,29 @@ module mpas_atm_boundaries
         ! query the field as a scalar constituent
         !
         if (associated(tend) .and. associated(state)) then
-            return_state(:,:) = state(:,:) - dt * tend(:,:)
+            !$acc parallel
+            !$acc loop gang vector collapse(2)
+            do i=1, horizDim+1
+                do j=1, vertDim
+                    return_state(j,i) = state(j,i) - dt * tend(j,i)
+                end do
+            end do
+            !$acc end parallel
         else
             call mpas_pool_get_array(lbc, 'lbc_scalars', tend_scalars, 1)
             call mpas_pool_get_array(lbc, 'lbc_scalars', state_scalars, 2)
-            call mpas_pool_get_dimension(lbc, 'index_'//trim(field), idx)
+            call mpas_pool_get_dimension(lbc, 'index_'//trim(field), idx_ptr)
 
-            return_state(:,:) = state_scalars(idx,:,:) - dt * tend_scalars(idx,:,:)
+            idx=idx_ptr ! Avoid non-array pointer for OpenACC
+
+            !$acc parallel
+            !$acc loop gang vector collapse(2)
+            do i=1, horizDim+1
+                do j=1, vertDim
+                    return_state(j,i) = state_scalars(idx,j,i) - dt * tend_scalars(idx,j,i)
+                end do
+            end do
+            !$acc end parallel
         end if
 
     end function mpas_atm_get_bdy_state_2d
@@ -476,6 +493,7 @@ module mpas_atm_boundaries
         real (kind=RKIND) :: dt
         integer :: err_level
         integer :: ierr
+        integer :: i,j,k
 
 
         currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
@@ -496,7 +514,16 @@ module mpas_atm_boundaries
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), tend, 1)
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), state, 2)
 
-        return_state(:,:,:) = state(:,:,:) - dt * tend(:,:,:)
+        !$acc parallel
+        !$acc loop gang vector collapse(3)
+        do i=1, horizDim+1
+            do j=1, vertDim
+                do k=1, innerDim
+                    return_state(k,j,i) = state(k,j,i) - dt * tend(k,j,i)
+                end do
+            end do
+        end do
+        !$acc end parallel
 
     end function mpas_atm_get_bdy_state_3d
 

--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -7,6 +7,15 @@
 !
 module mpas_atm_boundaries
 
+#ifdef MPAS_OPENACC
+    use mpas_timer, only: mpas_timer_start, mpas_timer_stop
+#define MPAS_ACC_TIMER_START(X) call mpas_timer_start(X)
+#define MPAS_ACC_TIMER_STOP(X) call mpas_timer_stop(X)
+#else
+#define MPAS_ACC_TIMER_START(X)
+#define MPAS_ACC_TIMER_STOP(X)
+#endif
+
     use mpas_derived_types, only : mpas_pool_type, mpas_clock_type, block_type, mpas_time_type, mpas_timeInterval_type, MPAS_NOW, &
                                    MPAS_STREAM_LATEST_BEFORE, MPAS_STREAM_EARLIEST_STRICTLY_AFTER, &
                                    MPAS_streamManager_type
@@ -411,6 +420,11 @@ module mpas_atm_boundaries
         ! query the field as a scalar constituent
         !
         if (associated(tend) .and. associated(state)) then
+            MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
+            !$acc enter data create(return_state) &
+            !$acc            copyin(tend, state)
+            MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
+
             !$acc parallel
             !$acc loop gang vector collapse(2)
             do i=1, horizDim+1
@@ -419,12 +433,22 @@ module mpas_atm_boundaries
                 end do
             end do
             !$acc end parallel
+
+            MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
+            !$acc exit data copyout(return_state) &
+            !$acc           delete(tend, state)
+            MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
         else
             call mpas_pool_get_array(lbc, 'lbc_scalars', tend_scalars, 1)
             call mpas_pool_get_array(lbc, 'lbc_scalars', state_scalars, 2)
             call mpas_pool_get_dimension(lbc, 'index_'//trim(field), idx_ptr)
 
             idx=idx_ptr ! Avoid non-array pointer for OpenACC
+
+            MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
+            !$acc enter data create(return_state) &
+            !$acc            copyin(tend_scalars, state_scalars)
+            MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
 
             !$acc parallel
             !$acc loop gang vector collapse(2)
@@ -434,6 +458,11 @@ module mpas_atm_boundaries
                 end do
             end do
             !$acc end parallel
+
+            MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
+            !$acc exit data copyout(return_state) &
+            !$acc           delete(tend_scalars, state_scalars)
+            MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
         end if
 
     end function mpas_atm_get_bdy_state_2d
@@ -514,6 +543,11 @@ module mpas_atm_boundaries
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), tend, 1)
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), state, 2)
 
+        MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
+        !$acc enter data create(return_state) &
+        !$acc            copyin(tend, state)
+        MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
+
         !$acc parallel
         !$acc loop gang vector collapse(3)
         do i=1, horizDim+1
@@ -524,6 +558,11 @@ module mpas_atm_boundaries
             end do
         end do
         !$acc end parallel
+
+        MPAS_ACC_TIMER_START('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
+        !$acc exit data copyout(return_state) &
+        !$acc           delete(tend, state)
+        MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
 
     end function mpas_atm_get_bdy_state_3d
 

--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -425,7 +425,7 @@ module mpas_atm_boundaries
             !$acc            copyin(tend, state)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
 
-            !$acc parallel
+            !$acc parallel default(present)
             !$acc loop gang vector collapse(2)
             do i=1, horizDim+1
                 do j=1, vertDim
@@ -450,7 +450,7 @@ module mpas_atm_boundaries
             !$acc            copyin(tend_scalars, state_scalars)
             MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_2d [ACC_data_xfer]')
 
-            !$acc parallel
+            !$acc parallel default(present)
             !$acc loop gang vector collapse(2)
             do i=1, horizDim+1
                 do j=1, vertDim
@@ -548,7 +548,7 @@ module mpas_atm_boundaries
         !$acc            copyin(tend, state)
         MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_state_3d [ACC_data_xfer]')
 
-        !$acc parallel
+        !$acc parallel default(present)
         !$acc loop gang vector collapse(3)
         do i=1, horizDim+1
             do j=1, vertDim


### PR DESCRIPTION
This PR adds OpenACC directives and data movement to the `mpas_atm_get_bdy_state_2d` and `mpas_atm_get_bdy_state_3d` functions.

Timing information for the OpenACC data transfers in this routine is captured in the log file by new timers:
- `mpas_atm_get_bdy_state_2d [ACC_data_xfer]`.
- `mpas_atm_get_bdy_state_3d [ACC_data_xfer]`.