### PR TITLE
Change the zero-gradient w LBC to setting w=0 in the specified zone

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6113,7 +6113,8 @@ module atm_time_integration
          if (bdyMaskCell(iCell) > nRelaxZone) then
 !DIR$ IVDEP
             do k = 2, nVertLevels
-              w(k,iCell) = w(k,nearestRelaxationCell(iCell))
+               ! w(k,iCell) = w(k,nearestRelaxationCell(iCell))
+               w(k,iCell) = 0.0  ! WCS fix for instabilities caused by zero-gradient condition on inflow, 20240806
             end do
          end if  
       end do


### PR DESCRIPTION
For the regional configuration, this commit changes the zero-gradient boundary condition for setting the vertical velocity w, to setting the vertical velocity to zero in the specified region.  This alleviates the spurious streamers and instabilities that appeared near the boundaries in regions of strong inflow.


