### PR TITLE
Consolidating access to the config_dt namelist option

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -838,7 +838,6 @@ module atm_time_integration
       logical, pointer :: config_scalar_advection
       logical, pointer :: config_positive_definite
       logical, pointer :: config_monotonic
-      real (kind=RKIND), pointer :: config_dt
       character (len=StrKIND), pointer :: config_microp_scheme
       character (len=StrKIND), pointer :: config_convection_scheme
 
@@ -880,7 +879,6 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_scalar_advection', config_scalar_advection)
       call mpas_pool_get_config(block % configs, 'config_positive_definite', config_positive_definite)
       call mpas_pool_get_config(block % configs, 'config_monotonic', config_monotonic)
-      call mpas_pool_get_config(block % configs, 'config_dt', config_dt)
       call mpas_pool_get_config(block % configs, 'config_IAU_option', config_IAU_option)
       !  config variables for dynamics-transport splitting, WCS 18 November 2014
       call mpas_pool_get_config(block % configs, 'config_split_dynamics_transport', config_split_dynamics_transport)
@@ -1602,7 +1600,7 @@ module atm_time_integration
          !requires that the subroutine atm_advance_scalars_mono was called on the third Runge Kutta step, so that a halo
          !update for the scalars at time_levs(1) is applied. A halo update for the scalars at time_levs(2) is done above. 
          if (config_monotonic) then
-            rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / config_dt
+            rqvdynten(:,:) = ( scalars_2(index_qv,:,:) - scalars_1(index_qv,:,:) ) / dt
          else
             rqvdynten(:,:) = 0._RKIND
          end if

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -604,7 +604,7 @@ module atm_core
       type (domain_type), intent(inout) :: domain
       integer :: ierr
    
-      real (kind=RKIND), pointer :: dt
+      real (kind=RKIND) :: dt
       logical, pointer :: config_do_restart
       logical, pointer :: config_apply_lbcs
       type (block_type), pointer :: block_ptr
@@ -631,8 +631,7 @@ module atm_core
       clock => domain % clock
       mpas_log_info => domain % logInfo
       
-      ! Eventually, dt should be domain specific
-      call mpas_pool_get_config(domain % blocklist % configs, 'config_dt', dt)
+      call mpas_get_timeInterval(mpas_get_clock_timestep(clock, ierr), dt=dt)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(domain % blocklist % configs, 'config_restart_timestamp_name', config_restart_timestamp_name)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -401,7 +401,7 @@ use mpas_stream_manager
     if(config_lsm_scheme .eq. 'sf_noah') then
        call init_lsm(dminfo,mesh,configs,diag_physics,sfc_input)
     elseif(config_lsm_scheme .eq. 'sf_noahmp') then
