### PR TITLE
Capability for understanding ICON soil variables

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3499,6 +3499,14 @@ module init_atm_cases
              trim(field % field) == 'SM028100' .or. &
              trim(field % field) == 'SM100255' .or. &
              trim(field % field) == 'SM100289' .or. &
+             trim(field % field) == 'SOILM001' .or. &
+             trim(field % field) == 'SOILM002' .or. &
+             trim(field % field) == 'SOILM006' .or. &
+             trim(field % field) == 'SOILM018' .or. &
+             trim(field % field) == 'SOILM054' .or. &
+             trim(field % field) == 'SOILM162' .or. &
+             trim(field % field) == 'SOILM486' .or. &
+             trim(field % field) == 'SOILM999' .or. &
              trim(field % field) == 'ST000010' .or. &
              trim(field % field) == 'ST010040' .or. &
              trim(field % field) == 'ST040100' .or. &
@@ -3509,6 +3517,14 @@ module init_atm_cases
              trim(field % field) == 'ST028100' .or. &
              trim(field % field) == 'ST100255' .or. &
              trim(field % field) == 'ST100289' .or. &
+             trim(field % field) == 'SOILT001' .or. &
+             trim(field % field) == 'SOILT002' .or. &
+             trim(field % field) == 'SOILT006' .or. &
+             trim(field % field) == 'SOILT018' .or. &
+             trim(field % field) == 'SOILT054' .or. &
+             trim(field % field) == 'SOILT162' .or. &
+             trim(field % field) == 'SOILT486' .or. &
+             trim(field % field) == 'SOILT999' .or. &
              trim(field % field) == 'PRES' .or. &
              trim(field % field) == 'PRESSURE' .or. &
              trim(field % field) == 'SNOW' .or. &
@@ -3525,6 +3541,14 @@ module init_atm_cases
                 trim(field % field) == 'SM028100' .or. &
                 trim(field % field) == 'SM100255' .or. &
                 trim(field % field) == 'SM100289' .or. &
+                trim(field % field) == 'SOILM001' .or. &
+                trim(field % field) == 'SOILM002' .or. &
+                trim(field % field) == 'SOILM006' .or. &
+                trim(field % field) == 'SOILM018' .or. &
+                trim(field % field) == 'SOILM054' .or. &
+                trim(field % field) == 'SOILM162' .or. &
+                trim(field % field) == 'SOILM486' .or. &
+                trim(field % field) == 'SOILM999' .or. &
                 trim(field % field) == 'ST000010' .or. &
                 trim(field % field) == 'ST010040' .or. &
                 trim(field % field) == 'ST040100' .or. &
@@ -3535,6 +3559,14 @@ module init_atm_cases
                 trim(field % field) == 'ST028100' .or. &
                 trim(field % field) == 'ST100255' .or. &
                 trim(field % field) == 'ST100289' .or. &
+                trim(field % field) == 'SOILT001' .or. &
+                trim(field % field) == 'SOILT002' .or. &
+                trim(field % field) == 'SOILT006' .or. &
+                trim(field % field) == 'SOILT018' .or. &
+                trim(field % field) == 'SOILT054' .or. &
+                trim(field % field) == 'SOILT162' .or. &
+                trim(field % field) == 'SOILT486' .or. &
+                trim(field % field) == 'SOILT999' .or. &
                 trim(field % field) == 'SNOW' .or. &
                 trim(field % field) == 'SEAICE' .or. &
                 trim(field % field) == 'SKINTEMP') then
@@ -3905,6 +3937,166 @@ module init_atm_cases
                ndims = 2
                dzs_fg(k,:) = 289.-100.
                zs_fg(k,:) = 289.
