### PR TITLE
Disable physics for MPAS dycore-only build

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -4,8 +4,11 @@
 # To build a dycore-only MPAS-Atmosphere model, comment-out or delete
 # the definition of PHYSICS, below
 #
-PHYSICS=-DDO_PHYSICS
-
+# If MPAS_CAM_DYCORE is found in CPPFLAGS, PHYSICS will become undefined automatically
+#
+ifeq ($(findstring MPAS_CAM_DYCORE,$(CPPFLAGS)),)
+    PHYSICS = -DDO_PHYSICS
+endif
 
 ifdef PHYSICS
     PHYSCORE = physcore


### PR DESCRIPTION
When building MPAS as a dynamical core, all physics-related components are disabled. This build configuration is usually used by CAM/CAM-SIMA, and can be achieved by defining the `MPAS_CAM_DYCORE` macro in `CPPFLAGS`.

On the other hand, the `PHYSICS` Makefile variable controls whether physics are enabled in MPAS, but its logic is decoupled from the `MPAS_CAM_DYCORE` macro. Disabling physics in MPAS currently requires manual interventions.

This PR disables physics automatically when the `MPAS_CAM_DYCORE` macro is found in `CPPFLAGS`. It mainly benefits CAM-SIMA, which reuses the build infrastructure of MPAS for building it as a dynamical core.

For stand-alone MPAS and CAM, this PR is an NFC (No Functional Change).