### PR TITLE
Eliminate host-device copies of the tendencies provided by mpas_atm_get_bdy_tend

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -311,7 +311,6 @@ module mpas_atm_boundaries
         call mpas_pool_get_array(lbc, 'lbc_'//trim(field), tend, 1)
 
         MPAS_ACC_TIMER_START('mpas_atm_get_bdy_tend [ACC_data_xfer]')
-        !$acc enter data create(return_tend)
         if (associated(tend)) then
             !$acc enter data copyin(tend)
         else
@@ -343,7 +342,6 @@ module mpas_atm_boundaries
         !$acc end parallel
 
         MPAS_ACC_TIMER_START('mpas_atm_get_bdy_tend [ACC_data_xfer]')
-        !$acc exit data copyout(return_tend)
         if (associated(tend)) then
             !$acc exit data delete(tend)
         else

--- a/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_boundaries.F
@@ -258,11 +258,11 @@ module mpas_atm_boundaries
     !
     !  routine mpas_atm_get_bdy_tend
     !
-    !> \brief   Returns LBC tendencies a specified delta-t in the future
+    !> \brief   Provide LBC tendencies a specified delta-t in the future
     !> \author  Michael Duda
     !> \date    28 September 2016
     !> \details 
-    !>  This function returns an array providing the tendency for the requested
+    !>  This subroutine returns an array with the tendency for the requested
     !>  progostic variable delta_t in the future from the current time known
     !>  by the simulation clock (which is typically the time at the start of
     !>  the current timestep).
@@ -270,7 +270,7 @@ module mpas_atm_boundaries
     !>  The vertDim and horizDim should match the nominal block dimensions of
     !>  the field to be returned by the call; for example, a call to retrieve
     !>  the tendency for the 'u' field would set vertDim=nVertLevels and 
-    !>  horizDim=nEdges. This function internally adds 1 to the horizontal
+    !>  horizDim=nEdges. This routine internally adds 1 to the horizontal
     !>  dimension to account for the "garbage" element.
     !>
     !>  The field is identified by the 'field' argument, and this argument is
@@ -278,16 +278,16 @@ module mpas_atm_boundaries
     !>  the 'lbc' pool. For scalars, the field argument should give the name 
     !>  of the constituent, e.g., 'qv'.
     !>
-    !>  Example calls to this function:
+    !>  Example calls to this subroutine:
     !>  
-    !>   tend_u(:,:) = mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nEdges, 'u', 0.0_RKIND)
-    !>   tend_w(:,:) = mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels+1, nCells, 'w', 0.0_RKIND)
-    !>   tend_rho_zz(:,:) = mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND)
-    !>   tend_theta(:,:) = mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'theta', 0.0_RKIND)
-    !>   tend_scalars(1,:,:) = mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND)
+    !>   call mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nEdges, 'u', 0.0_RKIND, tend_u)
+    !>   call mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels+1, nCells, 'w', 0.0_RKIND, tend_w)
+    !>   call mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'rho_zz', 0.0_RKIND, tend_rho_zz)
+    !>   call mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'theta', 0.0_RKIND, tend_theta)
+    !>   call mpas_atm_get_bdy_tend(clock, domain % blocklist, nVertLevels, nCells, 'qv', 0.0_RKIND, tend_qv)
     !
     !-----------------------------------------------------------------------
-    function mpas_atm_get_bdy_tend(clock, block, vertDim, horizDim, field, delta_t) result(return_tend)
+    subroutine mpas_atm_get_bdy_tend(clock, block, vertDim, horizDim, field, delta_t, return_tend)
 
         implicit none
 
@@ -296,8 +296,7 @@ module mpas_atm_boundaries
         integer, intent(in) :: vertDim, horizDim
         character(len=*), intent(in) :: field
         real (kind=RKIND), intent(in) :: delta_t
-
-        real (kind=RKIND), dimension(vertDim,horizDim+1) :: return_tend
+        real (kind=RKIND), dimension(vertDim,horizDim+1), intent(out) :: return_tend
 
         type (mpas_pool_type), pointer :: lbc
         integer, pointer :: idx_ptr
@@ -352,7 +351,7 @@ module mpas_atm_boundaries
         end if
         MPAS_ACC_TIMER_STOP('mpas_atm_get_bdy_tend [ACC_data_xfer]')
 
