### PR TITLE
This commit changes the horizontal interpolation from a four-point to a 16 point interp in init_atmosphere cases 7 and 9 for the dynamics variables

### DIFF
--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -3469,7 +3469,8 @@ module init_atm_cases
 
       do while (istatus == 0)
 
-         interp_list(1) = FOUR_POINT
+         ! interp_list(1) = FOUR_POINT
+         interp_list(1) = SIXTEEN_POINT
          interp_list(2) = SEARCH
          interp_list(3) = 0
 
@@ -5261,7 +5262,8 @@ call mpas_log_write('Done with soil consistency check')
 
       do while (istatus == 0)
 
-         interp_list(1) = FOUR_POINT
+         ! interp_list(1) = FOUR_POINT
+         interp_list(1) = SIXTEEN_POINT
          interp_list(2) = SEARCH
          interp_list(3) = 0
 


### PR DESCRIPTION
This commit changes the horizontal interpolation from a four-point bilinear interpolation to a sixteen point overlapping parabolic interpolation for both initialization of the state variables from an existing analysis (e.g. GFS, ERA5, etc; case 7 for init_atmosphere) and for interpolating lateral boundary values for the regional MPAS-A configuration (case 9 for init_atmosphere).


