### PR TITLE
Fix bug in determining when decompositions can be reused by the SMIOL library

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -1483,6 +1483,28 @@ module mpas_io
                end if
             end do
 #endif
+#ifdef MPAS_SMIOL_SUPPORT
+            !
+            ! For the SMIOL library, only the size of the outermost (decomposed) dimension
+            ! must match, and the sizes of any inner dimensions do not need to be checked.
+            ! Since the dimensionality of fields may vary, previously created decopositions
+            ! always store the size of the decomposed dimension at decomphandle % dims(1)
+            ! rather than at decomphandle % dims(ndims)
+            !
+            if (.not. field_cursor % fieldhandle % has_unlimited_dim) then
+               if (decomp_cursor % decomphandle % dims(1) /= &
+                   field_cursor % fieldhandle % dims(field_cursor % fieldhandle % ndims) % dimsize) then
+                  decomp_cursor => decomp_cursor % next
+                  cycle DECOMP_LOOP
+               end if
+            else
+               if (decomp_cursor % decomphandle % dims(1) /= &
+                   field_cursor % fieldhandle % dims(field_cursor % fieldhandle % ndims - 1) % dimsize) then
+                  decomp_cursor => decomp_cursor % next
+                  cycle DECOMP_LOOP
+               end if
+            end if
+#endif
 
             if (size(decomp_cursor % decomphandle % indices) /= size(indices)) then
 !call mpas_log_write('We do not have the same number of indices in this decomposition...')
@@ -1660,6 +1682,11 @@ module mpas_io
 #endif
 
 #ifdef MPAS_SMIOL_SUPPORT
+      ! Save the size of the outermost (decomposed) dimension for the field for use in
+      ! subsequent calls to MPAS_io_set_var_indices when checking whether this
+      ! decomposition can be reused for other fields
+      new_decomp % decomphandle % dims(1) = field_cursor % fieldhandle % dims(ndims) % dimsize
+
       allocate(smiol_indices(size(indices)))
       smiol_indices(:) = int(indices(:), kind=SMIOL_offset_kind) - 1_SMIOL_offset_kind   ! SMIOL indices are 0-based
       smiol_n_compute_elements = size(indices,kind=SMIOL_offset_kind)


### PR DESCRIPTION
This PR fixes a bug in logic for determining when decompositions can be reused by the SMIOL library.

The `MPAS_io_set_var_indices()` routine in `mpas_io.F` contains logic to determine whether a decomposition can be reused from the set of existing decompositions; this can save time, as the creation of a new decomposition structure can incur a non-trivial cost.

The checks to determine whether a SMIOL decomposition can be reused previously employed the following criteria:

* The number of compute offsets (indices) on an MPI rank matches
* The offsets themselves for the MPI rank all agreed

These two criteria alone left open the possibility that all MPI ranks may individually find apparently compatible decompositions, but that the decomposition selected by each MPI rank may be different, leading to I/O errors.

Consider the following two decompositions with sets of compute offsets on two MPI ranks:
```
           MPI rank 0    MPI rank 1
Decomp 1:  {0,2}         {1}
Decomp 2:  {0}           {1}
```
If a new field in which rank 0 has offset {0} and rank 1 has offset {1} was considered, MPI rank 0 would select decomp 2 as a matching decomposition, while MPI rank 1 would select decomp 1 (because decompositions are tested in order).

Now, a third criterion has been added to the checks, namely, that the decomposition must have the same global number of offsets. It is worth noting that this new criterion is a necessary condition for correctly reusing decompositions, but combined with the existing criteria, may not be sufficient to guarantee correct reuse of decompositions under all possible conditions. Nonetheless, the addition of the third criterion enables the correct selection of decompositions under conditions
that previously resulted in failure.