### PR TITLE
Make SMIOL the default I/O layer when running cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,14 @@ option(MPAS_DOUBLE_PRECISION "Use double precision 64-bit Floating point." TRUE)
 option(MPAS_PROFILE "Enable GPTL profiling" OFF)
 option(MPAS_OPENMP "Enable OpenMP" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-option(MPAS_USE_SMIOL "Build with smiol I/O library" OFF)
+option(MPAS_USE_PIO "Build with PIO I/O library" OFF)
 
 message(STATUS "[OPTION] MPAS_CORES: ${MPAS_CORES}")
 message(STATUS "[OPTION] MPAS_DOUBLE_PRECISION: ${MPAS_DOUBLE_PRECISION}")
 message(STATUS "[OPTION] MPAS_PROFILE: ${MPAS_PROFILE}")
 message(STATUS "[OPTION] MPAS_OPENMP: ${MPAS_OPENMP}")
 message(STATUS "[OPTION] BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
-message(STATUS "[OPTION] MPAS_USE_SMIOL: ${MPAS_USE_SMIOL}")
+message(STATUS "[OPTION] MPAS_USE_PIO: ${MPAS_USE_PIO}")
 
 # Build product output locations
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -61,7 +61,7 @@ find_package(OpenMP COMPONENTS Fortran)
 find_package(MPI REQUIRED COMPONENTS Fortran)
 find_package(NetCDF REQUIRED COMPONENTS Fortran C)
 find_package(PnetCDF REQUIRED COMPONENTS Fortran)
-if(NOT MPAS_USE_SMIOL)
+if(MPAS_USE_PIO)
     find_package(PIO REQUIRED COMPONENTS Fortran C)
 endif()
 if(MPAS_PROFILE)
@@ -92,7 +92,7 @@ set(MPAS_SUBDRIVER_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/src/driver/mpas_subdriver.F)
 
 ## Create targets
 add_subdirectory(src/external/ezxml) # Target: MPAS::external::ezxml
-if(MPAS_USE_SMIOL)
+if(NOT MPAS_USE_PIO)
     add_subdirectory(src/external/SMIOL) # Target: MPAS::external::smiol
 endif()
 if(ESMF_FOUND)

--- a/cmake/Functions/MPAS_Functions.cmake
+++ b/cmake/Functions/MPAS_Functions.cmake
@@ -80,13 +80,13 @@ function(mpas_fortran_target target)
 
     # Global Fortran configuration
     set_target_properties(${target} PROPERTIES Fortran_FORMAT FREE)
-    if(MPAS_USE_SMIOL)
+    if(MPAS_USE_PIO)
         set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
-            MPAS_SMIOL_SUPPORT=1
+            USE_PIO2=1
         )
     else()
         set(MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS
-            USE_PIO2=1
+            MPAS_SMIOL_SUPPORT=1
         )
     endif()
     list(APPEND MPAS_FORTRAN_TARGET_COMPILE_DEFINITIONS _MPI=1)

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -41,15 +41,15 @@ set_MPAS_DEBUG_flag(framework)
 set(FRAMEWORK_COMPILE_DEFINITIONS
     mpas=1
     MPAS_NATIVE_TIMERS)
-if (MPAS_USE_SMIOL)
-    list(APPEND FRAMEWORK_COMPILE_DEFINITIONS MPAS_SMIOL_SUPPORT)
-    set(IO_LIBS
-        ${PROJECT_NAME}::external::smiolf)
-else()
+if (MPAS_USE_PIO)
     list(APPEND FRAMEWORK_COMPILE_DEFINITIONS USE_PIO2 MPAS_PIO_SUPPORT)
     set(IO_LIBS
         PIO::PIO_Fortran
         PIO::PIO_C)
+else()
+    list(APPEND FRAMEWORK_COMPILE_DEFINITIONS MPAS_SMIOL_SUPPORT)
+    set(IO_LIBS
+        ${PROJECT_NAME}::external::smiolf)
 endif()
 target_compile_definitions(framework PRIVATE ${FRAMEWORK_COMPILE_DEFINITIONS})
 


### PR DESCRIPTION
The default I/O layer when building MPAS-Model via cmake used to be PIO, but when building via make SMIOL is the default I/O layer. This change makes SMIOL the default I/O layer when building via cmake.

The cmake variable MPAS_USE_SMIOL is changed to be MPAS_USE_PIO. The default value of MPAS_USE_PIO is OFF.
To build with the PIO library run cmake with -DMPAS_USE_PIO=ON.

This change was verified by running
`cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DMPAS_DOUBLE_PRECISION=OFF` then running make to build MPAS-Model.
After the build completed I verified that the executables were linked against `libsmiolf.so` and `libsmiol.so`.

I then tested the build by running the panda-c cylc test suite,
3dvar_OIE120km_WarmStart_TEST/
3dvar_OIE120km_ColdStart_TEST/
3dvar_O30kmIE60km_ColdStart_TEST/
3denvar_O30kmIE60km_WarmStart_TEST/
4denvar_OIE120km_WarmStart_TEST/
4dhybrid_OIE120km_WarmStart_TEST/
eda_OIE120km_WarmStart_TEST/
getkf_OIE120km_WarmStart_TEST/
ForecastFromGFSAnalysesMPT_TEST/
3denvar_OIE120km_IAU_WarmStart_TEST/

The 3denvar_OIE120km_IAU_WarmStart_TEST scenario failed because it tries to read an HDF5 data file, which isn't supported by SMIOL.

Building with the PIO library was verified by running
`cmake -DMPAS_USE_PIO=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DMPAS_DOUBLE_PRECISION=OFF`
then building with make. After the build completed I verified executables were linked against `libpiof.so` and `libpioc.so`

I then tested the build by running the panda-c cylc test suite, as above. All tests passed.
