### PR TITLE
Build flag to keep nvhpc GPU builds bit-identical with CPU builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ nvhpc:   # BUILDTARGET NVIDIA HPC SDK
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
 	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel" \
+	"FFLAGS_NVHPC_ACC_BFB = -Mnofma -gpu=math_uniform" \
+	"FFLAGS_NVHPC_BFB = -Mnofma" \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \
@@ -849,6 +851,14 @@ ifeq "$(OPENACC)" "true"
         override CPPFLAGS += "-DMPAS_OPENACC"
         LDFLAGS += $(FFLAGS_ACC)
 endif #OPENACC IF
+
+ifeq "$(NVHPC_BFB)" "true"
+        ifeq "$(OPENACC)" "true"
+		FFLAGS += ${FFLAGS_NVHPC_ACC_BFB}
+        else
+		FFLAGS += ${FFLAGS_NVHPC_BFB}
+        endif
+endif #NVHPC IF
 
 ifeq "$(OPENMP_OFFLOAD)" "true"
 	FFLAGS += $(FFLAGS_GPU)


### PR DESCRIPTION
In order for MPAS-A OpenACC runs on GPU to remain bit-identical with the CPU runs, we need to use  the `-Mnofma` ( no Fuse-Multiply-Add)  switch  to the NVHPC CPU build and `-Mnofma -gpu=math_uniform` for the NVHPC GPU builds. This PR introduces a new compile-time switch `NVHPC_BFB` to request the CPU and GPU builds have these properties. 

Prior to this PR, the `-Mnofma` was only set inside `FFLAGS_ACC`, which did nevertheless not apply to CPU builds. This has been fixed. Additionally, with this change, we could potentially remove the `-Mnofma` option from the optimized builds, and only selectively request it for verifying the GPU results against the CPU reference.

The usage is as follows:

CPU build:
```
make nvhpc -j4 NVHPC_BFB=true
```

GPU build:
```
make nvhpc -j4 OPENACC=true NVHPC_BFB=true
```