### PR TITLE
Fix error reporting when config_nfglevels is insufficiently large

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3547,6 +3547,7 @@ module init_atm_cases
                ! many unique levels are found using the code above
                !
                if (too_many_fg_levs) then
+                  deallocate(field % slab)
                   call read_next_met_field(field, istatus)
                   cycle
                end if
@@ -5283,6 +5284,7 @@ call mpas_log_write('Done with soil consistency check')
                ! many unique levels are found using the code above
                !
                if (too_many_fg_levs) then
+                  deallocate(field % slab)
                   call read_next_met_field(field, istatus)
                   cycle
                end if


### PR DESCRIPTION
In init_atmosphere, during the interpolation of first-guess meteorological fields from the intermediate files (`config_init_case` = 7 or 9), the value of `config_nfglevels` must be set to a minimum of the number of vertical levels in the intermediate file. Currently, the routines `init_atm_case_gfs` and `init_atm_case_lbc` have a logic to throw an error and exit if `config_nfglevels` is not sufficiently large. In practice, this error message is not reported consistently with intermediate files containing many levels and/or many MPI ranks being used.

This PR fixes the inconsistent error reporting issue by adding the required `deallocate` statements before the repeated calls to read_next_met_field in the case of `config_nfglevels` being insufficiently large. Without the `deallocate` one or more MPI ranks crash during the read of the `field % slab` from the intermediate file. This typically results in a crash of init_atmosphere without any useful error messages in the log files.