-    end function mpas_atm_get_bdy_tend
+    end subroutine mpas_atm_get_bdy_tend
 
 
     !***********************************************************************

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -1130,9 +1130,9 @@ module atm_time_integration
                allocate(ru_driving_tend(nVertLevels,nEdges+1))
                allocate(rt_driving_tend(nVertLevels,nCells+1))
                allocate(rho_driving_tend(nVertLevels,nCells+1))
-               ru_driving_tend(1:nVertLevels,1:nEdges+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nEdges, 'ru', 0.0_RKIND )
-               rt_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND )
-               rho_driving_tend(1:nVertLevels,1:nCells+1) =  mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rho_zz', 0.0_RKIND )
+               call mpas_atm_get_bdy_tend( clock, block, nVertLevels, nEdges, 'ru', 0.0_RKIND, ru_driving_tend)
+               call mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rtheta_m', 0.0_RKIND, rt_driving_tend)
+               call mpas_atm_get_bdy_tend( clock, block, nVertLevels, nCells, 'rho_zz', 0.0_RKIND, rho_driving_tend)
 !$OMP PARALLEL DO
                do thread=1,nThreads
                   call atm_bdy_adjust_dynamics_speczone_tend( tend, mesh, block % configs, nVertLevels,                 &

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -79,9 +79,14 @@ module atm_time_integration
    real (kind=RKIND), dimension(:,:), allocatable :: rho_zz_int
 
    real (kind=RKIND), dimension(:,:,:), allocatable :: scalars_driving ! regional_MPAS addition 
+
    real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_tend ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_tend ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_tend ! regional_MPAS addition 
+   !$acc declare create(ru_driving_tend)
+   !$acc declare create(rt_driving_tend)
+   !$acc declare create(rho_driving_tend)
+
    real (kind=RKIND), dimension(:,:), allocatable :: ru_driving_values ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rt_driving_values ! regional_MPAS addition 
    real (kind=RKIND), dimension(:,:), allocatable :: rho_driving_values ! regional_MPAS addition 
@@ -6849,9 +6854,7 @@ module atm_time_integration
 
       MPAS_ACC_TIMER_START('atm_bdy_adjust_dynamics_speczone_tend [ACC_data_xfer]')
       !$acc enter data copyin(tend_ru,tend_rho,tend_rt,tend_rw, &
-      !$acc                   rt_diabatic_tend) &
-      !$acc            copyin(rho_driving_tend,rt_driving_tend, &
-      !$acc                   ru_driving_tend)
+      !$acc                   rt_diabatic_tend)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_dynamics_speczone_tend [ACC_data_xfer]')
 
       !$acc parallel default(present)
@@ -6883,9 +6886,7 @@ module atm_time_integration
 
       MPAS_ACC_TIMER_START('atm_bdy_adjust_dynamics_speczone_tend [ACC_data_xfer]')
       !$acc exit data copyout(tend_ru,tend_rho,tend_rt, &
-      !$acc                   tend_rw,rt_diabatic_tend) &
-      !$acc            delete(rho_driving_tend,rt_driving_tend, &
-      !$acc                   ru_driving_tend)
+      !$acc                   tend_rw,rt_diabatic_tend)
       MPAS_ACC_TIMER_STOP('atm_bdy_adjust_dynamics_speczone_tend [ACC_data_xfer]')
       
     end subroutine atm_bdy_adjust_dynamics_speczone_tend


### PR DESCRIPTION
This PR converts the `mpas_atm_get_bdy_tend` function into a subroutine, thereby enabling the tendencies provided by this routine to be entirely resident on the GPU when MPAS-A is built with OpenACC. The `ru_driving_tend`, `rt_driving_tend`, and `rho_driving_tend` allocatable arrrays that are set by the `mpas_atm_get_bdy_tend` subroutine are automatically allocated on the GPU through `!$acc declare create` directives in the `atm_time_integration` module, and the `create` and `copyout` of these variables can be eliminated from the `mpas_atm_get_bdy_tend` routine, as can the `copyin` and `delete` of these variables from the `atm_bdy_adjust_dynamics_speczone_tend` routine.