### PR TITLE
Declare constants at the native precision of MPAS

### DIFF
--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -12,7 +12,7 @@
 !> \brief   MPAS Constant Module
 !> \author  Michael Duda
 !> \date    03/27/13
-!> \details 
+!> \details
 !> This module provides various constants that can be used in different parts of MPAS.
 !> They may or may not be a physical quantity.
 !
@@ -55,6 +55,7 @@ module mpas_constants
    real (kind=RKIND), parameter :: p0 = 1.0e5_RKIND                   !< Constant: 100000 Pa
    real (kind=RKIND), parameter :: prandtl = 1.0_RKIND                !< Constant: Prandtl number
 
+
    contains
 
 
@@ -65,7 +66,7 @@ module mpas_constants
 !> \brief   Computes derived constants
 !> \author  Michael Duda
 !> \date    8 May 2020
-!> \details 
+!> \details
 !>  This routine provides a place where physical constants provided by
 !>  the mpas_constants module may be computed at runtime. For example,
 !>  if some constants depend on namelist options or other runtime

--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -20,7 +20,7 @@
 
 module mpas_constants
 
-   use mpas_kind_types
+   use mpas_kind_types, only: RKIND
 
    implicit none
 

--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -22,6 +22,8 @@ module mpas_constants
 
    use mpas_kind_types
 
+   implicit none
+
 #ifdef MPAS_CAM_DYCORE
    ! Set at run-time by `mpas_constants_compute_derived`.
    real (kind=RKIND), protected :: pii     = huge(1.0_RKIND)
@@ -83,8 +85,6 @@ module mpas_constants
        use physconst, only: external_rgas => rair
        use physconst, only: external_rv => rh2o
        use physconst, only: external_cp => cpair
-
-       implicit none
 
        ! Convert external constants to the native precision of MPAS (i.e., `RKIND`).
 

--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -23,16 +23,17 @@ module mpas_constants
    use mpas_kind_types
 
 #ifdef MPAS_CAM_DYCORE
-   use physconst, only : pii => pi
-   use physconst, only : gravity => gravit
-   use physconst, only : omega
-   use physconst, only : a => rearth
-   use physconst, only : cp => cpair
-   use physconst, only : rgas => rair
-   use physconst, only : rv => rh2o
-   real (kind=RKIND) :: rvord = huge(1.0_RKIND)                       ! Derived in mpas_constants_compute_derived
-   real (kind=RKIND) :: cv = huge(1.0_RKIND)                          ! Derived in mpas_constants_compute_derived
-   real (kind=RKIND) :: cvpm = huge(1.0_RKIND)                        ! Derived in mpas_constants_compute_derived
+   ! Set at run-time by `mpas_constants_compute_derived`.
+   real (kind=RKIND), protected :: pii     = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: a       = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: omega   = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: gravity = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: rgas    = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: rv      = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: cp      = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: rvord   = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: cv      = huge(1.0_RKIND)
+   real (kind=RKIND), protected :: cvpm    = huge(1.0_RKIND)
 #else
    real (kind=RKIND), parameter :: pii     = 3.141592653589793_RKIND  !< Constant: Pi
    real (kind=RKIND), parameter :: a       = 6371229.0_RKIND          !< Constant: Spherical Earth radius [m]
@@ -74,9 +75,27 @@ module mpas_constants
 !-----------------------------------------------------------------------
    subroutine mpas_constants_compute_derived()
 
+#ifdef MPAS_CAM_DYCORE
+       use physconst, only: external_pii => pi
+       use physconst, only: external_a => rearth
+       use physconst, only: external_omega => omega
+       use physconst, only: external_gravity => gravit
+       use physconst, only: external_rgas => rair
+       use physconst, only: external_rv => rh2o
+       use physconst, only: external_cp => cpair
+
        implicit none
 
-#ifdef MPAS_CAM_DYCORE
+       ! Convert external constants to the native precision of MPAS (i.e., `RKIND`).
+
+       pii = real(external_pii, RKIND)
+       a = real(external_a, RKIND)
+       omega = real(external_omega, RKIND)
+       gravity = real(external_gravity, RKIND)
+       rgas = real(external_rgas, RKIND)
+       rv = real(external_rv, RKIND)
+       cp = real(external_cp, RKIND)
+
        !
        ! In the case of CAM-MPAS, rgas may depend on a CAM namelist option,
        ! so physical constants that depend on rgas must be computed here after

--- a/src/framework/mpas_constants.F
+++ b/src/framework/mpas_constants.F
@@ -24,6 +24,9 @@ module mpas_constants
 
    implicit none
 
+   public
+   private :: RKIND
+
 #ifdef MPAS_CAM_DYCORE
    ! Set at run-time by `mpas_constants_compute_derived`.
    real (kind=RKIND), protected :: pii     = huge(1.0_RKIND)


### PR DESCRIPTION
When building MPAS as a dynamical core, certain constants in the `mpas_constants` module are imported from the `physconst` module, which is a part of CAM/CAM-SIMA. However, multiple issues arise if the precision of those constants differs from MPAS.

For example, building MPAS in single precision mode with CAM-SIMA fails due to multiple occurrences of type mismatch between actual and dummy arguments.

```
mpas_geometry_utils.F:885:157:

  885 |          call mpas_log_write('$r', MPAS_LOG_ERR, realArgs=(/mpas_triangle_signed_area_sphere(a,b,c,sphereRadius) - pii/2.0_RKIND*sphereRadius*sphereRadius/))
      |                                                                                                                                                             1
Error: Type mismatch in argument 'realargs' at (1); passed REAL(8) to REAL(4)
```

Here, `pii` is declared by CAM-SIMA to be double precision, and it causes unintended floating-point promotion in the expression.

The solution is to ensure that constants in the `mpas_constants` module are declared at the native precision of MPAS. Note that CAM does not support running MPAS in single precision mode at all, so the above build error cannot be reproduced.

In addition, some best practices of modern Fortran have been implemented.

For stand-alone MPAS, the compiled executables stay bitwise identical, with or without this PR. No further tests are needed. For CAM/CAM-SIMA, it generates bitwise identical model results, with or without this PR. Additionally for CAM-SIMA, its regression tests all pass, indicating identical model results to the previous baseline.