+            else if (trim(field % field) == 'SOILM001') then
+               call mpas_log_write('Interpolating SOILM001')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 1
+               ndims = 2
+               dzs_fg(k,:) = 1.-0.
+               zs_fg(k,:) = 1.
+            else if (trim(field % field) == 'SOILM002') then
+               call mpas_log_write('Interpolating SOILM002')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 2
+               ndims = 2
+               dzs_fg(k,:) = 3.-1.
+               zs_fg(k,:) = 3.
+            else if (trim(field % field) == 'SOILM006') then
+               call mpas_log_write('Interpolating SOILM006')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 3
+               ndims = 2
+               dzs_fg(k,:) = 9.-3.
+               zs_fg(k,:) = 9.
+            else if (trim(field % field) == 'SOILM018') then
+               call mpas_log_write('Interpolating SOILM018')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 4
+               ndims = 2
+               dzs_fg(k,:) = 27.-9.
+               zs_fg(k,:) = 27.
+            else if (trim(field % field) == 'SOILM054') then
+               call mpas_log_write('Interpolating SOILM054')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 5
+               ndims = 2
+               dzs_fg(k,:) = 81.-27.
+               zs_fg(k,:) = 81.
+            else if (trim(field % field) == 'SOILM162') then
+               call mpas_log_write('Interpolating SOILM162')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 6
+               ndims = 2
+               dzs_fg(k,:) = 243.-81.
+               zs_fg(k,:) = 243.
+            else if (trim(field % field) == 'SOILM486') then
+               call mpas_log_write('Interpolating SOILM486')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 7
+               ndims = 2
+               dzs_fg(k,:) = 729.-243.
+               zs_fg(k,:) = 729.
+            else if (trim(field % field) == 'SOILM999') then
+               call mpas_log_write('Interpolating SOILM999')
+
+               interp_list(1) = FOUR_POINT
+               interp_list(2) = W_AVERAGE4
+               interp_list(3) = SEARCH
+               interp_list(4) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 1.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'sm_fg', destField2d)
+               k = 8
+               ndims = 2
+               dzs_fg(k,:) = 2187.-729.
+               zs_fg(k,:) = 2187.
             else if (trim(field % field) == 'ST000010') then
                call mpas_log_write('Interpolating ST000010')
 
@@ -4115,6 +4307,174 @@ module init_atm_cases
                ndims = 2
                dzs_fg(k,:) = 289.-100.
                zs_fg(k,:) = 289.
+            else if (trim(field % field) == 'SOILT001') then
+               call mpas_log_write('Interpolating SOILT001')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 1
+               ndims = 2
+               dzs_fg(k,:) = 1.-0.
+               zs_fg(k,:) = 1.
+            else if (trim(field % field) == 'SOILT002') then
+               call mpas_log_write('Interpolating SOILT002')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 2
+               ndims = 2
+               dzs_fg(k,:) = 3.-1.
+               zs_fg(k,:) = 3.
+            else if (trim(field % field) == 'SOILT006') then
+               call mpas_log_write('Interpolating SOILT006')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 3
+               ndims = 2
+               dzs_fg(k,:) = 9.-3.
+               zs_fg(k,:) = 9.
+            else if (trim(field % field) == 'SOILT018') then
+               call mpas_log_write('Interpolating SOILT018')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 4
+               ndims = 2
+               dzs_fg(k,:) = 27.-9.
+               zs_fg(k,:) = 27.
+            else if (trim(field % field) == 'SOILT054') then
+               call mpas_log_write('Interpolating SOILT054')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 5
+               ndims = 2
+               dzs_fg(k,:) = 81.-27.
+               zs_fg(k,:) = 81.
+            else if (trim(field % field) == 'SOILT162') then
+               call mpas_log_write('Interpolating SOILT162')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 6
+               ndims = 2
+               dzs_fg(k,:) = 243.-81.
+               zs_fg(k,:) = 243.
+            else if (trim(field % field) == 'SOILT486') then
+               call mpas_log_write('Interpolating SOILT486')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 7
+               ndims = 2
+               dzs_fg(k,:) = 729.-243.
+               zs_fg(k,:) = 729.
+            else if (trim(field % field) == 'SOILT999') then
+               call mpas_log_write('Interpolating SOILT999')
+
+               interp_list(1) = SIXTEEN_POINT
+               interp_list(2) = FOUR_POINT
+               interp_list(3) = W_AVERAGE4
+               interp_list(4) = SEARCH
+               interp_list(5) = 0
+
+               maskval = 0.0
+               masked = 0
+               fillval = 285.0
+
+               nInterpPoints = nCells
+               latPoints => latCell
+               lonPoints => lonCell
+               call mpas_pool_get_array(fg, 'st_fg', destField2d)
+               k = 8
+               ndims = 2
+               dzs_fg(k,:) = 2187.-729.
+               zs_fg(k,:) = 2187.
             else if (trim(field % field) == 'SNOW') then
                call mpas_log_write('Interpolating SNOW')
 


### PR DESCRIPTION
The ICON models have a soil grid that is different from the Noah LSM grid, which is why this pull request contains the capability for understanding 16 more soil variables in the output files of ungrib.

The new variables are listed in the [Vtable](https://github.com/wrf-model/WPS/blob/master/ungrib/Variable_Tables/Vtable.ICONm) of ICON.

ICON data can be found [here](https://opendata.dwd.de/weather/nwp).

If this pull request is successful, I can do the same for the soil output of RAP/HRRR.