-       call init_lsm_noahmp(configs,mesh,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
+       call init_lsm_noahmp(configs,mesh,clock,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
     endif
  endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahmpinit.F
@@ -9,7 +9,7 @@
  module mpas_atmphys_lsm_noahmpinit
  use mpas_log
  use mpas_pool_routines
-
+ use mpas_timekeeping,only      : mpas_get_timeInterval, mpas_get_clock_timestep
  use mpas_atmphys_utilities,only: physics_error_fatal
  use mpas_atmphys_vars,only     : mpas_noahmp
 
@@ -28,12 +28,13 @@
 
 
 !=================================================================================================================
- subroutine init_lsm_noahmp(configs,mesh,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
+ subroutine init_lsm_noahmp(configs,mesh,clock,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
 !=================================================================================================================
 
 !--- input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_clock_type),intent(in):: clock
 
 !--- inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
@@ -88,7 +89,7 @@
 
 
 !--- initialize noahmp:
- call noahmp_init(configs,mesh,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
+ call noahmp_init(configs,mesh,clock,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
 
 
 !call mpas_log_write('--- end subroutine init_lsm_noahmp:')
@@ -213,12 +214,13 @@
  end subroutine noahmp_read_namelist
 
 !=================================================================================================================
- subroutine noahmp_init(configs,mesh,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
+ subroutine noahmp_init(configs,mesh,clock,diag_physics,diag_physics_noahmp,output_noahmp,sfc_input)
 !=================================================================================================================
 
 !--- input arguments:
  type(mpas_pool_type),intent(in):: configs
  type(mpas_pool_type),intent(in):: mesh
+ type(mpas_clock_type),intent(in):: clock
 
 !--- inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
@@ -234,7 +236,7 @@
  integer,dimension(:),pointer:: isnowxy
  integer,dimension(:),pointer:: irnumsi,irnummi,irnumfi
  
- real(kind=RKIND),pointer:: dt
+ real(kind=RKIND):: dt
 
  real(kind=RKIND),dimension(:),pointer:: soilcl1,soilcl2,soilcl3,soilcl4
  real(kind=RKIND),dimension(:,:),pointer:: soilcomp
@@ -271,7 +273,7 @@
 !--- initialization of Noah-MP run parameters:
  call mpas_pool_get_config(configs,'config_do_restart',do_restart)
  call mpas_pool_get_config(configs,'config_urban_physics',urban_physics)
- call mpas_pool_get_config(configs,'config_dt',dt)
+ call mpas_get_timeInterval(mpas_get_clock_timestep(clock, ierr), dt=dt)
 
  mpas_noahmp%restart_flag = do_restart
  mpas_noahmp%sf_urban_physics = 0

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -410,7 +410,7 @@
  integer,pointer:: nAerosols,nAerLevels,nOznLevels
  integer,pointer:: nCellsSolve,nSoilLevels,nVertLevels
 
- real(kind=RKIND),pointer:: config_dt
+ real(kind=RKIND):: dt
 
 !local variables:
  type(MPAS_Time_Type):: startTime,alarmStartTime
@@ -439,7 +439,7 @@
  call mpas_pool_get_config(configs,'config_frac_seaice'      ,config_frac_seaice      )
  call mpas_pool_get_config(configs,'config_microp_re'        ,config_microp_re        )
 
- call mpas_pool_get_config(configs,'config_dt',config_dt)
+ call mpas_get_timeInterval(mpas_get_clock_timestep(clock, ierr), dt=dt)
 
 
  call mpas_pool_get_dimension(mesh,'cam_dim1'   ,cam_dim1   )
@@ -482,7 +482,7 @@
        call physics_error_fatal('subroutine physics_run_init: error defining dt_radtlw')
 
  elseif(trim(config_radtlw_interval) == "none") then
-    dt_radtlw = config_dt
+    dt_radtlw = dt
 
  else
     call physics_error_fatal('subroutine physics_run_init: dt_radtlw is not defined')
@@ -501,7 +501,7 @@
        call physics_error_fatal('subroutine physics_run_init: error defining radtswAlarmID')
 
  elseif(trim(config_radtsw_interval) == "none") then
-    dt_radtsw = config_dt
+    dt_radtsw = dt
 
  else
     call physics_error_fatal('subroutine physics_run_init: dt_radtsw is not defined')
@@ -520,7 +520,7 @@
        call physics_error_fatal('subroutine physics_run_init: error defining dt_cu')
 
  elseif(trim(config_conv_interval) == "none") then
-    dt_cu = config_dt
+    dt_cu = dt
 
  else
     call physics_error_fatal('subroutine physics_run_init: dt_cu is not defined')
@@ -539,7 +539,7 @@
        call physics_error_fatal('subroutine physics_run_init: error defining dt_pbl')
 
  elseif(trim(config_pbl_interval) == "none") then
-    dt_pbl = config_dt
+    dt_pbl = dt
 
  else
     call physics_error_fatal('subroutine physics_run_init: dt_pbl is not defined')
@@ -578,7 +578,7 @@
 !set alarm to write the "CAM" local arrays absnst_p, absnxt_p, and emstot_p to the MPAS arrays
 !for writing to the restart file at the bottom of the time-step:
  if(trim(config_radt_lw_scheme) .eq. "cam_lw" ) then
-    call mpas_set_timeInterval(camlwTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(camlwTimeStep,dt=dt,ierr=ierr)
     call MPAS_stream_mgr_get_property(stream_manager, 'restart', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
                                       direction=MPAS_STREAM_OUTPUT, ierr=ierr)
     if(trim(stream_interval) /= 'none') then
@@ -593,7 +593,7 @@
 !set alarm to check if the accumulated rain due to cloud microphysics and convection is
 !greater than its maximum allowed value:
  if(config_bucket_update /= "none") then
-    call mpas_set_timeInterval(acrainTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(acrainTimeStep,dt=dt,ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
     alarmStartTime = startTime + alarmTimeStep
     call mpas_add_clock_alarm(clock,acrainAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
@@ -604,7 +604,7 @@
 !set alarm to check if the accumulated radiation diagnostics due to long- and short-wave radiation
 !is greater than its maximum allowed value:
  if(config_bucket_update /= "none") then
-    call mpas_set_timeInterval(acradtTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(acradtTimeStep,dt=dt,ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
     alarmStartTime = startTime + alarmTimeStep
     call mpas_add_clock_alarm(clock,acradtAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
@@ -681,7 +681,7 @@
 
 !initialization of local physics time-steps:
 !... dynamics:
- dt_dyn    = config_dt
+ dt_dyn    = dt
 !... cloud microphysics:
  dt_microp = dt_dyn
  n_microp  = 1


### PR DESCRIPTION
This PR introduces changes to the atmosphere core in order to ensure that the `config_dt` namelist option is accessed only once during the model run inside `atm_simulation_clock_init` called from the `atm_setup_clock` function. Therafter, the various parts of the atmosphere core are expected to retrieve the timestep size from either the clock or via an argument list. 
