### PR TITLE
Correct the loop for NoahMP snow initialization check - capping maximum SWE for 2000mm

### DIFF
--- a/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
+++ b/src/core_atmosphere/physics/physics_noahmp/drivers/mpas/NoahmpInitMainMod.F90
@@ -50,7 +50,7 @@
 
     ! Check if snow/snowh are consistent and cap SWE at 2000mm
     ! the Noah-MP code does it internally but if we don't do it here, problems ensue
-    do i = its, its
+    do i = its, ite 
        if ( NoahmpIO%snow(i)  < 0.0 ) NoahmpIO%snow(i)  = 0.0
        if ( NoahmpIO%snowh(i) < 0.0 ) NoahmpIO%snowh(i) = 0.0
        if ( (NoahmpIO%snow(i) > 0.0) .and. (NoahmpIO%snowh(i) == 0.0) ) &


### PR DESCRIPTION
This merge corrects the loop for NoahMP snow initialization, cappting snow water equivalent maximum at 2000 mm. (https://github.com/MPAS-Dev/MPAS-Model/issues/1299)
Merge this PR to hotfix-v8.2.3. 